### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,16 @@
+---
+name: Documentation problem
+about: Create a report for a documentation problem.
+labels: A-docs
+---
+<!--
+Thank you for finding a documentation problem! 📚
+
+Documentation problems might be grammatical issues, typos, or unclear wording, please provide details regarding the documentation including where it is present.
+
+-->
+
+### Location
+
+### Summary
+

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -78,6 +78,8 @@ Compatibility Notes
 - [rustdoc: doctests are now run on unexported `macro_rules!` macros, matching other private items][96630]
 - [rustdoc: Remove .woff font files][96279]
 - [Enforce Copy bounds for repeat elements while considering lifetimes][95819]
+- [Windows: Fix potentinal unsoundness by aborting if `File` reads or writes cannot
+  complete synchronously][95469].
 
 Internal Changes
 ----------------
@@ -99,6 +101,7 @@ and related tools.
 [95372]: https://github.com/rust-lang/rust/pull/95372/
 [95380]: https://github.com/rust-lang/rust/pull/95380/
 [95431]: https://github.com/rust-lang/rust/pull/95431/
+[95469]: https://github.com/rust-lang/rust/pull/95469/
 [95705]: https://github.com/rust-lang/rust/pull/95705/
 [95801]: https://github.com/rust-lang/rust/pull/95801/
 [95819]: https://github.com/rust-lang/rust/pull/95819/

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2031,6 +2031,8 @@ impl Step for RustDev {
         let mut tarball = Tarball::new(builder, "rust-dev", &target.triple);
         tarball.set_overlay(OverlayKind::LLVM);
 
+        builder.ensure(crate::native::Llvm { target });
+
         let src_bindir = builder.llvm_out(target).join("bin");
         // If updating this list, you likely want to change
         // src/bootstrap/download-ci-llvm-stamp as well, otherwise local users

--- a/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-1.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-1.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+#![feature(adt_const_params, generic_const_exprs)]
+//~^ WARN the feature `adt_const_params` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+//~^^ WARN the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+pub struct Changes<const CHANGES: &'static [&'static str]>
+where
+    [(); CHANGES.len()]:,
+{
+    changes: [usize; CHANGES.len()],
+}
+
+impl<const CHANGES: &'static [&'static str]> Changes<CHANGES>
+where
+    [(); CHANGES.len()]:,
+{
+    pub const fn new() -> Self {
+        Self {
+            changes: [0; CHANGES.len()],
+        }
+    }
+}
+
+pub fn main() {}

--- a/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-1.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-1.stderr
@@ -1,0 +1,19 @@
+warning: the feature `adt_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-97047-ice-1.rs:3:12
+   |
+LL | #![feature(adt_const_params, generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-97047-ice-1.rs:3:30
+   |
+LL | #![feature(adt_const_params, generic_const_exprs)]
+   |                              ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-2.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-2.rs
@@ -1,0 +1,23 @@
+// check-pass
+
+#![feature(adt_const_params, generic_const_exprs)]
+//~^ WARN the feature `adt_const_params` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+//~^^ WARN the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+pub struct Changes<const CHANGES: &'static [&'static str]>
+where
+    [(); CHANGES.len()]:,
+{
+    changes: [usize; CHANGES.len()],
+}
+
+impl<const CHANGES: &'static [&'static str]> Changes<CHANGES>
+where
+    [(); CHANGES.len()]:,
+{
+    pub fn combine(&mut self, other: &Self) {
+        for _change in &self.changes {}
+    }
+}
+
+pub fn main() {}

--- a/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-2.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-97047-ice-2.stderr
@@ -1,0 +1,19 @@
+warning: the feature `adt_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-97047-ice-2.rs:3:12
+   |
+LL | #![feature(adt_const_params, generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-97047-ice-2.rs:3:30
+   |
+LL | #![feature(adt_const_params, generic_const_exprs)]
+   |                              ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/consts/issue-50439.rs
+++ b/src/test/ui/consts/issue-50439.rs
@@ -1,0 +1,29 @@
+#![feature(specialization)]
+#![allow(incomplete_features)]
+
+pub trait ReflectDrop {
+    const REFLECT_DROP: bool = false;
+}
+
+impl<T> ReflectDrop for T where T: Clone {}
+
+pub trait PinDropInternal {
+    fn is_valid()
+    where
+        Self: ReflectDrop;
+}
+
+struct Bears<T>(T);
+
+default impl<T> ReflectDrop for Bears<T> {}
+
+impl<T: Sized> PinDropInternal for Bears<T> {
+    fn is_valid()
+    where
+        Self: ReflectDrop,
+    {
+        let _ = [(); 0 - !!(<Bears<T> as ReflectDrop>::REFLECT_DROP) as usize]; //~ ERROR constant expression depends on a generic parameter
+    }
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-50439.stderr
+++ b/src/test/ui/consts/issue-50439.stderr
@@ -1,0 +1,10 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-50439.rs:25:22
+   |
+LL |         let _ = [(); 0 - !!(<Bears<T> as ReflectDrop>::REFLECT_DROP) as usize];
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #98701 (Add regression test for #50439)
 - #98715 (add ice test for #97047)
 - #98753 (Fix `x dist rust-dev` on a fresh checkout)
 - #98805 (Add #95469 to the release notes)
 - #98812 (feat: Add a documentation problem issue template)
 - #98819 (update Miri)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98701,98715,98753,98805,98812,98819)
<!-- homu-ignore:end -->