### PR TITLE
incr.comp.: Make split-dwarf commandline options [TRACKED].

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2724,8 +2724,8 @@ pub(crate) mod dep_tracking {
     use super::{
         BranchProtection, CFGuard, CFProtection, CrateType, DebugInfo, ErrorOutputType,
         InstrumentCoverage, LdImpl, LinkerPluginLto, LocationDetail, LtoCli, OomStrategy, OptLevel,
-        OutputType, OutputTypes, Passes, SourceFileHashAlgorithm, SwitchWithOptPath,
-        SymbolManglingVersion, TrimmedDefPaths,
+        OutputType, OutputTypes, Passes, SourceFileHashAlgorithm, SplitDwarfKind,
+        SwitchWithOptPath, SymbolManglingVersion, TrimmedDefPaths,
     };
     use crate::lint;
     use crate::options::WasiExecModel;
@@ -2812,6 +2812,7 @@ pub(crate) mod dep_tracking {
         Edition,
         LinkerPluginLto,
         SplitDebuginfo,
+        SplitDwarfKind,
         StackProtector,
         SwitchWithOptPath,
         SymbolManglingVersion,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1496,7 +1496,7 @@ options! {
         "control if mem::uninitialized and mem::zeroed panic on more UB"),
     strip: Strip = (Strip::None, parse_strip, [UNTRACKED],
         "tell the linker which information to strip (`none` (default), `debuginfo` or `symbols`)"),
-    split_dwarf_kind: SplitDwarfKind = (SplitDwarfKind::Split, parse_split_dwarf_kind, [UNTRACKED],
+    split_dwarf_kind: SplitDwarfKind = (SplitDwarfKind::Split, parse_split_dwarf_kind, [TRACKED],
         "split dwarf variant (only if -Csplit-debuginfo is enabled and on relevant platform)
         (default: `split`)
 
@@ -1504,7 +1504,7 @@ options! {
                  file which is ignored by the linker
         `single`: sections which do not require relocation are written into object file but ignored
                   by the linker"),
-    split_dwarf_inlining: bool = (true, parse_bool, [UNTRACKED],
+    split_dwarf_inlining: bool = (true, parse_bool, [TRACKED],
         "provide minimal debug info in the object/executable to facilitate online \
          symbolication/stack traces in the absence of .dwo/.dwp files when using Split DWARF"),
     symbol_mangling_version: Option<SymbolManglingVersion> = (None,

--- a/src/test/incremental/split_debuginfo_mode.rs
+++ b/src/test/incremental/split_debuginfo_mode.rs
@@ -1,0 +1,33 @@
+// This test case makes sure that changing split-debuginfo commandline options triggers a full re-compilation.
+// We only test on x86_64-unknown-linux-gnu because there all combinations split-debuginfo settings are valid
+// and the test is platform-independent otherwise.
+
+// ignore-tidy-linelength
+// only-x86_64-unknown-linux-gnu
+// revisions:rpass1 rpass2 rpass3 rpass4
+
+// [rpass1]compile-flags: -Zquery-dep-graph -Zunstable-options -Csplit-debuginfo=unpacked -Zsplit-dwarf-kind=single -Zsplit-dwarf-inlining=on
+// [rpass2]compile-flags: -Zquery-dep-graph -Zunstable-options -Csplit-debuginfo=packed -Zsplit-dwarf-kind=single -Zsplit-dwarf-inlining=on
+// [rpass3]compile-flags: -Zquery-dep-graph -Zunstable-options -Csplit-debuginfo=packed -Zsplit-dwarf-kind=split -Zsplit-dwarf-inlining=on
+// [rpass4]compile-flags: -Zquery-dep-graph -Zunstable-options -Csplit-debuginfo=packed -Zsplit-dwarf-kind=split -Zsplit-dwarf-inlining=off
+
+#![feature(rustc_attrs)]
+// For rpass2 we change -Csplit-debuginfo and thus expect every CGU to be recompiled
+#![rustc_partition_codegened(module = "split_debuginfo_mode", cfg = "rpass2")]
+#![rustc_partition_codegened(module = "split_debuginfo_mode-another_module", cfg = "rpass2")]
+// For rpass3 we change -Zsplit-dwarf-kind and thus also expect every CGU to be recompiled
+#![rustc_partition_codegened(module = "split_debuginfo_mode", cfg = "rpass3")]
+#![rustc_partition_codegened(module = "split_debuginfo_mode-another_module", cfg = "rpass3")]
+// For rpass4 we change -Zsplit-dwarf-inlining and thus also expect every CGU to be recompiled
+#![rustc_partition_codegened(module = "split_debuginfo_mode", cfg = "rpass4")]
+#![rustc_partition_codegened(module = "split_debuginfo_mode-another_module", cfg = "rpass4")]
+
+mod another_module {
+    pub fn foo() -> &'static str {
+        "hello world"
+    }
+}
+
+pub fn main() {
+    println!("{}", another_module::foo());
+}


### PR DESCRIPTION
This commandline options have an influence on the contents of object files (and .dwo files), so they need to be `[TRACKED]`.

r? @davidtwco 