### PR TITLE
Implement float literals in valtree

### DIFF
--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -1104,6 +1104,16 @@ pub(crate) fn parse_float_into_scalar(
     float_ty: ty::FloatTy,
     neg: bool,
 ) -> Option<Scalar> {
+    parse_float_into(num, float_ty, neg, |f| Scalar::from_f32(f), |f| Scalar::from_f64(f))
+}
+
+pub(crate) fn parse_float_into<T>(
+    num: Symbol,
+    float_ty: ty::FloatTy,
+    neg: bool,
+    on_f32: impl FnOnce(Single) -> T,
+    on_f64: impl FnOnce(Double) -> T,
+) -> Option<T> {
     let num = num.as_str();
     match float_ty {
         ty::FloatTy::F32 => {
@@ -1127,7 +1137,7 @@ pub(crate) fn parse_float_into_scalar(
                 f = -f;
             }
 
-            Some(Scalar::from_f32(f))
+            Some(on_f32(f))
         }
         ty::FloatTy::F64 => {
             let Ok(rust_f) = num.parse::<f64>() else { return None };
@@ -1150,7 +1160,7 @@ pub(crate) fn parse_float_into_scalar(
                 f = -f;
             }
 
-            Some(Scalar::from_f64(f))
+            Some(on_f64(f))
         }
     }
 }

--- a/src/test/ui/const-generics/issues/issue-98813.rs
+++ b/src/test/ui/const-generics/issues/issue-98813.rs
@@ -1,0 +1,13 @@
+// build-pass
+
+#![allow(incomplete_features)]
+#![feature(adt_const_params)]
+
+const F: f64 = 12.5;
+
+pub fn func<const F: f64>() {}
+
+fn main() {
+    let _ = func::<14.0>();
+    let _ = func::<F>();
+}


### PR DESCRIPTION
Fixes #98813
cc: @rust-lang/wg-const-eval