### PR TITLE
fix interpreter validity check on Box

### DIFF
--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -21,6 +21,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(trusted_step)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
+#![feature(is_some_with)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/98554: avoid walking over parts of the value twice.

And then move all that logic into the general visitor so not each visitor implementation has to deal with it...