### PR TITLE
Set crt_static_respected and crt_static_default to true for the Emscripten target

### DIFF
--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -19,6 +19,8 @@ pub fn target() -> Target {
         pre_link_args,
         post_link_args,
         relocation_model: RelocModel::Pic,
+        crt_static_respected: true,
+        crt_static_default: true,
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         families: cvs!["unix", "wasm"],


### PR DESCRIPTION
As a followup to https://github.com/rust-lang/rust/pull/98358, we should switch the default output kind to be static and allow the user to toggle it.

If I understand correctly, we are using `crt-static` to mean something different than it was originally intended to mean. It sounds like it normally controls whether libc is linked statically or dynamically. In Emscripten, it is impossible to dynamically link libc. However, standard Emscripten builds have dynamic linking disabled entirely.  We are using `+crt-static` to mean "disable dynamic linking" and `-crt-static` to mean "enable dynamic linking".

@sbc100

r? @petrochenkov
