### PR TITLE
Make functions part of `alloc_layout_extra` (#55724) const.

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -97,6 +97,7 @@
 // Library features:
 #![feature(const_align_offset)]
 #![feature(const_align_of_val)]
+#![feature(const_alloc_layout)]
 #![feature(const_arguments_as_str)]
 #![feature(const_array_into_iter_constructors)]
 #![feature(const_bigint_helper_methods)]
@@ -139,6 +140,7 @@
 #![feature(const_str_from_utf8_unchecked_mut)]
 #![feature(const_swap)]
 #![feature(const_trait_impl)]
+#![feature(const_try)]
 #![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_default_impls)]


### PR DESCRIPTION
Make functions part of `alloc_layout_extra` (#55724) const. Requires two additional feature flags: `const_alloc_layout` and `const_try` (from my understanding std already builds with many other nightly features). I added them in alphabetical order. The only implementation change is `std::cmp::max` has to be replaced with an explicit `if` expression since trait methods are not const.