### PR TITLE
assert Scalar sanity

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -306,9 +306,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             s.is_ptr() || (number_may_have_provenance && size == self.pointer_size())
         };
         if let Some(s) = scalar_layout {
-            //FIXME(#96185): let size = s.size(self);
-            //FIXME(#96185): assert_eq!(size, mplace.layout.size, "abi::Scalar size does not match layout size");
-            let size = mplace.layout.size; //FIXME(#96185): remove this line
+            let size = s.size(self);
+            assert_eq!(size, mplace.layout.size, "abi::Scalar size does not match layout size");
             let scalar =
                 alloc.read_scalar(alloc_range(Size::ZERO, size), read_provenance(s, size))?;
             return Ok(Some(ImmTy { imm: scalar.into(), layout: mplace.layout }));

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -793,7 +793,7 @@ where
                     )
                 };
                 let size = s.size(&tcx);
-                //FIXME(#96185): assert_eq!(dest.layout.size, size, "abi::Scalar size does not match layout size");
+                assert_eq!(size, dest.layout.size, "abi::Scalar size does not match layout size");
                 alloc.write_scalar(alloc_range(Size::ZERO, size), scalar)
             }
             Immediate::ScalarPair(a_val, b_val) => {

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -235,9 +235,8 @@ fn sanity_check_layout<'tcx>(
     if cfg!(debug_assertions) {
         fn check_layout_abi<'tcx>(tcx: TyCtxt<'tcx>, layout: Layout<'tcx>) {
             match layout.abi() {
-                Abi::Scalar(_scalar) => {
+                Abi::Scalar(scalar) => {
                     // No padding in scalars.
-                    /* FIXME(#96185):
                     assert_eq!(
                         layout.align().abi,
                         scalar.align(&tcx).abi,
@@ -247,7 +246,7 @@ fn sanity_check_layout<'tcx>(
                         layout.size(),
                         scalar.size(&tcx),
                         "size mismatch between ABI and layout in {layout:#?}"
-                    );*/
+                    );
                 }
                 Abi::Vector { count, element } => {
                     // No padding in vectors. Alignment can be strengthened, though.

--- a/src/test/ui/consts/const-enum-cast.rs
+++ b/src/test/ui/consts/const-enum-cast.rs
@@ -4,6 +4,19 @@
 enum A { A1, A2 }
 enum B { B1=4, B2=2 }
 
+#[allow(dead_code)]
+#[repr(align(8))]
+enum Aligned {
+    Zero = 0,
+    One = 1,
+}
+
+// regression test for https://github.com/rust-lang/rust/issues/96185
+const X: u8 = {
+    let aligned = Aligned::Zero;
+    aligned as u8
+};
+
 pub fn main () {
     static c1: isize = A::A2 as isize;
     static c2: isize = B::B2 as isize;
@@ -23,4 +36,6 @@ pub fn main () {
     assert_eq!(c2_2, 4);
     assert_eq!(a1_2, 0);
     assert_eq!(a2_2, 4);
+
+    assert_eq!(X, 0);
 }


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/96814 having landed, finally our `Scalar` layouts have the invariants they deserve. :)