### PR TITLE
Don't mark generators as `!Send` if a `Copy + !Send` value is dropped across a yield

### DIFF
--- a/src/test/ui/async-await/trivial-drop.rs
+++ b/src/test/ui/async-await/trivial-drop.rs
@@ -1,0 +1,12 @@
+// edition:2018
+// build-pass
+async fn trivial_drop() {
+    let x: *const usize = &0;
+    async {}.await;
+}
+
+fn assert_send<T: Send>(_: T) {}
+
+fn main() {
+    assert_send(trivial_drop());
+}

--- a/src/test/ui/generator/trivial-drop-non-copy.rs
+++ b/src/test/ui/generator/trivial-drop-non-copy.rs
@@ -1,0 +1,15 @@
+#![feature(generators, negative_impls)]
+
+fn assert_send<T: Send>(_: T) {}
+
+struct S;
+impl !Send for S {}
+
+fn main() {
+    println!("{}", std::mem::needs_drop::<S>());
+    let g = || {
+        let x = S; //~ type `S`
+        yield; //~ `x` maybe used later
+    };
+    assert_send(g); //~ ERROR generator cannot be sent between threads
+}

--- a/src/test/ui/generator/trivial-drop-non-copy.stderr
+++ b/src/test/ui/generator/trivial-drop-non-copy.stderr
@@ -1,0 +1,24 @@
+error: generator cannot be sent between threads safely
+  --> $DIR/trivial-drop-non-copy.rs:14:5
+   |
+LL |     assert_send(g);
+   |     ^^^^^^^^^^^ generator is not `Send`
+   |
+   = help: within `[generator@$DIR/trivial-drop-non-copy.rs:10:13: 10:15]`, the trait `Send` is not implemented for `S`
+note: generator is not `Send` as this value is used across a yield
+  --> $DIR/trivial-drop-non-copy.rs:12:9
+   |
+LL |         let x = S;
+   |             - has type `S` which is not `Send`
+LL |         yield;
+   |         ^^^^^ yield occurs here, with `x` maybe used later
+LL |     };
+   |     - `x` is later dropped here
+note: required by a bound in `assert_send`
+  --> $DIR/trivial-drop-non-copy.rs:3:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error: aborting due to previous error
+

--- a/src/test/ui/generator/trivial-drop.rs
+++ b/src/test/ui/generator/trivial-drop.rs
@@ -1,0 +1,12 @@
+// build-pass
+#![feature(generators)]
+
+fn assert_send<T: Send>(_: T) {}
+
+fn main() {
+    let g = || {
+        let x: *const usize = &0;
+        yield;
+    };
+    assert_send(g);
+}


### PR DESCRIPTION
Copy types can neither read nor write their values when dropped (the language guarantees Drop is a no-op).
So it doesn't make sense for them to make the generator non-Send.

Fixes https://github.com/rust-lang/rust/issues/99104.

This may need a T-lang FCP.

cc @eholk - maybe we want to feature-gate this behind `-Zdrop-tracking`? I don't think this is related to building the control-flow-graph, though, it also applies even when we naively assume the value is always dropped at the end of the lexical scope.