### PR TITLE
Fix cloning from a BitSet with a different domain size

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1061,12 +1061,8 @@ impl<T> Clone for BitSet<T> {
     }
 
     fn clone_from(&mut self, from: &Self) {
-        if self.domain_size != from.domain_size {
-            self.words.resize(from.domain_size, 0);
-            self.domain_size = from.domain_size;
-        }
-
-        self.words.copy_from_slice(&from.words);
+        self.domain_size = from.domain_size;
+        self.words.clone_from(&from.words);
     }
 }
 

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -41,6 +41,23 @@ fn bitset_iter_works_2() {
 }
 
 #[test]
+fn bitset_clone_from() {
+    let mut a: BitSet<usize> = BitSet::new_empty(10);
+    a.insert(4);
+    a.insert(7);
+    a.insert(9);
+
+    let mut b = BitSet::new_empty(2);
+    b.clone_from(&a);
+    assert_eq!(b.domain_size(), 10);
+    assert_eq!(b.iter().collect::<Vec<_>>(), [4, 7, 9]);
+
+    b.clone_from(&BitSet::new_empty(40));
+    assert_eq!(b.domain_size(), 40);
+    assert_eq!(b.iter().collect::<Vec<_>>(), []);
+}
+
+#[test]
 fn union_two_sets() {
     let mut set1: BitSet<usize> = BitSet::new_empty(65);
     let mut set2: BitSet<usize> = BitSet::new_empty(65);


### PR DESCRIPTION
The previous implementation incorrectly assumed that the
number of words in a bit set is equal to the domain size.

The new implementation delegates to `Vec::clone_from` which
is specialized for `Copy` elements.

Fixes #99006.