### PR TITLE
Forbid `$$crate`

### DIFF
--- a/src/test/ui/macros/rfc-3086-metavar-expr/dollar_dollar_crate.rs
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/dollar_dollar_crate.rs
@@ -1,0 +1,30 @@
+// All possible usages of $$crate are currently forbidden
+
+pub const IDX: usize = 1;
+
+macro_rules! _direct_usage_super {
+    () => {
+        macro_rules! _direct_usage_sub {
+            () => {{
+                $$crate
+                //~^ ERROR unexpected token: crate
+            }};
+        }
+    };
+}
+
+macro_rules! indirect_usage_crate {
+    ($d:tt) => {
+        const _FOO: usize = $d$d crate::IDX;
+        //~^ ERROR expected expression, found `$`
+    };
+}
+macro_rules! indirect_usage_use {
+    ($d:tt) => {
+        indirect_usage_crate!($d);
+    }
+}
+indirect_usage_use!($);
+
+fn main() {
+}

--- a/src/test/ui/macros/rfc-3086-metavar-expr/dollar_dollar_crate.stderr
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/dollar_dollar_crate.stderr
@@ -1,0 +1,16 @@
+error: unexpected token: crate
+  --> $DIR/dollar_dollar_crate.rs:9:19
+   |
+LL |                 $$crate
+   |                   ^^^^^
+
+note: `$$crate` is not allowed in any context
+
+error: expected expression, found `$`
+  --> $DIR/dollar_dollar_crate.rs:18:29
+   |
+LL |         const _FOO: usize = $d$d crate::IDX;
+   |                             ^^ expected expression
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #99035 by simply denying the usage of `$$crate`. Future decisions about how `$$crate` should behave (if it should) won't be a breaking change and I am out of a better idea.

cc @rust-lang/lang (Responsible team)
cc @petrochenkov (Reviewed most of the implementation)
cc @CAD97 (Created the issue)
cc @Mark-Simulacrum (Nominated the issue)

