### PR TITLE
Add test for and fix rust-lang/rust-clippy#9131

### DIFF
--- a/src/tools/clippy/clippy_lints/src/misc.rs
+++ b/src/tools/clippy/clippy_lints/src/misc.rs
@@ -301,7 +301,7 @@ fn in_attributes_expansion(expr: &Expr<'_>) -> bool {
     use rustc_span::hygiene::MacroKind;
     if expr.span.from_expansion() {
         let data = expr.span.ctxt().outer_expn_data();
-        matches!(data.kind, ExpnKind::Macro(MacroKind::Attr, _))
+        matches!(data.kind, ExpnKind::Macro(MacroKind::Attr|MacroKind::Derive, _))
     } else {
         false
     }

--- a/src/tools/clippy/tests/ui/used_underscore_binding.rs
+++ b/src/tools/clippy/tests/ui/used_underscore_binding.rs
@@ -44,6 +44,12 @@ fn in_struct_field() {
     s._underscore_field += 1;
 }
 
+/// Tests that we do not lint if the struct field is used in code created with derive.
+#[derive(Clone, Debug)]
+pub struct UnderscoreInStruct {
+    _foo: u32,
+}
+
 /// Tests that we do not lint if the underscore is not a prefix
 fn non_prefix_underscore(some_foo: u32) -> u32 {
     some_foo + 1

--- a/src/tools/clippy/tests/ui/used_underscore_binding.stderr
+++ b/src/tools/clippy/tests/ui/used_underscore_binding.stderr
@@ -31,7 +31,7 @@ LL |     s._underscore_field += 1;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: used binding `_i` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
-  --> $DIR/used_underscore_binding.rs:99:16
+  --> $DIR/used_underscore_binding.rs:105:16
    |
 LL |         uses_i(_i);
    |                ^^


### PR DESCRIPTION
This lint seems to have been broken by #98446 -- but of course, there was no clippy test for this case at the time.

`expr.span.ctxt().outer_expn_data()` now has `MacroKind::Derive` instead of `MacroKind::Attr` for something like:

```
#[derive(Clone, Debug)]
pub struct UnderscoreInStruct {
    _foo: u32,
}
```

---

changelog: none

closes: https://github.com/rust-lang/rust-clippy/issues/9131