### PR TITLE
Mention similarly named associated type even if it's not clearly in supertrait

### DIFF
--- a/src/test/ui/resolve/issue-55673.rs
+++ b/src/test/ui/resolve/issue-55673.rs
@@ -1,0 +1,12 @@
+trait Foo {
+    type Bar;
+}
+
+fn foo<T: Foo>()
+where
+    T::Baa: std::fmt::Debug,
+    //~^ ERROR associated type `Baa` not found for `T`
+{
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-55673.stderr
+++ b/src/test/ui/resolve/issue-55673.stderr
@@ -1,0 +1,9 @@
+error[E0220]: associated type `Baa` not found for `T`
+  --> $DIR/issue-55673.rs:7:8
+   |
+LL |     T::Baa: std::fmt::Debug,
+   |        ^^^ there is a similarly named associated type `Bar` in the trait `Foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0220`.

--- a/src/test/ui/traits/issue-59029-1.stderr
+++ b/src/test/ui/traits/issue-59029-1.stderr
@@ -2,13 +2,13 @@ error[E0220]: associated type `Res` not found for `Self`
   --> $DIR/issue-59029-1.rs:5:52
    |
 LL | trait MkSvc<Target, Req> = Svc<Target> where Self::Res: Svc<Req>;
-   |                                                    ^^^ associated type `Res` not found
+   |                                                    ^^^ there is a similarly named associated type `Res` in the trait `Svc`
 
 error[E0220]: associated type `Res` not found for `Self`
   --> $DIR/issue-59029-1.rs:5:52
    |
 LL | trait MkSvc<Target, Req> = Svc<Target> where Self::Res: Svc<Req>;
-   |                                                    ^^^ associated type `Res` not found
+   |                                                    ^^^ there is a similarly named associated type `Res` in the trait `Svc`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/not_well_formed.stderr
+++ b/src/test/ui/type-alias-impl-trait/not_well_formed.stderr
@@ -2,7 +2,7 @@ error[E0220]: associated type `Assoc` not found for `V`
   --> $DIR/not_well_formed.rs:9:29
    |
 LL | type Foo<V> = impl Trait<V::Assoc>;
-   |                             ^^^^^ associated type `Assoc` not found
+   |                             ^^^^^ there is a similarly named associated type `Assoc` in the trait `TraitWithAssoc`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Due to query cycle avoidance, we sometimes restrict the candidates in `complain_about_assoc_type_not_found` too much so that we can't detect typo replacements from just supertraits. 

This creates a more general note of the existence of a similarly named associated type from _all_ visible traits when possible.

Fixes #55673