### PR TITLE
EXPERIMENT: support well-nested unwinds

### DIFF
--- a/src/test/ui/panics/well-nested-panic.rs
+++ b/src/test/ui/panics/well-nested-panic.rs
@@ -1,0 +1,18 @@
+// run-pass
+// needs-unwind
+
+use std::panic::catch_unwind;
+
+struct Bomb;
+impl Drop for Bomb {
+    fn drop(&mut self) {
+        let _ = catch_unwind(|| panic!("bomb"));
+    }
+}
+
+fn main() {
+    let _ = catch_unwind(|| {
+        let _bomb = Bomb;
+        panic!("main");
+    });
+}


### PR DESCRIPTION
This is deceptively simple... experiment primarily for a perf run to estimate the cost of providing this behavior.

Currently, any panic during an unwind will immediately abort the process. That means that the otherwise inconspicuous code

```rust
catch_unwind(|| panic!());
```

will run normally in normal code, but if this happens to be called from a drop implementation during unwinding, abort the process.

This behavior is relied upon in the ecosystem for soundness by the way of stack guards which trigger an abort via panic-in-unwind when dropped. ***This PR does not change the behavior of such drop bombs.***

What this PR does is deceptively simple: it makes it so that `catch_unwind` clears the "is panicking" state when running the provided closure. This means that even if we were unwinding before calling `catch_unwind`, the code inside sees a normal non-panicking environment and can run normally, including to panic and unwind to the registered `catch_unwind` handler.

A second panic which is covered by the same `catch_unwind` continues to immediately abort.