### PR TITLE
Fix binary name in help message for test binaries

### DIFF
--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -196,6 +196,7 @@ Test Attributes:
 pub fn parse_opts(args: &[String]) -> Option<OptRes> {
     // Parse matches.
     let opts = optgroups();
+    let binary = args.get(0).map(|c| &**c).unwrap_or("...");
     let args = args.get(1..).unwrap_or(args);
     let matches = match opts.parse(args) {
         Ok(m) => m,
@@ -205,7 +206,7 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
     // Check if help was requested.
     if matches.opt_present("h") {
         // Show help and do nothing more.
-        usage(&args[0], &opts);
+        usage(binary, &opts);
         return None;
     }
 


### PR DESCRIPTION
Currently the help output for a test binary uses the first argument instead of the binary name in the help output:

```
$ cargo test -- --help
...
Usage: --help [OPTIONS] [FILTERS...]
...
```

This fixes it to use the name of the binary (or `...` if there is no binary name passed on argv):

```
$ cargo test -- --help
...
Usage: /tmp/x/target/debug/deps/x-80c11a15ad4e1bf3 [OPTIONS] [FILTERS...]
...
```