### PR TITLE
distinguish the method and associated function diagnostic information

### DIFF
--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1035,16 +1035,29 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // that had unsatisfied trait bounds
                     if unsatisfied_predicates.is_empty() {
                         let def_kind = lev_candidate.kind.as_def_kind();
-                        err.span_suggestion(
-                            span,
-                            &format!(
-                                "there is {} {} with a similar name",
-                                def_kind.article(),
-                                def_kind.descr(lev_candidate.def_id),
-                            ),
-                            lev_candidate.name,
-                            Applicability::MaybeIncorrect,
-                        );
+                        // Methods are defined within the context of a struct and their first parameter is always self,
+                        // which represents the instance of the struct the method is being called on
+                        // Associated functions don’t take self as a parameter and
+                        // they are not methods because they don’t have an instance of the struct to work with.
+                        if def_kind == DefKind::AssocFn && lev_candidate.fn_has_self_parameter {
+                            err.span_suggestion(
+                                span,
+                                &format!("there is a method with a similar name",),
+                                lev_candidate.name,
+                                Applicability::MaybeIncorrect,
+                            );
+                        } else {
+                            err.span_suggestion(
+                                span,
+                                &format!(
+                                    "there is {} {} with a similar name",
+                                    def_kind.article(),
+                                    def_kind.descr(lev_candidate.def_id),
+                                ),
+                                lev_candidate.name,
+                                Applicability::MaybeIncorrect,
+                            );
+                        }
                     }
                 }
 

--- a/src/test/ui/auto-ref-slice-plus-ref.stderr
+++ b/src/test/ui/auto-ref-slice-plus-ref.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `test_mut` found for struct `Vec<{integer}>` in th
   --> $DIR/auto-ref-slice-plus-ref.rs:7:7
    |
 LL |     a.test_mut();
-   |       ^^^^^^^^ help: there is an associated function with a similar name: `get_mut`
+   |       ^^^^^^^^ help: there is a method with a similar name: `get_mut`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `MyIter` defines an item `test_mut`, perhaps you need to implement it

--- a/src/test/ui/block-result/issue-3563.stderr
+++ b/src/test/ui/block-result/issue-3563.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `b` found for reference `&Self` in the current sco
   --> $DIR/issue-3563.rs:3:17
    |
 LL |         || self.b()
-   |                 ^ help: there is an associated function with a similar name: `a`
+   |                 ^ help: there is a method with a similar name: `a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -25,7 +25,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                         ^^^^^
    |                         |
    |                         function or associated item not found in `dyn BitXor<_>`
-   |                         help: there is an associated function with a similar name: `bitxor`
+   |                         help: there is a method with a similar name: `bitxor`
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-28344.rs:10:13
@@ -53,7 +53,7 @@ LL |     let g = BitXor::bitor;
    |                     ^^^^^
    |                     |
    |                     function or associated item not found in `dyn BitXor<_>`
-   |                     help: there is an associated function with a similar name: `bitxor`
+   |                     help: there is a method with a similar name: `bitxor`
 
 error: aborting due to 4 previous errors; 2 warnings emitted
 

--- a/src/test/ui/suggestions/dont-suggest-pin-array-dot-set.stderr
+++ b/src/test/ui/suggestions/dont-suggest-pin-array-dot-set.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `set` found for array `[u8; 1]` in the current sco
   --> $DIR/dont-suggest-pin-array-dot-set.rs:14:7
    |
 LL |     a.set(0, 3);
-   |       ^^^ help: there is an associated function with a similar name: `get`
+   |       ^^^ help: there is a method with a similar name: `get`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/suggest-methods.stderr
+++ b/src/test/ui/suggestions/suggest-methods.stderr
@@ -5,25 +5,25 @@ LL | struct Foo;
    |        --- method `bat` not found for this struct
 ...
 LL |     f.bat(1.0);
-   |       ^^^ help: there is an associated function with a similar name: `bar`
+   |       ^^^ help: there is a method with a similar name: `bar`
 
 error[E0599]: no method named `is_emtpy` found for struct `String` in the current scope
   --> $DIR/suggest-methods.rs:21:15
    |
 LL |     let _ = s.is_emtpy();
-   |               ^^^^^^^^ help: there is an associated function with a similar name: `is_empty`
+   |               ^^^^^^^^ help: there is a method with a similar name: `is_empty`
 
 error[E0599]: no method named `count_eos` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:25:19
    |
 LL |     let _ = 63u32.count_eos();
-   |                   ^^^^^^^^^ help: there is an associated function with a similar name: `count_zeros`
+   |                   ^^^^^^^^^ help: there is a method with a similar name: `count_zeros`
 
 error[E0599]: no method named `count_o` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:28:19
    |
 LL |     let _ = 63u32.count_o();
-   |                   ^^^^^^^ help: there is an associated function with a similar name: `count_ones`
+   |                   ^^^^^^^ help: there is a method with a similar name: `count_ones`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
+++ b/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `c` found for reference `&dyn Bar` in the current 
   --> $DIR/subtrait-method.rs:56:9
    |
 LL |     bar.c();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: there is a method with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it
@@ -15,7 +15,7 @@ error[E0599]: no method named `b` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:60:9
    |
 LL |     foo.b();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: there is a method with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `b`, perhaps you need to implement it
@@ -28,7 +28,7 @@ error[E0599]: no method named `c` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:62:9
    |
 LL |     foo.c();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: there is a method with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it
@@ -41,7 +41,7 @@ error[E0599]: no method named `b` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:66:9
    |
 LL |     foo.b();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: there is a method with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `b`, perhaps you need to implement it
@@ -54,7 +54,7 @@ error[E0599]: no method named `c` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:68:9
    |
 LL |     foo.c();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: there is a method with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it


### PR DESCRIPTION
Methods are defined within the context of a struct and their first parameter is always self
Associated functions don’t take self as a parameter
```
	modified:   compiler/rustc_typeck/src/check/method/suggest.rs
	modified:   src/test/ui/auto-ref-slice-plus-ref.stderr
	modified:   src/test/ui/block-result/issue-3563.stderr
	modified:   src/test/ui/issues/issue-28344.stderr
	modified:   src/test/ui/suggestions/dont-suggest-pin-array-dot-set.stderr
	modified:   src/test/ui/suggestions/suggest-methods.stderr
	modified:   src/test/ui/traits/trait-upcasting/subtrait-method.stderr
```