### PR TITLE
Extend and expose API for {:x?} and {:X?} formatting

### DIFF
--- a/compiler/rustc_parse_format/src/tests.rs
+++ b/compiler/rustc_parse_format/src/tests.rs
@@ -63,7 +63,7 @@ fn format_nothing() {
         "{}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: fmtdflt(),
         })],
     );
@@ -74,7 +74,7 @@ fn format_position() {
         "{3}",
         &[NextArgument(Argument {
             position: ArgumentIs(3),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: fmtdflt(),
         })],
     );
@@ -85,7 +85,7 @@ fn format_position_nothing_else() {
         "{3:}",
         &[NextArgument(Argument {
             position: ArgumentIs(3),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: fmtdflt(),
         })],
     );
@@ -96,7 +96,7 @@ fn format_named() {
         "{name}",
         &[NextArgument(Argument {
             position: ArgumentNamed("name"),
-            position_span: InnerSpan { start: 2, end: 6 },
+            position_span: InnerSpan::new(2, 6),
             format: fmtdflt(),
         })],
     )
@@ -107,7 +107,7 @@ fn format_type() {
         "{3:x}",
         &[NextArgument(Argument {
             position: ArgumentIs(3),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
@@ -117,7 +117,28 @@ fn format_type() {
                 precision_span: None,
                 width_span: None,
                 ty: "x",
-                ty_span: None,
+                ty_span: Some(InnerSpan::new(4, 5)),
+            },
+        })],
+    );
+}
+#[test]
+fn format_variant() {
+    same(
+        "{3:x?}",
+        &[NextArgument(Argument {
+            position: ArgumentIs(3),
+            position_span: InnerSpan::new(2, 3),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: (DebugVariant::LowerHex as u32),
+                precision: CountImplied,
+                width: CountImplied,
+                precision_span: None,
+                width_span: None,
+                ty: "?",
+                ty_span: Some(InnerSpan::new(5, 6)),
             },
         })],
     );
@@ -128,7 +149,7 @@ fn format_align_fill() {
         "{3:>}",
         &[NextArgument(Argument {
             position: ArgumentIs(3),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: FormatSpec {
                 fill: None,
                 align: AlignRight,
@@ -146,7 +167,7 @@ fn format_align_fill() {
         "{3:0<}",
         &[NextArgument(Argument {
             position: ArgumentIs(3),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: FormatSpec {
                 fill: Some('0'),
                 align: AlignLeft,
@@ -164,7 +185,7 @@ fn format_align_fill() {
         "{3:*<abcd}",
         &[NextArgument(Argument {
             position: ArgumentIs(3),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: FormatSpec {
                 fill: Some('*'),
                 align: AlignLeft,
@@ -185,7 +206,7 @@ fn format_counts() {
         "{:10x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
@@ -193,9 +214,9 @@ fn format_counts() {
                 precision: CountImplied,
                 precision_span: None,
                 width: CountIs(10),
-                width_span: Some(InnerSpan { start: 3, end: 5 }),
+                width_span: Some(InnerSpan::new(3, 5)),
                 ty: "x",
-                ty_span: None,
+                ty_span: Some(InnerSpan::new(5, 6)),
             },
         })],
     );
@@ -203,17 +224,17 @@ fn format_counts() {
         "{:10$.10x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
                 flags: 0,
                 precision: CountIs(10),
-                precision_span: Some(InnerSpan { start: 6, end: 9 }),
+                precision_span: Some(InnerSpan::new(6, 9)),
                 width: CountIsParam(10),
-                width_span: Some(InnerSpan { start: 3, end: 6 }),
+                width_span: Some(InnerSpan::new(3, 6)),
                 ty: "x",
-                ty_span: None,
+                ty_span: Some(InnerSpan::new(9, 10)),
             },
         })],
     );
@@ -221,17 +242,17 @@ fn format_counts() {
         "{1:0$.10x}",
         &[NextArgument(Argument {
             position: ArgumentIs(1),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
                 flags: 0,
                 precision: CountIs(10),
-                precision_span: Some(InnerSpan { start: 6, end: 9 }),
+                precision_span: Some(InnerSpan::new(6, 9)),
                 width: CountIsParam(0),
-                width_span: Some(InnerSpan { start: 4, end: 6 }),
+                width_span: Some(InnerSpan::new(4, 6)),
                 ty: "x",
-                ty_span: None,
+                ty_span: Some(InnerSpan::new(9, 10)),
             },
         })],
     );
@@ -239,17 +260,17 @@ fn format_counts() {
         "{:.*x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(1),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
                 flags: 0,
                 precision: CountIsStar(0),
-                precision_span: Some(InnerSpan { start: 3, end: 5 }),
+                precision_span: Some(InnerSpan::new(3, 5)),
                 width: CountImplied,
                 width_span: None,
                 ty: "x",
-                ty_span: None,
+                ty_span: Some(InnerSpan::new(5, 6)),
             },
         })],
     );
@@ -257,7 +278,7 @@ fn format_counts() {
         "{:.10$x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
@@ -267,7 +288,7 @@ fn format_counts() {
                 precision_span: Some(InnerSpan::new(3, 7)),
                 width_span: None,
                 ty: "x",
-                ty_span: None,
+                ty_span: Some(InnerSpan::new(7, 8)),
             },
         })],
     );
