### PR TITLE
A debug allocator which removes overalignment from align < 8 allocations

### DIFF
--- a/library/std/src/sys/common/alloc.rs
+++ b/library/std/src/sys/common/alloc.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout};
 use crate::cmp;
 use crate::ptr;
 
@@ -36,7 +36,7 @@ pub const MIN_ALIGN: usize = 16;
 pub const MIN_ALIGN: usize = 4;
 
 pub unsafe fn realloc_fallback(
-    alloc: &System,
+    alloc: &impl GlobalAlloc,
     ptr: *mut u8,
     old_layout: Layout,
     new_size: usize,

--- a/library/std/src/sys/hermit/alloc.rs
+++ b/library/std/src/sys/hermit/alloc.rs
@@ -1,8 +1,10 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout};
 use crate::ptr;
 use crate::sys::hermit::abi;
 
-#[stable(feature = "alloc_system_type", since = "1.28.0")]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct System;
+
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/library/std/src/sys/sgx/alloc.rs
+++ b/library/std/src/sys/sgx/alloc.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout};
 use crate::ptr;
 use crate::sys::sgx::abi::mem as sgx_mem;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -56,7 +56,9 @@ unsafe impl dlmalloc::Allocator for Sgx {
     }
 }
 
-#[stable(feature = "alloc_system_type", since = "1.28.0")]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct System;
+
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/library/std/src/sys/solid/alloc.rs
+++ b/library/std/src/sys/solid/alloc.rs
@@ -1,9 +1,11 @@
 use crate::{
-    alloc::{GlobalAlloc, Layout, System},
+    alloc::{GlobalAlloc, Layout},
     sys::common::alloc::{realloc_fallback, MIN_ALIGN},
 };
 
-#[stable(feature = "alloc_system_type", since = "1.28.0")]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct System;
+
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/library/std/src/sys/unix/alloc.rs
+++ b/library/std/src/sys/unix/alloc.rs
@@ -1,8 +1,10 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout};
 use crate::ptr;
 use crate::sys::common::alloc::{realloc_fallback, MIN_ALIGN};
 
-#[stable(feature = "alloc_system_type", since = "1.28.0")]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct System;
+
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/library/std/src/sys/unsupported/alloc.rs
+++ b/library/std/src/sys/unsupported/alloc.rs
@@ -1,7 +1,9 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout};
 use crate::ptr::null_mut;
 
-#[stable(feature = "alloc_system_type", since = "1.28.0")]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct System;
+
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {

--- a/library/std/src/sys/wasm/alloc.rs
+++ b/library/std/src/sys/wasm/alloc.rs
@@ -16,11 +16,13 @@
 //! The crate itself provides a global allocator which on wasm has no
 //! synchronization as there are no threads!
 
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout};
 
 static mut DLMALLOC: dlmalloc::Dlmalloc = dlmalloc::Dlmalloc::new();
 
-#[stable(feature = "alloc_system_type", since = "1.28.0")]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct System;
+
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/library/std/src/sys/windows/alloc.rs
+++ b/library/std/src/sys/windows/alloc.rs
@@ -1,6 +1,6 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout};
 use crate::ffi::c_void;
 use crate::ptr;
 use crate::sync::atomic::{AtomicPtr, Ordering};
@@ -187,7 +187,9 @@ unsafe fn allocate(layout: Layout, zeroed: bool) -> *mut u8 {
 // the pointer will be aligned to the specified alignment and not point to the start of the allocated block.
 // Instead there will be a header readable directly before the returned pointer, containing the actual
 // location of the start of the block.
-#[stable(feature = "alloc_system_type", since = "1.28.0")]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct System;
+
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {


### PR DESCRIPTION
This reorganizes the implementation of the System allocator to permit adding various debuggig features. Currently, all that this implements is a scheme that allocates a little extra space for low-alignment allocations then returns a pointer into the actual allocation which is offset so that it is not over-aligned.

This is a huge aid in discovering accidental reliance on over-alignment. Allocators designed for C can be relied upon to produce over-aligned pointers, so alignment-related bugs can be latent for a long time. Currently I am aware of ~100 crates in the wild where Miri detects misaligned pointer access. Many of these take a `&[u8]`, sometimes from a `Vec<u8>` and attempt to do reads by converting to a more-aligned type without checking if the access is aligned.

On its own, this PR does basically nothing to detect bugs, but we already have debug assertions in a number of standard library APIs which are enabled along with this allocator in `-Zbuild-std`. And if I ever finish https://github.com/rust-lang/rust/pull/98112, we will be able to catch uses which just do misaligned pointer dereferences directly.

This implementation is factored so accommodate other patches to the default allocator which can help in detecting other sources of UB.

@rustbot label +T-libs

---

~This technique I'm trying to use breaks a UI test and I do not know why and I can't figure out how to fix it. I feel like this suggestion that's now coming out of a UI test doesn't even make sense. I made the per-system `System` allocators `pub(crate)` but they're suggested outside of `std` I think? Help?~ resolved by https://github.com/rust-lang/rust/pull/99091 :heart: 