### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -50,7 +50,7 @@ If the feature is changed later, please add those PRs here as well.
 -->
 
 - [ ] Implementation: #...
-- [ ] Final comment period (FCP)
+- [ ] Final comment period (FCP)[^1]
 - [ ] Stabilization PR
 
 <!--
@@ -81,3 +81,5 @@ Zulip, or the internals forum) here.
 -->
 
 - None yet.
+
+[^1]: https://std-dev-guide.rust-lang.org/feature-lifecycle/stabilization.html

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -694,6 +694,7 @@ impl<'a> Builder<'a> {
                 doc::RustcBook,
                 doc::CargoBook,
                 doc::Clippy,
+                doc::Miri,
                 doc::EmbeddedBook,
                 doc::EditionGuide,
             ),

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1128,11 +1128,7 @@ impl Config {
             config.rust_codegen_units_std = rust.codegen_units_std.map(threads_from_config);
             config.rust_profile_use = flags.rust_profile_use.or(rust.profile_use);
             config.rust_profile_generate = flags.rust_profile_generate.or(rust.profile_generate);
-            config.download_rustc_commit = download_ci_rustc_commit(
-                &config.stage0_metadata,
-                rust.download_rustc,
-                config.verbose > 0,
-            );
+            config.download_rustc_commit = download_ci_rustc_commit(&config, rust.download_rustc);
         } else {
             config.rust_profile_use = flags.rust_profile_use;
             config.rust_profile_generate = flags.rust_profile_generate;
@@ -1304,6 +1300,15 @@ impl Config {
         config
     }
 
+    /// A git invocation which runs inside the source directory.
+    ///
+    /// Use this rather than `Command::new("git")` in order to support out-of-tree builds.
+    pub(crate) fn git(&self) -> Command {
+        let mut git = Command::new("git");
+        git.current_dir(&self.src);
+        git
+    }
+
     /// Try to find the relative path of `bindir`, otherwise return it in full.
     pub fn bindir_relative(&self) -> &Path {
         let bindir = &self.bindir;
@@ -1453,9 +1458,8 @@ fn threads_from_config(v: u32) -> u32 {
 
 /// Returns the commit to download, or `None` if we shouldn't download CI artifacts.
 fn download_ci_rustc_commit(
-    stage0_metadata: &Stage0Metadata,
+    config: &Config,
     download_rustc: Option<StringOrBool>,
-    verbose: bool,
 ) -> Option<String> {
     // If `download-rustc` is not set, default to rebuilding.
     let if_unchanged = match download_rustc {
@@ -1468,7 +1472,7 @@ fn download_ci_rustc_commit(
     };
 
     // Handle running from a directory other than the top level
-    let top_level = output(Command::new("git").args(&["rev-parse", "--show-toplevel"]));
+    let top_level = output(config.git().args(&["rev-parse", "--show-toplevel"]));
     let top_level = top_level.trim_end();
     let compiler = format!("{top_level}/compiler/");
     let library = format!("{top_level}/library/");
@@ -1476,9 +1480,10 @@ fn download_ci_rustc_commit(
     // Look for a version to compare to based on the current commit.
     // Only commits merged by bors will have CI artifacts.
     let merge_base = output(
-        Command::new("git")
+        config
+            .git()
             .arg("rev-list")
-            .arg(format!("--author={}", stage0_metadata.config.git_merge_commit_email))
+            .arg(format!("--author={}", config.stage0_metadata.config.git_merge_commit_email))
             .args(&["-n1", "--first-parent", "HEAD"]),
     );
     let commit = merge_base.trim_end();
@@ -1491,13 +1496,14 @@ fn download_ci_rustc_commit(
     }
 
     // Warn if there were changes to the compiler or standard library since the ancestor commit.
-    let has_changes = !t!(Command::new("git")
+    let has_changes = !t!(config
+        .git()
         .args(&["diff-index", "--quiet", &commit, "--", &compiler, &library])
         .status())
     .success();
     if has_changes {
         if if_unchanged {
-            if verbose {
+            if config.verbose > 0 {
                 println!(
                     "warning: saw changes to compiler/ or library/ since {commit}; \
                           ignoring `download-rustc`"

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -729,7 +729,17 @@ macro_rules! tool_doc {
                 cargo.rustdocflag("--show-type-layout");
                 cargo.rustdocflag("--generate-link-to-definition");
                 cargo.rustdocflag("-Zunstable-options");
-                builder.run(&mut cargo.into());
+                if $in_tree == true {
+                    builder.run(&mut cargo.into());
+                } else {
+                    // Allow out-of-tree docs to fail (since the tool might be in a broken state).
+                    if !builder.try_run(&mut cargo.into()) {
+                        builder.info(&format!(
+                            "WARNING: tool {} failed to document; ignoring failure because it is an out-of-tree tool",
+                            stringify!($tool).to_lowercase(),
+                        ));
+                    }
+                }
             }
         }
     }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -737,6 +737,7 @@ tool_doc!(
     ["rustfmt-nightly", "rustfmt-config_proc_macro"],
 );
 tool_doc!(Clippy, "clippy", "src/tools/clippy", ["clippy_utils"]);
+tool_doc!(Miri, "miri", "src/tools/miri", ["miri"]);
 
 #[derive(Ord, PartialOrd, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -643,7 +643,7 @@ impl Step for Rustc {
 }
 
 macro_rules! tool_doc {
-    ($tool: ident, $should_run: literal, $path: literal, [$($krate: literal),+ $(,)?] $(,)?) => {
+    ($tool: ident, $should_run: literal, $path: literal, [$($krate: literal),+ $(,)?], in_tree = $in_tree:expr $(,)?) => {
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct $tool {
             target: TargetSelection,
@@ -699,6 +699,12 @@ macro_rules! tool_doc {
                 t!(fs::create_dir_all(&out_dir));
                 t!(symlink_dir_force(&builder.config, &out, &out_dir));
 
+                let source_type = if $in_tree == true {
+                    SourceType::InTree
+                } else {
+                    SourceType::Submodule
+                };
+
                 // Build cargo command.
                 let mut cargo = prepare_tool_cargo(
                     builder,
@@ -707,7 +713,7 @@ macro_rules! tool_doc {
                     target,
                     "doc",
                     $path,
-                    SourceType::InTree,
+                    source_type,
                     &[],
                 );
 
@@ -729,15 +735,22 @@ macro_rules! tool_doc {
     }
 }
 
-tool_doc!(Rustdoc, "rustdoc-tool", "src/tools/rustdoc", ["rustdoc", "rustdoc-json-types"]);
+tool_doc!(
+    Rustdoc,
+    "rustdoc-tool",
+    "src/tools/rustdoc",
+    ["rustdoc", "rustdoc-json-types"],
+    in_tree = true
+);
 tool_doc!(
     Rustfmt,
     "rustfmt-nightly",
     "src/tools/rustfmt",
     ["rustfmt-nightly", "rustfmt-config_proc_macro"],
+    in_tree = true
 );
-tool_doc!(Clippy, "clippy", "src/tools/clippy", ["clippy_utils"]);
-tool_doc!(Miri, "miri", "src/tools/miri", ["miri"]);
+tool_doc!(Clippy, "clippy", "src/tools/clippy", ["clippy_utils"], in_tree = true);
+tool_doc!(Miri, "miri", "src/tools/miri", ["miri"], in_tree = false);
 
 #[derive(Ord, PartialOrd, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {

--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -72,7 +72,9 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
         Err(_) => false,
     };
     if git_available {
-        let in_working_tree = match Command::new("git")
+        let in_working_tree = match build
+            .config
+            .git()
             .arg("rev-parse")
             .arg("--is-inside-work-tree")
             .stdout(Stdio::null())
@@ -84,10 +86,7 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
         };
         if in_working_tree {
             let untracked_paths_output = output(
-                Command::new("git")
-                    .arg("status")
-                    .arg("--porcelain")
-                    .arg("--untracked-files=normal"),
+                build.config.git().arg("status").arg("--porcelain").arg("--untracked-files=normal"),
             );
             let untracked_paths = untracked_paths_output
                 .lines()

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -634,7 +634,8 @@ impl Build {
             return;
         }
         let output = output(
-            Command::new("git")
+            self.config
+                .git()
                 .args(&["config", "--file"])
                 .arg(&self.config.src.join(".gitmodules"))
                 .args(&["--get-regexp", "path"]),
@@ -1271,12 +1272,12 @@ impl Build {
         // That's our beta number!
         // (Note that we use a `..` range, not the `...` symmetric difference.)
         let count = output(
-            Command::new("git")
+            self.config
+                .git()
                 .arg("rev-list")
                 .arg("--count")
                 .arg("--merges")
-                .arg("refs/remotes/origin/master..HEAD")
-                .current_dir(&self.src),
+                .arg("refs/remotes/origin/master..HEAD"),
         );
         let n = count.trim().parse().unwrap();
         self.prerelease_version.set(Some(n));

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -118,7 +118,7 @@ pub(crate) fn maybe_download_ci_llvm(builder: &Builder<'_>) {
     if !config.llvm_from_ci {
         return;
     }
-    let mut rev_list = Command::new("git");
+    let mut rev_list = config.git();
     rev_list.args(&[
         PathBuf::from("rev-list"),
         format!("--author={}", builder.config.stage0_metadata.config.git_merge_commit_email).into(),


### PR DESCRIPTION
Successful merges:

 - #94831 (Link to stabilization section in std-dev-guide for library tracking issue template)
 - #98526 (Allow using `download-ci-llvm = true` outside the git checkout)
 - #98764 (add Miri to the nightly docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94831,98526,98764)
<!-- homu-ignore:end -->