@@ -275,17 +296,17 @@ fn format_counts() {
         "{:a$.b$?}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
                 flags: 0,
-                precision: CountIsName("b", InnerSpan { start: 6, end: 7 }),
-                precision_span: Some(InnerSpan { start: 5, end: 8 }),
-                width: CountIsName("a", InnerSpan { start: 3, end: 4 }),
-                width_span: Some(InnerSpan { start: 3, end: 5 }),
+                precision: CountIsName("b", InnerSpan::new(6, 7)),
+                precision_span: Some(InnerSpan::new(5, 8)),
+                width: CountIsName("a", InnerSpan::new(3, 4)),
+                width_span: Some(InnerSpan::new(3, 5)),
                 ty: "?",
-                ty_span: None,
+                ty_span: Some(InnerSpan::new(8, 9)),
             },
         })],
     );
@@ -293,13 +314,13 @@ fn format_counts() {
         "{:.4}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
                 flags: 0,
                 precision: CountIs(4),
-                precision_span: Some(InnerSpan { start: 3, end: 5 }),
+                precision_span: Some(InnerSpan::new(3, 5)),
                 width: CountImplied,
                 width_span: None,
                 ty: "",
@@ -314,11 +335,11 @@ fn format_flags() {
         "{:-}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
-                flags: (1 << FlagSignMinus as u32),
+                flags: FlagSignMinus as u32,
                 precision: CountImplied,
                 width: CountImplied,
                 precision_span: None,
@@ -332,11 +353,11 @@ fn format_flags() {
         "{:+#}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 2 },
+            position_span: InnerSpan::new(2, 2),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
-                flags: (1 << FlagSignPlus as u32) | (1 << FlagAlternate as u32),
+                flags: (FlagSignPlus as u32) | (FlagAlternate as u32),
                 precision: CountImplied,
                 width: CountImplied,
                 precision_span: None,
@@ -355,7 +376,7 @@ fn format_mixture() {
             String("abcd "),
             NextArgument(Argument {
                 position: ArgumentIs(3),
-                position_span: InnerSpan { start: 7, end: 8 },
+                position_span: InnerSpan::new(7, 8),
                 format: FormatSpec {
                     fill: None,
                     align: AlignUnknown,
@@ -365,7 +386,7 @@ fn format_mixture() {
                     precision_span: None,
                     width_span: None,
                     ty: "x",
-                    ty_span: None,
+                    ty_span: Some(InnerSpan::new(9, 10)),
                 },
             }),
             String(" efg"),
@@ -378,7 +399,7 @@ fn format_whitespace() {
         "{ }",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 3 },
+            position_span: InnerSpan::new(2, 3),
             format: fmtdflt(),
         })],
     );
@@ -386,7 +407,7 @@ fn format_whitespace() {
         "{  }",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
-            position_span: InnerSpan { start: 2, end: 4 },
+            position_span: InnerSpan::new(2, 4),
             format: fmtdflt(),
         })],
     );

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1830,7 +1830,11 @@ impl<T: fmt::Display + ?Sized, A: Allocator> fmt::Display for Box<T, A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: fmt::Debug + ?Sized, A: Allocator> fmt::Debug for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
+        if f.debug_variant() == fmt::DebugVariant::Pointer {
+            fmt::Pointer::fmt(self, f)
+        } else {
+            fmt::Debug::fmt(&**self, f)
+        }
     }
 }
 

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -319,7 +319,7 @@
 //! sign := '+' | '-'
 //! width := count
 //! precision := count | '*'
