### PR TITLE
add `BorrowedBuf::buf*` accessor functions for getting the original buffer

### DIFF
--- a/library/std/src/io/readbuf.rs
+++ b/library/std/src/io/readbuf.rs
@@ -246,4 +246,25 @@ impl<'a> ReadBuf<'a> {
     pub fn initialized_len(&self) -> usize {
         self.initialized
     }
+
+    /// Returns the buffer
+    #[inline]
+    pub fn buf(&self) -> &[MaybeUninit<u8>] {
+        &*self.buf
+    }
+
+    /// Returns the buffer
+    ///
+    /// # Safety
+    /// You must not write unitialized bytes to positions less than `self.initialized_len()`
+    #[inline]
+    pub unsafe fn buf_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.buf
+    }
+
+    /// Returns the buffer
+    #[inline]
+    pub fn into_buf(self) -> &'a mut [MaybeUninit<u8>] {
+        self.buf
+    }
 }


### PR DESCRIPTION
I noticed these functions were missing so I had to use an annoying workaround...

ACP: https://github.com/rust-lang/libs-team/issues/65 [accepted]