### PR TITLE
Replace `Result<Option<T>, SelectionError>` with `SelectionResult<T>`

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -7,7 +7,7 @@ use rustc_errors::{
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_infer::traits::{ImplSource, Obligation, ObligationCause};
+use rustc_infer::traits::{ImplSource, Obligation, ObligationCause, SelectionResult};
 use rustc_middle::mir;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
@@ -160,7 +160,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                         selcx.select(&obligation)
                     });
 
-                    if let Ok(Some(ImplSource::UserDefined(data))) = implsrc {
+                    if let SelectionResult::Success(ImplSource::UserDefined(data)) = implsrc {
                         let span = tcx.def_span(data.impl_def_id);
                         err.span_note(span, "impl defined here, but it is not `const`");
                     }

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -7,7 +7,7 @@ use rustc_errors::{
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_infer::traits::{ImplSource, Obligation, ObligationCause, SelectionResult};
+use rustc_infer::traits::{ImplSource, Obligation, ObligationCause};
 use rustc_middle::mir;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
@@ -160,7 +160,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                         selcx.select(&obligation)
                     });
 
-                    if let SelectionResult::Success(ImplSource::UserDefined(data)) = implsrc {
+                    if let Ok(ImplSource::UserDefined(data)) = implsrc {
                         let span = tcx.def_span(data.impl_def_id);
                         err.span_note(span, "impl defined here, but it is not `const`");
                     }

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -5,7 +5,7 @@
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::LangItem;
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_infer::traits::{SelectionResult, TraitEngine};
+use rustc_infer::traits::TraitEngine;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, subst::SubstsRef, AdtDef, Ty};
 use rustc_span::DUMMY_SP;
