### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/constraint_generation.rs
+++ b/compiler/rustc_borrowck/src/constraint_generation.rs
@@ -149,7 +149,7 @@ impl<'cg, 'cx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'tcx> {
     fn visit_ascribe_user_ty(
         &mut self,
         _place: &Place<'tcx>,
-        _variance: &ty::Variance,
+        _variance: ty::Variance,
         _user_ty: &UserTypeProjection,
         _location: Location,
     ) {

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2212,7 +2212,9 @@ fn add_local_native_libraries(
             NativeLibKind::Dylib { as_needed } => {
                 cmd.link_dylib(name, verbatim, as_needed.unwrap_or(true))
             }
-            NativeLibKind::Unspecified => cmd.link_dylib(name, verbatim, true),
+            NativeLibKind::RawDylib | NativeLibKind::Unspecified => {
+                cmd.link_dylib(name, verbatim, true)
+            }
             NativeLibKind::Framework { as_needed } => {
                 cmd.link_framework(name, as_needed.unwrap_or(true))
             }
@@ -2232,10 +2234,6 @@ fn add_local_native_libraries(
                 } else {
                     cmd.link_staticlib(name, verbatim)
                 }
-            }
-            NativeLibKind::RawDylib => {
-                // FIXME(#58713): Proper handling for raw dylibs.
-                bug!("raw_dylib feature not yet implemented");
             }
         }
     }

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -21,6 +21,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(trusted_step)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
+#![feature(is_some_with)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -990,11 +990,19 @@ pub enum Rvalue<'tcx> {
     ///   matching types and return a value of that type.
     BinaryOp(BinOp, Box<(Operand<'tcx>, Operand<'tcx>)>),
 
-    /// Same as `BinaryOp`, but yields `(T, bool)` instead of `T`. In addition to performing the
-    /// same computation as the matching `BinaryOp`, checks if the infinite precison result would be
-    /// unequal to the actual result and sets the `bool` if this is the case.
+    /// Same as `BinaryOp`, but yields `(T, bool)` with a `bool` indicating an error condition.
     ///
-    /// This only supports addition, subtraction, multiplication, and shift operations on integers.
+    /// When overflow checking is disabled, the error condition is false. Otherwise, the error
+    /// condition is determined as described below.
+    ///
+    /// For addition, subtraction, and multiplication on integers the error condition is set when
+    /// the infinite precision result would be unequal to the actual result.
+    ///
+    /// For shift operations on integers the error condition is set when the value of right-hand
+    /// side is greater than or equal to the number of bits in the type of the left-hand side, or
+    /// when the value of right-hand side is negative.
+    ///
+    /// Other combinations of types and operators are unsupported.
     CheckedBinaryOp(BinOp, Box<(Operand<'tcx>, Operand<'tcx>)>),
 
     /// Computes a value as described by the operation.

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -311,6 +311,7 @@ pub enum StatementKind<'tcx> {
 
 /// Describes what kind of retag is to be performed.
 #[derive(Copy, Clone, TyEncodable, TyDecodable, Debug, PartialEq, Eq, Hash, HashStable)]
