### PR TITLE
Fix sized check ICE in asm check

### DIFF
--- a/src/test/ui/asm/issue-99122-2.rs
+++ b/src/test/ui/asm/issue-99122-2.rs
@@ -1,0 +1,21 @@
+// check-pass
+// needs-asm-support
+// only-x86_64
+
+// This demonstrates why we need to erase regions before sized check in intrinsicck
+
+struct NoCopy;
+
+struct Wrap<'a, T, Tail: ?Sized>(&'a T, Tail);
+
+pub unsafe fn test() {
+    let i = NoCopy;
+    let j = Wrap(&i, ());
+    let pointer = &j as *const _;
+    core::arch::asm!(
+        "nop",
+        in("eax") pointer,
+    );
+}
+
+fn main() {}

--- a/src/test/ui/asm/issue-99122.rs
+++ b/src/test/ui/asm/issue-99122.rs
@@ -1,0 +1,13 @@
+// needs-asm-support
+// only-x86_64
+
+pub unsafe fn test() {
+    let pointer = 1u32 as *const _;
+    //~^ ERROR cannot cast to a pointer of an unknown kind
+    core::arch::asm!(
+        "nop",
+        in("eax") pointer,
+    );
+}
+
+fn main() {}

--- a/src/test/ui/asm/issue-99122.stderr
+++ b/src/test/ui/asm/issue-99122.stderr
@@ -1,0 +1,11 @@
+error[E0641]: cannot cast to a pointer of an unknown kind
+  --> $DIR/issue-99122.rs:5:27
+   |
+LL |     let pointer = 1u32 as *const _;
+   |                           ^^^^^^^^ needs more type information
+   |
+   = note: the type information given here is insufficient to check whether the pointer cast is valid
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0641`.


### PR DESCRIPTION
Fixes (beta nominated, so doesn't close) #99122

1. Moves a check for unresolved inference variables to _before_ other checks that could possibly ICE. We're not changing behavior here, just doing the same thing earlier in the function.
2. Erases region variables in sized check (which are not resolved at this point) because rustc will also ICE when region vars are passed to a query which does not canonicalize them.