### PR TITLE
rustdoc: filter '_ lifetimes from ty::Generics

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -629,6 +629,7 @@ fn clean_ty_generics<'tcx>(
         .params
         .iter()
         .filter_map(|param| match param.kind {
+            ty::GenericParamDefKind::Lifetime if param.name == kw::UnderscoreLifetime => None,
             ty::GenericParamDefKind::Lifetime => Some(param.clean(cx)),
             ty::GenericParamDefKind::Type { synthetic, .. } => {
                 if param.name == kw::SelfUpper {

--- a/src/test/rustdoc/auxiliary/issue-98697-reexport-with-anonymous-lifetime.rs
+++ b/src/test/rustdoc/auxiliary/issue-98697-reexport-with-anonymous-lifetime.rs
@@ -7,3 +7,11 @@ where
 {
     unimplemented!()
 }
+
+pub struct Extra;
+
+pub trait MyTrait<T> {
+    fn run() {}
+}
+
+impl MyTrait<&Extra> for Extra {}

--- a/src/test/rustdoc/issue-98697.rs
+++ b/src/test/rustdoc/issue-98697.rs
@@ -11,3 +11,7 @@ extern crate issue_98697_reexport_with_anonymous_lifetime;
 // @has issue_98697/fn.repro.html '//pre[@class="rust fn"]/code' 'fn repro<F>() where F: Fn(&str)'
 // @!has issue_98697/fn.repro.html '//pre[@class="rust fn"]/code' 'for<'
 pub use issue_98697_reexport_with_anonymous_lifetime::repro;
+
+// @has issue_98697/struct.Extra.html '//div[@id="trait-implementations-list"]//h3[@class="code-header in-band"]' 'impl MyTrait<&Extra> for Extra'
+// @!has issue_98697/struct.Extra.html '//div[@id="trait-implementations-list"]//h3[@class="code-header in-band"]' 'impl<'
+pub use issue_98697_reexport_with_anonymous_lifetime::Extra;


### PR DESCRIPTION
Fixes a weirdly-rendered section of the std::string::String docs.

Before:

![image](https://user-images.githubusercontent.com/1593513/177256873-20b9cf6e-2429-4865-853b-b269d74672f4.png)

After:

![image](https://user-images.githubusercontent.com/1593513/177256900-ef3efd17-f624-40c5-af90-fe709ec034f2.png)
