### PR TITLE
Group .test-arrow CSS rules and fix rgb/rgba property

### DIFF
--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -178,9 +178,6 @@ a {
 	color: #D2991D;
 }
 
-a.test-arrow {
-	color: #dedede;
-}
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
@@ -255,6 +252,7 @@ pre.rust .question-mark {
 }
 
 a.test-arrow {
+	color: #dedede;
 	background-color: rgba(78, 139, 202, 0.2);
 }
 

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -175,9 +175,6 @@ a {
 	color: #3873AD;
 }
 
-a.test-arrow {
-	color: #f5f5f5;
-}
 body.source .example-wrap pre.rust a {
 	background: #eee;
 }
@@ -239,7 +236,8 @@ pre.rust .question-mark {
 }
 
 a.test-arrow {
-	background-color: rgb(78, 139, 202, 0.2);
+	color: #f5f5f5;
+	background-color: rgba(78, 139, 202, 0.2);
 }
 
 a.test-arrow:hover{


### PR DESCRIPTION
Surprisingly, the web browsers were handling the `rgb`/`rgba` typo correctly. At least it now is as expected.

For the rest, it's simply grouping `.test-arrow` rules.

r? @Dylan-DPC 