### PR TITLE
Pad size of TypeId and remove structural equality

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -668,6 +668,8 @@ impl dyn Any + Send + Sync {
 #[derive(Clone, Copy, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
+    // This field is unused, and is intended solely
+    // to break invalid transmutes to `TypeId`.
     pad: u64,
     t: u64,
 }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -672,11 +672,13 @@ pub struct TypeId {
     t: u64,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq for TypeId {
     fn eq(&self, other: &Self) -> bool {
         self.t == other.t
     }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for TypeId {}
 
 impl TypeId {

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -665,7 +665,7 @@ impl dyn Any + Send + Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
     pad: u64,

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -668,8 +668,16 @@ impl dyn Any + Send + Sync {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
+    pad: u64,
     t: u64,
 }
+
+impl PartialEq for TypeId {
+    fn eq(&self, other: &Self) -> bool {
+        self.t == other.t
+    }
+}
+impl Eq for TypeId {}
 
 impl TypeId {
     /// Returns the `TypeId` of the type this generic function has been
@@ -691,7 +699,7 @@ impl TypeId {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
-        TypeId { t: intrinsics::type_id::<T>() }
+        TypeId { pad: 0, t: intrinsics::type_id::<T>() }
     }
 }
 

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -670,7 +670,7 @@ impl dyn Any + Send + Sync {
 pub struct TypeId {
     // This field is unused, and is intended solely
     // to break invalid transmutes to `TypeId`.
-    pad: u64,
+    pad: core::mem::MaybeUninit<u64>,
     t: u64,
 }
 
@@ -703,7 +703,7 @@ impl TypeId {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
-        TypeId { pad: 0, t: intrinsics::type_id::<T>() }
+        TypeId { pad: core::mem::MaybeUninit::new(), t: intrinsics::type_id::<T>() }
     }
 }
 

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -724,7 +724,7 @@ impl TypeId {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
-        TypeId { pad: core::mem::MaybeUninit::new(), t: intrinsics::type_id::<T>() }
+        TypeId { pad: core::mem::MaybeUninit::uninit(), t: intrinsics::type_id::<T>() }
     }
 }
 

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -665,7 +665,7 @@ impl dyn Any + Send + Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
-#[derive(Clone, Copy, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
     // This field is unused, and is intended solely
@@ -682,6 +682,27 @@ impl PartialEq for TypeId {
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for TypeId {}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl Hash for TypeId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.t.hash(state);
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl PartialOrd for TypeId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl Ord for TypeId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.t.cmp(&other.t)
+    }
+}
 
 impl TypeId {
     /// Returns the `TypeId` of the type this generic function has been

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -667,6 +667,7 @@ impl dyn Any + Send + Sync {
 /// of relying on them inside of your code!
 #[derive(Clone, Copy, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(dead_code)]
 pub struct TypeId {
     // This field is unused, and is intended solely
     // to break invalid transmutes to `TypeId`.

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -684,22 +684,22 @@ impl PartialEq for TypeId {
 impl Eq for TypeId {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl Hash for TypeId {
-    fn hash<H: Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for TypeId {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.t.hash(state);
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl PartialOrd for TypeId {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for TypeId {
-    fn cmp(&self, other: &Self) -> Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.t.cmp(&other.t)
     }
 }

--- a/src/test/ui/const-generics/issues/issue-90318.stderr
+++ b/src/test/ui/const-generics/issues/issue-90318.stderr
@@ -18,10 +18,9 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    |
-LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-   |                       ^^^^^^^^^
+LL | impl PartialEq for TypeId {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: overly complex generic constant
   --> $DIR/issue-90318.rs:22:8
@@ -43,10 +42,9 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    |
-LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-   |                       ^^^^^^^^^
+LL | impl PartialEq for TypeId {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/issue-73976-monomorphic.rs
+++ b/src/test/ui/consts/issue-73976-monomorphic.rs
@@ -5,20 +5,9 @@
 // will be properly rejected. This test will ensure that monomorphic use of these
 // would not be wrongly rejected in patterns.
 
-#![feature(const_type_id)]
 #![feature(const_type_name)]
 
-use std::any::{self, TypeId};
-
-pub struct GetTypeId<T>(T);
-
-impl<T: 'static> GetTypeId<T> {
-    pub const VALUE: TypeId = TypeId::of::<T>();
-}
-
-const fn check_type_id<T: 'static>() -> bool {
-    matches!(GetTypeId::<T>::VALUE, GetTypeId::<usize>::VALUE)
-}
+use std::any;
 
 pub struct GetTypeNameLen<T>(T);
 
@@ -31,6 +20,5 @@ const fn check_type_name_len<T: 'static>() -> bool {
 }
 
 fn main() {
-    assert!(check_type_id::<usize>());
     assert!(check_type_name_len::<usize>());
 }


### PR DESCRIPTION
This implements @eddyb's suggestions from #95845 

> Acouple smaller things could also be done (not sure if I'll be able to help with either):
> 
> * manual `PartialEq` impl for `TypeId` (i.e. turning off "structural match")
>   
>   * this would disallow `match`-ing on `TypeId`s (forcing the use of `==` instead), as to not box ourselves into a corner if address equality is _ever_ needed in the future
> * increasing `TypeId`'s size (and cratering that change)
>   
>   * should help with breaking misuses (just like comments on this PR describe)
>   * it doesn't have to be actual new data, could just be a dead field
>     
>     * this is library-only, e.g. `TypeId(type_hash::<T>())` -> `TypeId(type_hash::<T>(), 0)`

Given that the lang-team has already committed to a full length cryptographic hash, increasing the size of `TypeId` in preparation for a future change to a cryptographic hash should be a simple stepping stone. This also removes structural equality from `TypeId` for more futureproofing.