### PR TITLE
Remove (unused) inherent impl anchors

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1415,7 +1415,10 @@ fn render_impl(
                         id, item_type, in_trait_class,
                     );
                     render_rightside(w, cx, item, containing_item, render_mode);
-                    write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                    if trait_.is_some() {
+                        // Anchors are only used on trait impls.
+                        write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                    }
                     w.write_str("<h4 class=\"code-header\">");
                     render_assoc_item(
                         w,
@@ -1438,7 +1441,10 @@ fn render_impl(
                     id, item_type, in_trait_class
                 );
                 render_rightside(w, cx, item, containing_item, render_mode);
-                write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                if trait_.is_some() {
+                    // Anchors are only used on trait impls.
+                    write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                }
                 w.write_str("<h4 class=\"code-header\">");
                 assoc_const(
                     w,
@@ -1460,7 +1466,10 @@ fn render_impl(
                 let source_id = format!("{}.{}", item_type, name);
                 let id = cx.derive_id(source_id.clone());
                 write!(w, "<section id=\"{}\" class=\"{}{}\">", id, item_type, in_trait_class);
-                write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                if trait_.is_some() {
+                    // Anchors are only used on trait impls.
+                    write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                }
                 w.write_str("<h4 class=\"code-header\">");
                 assoc_type(
                     w,
@@ -1483,7 +1492,10 @@ fn render_impl(
                     "<section id=\"{}\" class=\"{}{} has-srclink\">",
                     id, item_type, in_trait_class
                 );
-                write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                if trait_.is_some() {
+                    // Anchors are only used on trait impls.
+                    write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
+                }
                 w.write_str("<h4 class=\"code-header\">");
                 assoc_type(
                     w,

--- a/src/test/rustdoc/anchors.no_const_anchor.html
+++ b/src/test/rustdoc/anchors.no_const_anchor.html
@@ -1,0 +1,1 @@
+<div id="associatedconstant.YOLO" class="method has-srclink"><div class="rightside"><a class="srclink" href="../src/foo/anchors.rs.html#16">source</a></div><h4 class="code-header">const <a href="#associatedconstant.YOLO" class="constant">YOLO</a>: <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a></h4></div>

--- a/src/test/rustdoc/anchors.no_const_anchor2.html
+++ b/src/test/rustdoc/anchors.no_const_anchor2.html
@@ -1,0 +1,1 @@
+<section id="associatedconstant.X" class="associatedconstant has-srclink"><span class="rightside"><a class="srclink" href="../src/foo/anchors.rs.html#42">source</a></span><h4 class="code-header">pub const <a href="#associatedconstant.X" class="constant">X</a>: <a class="primitive" href="{{channel}}/std/primitive.i32.html">i32</a> = 0i32</h4></section>

--- a/src/test/rustdoc/anchors.no_method_anchor.html
+++ b/src/test/rustdoc/anchors.no_method_anchor.html
@@ -1,0 +1,1 @@
+<section id="method.new" class="method has-srclink"><span class="rightside"><a class="srclink" href="../src/foo/anchors.rs.html#48">source</a></span><h4 class="code-header">pub fn <a href="#method.new" class="fnname">new</a>() -&gt; Self</h4></section>

--- a/src/test/rustdoc/anchors.no_trait_method_anchor.html
+++ b/src/test/rustdoc/anchors.no_trait_method_anchor.html
@@ -1,0 +1,1 @@
+<div id="method.bar" class="method has-srclink"><div class="rightside"><a class="srclink" href="../src/foo/anchors.rs.html#23">source</a></div><h4 class="code-header">fn <a href="#method.bar" class="fnname">bar</a>()</h4></div>

--- a/src/test/rustdoc/anchors.no_tymethod_anchor.html
+++ b/src/test/rustdoc/anchors.no_tymethod_anchor.html
@@ -1,0 +1,1 @@
+<div id="tymethod.foo" class="method has-srclink"><div class="rightside"><a class="srclink" href="../src/foo/anchors.rs.html#20">source</a></div><h4 class="code-header">fn <a href="#tymethod.foo" class="fnname">foo</a>()</h4></div>

--- a/src/test/rustdoc/anchors.no_type_anchor.html
+++ b/src/test/rustdoc/anchors.no_type_anchor.html
@@ -1,0 +1,1 @@
+<div id="associatedtype.T" class="method has-srclink"><div class="rightside"><a class="srclink" href="../src/foo/anchors.rs.html#13">source</a></div><h4 class="code-header">type <a href="#associatedtype.T" class="associatedtype">T</a></h4></div>

--- a/src/test/rustdoc/anchors.no_type_anchor2.html
+++ b/src/test/rustdoc/anchors.no_type_anchor2.html
@@ -1,0 +1,1 @@
+<section id="associatedtype.Y" class="associatedtype has-srclink"><h4 class="code-header">type <a href="#associatedtype.Y" class="associatedtype">Y</a> = <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a></h4></section>

--- a/src/test/rustdoc/anchors.rs
+++ b/src/test/rustdoc/anchors.rs
@@ -1,0 +1,49 @@
+// This test ensures that anchors are generated in the right places.
+
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+#![crate_name = "foo"]
+
+pub struct Foo;
+
+// @has 'foo/trait.Bar.html'
+pub trait Bar {
+    // There should be no anchors here.
+    // @snapshot no_type_anchor - '//*[@id="associatedtype.T"]'
+    type T;
+    // There should be no anchors here.
+    // @snapshot no_const_anchor - '//*[@id="associatedconstant.YOLO"]'
+    const YOLO: u32;
+
+    // There should be no anchors here.
+    // @snapshot no_tymethod_anchor - '//*[@id="tymethod.foo"]'
+    fn foo();
+    // There should be no anchors here.
+    // @snapshot no_trait_method_anchor - '//*[@id="method.bar"]'
+    fn bar() {}
+}
+
+// @has 'foo/struct.Foo.html'
+impl Bar for Foo {
+    // @has - '//*[@id="associatedtype.T"]/a[@class="anchor"]' ''
+    type T = u32;
+    // @has - '//*[@id="associatedconstant.YOLO"]/a[@class="anchor"]' ''
+    const YOLO: u32 = 0;
+
+    // @has - '//*[@id="method.foo"]/a[@class="anchor"]' ''
+    fn foo() {}
+    // Same check for provided "bar" method.
+    // @has - '//*[@id="method.bar"]/a[@class="anchor"]' ''
+}
+
+impl Foo {
+    // @snapshot no_const_anchor2 - '//*[@id="associatedconstant.X"]'
+    // There should be no anchors here.
+    pub const X: i32 = 0;
+    // @snapshot no_type_anchor2 - '//*[@id="associatedtype.Y"]'
+    // There should be no anchors here.
+    pub type Y = u32;
+    // @snapshot no_method_anchor - '//*[@id="method.new"]'
+    // There should be no anchors here.
+    pub fn new() -> Self { Self }
+}


### PR DESCRIPTION
This is something @notriddle realized a few days ago: we have unused anchors in the DOM.

This PR removes them.

You can test it [here](https://rustdoc.crud.net/imperio/inherent-impl-anchors/foo/index.html).

r? @notriddle 