### PR TITLE
respect CARGO_PKG_RUST_VERSION when issuing deprecation warnings

### DIFF
--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -126,14 +126,19 @@ pub fn deprecation_in_effect(depr: &Deprecation) -> bool {
             return false;
         }
 
+        let since: Vec<u32> = parse_version(&since);
+        // We simply treat invalid `since` attributes as relating to a previous
+        // Rust version, thus always displaying the warning.
+        if since.len() != 3 {
+            return true;
+        }
+
+        if let Ok(cargo_rust_version) = std::env::var("CARGO_PKG_RUST_VERSION") && !cargo_rust_version.is_empty() {
+            let parsed = parse_version(&cargo_rust_version);
+            return since <= parsed;
+        }
         if let Some(rustc) = option_env!("CFG_RELEASE") {
-            let since: Vec<u32> = parse_version(&since);
             let rustc: Vec<u32> = parse_version(rustc);
-            // We simply treat invalid `since` attributes as relating to a previous
-            // Rust version, thus always displaying the warning.
-            if since.len() != 3 {
-                return true;
-            }
             return since <= rustc;
         }
     };

--- a/src/test/ui/deprecation/respect-rust-version.rs
+++ b/src/test/ui/deprecation/respect-rust-version.rs
@@ -1,0 +1,6 @@
+// check-pass
+// rustc-env:CARGO_PKG_RUST_VERSION=1.28.0
+
+fn main() {
+    let _ = std::env::home_dir();
+}


### PR DESCRIPTION
you can specify the `rust-version`[0] in `Cargo.toml` file.
If you specify that, we should not emit a deprecated warning.
Reason for this is, that code will be sprinkled with
`#[allow(deprecated)]` and maybe be forgotten in the future, so
deprecated items will be used.
If you specify the `rust-version` field, no such deprecation warning
should be emitted, unless you upgrade your msrv.

[0]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

---

This might not be the perfect solution, yet, but I'd like to have this in rust because of the reasons metioned above. Any feedback is welcome.