### PR TITLE
Return a FxIndexSet in is_late_bound query.

### DIFF
--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -96,6 +96,7 @@ macro_rules! arena_types {
             // (during lowering) and the `librustc_middle` arena (for decoding MIR)
             [decode] asm_template: rustc_ast::InlineAsmTemplatePiece,
             [decode] used_trait_imports: rustc_data_structures::fx::FxHashSet<rustc_hir::def_id::LocalDefId>,
+            [decode] is_late_bound_map: rustc_data_structures::fx::FxIndexSet<rustc_hir::def_id::LocalDefId>,
             [decode] impl_source: rustc_middle::traits::ImplSource<'tcx, ()>,
 
             [] dep_kind: rustc_middle::dep_graph::DepKindStruct,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1573,7 +1573,7 @@ rustc_queries! {
         Option<&'tcx FxHashMap<ItemLocalId, Region>> {
         desc { "looking up a named region" }
     }
-    query is_late_bound_map(_: LocalDefId) -> Option<&'tcx FxHashSet<LocalDefId>> {
+    query is_late_bound_map(_: LocalDefId) -> Option<&'tcx FxIndexSet<LocalDefId>> {
         desc { "testing if a region is late bound" }
     }
     /// For a given item (like a struct), gets the default lifetimes to be used

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -2539,12 +2539,12 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 /// "Constrained" basically means that it appears in any type but
 /// not amongst the inputs to a projection. In other words, `<&'a
 /// T as Trait<''b>>::Foo` does not constrain `'a` or `'b`.
-fn is_late_bound_map(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<&FxHashSet<LocalDefId>> {
+fn is_late_bound_map(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<&FxIndexSet<LocalDefId>> {
     let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
     let decl = tcx.hir().fn_decl_by_hir_id(hir_id)?;
     let generics = tcx.hir().get_generics(def_id)?;
 
-    let mut late_bound = FxHashSet::default();
+    let mut late_bound = FxIndexSet::default();
 
     let mut constrained_by_input = ConstrainedCollector::default();
     for arg_ty in decl.inputs {

--- a/src/test/incremental/async-lifetimes.rs
+++ b/src/test/incremental/async-lifetimes.rs
@@ -1,6 +1,8 @@
 // revisions: rpass1 rpass2
 // edition:2021
 
+// See https://github.com/rust-lang/rust/issues/98890
+
 #![allow(unused)]
 
 struct Foo;

--- a/src/test/incremental/async-lifetimes.rs
+++ b/src/test/incremental/async-lifetimes.rs
@@ -1,0 +1,17 @@
+// revisions: rpass1 rpass2
+// edition:2021
+
+#![allow(unused)]
+
+struct Foo;
+
+impl Foo {
+    async fn f(&self, _: &&()) -> &() {
+        &()
+    }
+}
+
+#[cfg(rpass2)]
+enum Bar {}
+
+fn main() {}


### PR DESCRIPTION
This return value is iterated upon by borrowck, hence the need to preserve
a deterministic iteration order.

Fixes https://github.com/rust-lang/rust/issues/98890
Affects https://github.com/rust-lang/rust/issues/96655

I don't know if this supersedes https://github.com/rust-lang/rust/pull/98924 or fixes an unrelated bug.

r? @michaelwoerister 
This may deserve a backport.