### PR TITLE
Give a better error when `x dist` fails for an optional tool

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -39,7 +39,11 @@ fn missing_tool(tool_name: &str, skip: bool) {
     if skip {
         println!("Unable to build {}, skipping dist", tool_name)
     } else {
-        panic!("Unable to build {}", tool_name)
+        let help = "note: not all tools are available on all nightlies\nhelp: see https://forge.rust-lang.org/infra/toolstate.html for more information";
+        panic!(
+            "Unable to build submodule tool {} (use `missing-tools = true` to ignore this failure)\n{}",
+            tool_name, help
+        )
     }
 }
 


### PR DESCRIPTION
Before:
```
thread 'main' panicked at 'Unable to build RLS', dist.rs:42:9
```

After:
```
thread 'main' panicked at 'Unable to build submodule tool RLS (use `missing-tools = true` to ignore this failure)
note: not all tools are available on all nightlies
help: see https://forge.rust-lang.org/infra/toolstate.html for more information', dist.rs:43:9
```

Closes https://github.com/rust-lang/rust/issues/85683 by explaining better why the error is expected.