### PR TITLE
Track implicit `Sized` obligations in type params

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -271,7 +271,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
     }
 
     fn normalize(mut self) -> Vec<traits::PredicateObligation<'tcx>> {
-        let cause = self.cause(traits::MiscObligation);
+        let cause = self.cause(traits::WellFormed(None));
         let infcx = &mut self.infcx;
         let param_env = self.param_env;
         let mut obligations = Vec::with_capacity(self.out.len());
@@ -385,7 +385,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         self.out.extend(obligations);
 
         let tcx = self.tcx();
-        let cause = self.cause(traits::MiscObligation);
+        let cause = self.cause(traits::WellFormed(None));
         let param_env = self.param_env;
         let depth = self.recursion_depth;
 
@@ -445,7 +445,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                             let predicate =
                                 ty::Binder::dummy(ty::PredicateKind::ConstEvaluatable(uv.shrink()))
                                     .to_predicate(self.tcx());
-                            let cause = self.cause(traits::MiscObligation);
+                            let cause = self.cause(traits::WellFormed(None));
                             self.out.push(traits::Obligation::with_depth(
                                 cause,
                                 self.recursion_depth,
@@ -457,7 +457,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                             let resolved = self.infcx.shallow_resolve(infer);
                             // the `InferConst` changed, meaning that we made progress.
                             if resolved != infer {
-                                let cause = self.cause(traits::MiscObligation);
+                                let cause = self.cause(traits::WellFormed(None));
 
                                 let resolved_constant = self.infcx.tcx.mk_const(ty::ConstS {
                                     kind: ty::ConstKind::Infer(resolved),
@@ -648,7 +648,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     let defer_to_coercion = self.tcx().features().object_safe_for_dispatch;
 
                     if !defer_to_coercion {
-                        let cause = self.cause(traits::MiscObligation);
+                        let cause = self.cause(traits::WellFormed(None));
                         let component_traits = data.auto_traits().chain(data.principal_def_id());
                         let tcx = self.tcx();
                         self.out.extend(component_traits.map(|did| {
@@ -679,7 +679,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     let ty = self.infcx.shallow_resolve(ty);
                     if let ty::Infer(ty::TyVar(_)) = ty.kind() {
                         // Not yet resolved, but we've made progress.
-                        let cause = self.cause(traits::MiscObligation);
+                        let cause = self.cause(traits::WellFormed(None));
                         self.out.push(traits::Obligation::with_depth(
                             cause,
                             self.recursion_depth,

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         // we must check that return type of called functions is WF:
-        self.register_wf_obligation(output.into(), call_expr.span, traits::MiscObligation);
+        self.register_wf_obligation(output.into(), call_expr.span, traits::WellFormed(None));
 
         output
     }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -496,7 +496,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     pub fn to_ty(&self, ast_t: &hir::Ty<'_>) -> Ty<'tcx> {
         let t = <dyn AstConv<'_>>::ast_ty_to_ty(self, ast_t);
-        self.register_wf_obligation(t.into(), ast_t.span, traits::MiscObligation);
+        self.register_wf_obligation(t.into(), ast_t.span, traits::WellFormed(None));
         t
     }
 
@@ -526,7 +526,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.register_wf_obligation(
             c.into(),
             self.tcx.hir().span(ast_c.hir_id),
-            ObligationCauseCode::MiscObligation,
+            ObligationCauseCode::WellFormed(None),
         );
         c
     }
@@ -544,7 +544,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.register_wf_obligation(
             c.into(),
             self.tcx.hir().span(ast_c.hir_id),
-            ObligationCauseCode::MiscObligation,
+            ObligationCauseCode::WellFormed(None),
         );
         c
     }
@@ -607,7 +607,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         for arg in substs.iter().filter(|arg| {
             matches!(arg.unpack(), GenericArgKind::Type(..) | GenericArgKind::Const(..))
         }) {
-            self.register_wf_obligation(arg, expr.span, traits::MiscObligation);
+            self.register_wf_obligation(arg, expr.span, traits::WellFormed(None));
         }
     }
 

--- a/compiler/rustc_typeck/src/check/method/confirm.rs
+++ b/compiler/rustc_typeck/src/check/method/confirm.rs
@@ -501,7 +501,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         // the function type must also be well-formed (this is not
         // implied by the substs being well-formed because of inherent
         // impls and late-bound regions - see issue #28609).
-        self.register_wf_obligation(fty.into(), self.span, traits::MiscObligation);
+        self.register_wf_obligation(fty.into(), self.span, traits::WellFormed(None));
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -1180,7 +1180,7 @@ fn check_item_type(tcx: TyCtxt<'_>, item_id: LocalDefId, ty_span: Span, allow_fo
             fcx.register_bound(
                 item_ty,
                 tcx.require_lang_item(LangItem::Sized, None),
-                traits::ObligationCause::new(ty_span, fcx.body_id, traits::MiscObligation),
+                traits::ObligationCause::new(ty_span, fcx.body_id, traits::WellFormed(None)),
             );
         }
 

--- a/compiler/rustc_typeck/src/hir_wf_check.rs
+++ b/compiler/rustc_typeck/src/hir_wf_check.rs
@@ -72,7 +72,7 @@ fn diagnostic_hir_wf_check<'tcx>(
                 let cause = traits::ObligationCause::new(
                     ty.span,
                     self.hir_id,
-                    traits::ObligationCauseCode::MiscObligation,
+                    traits::ObligationCauseCode::WellFormed(None),
                 );
                 fulfill.register_predicate_obligation(
                     &infcx,

--- a/src/test/ui/associated-item/associated-item-enum.stderr
+++ b/src/test/ui/associated-item/associated-item-enum.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `mispellable` found for enum `
   --> $DIR/associated-item-enum.rs:17:11
    |
 LL | enum Enum { Variant }
-   |      ---- variant or associated item `mispellable` not found for this enum
+   | --------- variant or associated item `mispellable` not found for this enum
 ...
 LL |     Enum::mispellable();
    |           ^^^^^^^^^^^
@@ -14,7 +14,7 @@ error[E0599]: no variant or associated item named `mispellable_trait` found for 
   --> $DIR/associated-item-enum.rs:18:11
    |
 LL | enum Enum { Variant }
-   |      ---- variant or associated item `mispellable_trait` not found for this enum
+   | --------- variant or associated item `mispellable_trait` not found for this enum
 ...
 LL |     Enum::mispellable_trait();
    |           ^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ error[E0599]: no variant or associated item named `MISPELLABLE` found for enum `
   --> $DIR/associated-item-enum.rs:19:11
    |
 LL | enum Enum { Variant }
-   |      ---- variant or associated item `MISPELLABLE` not found for this enum
+   | --------- variant or associated item `MISPELLABLE` not found for this enum
 ...
 LL |     Enum::MISPELLABLE;
    |           ^^^^^^^^^^^

--- a/src/test/ui/async-await/pin-needed-to-poll.stderr
+++ b/src/test/ui/async-await/pin-needed-to-poll.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `poll` found for struct `Sleep` in the current sco
   --> $DIR/pin-needed-to-poll.rs:42:20
    |
 LL | struct Sleep;
-   |        ----- method `poll` not found for this struct
+   | ------------ method `poll` not found for this struct
 ...
 LL |         self.sleep.poll(cx)
    |                    ^^^^ method not found in `Sleep`

--- a/src/test/ui/bogus-tag.stderr
+++ b/src/test/ui/bogus-tag.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `Hsl` found for enum `Color` i
   --> $DIR/bogus-tag.rs:7:16
    |
 LL | enum Color { Rgb(isize, isize, isize), Rgba(isize, isize, isize, isize), }
-   |      ----- variant or associated item `Hsl` not found for this enum
+   | ---------- variant or associated item `Hsl` not found for this enum
 ...
 LL |         Color::Hsl(h, s, l) => { println!("hsl"); }
    |                ^^^ variant or associated item not found in `Color`

--- a/src/test/ui/confuse-field-and-method/issue-18343.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-18343.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-18343.rs:7:7
    |
 LL | struct Obj<F> where F: FnMut() -> u32 {
-   |        --- method `closure` not found for this struct
+   | ------------- method `closure` not found for this struct
 ...
 LL |     o.closure();
    |       ^^^^^^^ field, not a method

--- a/src/test/ui/confuse-field-and-method/issue-2392.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-2392.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:36:15
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   |        --- method `closure` not found for this struct
+   | ------------- method `closure` not found for this struct
 ...
 LL |     o_closure.closure();
    |               ^^^^^^^ field, not a method
@@ -16,7 +16,7 @@ error[E0599]: no method named `not_closure` found for struct `Obj` in the curren
   --> $DIR/issue-2392.rs:38:15
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   |        --- method `not_closure` not found for this struct
+   | ------------- method `not_closure` not found for this struct
 ...
 LL |     o_closure.not_closure();
    |               ^^^^^^^^^^^-- help: remove the arguments
@@ -27,7 +27,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:42:12
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   |        --- method `closure` not found for this struct
+   | ------------- method `closure` not found for this struct
 ...
 LL |     o_func.closure();
    |            ^^^^^^^ field, not a method
@@ -41,7 +41,7 @@ error[E0599]: no method named `boxed_closure` found for struct `BoxedObj` in the
   --> $DIR/issue-2392.rs:45:14
    |
 LL | struct BoxedObj {
-   |        -------- method `boxed_closure` not found for this struct
+   | --------------- method `boxed_closure` not found for this struct
 ...
 LL |     boxed_fn.boxed_closure();
    |              ^^^^^^^^^^^^^ field, not a method
@@ -55,7 +55,7 @@ error[E0599]: no method named `boxed_closure` found for struct `BoxedObj` in the
   --> $DIR/issue-2392.rs:48:19
    |
 LL | struct BoxedObj {
-   |        -------- method `boxed_closure` not found for this struct
+   | --------------- method `boxed_closure` not found for this struct
 ...
 LL |     boxed_closure.boxed_closure();
    |                   ^^^^^^^^^^^^^ field, not a method
@@ -69,7 +69,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:53:12
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   |        --- method `closure` not found for this struct
+   | ------------- method `closure` not found for this struct
 ...
 LL |     w.wrap.closure();
    |            ^^^^^^^ field, not a method
@@ -83,7 +83,7 @@ error[E0599]: no method named `not_closure` found for struct `Obj` in the curren
   --> $DIR/issue-2392.rs:55:12
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   |        --- method `not_closure` not found for this struct
+   | ------------- method `not_closure` not found for this struct
 ...
 LL |     w.wrap.not_closure();
    |            ^^^^^^^^^^^-- help: remove the arguments
@@ -94,7 +94,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:58:24
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   |        --- method `closure` not found for this struct
+   | ------------- method `closure` not found for this struct
 ...
 LL |     check_expression().closure();
    |                        ^^^^^^^ field, not a method
@@ -108,7 +108,7 @@ error[E0599]: no method named `f1` found for struct `FuncContainer` in the curre
   --> $DIR/issue-2392.rs:64:31
    |
 LL | struct FuncContainer {
-   |        ------------- method `f1` not found for this struct
+   | -------------------- method `f1` not found for this struct
 ...
 LL |             (*self.container).f1(1);
    |                               ^^ field, not a method
@@ -122,7 +122,7 @@ error[E0599]: no method named `f2` found for struct `FuncContainer` in the curre
   --> $DIR/issue-2392.rs:65:31
    |
 LL | struct FuncContainer {
-   |        ------------- method `f2` not found for this struct
+   | -------------------- method `f2` not found for this struct
 ...
 LL |             (*self.container).f2(1);
    |                               ^^ field, not a method
@@ -136,7 +136,7 @@ error[E0599]: no method named `f3` found for struct `FuncContainer` in the curre
   --> $DIR/issue-2392.rs:66:31
    |
 LL | struct FuncContainer {
-   |        ------------- method `f3` not found for this struct
+   | -------------------- method `f3` not found for this struct
 ...
 LL |             (*self.container).f3(1);
    |                               ^^ field, not a method

--- a/src/test/ui/confuse-field-and-method/issue-32128.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-32128.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `example` found for struct `Example` in the curren
   --> $DIR/issue-32128.rs:12:10
    |
 LL | struct Example {
-   |        ------- method `example` not found for this struct
+   | -------------- method `example` not found for this struct
 ...
 LL |     demo.example(1);
    |          ^^^^^^^ field, not a method

--- a/src/test/ui/confuse-field-and-method/private-field.stderr
+++ b/src/test/ui/confuse-field-and-method/private-field.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `dog_age` found for struct `Dog` in the current sc
   --> $DIR/private-field.rs:16:23
    |
 LL |     pub struct Dog {
-   |                --- method `dog_age` not found for this struct
+   |     -------------- method `dog_age` not found for this struct
 ...
 LL |     let dog_age = dog.dog_age();
    |                       ^^^^^^^ private field, not a method

--- a/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
@@ -8,7 +8,7 @@ error[E0599]: the function or associated item `foo` exists for struct `Foo<{_: u
   --> $DIR/issue-69654.rs:17:10
    |
 LL | struct Foo<const N: usize> {}
-   |        --- function or associated item `foo` not found for this struct
+   | -------------------------- function or associated item `foo` not found for this struct
 ...
 LL |     Foo::foo();
    |          ^^^ function or associated item cannot be called on `Foo<{_: usize}>` due to unsatisfied trait bounds

--- a/src/test/ui/const-generics/generic_const_exprs/issue-80742.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-80742.stderr
@@ -16,7 +16,7 @@ error[E0599]: the function or associated item `new` exists for struct `Inline<dy
   --> $DIR/issue-80742.rs:30:36
    |
 LL | struct Inline<T>
-   |        ------ function or associated item `new` not found for this struct
+   | ---------------- function or associated item `new` not found for this struct
 ...
 LL |     let dst = Inline::<dyn Debug>::new(0);
    |                                    ^^^ function or associated item cannot be called on `Inline<dyn Debug>` due to unsatisfied trait bounds

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -16,7 +16,7 @@ error[E0599]: no method named `f` found for struct `S` in the current scope
   --> $DIR/invalid-const-arg-for-type-param.rs:9:7
    |
 LL | struct S;
-   |        - method `f` not found for this struct
+   | -------- method `f` not found for this struct
 ...
 LL |     S.f::<0>();
    |       ^ method not found in `S`

--- a/src/test/ui/consts/const-needs_drop-monomorphic.stderr
+++ b/src/test/ui/consts/const-needs_drop-monomorphic.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `assert` found for struct `Bo
   --> $DIR/const-needs_drop-monomorphic.rs:11:46
    |
 LL | struct Bool<const B: bool> {}
-   |        ---- function or associated item `assert` not found for this struct
+   | -------------------------- function or associated item `assert` not found for this struct
 ...
 LL |     Bool::<{ std::mem::needs_drop::<T>() }>::assert();
    |                                              ^^^^^^ function or associated item cannot be called on `Bool<{ std::mem::needs_drop::<T>() }>` due to unsatisfied trait bounds

--- a/src/test/ui/copy-a-resource.stderr
+++ b/src/test/ui/copy-a-resource.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `Foo` in the current scop
   --> $DIR/copy-a-resource.rs:18:16
    |
 LL | struct Foo {
-   |        --- method `clone` not found for this struct
+   | ---------- method `clone` not found for this struct
 ...
 LL |     let _y = x.clone();
    |                ^^^^^ method not found in `Foo`

--- a/src/test/ui/derives/derive-assoc-type-not-impl.stderr
+++ b/src/test/ui/derives/derive-assoc-type-not-impl.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `clone` exists for struct `Bar<NotClone>`, but its trai
    |
 LL | struct Bar<T: Foo> {
    | ------------------
-   | |      |
-   | |      method `clone` not found for this struct
+   | |
+   | method `clone` not found for this struct
    | doesn't satisfy `Bar<NotClone>: Clone`
 ...
 LL | struct NotClone;

--- a/src/test/ui/derives/issue-91492.stderr
+++ b/src/test/ui/derives/issue-91492.stderr
@@ -37,7 +37,7 @@ LL | pub struct NoDerives;
    | -------------------- doesn't satisfy `NoDerives: Clone`
 ...
 LL | struct Object<T, A>(T, A);
-   |        ------ method `use_clone` not found for this struct
+   | ------------------- method `use_clone` not found for this struct
 ...
 LL |     foo.use_clone();
    |         ^^^^^^^^^ method cannot be called on `Object<NoDerives, SomeDerives>` due to unsatisfied trait bounds

--- a/src/test/ui/derives/issue-91550.stderr
+++ b/src/test/ui/derives/issue-91550.stderr
@@ -25,7 +25,7 @@ LL | pub struct NoDerives;
    | -------------------- doesn't satisfy `NoDerives: Eq`
 LL |
 LL | struct Object<T>(T);
-   |        ------ method `use_eq` not found for this struct
+   | ---------------- method `use_eq` not found for this struct
 ...
 LL |     foo.use_eq();
    |         ^^^^^^ method cannot be called on `Object<NoDerives>` due to unsatisfied trait bounds
@@ -44,7 +44,7 @@ LL | pub struct NoDerives;
    | -------------------- doesn't satisfy `NoDerives: Ord`
 LL |
 LL | struct Object<T>(T);
-   |        ------ method `use_ord` not found for this struct
+   | ---------------- method `use_ord` not found for this struct
 ...
 LL |     foo.use_ord();
    |         ^^^^^^^ method cannot be called on `Object<NoDerives>` due to unsatisfied trait bounds
@@ -66,7 +66,7 @@ LL | pub struct NoDerives;
    | doesn't satisfy `NoDerives: PartialOrd`
 LL |
 LL | struct Object<T>(T);
-   |        ------ method `use_ord_and_partial_ord` not found for this struct
+   | ---------------- method `use_ord_and_partial_ord` not found for this struct
 ...
 LL |     foo.use_ord_and_partial_ord();
    |         ^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Object<NoDerives>` due to unsatisfied trait bounds

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -88,7 +88,7 @@ error[E0599]: no method named `hello_method` found for struct `S` in the current
   --> $DIR/issue-40006.rs:38:7
    |
 LL | struct S;
-   |        - method `hello_method` not found for this struct
+   | -------- method `hello_method` not found for this struct
 ...
 LL |     S.hello_method();
    |       ^^^^^^^^^^^^ method not found in `S`

--- a/src/test/ui/dont-suggest-private-trait-method.stderr
+++ b/src/test/ui/dont-suggest-private-trait-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `new` found for struct `T` in
   --> $DIR/dont-suggest-private-trait-method.rs:4:8
    |
 LL | struct T;
-   |        - function or associated item `new` not found for this struct
+   | -------- function or associated item `new` not found for this struct
 ...
 LL |     T::new();
    |        ^^^ function or associated item not found in `T`

--- a/src/test/ui/error-codes/E0599.stderr
+++ b/src/test/ui/error-codes/E0599.stderr
@@ -2,7 +2,7 @@ error[E0599]: no associated item named `NotEvenReal` found for struct `Foo` in t
   --> $DIR/E0599.rs:4:20
    |
 LL | struct Foo;
-   |        --- associated item `NotEvenReal` not found for this struct
+   | ---------- associated item `NotEvenReal` not found for this struct
 ...
 LL |     || if let Foo::NotEvenReal() = Foo {};
    |                    ^^^^^^^^^^^ associated item not found in `Foo`

--- a/src/test/ui/generic-associated-types/method-unsatified-assoc-type-predicate.stderr
+++ b/src/test/ui/generic-associated-types/method-unsatified-assoc-type-predicate.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `f` exists for struct `S`, but its trait bounds were no
    |
 LL | struct S;
    | --------
-   | |      |
-   | |      method `f` not found for this struct
+   | |
+   | method `f` not found for this struct
    | doesn't satisfy `<S as X>::Y<i32> = i32`
    | doesn't satisfy `S: M`
 ...

--- a/src/test/ui/hrtb/issue-30786.stderr
+++ b/src/test/ui/hrtb/issue-30786.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `filterx` exists for struct `Map<Repeat, [closure@$DIR/
    |
 LL | pub struct Map<S, F> {
    | --------------------
-   | |          |
-   | |          method `filterx` not found for this struct
+   | |
+   | method `filterx` not found for this struct
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let filter = map.filterx(|x: &_| true);
@@ -28,8 +28,8 @@ error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'r> 
    |
 LL | pub struct Filter<S, F> {
    | -----------------------
-   | |          |
-   | |          method `countx` not found for this struct
+   | |
+   | method `countx` not found for this struct
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let count = filter.countx();

--- a/src/test/ui/impl-trait/issues/issue-21659-show-relevant-trait-impls-3.stderr
+++ b/src/test/ui/impl-trait/issues/issue-21659-show-relevant-trait-impls-3.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `foo` found for struct `Bar` in the current scope
   --> $DIR/issue-21659-show-relevant-trait-impls-3.rs:20:8
    |
 LL | struct Bar;
-   |        --- method `foo` not found for this struct
+   | ---------- method `foo` not found for this struct
 ...
 LL |     f1.foo(1usize);
    |        ^^^ method not found in `Bar`

--- a/src/test/ui/impl-trait/issues/issue-62742.stderr
+++ b/src/test/ui/impl-trait/issues/issue-62742.stderr
@@ -21,7 +21,7 @@ LL | pub struct RawImpl<T>(PhantomData<T>);
    | --------------------- doesn't satisfy `RawImpl<()>: Raw<()>`
 ...
 LL | pub struct SafeImpl<T: ?Sized, A: Raw<T>>(PhantomData<(A, T)>);
-   |            -------- function or associated item `foo` not found for this struct
+   | ----------------------------------------- function or associated item `foo` not found for this struct
    |
    = note: the following trait bounds were not satisfied:
            `RawImpl<()>: Raw<()>`

--- a/src/test/ui/impl-trait/method-suggestion-no-duplication.stderr
+++ b/src/test/ui/impl-trait/method-suggestion-no-duplication.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `is_empty` found for struct `Foo` in the current s
   --> $DIR/method-suggestion-no-duplication.rs:7:15
    |
 LL | struct Foo;
-   |        --- method `is_empty` not found for this struct
+   | ---------- method `is_empty` not found for this struct
 ...
 LL |     foo(|s| s.is_empty());
    |               ^^^^^^^^ method not found in `Foo`

--- a/src/test/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/src/test/ui/impl-trait/no-method-suggested-traits.stderr
@@ -94,7 +94,7 @@ error[E0599]: no method named `method` found for struct `Foo` in the current sco
   --> $DIR/no-method-suggested-traits.rs:40:9
    |
 LL | struct Foo;
-   |        --- method `method` not found for this struct
+   | ---------- method `method` not found for this struct
 ...
 LL |     Foo.method();
    |         ^^^^^^ method not found in `Foo`
@@ -201,7 +201,7 @@ error[E0599]: no method named `method3` found for struct `Foo` in the current sc
   --> $DIR/no-method-suggested-traits.rs:59:9
    |
 LL | struct Foo;
-   |        --- method `method3` not found for this struct
+   | ---------- method `method3` not found for this struct
 ...
 LL |     Foo.method3();
    |         ^^^^^^^ method not found in `Foo`
@@ -224,7 +224,7 @@ error[E0599]: no method named `method3` found for enum `Bar` in the current scop
   --> $DIR/no-method-suggested-traits.rs:63:12
    |
 LL | enum Bar { X }
-   |      --- method `method3` not found for this enum
+   | -------- method `method3` not found for this enum
 ...
 LL |     Bar::X.method3();
    |            ^^^^^^^ method not found in `Bar`

--- a/src/test/ui/infinite/infinite-autoderef.stderr
+++ b/src/test/ui/infinite/infinite-autoderef.stderr
@@ -43,7 +43,7 @@ error[E0599]: no method named `bar` found for struct `Foo` in the current scope
   --> $DIR/infinite-autoderef.rs:25:9
    |
 LL | struct Foo;
-   |        --- method `bar` not found for this struct
+   | ---------- method `bar` not found for this struct
 ...
 LL |     Foo.bar();
    |         ^^^ method not found in `Foo`

--- a/src/test/ui/issues/issue-19692.stderr
+++ b/src/test/ui/issues/issue-19692.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `kaname` found for struct `Homura` in the current 
   --> $DIR/issue-19692.rs:4:40
    |
 LL | struct Homura;
-   |        ------ method `kaname` not found for this struct
+   | ------------- method `kaname` not found for this struct
 ...
 LL |     let Some(ref madoka) = Some(homura.kaname());
    |                                        ^^^^^^ method not found in `Homura`

--- a/src/test/ui/issues/issue-22933-2.stderr
+++ b/src/test/ui/issues/issue-22933-2.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `PIE` found for enum `Deliciou
   --> $DIR/issue-22933-2.rs:4:55
    |
 LL | enum Delicious {
-   |      --------- variant or associated item `PIE` not found for this enum
+   | -------------- variant or associated item `PIE` not found for this enum
 ...
 LL |     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
    |                                                       ^^^

--- a/src/test/ui/issues/issue-23173.stderr
+++ b/src/test/ui/issues/issue-23173.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `Homura` found for enum `Token
   --> $DIR/issue-23173.rs:9:23
    |
 LL | enum Token { LeftParen, RightParen, Plus, Minus, /* etc */ }
-   |      ----- variant or associated item `Homura` not found for this enum
+   | ---------- variant or associated item `Homura` not found for this enum
 ...
 LL |     use_token(&Token::Homura);
    |                       ^^^^^^ variant or associated item not found in `Token`
@@ -11,7 +11,7 @@ error[E0599]: no function or associated item named `method` found for struct `St
   --> $DIR/issue-23173.rs:10:13
    |
 LL | struct Struct {
-   |        ------ function or associated item `method` not found for this struct
+   | ------------- function or associated item `method` not found for this struct
 ...
 LL |     Struct::method();
    |             ^^^^^^ function or associated item not found in `Struct`
@@ -20,7 +20,7 @@ error[E0599]: no function or associated item named `method` found for struct `St
   --> $DIR/issue-23173.rs:11:13
    |
 LL | struct Struct {
-   |        ------ function or associated item `method` not found for this struct
+   | ------------- function or associated item `method` not found for this struct
 ...
 LL |     Struct::method;
    |             ^^^^^^ function or associated item not found in `Struct`
@@ -29,7 +29,7 @@ error[E0599]: no associated item named `Assoc` found for struct `Struct` in the 
   --> $DIR/issue-23173.rs:12:13
    |
 LL | struct Struct {
-   |        ------ associated item `Assoc` not found for this struct
+   | ------------- associated item `Assoc` not found for this struct
 ...
 LL |     Struct::Assoc;
    |             ^^^^^ associated item not found in `Struct`

--- a/src/test/ui/issues/issue-23217.stderr
+++ b/src/test/ui/issues/issue-23217.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `A` found for enum `SomeEnum` 
   --> $DIR/issue-23217.rs:2:19
    |
 LL | pub enum SomeEnum {
-   |          -------- variant or associated item `A` not found for this enum
+   | ----------------- variant or associated item `A` not found for this enum
 LL |     B = SomeEnum::A,
    |                   ^
    |                   |

--- a/src/test/ui/issues/issue-2823.stderr
+++ b/src/test/ui/issues/issue-2823.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `C` in the current scope
   --> $DIR/issue-2823.rs:13:16
    |
 LL | struct C {
-   |        - method `clone` not found for this struct
+   | -------- method `clone` not found for this struct
 ...
 LL |     let _d = c.clone();
    |                ^^^^^ method not found in `C`

--- a/src/test/ui/issues/issue-28971.stderr
+++ b/src/test/ui/issues/issue-28971.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `Baz` found for enum `Foo` in 
   --> $DIR/issue-28971.rs:7:18
    |
 LL | enum Foo {
-   |      --- variant or associated item `Baz` not found for this enum
+   | -------- variant or associated item `Baz` not found for this enum
 ...
 LL |             Foo::Baz(..) => (),
    |                  ^^^

--- a/src/test/ui/issues/issue-41880.stderr
+++ b/src/test/ui/issues/issue-41880.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `iter` found for struct `Iterate` in the current s
   --> $DIR/issue-41880.rs:27:24
    |
 LL | pub struct Iterate<T, F> {
-   |            ------- method `iter` not found for this struct
+   | ------------------------ method `iter` not found for this struct
 ...
 LL |     println!("{:?}", a.iter().take(10).collect::<Vec<usize>>());
    |                        ^^^^ method not found in `Iterate<{integer}, [closure@$DIR/issue-41880.rs:26:24: 26:31]>`

--- a/src/test/ui/issues/issue-64430.stderr
+++ b/src/test/ui/issues/issue-64430.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `bar` found for struct `Foo` in the current scope
   --> $DIR/issue-64430.rs:7:9
    |
 LL | pub struct Foo;
-   |            --- method `bar` not found for this struct
+   | -------------- method `bar` not found for this struct
 ...
 LL |     Foo.bar()
    |         ^^^ method not found in `Foo`

--- a/src/test/ui/issues/issue-7950.stderr
+++ b/src/test/ui/issues/issue-7950.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `bar` found for struct `Foo` 
   --> $DIR/issue-7950.rs:6:10
    |
 LL | struct Foo;
-   |        --- function or associated item `bar` not found for this struct
+   | ---------- function or associated item `bar` not found for this struct
 ...
 LL |     Foo::bar();
    |          ^^^ function or associated item not found in `Foo`

--- a/src/test/ui/methods/method-call-err-msg.stderr
+++ b/src/test/ui/methods/method-call-err-msg.stderr
@@ -51,8 +51,8 @@ error[E0599]: `Foo` is not an iterator
    |
 LL | pub struct Foo;
    | --------------
-   | |          |
-   | |          method `take` not found for this struct
+   | |
+   | method `take` not found for this struct
    | doesn't satisfy `Foo: Iterator`
 ...
 LL |      .take()

--- a/src/test/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/src/test/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `distance` found for struct `Point<i32>` in the cu
   --> $DIR/method-not-found-generic-arg-elision.rs:82:23
    |
 LL | struct Point<T> {
-   |        ----- method `distance` not found for this struct
+   | --------------- method `distance` not found for this struct
 ...
 LL |     let d = point_i32.distance();
    |                       ^^^^^^^^ method not found in `Point<i32>`
@@ -14,7 +14,7 @@ error[E0599]: no method named `other` found for struct `Point` in the current sc
   --> $DIR/method-not-found-generic-arg-elision.rs:84:23
    |
 LL | struct Point<T> {
-   |        ----- method `other` not found for this struct
+   | --------------- method `other` not found for this struct
 ...
 LL |     let d = point_i32.other();
    |                       ^^^^^ method not found in `Point<i32>`
@@ -29,7 +29,7 @@ error[E0599]: no method named `method` found for struct `Wrapper<bool>` in the c
   --> $DIR/method-not-found-generic-arg-elision.rs:90:13
    |
 LL | struct Wrapper<T>(T);
-   |        ------- method `method` not found for this struct
+   | ----------------- method `method` not found for this struct
 ...
 LL |     wrapper.method();
    |             ^^^^^^ method not found in `Wrapper<bool>`
@@ -45,7 +45,7 @@ error[E0599]: no method named `other` found for struct `Wrapper` in the current 
   --> $DIR/method-not-found-generic-arg-elision.rs:92:13
    |
 LL | struct Wrapper<T>(T);
-   |        ------- method `other` not found for this struct
+   | ----------------- method `other` not found for this struct
 ...
 LL |     wrapper.other();
    |             ^^^^^ method not found in `Wrapper<bool>`
@@ -54,7 +54,7 @@ error[E0599]: no method named `method` found for struct `Wrapper2<'_, bool, 3_us
   --> $DIR/method-not-found-generic-arg-elision.rs:96:13
    |
 LL | struct Wrapper2<'a, T, const C: usize> {
-   |        -------- method `method` not found for this struct
+   | -------------------------------------- method `method` not found for this struct
 ...
 LL |     wrapper.method();
    |             ^^^^^^ method not found in `Wrapper2<'_, bool, 3_usize>`
@@ -68,7 +68,7 @@ error[E0599]: no method named `other` found for struct `Wrapper2` in the current
   --> $DIR/method-not-found-generic-arg-elision.rs:98:13
    |
 LL | struct Wrapper2<'a, T, const C: usize> {
-   |        -------- method `other` not found for this struct
+   | -------------------------------------- method `other` not found for this struct
 ...
 LL |     wrapper.other();
    |             ^^^^^ method not found in `Wrapper2<'_, bool, 3_usize>`
@@ -83,7 +83,7 @@ error[E0599]: the method `method` exists for struct `Struct<f64>`, but its trait
   --> $DIR/method-not-found-generic-arg-elision.rs:104:7
    |
 LL | struct Struct<T>{
-   |        ------ method `method` not found for this struct
+   | ---------------- method `method` not found for this struct
 ...
 LL |     s.method();
    |       ^^^^^^ method cannot be called on `Struct<f64>` due to unsatisfied trait bounds

--- a/src/test/ui/noncopyable-class.stderr
+++ b/src/test/ui/noncopyable-class.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `Foo` in the current scop
   --> $DIR/noncopyable-class.rs:34:16
    |
 LL | struct Foo {
-   |        --- method `clone` not found for this struct
+   | ---------- method `clone` not found for this struct
 ...
 LL |     let _y = x.clone();
    |                ^^^^^ method not found in `Foo`

--- a/src/test/ui/parser/emoji-identifiers.stderr
+++ b/src/test/ui/parser/emoji-identifiers.stderr
@@ -77,7 +77,7 @@ error[E0599]: no function or associated item named `full_of✨` found for struct
   --> $DIR/emoji-identifiers.rs:9:8
    |
 LL | struct 👀;
-   |        -- function or associated item `full_of✨` not found for this struct
+   | --------- function or associated item `full_of✨` not found for this struct
 ...
 LL |     👀::full_of✨()
    |         ^^^^^^^^^

--- a/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `deserialize` found for struc
   --> $DIR/issue-87932.rs:13:8
    |
 LL | pub struct A {}
-   |            - function or associated item `deserialize` not found for this struct
+   | ------------ function or associated item `deserialize` not found for this struct
 ...
 LL |     A::deserialize();
    |        ^^^^^^^^^^^ function or associated item not found in `A`

--- a/src/test/ui/self/point-at-arbitrary-self-type-method.stderr
+++ b/src/test/ui/self/point-at-arbitrary-self-type-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `foo` found for struct `A` in the current scope
   --> $DIR/point-at-arbitrary-self-type-method.rs:8:7
    |
 LL | struct A;
-   |        - method `foo` not found for this struct
+   | -------- method `foo` not found for this struct
 ...
 LL |     fn foo(self: Box<Self>) {}
    |        --- the method is available for `Box<A>` here

--- a/src/test/ui/self/point-at-arbitrary-self-type-trait-method.stderr
+++ b/src/test/ui/self/point-at-arbitrary-self-type-trait-method.stderr
@@ -6,7 +6,7 @@ LL | trait B { fn foo(self: Box<Self>); }
    |              |
    |              the method is available for `Box<A>` here
 LL | struct A;
-   |        - method `foo` not found for this struct
+   | -------- method `foo` not found for this struct
 ...
 LL |     A.foo()
    |       ^^^ method not found in `A`

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -42,7 +42,7 @@ error[E0599]: no method named `fff` found for struct `Myisize` in the current sc
   --> $DIR/issue-7575.rs:62:30
    |
 LL | struct Myisize(isize);
-   |        ------- method `fff` not found for this struct
+   | -------------- method `fff` not found for this struct
 ...
 LL |     u.f8(42) + u.f9(342) + m.fff(42)
    |                            --^^^

--- a/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
@@ -13,8 +13,8 @@ error[E0599]: the method `foo_one` exists for struct `MyStruct`, but its trait b
    |
 LL | struct MyStruct;
    | ---------------
-   | |      |
-   | |      method `foo_one` not found for this struct
+   | |
+   | method `foo_one` not found for this struct
    | doesn't satisfy `MyStruct: Foo`
 ...
 LL |     println!("{}", MyStruct.foo_one());

--- a/src/test/ui/suggestions/derive-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/derive-trait-for-method-call.stderr
@@ -11,7 +11,7 @@ LL | enum CloneEnum {
    | -------------- doesn't satisfy `CloneEnum: Default`
 ...
 LL | struct Foo<X, Y> (X, Y);
-   |        --- method `test` not found for this struct
+   | ---------------- method `test` not found for this struct
 ...
 LL |     let y = x.test();
    |               ^^^^ method cannot be called on `Foo<Enum, CloneEnum>` due to unsatisfied trait bounds
@@ -43,7 +43,7 @@ LL | struct CloneStruct {
    | ------------------ doesn't satisfy `CloneStruct: Default`
 ...
 LL | struct Foo<X, Y> (X, Y);
-   |        --- method `test` not found for this struct
+   | ---------------- method `test` not found for this struct
 ...
 LL |     let y = x.test();
    |               ^^^^ method cannot be called on `Foo<Struct, CloneStruct>` due to unsatisfied trait bounds
@@ -65,7 +65,7 @@ error[E0599]: the method `test` exists for struct `Foo<Vec<Enum>, Instant>`, but
   --> $DIR/derive-trait-for-method-call.rs:40:15
    |
 LL | struct Foo<X, Y> (X, Y);
-   |        --- method `test` not found for this struct
+   | ---------------- method `test` not found for this struct
 ...
 LL |     let y = x.test();
    |               ^^^^ method cannot be called on `Foo<Vec<Enum>, Instant>` due to unsatisfied trait bounds

--- a/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.stderr
+++ b/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `pick` found for struct `Chaenomeles` in the curre
   --> $DIR/dont-wrap-ambiguous-receivers.rs:18:25
    |
 LL |     pub struct Chaenomeles;
-   |                ----------- method `pick` not found for this struct
+   |     ---------------------- method `pick` not found for this struct
 ...
 LL |     banana::Chaenomeles.pick()
    |                         ^^^^ method not found in `Chaenomeles`

--- a/src/test/ui/suggestions/field-has-method.stderr
+++ b/src/test/ui/suggestions/field-has-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `kind` found for struct `InferOk` in the current s
   --> $DIR/field-has-method.rs:19:15
    |
 LL | struct InferOk<T> {
-   |        ------- method `kind` not found for this struct
+   | ----------------- method `kind` not found for this struct
 ...
 LL |     let k = i.kind();
    |               ^^^^ method not found in `InferOk<Ty>`

--- a/src/test/ui/suggestions/suggest-assoc-fn-call-with-turbofish.stderr
+++ b/src/test/ui/suggestions/suggest-assoc-fn-call-with-turbofish.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `default_hello` found for struct `GenericAssocMeth
   --> $DIR/suggest-assoc-fn-call-with-turbofish.rs:9:7
    |
 LL | struct GenericAssocMethod<T>(T);
-   |        ------------------ method `default_hello` not found for this struct
+   | ---------------------------- method `default_hello` not found for this struct
 ...
 LL |     x.default_hello();
    |     --^^^^^^^^^^^^^

--- a/src/test/ui/suggestions/suggest-methods.stderr
+++ b/src/test/ui/suggestions/suggest-methods.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `bat` found for struct `Foo` in the current scope
   --> $DIR/suggest-methods.rs:18:7
    |
 LL | struct Foo;
-   |        --- method `bat` not found for this struct
+   | ---------- method `bat` not found for this struct
 ...
 LL |     f.bat(1.0);
    |       ^^^ help: there is an associated function with a similar name: `bar`

--- a/src/test/ui/suggestions/suggest-variants.stderr
+++ b/src/test/ui/suggestions/suggest-variants.stderr
@@ -29,7 +29,7 @@ error[E0599]: no variant or associated item named `Squareee` found for enum `Sha
   --> $DIR/suggest-variants.rs:15:12
    |
 LL | enum Shape {
-   |      ----- variant or associated item `Squareee` not found for this enum
+   | ---------- variant or associated item `Squareee` not found for this enum
 ...
 LL |     Shape::Squareee;
    |            ^^^^^^^^
@@ -41,7 +41,7 @@ error[E0599]: no variant or associated item named `Circl` found for enum `Shape`
   --> $DIR/suggest-variants.rs:16:12
    |
 LL | enum Shape {
-   |      ----- variant or associated item `Circl` not found for this enum
+   | ---------- variant or associated item `Circl` not found for this enum
 ...
 LL |     Shape::Circl;
    |            ^^^^^
@@ -53,7 +53,7 @@ error[E0599]: no variant or associated item named `Rombus` found for enum `Shape
   --> $DIR/suggest-variants.rs:17:12
    |
 LL | enum Shape {
-   |      ----- variant or associated item `Rombus` not found for this enum
+   | ---------- variant or associated item `Rombus` not found for this enum
 ...
 LL |     Shape::Rombus;
    |            ^^^^^^ variant or associated item not found in `Shape`

--- a/src/test/ui/suggestions/use-placement-typeck.stderr
+++ b/src/test/ui/suggestions/use-placement-typeck.stderr
@@ -8,7 +8,7 @@ LL |         fn abc(&self) {}
    |            --- the method is available for `S` here
 LL |     }
 LL |     pub struct S;
-   |                - method `abc` not found for this struct
+   |     ------------ method `abc` not found for this struct
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound-2.rs
+++ b/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound-2.rs
@@ -1,0 +1,33 @@
+struct Victim<'a, T: Perpetrator + ?Sized> {
+  value: u8,
+  perp: &'a T,
+}
+
+trait VictimTrait {
+  type Ret;
+  fn get(self) -> Self::Ret;
+}
+
+// Actual fix is here
+impl<'a, T: Perpetrator /*+ ?Sized*/> VictimTrait for Victim<'a, T> {
+  type Ret = u8;
+  fn get(self) -> Self::Ret {
+    self.value
+  }
+}
+
+trait Perpetrator {
+  fn getter<'a>(&'a self) -> Victim<'a, Self> {
+    Victim {
+      value: 0,
+      perp: self,
+    }
+  }
+
+  fn trigger(&self) {
+    self.getter().get();
+    //~^ ERROR the method `get` exists for struct `Victim<'_, Self>`, but its trait bounds were not satisfied
+  }
+}
+
+fn main() {}

--- a/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound-2.stderr
+++ b/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound-2.stderr
@@ -1,7 +1,7 @@
 error[E0599]: the method `get` exists for struct `Victim<'_, Self>`, but its trait bounds were not satisfied
-  --> $DIR/impl-derived-implicit-sized-bound.rs:31:19
+  --> $DIR/impl-derived-implicit-sized-bound-2.rs:28:19
    |
-LL | struct Victim<'a, T: Perpetrator + ?Sized>
+LL | struct Victim<'a, T: Perpetrator + ?Sized> {
    | ------------------------------------------
    | |
    | method `get` not found for this struct
@@ -11,7 +11,7 @@ LL |     self.getter().get();
    |                   ^^^ method cannot be called on `Victim<'_, Self>` due to unsatisfied trait bounds
    |
 note: trait bound `Self: Sized` was not satisfied
-  --> $DIR/impl-derived-implicit-sized-bound.rs:15:10
+  --> $DIR/impl-derived-implicit-sized-bound-2.rs:12:10
    |
 LL | impl<'a, T: Perpetrator /*+ ?Sized*/> VictimTrait for Victim<'a, T> {
    |          ^                            -----------     -------------
@@ -23,8 +23,8 @@ LL | impl<'a, T: ?Sized + Perpetrator /*+ ?Sized*/> VictimTrait for Victim<'a, T
    |             ++++++++
 help: consider restricting the type parameter to satisfy the trait bound
    |
-LL |   Self: Sized, Self: Sized
-   |              +++++++++++++
+LL | struct Victim<'a, T: Perpetrator + ?Sized> where Self: Sized {
+   |                                            +++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound.rs
+++ b/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound.rs
@@ -1,0 +1,36 @@
+struct Victim<'a, T: Perpetrator + ?Sized>
+where
+  Self: Sized
+{
+  value: u8,
+  perp: &'a T,
+}
+
+trait VictimTrait {
+  type Ret;
+  fn get(self) -> Self::Ret;
+}
+
+// Actual fix is here
+impl<'a, T: Perpetrator /*+ ?Sized*/> VictimTrait for Victim<'a, T> {
+  type Ret = u8;
+  fn get(self) -> Self::Ret {
+    self.value
+  }
+}
+
+trait Perpetrator {
+  fn getter<'a>(&'a self) -> Victim<'a, Self> {
+    Victim {
+      value: 0,
+      perp: self,
+    }
+  }
+
+  fn trigger(&self) {
+    self.getter().get();
+    //~^ ERROR the method `get` exists for struct `Victim<'_, Self>`, but its trait bounds were not satisfied
+  }
+}
+
+fn main() {}

--- a/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound.stderr
+++ b/src/test/ui/trait-bounds/impl-derived-implicit-sized-bound.stderr
@@ -1,0 +1,33 @@
+error[E0599]: the method `get` exists for struct `Victim<'_, Self>`, but its trait bounds were not satisfied
+  --> $DIR/impl-derived-implicit-sized-bound.rs:31:19
+   |
+LL | / struct Victim<'a, T: Perpetrator + ?Sized>
+LL | | where
+LL | |   Self: Sized
+LL | | {
+LL | |   value: u8,
+LL | |   perp: &'a T,
+LL | | }
+   | | -
+   | | |
+   | |_method `get` not found for this
+   |   doesn't satisfy `Victim<'_, Self>: VictimTrait`
+...
+LL |       self.getter().get();
+   |                     ^^^ method cannot be called on `Victim<'_, Self>` due to unsatisfied trait bounds
+   |
+note: trait bound `Self: Sized` was not satisfied
+  --> $DIR/impl-derived-implicit-sized-bound.rs:15:10
+   |
+LL | impl<'a, T: Perpetrator /*+ ?Sized*/> VictimTrait for Victim<'a, T> {
+   |          ^                            -----------     -------------
+   |          |
+   |          unsatisfied trait bound introduced here
+help: consider restricting the type parameter to satisfy the trait bound
+   |
+LL |   Self: Sized, Self: Sized
+   |              +++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/traits/issue-3973.stderr
+++ b/src/test/ui/traits/issue-3973.stderr
@@ -11,7 +11,7 @@ error[E0599]: no function or associated item named `new` found for struct `Point
   --> $DIR/issue-3973.rs:22:20
    |
 LL | struct Point {
-   |        ----- function or associated item `new` not found for this struct
+   | ------------ function or associated item `new` not found for this struct
 ...
 LL |     let p = Point::new(0.0, 0.0);
    |                    ^^^ function or associated item not found in `Point`

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `a` found for struct `S` in the current scope
   --> $DIR/item-privacy.rs:67:7
    |
 LL | struct S;
-   |        - method `a` not found for this struct
+   | -------- method `a` not found for this struct
 ...
 LL |     S.a();
    |       ^ method not found in `S`
@@ -18,7 +18,7 @@ error[E0599]: no method named `b` found for struct `S` in the current scope
   --> $DIR/item-privacy.rs:68:7
    |
 LL | struct S;
-   |        - method `b` not found for this struct
+   | -------- method `b` not found for this struct
 ...
 LL |         fn b(&self) { }
    |            - the method is available for `S` here
@@ -45,7 +45,7 @@ error[E0599]: no function or associated item named `a` found for struct `S` in t
   --> $DIR/item-privacy.rs:78:8
    |
 LL | struct S;
-   |        - function or associated item `a` not found for this struct
+   | -------- function or associated item `a` not found for this struct
 ...
 LL |     S::a(&S);
    |        ^ function or associated item not found in `S`
@@ -61,7 +61,7 @@ error[E0599]: no function or associated item named `b` found for struct `S` in t
   --> $DIR/item-privacy.rs:80:8
    |
 LL | struct S;
-   |        - function or associated item `b` not found for this struct
+   | -------- function or associated item `b` not found for this struct
 ...
 LL |     S::b(&S);
    |        ^ function or associated item not found in `S`
@@ -85,7 +85,7 @@ error[E0599]: no associated item named `A` found for struct `S` in the current s
   --> $DIR/item-privacy.rs:97:8
    |
 LL | struct S;
-   |        - associated item `A` not found for this struct
+   | -------- associated item `A` not found for this struct
 ...
 LL |     S::A;
    |        ^ associated item not found in `S`
@@ -101,7 +101,7 @@ error[E0599]: no associated item named `B` found for struct `S` in the current s
   --> $DIR/item-privacy.rs:98:8
    |
 LL | struct S;
-   |        - associated item `B` not found for this struct
+   | -------- associated item `B` not found for this struct
 ...
 LL |     S::B;
    |        ^ associated item not found in `S`

--- a/src/test/ui/traits/negative-impls/explicitly-unimplemented-error-message.stderr
+++ b/src/test/ui/traits/negative-impls/explicitly-unimplemented-error-message.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `Qux` in the current scop
   --> $DIR/explicitly-unimplemented-error-message.rs:34:9
    |
 LL | struct Qux;
-   |        --- method `clone` not found for this struct
+   | ---------- method `clone` not found for this struct
 ...
 LL |     Qux.clone();
    |         ^^^^^ method not found in `Qux`
@@ -23,7 +23,7 @@ error[E0599]: no method named `foo` found for struct `Qux` in the current scope
   --> $DIR/explicitly-unimplemented-error-message.rs:44:9
    |
 LL | struct Qux;
-   |        --- method `foo` not found for this struct
+   | ---------- method `foo` not found for this struct
 ...
 LL |     Qux.foo();
    |         ^^^ method not found in `Qux`

--- a/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its tra
    |
 LL | union U5<T> {
    | -----------
-   | |     |
-   | |     method `clone` not found for this union
+   | |
+   | method `clone` not found for this union
    | doesn't satisfy `U5<CloneNoCopy>: Clone`
 ...
 LL | struct CloneNoCopy;

--- a/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its tra
    |
 LL | union U5<T> {
    | -----------
-   | |     |
-   | |     method `clone` not found for this union
+   | |
+   | method `clone` not found for this union
    | doesn't satisfy `U5<CloneNoCopy>: Clone`
 ...
 LL | struct CloneNoCopy;


### PR DESCRIPTION
When we evaluate `ty::GenericPredicates` we introduce the implicit
`Sized` predicate of type params, but we do so with only the `Predicate`
its `Span` as context, we don't have an `Obligation` or
`ObligationCauseCode` we could influence. To try and carry this
information through, we add a new field to `ty::GenericPredicates` that
tracks both which predicates come from a type param and whether that
param has any bounds already (to use in suggestions).
    
We also suggest adding a `?Sized` bound if appropriate on E0599.

Address part of #98539.