-//! type := '' | '?' | 'x?' | 'X?' | identifier
+//! type := '' | '?' | identifier | identifier '?'
 //! count := parameter | integer
 //! parameter := argument '$'
 //! ```
@@ -338,16 +338,18 @@
 //! well as [`isize`]). The current mapping of types to traits is:
 //!
 //! * *nothing* ⇒ [`Display`]
-//! * `?` ⇒ [`Debug`]
-//! * `x?` ⇒ [`Debug`] with lower-case hexadecimal integers
-//! * `X?` ⇒ [`Debug`] with upper-case hexadecimal integers
-//! * `o` ⇒ [`Octal`]
 //! * `x` ⇒ [`LowerHex`]
 //! * `X` ⇒ [`UpperHex`]
-//! * `p` ⇒ [`Pointer`]
+//! * `o` ⇒ [`Octal`]
 //! * `b` ⇒ [`Binary`]
+//! * `p` ⇒ [`Pointer`]
 //! * `e` ⇒ [`LowerExp`]
 //! * `E` ⇒ [`UpperExp`]
+//!
+//! Additionally, any formatting kind can add `?` to be converted into [`Debug`] formatting,
+//! which gives a hint to use a particular kind of formatting if possible. This means that `?`
+//! by itself will fall back to the default debug-formatting, but `x?` will hint to use
+//! `LowerHex`-style formatting if possible.
 //!
 //! What this means is that any type of argument which implements the
 //! [`fmt::Binary`][`Binary`] trait can then be formatted with `{:b}`. Implementations

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -113,6 +113,7 @@
 #![feature(const_pin)]
 #![feature(const_waker)]
 #![feature(cstr_from_bytes_until_nul)]
+#![feature(debug_variants)]
 #![feature(dispatch_from_dyn)]
 #![feature(error_generic_member_access)]
 #![feature(error_in_core)]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1843,7 +1843,11 @@ impl<T: ?Sized + fmt::Display> fmt::Display for Rc<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + fmt::Debug> fmt::Debug for Rc<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
+        if f.debug_variant() == fmt::DebugVariant::Pointer {
+            fmt::Pointer::fmt(self, f)
+        } else {
+            fmt::Debug::fmt(&**self, f)
+        }
     }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2421,7 +2421,11 @@ impl<T: ?Sized + fmt::Display> fmt::Display for Arc<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + fmt::Debug> fmt::Debug for Arc<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
+        if f.debug_variant() == fmt::DebugVariant::Pointer {
+            fmt::Pointer::fmt(self, f)
+        } else {
+            fmt::Debug::fmt(&**self, f)
+        }
     }
 }
 

--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -1,4 +1,4 @@
-use crate::fmt::{Debug, Display, Formatter, LowerExp, Result, UpperExp};
+use crate::fmt::{Debug, DebugVariant, Display, Formatter, LowerExp, Result, UpperExp};
 use crate::mem::MaybeUninit;
 use crate::num::flt2dec;
 use crate::num::fmt as numfmt;
@@ -195,7 +195,11 @@ macro_rules! floating {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Debug for $ty {
             fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
-                float_to_general_debug(fmt, self)
+                match fmt.debug_variant() {
+                    DebugVariant::LowerExp => LowerExp::fmt(self, fmt),
+                    DebugVariant::UpperExp => UpperExp::fmt(self, fmt),
+                    _ => float_to_general_debug(fmt, self),
+                }
             }
         }
 

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -183,12 +183,14 @@ macro_rules! debug {
         impl fmt::Debug for $T {
             #[inline]
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                if f.debug_lower_hex() {
-                    fmt::LowerHex::fmt(self, f)
-                } else if f.debug_upper_hex() {
-                    fmt::UpperHex::fmt(self, f)
-                } else {
-                    fmt::Display::fmt(self, f)
+                match f.debug_variant() {
+                    fmt::DebugVariant::LowerHex => fmt::LowerHex::fmt(self, f),
+                    fmt::DebugVariant::UpperHex => fmt::UpperHex::fmt(self, f),
+                    fmt::DebugVariant::Octal => fmt::Octal::fmt(self, f),
+                    fmt::DebugVariant::Binary => fmt::Binary::fmt(self, f),
+                    fmt::DebugVariant::LowerExp => fmt::LowerExp::fmt(self, f),
+                    fmt::DebugVariant::UpperExp => fmt::UpperExp::fmt(self, f),
+                    _ => fmt::Display::fmt(self, f),
                 }
             }
         }

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -3405,7 +3405,11 @@ impl fmt::Debug for AtomicBool {
 #[stable(feature = "atomic_debug", since = "1.3.0")]
 impl<T> fmt::Debug for AtomicPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.load(Ordering::Relaxed), f)
+        if f.debug_variant() == fmt::DebugVariant::Pointer {
+            fmt::Pointer::fmt(self, f)
+        } else {
+            fmt::Debug::fmt(&self.load(Ordering::Relaxed), f)
+        }
     }
 }
 

