### PR TITLE
Stabilize `core::ffi::CStr`, `alloc::ffi::CString`, and friends

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -108,7 +108,7 @@ use crate::sync::Arc;
 /// and other memory errors.
 #[derive(PartialEq, PartialOrd, Eq, Ord, Hash, Clone)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "cstring_type")]
-#[unstable(feature = "alloc_c_string", issue = "94079")]
+#[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub struct CString {
     // Invariant 1: the slice ends with a zero byte and has a length of at least one.
     // Invariant 2: the slice contains only one zero byte.
@@ -132,7 +132,7 @@ pub struct CString {
 /// let _: NulError = CString::new(b"f\0oo".to_vec()).unwrap_err();
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[unstable(feature = "alloc_c_string", issue = "94079")]
+#[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub struct NulError(usize, Vec<u8>);
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -157,7 +157,7 @@ enum FromBytesWithNulErrorKind {
 /// let _: FromVecWithNulError = CString::from_vec_with_nul(b"f\0oo".to_vec()).unwrap_err();
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[unstable(feature = "alloc_c_string", issue = "94079")]
+#[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub struct FromVecWithNulError {
     error_kind: FromBytesWithNulErrorKind,
     bytes: Vec<u8>,
@@ -223,7 +223,7 @@ impl FromVecWithNulError {
 /// This `struct` is created by [`CString::into_string()`]. See
 /// its documentation for more.
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[unstable(feature = "alloc_c_string", issue = "94079")]
+#[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub struct IntoStringError {
     inner: CString,
     error: Utf8Error,

--- a/library/alloc/src/ffi/mod.rs
+++ b/library/alloc/src/ffi/mod.rs
@@ -78,11 +78,11 @@
 //! [`String`]: crate::string::String
 //! [`CStr`]: core::ffi::CStr
 
-#![unstable(feature = "alloc_ffi", issue = "94079")]
+#![stable(feature = "alloc_ffi", since = "1.64.0")]
 
-#[unstable(feature = "alloc_c_string", issue = "94079")]
+#[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub use self::c_str::FromVecWithNulError;
-#[unstable(feature = "alloc_c_string", issue = "94079")]
+#[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub use self::c_str::{CString, IntoStringError, NulError};
 
 mod c_str;

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -86,7 +86,6 @@
 #![allow(explicit_outlives_requirements)]
 //
 // Library features:
-#![cfg_attr(not(no_global_oom_handling), feature(alloc_c_string))]
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
 #![feature(array_chunks)]
@@ -106,7 +105,6 @@
 #![feature(const_maybe_uninit_write)]
 #![feature(const_maybe_uninit_as_mut_ptr)]
 #![feature(const_refs_to_cell)]
-#![feature(core_c_str)]
 #![feature(core_intrinsics)]
 #![feature(const_eval_select)]
 #![feature(const_pin)]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -11,7 +11,6 @@
 #![feature(const_nonnull_slice_from_raw_parts)]
 #![feature(const_ptr_write)]
 #![feature(const_try)]
-#![feature(core_c_str)]
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
 #![feature(exact_size_is_empty)]

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -76,7 +76,7 @@ use crate::str;
 /// [str]: prim@str "str"
 #[derive(Hash)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "CStr")]
-#[unstable(feature = "core_c_str", issue = "94079")]
+#[stable(feature = "core_c_str", since = "1.64.0")]
 #[rustc_has_incoherent_inherent_impls]
 // FIXME:
 // `fn from` in `impl From<&CStr> for Box<CStr>` current implementation relies
@@ -108,7 +108,7 @@ pub struct CStr {
 /// let _: FromBytesWithNulError = CStr::from_bytes_with_nul(b"f\0oo").unwrap_err();
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[unstable(feature = "core_c_str", issue = "94079")]
+#[stable(feature = "core_c_str", since = "1.64.0")]
 pub struct FromBytesWithNulError {
     kind: FromBytesWithNulErrorKind,
 }

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -14,7 +14,7 @@ use crate::marker::PhantomData;
 use crate::num::*;
 use crate::ops::{Deref, DerefMut};
 
-#[unstable(feature = "core_c_str", issue = "94079")]
+#[stable(feature = "core_c_str", since = "1.64.0")]
 pub use self::c_str::{CStr, FromBytesUntilNulError, FromBytesWithNulError};
 
 mod c_str;

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -146,24 +146,10 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-/// See [alloc::ffi::FromVecWithNulError].
-#[stable(feature = "cstring_from_vec_with_nul", since = "1.58.0")]
-pub type FromVecWithNulError = alloc::ffi::FromVecWithNulError;
-/// See [alloc::ffi::CString].
-#[stable(feature = "rust1", since = "1.0.0")]
-pub type CString = alloc::ffi::CString;
-/// See [alloc::ffi::IntoStringError].
-#[stable(feature = "rust1", since = "1.0.0")]
-pub type IntoStringError = alloc::ffi::IntoStringError;
-/// See [alloc::ffi::NulError].
-#[stable(feature = "rust1", since = "1.0.0")]
-pub type NulError = alloc::ffi::NulError;
-/// See [core::ffi::CStr].
-#[stable(feature = "rust1", since = "1.0.0")]
-pub type CStr = core::ffi::CStr;
-/// See [core::ffi::FromBytesWithNulError].
-#[stable(feature = "cstr_from_bytes", since = "1.10.0")]
-pub type FromBytesWithNulError = core::ffi::FromBytesWithNulError;
+#[stable(feature = "alloc_c_string", since = "1.64.0")]
+pub use alloc::ffi::{CString, FromVecWithNulError, IntoStringError, NulError};
+#[stable(feature = "core_c_str", since = "1.64.0")]
+pub use core::ffi::{CStr, FromBytesWithNulError};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::os_str::{OsStr, OsString};

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -264,7 +264,6 @@
 #![feature(atomic_mut_ptr)]
 #![feature(char_error_internals)]
 #![feature(char_internals)]
-#![feature(core_c_str)]
 #![feature(core_intrinsics)]
 #![feature(cstr_from_bytes_until_nul)]
 #![feature(cstr_internals)]
@@ -297,8 +296,6 @@
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]
-#![feature(alloc_c_string)]
-#![feature(alloc_ffi)]
 #![feature(allocator_api)]
 #![feature(get_mut_unchecked)]
 #![feature(map_try_insert)]


### PR DESCRIPTION
Stabilize the `core_c_str` and `alloc_c_string` feature gates.

Change `std::ffi` to re-export these types rather than creating type
aliases, since they now have matching stability.
