### PR TITLE
Don't rerun the build script for the compiler each time on non-windows platforms

### DIFF
--- a/compiler/rustc/build.rs
+++ b/compiler/rustc/build.rs
@@ -5,6 +5,9 @@ fn main() {
     let target_env = env::var("CARGO_CFG_TARGET_ENV");
     if Ok("windows") == target_os.as_deref() && Ok("msvc") == target_env.as_deref() {
         set_windows_exe_options();
+    } else {
+        // Avoid rerunning the build script every time.
+        println!("cargo:rerun-if-changed=build.rs");
     }
 }
 


### PR DESCRIPTION
In practice, this doesn't matter very much because the script takes ~no time to run.
But this makes `CARGO_LOG=info` easier to read, and theoretically saves a few milliseconds.