### PR TITLE
don't use `commit_if_ok` during `higher_ranked_sub`

### DIFF
--- a/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
+++ b/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
@@ -34,31 +34,27 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
         T: Relate<'tcx>,
     {
         let span = self.trace.cause.span;
+        // First, we instantiate each bound region in the supertype with a
+        // fresh placeholder region. Note that this automatically creates
+        // a new universe if needed.
+        let sup_prime = self.infcx.replace_bound_vars_with_placeholders(sup);
 
-        self.infcx.commit_if_ok(|_| {
-            // First, we instantiate each bound region in the supertype with a
-            // fresh placeholder region. Note that this automatically creates
-            // a new universe if needed.
-            let sup_prime = self.infcx.replace_bound_vars_with_placeholders(sup);
+        // Next, we instantiate each bound region in the subtype
+        // with a fresh region variable. These region variables --
+        // but no other pre-existing region variables -- can name
+        // the placeholders.
+        let sub_prime = self.infcx.replace_bound_vars_with_fresh_vars(span, HigherRankedType, sub);
 
-            // Next, we instantiate each bound region in the subtype
-            // with a fresh region variable. These region variables --
-            // but no other pre-existing region variables -- can name
-            // the placeholders.
-            let sub_prime =
-                self.infcx.replace_bound_vars_with_fresh_vars(span, HigherRankedType, sub);
+        debug!("a_prime={:?}", sub_prime);
+        debug!("b_prime={:?}", sup_prime);
 
-            debug!("a_prime={:?}", sub_prime);
-            debug!("b_prime={:?}", sup_prime);
+        // Compare types now that bound regions have been replaced.
+        let result = self.sub(sub_is_expected).relate(sub_prime, sup_prime)?;
 
-            // Compare types now that bound regions have been replaced.
-            let result = self.sub(sub_is_expected).relate(sub_prime, sup_prime)?;
-
-            debug!("higher_ranked_sub: OK result={result:?}");
-            // NOTE: returning the result here would be dangerous as it contains
-            // placeholders which **must not** be named afterwards.
-            Ok(())
-        })
+        debug!("OK result={result:?}");
+        // NOTE: returning the result here would be dangerous as it contains
+        // placeholders which **must not** be named afterwards.
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This snapshot doesn't really do anything useful for us, especially once we deal with placeholder outlive bounds during trait solving.

I guess that currently the idea is that `higher_ranked_sub` could cause a later `leak_check` to fail even if the combine operation isn't actually relevant. But really, using combine outside of snapshot and ignoring its result is wrong anyways, as it can constrain inference variables.

r? rust-lang/types