### PR TITLE
Apply deprecation lint to trait method overrides.

### DIFF
--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -760,8 +760,12 @@ impl<'tcx> Visitor<'tcx> for Checker<'tcx> {
                     let impl_item = self.tcx.associated_item(impl_item_ref.id.def_id);
 
                     if let Some(def_id) = impl_item.trait_item_def_id {
-                        // Pass `None` to skip deprecation warnings.
-                        self.tcx.check_stability(def_id, None, impl_item_ref.span, None);
+                        self.tcx.check_stability(
+                            def_id,
+                            Some(impl_item_ref.id.hir_id()),
+                            impl_item_ref.span,
+                            None,
+                        );
                     }
                 }
             }

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -603,6 +603,7 @@ impl Error for string::FromUtf16Error {
 
 #[stable(feature = "str_parse_error2", since = "1.8.0")]
 impl Error for Infallible {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {}
     }


### PR DESCRIPTION
Fixes #98990

Marking this as draft, because it's not completely clear whether #98990 is a bug or intentional.