### PR TITLE
Configure nightly branch name in `stage0.json`

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -226,6 +226,7 @@ pub struct Stage0Config {
     pub artifacts_server: String,
     pub artifacts_with_llvm_assertions_server: String,
     pub git_merge_commit_email: String,
+    pub nightly_branch: String,
 }
 #[derive(Default, Deserialize)]
 #[cfg_attr(test, derive(Clone))]

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1280,14 +1280,11 @@ impl Build {
         // Figure out how many merge commits happened since we branched off master.
         // That's our beta number!
         // (Note that we use a `..` range, not the `...` symmetric difference.)
-        let count = output(
-            self.config
-                .git()
-                .arg("rev-list")
-                .arg("--count")
-                .arg("--merges")
-                .arg("refs/remotes/origin/master..HEAD"),
-        );
+        let count =
+            output(self.config.git().arg("rev-list").arg("--count").arg("--merges").arg(format!(
+                "refs/remotes/origin/{}..HEAD",
+                self.config.stage0_metadata.config.nightly_branch
+            )));
         let n = count.trim().parse().unwrap();
         self.prerelease_version.set(Some(n));
         n

--- a/src/stage0.json
+++ b/src/stage0.json
@@ -3,7 +3,8 @@
     "dist_server": "https://static.rust-lang.org",
     "artifacts_server": "https://ci-artifacts.rust-lang.org/rustc-builds",
     "artifacts_with_llvm_assertions_server": "https://ci-artifacts.rust-lang.org/rustc-builds-alt",
-    "git_merge_commit_email": "bors@rust-lang.org"
+    "git_merge_commit_email": "bors@rust-lang.org",
+    "nightly_branch": "master"
   },
   "__comments": [
     "The configuration above this comment is editable, and can be changed",

--- a/src/tools/bump-stage0/Cargo.toml
+++ b/src/tools/bump-stage0/Cargo.toml
@@ -10,5 +10,5 @@ anyhow = "1.0.34"
 curl = "0.4.38"
 indexmap = { version = "1.7.0", features = ["serde"] }
 serde = { version = "1.0.125", features = ["derive"] }
-serde_json = "1.0.59"
+serde_json = { version = "1.0.59", features = ["preserve_order"] }
 toml = "0.5.7"

--- a/src/tools/bump-stage0/src/main.rs
+++ b/src/tools/bump-stage0/src/main.rs
@@ -198,9 +198,12 @@ struct Stage0 {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Config {
     dist_server: String,
-    artifacts_server: String,
-    artifacts_with_llvm_assertions_server: String,
-    git_merge_commit_email: String,
+    // There are other fields in the configuration, which will be read by src/bootstrap or other
+    // tools consuming stage0.json. To avoid the need to update bump-stage0 every time a new field
+    // is added, we collect all the fields in an untyped Value and serialize them back with the
+    // same order and structure they were deserialized in.
+    #[serde(flatten)]
+    other: serde_json::Value,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
The beta version number detection code relies on git to know how many merge commits were made since we branched off, and in doing so hardcodes `master` as the default branch name. This works for rust-lang/rust, but is problematic for forks that use a different default branch name (in Ferrocene we use `main` instead).

This PR changes the code to instead load the default branch name from `src/stage0.json`. `bump-stage0` has also been updated to remove the need to update it every time a new field is added to `stage0.json`.