### PR TITLE
Remove erroneous doc comment

### DIFF
--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -911,7 +911,7 @@ pub enum Operand<'tcx> {
 static_assert_size!(Operand<'_>, 24);
 
 ///////////////////////////////////////////////////////////////////////////
-/// Rvalues
+// Rvalues
 
 /// The various kinds of rvalues that can appear in MIR.
 ///


### PR DESCRIPTION
Fixes the formatting issue shown here:

<img width="803" alt="Screen Shot 2022-07-06 at 12 50 56 PM" src="https://user-images.githubusercontent.com/19642016/177612734-2d881c6a-2850-4c1b-8f1a-08339ad5bfbc.png">