### PR TITLE
interpret: track place alignment together with the type, not the value

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -182,7 +182,8 @@ pub struct OpTy<'tcx, Tag: Provenance = AllocId> {
     /// So we represent this here with a separate field that "overwrites" `layout.align`.
     /// This means `layout.align` should never be used for an `OpTy`!
     /// `None` means "alignment does not matter since this is a by-value operand"
-    /// (`Operand::Immediate`).
+    /// (`Operand::Immediate`); this field is only relevant for `Operand::Indirect`.
+    /// Also CTFE ignores alignment anyway, so this is for Miri only.
     pub align: Option<Align>,
 }
 


### PR DESCRIPTION
This matches how I handle alignment in [MiniRust](https://github.com/RalfJung/minirust). I think it makes conceptually a lot more sense.
Fixes https://github.com/rust-lang/rust/issues/63085

r? @oli-obk 