### PR TITLE
[docs] In the documentation of the identify function, clarify that using `flatten()` is probably a better idea than using `filter_map`

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -93,6 +93,8 @@ pub use num::FloatToInt;
 ///
 /// let iter = [Some(1), None, Some(3)].into_iter();
 /// let filtered = iter.filter_map(identity).collect::<Vec<_>>();
+/// // Equivalent, since Option is also a Iterator itself:
+/// // let filtered = iter.flatten().collect::<Vec<_>>();
 /// assert_eq!(vec![1, 3], filtered);
 /// ```
 #[stable(feature = "convert_id", since = "1.33.0")]

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -93,7 +93,7 @@ pub use num::FloatToInt;
 ///
 /// let iter = [Some(1), None, Some(3)].into_iter();
 /// let filtered = iter.filter_map(identity).collect::<Vec<_>>();
-/// // Equivalent, since Option impements IntoIterator:
+/// // Equivalent, since Option implements IntoIterator:
 /// // let filtered = iter.flatten().collect::<Vec<_>>();
 /// assert_eq!(vec![1, 3], filtered);
 /// ```

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -93,7 +93,7 @@ pub use num::FloatToInt;
 ///
 /// let iter = [Some(1), None, Some(3)].into_iter();
 /// let filtered = iter.filter_map(identity).collect::<Vec<_>>();
-/// // Equivalent, since Option is also a Iterator itself:
+/// // Equivalent, since Option impements IntoIterator:
 /// // let filtered = iter.flatten().collect::<Vec<_>>();
 /// assert_eq!(vec![1, 3], filtered);
 /// ```


### PR DESCRIPTION
There is a odd example on [the documentation for identity](https://doc.rust-lang.org/std/convert/fn.identity.html#examples) that seems to suggest using `filter_map` to flatten a array of `Option<T>`. However, this can be done far shorter using flatten.

The example is good to showcase how identity works but I think a clarification would be good so people don't actually use it that way.

I hope this extra note will help people decide for themselves what the best solution to this problem is.