### PR TITLE
Remove some usages of `guess_head_span`

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -714,10 +714,7 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for QueryTypeRelatingDelegate<'_, 'tcx> {
     }
 
     fn const_equate(&mut self, _a: Const<'tcx>, _b: Const<'tcx>) {
-        span_bug!(
-            self.cause.span(self.infcx.tcx),
-            "generic_const_exprs: unreachable `const_equate`"
-        );
+        span_bug!(self.cause.span(), "generic_const_exprs: unreachable `const_equate`");
     }
 
     fn normalization() -> NormalizationStrategy {

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1435,7 +1435,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         swap_secondary_and_primary: bool,
         force_label: bool,
     ) {
-        let span = cause.span(self.tcx);
+        let span = cause.span();
 
         // For some types of errors, expected-found does not make
         // sense, so just ignore the values we were given.
@@ -2085,7 +2085,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
         debug!("report_and_explain_type_error(trace={:?}, terr={:?})", trace, terr);
 
-        let span = trace.cause.span(self.tcx);
+        let span = trace.cause.span();
         let failure_code = trace.cause.as_failure_code(terr);
         let mut diag = match failure_code {
             FailureCode::Error0038(did) => {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -204,7 +204,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
         expected_substs: SubstsRef<'tcx>,
         actual_substs: SubstsRef<'tcx>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        let span = cause.span(self.tcx());
+        let span = cause.span();
         let msg = format!(
             "implementation of `{}` is not general enough",
             self.tcx().def_path_str(trait_def_id),

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -18,20 +18,22 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         trait_item_def_id: DefId,
         requirement: &dyn fmt::Display,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        let msg = "impl has stricter requirements than trait";
-        let sp = self.tcx.sess.source_map().guess_head_span(error_span);
+        let mut err = struct_span_err!(
+            self.tcx.sess,
+            error_span,
+            E0276,
+            "impl has stricter requirements than trait"
+        );
 
-        let mut err = struct_span_err!(self.tcx.sess, sp, E0276, "{}", msg);
-
-        if trait_item_def_id.is_local() {
+        if let Some(span) = self.tcx.hir().span_if_local(trait_item_def_id) {
             let item_name = self.tcx.item_name(impl_item_def_id.to_def_id());
             err.span_label(
-                self.tcx.def_span(trait_item_def_id),
+                span,
                 format!("definition of `{}` from trait", item_name),
             );
         }
 
-        err.span_label(sp, format!("impl has extra requirement {}", requirement));
+        err.span_label(error_span, format!("impl has extra requirement {}", requirement));
 
         err
     }
@@ -48,7 +50,6 @@ pub fn report_object_safety_error<'tcx>(
         hir::Node::Item(item) => Some(item.ident.span),
         _ => None,
     });
-    let span = tcx.sess.source_map().guess_head_span(span);
     let mut err = struct_span_err!(
         tcx.sess,
         span,

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -27,10 +27,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
         if let Some(span) = self.tcx.hir().span_if_local(trait_item_def_id) {
             let item_name = self.tcx.item_name(impl_item_def_id.to_def_id());
-            err.span_label(
-                span,
-                format!("definition of `{}` from trait", item_name),
-            );
+            err.span_label(span, format!("definition of `{}` from trait", item_name));
         }
 
         err.span_label(error_span, format!("impl has extra requirement {}", requirement));

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -694,9 +694,8 @@ pub trait LintContext: Sized {
                     }
 
                     if let Some(span) = in_test_module {
-                        let def_span = self.sess().source_map().guess_head_span(span);
                         db.span_help(
-                            span.shrink_to_lo().to(def_span),
+                            self.sess().source_map().guess_head_span(span),
                             "consider adding a `#[cfg(test)]` to the containing module",
                         );
                     }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -139,7 +139,7 @@ impl<'tcx> ObligationCause<'tcx> {
         ObligationCause { span, body_id: hir::CRATE_HIR_ID, code: Default::default() }
     }
 
-    pub fn span(&self, _tcx: TyCtxt<'tcx>) -> Span {
+    pub fn span(&self) -> Span {
         match *self.code() {
             ObligationCauseCode::MatchExpressionArm(box MatchExpressionArmCause {
                 arm_span,

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -139,13 +139,8 @@ impl<'tcx> ObligationCause<'tcx> {
         ObligationCause { span, body_id: hir::CRATE_HIR_ID, code: Default::default() }
     }
 
-    pub fn span(&self, tcx: TyCtxt<'tcx>) -> Span {
+    pub fn span(&self, _tcx: TyCtxt<'tcx>) -> Span {
         match *self.code() {
-            ObligationCauseCode::CompareImplMethodObligation { .. }
-            | ObligationCauseCode::MainFunctionType
-            | ObligationCauseCode::StartFunctionType => {
-                tcx.sess.source_map().guess_head_span(self.span)
-            }
             ObligationCauseCode::MatchExpressionArm(box MatchExpressionArmCause {
                 arm_span,
                 ..

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1759,8 +1759,7 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
                 || self.tcx.resolutions(()).has_pub_restricted
             {
                 let descr = descr.to_string();
-                let vis_span =
-                    self.tcx.sess.source_map().guess_head_span(self.tcx.def_span(def_id));
+                let vis_span = self.tcx.def_span(def_id);
                 if kind == "trait" {
                     self.tcx.sess.emit_err(InPublicInterfaceTraits {
                         span,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -953,7 +953,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
                 let found_span = found_did
                     .and_then(|did| self.tcx.hir().span_if_local(did))
-                    .map(|sp| self.tcx.sess.source_map().guess_head_span(sp)); // the sp could be an fn def
+                    .map(|sp| self.tcx.sess.source_map().guess_head_span(sp)); // the sp could be a closure
 
                 if self.reported_closure_mismatch.borrow().contains(&(span, found_span)) {
                     // We check closures twice, with obligations flowing in different directions,
@@ -1089,7 +1089,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 kind: hir::ExprKind::Closure(&hir::Closure { body, fn_decl_span, .. }),
                 ..
             }) => (
-                sm.guess_head_span(fn_decl_span),
+                fn_decl_span,
                 hir.body(body)
                     .params
                     .iter()

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -823,10 +823,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
                     ty::PredicateKind::ClosureKind(closure_def_id, closure_substs, kind) => {
                         let found_kind = self.closure_kind(closure_substs).unwrap();
-                        let closure_span =
-                            self.tcx.sess.source_map().guess_head_span(
-                                self.tcx.hir().span_if_local(closure_def_id).unwrap(),
-                            );
+                        let closure_span = self.tcx.def_span(closure_def_id);
                         let mut err = struct_span_err!(
                             self.tcx.sess,
                             closure_span,
@@ -951,9 +948,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     _ => None,
                 };
 
-                let found_span = found_did
-                    .and_then(|did| self.tcx.hir().span_if_local(did))
-                    .map(|sp| self.tcx.sess.source_map().guess_head_span(sp)); // the sp could be a closure
+                let found_span = found_did.and_then(|did| self.tcx.hir().span_if_local(did));
 
                 if self.reported_closure_mismatch.borrow().contains(&(span, found_span)) {
                     // We check closures twice, with obligations flowing in different directions,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1543,7 +1543,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             ty::Generator(..) => "generator",
             _ => "function",
         };
-        let span = self.tcx.sess.source_map().guess_head_span(span);
         let mut err = struct_span_err!(
             self.tcx.sess,
             span,

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -603,7 +603,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                         ),
                         (Err(ErrorHandled::Linted), _) | (_, Err(ErrorHandled::Linted)) => {
                             span_bug!(
-                                obligation.cause.span(self.selcx.tcx()),
+                                obligation.cause.span(),
                                 "ConstEquate: const_eval_resolve returned an unexpected error"
                             )
                         }

--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -84,7 +84,7 @@ impl<'cx, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'cx, 'tcx> {
         // Run canonical query. If overflow occurs, rerun from scratch but this time
         // in standard trait query mode so that overflow is handled appropriately
         // within `SelectionContext`.
-        self.tcx.at(obligation.cause.span(self.tcx)).evaluate_obligation(c_pred)
+        self.tcx.at(obligation.cause.span()).evaluate_obligation(c_pred)
     }
 
     // Helper function that canonicalizes and runs the query. If an

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -742,7 +742,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         | (_, Err(ErrorHandled::Reported(_))) => Ok(EvaluatedToErr),
                         (Err(ErrorHandled::Linted), _) | (_, Err(ErrorHandled::Linted)) => {
                             span_bug!(
-                                obligation.cause.span(self.tcx()),
+                                obligation.cause.span(),
                                 "ConstEquate: const_eval_resolve returned an unexpected error"
                             )
                         }

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1958,11 +1958,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         );
                     }
 
-                    if adt_def.did().is_local() {
-                        err.span_label(
-                            tcx.def_span(adt_def.did()),
-                            format!("variant `{assoc_ident}` not found for this enum"),
-                        );
+                    if let Some(sp) = tcx.hir().span_if_local(adt_def.did()) {
+                        err.span_label(sp, format!("variant `{}` not found here", assoc_ident));
                     }
 
                     err.emit()

--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -1,6 +1,6 @@
 use crate::check::coercion::{AsCoercionSite, CoerceMany};
 use crate::check::{Diverges, Expectation, FnCtxt, Needs};
-use rustc_errors::{Applicability, Diagnostic, MultiSpan};
+use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::{self as hir, ExprKind};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::traits::Obligation;
@@ -127,7 +127,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &cause,
                 Some(&arm.body),
                 arm_ty,
-                Some(&mut |err: &mut Diagnostic| {
+                Some(&mut |err| {
                     let Some(ret) = self.ret_type_span else {
                         return;
                     };

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -437,15 +437,17 @@ fn check_region_bounds_on_impl_item<'tcx>(
     // the moment, give a kind of vague error message.
     if trait_params != impl_params {
         let item_kind = assoc_item_kind_str(impl_m);
-        let def_span = tcx.sess.source_map().guess_head_span(span);
         let span = impl_m
             .def_id
             .as_local()
             .and_then(|did| tcx.hir().get_generics(did))
-            .map_or(def_span, |g| g.span);
-        let generics_span = trait_m.def_id.as_local().map(|did| {
-            let def_sp = tcx.def_span(did);
-            tcx.hir().get_generics(did).map_or(def_sp, |g| g.span)
+            .map_or(span, |g| g.span);
+        let generics_span = tcx.hir().span_if_local(trait_m.def_id).map(|sp| {
+            trait_m
+                .def_id
+                .as_local()
+                .and_then(|did| tcx.hir().get_generics(did))
+                .map_or(sp, |g| g.span)
         });
 
         let reported = tcx.sess.emit_err(LifetimesOrBoundsMismatchOnTrait {

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -298,7 +298,7 @@ fn compare_predicate_entailment<'tcx>(
 
             let mut diag = struct_span_err!(
                 tcx.sess,
-                cause.span(tcx),
+                cause.span(),
                 E0053,
                 "method `{}` has an incompatible type for trait",
                 trait_m.name
@@ -492,7 +492,7 @@ fn extract_spans_for_error_reporting<'a, 'tcx>(
         TypeError::ArgumentSorts(ExpectedFound { .. }, i) => {
             (impl_args.nth(i).unwrap(), trait_args.and_then(|mut args| args.nth(i)))
         }
-        _ => (cause.span(tcx), tcx.hir().span_if_local(trait_m.def_id)),
+        _ => (cause.span(), tcx.hir().span_if_local(trait_m.def_id)),
     }
 }
 

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -183,8 +183,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else if let (ty::FnDef(def_id, ..), true) =
             (&found.kind(), self.suggest_fn_call(err, expr, expected, found))
         {
-            if def_id.is_local() {
-                err.span_label(self.tcx.def_span(def_id), &format!("{} defined here", found));
+            if let Some(sp) = self.tcx.hir().span_if_local(*def_id) {
+                err.span_label(sp, format!("{found} defined here"));
             }
         } else if !self.check_for_cast(err, expr, found, expected, expected_ty_expr) {
             let is_struct_pat_shorthand_field =

--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -621,9 +621,8 @@ fn missing_items_err(
     // adding the associated item at the end of its body.
     let sugg_sp = full_impl_span.with_lo(hi).with_hi(hi);
     // Obtain the level of indentation ending in `sugg_sp`.
-    let indentation = tcx.sess.source_map().span_to_margin(sugg_sp).unwrap_or(0);
-    // Make the whitespace that will make the suggestion have the right indentation.
-    let padding: String = " ".repeat(indentation);
+    let padding =
+        tcx.sess.source_map().indentation_before(sugg_sp).unwrap_or_else(|| String::new());
 
     for trait_item in missing_items {
         let snippet = suggestion_signature(trait_item, tcx);

--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -534,7 +534,7 @@ fn fn_maybe_err(tcx: TyCtxt<'_>, sp: Span, abi: Abi) {
     }
 }
 
-fn maybe_check_static_with_link_section(tcx: TyCtxt<'_>, id: LocalDefId, span: Span) {
+fn maybe_check_static_with_link_section(tcx: TyCtxt<'_>, id: LocalDefId) {
     // Only restricted on wasm target for now
     if !tcx.sess.target.is_like_wasm {
         return;
@@ -560,7 +560,7 @@ fn maybe_check_static_with_link_section(tcx: TyCtxt<'_>, id: LocalDefId, span: S
         let msg = "statics with a custom `#[link_section]` must be a \
                         simple list of bytes on the wasm target with no \
                         extra levels of indirection such as references";
-        tcx.sess.span_err(span, msg);
+        tcx.sess.span_err(tcx.def_span(id), msg);
     }
 }
 

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -1838,7 +1838,7 @@ fn check_false_global_bounds(fcx: &FnCtxt<'_, '_>, mut span: Span, id: hir::HirI
             if let Some(hir::Generics { predicates, .. }) =
                 hir_node.and_then(|node| node.generics())
             {
-                let obligation_span = obligation.cause.span(fcx.tcx);
+                let obligation_span = obligation.cause.span();
 
                 span = predicates
                     .iter()

--- a/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
@@ -76,17 +76,17 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
                 let name = item1.ident(self.tcx).normalize_to_macros_2_0();
                 let mut err = struct_span_err!(
                     self.tcx.sess,
-                    self.tcx.span_of_impl(item1.def_id).unwrap(),
+                    self.tcx.def_span(item1.def_id),
                     E0592,
                     "duplicate definitions with name `{}`",
                     name
                 );
                 err.span_label(
-                    self.tcx.span_of_impl(item1.def_id).unwrap(),
+                    self.tcx.def_span(item1.def_id),
                     format!("duplicate definitions for `{}`", name),
                 );
                 err.span_label(
-                    self.tcx.span_of_impl(item2.def_id).unwrap(),
+                    self.tcx.def_span(item2.def_id),
                     format!("other definition for `{}`", name),
                 );
 

--- a/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.stderr
+++ b/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.stderr
@@ -1,13 +1,8 @@
 error[E0732]: `#[repr(inttype)]` must be specified
   --> $DIR/arbitrary_enum_discriminant-no-repr.rs:4:1
    |
-LL | / enum Enum {
-LL | |
-LL | |   Unit = 1,
-LL | |   Tuple() = 2,
-LL | |   Struct{} = 3,
-LL | | }
-   | |_^
+LL | enum Enum {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/enum/enum-discrim-autosizing.stderr
+++ b/src/test/ui/enum/enum-discrim-autosizing.stderr
@@ -1,16 +1,14 @@
 error[E0081]: discriminant value `0` assigned more than once
   --> $DIR/enum-discrim-autosizing.rs:6:1
    |
-LL | / enum Eu64 {
-LL | |
-LL | |     Au64 = 0,
-   | |            - first assignment of `0`
-LL | |
-LL | |     Bu64 = 0x8000_0000_0000_0000
-   | |            --------------------- second assignment of `0` (overflowed from `9223372036854775808`)
-LL | |
-LL | | }
-   | |_^
+LL | enum Eu64 {
+   | ^^^^^^^^^
+LL |
+LL |     Au64 = 0,
+   |            - first assignment of `0`
+LL |
+LL |     Bu64 = 0x8000_0000_0000_0000
+   |            --------------------- second assignment of `0` (overflowed from `9223372036854775808`)
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0081.stderr
+++ b/src/test/ui/error-codes/E0081.stderr
@@ -1,48 +1,41 @@
 error[E0081]: discriminant value `3` assigned more than once
   --> $DIR/E0081.rs:1:1
    |
-LL | / enum Enum {
-LL | |
-LL | |     P = 3,
-   | |         - first assignment of `3`
-LL | |
-LL | |     X = 3,
-   | |         - second assignment of `3`
-LL | |
-LL | |     Y = 5
-LL | | }
-   | |_^
+LL | enum Enum {
+   | ^^^^^^^^^
+LL |
+LL |     P = 3,
+   |         - first assignment of `3`
+LL |
+LL |     X = 3,
+   |         - second assignment of `3`
 
 error[E0081]: discriminant value `1` assigned more than once
   --> $DIR/E0081.rs:11:1
    |
-LL | / enum EnumOverflowRepr {
-LL | |
-LL | |     P = 257,
-   | |         --- first assignment of `1` (overflowed from `257`)
-LL | |
-LL | |     X = 513,
-   | |         --- second assignment of `1` (overflowed from `513`)
-LL | |
-LL | | }
-   | |_^
+LL | enum EnumOverflowRepr {
+   | ^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |     P = 257,
+   |         --- first assignment of `1` (overflowed from `257`)
+LL |
+LL |     X = 513,
+   |         --- second assignment of `1` (overflowed from `513`)
 
 error[E0081]: discriminant value `-1` assigned more than once
   --> $DIR/E0081.rs:20:1
    |
-LL | / enum NegDisEnum {
-LL | |
-LL | |     First = -1,
-   | |             -- first assignment of `-1`
-LL | |
-LL | |     Second = -2,
-   | |     ----------- assigned discriminant for `Last` was incremented from this discriminant
-LL | |
-LL | |     Last,
-   | |     ---- second assignment of `-1`
-LL | |
-LL | | }
-   | |_^
+LL | enum NegDisEnum {
+   | ^^^^^^^^^^^^^^^
+LL |
+LL |     First = -1,
+   |             -- first assignment of `-1`
+LL |
+LL |     Second = -2,
+   |     ----------- assigned discriminant for `Last` was incremented from this discriminant
+LL |
+LL |     Last,
+   |     ---- second assignment of `-1`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/error-codes/E0084.stderr
+++ b/src/test/ui/error-codes/E0084.stderr
@@ -4,7 +4,7 @@ error[E0084]: unsupported representation for zero-variant enum
 LL | #[repr(i32)]
    | ^^^^^^^^^^^^
 LL | enum Foo {}
-   | ----------- zero-variant enum
+   | -------- zero-variant enum
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0658.stderr
+++ b/src/test/ui/error-codes/E0658.stderr
@@ -1,10 +1,8 @@
 error[E0658]: repr with 128-bit type is unstable
   --> $DIR/E0658.rs:2:1
    |
-LL | / enum Foo {
-LL | |     Bar(u64),
-LL | | }
-   | |_^
+LL | enum Foo {
+   | ^^^^^^^^
    |
    = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
    = help: add `#![feature(repr128)]` to the crate attributes to enable

--- a/src/test/ui/extern/extern-static-size-overflow.stderr
+++ b/src/test/ui/extern/extern-static-size-overflow.stderr
@@ -2,19 +2,19 @@ error: extern static is too large for the current architecture
   --> $DIR/extern-static-size-overflow.rs:38:5
    |
 LL |     static BAZ: [u8; max_size()];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: extern static is too large for the current architecture
   --> $DIR/extern-static-size-overflow.rs:39:5
    |
 LL |     static UWU: [usize; usize::MAX];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: extern static is too large for the current architecture
   --> $DIR/extern-static-size-overflow.rs:40:5
    |
 LL |     static A: ReallyBig;
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-repr128.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr128.stderr
@@ -1,10 +1,8 @@
 error[E0658]: repr with 128-bit type is unstable
   --> $DIR/feature-gate-repr128.rs:2:1
    |
-LL | / enum A {
-LL | |     A(u64)
-LL | | }
-   | |_^
+LL | enum A {
+   | ^^^^^^
    |
    = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
    = help: add `#![feature(repr128)]` to the crate attributes to enable

--- a/src/test/ui/issues/issue-15524.stderr
+++ b/src/test/ui/issues/issue-15524.stderr
@@ -1,53 +1,39 @@
 error[E0081]: discriminant value `1` assigned more than once
   --> $DIR/issue-15524.rs:3:1
    |
-LL | / enum Foo {
-LL | |
-LL | |
-LL | |
-LL | |     A = 1,
-   | |         - first assignment of `1`
-LL | |     B = 1,
-   | |         - second assignment of `1`
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | enum Foo {
+   | ^^^^^^^^
+...
+LL |     A = 1,
+   |         - first assignment of `1`
+LL |     B = 1,
+   |         - second assignment of `1`
 
 error[E0081]: discriminant value `1` assigned more than once
   --> $DIR/issue-15524.rs:3:1
    |
-LL | / enum Foo {
-LL | |
-LL | |
-LL | |
-LL | |     A = 1,
-   | |         - first assignment of `1`
-LL | |     B = 1,
-LL | |     C = 0,
-   | |     ----- assigned discriminant for `D` was incremented from this discriminant
-LL | |     D,
-   | |     - second assignment of `1`
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | enum Foo {
+   | ^^^^^^^^
+...
+LL |     A = 1,
+   |         - first assignment of `1`
+LL |     B = 1,
+LL |     C = 0,
+   |     ----- assigned discriminant for `D` was incremented from this discriminant
+LL |     D,
+   |     - second assignment of `1`
 
 error[E0081]: discriminant value `1` assigned more than once
   --> $DIR/issue-15524.rs:3:1
    |
-LL | / enum Foo {
-LL | |
-LL | |
-LL | |
-LL | |     A = 1,
-   | |         - first assignment of `1`
-...  |
-LL | |     E = N,
-   | |         - second assignment of `1`
-LL | |
-LL | | }
-   | |_^
+LL | enum Foo {
+   | ^^^^^^^^
+...
+LL |     A = 1,
+   |         - first assignment of `1`
+...
+LL |     E = N,
+   |         - second assignment of `1`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-34209.stderr
+++ b/src/test/ui/issues/issue-34209.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant named `B` found for enum `S`
   --> $DIR/issue-34209.rs:7:12
    |
 LL | enum S {
-   | ------ variant `B` not found for this enum
+   | ------ variant `B` not found here
 ...
 LL |         S::B {} => {},
    |            ^ help: there is a variant with a similar name: `A`

--- a/src/test/ui/repr/issue-83505-repr-simd.stderr
+++ b/src/test/ui/repr/issue-83505-repr-simd.stderr
@@ -22,7 +22,7 @@ LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
 ...
 LL | enum Es {}
-   | ---------- zero-variant enum
+   | ------- zero-variant enum
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/repr/repr-transparent.stderr
+++ b/src/test/ui/repr/repr-transparent.stderr
@@ -34,7 +34,7 @@ error[E0084]: unsupported representation for zero-variant enum
 LL | #[repr(transparent)]
    | ^^^^^^^^^^^^^^^^^^^^
 LL | enum Void {}
-   | ------------ zero-variant enum
+   | --------- zero-variant enum
 
 error[E0731]: transparent enum needs exactly one variant, but has 0
   --> $DIR/repr-transparent.rs:45:1

--- a/src/test/ui/statics/uninhabited-static.stderr
+++ b/src/test/ui/statics/uninhabited-static.stderr
@@ -2,7 +2,7 @@ error: static of uninhabited type
   --> $DIR/uninhabited-static.rs:6:5
    |
 LL |     static VOID: Void;
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/uninhabited-static.rs:2:9
@@ -17,7 +17,7 @@ error: static of uninhabited type
   --> $DIR/uninhabited-static.rs:8:5
    |
 LL |     static NEVER: !;
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>

--- a/src/test/ui/suggestions/suggest-variants.stderr
+++ b/src/test/ui/suggestions/suggest-variants.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant named `Squareee` found for enum `Shape`
   --> $DIR/suggest-variants.rs:12:41
    |
 LL | enum Shape {
-   | ---------- variant `Squareee` not found for this enum
+   | ---------- variant `Squareee` not found here
 ...
 LL |     println!("My shape is {:?}", Shape::Squareee { size: 5});
    |                                         ^^^^^^^^ help: there is a variant with a similar name: `Square`
@@ -11,7 +11,7 @@ error[E0599]: no variant named `Circl` found for enum `Shape`
   --> $DIR/suggest-variants.rs:13:41
    |
 LL | enum Shape {
-   | ---------- variant `Circl` not found for this enum
+   | ---------- variant `Circl` not found here
 ...
 LL |     println!("My shape is {:?}", Shape::Circl { size: 5});
    |                                         ^^^^^ help: there is a variant with a similar name: `Circle`
@@ -20,7 +20,7 @@ error[E0599]: no variant named `Rombus` found for enum `Shape`
   --> $DIR/suggest-variants.rs:14:41
    |
 LL | enum Shape {
-   | ---------- variant `Rombus` not found for this enum
+   | ---------- variant `Rombus` not found here
 ...
 LL |     println!("My shape is {:?}", Shape::Rombus{ size: 5});
    |                                         ^^^^^^ variant not found in `Shape`

--- a/src/test/ui/tag-variant-disr-dup.stderr
+++ b/src/test/ui/tag-variant-disr-dup.stderr
@@ -1,17 +1,13 @@
 error[E0081]: discriminant value `0` assigned more than once
   --> $DIR/tag-variant-disr-dup.rs:3:1
    |
-LL | / enum Color {
-LL | |
-LL | |     Red = 0xff0000,
-LL | |     Green = 0x00ff00,
-LL | |     Blue = 0x0000ff,
-LL | |     Black = 0x000000,
-   | |             -------- first assignment of `0`
-LL | |     White = 0x000000,
-   | |             -------- second assignment of `0`
-LL | | }
-   | |_^
+LL | enum Color {
+   | ^^^^^^^^^^
+...
+LL |     Black = 0x000000,
+   |             -------- first assignment of `0`
+LL |     White = 0x000000,
+   |             -------- second assignment of `0`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
+++ b/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
@@ -31,8 +31,12 @@ LL | trait Trait: Sized {}
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-unsafe-trait-obj-match.rs:25:25
    |
-LL |     let t: &dyn Trait = match opt() {
-   |                         ^^^^^^^^^^^ `Trait` cannot be made into an object
+LL |       let t: &dyn Trait = match opt() {
+   |  _________________________^
+LL | |         Some(()) => &S,
+LL | |         None => &R,
+LL | |     };
+   | |_____^ `Trait` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-unsafe-trait-obj-match.rs:6:14


### PR DESCRIPTION
No need to pass things through `guess_head_span` if they already point to the head span.

Only major change is that we point to the head span of `enum`s on some errors now, which I prefer.

r? @cjgillot 