### PR TITLE
Format `src/test/ui-fulldeps`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -14,6 +14,9 @@ ignore = [
     # tests for now are not formatted, as they are sometimes pretty-printing constrained
     # (and generally rustfmt can move around comments in UI-testing incompatible ways)
     "src/test",
+    # format ui-fulldeps as they aren't so susceptible to pretty-printing and
+    # UI-testing comments are used sparingly (and then mostly only error annotations).
+    "!src/test/ui-fulldeps",
 
     # do not format submodules
     "library/backtrace",

--- a/src/test/ui-fulldeps/auxiliary/issue-13560-3.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-13560-3.rs
@@ -2,5 +2,8 @@
 
 #![crate_type = "rlib"]
 
-#[macro_use] #[no_link] extern crate issue_13560_1 as t1;
-#[macro_use] extern crate issue_13560_2 as t2;
+#[macro_use]
+#[no_link]
+extern crate issue_13560_1 as t1;
+#[macro_use]
+extern crate issue_13560_2 as t2;

--- a/src/test/ui-fulldeps/auxiliary/issue-16822.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-16822.rs
@@ -1,12 +1,12 @@
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
 use std::cell::RefCell;
 
-pub struct Window<Data>{
-    pub data: RefCell<Data>
+pub struct Window<Data> {
+    pub data: RefCell<Data>,
 }
 
-impl<Data:  Update> Window<Data> {
+impl<Data: Update> Window<Data> {
     pub fn update(&self, e: i32) {
         match e {
             1 => self.data.borrow_mut().update(),

--- a/src/test/ui-fulldeps/auxiliary/issue-18502.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-18502.rs
@@ -1,4 +1,4 @@
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
 struct Foo;
 // This is the ICE trigger
@@ -12,7 +12,7 @@ impl Show for Foo {
     fn fmt(&self) {}
 }
 
-fn bar<T>(f: extern "Rust" fn(&T), t: &T) { }
+fn bar<T>(f: fn(&T), t: &T) {}
 
 // ICE requirement: this has to be marked as inline
 #[inline]

--- a/src/test/ui-fulldeps/auxiliary/issue-24106.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-24106.rs
@@ -1,6 +1,9 @@
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
-enum E { E0 = 0, E1 = 1 }
+enum E {
+    E0 = 0,
+    E1 = 1,
+}
 const E0_U8: u8 = E::E0 as u8;
 const E1_U8: u8 = E::E1 as u8;
 

--- a/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
@@ -11,9 +11,9 @@ extern crate rustc_lint;
 #[macro_use]
 extern crate rustc_session;
 
+use rustc_ast as ast;
 use rustc_driver::plugin::Registry;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
-use rustc_ast as ast;
 declare_lint!(TEST_LINT, Warn, "Warn about items named 'lintme'");
 
 declare_lint_pass!(Pass => [TEST_LINT]);

--- a/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
@@ -9,9 +9,9 @@ extern crate rustc_lint;
 #[macro_use]
 extern crate rustc_session;
 
+use rustc_ast as ast;
 use rustc_driver::plugin::Registry;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintId, LintPass};
-use rustc_ast as ast;
 declare_tool_lint!(pub clippy::TEST_LINT, Warn, "Warn about stuff");
 declare_tool_lint!(
     /// Some docs

--- a/src/test/ui-fulldeps/auxiliary/lto-syntax-extension-plugin.rs
+++ b/src/test/ui-fulldeps/auxiliary/lto-syntax-extension-plugin.rs
@@ -2,8 +2,8 @@
 
 #![feature(rustc_private)]
 
-extern crate rustc_middle;
 extern crate rustc_driver;
+extern crate rustc_middle;
 
 use rustc_driver::plugin::Registry;
 

--- a/src/test/ui-fulldeps/auxiliary/multiple-plugins-1.rs
+++ b/src/test/ui-fulldeps/auxiliary/multiple-plugins-1.rs
@@ -1,8 +1,8 @@
 #![crate_type = "dylib"]
 #![feature(rustc_private)]
 
-extern crate rustc_middle;
 extern crate rustc_driver;
+extern crate rustc_middle;
 
 use rustc_driver::plugin::Registry;
 

--- a/src/test/ui-fulldeps/auxiliary/multiple-plugins-2.rs
+++ b/src/test/ui-fulldeps/auxiliary/multiple-plugins-2.rs
@@ -1,8 +1,8 @@
 #![crate_type = "dylib"]
 #![feature(rustc_private)]
 
-extern crate rustc_middle;
 extern crate rustc_driver;
+extern crate rustc_middle;
 
 use rustc_driver::plugin::Registry;
 

--- a/src/test/ui-fulldeps/auxiliary/outlive-expansion-phase.rs
+++ b/src/test/ui-fulldeps/auxiliary/outlive-expansion-phase.rs
@@ -2,15 +2,15 @@
 
 #![feature(rustc_private)]
 
-extern crate rustc_middle;
 extern crate rustc_driver;
+extern crate rustc_middle;
 
+use rustc_driver::plugin::Registry;
 use std::any::Any;
 use std::cell::RefCell;
-use rustc_driver::plugin::Registry;
 
 struct Foo {
-    foo: isize
+    foo: isize,
 }
 
 impl Drop for Foo {
@@ -20,5 +20,5 @@ impl Drop for Foo {
 #[no_mangle]
 fn __rustc_plugin_registrar(_: &mut Registry) {
     thread_local!(static FOO: RefCell<Option<Box<Any+Send>>> = RefCell::new(None));
-    FOO.with(|s| *s.borrow_mut() = Some(Box::new(Foo { foo: 10 }) as Box<Any+Send>));
+    FOO.with(|s| *s.borrow_mut() = Some(Box::new(Foo { foo: 10 }) as Box<Any + Send>));
 }

--- a/src/test/ui-fulldeps/auxiliary/proc-macro-panic.rs
+++ b/src/test/ui-fulldeps/auxiliary/proc-macro-panic.rs
@@ -4,7 +4,7 @@
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;
-use proc_macro::{TokenStream, Ident, Span};
+use proc_macro::{Ident, Span, TokenStream};
 
 #[proc_macro]
 pub fn panic_in_libproc_macro(_: TokenStream) -> TokenStream {

--- a/src/test/ui-fulldeps/auxiliary/rlib-crate-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/rlib-crate-test.rs
@@ -3,8 +3,8 @@
 #![crate_type = "rlib"]
 #![feature(rustc_private)]
 
-extern crate rustc_middle;
 extern crate rustc_driver;
+extern crate rustc_middle;
 
 use rustc_driver::plugin::Registry;
 

--- a/src/test/ui-fulldeps/compiler-calls.rs
+++ b/src/test/ui-fulldeps/compiler-calls.rs
@@ -13,7 +13,7 @@ extern crate rustc_interface;
 use rustc_interface::interface;
 
 struct TestCalls<'a> {
-    count: &'a mut u32
+    count: &'a mut u32,
 }
 
 impl rustc_driver::Callbacks for TestCalls<'_> {

--- a/src/test/ui-fulldeps/dropck-tarena-cycle-checked.rs
+++ b/src/test/ui-fulldeps/dropck-tarena-cycle-checked.rs
@@ -10,9 +10,9 @@
 
 extern crate rustc_arena;
 
+use id::Id;
 use rustc_arena::TypedArena;
 use std::cell::Cell;
-use id::Id;
 
 mod s {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -57,14 +57,16 @@ trait HasId {
 }
 
 #[derive(Debug)]
-struct CheckId<T:HasId> {
-    v: T
+struct CheckId<T: HasId> {
+    v: T,
 }
 
 #[allow(non_snake_case)]
-fn CheckId<T:HasId>(t: T) -> CheckId<T> { CheckId{ v: t } }
+fn CheckId<T: HasId>(t: T) -> CheckId<T> {
+    CheckId { v: t }
+}
 
-impl<T:HasId> Drop for CheckId<T> {
+impl<T: HasId> Drop for CheckId<T> {
     fn drop(&mut self) {
         assert!(self.v.count() > 0);
     }

--- a/src/test/ui-fulldeps/dropck-tarena-cycle-checked.stderr
+++ b/src/test/ui-fulldeps/dropck-tarena-cycle-checked.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `arena` does not live long enough
-  --> $DIR/dropck-tarena-cycle-checked.rs:116:7
+  --> $DIR/dropck-tarena-cycle-checked.rs:118:7
    |
 LL |     f(&arena);
    |       ^^^^^^ borrowed value does not live long enough

--- a/src/test/ui-fulldeps/dropck-tarena-unsound-drop.rs
+++ b/src/test/ui-fulldeps/dropck-tarena-unsound-drop.rs
@@ -15,24 +15,34 @@ extern crate rustc_arena;
 
 use rustc_arena::TypedArena;
 
-trait HasId { fn count(&self) -> usize; }
+trait HasId {
+    fn count(&self) -> usize;
+}
 
-struct CheckId<T:HasId> { v: T }
+struct CheckId<T: HasId> {
+    v: T,
+}
 
 // In the code below, the impl of HasId for `&'a usize` does not
 // actually access the borrowed data, but the point is that the
 // interface to CheckId does not (and cannot) know that, and therefore
 // when encountering a value V of type CheckId<S>, we must
 // conservatively force the type S to strictly outlive V.
-impl<T:HasId> Drop for CheckId<T> {
+impl<T: HasId> Drop for CheckId<T> {
     fn drop(&mut self) {
         assert!(self.v.count() > 0);
     }
 }
 
-struct C<'a> { v: CheckId<&'a usize>, }
+struct C<'a> {
+    v: CheckId<&'a usize>,
+}
 
-impl<'a> HasId for &'a usize { fn count(&self) -> usize { 1 } }
+impl<'a> HasId for &'a usize {
+    fn count(&self) -> usize {
+        1
+    }
+}
 
 fn f<'a>(_arena: &'a TypedArena<C<'a>>) {}
 

--- a/src/test/ui-fulldeps/dropck-tarena-unsound-drop.stderr
+++ b/src/test/ui-fulldeps/dropck-tarena-unsound-drop.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `arena` does not live long enough
-  --> $DIR/dropck-tarena-unsound-drop.rs:41:7
+  --> $DIR/dropck-tarena-unsound-drop.rs:51:7
    |
 LL |     f(&arena);
    |       ^^^^^^ borrowed value does not live long enough

--- a/src/test/ui-fulldeps/dropck_tarena_sound_drop.rs
+++ b/src/test/ui-fulldeps/dropck_tarena_sound_drop.rs
@@ -8,7 +8,6 @@
 // Compare against ui-fulldeps/dropck-tarena-unsound-drop.rs, which
 // shows a similar setup, but restricts `f` so that the struct `C<'a>`
 // is force-fed a lifetime equal to that of the borrowed arena.
-
 #![allow(unstable)]
 #![feature(rustc_private)]
 
@@ -16,24 +15,34 @@ extern crate rustc_arena;
 
 use rustc_arena::TypedArena;
 
-trait HasId { fn count(&self) -> usize; }
+trait HasId {
+    fn count(&self) -> usize;
+}
 
-struct CheckId<T:HasId> { v: T }
+struct CheckId<T: HasId> {
+    v: T,
+}
 
 // In the code below, the impl of HasId for `&'a usize` does not
 // actually access the borrowed data, but the point is that the
 // interface to CheckId does not (and cannot) know that, and therefore
 // when encountering a value V of type CheckId<S>, we must
 // conservatively force the type S to strictly outlive V.
-impl<T:HasId> Drop for CheckId<T> {
+impl<T: HasId> Drop for CheckId<T> {
     fn drop(&mut self) {
         assert!(self.v.count() > 0);
     }
 }
 
-struct C<'a> { _v: CheckId<&'a usize>, }
+struct C<'a> {
+    _v: CheckId<&'a usize>,
+}
 
-impl<'a> HasId for &'a usize { fn count(&self) -> usize { 1 } }
+impl<'a> HasId for &'a usize {
+    fn count(&self) -> usize {
+        1
+    }
+}
 
 fn f<'a, 'b>(_arena: &'a TypedArena<C<'b>>) {}
 

--- a/src/test/ui-fulldeps/fluent-messages/test.rs
+++ b/src/test/ui-fulldeps/fluent-messages/test.rs
@@ -22,37 +22,37 @@ mod missing_absolute {
     use super::fluent_messages;
 
     fluent_messages! {
-        missing_absolute => "/definitely_does_not_exist.ftl",
-//~^ ERROR could not open Fluent resource
-    }
+            missing_absolute => "/definitely_does_not_exist.ftl",
+    //~^ ERROR could not open Fluent resource
+        }
 }
 
 mod missing_relative {
     use super::fluent_messages;
 
     fluent_messages! {
-        missing_relative => "../definitely_does_not_exist.ftl",
-//~^ ERROR could not open Fluent resource
-    }
+            missing_relative => "../definitely_does_not_exist.ftl",
+    //~^ ERROR could not open Fluent resource
+        }
 }
 
 mod missing_message {
     use super::fluent_messages;
 
     fluent_messages! {
-        missing_message => "./missing-message.ftl",
-//~^ ERROR could not parse Fluent resource
-    }
+            missing_message => "./missing-message.ftl",
+    //~^ ERROR could not parse Fluent resource
+        }
 }
 
 mod duplicate {
     use super::fluent_messages;
 
     fluent_messages! {
-        a => "./duplicate-a.ftl",
-        b => "./duplicate-b.ftl",
-//~^ ERROR overrides existing message: `key`
-    }
+            a => "./duplicate-a.ftl",
+            b => "./duplicate-b.ftl",
+    //~^ ERROR overrides existing message: `key`
+        }
 }
 
 mod valid {
@@ -62,5 +62,5 @@ mod valid {
         valid => "./valid.ftl",
     }
 
-    use self::fluent_generated::{DEFAULT_LOCALE_RESOURCES, valid::valid};
+    use self::fluent_generated::{valid::valid, DEFAULT_LOCALE_RESOURCES};
 }

--- a/src/test/ui-fulldeps/fluent-messages/test.stderr
+++ b/src/test/ui-fulldeps/fluent-messages/test.stderr
@@ -1,24 +1,24 @@
 error: could not open Fluent resource
-  --> $DIR/test.rs:25:29
+  --> $DIR/test.rs:25:33
    |
-LL |         missing_absolute => "/definitely_does_not_exist.ftl",
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             missing_absolute => "/definitely_does_not_exist.ftl",
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: os-specific message
 
 error: could not open Fluent resource
-  --> $DIR/test.rs:34:29
+  --> $DIR/test.rs:34:33
    |
-LL |         missing_relative => "../definitely_does_not_exist.ftl",
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             missing_relative => "../definitely_does_not_exist.ftl",
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: os-specific message
 
 error: could not parse Fluent resource
-  --> $DIR/test.rs:43:28
+  --> $DIR/test.rs:43:32
    |
-LL |         missing_message => "./missing-message.ftl",
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^
+LL |             missing_message => "./missing-message.ftl",
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: see additional errors emitted
 
@@ -30,16 +30,16 @@ error: expected a message field for "missing-message"
   |
 
 error: overrides existing message: `key`
-  --> $DIR/test.rs:53:9
+  --> $DIR/test.rs:53:13
    |
-LL |         b => "./duplicate-b.ftl",
-   |         ^
+LL |             b => "./duplicate-b.ftl",
+   |             ^
    |
 help: previously defined in this resource
-  --> $DIR/test.rs:52:9
+  --> $DIR/test.rs:52:13
    |
-LL |         a => "./duplicate-a.ftl",
-   |         ^
+LL |             a => "./duplicate-a.ftl",
+   |             ^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.rs
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.rs
@@ -10,7 +10,7 @@ extern crate rustc_macros;
 extern crate rustc_session;
 extern crate rustc_span;
 
-use rustc_errors::{AddSubdiagnostic, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, fluent};
+use rustc_errors::{fluent, AddSubdiagnostic, Diagnostic, DiagnosticBuilder, ErrorGuaranteed};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_session::{parse::ParseSess, SessionDiagnostic};
 use rustc_span::Span;

--- a/src/test/ui-fulldeps/internal-lints/existing_doc_keyword.rs
+++ b/src/test/ui-fulldeps/internal-lints/existing_doc_keyword.rs
@@ -2,9 +2,7 @@
 
 #![feature(rustc_private)]
 #![feature(rustdoc_internals)]
-
 #![crate_type = "lib"]
-
 #![deny(rustc::existing_doc_keyword)]
 
 #[doc(keyword = "tadam")] //~ ERROR

--- a/src/test/ui-fulldeps/internal-lints/existing_doc_keyword.stderr
+++ b/src/test/ui-fulldeps/internal-lints/existing_doc_keyword.stderr
@@ -1,11 +1,11 @@
 error: Found non-existing keyword `tadam` used in `#[doc(keyword = "...")]`
-  --> $DIR/existing_doc_keyword.rs:10:1
+  --> $DIR/existing_doc_keyword.rs:8:1
    |
 LL | #[doc(keyword = "tadam")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/existing_doc_keyword.rs:8:9
+  --> $DIR/existing_doc_keyword.rs:6:9
    |
 LL | #![deny(rustc::existing_doc_keyword)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.rs
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.rs
@@ -17,7 +17,8 @@ declare_lint! {
 
 struct Foo;
 
-impl LintPass for Foo { //~ERROR implementing `LintPass` by hand
+impl LintPass for Foo {
+    //~^ERROR implementing `LintPass` by hand
     fn name(&self) -> &'static str {
         "Foo"
     }
@@ -27,7 +28,8 @@ macro_rules! custom_lint_pass_macro {
     () => {
         struct Custom;
 
-        impl LintPass for Custom { //~ERROR implementing `LintPass` by hand
+        impl LintPass for Custom {
+            //~^ERROR implementing `LintPass` by hand
             fn name(&self) -> &'static str {
                 "Custom"
             }

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
@@ -12,7 +12,7 @@ LL | #![deny(rustc::lint_pass_impl_without_macro)]
    = help: try using `declare_lint_pass!` or `impl_lint_pass!` instead
 
 error: implementing `LintPass` by hand
-  --> $DIR/lint_pass_impl_without_macro.rs:30:14
+  --> $DIR/lint_pass_impl_without_macro.rs:31:14
    |
 LL |         impl LintPass for Custom {
    |              ^^^^^^^^

--- a/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.rs
+++ b/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.rs
@@ -29,7 +29,6 @@ fn ty_qualified(
 ) {
 }
 
-
 fn main() {
     qualified_macro!(a);
 }

--- a/src/test/ui-fulldeps/issue-11881.rs
+++ b/src/test/ui-fulldeps/issue-11881.rs
@@ -7,8 +7,8 @@
 use std::fmt;
 use std::io::prelude::*;
 use std::io::Cursor;
-use std::slice;
 use std::marker::PhantomData;
+use std::slice;
 
 trait Encoder {
     type Error;
@@ -44,7 +44,6 @@ struct OpaqueEncoder(Vec<u8>);
 impl Encoder for OpaqueEncoder {
     type Error = ();
 }
-
 
 struct Foo {
     baz: bool,

--- a/src/test/ui-fulldeps/issue-15778-fail.rs
+++ b/src/test/ui-fulldeps/issue-15778-fail.rs
@@ -6,4 +6,4 @@
 #![plugin(lint_for_crate)]
 //~^ WARN use of deprecated attribute `plugin`
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/ui-fulldeps/issue-15778-fail.stderr
+++ b/src/test/ui-fulldeps/issue-15778-fail.stderr
@@ -13,8 +13,8 @@ LL | / #![feature(plugin)]
 LL | | #![plugin(lint_for_crate)]
 LL | |
 LL | |
-LL | | pub fn main() { }
-   | |_________________^
+LL | | pub fn main() {}
+   | |________________^
    |
    = note: requested on the command line with `-D crate-not-okay`
 

--- a/src/test/ui-fulldeps/issue-15778-pass.rs
+++ b/src/test/ui-fulldeps/issue-15778-pass.rs
@@ -4,15 +4,7 @@
 // compile-flags: -D crate-not-okay
 
 #![feature(plugin, register_attr, custom_inner_attributes)]
-
-#![register_attr(
-    crate_okay,
-    crate_blue,
-    crate_red,
-    crate_grey,
-    crate_green,
-)]
-
+#![register_attr(crate_okay, crate_blue, crate_red, crate_grey, crate_green)]
 #![plugin(lint_for_crate_rpass)] //~ WARNING compiler plugins are deprecated
 #![crate_okay]
 #![crate_blue]

--- a/src/test/ui-fulldeps/issue-15778-pass.stderr
+++ b/src/test/ui-fulldeps/issue-15778-pass.stderr
@@ -1,5 +1,5 @@
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/issue-15778-pass.rs:16:1
+  --> $DIR/issue-15778-pass.rs:8:1
    |
 LL | #![plugin(lint_for_crate_rpass)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version

--- a/src/test/ui-fulldeps/issue-15924.rs
+++ b/src/test/ui-fulldeps/issue-15924.rs
@@ -27,9 +27,7 @@ impl Encoder for JsonEncoder<'_> {
     type Error = ();
 }
 
-fn encode_json<T: for<'r> Encodable<JsonEncoder<'r>>>(
-    object: &T,
-) -> Result<String, ()> {
+fn encode_json<T: for<'r> Encodable<JsonEncoder<'r>>>(object: &T) -> Result<String, ()> {
     let s = String::new();
     {
         let mut encoder = JsonEncoder(PhantomData);

--- a/src/test/ui-fulldeps/issue-16822.rs
+++ b/src/test/ui-fulldeps/issue-16822.rs
@@ -6,7 +6,7 @@ extern crate issue_16822 as lib;
 use std::cell::RefCell;
 
 struct App {
-    i: isize
+    i: isize,
 }
 
 impl lib::Update for App {
@@ -15,7 +15,7 @@ impl lib::Update for App {
     }
 }
 
-fn main(){
+fn main() {
     let app = App { i: 5 };
     let window = lib::Window { data: RefCell::new(app) };
     window.update(1);

--- a/src/test/ui-fulldeps/issue-2804.rs
+++ b/src/test/ui-fulldeps/issue-2804.rs
@@ -26,29 +26,21 @@ enum object {
     int_value(i64),
 }
 
-fn lookup(table: Object, key: String, default: String) -> String
-{
+fn lookup(table: Object, key: String, default: String) -> String {
     match table.get(&key) {
-        option::Option::Some(&Json::String(ref s)) => {
-            s.to_string()
-        }
+        option::Option::Some(&Json::String(ref s)) => s.to_string(),
         option::Option::Some(value) => {
             println!("{} was expected to be a string but is a {:?}", key, value);
             default
         }
-        option::Option::None => {
-            default
-        }
+        option::Option::None => default,
     }
 }
 
-fn add_interface(_store: isize, managed_ip: String, data: Json) -> (String, object)
-{
+fn add_interface(_store: isize, managed_ip: String, data: Json) -> (String, object) {
     match &data {
         &Json::Object(ref interface) => {
-            let name = lookup(interface.clone(),
-                              "ifDescr".to_string(),
-                              "".to_string());
+            let name = lookup(interface.clone(), "ifDescr".to_string(), "".to_string());
             let label = format!("{}-{}", managed_ip, name);
 
             (label, object::bool_value(false))
@@ -60,19 +52,21 @@ fn add_interface(_store: isize, managed_ip: String, data: Json) -> (String, obje
     }
 }
 
-fn add_interfaces(store: isize, managed_ip: String, device: HashMap<String, Json>)
--> Vec<(String, object)> {
+fn add_interfaces(
+    store: isize,
+    managed_ip: String,
+    device: HashMap<String, Json>,
+) -> Vec<(String, object)> {
     match device["interfaces"] {
-        Json::Array(ref interfaces) =>
-        {
-          interfaces.iter().map(|interface| {
-                add_interface(store, managed_ip.clone(), (*interface).clone())
-          }).collect()
-        }
-        _ =>
-        {
-            println!("Expected list for {} interfaces, found {:?}", managed_ip,
-                     device["interfaces"]);
+        Json::Array(ref interfaces) => interfaces
+            .iter()
+            .map(|interface| add_interface(store, managed_ip.clone(), (*interface).clone()))
+            .collect(),
+        _ => {
+            println!(
+                "Expected list for {} interfaces, found {:?}",
+                managed_ip, device["interfaces"]
+            );
             Vec::new()
         }
     }

--- a/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.rs
+++ b/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.rs
@@ -3,13 +3,12 @@
 // compile-flags: -D lint-me
 
 #![feature(plugin)]
-
 #![plugin(lint_group_plugin_test)]
 //~^ WARN use of deprecated attribute `plugin`
 
-fn lintme() { } //~ ERROR item is named 'lintme'
+fn lintme() {} //~ ERROR item is named 'lintme'
 
-fn pleaselintme() { } //~ ERROR item is named 'pleaselintme'
+fn pleaselintme() {} //~ ERROR item is named 'pleaselintme'
 
 pub fn main() {
     lintme();

--- a/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.stderr
@@ -1,5 +1,5 @@
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/lint-group-plugin-deny-cmdline.rs:7:1
+  --> $DIR/lint-group-plugin-deny-cmdline.rs:6:1
    |
 LL | #![plugin(lint_group_plugin_test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
@@ -7,18 +7,18 @@ LL | #![plugin(lint_group_plugin_test)]
    = note: `#[warn(deprecated)]` on by default
 
 error: item is named 'lintme'
-  --> $DIR/lint-group-plugin-deny-cmdline.rs:10:1
+  --> $DIR/lint-group-plugin-deny-cmdline.rs:9:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
    = note: `-D test-lint` implied by `-D lint-me`
 
 error: item is named 'pleaselintme'
-  --> $DIR/lint-group-plugin-deny-cmdline.rs:12:1
+  --> $DIR/lint-group-plugin-deny-cmdline.rs:11:1
    |
-LL | fn pleaselintme() { }
-   | ^^^^^^^^^^^^^^^^^^^^^
+LL | fn pleaselintme() {}
+   | ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D please-lint` implied by `-D lint-me`
 

--- a/src/test/ui-fulldeps/lint-group-plugin.rs
+++ b/src/test/ui-fulldeps/lint-group-plugin.rs
@@ -6,12 +6,12 @@
 #![plugin(lint_group_plugin_test)] //~ WARNING use of deprecated attribute
 #![allow(dead_code)]
 
-fn lintme() { } //~ WARNING item is named 'lintme'
-fn pleaselintme() { } //~ WARNING item is named 'pleaselintme'
+fn lintme() {} //~ WARNING item is named 'lintme'
+fn pleaselintme() {} //~ WARNING item is named 'pleaselintme'
 
 #[allow(lint_me)]
 pub fn main() {
-    fn lintme() { }
+    fn lintme() {}
 
-    fn pleaselintme() { }
+    fn pleaselintme() {}
 }

--- a/src/test/ui-fulldeps/lint-group-plugin.stderr
+++ b/src/test/ui-fulldeps/lint-group-plugin.stderr
@@ -9,16 +9,16 @@ LL | #![plugin(lint_group_plugin_test)]
 warning: item is named 'lintme'
   --> $DIR/lint-group-plugin.rs:9:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
    = note: `#[warn(test_lint)]` on by default
 
 warning: item is named 'pleaselintme'
   --> $DIR/lint-group-plugin.rs:10:1
    |
-LL | fn pleaselintme() { }
-   | ^^^^^^^^^^^^^^^^^^^^^
+LL | fn pleaselintme() {}
+   | ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(please_lint)]` on by default
 

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-allow.rs
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-allow.rs
@@ -6,7 +6,6 @@
 #![feature(plugin)]
 #![plugin(lint_plugin_test)] //~ WARNING compiler plugins are deprecated
 
-fn lintme() { }
+fn lintme() {}
 
-pub fn main() {
-}
+pub fn main() {}

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-load.rs
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-load.rs
@@ -5,9 +5,9 @@
 
 #![feature(plugin)]
 
-fn lintme() { } //~ WARNING item is named 'lintme'
+fn lintme() {} //~ WARNING item is named 'lintme'
 
 #[allow(test_lint)]
 pub fn main() {
-    fn lintme() { }
+    fn lintme() {}
 }

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-load.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-load.stderr
@@ -9,8 +9,8 @@ LL | plugin(lint_plugin_test)
 warning: item is named 'lintme'
   --> $DIR/lint-plugin-cmdline-load.rs:8:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
    = note: `#[warn(test_lint)]` on by default
 

--- a/src/test/ui-fulldeps/lint-plugin-deny-attr.rs
+++ b/src/test/ui-fulldeps/lint-plugin-deny-attr.rs
@@ -6,7 +6,7 @@
 //~^ WARN use of deprecated attribute `plugin`
 #![deny(test_lint)]
 
-fn lintme() { } //~ ERROR item is named 'lintme'
+fn lintme() {} //~ ERROR item is named 'lintme'
 
 pub fn main() {
     lintme();

--- a/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
@@ -9,8 +9,8 @@ LL | #![plugin(lint_plugin_test)]
 error: item is named 'lintme'
   --> $DIR/lint-plugin-deny-attr.rs:9:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-plugin-deny-attr.rs:7:9

--- a/src/test/ui-fulldeps/lint-plugin-deny-cmdline.rs
+++ b/src/test/ui-fulldeps/lint-plugin-deny-cmdline.rs
@@ -6,7 +6,7 @@
 #![plugin(lint_plugin_test)]
 //~^ WARN use of deprecated attribute `plugin`
 
-fn lintme() { } //~ ERROR item is named 'lintme'
+fn lintme() {} //~ ERROR item is named 'lintme'
 
 pub fn main() {
     lintme();

--- a/src/test/ui-fulldeps/lint-plugin-deny-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-deny-cmdline.stderr
@@ -9,8 +9,8 @@ LL | #![plugin(lint_plugin_test)]
 error: item is named 'lintme'
   --> $DIR/lint-plugin-deny-cmdline.rs:9:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-D test-lint`
 

--- a/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.rs
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.rs
@@ -5,11 +5,14 @@
 #![feature(plugin)]
 #![plugin(lint_plugin_test)]
 //~^ WARN use of deprecated attribute `plugin`
-fn lintme() { } //~ ERROR item is named 'lintme'
 
-#[allow(test_lint)] //~ ERROR allow(test_lint) incompatible
-                    //~| ERROR allow(test_lint) incompatible
-                    //~| ERROR allow(test_lint)
+fn lintme() {}
+//~^ ERROR item is named 'lintme'
+
+#[allow(test_lint)]
+//~^ ERROR allow(test_lint) incompatible
+//~| ERROR allow(test_lint) incompatible
+//~| ERROR allow(test_lint)
 pub fn main() {
     lintme();
 }

--- a/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.stderr
@@ -1,5 +1,5 @@
 error[E0453]: allow(test_lint) incompatible with previous forbid
-  --> $DIR/lint-plugin-forbid-cmdline.rs:10:9
+  --> $DIR/lint-plugin-forbid-cmdline.rs:12:9
    |
 LL | #[allow(test_lint)]
    |         ^^^^^^^^^ overruled by previous forbid
@@ -7,7 +7,7 @@ LL | #[allow(test_lint)]
    = note: `forbid` lint level was set on command line
 
 error[E0453]: allow(test_lint) incompatible with previous forbid
-  --> $DIR/lint-plugin-forbid-cmdline.rs:10:9
+  --> $DIR/lint-plugin-forbid-cmdline.rs:12:9
    |
 LL | #[allow(test_lint)]
    |         ^^^^^^^^^ overruled by previous forbid
@@ -23,15 +23,15 @@ LL | #![plugin(lint_plugin_test)]
    = note: `#[warn(deprecated)]` on by default
 
 error: item is named 'lintme'
-  --> $DIR/lint-plugin-forbid-cmdline.rs:8:1
+  --> $DIR/lint-plugin-forbid-cmdline.rs:9:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-F test-lint`
 
 error[E0453]: allow(test_lint) incompatible with previous forbid
-  --> $DIR/lint-plugin-forbid-cmdline.rs:10:9
+  --> $DIR/lint-plugin-forbid-cmdline.rs:12:9
    |
 LL | #[allow(test_lint)]
    |         ^^^^^^^^^ overruled by previous forbid

--- a/src/test/ui-fulldeps/lint-plugin.rs
+++ b/src/test/ui-fulldeps/lint-plugin.rs
@@ -5,9 +5,9 @@
 #![plugin(lint_plugin_test)] //~ WARNING use of deprecated attribute
 #![allow(dead_code)]
 
-fn lintme() { } //~ WARNING item is named 'lintme'
+fn lintme() {} //~ WARNING item is named 'lintme'
 
 #[allow(test_lint)]
 pub fn main() {
-    fn lintme() { }
+    fn lintme() {}
 }

--- a/src/test/ui-fulldeps/lint-plugin.stderr
+++ b/src/test/ui-fulldeps/lint-plugin.stderr
@@ -9,8 +9,8 @@ LL | #![plugin(lint_plugin_test)]
 warning: item is named 'lintme'
   --> $DIR/lint-plugin.rs:8:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
    = note: `#[warn(test_lint)]` on by default
 

--- a/src/test/ui-fulldeps/lint-tool-test.rs
+++ b/src/test/ui-fulldeps/lint-tool-test.rs
@@ -17,15 +17,15 @@
 //~| WARNING lint name `clippy_group` is deprecated and may not have an effect in the future
 //~| WARNING lint name `clippy_group` is deprecated and may not have an effect in the future
 
-fn lintme() { } //~ ERROR item is named 'lintme'
+fn lintme() {} //~ ERROR item is named 'lintme'
 
 #[allow(clippy::group)]
 fn lintmetoo() {}
 
 #[allow(clippy::test_lint)]
 pub fn main() {
-    fn lintme() { }
-    fn lintmetoo() { } //~ ERROR item is named 'lintmetoo'
+    fn lintme() {}
+    fn lintmetoo() {} //~ ERROR item is named 'lintmetoo'
 }
 
 #[allow(test_group)]
@@ -35,5 +35,5 @@ pub fn main() {
 //~| WARNING lint name `test_group` is deprecated and may not have an effect in the future
 #[deny(this_lint_does_not_exist)] //~ WARNING unknown lint: `this_lint_does_not_exist`
 fn hello() {
-    fn lintmetoo() { }
+    fn lintmetoo() {}
 }

--- a/src/test/ui-fulldeps/lint-tool-test.stderr
+++ b/src/test/ui-fulldeps/lint-tool-test.stderr
@@ -67,8 +67,8 @@ LL | #![deny(clippy_group)]
 error: item is named 'lintme'
   --> $DIR/lint-tool-test.rs:20:1
    |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
+LL | fn lintme() {}
+   | ^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-tool-test.rs:14:9
@@ -80,8 +80,8 @@ LL | #![deny(clippy_group)]
 error: item is named 'lintmetoo'
   --> $DIR/lint-tool-test.rs:28:5
    |
-LL |     fn lintmetoo() { }
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     fn lintmetoo() {}
+   |     ^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(clippy::test_group)]` implied by `#[deny(clippy::group)]`
 

--- a/src/test/ui-fulldeps/mod_dir_simple/test.rs
+++ b/src/test/ui-fulldeps/mod_dir_simple/test.rs
@@ -1,3 +1,5 @@
 // run-pass
 
-pub fn foo() -> isize { 10 }
+pub fn foo() -> isize {
+    10
+}

--- a/src/test/ui-fulldeps/myriad-closures.rs
+++ b/src/test/ui-fulldeps/myriad-closures.rs
@@ -17,7 +17,9 @@ macro_rules! go_bacterial {
 }
 
 macro_rules! mk_closure {
-    () => ((move || {})())
+    () => {
+        (move || {})()
+    };
 }
 
 macro_rules! mk_fn {

--- a/src/test/ui-fulldeps/regions-mock-tcx.rs
+++ b/src/test/ui-fulldeps/regions-mock-tcx.rs
@@ -2,23 +2,21 @@
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
-
 // Test a sample usage pattern for regions. Makes use of the
 // following features:
 //
 // - Multiple lifetime parameters
 // - Arenas
-
 #![feature(rustc_private, libc)]
 
-extern crate rustc_arena;
 extern crate libc;
+extern crate rustc_arena;
 
-use TypeStructure::{TypeInt, TypeFunction};
-use AstKind::{ExprInt, ExprVar, ExprLambda};
 use rustc_arena::TypedArena;
 use std::collections::HashMap;
 use std::mem;
+use AstKind::{ExprInt, ExprLambda, ExprVar};
+use TypeStructure::{TypeFunction, TypeInt};
 
 type Type<'tcx> = &'tcx TypeStructure<'tcx>;
 
@@ -33,7 +31,7 @@ impl<'tcx> PartialEq for TypeStructure<'tcx> {
         match (*self, *other) {
             (TypeInt, TypeInt) => true,
             (TypeFunction(s_a, s_b), TypeFunction(o_a, o_b)) => *s_a == *o_a && *s_b == *o_b,
-            _ => false
+            _ => false,
         }
     }
 }
@@ -45,22 +43,26 @@ type AstArena<'ast> = TypedArena<AstStructure<'ast>>;
 
 struct TypeContext<'tcx, 'ast> {
     ty_arena: &'tcx TyArena<'tcx>,
-    types: Vec<Type<'tcx>> ,
+    types: Vec<Type<'tcx>>,
     type_table: HashMap<NodeId, Type<'tcx>>,
 
     ast_arena: &'ast AstArena<'ast>,
     ast_counter: usize,
 }
 
-impl<'tcx,'ast> TypeContext<'tcx, 'ast> {
-    fn new(ty_arena: &'tcx TyArena<'tcx>, ast_arena: &'ast AstArena<'ast>)
-           -> TypeContext<'tcx, 'ast> {
-        TypeContext { ty_arena: ty_arena,
-                      types: Vec::new(),
-                      type_table: HashMap::new(),
+impl<'tcx, 'ast> TypeContext<'tcx, 'ast> {
+    fn new(
+        ty_arena: &'tcx TyArena<'tcx>,
+        ast_arena: &'ast AstArena<'ast>,
+    ) -> TypeContext<'tcx, 'ast> {
+        TypeContext {
+            ty_arena: ty_arena,
+            types: Vec::new(),
+            type_table: HashMap::new(),
 
-                      ast_arena: ast_arena,
-                      ast_counter: 0 }
+            ast_arena: ast_arena,
+            ast_counter: 0,
+        }
     }
 
     fn add_type(&mut self, s: TypeStructure<'tcx>) -> Type<'tcx> {
@@ -83,13 +85,13 @@ impl<'tcx,'ast> TypeContext<'tcx, 'ast> {
     fn ast(&mut self, a: AstKind<'ast>) -> Ast<'ast> {
         let id = self.ast_counter;
         self.ast_counter += 1;
-        self.ast_arena.alloc(AstStructure { id: NodeId {id:id}, kind: a })
+        self.ast_arena.alloc(AstStructure { id: NodeId { id: id }, kind: a })
     }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 struct NodeId {
-    id: usize
+    id: usize,
 }
 
 type Ast<'ast> = &'ast AstStructure<'ast>;
@@ -97,7 +99,7 @@ type Ast<'ast> = &'ast AstStructure<'ast>;
 #[derive(Copy, Clone)]
 struct AstStructure<'ast> {
     id: NodeId,
-    kind: AstKind<'ast>
+    kind: AstKind<'ast>,
 }
 
 #[derive(Copy, Clone)]
@@ -107,9 +109,7 @@ enum AstKind<'ast> {
     ExprLambda(Ast<'ast>),
 }
 
-fn compute_types<'tcx,'ast>(tcx: &mut TypeContext<'tcx,'ast>,
-                            ast: Ast<'ast>) -> Type<'tcx>
-{
+fn compute_types<'tcx, 'ast>(tcx: &mut TypeContext<'tcx, 'ast>, ast: Ast<'ast>) -> Type<'tcx> {
     match ast.kind {
         ExprInt | ExprVar(_) => {
             let ty = tcx.add_type(TypeInt);

--- a/src/test/ui-fulldeps/rename-directory.rs
+++ b/src/test/ui-fulldeps/rename-directory.rs
@@ -27,4 +27,6 @@ fn rename_directory() {
     assert!(new_path.join("newdir/temp.txt").exists());
 }
 
-pub fn main() { rename_directory() }
+pub fn main() {
+    rename_directory()
+}

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -11,13 +11,13 @@
 #![crate_type = "lib"]
 
 extern crate rustc_errors;
+extern crate rustc_macros;
 extern crate rustc_session;
 extern crate rustc_span;
-extern crate rustc_macros;
 
 use rustc_errors::Applicability;
-use rustc_span::Span;
 use rustc_macros::SessionSubdiagnostic;
+use rustc_span::Span;
 
 #[derive(SessionSubdiagnostic)]
 #[label(parser::add_paren)]
@@ -40,7 +40,7 @@ enum B {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
@@ -161,66 +161,66 @@ enum P {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
 enum Q {
     #[bar]
-//~^ ERROR `#[bar]` is not a valid attribute
-//~^^ ERROR cannot find attribute `bar` in this scope
+    //~^ ERROR `#[bar]` is not a valid attribute
+    //~^^ ERROR cannot find attribute `bar` in this scope
     A {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
 enum R {
     #[bar = "..."]
-//~^ ERROR `#[bar = ...]` is not a valid attribute
-//~^^ ERROR cannot find attribute `bar` in this scope
+    //~^ ERROR `#[bar = ...]` is not a valid attribute
+    //~^^ ERROR cannot find attribute `bar` in this scope
     A {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
 enum S {
     #[bar = 4]
-//~^ ERROR `#[bar = ...]` is not a valid attribute
-//~^^ ERROR cannot find attribute `bar` in this scope
+    //~^ ERROR `#[bar = ...]` is not a valid attribute
+    //~^^ ERROR cannot find attribute `bar` in this scope
     A {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
 enum T {
     #[bar("...")]
-//~^ ERROR `#[bar("...")]` is not a valid attribute
-//~^^ ERROR cannot find attribute `bar` in this scope
+    //~^ ERROR `#[bar("...")]` is not a valid attribute
+    //~^^ ERROR cannot find attribute `bar` in this scope
     A {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
 enum U {
     #[label(code = "...")]
-//~^ ERROR diagnostic slug must be first argument of a `#[label(...)]` attribute
+    //~^ ERROR diagnostic slug must be first argument of a `#[label(...)]` attribute
     A {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
@@ -232,11 +232,11 @@ enum V {
         var: String,
     },
     B {
-//~^ ERROR subdiagnostic kind not specified
+        //~^ ERROR subdiagnostic kind not specified
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
@@ -297,14 +297,14 @@ struct AB {
     #[primary_span]
     span: Span,
     #[skip_arg]
-    z: Z
+    z: Z,
 }
 
 #[derive(SessionSubdiagnostic)]
 union AC {
-//~^ ERROR unexpected unsupported untagged union
+    //~^ ERROR unexpected unsupported untagged union
     span: u32,
-    b: u64
+    b: u64,
 }
 
 #[derive(SessionSubdiagnostic)]
@@ -331,16 +331,16 @@ struct AE {
 #[label(parser::add_paren)]
 struct AF {
     #[primary_span]
-//~^ NOTE previously specified here
+    //~^ NOTE previously specified here
     span_a: Span,
     #[primary_span]
-//~^ ERROR specified multiple times
+    //~^ ERROR specified multiple times
     span_b: Span,
 }
 
 #[derive(SessionSubdiagnostic)]
 struct AG {
-//~^ ERROR subdiagnostic kind not specified
+    //~^ ERROR subdiagnostic kind not specified
     #[primary_span]
     span: Span,
 }
@@ -372,7 +372,7 @@ enum AI {
         #[applicability]
         applicability: Applicability,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
@@ -392,10 +392,10 @@ struct AK {
     #[primary_span]
     span: Span,
     #[applicability]
-//~^ NOTE previously specified here
+    //~^ NOTE previously specified here
     applicability_a: Applicability,
     #[applicability]
-//~^ ERROR specified multiple times
+    //~^ ERROR specified multiple times
     applicability_b: Applicability,
 }
 
@@ -406,7 +406,7 @@ struct AL {
     #[primary_span]
     span: Span,
     #[applicability]
-//~^ ERROR the `#[applicability]` attribute can only be applied to fields of type `Applicability`
+    //~^ ERROR the `#[applicability]` attribute can only be applied to fields of type `Applicability`
     applicability: Span,
 }
 
@@ -429,7 +429,7 @@ struct AN {
 }
 
 #[derive(SessionSubdiagnostic)]
-#[suggestion(parser::add_paren, code ="...", applicability = "foo")]
+#[suggestion(parser::add_paren, code = "...", applicability = "foo")]
 //~^ ERROR invalid applicability
 struct AO {
     #[primary_span]
@@ -439,7 +439,7 @@ struct AO {
 #[derive(SessionSubdiagnostic)]
 #[help(parser::add_paren)]
 struct AP {
-    var: String
+    var: String,
 }
 
 #[derive(SessionSubdiagnostic)]
@@ -455,7 +455,7 @@ struct AR {
 }
 
 #[derive(SessionSubdiagnostic)]
-#[suggestion(parser::add_paren, code ="...", applicability = "machine-applicable")]
+#[suggestion(parser::add_paren, code = "...", applicability = "machine-applicable")]
 struct AS {
     #[primary_span]
     span: Span,
@@ -470,11 +470,11 @@ enum AT {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
-#[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
+#[suggestion(parser::add_paren, code = "{var}", applicability = "machine-applicable")]
 struct AU {
     #[primary_span]
     span: Span,
@@ -482,7 +482,7 @@ struct AU {
 }
 
 #[derive(SessionSubdiagnostic)]
-#[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
+#[suggestion(parser::add_paren, code = "{var}", applicability = "machine-applicable")]
 //~^ ERROR `var` doesn't refer to a field on this type
 struct AV {
     #[primary_span]
@@ -491,20 +491,20 @@ struct AV {
 
 #[derive(SessionSubdiagnostic)]
 enum AW {
-    #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
+    #[suggestion(parser::add_paren, code = "{var}", applicability = "machine-applicable")]
     A {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(SessionSubdiagnostic)]
 enum AX {
-    #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
-//~^ ERROR `var` doesn't refer to a field on this type
+    #[suggestion(parser::add_paren, code = "{var}", applicability = "machine-applicable")]
+    //~^ ERROR `var` doesn't refer to a field on this type
     A {
         #[primary_span]
         span: Span,
-    }
+    },
 }

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -170,7 +170,7 @@ error: unexpected unsupported untagged union
 LL | / union AC {
 LL | |
 LL | |     span: u32,
-LL | |     b: u64
+LL | |     b: u64,
 LL | | }
    | |_^
 
@@ -290,10 +290,10 @@ LL | | }
    | |_^
 
 error: invalid applicability
-  --> $DIR/subdiagnostic-derive.rs:432:46
+  --> $DIR/subdiagnostic-derive.rs:432:47
    |
-LL | #[suggestion(parser::add_paren, code ="...", applicability = "foo")]
-   |                                              ^^^^^^^^^^^^^^^^^^^^^
+LL | #[suggestion(parser::add_paren, code = "...", applicability = "foo")]
+   |                                               ^^^^^^^^^^^^^^^^^^^^^
 
 error: suggestion without `applicability`
   --> $DIR/subdiagnostic-derive.rs:450:1
@@ -324,16 +324,16 @@ LL | #[label]
    | ^^^^^^^^
 
 error: `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:485:39
+  --> $DIR/subdiagnostic-derive.rs:485:40
    |
-LL | #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
-   |                                       ^^^^^^^
+LL | #[suggestion(parser::add_paren, code = "{var}", applicability = "machine-applicable")]
+   |                                        ^^^^^^^
 
 error: `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:504:43
+  --> $DIR/subdiagnostic-derive.rs:504:44
    |
-LL |     #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
-   |                                           ^^^^^^^
+LL |     #[suggestion(parser::add_paren, code = "{var}", applicability = "machine-applicable")]
+   |                                            ^^^^^^^
 
 error: cannot find attribute `foo` in this scope
   --> $DIR/subdiagnostic-derive.rs:63:3

--- a/src/test/ui-fulldeps/stdio-from.rs
+++ b/src/test/ui-fulldeps/stdio-from.rs
@@ -5,15 +5,11 @@ use std::env;
 use std::fs::File;
 use std::io;
 use std::io::{Read, Write};
-use std::process::{Command, Stdio};
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 fn main() {
-    if env::args().len() > 1 {
-        child().unwrap()
-    } else {
-        parent().unwrap()
-    }
+    if env::args().len() > 1 { child().unwrap() } else { parent().unwrap() }
 }
 
 fn parent() -> io::Result<()> {


### PR DESCRIPTION
These tests are relatively special as they don't need a lot of UI-testing comments (other than a small number of error annotations). Honestly, this was easier to do than describe. A simple fmt then bless seems to have worked out ok, only needing a very few manual fixups where an `ERROR` was moved to the next line (see `internal-lints/lint_pass_impl_without_macro.rs` and `lint-plugin-forbid-cmdline.rs`).