### PR TITLE
Remove most box syntax from librustdoc

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
             attrs: Default::default(),
             visibility: Inherited,
             item_id: ItemId::Auto { trait_: trait_def_id, for_: item_def_id },
-            kind: box ImplItem(Impl {
+            kind: Box::new(ImplItem(Impl {
                 unsafety: hir::Unsafety::Normal,
                 generics: new_generics,
                 trait_: Some(trait_ref.clean(self.cx)),
@@ -125,7 +125,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 items: Vec::new(),
                 polarity,
                 kind: ImplKind::Auto,
-            }),
+            })),
             cfg: None,
         })
     }

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                         attrs: Default::default(),
                         visibility: Inherited,
                         item_id: ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
-                        kind: box ImplItem(Impl {
+                        kind: Box::new(ImplItem(Impl {
                             unsafety: hir::Unsafety::Normal,
                             generics: clean_ty_generics(
                                 cx,
@@ -123,8 +123,8 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                                 .map(|x| x.clean(cx))
                                 .collect::<Vec<_>>(),
                             polarity: ty::ImplPolarity::Positive,
-                            kind: ImplKind::Blanket(box trait_ref.0.self_ty().clean(cx)),
-                        }),
+                            kind: ImplKind::Blanket(Box::new(trait_ref.0.self_ty().clean(cx))),
+                        })),
                         cfg: None,
                     });
                 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -124,8 +124,14 @@ pub(crate) fn try_inline(
 
     let (attrs, cfg) = merge_attrs(cx, Some(parent_module), load_attrs(cx, did), attrs_clone);
     cx.inlined.insert(did.into());
-    let mut item =
-        clean::Item::from_def_id_and_attrs_and_parts(did, Some(name), kind, box attrs, cx, cfg);
+    let mut item = clean::Item::from_def_id_and_attrs_and_parts(
+        did,
+        Some(name),
+        kind,
+        Box::new(attrs),
+        cx,
+        cfg,
+    );
     if let Some(import_def_id) = import_def_id {
         // The visibility needs to reflect the one from the reexport and not from the "source" DefId.
         item.visibility = cx.tcx.visibility(import_def_id).clean(cx);
@@ -506,7 +512,7 @@ pub(crate) fn build_impl(
                 ImplKind::Normal
             },
         }),
-        box merged_attrs,
+        Box::new(merged_attrs),
         cx,
         cfg,
     ));
