### PR TITLE
Loosen shadowing check inside macro contexts.

### DIFF
--- a/src/test/ui/hygiene/shadow-static-1.rs
+++ b/src/test/ui/hygiene/shadow-static-1.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+// Check that a macro doesn't generate an error when a let binding shadows a
+// static defined outside the macro.
+
+macro_rules! h {
+  () => {
+    let x = 2;
+  }
+}
+
+#[allow(non_upper_case_globals)]
+static x: usize = 3;
+
+fn main() {
+  h!();
+}

--- a/src/test/ui/hygiene/shadow-static-2.rs
+++ b/src/test/ui/hygiene/shadow-static-2.rs
@@ -1,0 +1,15 @@
+// Check that a macro generated static does cause a shadowing error
+
+macro_rules! h {
+  () => {
+    #[allow(non_upper_case_globals)]
+    static x: usize = 3;
+  }
+}
+
+h!();
+
+fn main() {
+  let x = 2;
+//~^ ERROR let bindings cannot shadow statics
+}

--- a/src/test/ui/hygiene/shadow-static-2.stderr
+++ b/src/test/ui/hygiene/shadow-static-2.stderr
@@ -1,0 +1,12 @@
+error[E0530]: let bindings cannot shadow statics
+  --> $DIR/shadow-static-2.rs:13:7
+   |
+LL |     static x: usize = 3;
+   |     -------------------- the static `x` is defined here
+...
+LL |   let x = 2;
+   |       ^ cannot be named the same as a static
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0530`.


### PR DESCRIPTION
This allows macro code to use identifiers for local variables which
are also defined as statics/consts/ctors outside of the macro. This
improves robustness of macro hygiene, as identifiers used inside a
macro can no longer produce unexpected restrictions on names for
statics and consts defined outside of it. Concretely, constructions
such as
```rust
thread_local!(static FOO: usize = 0);
static init: usize = 0;
```
no longer unexpectedly fail to compile because thread_local! happens
to define a function with init as a parameter name.

This fixes #99018