### PR TITLE
Prefer suggestion paths that are not `#[doc(hidden)]`

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -394,9 +394,10 @@ where
     }
 }
 
-impl<A, CTX> HashStable<CTX> for SmallVec<[A; 1]>
+impl<T, CTX, const N: usize> HashStable<CTX> for SmallVec<[T; N]>
 where
-    A: HashStable<CTX>,
+    [T; N]: smallvec::Array,
+    <[T; N] as smallvec::Array>::Item: HashStable<CTX>,
 {
     #[inline]
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -369,7 +369,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 let depr_attr = &depr_entry.attr;
                 if !skip || depr_attr.is_since_rustc_version {
                     // Calculating message for lint involves calling `self.def_path_str`.
-                    // Which by default to calculate visible path will invoke expensive `visible_parent_map` query.
+                    // Which by default to calculate visible path will invoke expensive `visible_parents_map` query.
                     // So we skip message calculation altogether, if lint is allowed.
                     let is_in_effect = deprecation_in_effect(depr_attr);
                     let lint = deprecation_lint(is_in_effect);

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1668,9 +1668,12 @@ rustc_queries! {
         desc { "calculating the missing lang items in a crate" }
         separate_provide_extern
     }
-    query visible_parent_map(_: ()) -> DefIdMap<DefId> {
+    query visible_parents_map(_: ()) -> DefIdMap<smallvec::SmallVec<[(DefId, Symbol); 4]>> {
         storage(ArenaCacheSelector<'tcx>)
         desc { "calculating the visible parent map" }
+    }
+    query best_visible_parent(def_id: DefId) -> Option<DefId> {
+        desc { |tcx| "computing the best visible parent for `{}`", tcx.def_path_str(def_id) }
     }
     query trimmed_def_paths(_: ()) -> FxHashMap<DefId, Symbol> {
         storage(ArenaCacheSelector<'tcx>)

--- a/src/test/ui/proc-macro/issue-37788.rs
+++ b/src/test/ui/proc-macro/issue-37788.rs
@@ -4,6 +4,6 @@
 extern crate test_macros;
 
 fn main() {
-    // Test that constructing the `visible_parent_map` (in `cstore_impl.rs`) does not ICE.
+    // Test that constructing the `visible_parents_map` (in `cstore_impl.rs`) does not ICE.
     std::cell::Cell::new(0) //~ ERROR mismatched types
 }

--- a/src/test/ui/proc-macro/issue-37788.stderr
+++ b/src/test/ui/proc-macro/issue-37788.stderr
@@ -3,7 +3,7 @@ error[E0308]: mismatched types
    |
 LL | fn main() {
    |           - expected `()` because of default return type
-LL |     // Test that constructing the `visible_parent_map` (in `cstore_impl.rs`) does not ICE.
+LL |     // Test that constructing the `visible_parents_map` (in `cstore_impl.rs`) does not ICE.
 LL |     std::cell::Cell::new(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^- help: consider using a semicolon here: `;`
    |     |

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/auxiliary/other_crate.rs
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/auxiliary/other_crate.rs
@@ -1,0 +1,8 @@
+#![crate_type = "lib"]
+
+extern crate core;
+
+#[doc(hidden)]
+pub mod __private {
+    pub use core::option::Option::{self, None, Some};
+}

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.rs
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.rs
@@ -1,0 +1,7 @@
+// aux-build:other_crate.rs
+
+extern crate other_crate;
+
+fn main() {
+    let x: Option<i32> = 1i32; //~ ERROR 6:26: 6:30: mismatched types [E0308]
+}

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
@@ -2,14 +2,16 @@ error[E0308]: mismatched types
   --> $DIR/dont-suggest-doc-hidden-variant-for-enum.rs:6:26
    |
 LL |     let x: Option<i32> = 1i32;
-   |            -----------   ^^^^
-   |            |             |
-   |            |             expected enum `Option`, found `i32`
-   |            |             help: try using a variant of the expected enum: `Some(1i32)`
+   |            -----------   ^^^^ expected enum `Option`, found `i32`
+   |            |
    |            expected due to this
    |
    = note: expected enum `Option<i32>`
               found type `i32`
+help: try wrapping the expression in `Some`
+   |
+LL |     let x: Option<i32> = Some(1i32);
+   |                          +++++    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-doc-hidden-variant-for-enum.rs:6:26
+   |
+LL |     let x: Option<i32> = 1i32;
+   |            -----------   ^^^^
+   |            |             |
+   |            |             expected enum `Option`, found `i32`
+   |            |             help: try using a variant of the expected enum: `Some(1i32)`
+   |            expected due to this
+   |
+   = note: expected enum `Option<i32>`
+              found type `i32`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This is a revival of #87349

Maybe we don't even need to make it this complicated? I guess I could also just insert children that have `doc_hidden` parents using the same `fallback_map` I added a while back to filter out `use ... as _;` imports.