### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -13,7 +13,7 @@ use crate::traits::{
     self, FulfillmentContext, Normalized, Obligation, ObligationCause, PredicateObligation,
     PredicateObligations, SelectionContext,
 };
-//use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::FxIndexSet;
 use rustc_errors::Diagnostic;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
@@ -44,7 +44,7 @@ pub enum Conflict {
 
 pub struct OverlapResult<'tcx> {
     pub impl_header: ty::ImplHeader<'tcx>,
-    pub intercrate_ambiguity_causes: Vec<IntercrateAmbiguityCause>,
+    pub intercrate_ambiguity_causes: FxIndexSet<IntercrateAmbiguityCause>,
 
     /// `true` if the overlap might've been permitted before the shift
     /// to universes.

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -110,7 +110,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                             IntercrateAmbiguityCause::DownstreamCrate { trait_desc, self_desc }
                         };
                         debug!(?cause, "evaluate_stack: pushing cause");
-                        self.intercrate_ambiguity_causes.as_mut().unwrap().push(cause);
+                        self.intercrate_ambiguity_causes.as_mut().unwrap().insert(cause);
                     }
                 }
             }

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -15,7 +15,7 @@ use specialization_graph::GraphExt;
 use crate::infer::{InferCtxt, InferOk, TyCtxtInferExt};
 use crate::traits::select::IntercrateAmbiguityCause;
 use crate::traits::{self, coherence, FutureCompatOverlapErrorKind, ObligationCause, TraitEngine};
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::{struct_span_err, EmissionGuarantee, LintDiagnosticBuilder};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::ty::subst::{InternalSubsts, Subst, SubstsRef};
@@ -33,7 +33,7 @@ pub struct OverlapError {
     pub with_impl: DefId,
     pub trait_desc: String,
     pub self_desc: Option<String>,
-    pub intercrate_ambiguity_causes: Vec<IntercrateAmbiguityCause>,
+    pub intercrate_ambiguity_causes: FxIndexSet<IntercrateAmbiguityCause>,
     pub involves_placeholder: bool,
 }
 

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -991,7 +991,7 @@ impl<T> AtomicPtr<T> {
     /// use std::sync::atomic::AtomicPtr;
     ///
     /// let ptr = &mut 5;
-    /// let atomic_ptr  = AtomicPtr::new(ptr);
+    /// let atomic_ptr = AtomicPtr::new(ptr);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -147,8 +147,8 @@ pub(crate) fn maybe_download_ci_llvm(builder: &Builder<'_>) {
     let key = format!("{}{}", llvm_sha, config.llvm_assertions);
     if program_out_of_date(&llvm_stamp, &key) && !config.dry_run {
         download_ci_llvm(builder, &llvm_sha);
-        for binary in ["llvm-config", "FileCheck"] {
-            builder.fix_bin_or_dylib(&llvm_root.join("bin").join(binary));
+        for entry in t!(fs::read_dir(llvm_root.join("bin"))) {
+            builder.fix_bin_or_dylib(&t!(entry).path());
         }
 
         // Update the timestamp of llvm-config to force rustc_llvm to be

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -178,9 +178,6 @@ a {
 	color: #D2991D;
 }
 
-a.test-arrow {
-	color: #dedede;
-}
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
@@ -255,6 +252,7 @@ pre.rust .question-mark {
 }
 
 a.test-arrow {
+	color: #dedede;
 	background-color: rgba(78, 139, 202, 0.2);
 }
 

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -175,9 +175,6 @@ a {
 	color: #3873AD;
 }
 
-a.test-arrow {
-	color: #f5f5f5;
-}
 body.source .example-wrap pre.rust a {
 	background: #eee;
 }
@@ -239,7 +236,8 @@ pre.rust .question-mark {
 }
 
 a.test-arrow {
-	background-color: rgb(78, 139, 202, 0.2);
+	color: #f5f5f5;
+	background-color: rgba(78, 139, 202, 0.2);
 }
 
 a.test-arrow:hover{

--- a/src/test/ui/coherence/coherence-projection-conflict-orphan.stderr
+++ b/src/test/ui/coherence/coherence-projection-conflict-orphan.stderr
@@ -8,7 +8,6 @@ LL | impl<A:Iterator> Foo<A::Item> for A { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `i32`
    |
    = note: upstream crates may add a new impl of trait `std::iter::Iterator` for type `i32` in future versions
-   = note: upstream crates may add a new impl of trait `std::iter::Iterator` for type `i32` in future versions
 
 error: aborting due to previous error
 

--- a/src/test/ui/coherence/inter-crate-ambiguity-causes-notes.rs
+++ b/src/test/ui/coherence/inter-crate-ambiguity-causes-notes.rs
@@ -1,0 +1,19 @@
+struct S;
+
+impl From<()> for S {
+    fn from(x: ()) -> Self {
+        S
+    }
+}
+
+impl<I> From<I> for S
+//~^ ERROR conflicting implementations of trait
+where
+    I: Iterator<Item = ()>,
+{
+    fn from(x: I) -> Self {
+        S
+    }
+}
+
+fn main() {}

--- a/src/test/ui/coherence/inter-crate-ambiguity-causes-notes.stderr
+++ b/src/test/ui/coherence/inter-crate-ambiguity-causes-notes.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `std::convert::From<()>` for type `S`
+  --> $DIR/inter-crate-ambiguity-causes-notes.rs:9:1
+   |
+LL | impl From<()> for S {
+   | ------------------- first implementation here
+...
+LL | impl<I> From<I> for S
+   | ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S`
+   |
+   = note: upstream crates may add a new impl of trait `std::iter::Iterator` for type `()` in future versions
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/generic-associated-types/issue-91139.rs
+++ b/src/test/ui/generic-associated-types/issue-91139.rs
@@ -22,6 +22,7 @@ fn foo<T>() {
     //~| ERROR `T` does not live long enough
     //~| ERROR `T` does not live long enough
     //~| ERROR `T` does not live long enough
+    //~| ERROR `T` may not live long enough
     //
     // FIXME: This error is bogus, but it arises because we try to validate
     // that `<() as Foo<T>>::Type<'a>` is valid, which requires proving

--- a/src/test/ui/generic-associated-types/issue-91139.stderr
+++ b/src/test/ui/generic-associated-types/issue-91139.stderr
@@ -34,6 +34,17 @@ error: `T` does not live long enough
 LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
    |                                                          ^^^^^^^^^
 
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue-91139.rs:16:58
+   |
+LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
+   |                                                          ^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn foo<T: 'static>() {
+   |         +++++++++
+
 error: `T` does not live long enough
   --> $DIR/issue-91139.rs:16:58
    |
@@ -46,5 +57,6 @@ error: `T` does not live long enough
 LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
    |                                                          ^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 
+For more information about this error, try `rustc --explain E0310`.

--- a/src/test/ui/nll/issue-98693.rs
+++ b/src/test/ui/nll/issue-98693.rs
@@ -1,0 +1,21 @@
+// Regression test for #98693.
+//
+// The closure encounters an obligation that `T` must outlive `!U1`,
+// a placeholder from universe U1. We were ignoring this placeholder
+// when promoting the constraint to the enclosing function, and
+// thus incorrectly judging the closure to be safe.
+
+fn assert_static<T>()
+where
+    for<'a> T: 'a,
+{
+}
+
+fn test<T>() {
+    || {
+        //~^ ERROR the parameter type `T` may not live long enough
+        assert_static::<T>();
+    };
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-98693.stderr
+++ b/src/test/ui/nll/issue-98693.stderr
@@ -1,0 +1,17 @@
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue-98693.rs:15:5
+   |
+LL | /     || {
+LL | |
+LL | |         assert_static::<T>();
+LL | |     };
+   | |_____^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn test<T: 'static>() {
+   |          +++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
Successful merges:

 - #98713 (promote placeholder bounds to 'static obligations)
 - #99094 (Remove extra space in AtomicPtr::new docs)
 - #99095 (Remove duplicate notes from error on inter-crate ambiguous impl of traits)
 - #99114 (Group .test-arrow CSS rules and fix rgb/rgba property)
 - #99128 (Fix `download-ci-llvm` NixOS patching for binaries)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98713,99094,99095,99114,99128)
<!-- homu-ignore:end -->