### PR TITLE
Use ICF (identical code folding) for building rustc

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -651,6 +651,12 @@ impl Step for Rustc {
             panic!("Cannot use and generate PGO profiles at the same time");
         }
 
+        // With LLD, we can use ICF (identical code folding) to reduce the executable size
+        // of librustc_driver/rustc and to improve i-cache utilization.
+        if builder.config.use_lld {
+            cargo.rustflag("-Clink-args=-Wl,--icf=all");
+        }
+
         let is_collecting = if let Some(path) = &builder.config.rust_profile_generate {
             if compiler.stage == 1 {
                 cargo.rustflag(&format!("-Cprofile-generate={}", path));

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -122,7 +122,8 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
-      --set rust.jemalloc
+      --set rust.jemalloc \
+      --set rust.use-lld=true
 ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \
     --include-default-paths \

--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -195,3 +195,7 @@ rm -r $BUILD_ARTIFACTS/llvm $BUILD_ARTIFACTS/lld
 $@ \
     --rust-profile-use=${RUSTC_PROFILE_MERGED_FILE} \
     --llvm-profile-use=${LLVM_PROFILE_MERGED_FILE}
+
+echo "Rustc binary size"
+ls -la ./build/$PGO_HOST/stage2/bin
+ls -la ./build/$PGO_HOST/stage2/lib


### PR DESCRIPTION
It seems that ICF (identical code folding) is able to remove duplicated functions created by monomorphization from binaries, resulting in smaller binary size and better i-cache utilization. Let's see if it helps for `rustc`.

I'm not sure if `lld` is even used for linking `rustc` on the Linux `dist` builder, let's see.