### PR TITLE
Fix spans for asm diagnostics

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -534,8 +534,8 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
 
     let mut template_strs = Vec::with_capacity(args.templates.len());
 
-    for template_expr in args.templates.into_iter() {
-        if !template.is_empty() {
+    for (i, template_expr) in args.templates.into_iter().enumerate() {
+        if i != 0 {
             template.push(ast::InlineAsmTemplatePiece::String("\n".to_string()));
         }
 

--- a/src/test/ui/asm/aarch64/srcloc.rs
+++ b/src/test/ui/asm/aarch64/srcloc.rs
@@ -118,5 +118,12 @@ fn main() {
         //~^^^^^^^^^^ ERROR: unrecognized instruction mnemonic
         //~^^^^^^^ ERROR: unrecognized instruction mnemonic
         //~^^^^^^^^ ERROR: unrecognized instruction mnemonic
+
+        asm!(
+            "",
+            "\n",
+            "invalid_instruction"
+        );
+        //~^^ ERROR: unrecognized instruction mnemonic
     }
 }

--- a/src/test/ui/asm/aarch64/srcloc.stderr
+++ b/src/test/ui/asm/aarch64/srcloc.stderr
@@ -274,5 +274,17 @@ note: instantiated into assembly here
 LL | invalid_instruction4
    | ^
 
-error: aborting due to 23 previous errors
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:125:14
+   |
+LL |             "invalid_instruction"
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: aborting due to 24 previous errors
 

--- a/src/test/ui/asm/x86_64/srcloc.rs
+++ b/src/test/ui/asm/x86_64/srcloc.rs
@@ -120,5 +120,12 @@ fn main() {
         //~^^^^^^^^^^ ERROR: invalid instruction mnemonic 'invalid_instruction2'
         //~^^^^^^^ ERROR: invalid instruction mnemonic 'invalid_instruction3'
         //~^^^^^^^^ ERROR: invalid instruction mnemonic 'invalid_instruction4'
+
+        asm!(
+            "",
+            "\n",
+            "invalid_instruction"
+        );
+        //~^^ ERROR: invalid instruction mnemonic 'invalid_instruction'
     }
 }

--- a/src/test/ui/asm/x86_64/srcloc.stderr
+++ b/src/test/ui/asm/x86_64/srcloc.stderr
@@ -286,5 +286,17 @@ note: instantiated into assembly here
 LL | invalid_instruction4
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 23 previous errors; 1 warning emitted
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:127:14
+   |
+LL |             "invalid_instruction"
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:5:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 24 previous errors; 1 warning emitted
 


### PR DESCRIPTION
Line spans were incorrect if the first line of an asm statement was an
empty string.