### PR TITLE
Mention rust-analyzer maintainers when `proc_macro` bridge is changed

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -279,6 +279,9 @@ Examples of `T-libs-api` changes:
 * Changing observable runtime behavior of library APIs
 """
 
+[mentions."library/proc_macro/src/bridge"]
+cc = ["@rust-lang/wg-rls-2"]
+
 [mentions."src/librustdoc/clean/types.rs"]
 cc = ["@camelid"]
 


### PR DESCRIPTION
rust-analyzer vendors a modified copy of the `proc_macro` crate in order to expand procedural macros built by Cargo. Since the ABI used by proc macros can change, we need to follow along with those changes. Getting notified when the proc macro bridge changes should make that easier, since that's what defines the ABI.

cc @rust-lang/wg-rls-2 