### PR TITLE
Make Vecs swap don't use stack

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -898,6 +898,8 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
         {
             attempt_swap_as_chunks!(usize);
             attempt_swap_as_chunks!(u8);
+            // Should not happen because anything must be splittable by u8.
+            unreachable!();
         }
     }
 

--- a/src/test/codegen/swap-small-types.rs
+++ b/src/test/codegen/swap-small-types.rs
@@ -12,9 +12,25 @@ type RGB48 = [u16; 3];
 #[no_mangle]
 pub fn swap_rgb48(x: &mut RGB48, y: &mut RGB48) {
     // FIXME MIR inlining messes up LLVM optimizations.
-// WOULD-CHECK-NOT: alloca
-// WOULD-CHECK: load i48
-// WOULD-CHECK: store i48
+    // WOULD-CHECK-NOT: alloca
+    // WOULD-CHECK: load i48
+    // WOULD-CHECK: store i48
+    swap(x, y)
+}
+
+// CHECK-LABEL: @swap_vecs
+#[no_mangle]
+pub fn swap_vecs(x: &mut Vec<u32>, y: &mut Vec<u32>) {
+    // CHECK-NOT: alloca
+    // CHECK: ret void
+    swap(x, y)
+}
+
+// CHECK-LABEL: @swap_slices
+#[no_mangle]
+pub fn swap_slices<'a>(x: &mut &'a [u32], y: &mut &'a [u32]) {
+    // CHECK-NOT: alloca
+    // CHECK: ret void
     swap(x, y)
 }
 
@@ -25,9 +41,9 @@ type RGB24 = [u8; 3];
 // CHECK-LABEL: @swap_rgb24_slices
 #[no_mangle]
 pub fn swap_rgb24_slices(x: &mut [RGB24], y: &mut [RGB24]) {
-// CHECK-NOT: alloca
-// CHECK: load <{{[0-9]+}} x i8>
-// CHECK: store <{{[0-9]+}} x i8>
+    // CHECK-NOT: alloca
+    // CHECK: load <{{[0-9]+}} x i8>
+    // CHECK: store <{{[0-9]+}} x i8>
     if x.len() == y.len() {
         x.swap_with_slice(y);
     }
@@ -39,9 +55,9 @@ type RGBA32 = [u8; 4];
 // CHECK-LABEL: @swap_rgba32_slices
 #[no_mangle]
 pub fn swap_rgba32_slices(x: &mut [RGBA32], y: &mut [RGBA32]) {
-// CHECK-NOT: alloca
-// CHECK: load <{{[0-9]+}} x i32>
-// CHECK: store <{{[0-9]+}} x i32>
+    // CHECK-NOT: alloca
+    // CHECK: load <{{[0-9]+}} x i32>
+    // CHECK: store <{{[0-9]+}} x i32>
     if x.len() == y.len() {
         x.swap_with_slice(y);
     }
@@ -54,9 +70,9 @@ const _: () = assert!(!std::mem::size_of::<String>().is_power_of_two());
 // CHECK-LABEL: @swap_string_slices
 #[no_mangle]
 pub fn swap_string_slices(x: &mut [String], y: &mut [String]) {
-// CHECK-NOT: alloca
-// CHECK: load <{{[0-9]+}} x i64>
-// CHECK: store <{{[0-9]+}} x i64>
+    // CHECK-NOT: alloca
+    // CHECK: load <{{[0-9]+}} x i64>
+    // CHECK: store <{{[0-9]+}} x i64>
     if x.len() == y.len() {
         x.swap_with_slice(y);
     }


### PR DESCRIPTION
Solved by doing swaps by usizes instead of temporaries of swapped type.
Also should affect `String`s too.

Tested using codegen test.

Example of changes below.

Code:
```rust
pub fn swap_2_vecs(a: &mut Vec<u32>, b: &mut Vec<u32>){
    std::mem::swap(a, b)
}
```

Asm before change:
```asm
_ZN11swap_2_vecs11swap_2_vecs17h9eab7dfc40f308e2E:
.seh_proc _ZN11swap_2_vecs11swap_2_vecs17h9eab7dfc40f308e2E
    subq    $24, %rsp      ; Reserve memory on stack
    .seh_stackalloc 24
    .seh_endprologue
    movq    16(%rcx), %rax
    vmovups (%rcx), %xmm0
    vmovups (%rdx), %xmm2
    movq    %rax, 16(%rsp) ; Copy memory to stack
    movq    16(%rdx), %rax
    vmovaps %xmm0, (%rsp)  ; Copy memory to stack again
    vmovups %xmm2, (%rcx)
    vmovaps (%rsp), %xmm1  ; Copy memory from stack to register
    movq    %rax, 16(%rcx)
    movq    16(%rsp), %rax ; Copy memory from stack to register
    vmovups %xmm1, (%rdx)
    movq    %rax, 16(%rdx)
    addq    $24, %rsp
    retq
    .seh_endproc
```

Asm after change:
```asm
_ZN11swap_2_vecs11swap_2_vecs17h9eab7dfc40f308e2E:
    movq    (%rcx), %r8
    movq    (%rdx), %rax
    movq    %rax, (%rcx)
    movq    %r8, (%rdx)
    movq    8(%rcx), %r8
    movq    8(%rdx), %rax
    movq    %rax, 8(%rcx)
    movq    %r8, 8(%rdx)
    movq    16(%rcx), %r8
    movq    16(%rdx), %rax
    movq    %rax, 16(%rcx)
    movq    %r8, 16(%rdx)
    retq
```

Probably worth running perf on this.
r? @scottmcm