### PR TITLE
Refactor: remove an unnecessary `span_to_snippet`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1598,21 +1598,18 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             let return_ty = tcx.erase_regions(return_ty);
 
             // to avoid panics
-            if let Some(iter_trait) = tcx.get_diagnostic_item(sym::Iterator) {
-                if self
+            if let Some(iter_trait) = tcx.get_diagnostic_item(sym::Iterator)
+                && self
                     .infcx
                     .type_implements_trait(iter_trait, return_ty, ty_params, self.param_env)
                     .must_apply_modulo_regions()
-                {
-                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(return_span) {
-                        err.span_suggestion_hidden(
-                            return_span,
-                            "use `.collect()` to allocate the iterator",
-                            format!("{snippet}.collect::<Vec<_>>()"),
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
-                }
+            {
+                err.span_suggestion_hidden(
+                    return_span.shrink_to_hi(),
+                    "use `.collect()` to allocate the iterator",
+                    ".collect::<Vec<_>>()",
+                    Applicability::MaybeIncorrect,
+                );
             }
         }
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -508,7 +508,7 @@ impl<'a> Resolver<'a> {
                     E0401,
                     "can't use generic parameters from outer function",
                 );
-                err.span_label(span, "use of generic parameter from outer function".to_string());
+                err.span_label(span, "use of generic parameter from outer function");
 
                 let sm = self.session.source_map();
                 match outer_res {
@@ -990,7 +990,7 @@ impl<'a> Resolver<'a> {
                     E0735,
                     "generic parameters cannot use `Self` in their defaults"
                 );
-                err.span_label(span, "`Self` in generic parameter default".to_string());
+                err.span_label(span, "`Self` in generic parameter default");
                 err
             }
             ResolutionError::UnreachableLabel { name, definition_span, suggestion } => {


### PR DESCRIPTION
`span_suggestion_hidden` does not show the suggested code and the suggestion is used just for rustfix, so `span_to_snippet` is unnecessary here.