### PR TITLE
Check that RPITs constrained by a recursive call in a closure are compatible

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -227,9 +227,17 @@ pub(crate) fn type_check<'mir, 'tcx>(
                     let mut hidden_type = infcx.resolve_vars_if_possible(decl.hidden_type);
                     // Check that RPITs are only constrained in their outermost
                     // function, otherwise report a mismatched types error.
-                    if let OpaqueTyOrigin::FnReturn(parent) | OpaqueTyOrigin::AsyncFn(parent)
-                            = infcx.opaque_ty_origin_unchecked(opaque_type_key.def_id, hidden_type.span)
-                        && parent.to_def_id() != body.source.def_id()
+                    if let hir::Node::Item(hir::Item {
+                        kind:
+                            hir::ItemKind::OpaqueTy(hir::OpaqueTy {
+                                origin:
+                                    hir::OpaqueTyOrigin::AsyncFn(parent)
+                                    | hir::OpaqueTyOrigin::FnReturn(parent),
+                                ..
+                            }),
+                        ..
+                    }) = infcx.tcx.hir().get_by_def_id(opaque_type_key.def_id.expect_local()) &&
+                        parent.to_def_id() != body.source.def_id()
                     {
                         infcx
                             .report_mismatched_types(
@@ -239,7 +247,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
                                         body.source.def_id().expect_local(),
                                     ),
                                 ),
-                                infcx.tcx.mk_opaque(opaque_type_key.def_id.to_def_id(), opaque_type_key.substs),
+                                infcx.tcx.mk_opaque(opaque_type_key.def_id, opaque_type_key.substs),
                                 hidden_type.ty,
                                 ty::error::TypeError::Mismatch,
                             )

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -21,7 +21,6 @@ use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKi
 use rustc_infer::infer::{
     InferCtxt, InferOk, LateBoundRegion, LateBoundRegionConversionTime, NllRegionVariableOrigin,
 };
-use rustc_infer::traits::ObligationCause;
 use rustc_middle::mir::tcx::PlaceTy;
 use rustc_middle::mir::visit::{NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::AssertKind;
@@ -225,34 +224,6 @@ pub(crate) fn type_check<'mir, 'tcx>(
                     )
                     .unwrap();
                     let mut hidden_type = infcx.resolve_vars_if_possible(decl.hidden_type);
-                    // Check that RPITs are only constrained in their outermost
-                    // function, otherwise report a mismatched types error.
-                    if let hir::Node::Item(hir::Item {
-                        kind:
-                            hir::ItemKind::OpaqueTy(hir::OpaqueTy {
-                                origin:
-                                    hir::OpaqueTyOrigin::AsyncFn(parent)
-                                    | hir::OpaqueTyOrigin::FnReturn(parent),
-                                ..
-                            }),
-                        ..
-                    }) = infcx.tcx.hir().get_by_def_id(opaque_type_key.def_id.expect_local()) &&
-                        parent.to_def_id() != body.source.def_id()
-                    {
-                        infcx
-                            .report_mismatched_types(
-                                &ObligationCause::misc(
-                                    hidden_type.span,
-                                    infcx.tcx.hir().local_def_id_to_hir_id(
-                                        body.source.def_id().expect_local(),
-                                    ),
-                                ),
-                                infcx.tcx.mk_opaque(opaque_type_key.def_id, opaque_type_key.substs),
-                                hidden_type.ty,
-                                ty::error::TypeError::Mismatch,
-                            )
-                            .emit();
-                    }
                     trace!(
                         "finalized opaque type {:?} to {:#?}",
                         opaque_type_key,

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -438,7 +438,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     #[instrument(skip(self), level = "trace")]
-    pub fn opaque_ty_origin_unchecked(&self, def_id: LocalDefId, span: Span) -> OpaqueTyOrigin {
+    fn opaque_ty_origin_unchecked(&self, def_id: LocalDefId, span: Span) -> OpaqueTyOrigin {
         let origin = match self.tcx.hir().expect_item(def_id).kind {
             hir::ItemKind::OpaqueTy(hir::OpaqueTy { origin, .. }) => origin,
             ref itemkind => {

--- a/src/test/ui/impl-trait/issue-99073-2.rs
+++ b/src/test/ui/impl-trait/issue-99073-2.rs
@@ -7,7 +7,7 @@ fn main() {
 fn test<T: Display>(t: T, recurse: bool) -> impl Display {
     let f = || {
         let i: u32 = test::<i32>(-1, false);
-        //~^ ERROR mismatched types
+        //~^ ERROR concrete type differs from previous defining opaque type use
         println!("{i}");
     };
     if recurse {

--- a/src/test/ui/impl-trait/issue-99073-2.stderr
+++ b/src/test/ui/impl-trait/issue-99073-2.stderr
@@ -1,15 +1,14 @@
-error[E0308]: mismatched types
+error: concrete type differs from previous defining opaque type use
   --> $DIR/issue-99073-2.rs:9:22
    |
-LL | fn test<T: Display>(t: T, recurse: bool) -> impl Display {
-   |                                             ------------ the expected opaque type
-LL |     let f = || {
 LL |         let i: u32 = test::<i32>(-1, false);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^ types differ
+   |                      ^^^^^^^^^^^^^^^^^^^^^^ expected `T`, got `u32`
    |
-   = note: expected opaque type `impl std::fmt::Display`
-                     found type `u32`
+note: previous use here
+  --> $DIR/issue-99073-2.rs:16:5
+   |
+LL |     t
+   |     ^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/impl-trait/issue-99073.rs
+++ b/src/test/ui/impl-trait/issue-99073.rs
@@ -1,8 +1,8 @@
 fn main() {
-    let _ = fix(|_: &dyn Fn()| {});
+  let _ = fix(|_: &dyn Fn()| {});
 }
 
 fn fix<F: Fn(G), G: Fn()>(f: F) -> impl Fn() {
-    move || f(fix(&f))
-    //~^ ERROR mismatched types
+  move || f(fix(&f))
+  //~^ ERROR concrete type differs from previous defining opaque type use
 }

--- a/src/test/ui/impl-trait/issue-99073.stderr
+++ b/src/test/ui/impl-trait/issue-99073.stderr
@@ -1,14 +1,14 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-99073.rs:6:13
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/issue-99073.rs:6:11
    |
-LL | fn fix<F: Fn(G), G: Fn()>(f: F) -> impl Fn() {
-   |                                    --------- the expected opaque type
-LL |     move || f(fix(&f))
-   |             ^^^^^^^^^^ types differ
+LL |   move || f(fix(&f))
+   |           ^^^^^^^^^^ expected `[closure@$DIR/issue-99073.rs:6:3: 6:10]`, got `G`
    |
-   = note: expected opaque type `impl Fn()`
-           found type parameter `G`
+note: previous use here
+  --> $DIR/issue-99073.rs:6:3
+   |
+LL |   move || f(fix(&f))
+   |   ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #99073

Adapts a similar visitor pattern to `find_opaque_ty_constraints` (that we use to check TAITs), but with some changes:
1. Only walk the "OnlyBody" children, instead of all items in the RPIT's defining scope
1. Only walk through the body's children if we found a constraining usage
2. Don't actually do any inference, just do a comparison and error if they're mismatched

----

r? @oli-obk -- you know all this impl-trait stuff best... is this the right approach? I can explain the underlying issue better if you'd like, in case that might reveal a better solution. Not sure if it's possible to gather up the closure's defining usages of the RPIT while borrowck'ing the outer function, that might be a better place to put this check...