### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -132,8 +132,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Some(p) => p,
         };
 
-        // Keep the patterns in this match ordered the same as the list in
-        // `src/librustc_middle/ty/constness.rs`
         match intrinsic_name {
             sym::caller_location => {
                 let span = self.find_closest_untracked_caller_location();

--- a/compiler/rustc_middle/src/ty/closure.rs
+++ b/compiler/rustc_middle/src/ty/closure.rs
@@ -128,6 +128,14 @@ impl<'tcx> ClosureKind {
             None
         }
     }
+
+    pub fn to_def_id(&self, tcx: TyCtxt<'_>) -> DefId {
+        match self {
+            ClosureKind::Fn => tcx.lang_items().fn_once_trait().unwrap(),
+            ClosureKind::FnMut => tcx.lang_items().fn_mut_trait().unwrap(),
+            ClosureKind::FnOnce => tcx.lang_items().fn_trait().unwrap(),
+        }
+    }
 }
 
 /// A composite describing a `Place` that is captured by a closure.

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -125,6 +125,7 @@
 #![cfg_attr(test, feature(new_uninit))]
 #![feature(nonnull_slice_from_raw_parts)]
 #![feature(pattern)]
+#![feature(pointer_byte_offsets)]
 #![feature(ptr_internals)]
 #![feature(ptr_metadata)]
 #![feature(ptr_sub_ptr)]

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -908,8 +908,7 @@ impl<T: ?Sized> Arc<T> {
             let offset = data_offset(ptr);
 
             // Reverse the offset to find the original ArcInner.
-            let arc_ptr =
-                (ptr as *mut u8).offset(-offset).with_metadata_of(ptr as *mut ArcInner<T>);
+            let arc_ptr = ptr.byte_sub(offset) as *mut ArcInner<T>;
 
             Self::from_ptr(arc_ptr)
         }
@@ -1942,7 +1941,7 @@ impl<T: ?Sized> Weak<T> {
             let offset = unsafe { data_offset(ptr) };
             // Thus, we reverse the offset to get the whole RcBox.
             // SAFETY: the pointer originated from a Weak, so this offset is safe.
-            unsafe { (ptr as *mut u8).offset(-offset).with_metadata_of(ptr as *mut ArcInner<T>) }
+            unsafe { ptr.byte_sub(offset) as *mut ArcInner<T> }
         };
 
         // SAFETY: we now have recovered the original Weak pointer, so can create the Weak.
@@ -2749,7 +2748,7 @@ impl<T: ?Sized> Unpin for Arc<T> {}
 ///
 /// The pointer must point to (and have valid metadata for) a previously
 /// valid instance of T, but the T is allowed to be dropped.
-unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
+unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> usize {
     // Align the unsized value to the end of the ArcInner.
     // Because RcBox is repr(C), it will always be the last field in memory.
     // SAFETY: since the only unsized types possible are slices, trait objects,
@@ -2760,7 +2759,7 @@ unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
 }
 
 #[inline]