--- a/library/core/tests/fmt/mod.rs
+++ b/library/core/tests/fmt/mod.rs
@@ -19,6 +19,14 @@ fn test_pointer_formats_data_pointer() {
     assert_eq!(format!("{b:p}"), format!("{:p}", b.as_ptr()));
 }
 
+#[cfg(not(bootstrap))]
+#[test]
+fn test_pointer_debug() {
+    let data = &1;
+    assert_eq!(format!("{:?}", data), "1");
+    assert_eq!(format!("{data:p?}"), format!("{data:p}"));
+}
+
 #[test]
 fn test_estimated_capacity() {
     assert_eq!(format_args!("").estimated_capacity(), 0);

--- a/library/core/tests/fmt/num.rs
+++ b/library/core/tests/fmt/num.rs
@@ -218,8 +218,21 @@ fn test_format_int_twos_complement() {
     assert_eq!(format!("{}", i64::MIN), "-9223372036854775808");
 }
 
+#[cfg(not(bootstrap))]
 #[test]
-fn test_format_debug_hex() {
+fn test_format_debug_bases() {
     assert_eq!(format!("{:02x?}", b"Foo\0"), "[46, 6f, 6f, 00]");
     assert_eq!(format!("{:02X?}", b"Foo\0"), "[46, 6F, 6F, 00]");
+    #[cfg(not(bootstrap))]
+    {
+        assert_eq!(format!("{:03o?}", b"Foo\0"), "[106, 157, 157, 000]");
+        assert_eq!(format!("{:07b?}", b"Foo\0"), "[1000110, 1101111, 1101111, 0000000]");
+    }
+}
+
+#[cfg(not(bootstrap))]
+#[test]
+fn test_format_debug_exp() {
+    assert_eq!(format!("{:e?}", &[1, 20, 300]), "[1e0, 2e1, 3e2]");
+    assert_eq!(format!("{:E?}", &[1, 20, 300]), "[1E0, 2E1, 3E2]");
 }


### PR DESCRIPTION
[RFC 2226](https://rust-lang.github.io/rfcs/2226-fmt-debug-hex.html), originally tracked in #48584, added the `x?` and `X?` debug formats, which allow printing integers as hexadecimal even in debug contexts.

There was some discussion on exposing this to downstream APIs in both the tracking issue and the RFC, and ultimately, the tracking issue was closed without any progress on this. In fact, the code still references the now-closed tracking issue when asking how this should be exposed.

This takes the approach of expanding the RFC to all formatting traits, such that `o?`, `b?`, `e?`, `E?`, and `p?` are all possible. It uses these as applicable for all the types in the library crates, assuming I didn't miss any.

This is just a hint, meaning that it can safely be ignored by any debug implementations. For example, `format!("{:x?}", Some("hello"))` is still allowed, and it simply ignores the `x` specifier.

This implementation replaces the existing flags used for `DebugLowerHex` and `DebugUpperHex` with a four-bit bitfield on the formatting flags. It exposes this via a new `DebugVariant` field, which states what variant is used in `Debug` implementations, defaulting to `Display` if none is specified. For non-debug flags, it will always show `Display`, but we could potentially change that to show the current format.

-----

Currently, this insta-stabilises the ability to use these variants in formatting (`format!("{var:p?}")` now works) but still leaves the `Formatter::debug_variant` method and `DebugVariant` enum as unstable under the `debug_variants` feature. This is mostly because I have no idea how we'd actually gate the parsing under the feature; if this is desired, I'd need some guidance on how to accomplish that.

-----

Side note, this actually changes the layout of the flags for the hex-debug variants, which may be undesired. I assume this is okay since the `flags` method is deprecated, but will modify it to be backwards-compatible if this is a requirement. My thought process was that it would be better to add some padding to separate out the flags a bit better (allow 8 boolean flags before moving onto bitfield for variant), but this is honestly a weak justification. I'm not sure how much code out in the wild is using `flags` due to the lack of API for the existing hex-debug variants.