### PR TITLE
improve print styles

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2067,7 +2067,7 @@ in storage.js plus the media query with (min-width: 701px)
 	}
 
 	main {
-		padding-left: 15px;
+		padding: 10px;
 	}
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2056,9 +2056,19 @@ in storage.js plus the media query with (min-width: 701px)
 }
 
 @media print {
-	nav.sub, .content .out-of-band {
+	nav.sidebar, nav.sub, .content .out-of-band, a.srclink, #copy-path,
+    details.rustdoc-toggle[open] > summary::before, details.rustdoc-toggle > summary::before,
+    details.rustdoc-toggle.top-doc > summary {
 		display: none;
 	}
+    
+    .docblock {
+        margin-left: 0;
+    }
+    
+    main {
+        padding-left: 15px;
+    }
 }
 
 @media (max-width: 464px) {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2057,18 +2057,18 @@ in storage.js plus the media query with (min-width: 701px)
 
 @media print {
 	nav.sidebar, nav.sub, .content .out-of-band, a.srclink, #copy-path,
-    details.rustdoc-toggle[open] > summary::before, details.rustdoc-toggle > summary::before,
-    details.rustdoc-toggle.top-doc > summary {
+	details.rustdoc-toggle[open] > summary::before, details.rustdoc-toggle > summary::before,
+	details.rustdoc-toggle.top-doc > summary {
 		display: none;
 	}
-    
-    .docblock {
-        margin-left: 0;
-    }
-    
-    main {
-        padding-left: 15px;
-    }
+
+	.docblock {
+		margin-left: 0;
+	}
+
+	main {
+		padding-left: 15px;
+	}
 }
 
 @media (max-width: 464px) {


### PR DESCRIPTION
this change removes some interactive elements in `@media print` form.

more specifically, it removes the sidebar, source links, the expand/collapse toggle buttons, and the `#copy-path` button.
it also adjusts some spacing and removes the `.top-doc` description completely if it's currently collapsed.