### PR TITLE
Do not error during method probe on `Sized` predicates for types that aren't the method receiver

### DIFF
--- a/compiler/rustc_typeck/src/check/method/mod.rs
+++ b/compiler/rustc_typeck/src/check/method/mod.rs
@@ -20,8 +20,8 @@ use rustc_hir::def_id::DefId;
 use rustc_infer::infer::{self, InferOk};
 use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::subst::{InternalSubsts, SubstsRef};
-use rustc_middle::ty::GenericParamDefKind;
 use rustc_middle::ty::{self, ToPredicate, Ty, TypeVisitable};
+use rustc_middle::ty::{DefIdTree, GenericParamDefKind};
 use rustc_span::symbol::Ident;
 use rustc_span::Span;
 use rustc_trait_selection::traits;
@@ -221,7 +221,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
 
             // We probe again, taking all traits into account (not only those in scope).
-            let candidates = match self.lookup_probe(
+            let mut candidates = match self.lookup_probe(
                 span,
                 segment.ident,
                 self_ty,
@@ -243,6 +243,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .collect(),
                 _ => Vec::new(),
             };
+            candidates.retain(|candidate| *candidate != self.tcx.parent(result.callee.def_id));
 
             return Err(IllegalSizedBound(candidates, needs_mut, span));
         }

--- a/src/test/ui/issues/issue-35976.stderr
+++ b/src/test/ui/issues/issue-35976.stderr
@@ -6,11 +6,6 @@ LL |         fn wait(&self) where Self: Sized;
 ...
 LL |     arg.wait();
    |         ^^^^
-   |
-help: another candidate was found in the following trait, perhaps add a `use` for it:
-   |
-LL | use private::Future;
-   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/issues/issue-61525.rs
+++ b/src/test/ui/methods/issues/issue-61525.rs
@@ -1,0 +1,20 @@
+pub trait Example {
+    fn query<Q>(self, q: Q);
+}
+
+impl Example for i32 {
+    fn query<Q>(self, _: Q) {
+        unimplemented!()
+    }
+}
+
+mod nested {
+    use super::Example;
+    fn example() {
+        1.query::<dyn ToString>("")
+        //~^ ERROR the size for values of type `dyn ToString` cannot be known at compilation time
+        //~| ERROR mismatched types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/methods/issues/issue-61525.stderr
+++ b/src/test/ui/methods/issues/issue-61525.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the size for values of type `dyn ToString` cannot be known at compilation time
+  --> $DIR/issue-61525.rs:14:33
+   |
+LL |         1.query::<dyn ToString>("")
+   |           -----                 ^^ doesn't have a size known at compile-time
+   |           |
+   |           required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `dyn ToString`
+note: required by a bound in `Example::query`
+  --> $DIR/issue-61525.rs:2:14
+   |
+LL |     fn query<Q>(self, q: Q);
+   |              ^ required by this bound in `Example::query`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     fn query<Q: ?Sized>(self, q: Q);
+   |               ++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/issue-61525.rs:14:33
+   |
+LL |         1.query::<dyn ToString>("")
+   |           --------------------- ^^ expected trait object `dyn ToString`, found `&str`
+   |           |
+   |           arguments to this function are incorrect
+   |
+   = note: expected trait object `dyn ToString`
+                 found reference `&'static str`
+note: associated function defined here
+  --> $DIR/issue-61525.rs:2:8
+   |
+LL |     fn query<Q>(self, q: Q);
+   |        ^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #61525

This is safe even though we're skipping an error because we end up confirming the method, which means we're still checking the `Sized` predicate in the end. It just means that we don't emit an erroneous message as below:

```
error: the `query` method cannot be invoked on a trait object
  --> src/lib.rs:14:11
   |
14 |         1.query::<dyn ToString>("")
   |           ^^^^^
   |
   = note: another candidate was found in the following trait, perhaps add a `use` for it:
           `use crate::Example;`
```

Also fixes erroneously suggesting the same trait over again, as seen in the `issue-35976.rs` UI test.