### PR TITLE
diagnostics: error messages when struct literals fail to parse

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3012,6 +3012,11 @@ impl<'a> Parser<'a> {
                 }
             };
 
+            let is_shorthand = parsed_field.as_ref().map_or(false, |f| f.ident.span == f.expr.span);
+            // A shorthand field can be turned into a full field with `:`.
+            // We should point this out.
+            self.check_or_expected(!is_shorthand, TokenType::Token(token::Colon));
+
             match self.expect_one_of(&[token::Comma], &[token::CloseDelim(close_delim)]) {
                 Ok(_) => {
                     if let Some(f) = parsed_field.or(recovery_field) {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3012,7 +3012,7 @@ impl<'a> Parser<'a> {
                 }
             };
 
-            let is_shorthand = parsed_field.as_ref().map_or(false, |f| f.ident.span == f.expr.span);
+            let is_shorthand = parsed_field.as_ref().map_or(false, |f| f.is_shorthand);
             // A shorthand field can be turned into a full field with `:`.
             // We should point this out.
             self.check_or_expected(!is_shorthand, TokenType::Token(token::Colon));

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3037,6 +3037,19 @@ impl<'a> Parser<'a> {
                                 ",",
                                 Applicability::MachineApplicable,
                             );
+                        } else if is_shorthand
+                            && (AssocOp::from_token(&self.token).is_some()
+                                || matches!(&self.token.kind, token::OpenDelim(_))
+                                || self.token.kind == token::Dot)
+                        {
+                            // Looks like they tried to write a shorthand, complex expression.
+                            let ident = parsed_field.expect("is_shorthand implies Some").ident;
+                            e.span_suggestion(
+                                ident.span.shrink_to_lo(),
+                                "try naming a field",
+                                &format!("{ident}: "),
+                                Applicability::HasPlaceholders,
+                            );
                         }
                     }
                     if !recover {

--- a/src/test/ui/parser/issues/issue-52496.stderr
+++ b/src/test/ui/parser/issues/issue-52496.stderr
@@ -4,11 +4,11 @@ error: float literals must have an integer part
 LL |     let _ = Foo { bar: .5, baz: 42 };
    |                        ^^ help: must have an integer part: `0.5`
 
-error: expected one of `,` or `}`, found `.`
+error: expected one of `,`, `:`, or `}`, found `.`
   --> $DIR/issue-52496.rs:8:22
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
-   |             ---      ^ expected one of `,` or `}`
+   |             ---      ^ expected one of `,`, `:`, or `}`
    |             |
    |             while parsing this struct
 

--- a/src/test/ui/parser/issues/issue-52496.stderr
+++ b/src/test/ui/parser/issues/issue-52496.stderr
@@ -8,8 +8,9 @@ error: expected one of `,`, `:`, or `}`, found `.`
   --> $DIR/issue-52496.rs:8:22
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
-   |             ---      ^ expected one of `,`, `:`, or `}`
-   |             |
+   |             ---   -  ^ expected one of `,`, `:`, or `}`
+   |             |     |
+   |             |     help: try naming a field: `bar:`
    |             while parsing this struct
 
 error: expected identifier, found `.`

--- a/src/test/ui/parser/issues/issue-62973.stderr
+++ b/src/test/ui/parser/issues/issue-62973.stderr
@@ -24,11 +24,19 @@ error: expected one of `,`, `:`, or `}`, found `{`
   --> $DIR/issue-62973.rs:6:8
    |
 LL | fn p() { match s { v, E { [) {) }
-   |        ^       -       -^ expected one of `,`, `:`, or `}`
-   |        |       |       |
-   |        |       |       help: `}` may belong here
+   |        ^       -        ^ expected one of `,`, `:`, or `}`
+   |        |       |
    |        |       while parsing this struct
    |        unclosed delimiter
+   |
+help: `}` may belong here
+   |
+LL | fn p() { match s { v, E} { [) {) }
+   |                        +
+help: try naming a field
+   |
+LL | fn p() { match s { v, E: E { [) {) }
+   |                       ++
 
 error: struct literals are not allowed here
   --> $DIR/issue-62973.rs:6:16

--- a/src/test/ui/parser/issues/issue-62973.stderr
+++ b/src/test/ui/parser/issues/issue-62973.stderr
@@ -20,11 +20,11 @@ LL |
 LL |
    |  ^
 
-error: expected one of `,` or `}`, found `{`
+error: expected one of `,`, `:`, or `}`, found `{`
   --> $DIR/issue-62973.rs:6:8
    |
 LL | fn p() { match s { v, E { [) {) }
-   |        ^       -       -^ expected one of `,` or `}`
+   |        ^       -       -^ expected one of `,`, `:`, or `}`
    |        |       |       |
    |        |       |       help: `}` may belong here
    |        |       while parsing this struct

--- a/src/test/ui/parser/removed-syntax-with-2.rs
+++ b/src/test/ui/parser/removed-syntax-with-2.rs
@@ -6,6 +6,6 @@ fn main() {
 
     let a = S { foo: (), bar: () };
     let b = S { foo: (), with a };
-    //~^ ERROR expected one of `,` or `}`, found `a`
+    //~^ ERROR expected one of `,`, `:`, or `}`, found `a`
     //~| ERROR missing field `bar` in initializer of `S`
 }

--- a/src/test/ui/parser/removed-syntax-with-2.stderr
+++ b/src/test/ui/parser/removed-syntax-with-2.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,` or `}`, found `a`
+error: expected one of `,`, `:`, or `}`, found `a`
   --> $DIR/removed-syntax-with-2.rs:8:31
    |
 LL |     let b = S { foo: (), with a };
-   |             -                 ^ expected one of `,` or `}`
+   |             -                 ^ expected one of `,`, `:`, or `}`
    |             |
    |             while parsing this struct
 


### PR DESCRIPTION
If an expression is supplied where a field is expected, the parser can become convinced that it's a shorthand field syntax when it's not.

This PR addresses it by explicitly recording the permitted `:` token immediately after the identifier, and also adds a suggestion to insert the name of the field if it looks like a complex expression.

Fixes #98917