### PR TITLE
Correctly handle crate level page on docs.rs as well

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -479,23 +479,20 @@ function loadCss(cssFileName) {
         }
 
         if (sidebar) {
-            const isModule = hasClass(document.body, "mod");
-            if (!isModule) {
-                block("primitive", "primitives", "Primitive Types");
-                block("mod", "modules", "Modules");
-                block("macro", "macros", "Macros");
-                block("struct", "structs", "Structs");
-                block("enum", "enums", "Enums");
-                block("union", "unions", "Unions");
-                block("constant", "constants", "Constants");
-                block("static", "static", "Statics");
-                block("trait", "traits", "Traits");
-                block("fn", "functions", "Functions");
-                block("type", "types", "Type Definitions");
-                block("foreigntype", "foreign-types", "Foreign Types");
-                block("keyword", "keywords", "Keywords");
-                block("traitalias", "trait-aliases", "Trait Aliases");
-            }
+            block("primitive", "primitives", "Primitive Types");
+            block("mod", "modules", "Modules");
+            block("macro", "macros", "Macros");
+            block("struct", "structs", "Structs");
+            block("enum", "enums", "Enums");
+            block("union", "unions", "Unions");
+            block("constant", "constants", "Constants");
+            block("static", "static", "Statics");
+            block("trait", "traits", "Traits");
+            block("fn", "functions", "Functions");
+            block("type", "types", "Type Definitions");
+            block("foreigntype", "foreign-types", "Foreign Types");
+            block("keyword", "keywords", "Keywords");
+            block("traitalias", "trait-aliases", "Trait Aliases");
         }
     }
 

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -39,7 +39,7 @@
     {%- else if page.css_class == "source" -%}
     <script defer src="{{static_root_path|safe}}source-script{{page.resource_suffix}}.js"></script> {#- -#}
     <script defer src="{{page.root_path|safe}}source-files{{page.resource_suffix}}.js"></script> {#- -#}
-    {%- else -%}
+    {%- else if !page.css_class.contains("mod") -%}
     <script defer src="sidebar-items{{page.resource_suffix}}.js"></script> {#- -#}
     {%- endif -%}
     <script defer src="{{static_root_path|safe}}main{{page.resource_suffix}}.js"></script> {#- -#}


### PR DESCRIPTION
Fixes #99121.

On docs.rs, they move the `class` attribute into a child which still has `rustdoc`. So instead of using the `<body>`, we can simply use this one directly.

r? @jsha