### PR TITLE
Inline `has_type_flags`

### DIFF
--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -120,6 +120,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
         self.has_vars_bound_at_or_above(ty::INNERMOST)
     }
 
+    #[inline]
     #[instrument(level = "trace")]
     fn has_type_flags(&self, flags: TypeFlags) -> bool {
         self.visit_with(&mut HasTypeFlagsVisitor { flags }).break_value() == Some(FoundFlags)


### PR DESCRIPTION
This function was called a lot of times in a local profile. It's probably already optimized with PGO, but let's check anyway.

r? @ghost