### PR TITLE
Proper macOS libLLVM symlink when cross compiling

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -487,16 +487,14 @@ impl Step for Llvm {
             let version = output(cmd.arg("--version"));
             let major = version.split('.').next().unwrap();
             let lib_name = match llvm_version_suffix {
-                Some(s) => format!("lib/libLLVM-{}{}.dylib", major, s),
-                None => format!("lib/libLLVM-{}.dylib", major),
+                Some(s) => format!("libLLVM-{}{}.dylib", major, s),
+                None => format!("libLLVM-{}.dylib", major),
             };
 
-            // The reason why we build the library path from llvm-config is because
-            // the output of llvm-config depends on its location in the file system.
-            // Make sure we create the symlink exactly where it's needed.
-            let llvm_base = build_llvm_config.parent().unwrap().parent().unwrap();
-            let lib_llvm = llvm_base.join(lib_name);
-            t!(builder.symlink_file("libLLVM.dylib", &lib_llvm));
+            let lib_llvm = out_dir.join("build").join("lib").join(lib_name);
+            if !lib_llvm.exists() {
+                t!(builder.symlink_file("libLLVM.dylib", &lib_llvm));
+            }
         }
 
         t!(stamp.write());


### PR DESCRIPTION
Follow up of #98418

When cross compiling on macOS with `llvm.link-shared` enabled, the symlink creation will fail after compiling LLVM for the target architecture, because it will attempt to create the symlink in the host LLVM directory, which was already created when being built.

This commit changes the symlink path to the actual LLVM output.

r? @jyn514 