### PR TITLE
compiletest: trim edition before passing as flag

### DIFF
--- a/src/test/ui/async-await/async-await.rs
+++ b/src/test/ui/async-await/async-await.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused)]
 
-// edition:2018
+// edition: 2018
 // aux-build:arc_wake.rs
 
 extern crate arc_wake;

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -294,7 +294,7 @@ impl TestProps {
                 }
 
                 if let Some(edition) = config.parse_edition(ln) {
-                    self.compile_flags.push(format!("--edition={}", edition));
+                    self.compile_flags.push(format!("--edition={}", edition.trim()));
                     has_edition = true;
                 }
 


### PR DESCRIPTION
This makes `edition: 2021` work instead of the ugly
`edition:2021` one has to write.