@@ -535,7 +541,7 @@ fn build_module(
                 let prim_ty = clean::PrimitiveType::from(p);
                 items.push(clean::Item {
                     name: None,
-                    attrs: box clean::Attributes::default(),
+                    attrs: Box::new(clean::Attributes::default()),
                     item_id: ItemId::Primitive(prim_ty, did.krate),
                     visibility: clean::Public,
                     kind: box clean::ImportItem(clean::Import::new_simple(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2062,7 +2062,7 @@ fn clean_extern_crate<'tcx>(
     // FIXME: using `from_def_id_and_kind` breaks `rustdoc/masked` for some reason
     vec![Item {
         name: Some(name),
-        attrs: box attrs.clean(cx),
+        attrs: Box::new(attrs.clean(cx)),
         item_id: crate_def_id.into(),
         visibility: ty_vis.clean(cx),
         kind: box ExternCrateItem { src: orig_name },

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1490,7 +1490,7 @@ impl<'tcx> Clean<'tcx, Type> for hir::Ty<'tcx> {
                 let lifetime = if !lifetime.is_elided() { Some(lifetime.clean(cx)) } else { None };
                 DynTrait(bounds, lifetime)
             }
-            TyKind::BareFn(barefn) => BareFunction(box barefn.clean(cx)),
+            TyKind::BareFn(barefn) => BareFunction(Box::new(barefn.clean(cx))),
             // Rustdoc handles `TyKind::Err`s by turning them into `Type::Infer`s.
             TyKind::Infer | TyKind::Err => Infer,
             TyKind::Typeof(..) => panic!("unimplemented type {:?}", self.kind),
@@ -1555,12 +1555,12 @@ fn clean_ty<'tcx>(this: Ty<'tcx>, cx: &mut DocContext<'tcx>, def_id: Option<DefI
             let ty = cx.tcx.lift(this).expect("FnPtr lift failed");
             let sig = ty.fn_sig(cx.tcx);
             let decl = clean_fn_decl_from_did_and_sig(cx, None, sig);
-            BareFunction(box BareFunctionDecl {
+            BareFunction(Box::new(BareFunctionDecl {
                 unsafety: sig.unsafety(),
                 generic_params: Vec::new(),
                 decl,
                 abi: sig.abi(),
-            })
+            }))
         }
         ty::Adt(def, substs) => {
             let did = def.did();

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -477,7 +477,7 @@ impl Item {
             def_id,
             name,
             kind,
-            box ast_attrs.clean(cx),
+            Box::new(ast_attrs.clean(cx)),
             cx,
             ast_attrs.cfg(cx.tcx, &cx.cache.hidden_cfg),
         )

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -285,7 +285,7 @@ pub(crate) fn create_config(
         diagnostic_output: DiagnosticOutput::Default,
         lint_caps,
         parse_sess_created: None,
-        register_lints: Some(box crate::lint::register_lints),
+        register_lints: Some(Box::new(crate::lint::register_lints)),
         override_queries: Some(|_sess, providers, _external_providers| {
             // Most lints will require typechecking, so just don't run them.
             providers.lint_mod = |_, _| {};

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -103,7 +103,7 @@ pub(crate) fn run(options: RustdocOptions) -> Result<(), ErrorGuaranteed> {
         diagnostic_output: DiagnosticOutput::Default,
         lint_caps,
         parse_sess_created: None,
-        register_lints: Some(box crate::lint::register_lints),
+        register_lints: Some(Box::new(crate::lint::register_lints)),
         override_queries: None,
         make_codegen_backend: None,
         registry: rustc_driver::diagnostics_registry(),
@@ -556,7 +556,7 @@ pub(crate) fn make_test(
             .supports_color();
 
             let emitter = EmitterWriter::new(
-                box io::sink(),
+                Box::new(io::sink()),
                 None,
                 None,
                 fallback_bundle,
@@ -568,7 +568,7 @@ pub(crate) fn make_test(
             );
 
             // FIXME(misdreavus): pass `-Z treat-err-as-bug` to the doctest parser
-            let handler = Handler::with_emitter(false, None, box emitter);
+            let handler = Handler::with_emitter(false, None, Box::new(emitter));
             let sess = ParseSess::with_span_handler(handler, sm);
 
             let mut found_main = false;
@@ -1005,7 +1005,7 @@ impl Tester for Collector {
 
             if let Err(err) = std::fs::create_dir_all(&path) {
                 eprintln!("Couldn't create directory for doctest executables: {}", err);
-                panic::resume_unwind(box ());
+                panic::resume_unwind(Box::new(()));
             }
 
             DirState::Perm(path)
@@ -1034,7 +1034,7 @@ impl Tester for Collector {
                 no_run,
                 test_type: test::TestType::DocTest,
             },
-            testfn: test::DynTestFn(box move || {
+            testfn: test::DynTestFn(Box::new(move || {
                 let report_unused_externs = |uext| {
                     unused_externs.lock().unwrap().push(uext);
                 };
@@ -1105,9 +1105,9 @@ impl Tester for Collector {
                         }
                     }
 
-                    panic::resume_unwind(box ());
+                    panic::resume_unwind(Box::new(()));
                 }
-            }),
+            })),
         });
     }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -737,21 +737,23 @@ pub(crate) fn href_relative_parts<'fqp>(
         if f != r {
             let dissimilar_part_count = relative_to_fqp.len() - i;
             let fqp_module = &fqp[i..fqp.len()];
-            return box iter::repeat(sym::dotdot)
-                .take(dissimilar_part_count)
-                .chain(fqp_module.iter().copied());
+            return Box::new(
+                iter::repeat(sym::dotdot)
+                    .take(dissimilar_part_count)
+                    .chain(fqp_module.iter().copied()),
+            );
         }
     }
     // e.g. linking to std::sync::atomic from std::sync
     if relative_to_fqp.len() < fqp.len() {
-        box fqp[relative_to_fqp.len()..fqp.len()].iter().copied()
+        Box::new(fqp[relative_to_fqp.len()..fqp.len()].iter().copied())
     // e.g. linking to std::sync from std::sync::atomic
     } else if fqp.len() < relative_to_fqp.len() {
         let dissimilar_part_count = relative_to_fqp.len() - fqp.len();
-        box iter::repeat(sym::dotdot).take(dissimilar_part_count)
+        Box::new(iter::repeat(sym::dotdot).take(dissimilar_part_count))
     // linking to the same module
     } else {
-        box iter::empty()
+        Box::new(iter::empty())
     }
 }
 


### PR DESCRIPTION
This is the second attempt after the librustdoc specific changes have been reverted from #87781 in #89134, due to a minor, but exant regression caused by the changes. ~~There have been some changes to librustdoc in the past and maybe thanks to them there is no regression any more. If there is still a regression, one can investigate further and maybe find ways to fix the regressions. Thus, i request a perf run.~~ Edit: turns out there is still a regression, but it's caused only by a subset of the changes. So I've changed this PR to only contains the changes that don't cause any performance regressions, keeping the regression causing changes for a later PR.