### PR TITLE
Add regression test for #89436

### DIFF
--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89436.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89436.rs
@@ -1,0 +1,44 @@
+// check-pass
+
+#![allow(unused)]
+
+trait MiniYokeable<'a> {
+    type Output;
+}
+
+struct MiniYoke<Y: for<'a> MiniYokeable<'a>> {
+    pub yokeable: Y,
+}
+
+fn map_project_broken<Y, P>(
+    source: MiniYoke<Y>,
+    f: impl for<'a> FnOnce(
+        <Y as MiniYokeable<'a>>::Output,
+        core::marker::PhantomData<&'a ()>,
+    ) -> <P as MiniYokeable<'a>>::Output,
+) -> MiniYoke<P>
+where
+    Y: for<'a> MiniYokeable<'a>,
+    P: for<'a> MiniYokeable<'a>
+{
+    unimplemented!()
+}
+
+struct Bar<'a> {
+    string_1: &'a str,
+    string_2: &'a str,
+}
+
+impl<'a> MiniYokeable<'a> for Bar<'static> {
+    type Output = Bar<'a>;
+}
+
+impl<'a> MiniYokeable<'a> for &'static str {
+    type Output = &'a str;
+}
+
+fn demo_broken(bar: MiniYoke<Bar<'static>>) -> MiniYoke<&'static str> {
+    map_project_broken(bar, |bar, _| bar.string_1)
+}
+
+fn main() {}


### PR DESCRIPTION
I never got around to adding such a test.


In general I think the `yoke` crate has a bunch of interesting testcases that exercise various edges of the algorithms here, it would be nice if we could simply depend on the crate and add some tests that exercise it, but I don't think that's possible. Do you or @eddyb think there's any use trying to upstream a bunch of common yoke minimal working example code to the testsuite and having a ton of yoke tests?