+#[rustc_pass_by_value]
 pub enum RetagKind {
     /// The initial retag when entering a function.
     FnEntry,

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -147,7 +147,7 @@ macro_rules! make_mir_visitor {
             fn visit_ascribe_user_ty(
                 &mut self,
                 place: & $($mutability)? Place<'tcx>,
-                variance: & $($mutability)? ty::Variance,
+                variance: $(& $mutability)? ty::Variance,
                 user_ty: & $($mutability)? UserTypeProjection,
                 location: Location,
             ) {
@@ -164,7 +164,7 @@ macro_rules! make_mir_visitor {
 
             fn visit_retag(
                 &mut self,
-                kind: & $($mutability)? RetagKind,
+                kind: $(& $mutability)? RetagKind,
                 place: & $($mutability)? Place<'tcx>,
                 location: Location,
             ) {
@@ -425,7 +425,7 @@ macro_rules! make_mir_visitor {
                 self.visit_source_info(source_info);
                 match kind {
                     StatementKind::Assign(
-                        box(ref $($mutability)? place, ref $($mutability)? rvalue)
+                        box (place, rvalue)
                     ) => {
                         self.visit_assign(place, rvalue, location);
                     }
@@ -465,13 +465,13 @@ macro_rules! make_mir_visitor {
                         );
                     }
                     StatementKind::Retag(kind, place) => {
-                        self.visit_retag(kind, place, location);
+                        self.visit_retag($(& $mutability)? *kind, place, location);
                     }
                     StatementKind::AscribeUserType(
-                        box(ref $($mutability)? place, ref $($mutability)? user_ty),
+                        box (place, user_ty),
                         variance
                     ) => {
-                        self.visit_ascribe_user_ty(place, variance, user_ty, location);
+                        self.visit_ascribe_user_ty(place, $(& $mutability)? *variance, user_ty, location);
                     }
                     StatementKind::Coverage(coverage) => {
                         self.visit_coverage(
@@ -480,9 +480,9 @@ macro_rules! make_mir_visitor {
                         )
                     }
                     StatementKind::CopyNonOverlapping(box crate::mir::CopyNonOverlapping{
-                      ref $($mutability)? src,
-                      ref $($mutability)? dst,
-                      ref $($mutability)? count,
+                        src,
+                        dst,
+                        count,
                     }) => {
                       self.visit_operand(src, location);
                       self.visit_operand(dst, location);
@@ -517,8 +517,7 @@ macro_rules! make_mir_visitor {
                     TerminatorKind::GeneratorDrop |
                     TerminatorKind::Unreachable |
                     TerminatorKind::FalseEdge { .. } |
-                    TerminatorKind::FalseUnwind { .. } => {
-                    }
+                    TerminatorKind::FalseUnwind { .. } => {}
 
                     TerminatorKind::Return => {
                         // `return` logically moves from the return place `_0`. Note that the place
@@ -830,7 +829,7 @@ macro_rules! make_mir_visitor {
 
             fn super_ascribe_user_ty(&mut self,
                                      place: & $($mutability)? Place<'tcx>,
-                                     _variance: & $($mutability)? ty::Variance,
+                                     _variance: $(& $mutability)? ty::Variance,
                                      user_ty: & $($mutability)? UserTypeProjection,
                                      location: Location) {
                 self.visit_place(
@@ -847,7 +846,7 @@ macro_rules! make_mir_visitor {
             }
 
             fn super_retag(&mut self,
-                           _kind: & $($mutability)? RetagKind,
+                           _kind: $(& $mutability)? RetagKind,
                            place: & $($mutability)? Place<'tcx>,
                            location: Location) {
                 self.visit_place(

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1495,6 +1495,15 @@ impl<'a> Resolver<'a> {
             err.help("have you added the `#[macro_use]` on the module/import?");
             return;
         }
+        if ident.name == kw::Default
+            && let ModuleKind::Def(DefKind::Enum, def_id, _) = parent_scope.module.kind
+            && let Some(span) = self.opt_span(def_id)
+        {
+            err.span_help(
+                self.session.source_map().guess_head_span(span),
+                "consider adding `#[derive(Default)]` to this enum",
+            );
+        }
         for ns in [Namespace::MacroNS, Namespace::TypeNS, Namespace::ValueNS] {
             if let Ok(binding) = self.early_resolve_ident_in_lexical_scope(
                 ident,

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -599,6 +599,7 @@ impl UnifyKey for FloatVid {
 }
 
 #[derive(Copy, Clone, PartialEq, Decodable, Encodable, Hash)]
+#[rustc_pass_by_value]
 pub enum Variance {
     Covariant,     // T<A> <: T<B> iff A <: B -- e.g., function return type
     Invariant,     // T<A> <: T<B> iff B == A -- e.g., type of mutable cell

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -7,6 +7,7 @@ use crate::io::prelude::*;
 
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
+use crate::iter::FusedIterator;
 use crate::net::{Shutdown, SocketAddr, ToSocketAddrs};
 use crate::sys_common::net as net_imp;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
@@ -1009,6 +1010,9 @@ impl<'a> Iterator for Incoming<'a> {
     }
 }
 
+#[stable(feature = "tcp_listener_incoming_fused_iterator", since = "1.63.0")]
+impl FusedIterator for Incoming<'_> {}
+
 #[unstable(feature = "tcplistener_into_incoming", issue = "88339")]
 impl Iterator for IntoIncoming {
     type Item = io::Result<TcpStream>;
@@ -1016,6 +1020,9 @@ impl Iterator for IntoIncoming {
         Some(self.listener.accept().map(|p| p.0))
     }
 }
+
+#[unstable(feature = "tcplistener_into_incoming", issue = "88339")]
+impl FusedIterator for IntoIncoming {}
 
 impl AsInner<net_imp::TcpListener> for TcpListener {
     fn as_inner(&self) -> &net_imp::TcpListener {

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -1010,7 +1010,7 @@ impl<'a> Iterator for Incoming<'a> {
     }
 }
 
-#[stable(feature = "tcp_listener_incoming_fused_iterator", since = "1.63.0")]
+#[stable(feature = "tcp_listener_incoming_fused_iterator", since = "1.64.0")]
 impl FusedIterator for Incoming<'_> {}
 
 #[unstable(feature = "tcplistener_into_incoming", issue = "88339")]

--- a/src/test/run-make/raw-dylib-c/Makefile
+++ b/src/test/run-make/raw-dylib-c/Makefile
@@ -16,10 +16,13 @@ else
 endif
 	$(RUSTC) --crate-type lib --crate-name raw_dylib_test lib.rs
 	$(RUSTC) --crate-type bin driver.rs -L "$(TMPDIR)"
+	$(RUSTC) --crate-type bin --crate-name raw_dylib_test_bin lib.rs
 	"$(TMPDIR)"/driver > "$(TMPDIR)"/output.txt
+	"$(TMPDIR)"/raw_dylib_test_bin > "$(TMPDIR)"/output_bin.txt
 
 ifdef RUSTC_BLESS_TEST
 	cp "$(TMPDIR)"/output.txt output.txt
 else
 	$(DIFF) output.txt "$(TMPDIR)"/output.txt
+	$(DIFF) output.txt "$(TMPDIR)"/output_bin.txt
 endif

--- a/src/test/run-make/raw-dylib-c/lib.rs
+++ b/src/test/run-make/raw-dylib-c/lib.rs
@@ -20,3 +20,7 @@ pub fn library_function() {
         extern_fn_3();
     }
 }
+
+fn main() {
+    library_function();
+}

--- a/src/test/ui/enum/suggest-default-attribute.rs
+++ b/src/test/ui/enum/suggest-default-attribute.rs
@@ -1,0 +1,8 @@
+pub enum Test { //~ HELP consider adding `#[derive(Default)]` to this enum
+    #[default]
+    //~^ ERROR cannot find attribute `default` in this scope
+    First,
+    Second,
+}
+
+fn main() {}

--- a/src/test/ui/enum/suggest-default-attribute.stderr
+++ b/src/test/ui/enum/suggest-default-attribute.stderr
@@ -1,0 +1,14 @@
+error: cannot find attribute `default` in this scope
+  --> $DIR/suggest-default-attribute.rs:2:7
+   |
+LL |     #[default]
+   |       ^^^^^^^
+   |
+help: consider adding `#[derive(Default)]` to this enum
+  --> $DIR/suggest-default-attribute.rs:1:1
+   |
+LL | pub enum Test {
+   | ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/specialization/min_specialization/repeated_projection_type.stderr
+++ b/src/test/ui/specialization/min_specialization/repeated_projection_type.stderr
@@ -1,8 +1,8 @@
-error: cannot specialize on `Binder(ProjectionPredicate(ProjectionTy { substs: [V], item_def_id: DefId(0:6 ~ repeated_projection_type[54ea]::Id::This) }, Ty((I,))), [])`
-  --> $DIR/repeated_projection_type.rs:19:1
+error: cannot specialize on associated type `<V as Id>::This == (I,)`
+  --> $DIR/repeated_projection_type.rs:19:15
    |
 LL | impl<I, V: Id<This = (I,)>> X for V {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/specialization/min_specialization/spec-marker-supertraits.stderr
+++ b/src/test/ui/specialization/min_specialization/spec-marker-supertraits.stderr
@@ -1,8 +1,8 @@
 error: cannot specialize on trait `HasMethod`
-  --> $DIR/spec-marker-supertraits.rs:22:1
+  --> $DIR/spec-marker-supertraits.rs:22:9
    |
 LL | impl<T: Marker> Spec for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/specialization/min_specialization/specialization_super_trait.stderr
+++ b/src/test/ui/specialization/min_specialization/specialization_super_trait.stderr
@@ -1,8 +1,8 @@
 error: cannot specialize on trait `Default`
-  --> $DIR/specialization_super_trait.rs:13:1
+  --> $DIR/specialization_super_trait.rs:13:9
    |
 LL | impl<T: Default> SpecMarker for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/specialization/min_specialization/specialization_trait.stderr
+++ b/src/test/ui/specialization/min_specialization/specialization_trait.stderr
@@ -11,10 +11,10 @@ LL | impl<T> SpecMarker for (T, T) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cannot specialize on trait `Clone`
-  --> $DIR/specialization_trait.rs:21:1
+  --> $DIR/specialization_trait.rs:21:9
    |
 LL | impl<T: Clone> SpecMarker for [T] {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/specialization/min_specialization/specialize_on_trait.stderr
+++ b/src/test/ui/specialization/min_specialization/specialize_on_trait.stderr
@@ -1,8 +1,8 @@
 error: cannot specialize on trait `SpecMarker`
-  --> $DIR/specialize_on_trait.rs:15:1
+  --> $DIR/specialize_on_trait.rs:15:9
    |
 LL | impl<T: SpecMarker> X for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/suggest-on-bare-closure-call.rs
+++ b/src/test/ui/suggestions/suggest-on-bare-closure-call.rs
@@ -1,4 +1,11 @@
+// edition:2021
+
+#![feature(async_closure)]
+
 fn main() {
     let _ = ||{}();
+    //~^ ERROR expected function, found `()`
+
+    let _ = async ||{}();
     //~^ ERROR expected function, found `()`
 }

--- a/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
+++ b/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
@@ -1,5 +1,5 @@
 error[E0618]: expected function, found `()`
-  --> $DIR/suggest-on-bare-closure-call.rs:2:15
+  --> $DIR/suggest-on-bare-closure-call.rs:6:15
    |
 LL |     let _ = ||{}();
    |               ^^--
@@ -11,6 +11,19 @@ help: if you meant to create this closure and immediately call it, surround the 
 LL |     let _ = (||{})();
    |             +    +
 
-error: aborting due to previous error
+error[E0618]: expected function, found `()`
+  --> $DIR/suggest-on-bare-closure-call.rs:9:21
+   |
+LL |     let _ = async ||{}();
+   |                     ^^--
+   |                     |
+   |                     call expression requires function
+   |
+help: if you meant to create this closure and immediately call it, surround the closure with parentheses
+   |
+LL |     let _ = (async ||{})();
+   |             +          +
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0618`.


### PR DESCRIPTION
Successful merges:

 - #97300 (Implement `FusedIterator` for `std::net::[Into]Incoming`)
 - #98738 (Clarify MIR semantics of checked binary operations)
 - #98778 (Enable raw-dylib for bin crates)
 - #98782 (Improve spans for specialization error)
 - #98847 (fix interpreter validity check on Box)
 - #98873 (Suggest `#[derive(Default)]` to enums with `#[default]`)
 - #98878 (add more `rustc_pass_by_value`)
 - #98879 (Fix "wrap closure in parenthesis" suggestion for `async` closure)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97300,98738,98778,98782,98847,98873,98878,98879)
<!-- homu-ignore:end -->