### PR TITLE
Refactor metadata emission to avoid visiting HIR

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1315,6 +1315,19 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             if should_encode_type(tcx, local_id, def_kind) {
                 record!(self.tables.type_of[def_id] <- self.tcx.type_of(def_id));
             }
+            if let DefKind::Fn | DefKind::AssocFn = def_kind {
+                self.tables.asyncness.set_some(def_id.index, tcx.asyncness(def_id));
+                record_array!(self.tables.fn_arg_names[def_id] <- tcx.fn_arg_names(def_id));
+                let constness = if self.tcx.is_const_fn_raw(def_id) {
+                    hir::Constness::Const
+                } else {
+                    hir::Constness::NotConst
+                };
+                self.tables.constness.set_some(def_id.index, constness);
+
+                record!(self.tables.fn_sig[def_id] <- tcx.fn_sig(def_id));
+                self.tables.is_intrinsic.set(def_id.index, tcx.is_intrinsic(def_id));
+            }
             if let DefKind::TyParam = def_kind {
                 let default = self.tcx.object_lifetime_default(def_id);
                 record!(self.tables.object_lifetime_default[def_id] <- default);
@@ -1446,18 +1459,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         self.tables.assoc_container.set_some(def_id.index, trait_item.container);
 
         match trait_item.kind {
-            ty::AssocKind::Const => {}
-            ty::AssocKind::Fn => {
-                record_array!(self.tables.fn_arg_names[def_id] <- tcx.fn_arg_names(def_id));
-                self.tables.asyncness.set_some(def_id.index, tcx.asyncness(def_id));
-                self.tables.constness.set_some(def_id.index, hir::Constness::NotConst);
-            }
+            ty::AssocKind::Const | ty::AssocKind::Fn => {}
             ty::AssocKind::Type => {
                 self.encode_explicit_item_bounds(def_id);
             }
-        }
-        if trait_item.kind == ty::AssocKind::Fn {
-            record!(self.tables.fn_sig[def_id] <- tcx.fn_sig(def_id));
         }
         if let Some(rpitit_info) = trait_item.opt_rpitit_info {
             let rpitit_info = self.lazy(rpitit_info);
@@ -1467,35 +1472,14 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
     fn encode_info_for_impl_item(&mut self, def_id: DefId) {
         debug!("EncodeContext::encode_info_for_impl_item({:?})", def_id);
-        let tcx = self.tcx;
 
         let defaultness = self.tcx.defaultness(def_id.expect_local());
         self.tables.defaultness.set_some(def_id.index, defaultness);
         let impl_item = self.tcx.associated_item(def_id);
         self.tables.assoc_container.set_some(def_id.index, impl_item.container);
 
-        match impl_item.kind {
-            ty::AssocKind::Fn => {
-                let (sig, body) =
-                    self.tcx.hir().expect_impl_item(def_id.expect_local()).expect_fn();
-                self.tables.asyncness.set_some(def_id.index, sig.header.asyncness);
-                record_array!(self.tables.fn_arg_names[def_id] <- self.tcx.hir().body_param_names(body));
-                // Can be inside `impl const Trait`, so using sig.header.constness is not reliable
-                let constness = if self.tcx.is_const_fn_raw(def_id) {
-                    hir::Constness::Const
-                } else {
-                    hir::Constness::NotConst
-                };
-                self.tables.constness.set_some(def_id.index, constness);
-            }
-            ty::AssocKind::Const | ty::AssocKind::Type => {}
-        }
         if let Some(trait_item_def_id) = impl_item.trait_item_def_id {
             self.tables.trait_item_def_id.set_some(def_id.index, trait_item_def_id.into());
-        }
-        if impl_item.kind == ty::AssocKind::Fn {
-            record!(self.tables.fn_sig[def_id] <- tcx.fn_sig(def_id));
-            self.tables.is_intrinsic.set(def_id.index, tcx.is_intrinsic(def_id));
         }
         if let Some(rpitit_info) = impl_item.opt_rpitit_info {
             let rpitit_info = self.lazy(rpitit_info);
@@ -1624,7 +1608,6 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     }
 
     fn encode_info_for_item(&mut self, item: &'tcx hir::Item<'tcx>) {
-        let tcx = self.tcx;
         let def_id = item.owner_id.to_def_id();
         debug!("EncodeContext::encode_info_for_item({:?})", def_id);
 
@@ -1636,13 +1619,6 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         };
 
         match item.kind {
-            hir::ItemKind::Fn(ref sig, .., body) => {
-                self.tables.asyncness.set_some(def_id.index, sig.header.asyncness);
-                record_array!(self.tables.fn_arg_names[def_id] <- self.tcx.hir().body_param_names(body));
-                self.tables.constness.set_some(def_id.index, sig.header.constness);
-                record!(self.tables.fn_sig[def_id] <- tcx.fn_sig(def_id));
-                self.tables.is_intrinsic.set(def_id.index, tcx.is_intrinsic(def_id));
-            }
             hir::ItemKind::Macro(ref macro_def, _) => {
                 self.tables.is_macro_rules.set(def_id.index, macro_def.macro_rules);
                 record!(self.tables.macro_definition[def_id] <- &*macro_def.body);
@@ -1691,7 +1667,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             hir::ItemKind::Trait(..) => {
                 record!(self.tables.trait_def[def_id] <- self.tcx.trait_def(def_id));
 
-                let module_children = tcx.module_children_local(item.owner_id.def_id);
+                let module_children = self.tcx.module_children_local(item.owner_id.def_id);
                 record_array!(self.tables.module_children_non_reexports[def_id] <-
                     module_children.iter().map(|child| child.res.def_id().index));
 
@@ -1713,6 +1689,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             | hir::ItemKind::Union(..)
             | hir::ItemKind::ForeignMod { .. }
             | hir::ItemKind::GlobalAsm(..)
+            | hir::ItemKind::Fn(..)
             | hir::ItemKind::TyAlias(..) => {}
         }
     }
@@ -2079,30 +2056,6 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         }
         LazyArray::default()
     }
-
-    fn encode_info_for_foreign_item(&mut self, def_id: DefId, nitem: &hir::ForeignItem<'_>) {
-        let tcx = self.tcx;
-
-        debug!("EncodeContext::encode_info_for_foreign_item({:?})", def_id);
-
-        match nitem.kind {
-            hir::ForeignItemKind::Fn(_, ref names, _) => {
-                self.tables.asyncness.set_some(def_id.index, hir::IsAsync::NotAsync);
-                record_array!(self.tables.fn_arg_names[def_id] <- *names);
-                let constness = if self.tcx.is_const_fn_raw(def_id) {
-                    hir::Constness::Const
-                } else {
-                    hir::Constness::NotConst
-                };
-                self.tables.constness.set_some(def_id.index, constness);
-                record!(self.tables.fn_sig[def_id] <- tcx.fn_sig(def_id));
-            }
-            hir::ForeignItemKind::Static(..) | hir::ForeignItemKind::Type => {}
-        }
-        if let hir::ForeignItemKind::Fn(..) = nitem.kind {
-            self.tables.is_intrinsic.set(def_id.index, tcx.is_intrinsic(def_id));
-        }
-    }
 }
 
 // FIXME(eddyb) make metadata encoding walk over all definitions, instead of HIR.
@@ -2119,10 +2072,6 @@ impl<'a, 'tcx> Visitor<'tcx> for EncodeContext<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         intravisit::walk_item(self, item);
         self.encode_info_for_item(item);
-    }
-    fn visit_foreign_item(&mut self, ni: &'tcx hir::ForeignItem<'tcx>) {
-        intravisit::walk_foreign_item(self, ni);
-        self.encode_info_for_foreign_item(ni.owner_id.to_def_id(), ni);
     }
     fn visit_generics(&mut self, generics: &'tcx hir::Generics<'tcx>) {
         intravisit::walk_generics(self, generics);

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1317,14 +1317,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             }
             if let DefKind::Fn | DefKind::AssocFn = def_kind {
                 self.tables.asyncness.set_some(def_id.index, tcx.asyncness(def_id));
+                self.tables.constness.set_some(def_id.index, tcx.constness(def_id));
                 record_array!(self.tables.fn_arg_names[def_id] <- tcx.fn_arg_names(def_id));
-                let constness = if self.tcx.is_const_fn_raw(def_id) {
-                    hir::Constness::Const
-                } else {
-                    hir::Constness::NotConst
-                };
-                self.tables.constness.set_some(def_id.index, constness);
-
                 record!(self.tables.fn_sig[def_id] <- tcx.fn_sig(def_id));
                 self.tables.is_intrinsic.set(def_id.index, tcx.is_intrinsic(def_id));
             }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1523,7 +1523,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self))]
     fn encode_info_for_mod(&mut self, local_def_id: LocalDefId) {
         let tcx = self.tcx;
         let def_id = local_def_id.to_def_id();
@@ -1554,7 +1554,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         record_defaulted_array!(self.tables.explicit_item_bounds[def_id] <- bounds);
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self))]
     fn encode_info_for_assoc_item(&mut self, def_id: DefId) {
         let tcx = self.tcx;
         let item = tcx.associated_item(def_id);
@@ -1648,9 +1648,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn encode_stability(&mut self, def_id: DefId) {
-        debug!("EncodeContext::encode_stability({:?})", def_id);
-
         // The query lookup can take a measurable amount of time in crates with many items. Check if
         // the stability attributes are even enabled before using their queries.
         if self.feat.staged_api || self.tcx.sess.opts.unstable_opts.force_unstable_if_unmarked {
@@ -1660,9 +1659,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn encode_const_stability(&mut self, def_id: DefId) {
-        debug!("EncodeContext::encode_const_stability({:?})", def_id);
-
         // The query lookup can take a measurable amount of time in crates with many items. Check if
         // the stability attributes are even enabled before using their queries.
         if self.feat.staged_api || self.tcx.sess.opts.unstable_opts.force_unstable_if_unmarked {
@@ -1672,9 +1670,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn encode_default_body_stability(&mut self, def_id: DefId) {
-        debug!("EncodeContext::encode_default_body_stability({:?})", def_id);
-
         // The query lookup can take a measurable amount of time in crates with many items. Check if
         // the stability attributes are even enabled before using their queries.
         if self.feat.staged_api || self.tcx.sess.opts.unstable_opts.force_unstable_if_unmarked {
@@ -1684,8 +1681,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn encode_deprecation(&mut self, def_id: DefId) {
-        debug!("EncodeContext::encode_deprecation({:?})", def_id);
         if let Some(depr) = self.tcx.lookup_deprecation(def_id) {
             record!(self.tables.lookup_deprecation_entry[def_id] <- depr);
         }
@@ -1699,7 +1696,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         })
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self))]
     fn encode_info_for_macro(&mut self, def_id: LocalDefId) {
         let tcx = self.tcx;
 
@@ -1708,7 +1705,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         record!(self.tables.macro_definition[def_id.to_def_id()] <- &*macro_def.body);
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self))]
     fn encode_info_for_impl(&mut self, def_id: DefId, of_trait: bool) {
         let tcx = self.tcx;
 
@@ -1962,8 +1959,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     }
 
     /// Encodes an index, mapping each trait to its (local) implementations.
+    #[instrument(level = "debug", skip(self))]
     fn encode_impls(&mut self) -> LazyArray<TraitImpls> {
-        debug!("EncodeContext::encode_traits_and_impls()");
         empty_proc_macro!(self);
         let tcx = self.tcx;
         let mut fx_hash_map: FxHashMap<DefId, Vec<(DefIndex, Option<SimplifiedType>)>> =
@@ -2011,8 +2008,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         self.lazy_array(&all_impls)
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn encode_incoherent_impls(&mut self) -> LazyArray<IncoherentImpls> {
-        debug!("EncodeContext::encode_traits_and_impls()");
         empty_proc_macro!(self);
         let tcx = self.tcx;
         let mut all_impls: Vec<_> = tcx.crate_inherent_impls(()).incoherent_impls.iter().collect();

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1407,9 +1407,15 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 record!(self.tables.object_lifetime_default[def_id] <- default);
             }
             if let DefKind::Trait = def_kind {
+                record!(self.tables.trait_def[def_id] <- self.tcx.trait_def(def_id));
                 record!(self.tables.super_predicates_of[def_id] <- self.tcx.super_predicates_of(def_id));
+
+                let module_children = self.tcx.module_children_local(local_id);
+                record_array!(self.tables.module_children_non_reexports[def_id] <-
+                    module_children.iter().map(|child| child.res.def_id().index));
             }
             if let DefKind::TraitAlias = def_kind {
+                record!(self.tables.trait_def[def_id] <- self.tcx.trait_def(def_id));
                 record!(self.tables.super_predicates_of[def_id] <- self.tcx.super_predicates_of(def_id));
                 record!(self.tables.implied_predicates_of[def_id] <- self.tcx.implied_predicates_of(def_id));
             }
@@ -1723,18 +1729,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     }
                 }
             }
-            hir::ItemKind::Trait(..) => {
-                record!(self.tables.trait_def[def_id] <- self.tcx.trait_def(def_id));
-
-                let module_children = self.tcx.module_children_local(item.owner_id.def_id);
-                record_array!(self.tables.module_children_non_reexports[def_id] <-
-                    module_children.iter().map(|child| child.res.def_id().index));
-            }
-            hir::ItemKind::TraitAlias(..) => {
-                record!(self.tables.trait_def[def_id] <- self.tcx.trait_def(def_id));
-            }
             hir::ItemKind::ExternCrate(_)
             | hir::ItemKind::Use(..)
+            | hir::ItemKind::Trait(..)
+            | hir::ItemKind::TraitAlias(..)
             | hir::ItemKind::Static(..)
             | hir::ItemKind::Const(..)
             | hir::ItemKind::Enum(..)


### PR DESCRIPTION
This PR refactors metadata emission to be based on tables and iteration over definitions.

In a first part, this PR moves information from the `EntryKind` enum to tables, until removing the `EntryKind` enum.
In a second part, the iteration scheme is refactored to avoid fetching HIR unless strictly necessary.

r? @ghost