### PR TITLE
Disable unwinding for `catch_unwind` error payloads.

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -245,7 +245,9 @@ impl<T> Drop for DropNoUnwindSameAnyTypeId<T> {
 
         impl Drop for AbortOnDrop {
             fn drop(&mut self) {
-                crate::intrinsics::abort();
+                crate::panicking::panic_abort(Some(&format_args!(
+                    "fatal runtime error: drop of the panic payload panicked"
+                )))
             }
         }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -170,6 +170,7 @@
 #![feature(adt_const_params)]
 #![feature(allow_internal_unsafe)]
 #![feature(allow_internal_unstable)]
+#![feature(arbitrary_self_types)]
 #![feature(associated_type_bounds)]
 #![feature(auto_traits)]
 #![feature(cfg_sanitize)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -280,6 +280,7 @@
 #![feature(cstr_internals)]
 #![feature(duration_checked_float)]
 #![feature(duration_constants)]
+#![feature(dyn_into_drop_no_unwind)]
 #![feature(error_generic_member_access)]
 #![feature(error_in_core)]
 #![feature(error_iter)]

--- a/src/test/ui/panics/drop_in_panic_payload_does_not_unwind.rs
+++ b/src/test/ui/panics/drop_in_panic_payload_does_not_unwind.rs
@@ -1,0 +1,73 @@
+// run-pass
+// needs-unwind
+// ignore-emscripten no processes
+// ignore-sgx no processes
+// ignore-wasm32-bare no unwinding panic
+// ignore-avr no unwinding panic
+// ignore-nvptx64 no unwinding panic
+
+use std::{env, ops::Not, panic, process};
+
+fn main() {
+    match &env::args().collect::<Vec<_>>()[..] {
+        [just_me] => parent(just_me),
+        [_me, subprocess] if subprocess == "panic" => subprocess_panic(),
+        [_me, subprocess] if subprocess == "resume_unwind" => subprocess_resume_unwind(),
+        _ => unreachable!(),
+    }
+}
+
+fn parent(self_exe: &str) {
+    // call the subprocess 1: panic with a drop bomb
+    let status =
+        process::Command::new(self_exe)
+            .arg("panic")
+            .status()
+            .expect("running the command should have succeeded")
+    ;
+    assert!(status.success().not(), "`subprocess_panic()` is expected to have aborted");
+
+    // call the subprocess 2: resume_unwind with a drop bomb
+    let status =
+        process::Command::new(self_exe)
+            .arg("resume_unwind")
+            .status()
+            .expect("running the command should have succeeded")
+    ;
+    assert!(status.success().not(), "`subprocess_resume_unwind()` is expected to have aborted");
+}
+
+fn subprocess_panic() {
+    let _ = panic::catch_unwind(|| {
+        struct Bomb;
+
+        impl Drop for Bomb {
+            fn drop(&mut self) {
+                panic!();
+            }
+        }
+
+        let panic_payload = panic::catch_unwind(|| panic::panic_any(Bomb)).unwrap_err();
+        // Calls `Bomb::drop`, which starts unwinding. But since this is a panic payload already,
+        // the drop glue is amended to abort on unwind. So this ought to abort the process.
+        drop(panic_payload);
+    });
+}
+
+fn subprocess_resume_unwind() {
+    use panic::resume_unwind;
+    let _ = panic::catch_unwind(|| {
+        struct Bomb;
+
+        impl Drop for Bomb {
+            fn drop(&mut self) {
+                panic!();
+            }
+        }
+
+        let panic_payload = panic::catch_unwind(|| resume_unwind(Box::new(Bomb))).unwrap_err();
+        // Calls `Bomb::drop`, which starts unwinding. But since this is a panic payload already,
+        // the drop glue is amended to abort on unwind. So this ought to abort the process.
+        drop(panic_payload);
+    });
+}

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -21,8 +21,7 @@ fn main() {
         [..] => std::panic::panic_any(Bomb),
     }.expect("running the command should have succeeded");
     println!("{:#?}", output);
-    let stderr = std::str::from_utf8(&output.stderr);
-    assert!(stderr.map(|v| {
-        v.ends_with("fatal runtime error: drop of the panic payload panicked\n")
-    }).unwrap_or(false));
+    let stderr = std::str::from_utf8(&output.stderr).expect("UTF-8 stderr");
+    // the drop of the panic payload cannot unwind anymore:
+    assert!(stderr.contains("fatal runtime error: drop of the panic payload panicked"));
 }


### PR DESCRIPTION
Fixes #86027.

This does something similar to what was suggested over https://github.com/rust-lang/rust/issues/86027#issuecomment-858083087, that is, to tweak/amend the `Box<dyn Any…>` obtained from `catch_unwind`:
  - keep the `.type_id()` the same to avoid breakage with downcasting;
  - but make it so the virtual `.drop_in_place()` is somehow overridden with a shim around the real drop glue that prevents unwinding (_e.g._, by aborting when that happens).

This is achieved through the `DropNoUnwindSameAnyTypeId<T>`, wrapper:
  - with the very same layout as the `T` it wraps;
  - with an overridden/fake `.type_id()` so as to impersonate its inner `T`;
  - with a manual `impl Drop` which uses an abort bomb to ensure no unwinding can happen.

That way, the `Box<DropNoUnwindSameAnyTypeId<T>>`, when box-erased to a `Box<dyn Any…>`, becomes, both layout-wise, and `type_id`-wise, undistinguishable from a `Box<T>`, thence avoiding any breakage.

And yet, when that `Box<dyn Any…>` is implicitly dropped with `catch_unwind`s, no further unwinding can happen.

___

### Alternative implementation

FWIW, another approach to achieve the same idea would be to create one's own tweaked version of the vtable of `Any`, and directly use it to _manually_ unsize a `Box<T>` to a `Box<dyn Any…>` (using `ptr::from_raw_parts_mut`) to achieve what this PR automagically does with `Box<Wrapper<T>>`. That being said, since _the exact vtable layout of `Any`_, much like the vtable layout of any trait, is only known to the compiler, this other approach could only be achieved by exploiting stdlib magic knowledge of `lang` stuff. For instance, it would be brittle: `Any`'s definition, the vtable generation algorithm of the compiler, and this hand-rolled vtable would all three have to remain in sync at all times.

  - EDIT: see, however, https://github.com/rust-lang/rust/issues/86027#issuecomment-1179836170 for arguments against such alternative implementation