-fn data_offset_align(align: usize) -> isize {
+fn data_offset_align(align: usize) -> usize {
     let layout = Layout::new::<ArcInner<()>>();
-    (layout.size() + layout.padding_needed_for(align)) as isize
+    layout.size() + layout.padding_needed_for(align)
 }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1442,7 +1442,6 @@ static DEFAULT_ID_MAP: Lazy<FxHashMap<Cow<'static, str>, usize>> = Lazy::new(|| 
 fn init_id_map() -> FxHashMap<Cow<'static, str>, usize> {
     let mut map = FxHashMap::default();
     // This is the list of IDs used in Javascript.
-    map.insert("help".into(), 1);
     map.insert("settings".into(), 1);
     map.insert("not-displayed".into(), 1);
     map.insert("alternative-display".into(), 1);
@@ -1455,7 +1454,6 @@ fn init_id_map() -> FxHashMap<Cow<'static, str>, usize> {
     map.insert("help-button".into(), 1);
     map.insert("main-content".into(), 1);
     map.insert("crate-search".into(), 1);
-    map.insert("render-detail".into(), 1);
     map.insert("toggle-all-docs".into(), 1);
     map.insert("all-types".into(), 1);
     map.insert("default-settings".into(), 1);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1733,13 +1733,12 @@ details.rustdoc-toggle[open] > summary.hideme > span {
 	display: none;
 }
 
-details.undocumented[open] > summary::before,
 details.rustdoc-toggle[open] > summary::before,
 details.rustdoc-toggle[open] > summary.hideme::before {
 	background-image: /* AUTOREPLACE: */url("toggle-minus.svg");
 }
 
-details.undocumented > summary::before, details.rustdoc-toggle > summary::before {
+details.rustdoc-toggle > summary::before {
 	background-image: /* AUTOREPLACE: */url("toggle-plus.svg");
 }
 

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -174,13 +174,11 @@ body.source .example-wrap pre.rust a {
 }
 
 details.rustdoc-toggle > summary.hideme > span,
-details.rustdoc-toggle > summary::before,
-details.undocumented > summary::before {
+details.rustdoc-toggle > summary::before {
 	color: #999;
 }
 
-details.rustdoc-toggle > summary::before,
-details.undocumented > summary::before {
+details.rustdoc-toggle > summary::before {
 	filter: invert(100%);
 }
 
@@ -216,17 +214,6 @@ details.undocumented > summary::before {
 .stab.portability > code {
 	color: #e6e1cf;
 	background: none;
-}
-
-#help > div {
-	background: #14191f;
-	box-shadow: 0px 6px 20px 0px black;
-	border: none;
-	border-radius: 4px;
-}
-
-#help span.bottom, #help span.top {
-	border-color: #5c6773;
 }
 
 .rightside,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -148,13 +148,11 @@ body.source .example-wrap pre.rust a {
 }
 
 details.rustdoc-toggle > summary.hideme > span,
-details.rustdoc-toggle > summary::before,
-details.undocumented > summary::before {
+details.rustdoc-toggle > summary::before {
 	color: #999;
 }
 
-details.rustdoc-toggle > summary::before,
-details.undocumented > summary::before {
+details.rustdoc-toggle > summary::before {
 	filter: invert(100%);
 }
 
@@ -178,20 +176,6 @@ details.undocumented > summary::before {
 .stab.deprecated { background: #ffc4c4; border-color: #db7b7b; color: #2f2f2f; }
 .stab.portability { background: #F3DFFF; border-color: #b07bdb; color: #2f2f2f; }
 .stab.portability > code { background: none; }
-
-#help > div {
-	background: #4d4d4d;
-	border-color: #bfbfbf;
-}
-
-#help span.bottom, #help span.top {
-	border-color: #bfbfbf;
-}
-
-#help dt {
-	border-color: #bfbfbf;
-	background: rgba(0,0,0,0);
-}
 
 .rightside,
 .out-of-band {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -140,8 +140,7 @@ body.source .example-wrap pre.rust a {
 }
 
 details.rustdoc-toggle > summary.hideme > span,
-details.rustdoc-toggle > summary::before,
-details.undocumented > summary::before {
+details.rustdoc-toggle > summary::before {
 	color: #999;
 }
 
@@ -160,15 +159,6 @@ details.undocumented > summary::before {
 .stab.deprecated { background: #ffc4c4; border-color: #db7b7b; }
 .stab.portability { background: #F3DFFF; border-color: #b07bdb; }
 .stab.portability > code { background: none; }
-
-#help > div {
-	background: #e9e9e9;
-	border-color: #bfbfbf;
-}
-
-#help span.bottom, #help span.top {
-	border-color: #bfbfbf;
-}
 
 .rightside,
 .out-of-band {

--- a/src/test/ui/argument-suggestions/exotic-calls.rs
+++ b/src/test/ui/argument-suggestions/exotic-calls.rs
@@ -1,0 +1,26 @@
+fn foo<T: Fn()>(t: T) {
+    t(1i32);
+    //~^ ERROR this function takes 0 arguments but 1 argument was supplied
+}
+
+fn bar(t: impl Fn()) {
+    t(1i32);
+    //~^ ERROR this function takes 0 arguments but 1 argument was supplied
+}
+
+fn baz() -> impl Fn() {
+    || {}
+}
+
+fn baz2() {
+    baz()(1i32)
+    //~^ ERROR this function takes 0 arguments but 1 argument was supplied
+}
+
+fn qux() {
+    let x = || {};
+    x(1i32);
+    //~^ ERROR this function takes 0 arguments but 1 argument was supplied
+}
+
+fn main() {}

--- a/src/test/ui/argument-suggestions/exotic-calls.stderr
+++ b/src/test/ui/argument-suggestions/exotic-calls.stderr
@@ -1,0 +1,67 @@
+error[E0057]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/exotic-calls.rs:2:5
+   |
+LL |     t(1i32);
+   |     ^ ---- argument of type `i32` unexpected
+   |
+note: callable defined here
+  --> $DIR/exotic-calls.rs:1:11
+   |
+LL | fn foo<T: Fn()>(t: T) {
+   |           ^^^^
+help: remove the extra argument
+   |
+LL |     t();
+   |     ~~~
+
+error[E0057]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/exotic-calls.rs:7:5
+   |
+LL |     t(1i32);
+   |     ^ ---- argument of type `i32` unexpected
+   |
+note: type parameter defined here
+  --> $DIR/exotic-calls.rs:6:11
+   |
+LL | fn bar(t: impl Fn()) {
+   |           ^^^^^^^^^
+help: remove the extra argument
+   |
+LL |     t();
+   |     ~~~
+
+error[E0057]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/exotic-calls.rs:16:5
+   |
+LL |     baz()(1i32)
+   |     ^^^^^ ---- argument of type `i32` unexpected
+   |
+note: opaque type defined here
+  --> $DIR/exotic-calls.rs:11:13
+   |
+LL | fn baz() -> impl Fn() {
+   |             ^^^^^^^^^
+help: remove the extra argument
+   |
+LL |     baz()()
+   |
+
+error[E0057]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/exotic-calls.rs:22:5
+   |
+LL |     x(1i32);
+   |     ^ ---- argument of type `i32` unexpected
+   |
+note: closure defined here
+  --> $DIR/exotic-calls.rs:21:13
+   |
+LL |     let x = || {};
+   |             ^^
+help: remove the extra argument
+   |
+LL |     x();
+   |     ~~~
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0057`.

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89436.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89436.rs
@@ -1,0 +1,44 @@
+// check-pass
+
+#![allow(unused)]
+
+trait MiniYokeable<'a> {
+    type Output;
+}
+
+struct MiniYoke<Y: for<'a> MiniYokeable<'a>> {
+    pub yokeable: Y,
+}
+
+fn map_project_broken<Y, P>(
+    source: MiniYoke<Y>,
+    f: impl for<'a> FnOnce(
+        <Y as MiniYokeable<'a>>::Output,
+        core::marker::PhantomData<&'a ()>,
+    ) -> <P as MiniYokeable<'a>>::Output,
+) -> MiniYoke<P>
+where
+    Y: for<'a> MiniYokeable<'a>,
+    P: for<'a> MiniYokeable<'a>
+{
+    unimplemented!()
+}
+
+struct Bar<'a> {
+    string_1: &'a str,
+    string_2: &'a str,
+}
+
+impl<'a> MiniYokeable<'a> for Bar<'static> {
+    type Output = Bar<'a>;
+}
+
+impl<'a> MiniYokeable<'a> for &'static str {
+    type Output = &'a str;
+}
+
+fn demo_broken(bar: MiniYoke<Bar<'static>>) -> MiniYoke<&'static str> {
+    map_project_broken(bar, |bar, _| bar.string_1)
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-16939.stderr
+++ b/src/test/ui/issues/issue-16939.stderr
@@ -4,11 +4,11 @@ error[E0057]: this function takes 0 arguments but 1 argument was supplied
 LL |     |t| f(t);
    |         ^ - argument unexpected
    |
-note: associated function defined here
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+note: callable defined here
+  --> $DIR/issue-16939.rs:4:12
    |
-LL |     extern "rust-call" fn call(&self, args: Args) -> Self::Output;
-   |                           ^^^^
+LL | fn _foo<F: Fn()> (f: F) {
+   |            ^^^^
 help: remove the extra argument
    |
 LL |     |t| f();

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -5,6 +5,12 @@ LL |     let ans = s("what");
    |               - ^^^^^^ expected `isize`, found `&str`
    |               |
    |               arguments to this function are incorrect
+   |
+note: implementation defined here
+  --> $DIR/overloaded-calls-bad.rs:10:1
+   |
+LL | impl FnMut<(isize,)> for S {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:29:15
@@ -12,6 +18,11 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
 LL |     let ans = s();
    |               ^-- an argument of type `isize` is missing
    |
+note: implementation defined here
+  --> $DIR/overloaded-calls-bad.rs:10:1
+   |
+LL | impl FnMut<(isize,)> for S {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: provide the argument
    |
 LL |     let ans = s(/* isize */);
@@ -25,6 +36,11 @@ LL |     let ans = s("burma", "shave");
    |                 |
    |                 expected `isize`, found `&str`
    |
+note: implementation defined here
+  --> $DIR/overloaded-calls-bad.rs:10:1
+   |
+LL | impl FnMut<(isize,)> for S {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL |     let ans = s(/* isize */);

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -5,12 +5,6 @@ LL |     let ans = s("what");
    |               - ^^^^^^ expected `isize`, found `&str`
    |               |
    |               arguments to this function are incorrect
-   |
-note: associated function defined here
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
-   |                           ^^^^^^^^
 
 error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:29:15
@@ -18,11 +12,6 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
 LL |     let ans = s();
    |               ^-- an argument of type `isize` is missing
    |
-note: associated function defined here
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
-   |                           ^^^^^^^^
 help: provide the argument
    |
 LL |     let ans = s(/* isize */);
@@ -36,11 +25,6 @@ LL |     let ans = s("burma", "shave");
    |                 |
    |                 expected `isize`, found `&str`
    |
-note: associated function defined here
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
-   |                           ^^^^^^^^
 help: remove the extra argument
    |
 LL |     let ans = s(/* isize */);

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -340,4 +340,4 @@ cc = ["@rust-lang/rustfmt"]
 
 [mentions."compiler/rustc_middle/src/mir/syntax.rs"]
 message = "This PR changes MIR"
-cc = ["@oli-obk", "@RalfJung", "@JakobDegen", "@davidtwco", "@celinval"]
+cc = ["@oli-obk", "@RalfJung", "@JakobDegen", "@davidtwco", "@celinval", "@vakaras"]


### PR DESCRIPTION
Successful merges:

 - #99113 (Simplify [a]rc code a little)
 - #99131 (Add label for generic arg (+ APIT) and RPIT callables in `label_fn_like`)
 - #99237 (removed unused CSS and unused HTML IDs)
 - #99239 (Add myself to the set of people notified when MIR changes.)
 - #99241 (Remove comment referring to constness.rs)
 - #99257 (Add regression test for #89436)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99113,99131,99237,99239,99241,99257)
<!-- homu-ignore:end -->