### PR TITLE
Fix gdb-cmd for rust-gdbgui

### DIFF
--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -58,7 +58,6 @@ GDB_ARGS="--directory=\"$GDB_PYTHON_MODULE_DIRECTORY\" -iex \"add-auto-load-safe
 # Finally we execute gdbgui.
 PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" \
   exec ${RUST_GDBGUI} \
-  --gdb ${RUST_GDB} \
-  --gdb-args "${GDB_ARGS}" \
+  --gdb-cmd "${RUST_GDB} ${GDB_ARGS}" \
   "${@}"
 


### PR DESCRIPTION
With https://github.com/cs01/gdbgui/pull/198, the way that gdbgui arguments were specified changed. I've tested this with program generated from `cargo new --bin` and it worked as gdbgui should.

Closes #76383.