### PR TITLE
[WIP] Remove allow(rustc::potential_query_instability) in rustc_session

### DIFF
--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -8,7 +8,6 @@
 #![feature(rustc_attrs)]
 #![feature(map_many_mut)]
 #![recursion_limit = "256"]
-#![allow(rustc::potential_query_instability)]
 
 #[macro_use]
 extern crate rustc_macros;


### PR DESCRIPTION
Replace a use of FxHashMap with FxIndexMap

Relates #84447 

Haven't contributed before so not 100 % sure of who to ask for a review but

r? @cjgillot

seems reasonable as you commented last on the issue 😄 