### PR TITLE
fix typo in note about multiple inaccessible type aliases

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2589,8 +2589,10 @@ fn show_candidates(
             } else {
                 "item".to_string()
             };
+            let plural_descr =
+                if descr.ends_with("s") { format!("{}es", descr) } else { format!("{}s", descr) };
 
-            let mut msg = format!("{}these {}s exist but are inaccessible", prefix, descr);
+            let mut msg = format!("{}these {} exist but are inaccessible", prefix, plural_descr);
             let mut has_colon = false;
 
             let mut spans = Vec::new();

--- a/src/test/ui/imports/inaccessible_type_aliases.rs
+++ b/src/test/ui/imports/inaccessible_type_aliases.rs
@@ -1,0 +1,14 @@
+mod a {
+    type Foo = u64;
+    type Bar = u64;
+}
+
+mod b {
+    type Foo = u64;
+}
+
+fn main() {
+    let x: Foo = 100; //~ ERROR: cannot find type `Foo` in this scope
+    let y: Bar = 100; //~ ERROR: cannot find type `Bar` in this scope
+    println!("x: {}, y: {}", x, y);
+}

--- a/src/test/ui/imports/inaccessible_type_aliases.stderr
+++ b/src/test/ui/imports/inaccessible_type_aliases.stderr
@@ -1,0 +1,30 @@
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/inaccessible_type_aliases.rs:11:12
+   |
+LL |     let x: Foo = 100;
+   |            ^^^ not found in this scope
+   |
+note: these type aliases exist but are inaccessible
+  --> $DIR/inaccessible_type_aliases.rs:2:5
+   |
+LL |     type Foo = u64;
+   |     ^^^^^^^^^^^^^^^ `a::Foo`: not accessible
+...
+LL |     type Foo = u64;
+   |     ^^^^^^^^^^^^^^^ `b::Foo`: not accessible
+
+error[E0412]: cannot find type `Bar` in this scope
+  --> $DIR/inaccessible_type_aliases.rs:12:12
+   |
+LL |     let y: Bar = 100;
+   |            ^^^ not found in this scope
+   |
+note: type alias `a::Bar` exists but is inaccessible
+  --> $DIR/inaccessible_type_aliases.rs:3:5
+   |
+LL |     type Bar = u64;
+   |     ^^^^^^^^^^^^^^^ not accessible
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Mainly intended as a small typo fix ("aliass" -> "aliases") for the case where a type cannot be found in scope but there are multiple inaccessible type aliases that match the missing type.

In general this change would use the correct plural form in this scenario for base words that end with 's'.