@@ -170,7 +170,7 @@ impl Qualif for NeedsNonConstDrop {
 
         cx.tcx.infer_ctxt().enter(|infcx| {
             let mut selcx = SelectionContext::new(&infcx);
-            let SelectionResult::Success(impl_src) = selcx.select(&obligation) else {
+            let Ok(impl_src) = selcx.select(&obligation) else {
                 // If we couldn't select a const destruct candidate, then it's bad
                 return true;
             };

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -5,7 +5,7 @@
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::LangItem;
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_infer::traits::TraitEngine;
+use rustc_infer::traits::{SelectionResult, TraitEngine};
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, subst::SubstsRef, AdtDef, Ty};
 use rustc_span::DUMMY_SP;
@@ -170,7 +170,7 @@ impl Qualif for NeedsNonConstDrop {
 
         cx.tcx.infer_ctxt().enter(|infcx| {
             let mut selcx = SelectionContext::new(&infcx);
-            let Some(impl_src) = selcx.select(&obligation).ok().flatten() else {
+            let SelectionResult::Success(impl_src) = selcx.select(&obligation) else {
                 // If we couldn't select a const destruct candidate, then it's bad
                 return true;
             };

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -557,18 +557,7 @@ pub enum AmbiguousSelection {
 
 TrivialTypeTraversalAndLiftImpls! { AmbiguousSelection, }
 
-/// When performing resolution, there are typically one of three outcomes
-/// represented by this enum.
-#[derive(Clone, Debug, TypeFoldable, TypeVisitable, Lift)]
-pub enum SelectionResult<'tcx, T> {
-    /// Success occurred with given result
-    Success(T),
-    /// Could not definitely determine anything, usually due to inconclusive
-    /// type inference.
-    Ambiguous,
-    /// Error occurred during selection
-    Error(SelectionError<'tcx>),
-}
+pub type SelectionResult<'tcx, T> = Result<T, SelectionError<'tcx>>;
 
 /// Given the successful resolution of an obligation, the `ImplSource`
 /// indicates where the impl comes from.

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -557,14 +557,18 @@ pub enum AmbiguousSelection {
 
 TrivialTypeTraversalAndLiftImpls! { AmbiguousSelection, }
 
-/// When performing resolution, it is typically the case that there
-/// can be one of three outcomes:
-///
-/// - `Ok(Some(r))`: success occurred with result `r`
-/// - `Ok(None)`: could not definitely determine anything, usually due
-///   to inconclusive type inference.
-/// - `Err(e)`: error `e` occurred
-pub type SelectionResult<'tcx, T> = Result<Option<T>, SelectionError<'tcx>>;
+/// When performing resolution, there are typically one of three outcomes
+/// represented by this enum.
+#[derive(Clone, Debug, TypeFoldable, TypeVisitable, Lift)]
+pub enum SelectionResult<'tcx, T> {
+    /// Success occurred with given result
+    Success(T),
+    /// Could not definitely determine anything, usually due to inconclusive
+    /// type inference.
+    Ambiguous,
+    /// Error occurred during selection
+    Error(SelectionError<'tcx>),
+}
 
 /// Given the successful resolution of an obligation, the `ImplSource`
 /// indicates where the impl comes from.

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -98,7 +98,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             ));
 
             match result {
-                SelectionResult::Success(ImplSource::UserDefined(_)) => {
+                Ok(ImplSource::UserDefined(_)) => {
                     debug!(
                         "find_auto_trait_generics({:?}): \
                          manual impl found, bailing out",
@@ -116,7 +116,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             ));
 
             match result {
-                SelectionResult::Success(ImplSource::UserDefined(_)) => {
+                Ok(ImplSource::UserDefined(_)) => {
                     debug!(
                         "find_auto_trait_generics({:?}): \
                          manual impl found, bailing out",
@@ -324,7 +324,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             let result = select.select(&obligation);
 
             match result {
-                SelectionResult::Success(ref impl_source) => {
+                Ok(ref impl_source) => {
                     // If we see an explicit negative impl (e.g., `impl !Send for MyStruct`),
                     // we immediately bail out, since it's impossible for us to continue.
 
@@ -357,8 +357,8 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                         return None;
                     }
                 }
-                SelectionResult::Ambiguous => {}
-                SelectionResult::Error(SelectionError::Unimplemented) => {
+                Err(SelectionError::Ambiguous(_)) => {}
+                Err(SelectionError::Unimplemented) => {
                     if self.is_param_no_infer(pred.skip_binder().trait_ref.substs) {
                         already_visited.remove(&pred);
                         self.add_user_pred(&mut user_computed_preds, pred.to_predicate(self.tcx));

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -98,7 +98,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             ));
 
             match result {
-                Ok(Some(ImplSource::UserDefined(_))) => {
+                SelectionResult::Success(ImplSource::UserDefined(_)) => {
                     debug!(
                         "find_auto_trait_generics({:?}): \
                          manual impl found, bailing out",
@@ -116,7 +116,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             ));
 
             match result {
-                Ok(Some(ImplSource::UserDefined(_))) => {
+                SelectionResult::Success(ImplSource::UserDefined(_)) => {
                     debug!(
                         "find_auto_trait_generics({:?}): \
                          manual impl found, bailing out",
@@ -324,7 +324,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             let result = select.select(&obligation);
 
             match result {
-                Ok(Some(ref impl_source)) => {
+                SelectionResult::Success(ref impl_source) => {
                     // If we see an explicit negative impl (e.g., `impl !Send for MyStruct`),
                     // we immediately bail out, since it's impossible for us to continue.
 
@@ -357,8 +357,8 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                         return None;
                     }
                 }
-                Ok(None) => {}
-                Err(SelectionError::Unimplemented) => {
+                SelectionResult::Ambiguous => {}
+                SelectionResult::Error(SelectionError::Unimplemented) => {
                     if self.is_param_no_infer(pred.skip_binder().trait_ref.substs) {
                         already_visited.remove(&pred);
                         self.add_user_pred(&mut user_computed_preds, pred.to_predicate(self.tcx));

--- a/compiler/rustc_trait_selection/src/traits/codegen.rs
+++ b/compiler/rustc_trait_selection/src/traits/codegen.rs
@@ -8,6 +8,7 @@ use crate::traits::{
     FulfillmentContext, ImplSource, Obligation, ObligationCause, SelectionContext, TraitEngine,
     Unimplemented,
 };
+use rustc_infer::traits::SelectionResult;
 use rustc_middle::traits::CodegenObligationError;
 use rustc_middle::ty::{self, TyCtxt};
 
@@ -38,10 +39,12 @@ pub fn codegen_fulfill_obligation<'tcx>(
             Obligation::new(obligation_cause, param_env, trait_ref.to_poly_trait_predicate());
 
         let selection = match selcx.select(&obligation) {
-            Ok(Some(selection)) => selection,
-            Ok(None) => return Err(CodegenObligationError::Ambiguity),
-            Err(Unimplemented) => return Err(CodegenObligationError::Unimplemented),
-            Err(e) => {
+            SelectionResult::Success(selection) => selection,
+            SelectionResult::Ambiguous => return Err(CodegenObligationError::Ambiguity),
+            SelectionResult::Error(Unimplemented) => {
+                return Err(CodegenObligationError::Unimplemented);
+            }
+            SelectionResult::Error(e) => {
                 bug!("Encountered error `{:?}` selecting `{:?}` during codegen", e, trait_ref)
             }
         };

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -23,7 +23,7 @@ use rustc_hir::GenericParam;
 use rustc_hir::Item;
 use rustc_hir::Node;
 use rustc_infer::infer::error_reporting::same_type_modulo_infer;
-use rustc_infer::traits::{AmbiguousSelection, TraitEngine};
+use rustc_infer::traits::{AmbiguousSelection, SelectionResult, TraitEngine};
 use rustc_middle::thir::abstract_const::NotConstEvaluatable;
 use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::error::ExpectedFound;
@@ -2039,7 +2039,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     crate::traits::TraitQueryMode::Standard,
                 );
                 match selcx.select_from_obligation(&obligation) {
-                    Err(SelectionError::Ambiguous(impls)) if impls.len() > 1 => {
+                    SelectionResult::Error(SelectionError::Ambiguous(impls)) if impls.len() > 1 => {
                         if self.is_tainted_by_errors() && subst.is_none() {
                             // If `subst.is_none()`, then this is probably two param-env
                             // candidates or impl candidates that are equal modulo lifetimes.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -23,7 +23,7 @@ use rustc_hir::GenericParam;
 use rustc_hir::Item;
 use rustc_hir::Node;
 use rustc_infer::infer::error_reporting::same_type_modulo_infer;
-use rustc_infer::traits::{AmbiguousSelection, SelectionResult, TraitEngine};
+use rustc_infer::traits::{AmbiguousSelection, TraitEngine};
 use rustc_middle::thir::abstract_const::NotConstEvaluatable;
 use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::error::ExpectedFound;
@@ -2039,7 +2039,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     crate::traits::TraitQueryMode::Standard,
                 );
                 match selcx.select_from_obligation(&obligation) {
-                    SelectionResult::Error(SelectionError::Ambiguous(impls)) if impls.len() > 1 => {
+                    Err(SelectionError::Ambiguous(impls)) if impls.len() > 1 => {
                         if self.is_tainted_by_errors() && subst.is_none() {
                             // If `subst.is_none()`, then this is probably two param-env
                             // candidates or impl candidates that are equal modulo lifetimes.

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::obligation_forest::ProcessResult;
 use rustc_data_structures::obligation_forest::{Error, ForestObligation, Outcome};
 use rustc_data_structures::obligation_forest::{ObligationForest, ObligationProcessor};
-use rustc_infer::traits::{ProjectionCacheKey, SelectionResult};
+use rustc_infer::traits::ProjectionCacheKey;
 use rustc_infer::traits::{SelectionError, TraitEngine, TraitEngineExt as _, TraitObligation};
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::thir::abstract_const::NotConstEvaluatable;
@@ -17,6 +17,7 @@ use super::const_evaluatable;
 use super::project::{self, ProjectAndUnifyResult};
 use super::select::SelectionContext;
 use super::wf;
+use super::Ambiguous;
 use super::CodeAmbiguity;
 use super::CodeProjectionError;
 use super::CodeSelectionError;
@@ -666,11 +667,11 @@ impl<'a, 'b, 'tcx> FulfillProcessor<'a, 'b, 'tcx> {
         }
 
         match self.selcx.select(&trait_obligation) {
-            SelectionResult::Success(impl_source) => {
+            Ok(impl_source) => {
                 debug!("selecting trait at depth {} yielded Ok(Some)", obligation.recursion_depth);
                 ProcessResult::Changed(mk_pending(impl_source.nested_obligations()))
             }
-            SelectionResult::Ambiguous => {
+            Err(Ambiguous(_)) => {
                 debug!("selecting trait at depth {} yielded Ok(None)", obligation.recursion_depth);
 
                 // This is a bit subtle: for the most part, the
@@ -691,7 +692,7 @@ impl<'a, 'b, 'tcx> FulfillProcessor<'a, 'b, 'tcx> {
 
                 ProcessResult::Unchanged
             }
-            SelectionResult::Error(selection_err) => {
+            Err(selection_err) => {
                 debug!("selecting trait at depth {} yielded Err", obligation.recursion_depth);
 
                 ProcessResult::Error(CodeSelectionError(selection_err))

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -824,11 +824,14 @@ pub fn vtable_trait_upcasting_coercion_new_vptr_slot<'tcx>(
 
     let implsrc = tcx.infer_ctxt().enter(|infcx| {
         let mut selcx = SelectionContext::new(&infcx);
-        selcx.select(&obligation).unwrap()
+        match selcx.select(&obligation) {
+            SelectionResult::Success(src) => src,
+            e => bug!("Expected SelectionResult::Success, got {e:?}"),
+        }
     });
 
-    let Some(ImplSource::TraitUpcasting(implsrc_traitcasting)) = implsrc else {
-        bug!();
+    let ImplSource::TraitUpcasting(implsrc_traitcasting) = implsrc else {
+        bug!("expected ImplSource::TraitUpcasting, found {implsrc:?}");
     };
 
     implsrc_traitcasting.vtable_vptr_slot

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -825,8 +825,8 @@ pub fn vtable_trait_upcasting_coercion_new_vptr_slot<'tcx>(
     let implsrc = tcx.infer_ctxt().enter(|infcx| {
         let mut selcx = SelectionContext::new(&infcx);
         match selcx.select(&obligation) {
-            SelectionResult::Success(src) => src,
-            e => bug!("Expected SelectionResult::Success, got {e:?}"),
+            Ok(src) => src,
+            e => bug!("Expected Ok, got {e:?}"),
         }
     });
 

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -28,7 +28,6 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::resolve::OpportunisticRegionResolver;
-use rustc_infer::traits::SelectionResult;
 use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::fold::{TypeFoldable, TypeFolder, TypeSuperFoldable};
 use rustc_middle::ty::subst::Subst;
@@ -1398,12 +1397,12 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
     let trait_obligation = obligation.with(poly_trait_ref.to_poly_trait_predicate());
     let _ = selcx.infcx().commit_if_ok(|_| {
         let impl_source = match selcx.select(&trait_obligation) {
-            SelectionResult::Success(impl_source) => impl_source,
-            SelectionResult::Ambiguous => {
+            Ok(impl_source) => impl_source,
+            Err(SelectionError::Ambiguous(_)) => {
                 candidate_set.mark_ambiguous();
                 return Err(());
             }
-            SelectionResult::Error(e) => {
+            Err(e) => {
                 debug!(error = ?e, "selection error");
                 candidate_set.mark_error(e);
                 return Err(());

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -44,7 +44,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::{Coercion, InferOk, InferResult};
-use rustc_infer::traits::{Obligation, SelectionResult, TraitEngine, TraitEngineExt};
+use rustc_infer::traits::{Obligation, TraitEngine, TraitEngineExt};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability, PointerCast,
@@ -652,7 +652,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             };
             match selcx.select(&obligation.with(trait_pred)) {
                 // Uncertain or unimplemented.
-                SelectionResult::Ambiguous => {
+                Err(traits::Ambiguous(_)) => {
                     if trait_pred.def_id() == unsize_did {
                         let trait_pred = self.resolve_vars_if_possible(trait_pred);
                         let self_ty = trait_pred.skip_binder().self_ty();
@@ -680,22 +680,20 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                         return Err(TypeError::Mismatch);
                     }
                 }
-                SelectionResult::Error(traits::Unimplemented) => {
+                Err(traits::Unimplemented) => {
                     debug!("coerce_unsized: early return - can't prove obligation");
                     return Err(TypeError::Mismatch);
                 }
 
                 // Object safety violations or miscellaneous.
-                SelectionResult::Error(err) => {
+                Err(err) => {
                     self.report_selection_error(obligation.clone(), &obligation, &err, false);
                     // Treat this like an obligation and follow through
                     // with the unsizing - the lack of a coercion should
                     // be silent, as it causes a type mismatch later.
                 }
 
-                SelectionResult::Success(impl_source) => {
-                    queue.extend(impl_source.nested_obligations())
-                }
+                Ok(impl_source) => queue.extend(impl_source.nested_obligations()),
             }
         }
 

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -16,7 +16,6 @@ use rustc_infer::infer::canonical::OriginalQueryValues;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::{self, InferOk, TyCtxtInferExt};
-use rustc_infer::traits::SelectionResult;
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc_middle::middle::stability;
 use rustc_middle::ty::fast_reject::{simplify_type, TreatParams};
@@ -1440,7 +1439,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     .define_opaque_types(false)
                     .sup(candidate.xform_self_ty, self_ty);
                 match self.select_trait_candidate(trait_ref) {
-                    SelectionResult::Success(traits::ImplSource::UserDefined(ref impl_data)) => {
+                    Ok(traits::ImplSource::UserDefined(ref impl_data)) => {
                         // If only a single impl matches, make the error message point
                         // to that impl.
                         CandidateSource::Impl(impl_data.impl_def_id)
@@ -1555,8 +1554,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                         result = ProbeResult::NoMatch;
                         if self.probe(|_| {
                             match self.select_trait_candidate(trait_ref) {
-                                SelectionResult::Error(_) => return true,
-                                SelectionResult::Success(impl_source)
+                                Err(_) => return true,
+                                Ok(impl_source)
                                     if !impl_source.borrow_nested_obligations().is_empty() =>
                                 {
                                     for obligation in impl_source.borrow_nested_obligations() {

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -16,6 +16,7 @@ use rustc_infer::infer::canonical::OriginalQueryValues;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::{self, InferOk, TyCtxtInferExt};
+use rustc_infer::traits::SelectionResult;
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc_middle::middle::stability;
 use rustc_middle::ty::fast_reject::{simplify_type, TreatParams};
@@ -1439,7 +1440,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     .define_opaque_types(false)
                     .sup(candidate.xform_self_ty, self_ty);
                 match self.select_trait_candidate(trait_ref) {
-                    Ok(Some(traits::ImplSource::UserDefined(ref impl_data))) => {
+                    SelectionResult::Success(traits::ImplSource::UserDefined(ref impl_data)) => {
                         // If only a single impl matches, make the error message point
                         // to that impl.
                         CandidateSource::Impl(impl_data.impl_def_id)
@@ -1554,8 +1555,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                         result = ProbeResult::NoMatch;
                         if self.probe(|_| {
                             match self.select_trait_candidate(trait_ref) {
-                                Err(_) => return true,
-                                Ok(Some(impl_source))
+                                SelectionResult::Error(_) => return true,
+                                SelectionResult::Success(impl_source)
                                     if !impl_source.borrow_nested_obligations().is_empty() =>
                                 {
                                     for obligation in impl_source.borrow_nested_obligations() {


### PR DESCRIPTION
Not sure if this is a reasonable change or overkill. Also probably needs perf, since this might just be a perf regression due to the hotness of selection.

r? rust-lang/types