### PR TITLE
Only obey optimize-tests flag on UI tests that are run-pass

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1365,10 +1365,13 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         }
 
         let mut flags = if is_rustdoc { Vec::new() } else { vec!["-Crpath".to_string()] };
-        if !is_rustdoc {
+        if !is_rustdoc && mode != "ui" {
             if builder.config.rust_optimize_tests {
                 flags.push("-O".to_string());
             }
+        }
+        if builder.config.rust_optimize_tests {
+            cmd.arg("--optimize-tests");
         }
         flags.push(format!("-Cdebuginfo={}", builder.config.rust_debuginfo_level_tests));
         flags.push(builder.config.cmd.rustc_args().join(" "));

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1363,16 +1363,10 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         if let Some(ref npm) = builder.config.npm {
             cmd.arg("--npm").arg(npm);
         }
-
-        let mut flags = if is_rustdoc { Vec::new() } else { vec!["-Crpath".to_string()] };
-        if !is_rustdoc && mode != "ui" {
-            if builder.config.rust_optimize_tests {
-                flags.push("-O".to_string());
-            }
-        }
         if builder.config.rust_optimize_tests {
             cmd.arg("--optimize-tests");
         }
+        let mut flags = if is_rustdoc { Vec::new() } else { vec!["-Crpath".to_string()] };
         flags.push(format!("-Cdebuginfo={}", builder.config.rust_debuginfo_level_tests));
         flags.push(builder.config.cmd.rustc_args().join(" "));
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -269,9 +269,8 @@ pub struct Config {
     /// Flags to pass to the compiler when building for the target
     pub target_rustcflags: Option<String>,
 
-    /// Whether tests should be optimized.
-    /// Currently only provides a default for UI-tests that are run-pass.
-    /// Other tests are controlled by rustcflags or the testfiles themselves.
+    /// Whether tests should be optimized by default. Individual test-suites and test files may
+    /// override this setting.
     pub optimize_tests: bool,
 
     /// What panic strategy the target is built with.  Unwind supports Abort, but

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -269,6 +269,11 @@ pub struct Config {
     /// Flags to pass to the compiler when building for the target
     pub target_rustcflags: Option<String>,
 
+    /// Whether tests should be optimized.
+    /// Currently only provides a default for UI-tests that are run-pass.
+    /// Other tests are controlled by rustcflags or the testfiles themselves.
+    pub optimize_tests: bool,
+
     /// What panic strategy the target is built with.  Unwind supports Abort, but
     /// not vice versa.
     pub target_panic: PanicStrategy,

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -244,6 +244,7 @@ impl TestProps {
 
         // copy over select properties to the aux build:
         props.incremental_dir = self.incremental_dir.clone();
+        props.ignore_pass = true;
         props.load_from(testfile, cfg, config);
 
         props

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -102,6 +102,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         )
         .optmulti("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
         .optmulti("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS")
+        .optflag("", "optimize-tests", "build UI tests with optimization enabled")
         .optopt("", "target-panic", "what panic strategy the target supports", "unwind | abort")
         .optflag("", "verbose", "run tests verbosely, showing all output")
         .optflag(
@@ -253,6 +254,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         runtool: matches.opt_str("runtool"),
         host_rustcflags: Some(matches.opt_strs("host-rustcflags").join(" ")),
         target_rustcflags: Some(matches.opt_strs("target-rustcflags").join(" ")),
+        optimize_tests: matches.opt_present("optimize-tests"),
         target_panic: match matches.opt_str("target-panic").as_deref() {
             Some("unwind") | None => PanicStrategy::Unwind,
             Some("abort") => PanicStrategy::Abort,

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -102,7 +102,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         )
         .optmulti("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
         .optmulti("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS")
-        .optflag("", "optimize-tests", "build UI tests with optimization enabled")
+        .optflag("", "optimize-tests", "run tests with optimizations enabled")
         .optopt("", "target-panic", "what panic strategy the target supports", "unwind | abort")
         .optflag("", "verbose", "run tests verbosely, showing all output")
         .optflag(

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1875,6 +1875,18 @@ impl<'test> TestCx<'test> {
                 rustc.arg("-Zdeduplicate-diagnostics=no");
             }
             Ui => {
+                // If optimize-tests is true we still only want to optimize tests that actually get
+                // executed and that don't specify their own optimization levels
+                if self.config.optimize_tests
+                    && self.props.pass_mode(&self.config) == Some(PassMode::Run)
+                    && !self
+                        .props
+                        .compile_flags
+                        .iter()
+                        .any(|arg| arg == "-O" || arg.contains("opt-level"))
+                {
+                    rustc.arg("-O");
+                }
                 if !self.props.compile_flags.iter().any(|s| s.starts_with("--error-format")) {
                     rustc.args(&["--error-format", "json"]);
                     rustc.args(&["--json", "future-incompat"]);


### PR DESCRIPTION
stage1 UI tests walltime on my machine:

```
optimize-tests = false, master
25.98s

optimize-tests = true, master
34.69s

optimize-tests = true, patched
28.79s
```

Effects:

- faster UI tests
- llvm asserts get exercised less on build-pass tests
- the difference between opt and nopt builds shrinks a bit
- aux libs don't get optimized since they don't have a pass mode and almost never have explicit compile flags