### PR TITLE
bootstrap.py: Always use `.exe` for Windows

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -152,7 +152,7 @@ def run(args, verbose=False, exception=False, is_bootstrap=False, **kwargs):
     if verbose:
         print("running: " + ' '.join(args))
     sys.stdout.flush()
-    # Ensure that the .exe is used on Windoows just in case a Linux ELF has been
+    # Ensure that the .exe is used on Windows just in case a Linux ELF has been
     # compiled in the same directory.
     if os.name == 'nt' and not args[0].endswith('.exe'):
         args[0] += '.exe'

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -152,6 +152,10 @@ def run(args, verbose=False, exception=False, is_bootstrap=False, **kwargs):
     if verbose:
         print("running: " + ' '.join(args))
     sys.stdout.flush()
+    # Ensure that the .exe is used on Windoows just in case a Linux ELF has been
+    # compiled in the same directory.
+    if os.name == 'nt' and not args[0].endswith('.exe'):
+        args[0] += '.exe'
     # Use Popen here instead of call() as it apparently allows powershell on
     # Windows to not lock up waiting for input presumably.
     ret = subprocess.Popen(args, **kwargs)


### PR DESCRIPTION
This ensures that it will run the Windows executable if other files in the directory (such as Linux executables) have the same file name minus the extension. I've been tripped up by this a few times where both `bootstrap` and `bootstrap.exe` end up in the same directory.

This PR avoids ever having to see the following message:

`OSError: [WinError 193] %1 is not a valid Win32 application`
