### PR TITLE
[rustdoc-json] JSON no longer inlines

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2120,8 +2120,9 @@ fn clean_use_statement<'tcx>(
     // forcefully don't inline if this is not public or if the
     // #[doc(no_inline)] attribute is present.
     // Don't inline doc(hidden) imports so they can be stripped at a later stage.
-    let mut denied = !(visibility.is_public()
-        || (cx.render_options.document_private && is_visible_from_parent_mod))
+    let mut denied = cx.output_format.is_json()
+        || !(visibility.is_public()
+            || (cx.render_options.document_private && is_visible_from_parent_mod))
         || pub_underscore
         || attrs.iter().any(|a| {
             a.has_name(sym::doc)

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -81,6 +81,8 @@ pub(crate) struct DocContext<'tcx> {
     pub(crate) inlined: FxHashSet<ItemId>,
     /// Used by `calculate_doc_coverage`.
     pub(crate) output_format: OutputFormat,
+    /// Used by `strip_private`.
+    pub(crate) show_coverage: bool,
 }
 
 impl<'tcx> DocContext<'tcx> {
@@ -381,6 +383,7 @@ pub(crate) fn run_global_ctxt(
         inlined: FxHashSet::default(),
         output_format,
         render_options,
+        show_coverage,
     };
 
     // Small hack to force the Sized trait to be present.

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -24,6 +24,7 @@ pub(crate) fn strip_private(mut krate: clean::Crate, cx: &mut DocContext<'_>) ->
             retained: &mut retained,
             access_levels: &cx.cache.access_levels,
             update_retained: true,
+            is_json_output: cx.output_format.is_json() && !cx.show_coverage,
         };
         krate = ImportStripper.fold_crate(stripper.fold_crate(krate));
     }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -190,6 +190,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     ) -> bool {
         debug!("maybe_inline_local res: {:?}", res);
 
+        if self.cx.output_format.is_json() {
+            return false;
+        }
+
         let tcx = self.cx.tcx;
         let Some(res_did) = res.opt_def_id() else {
             return false;

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 15;
+pub const FORMAT_VERSION: u32 = 16;
 
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
@@ -245,6 +245,9 @@ pub enum ItemEnum {
 pub struct Module {
     pub is_crate: bool,
     pub items: Vec<Id>,
+    /// If `true`, this module is not part of the public API, but it contains
+    /// items that are re-exported as public API.
+    pub is_stripped: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/test/rustdoc-json/doc_hidden_failure.rs
+++ b/src/test/rustdoc-json/doc_hidden_failure.rs
@@ -1,0 +1,22 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/98007>.
+
+#![feature(no_core)]
+#![no_core]
+
+mod auto {
+    mod action_row {
+        pub struct ActionRowBuilder;
+    }
+
+    #[doc(hidden)]
+    pub mod builders {
+        pub use super::action_row::ActionRowBuilder;
+    }
+}
+
+// @count doc_hidden_failure.json "$.index[*][?(@.name=='builders')]" 2
+pub use auto::*;
+
+pub mod builders {
+    pub use crate::auto::builders::*;
+}

--- a/src/test/rustdoc-json/reexport/auxiliary/pub-struct.rs
+++ b/src/test/rustdoc-json/reexport/auxiliary/pub-struct.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/src/test/rustdoc-json/reexport/glob_extern.rs
+++ b/src/test/rustdoc-json/reexport/glob_extern.rs
@@ -3,15 +3,16 @@
 #![no_core]
 #![feature(no_core)]
 
-// @!has glob_extern.json "$.index[*][?(@.name=='mod1')]"
+// @is glob_extern.json "$.index[*][?(@.name=='mod1')].kind" \"module\"
+// @is glob_extern.json "$.index[*][?(@.name=='mod1')].inner.is_stripped" "true"
 mod mod1 {
     extern "C" {
-        // @set public_fn_id = - "$.index[*][?(@.name=='public_fn')].id"
+        // @has - "$.index[*][?(@.name=='public_fn')].id"
         pub fn public_fn();
         // @!has - "$.index[*][?(@.name=='private_fn')]"
         fn private_fn();
     }
 }
 
-// @has - "$.index[*][?(@.name=='glob_extern')].inner.items[*]" $public_fn_id
+// @is - "$.index[*][?(@.kind=='import')].inner.glob" true
 pub use mod1::*;

--- a/src/test/rustdoc-json/reexport/glob_private.rs
+++ b/src/test/rustdoc-json/reexport/glob_private.rs
@@ -3,9 +3,11 @@
 #![no_core]
 #![feature(no_core)]
 
-// @!has glob_private.json "$.index[*][?(@.name=='mod1')]"
+// @is glob_private.json "$.index[*][?(@.name=='mod1')].kind" \"module\"
+// @is glob_private.json "$.index[*][?(@.name=='mod1')].inner.is_stripped" "true"
 mod mod1 {
-    // @!has - "$.index[*][?(@.name=='mod2')]"
+    // @is - "$.index[*][?(@.name=='mod2')].kind" \"module\"
+    // @is - "$.index[*][?(@.name=='mod2')].inner.is_stripped" "true"
     mod mod2 {
         // @set m2pub_id = - "$.index[*][?(@.name=='Mod2Public')].id"
         pub struct Mod2Public;
@@ -13,15 +15,18 @@ mod mod1 {
         // @!has - "$.index[*][?(@.name=='Mod2Private')]"
         struct Mod2Private;
     }
+
+    // @has - "$.index[*][?(@.kind=='import' && @.inner.name=='mod2')]"
     pub use self::mod2::*;
 
     // @set m1pub_id = - "$.index[*][?(@.name=='Mod1Public')].id"
     pub struct Mod1Public;
-
     // @!has - "$.index[*][?(@.name=='Mod1Private')]"
     struct Mod1Private;
 }
+
+// @has - "$.index[*][?(@.kind=='import' && @.inner.name=='mod1')]"
 pub use mod1::*;
 
-// @has - "$.index[*][?(@.name=='glob_private')].inner.items[*]" $m2pub_id
-// @has - "$.index[*][?(@.name=='glob_private')].inner.items[*]" $m1pub_id
+// @has - "$.index[*][?(@.name=='mod2')].inner.items[*]" $m2pub_id
+// @has - "$.index[*][?(@.name=='mod1')].inner.items[*]" $m1pub_id

--- a/src/test/rustdoc-json/reexport/in_root_and_mod.rs
+++ b/src/test/rustdoc-json/reexport/in_root_and_mod.rs
@@ -1,15 +1,17 @@
 #![feature(no_core)]
 #![no_core]
 
+// @is in_root_and_mod.json "$.index[*][?(@.name=='foo')].kind" \"module\"
+// @is in_root_and_mod.json "$.index[*][?(@.name=='foo')].inner.is_stripped" "true"
 mod foo {
-    // @set foo_id = in_root_and_mod.json "$.index[*][?(@.name=='Foo')].id"
+    // @has - "$.index[*][?(@.name=='Foo')]"
     pub struct Foo;
 }
 
-// @has - "$.index[*][?(@.name=='in_root_and_mod')].inner.items[*]" $foo_id
+// @has - "$.index[*][?(@.kind=='import' && @.inner.source=='foo::Foo')]"
 pub use foo::Foo;
 
 pub mod bar {
-    // @has - "$.index[*][?(@.name=='bar')].inner.items[*]" $foo_id
+    // @has - "$.index[*][?(@.kind=='import' && @.inner.source=='crate::foo::Foo')]"
     pub use crate::foo::Foo;
 }

--- a/src/test/rustdoc-json/reexport/private_twice_one_inline.rs
+++ b/src/test/rustdoc-json/reexport/private_twice_one_inline.rs
@@ -1,0 +1,18 @@
+// aux-build:pub-struct.rs
+
+// Test for the ICE in rust/83057
+// Am external type re-exported with different attributes shouldn't cause an error
+
+#![no_core]
+#![feature(no_core)]
+
+extern crate pub_struct as foo;
+
+#[doc(inline)]
+pub use foo::Foo;
+
+pub mod bar {
+    pub use foo::Foo;
+}
+
+// @count private_twice_one_inline.json "$.index[*][?(@.kind=='import')]" 2

--- a/src/test/rustdoc-json/reexport/private_two_names.rs
+++ b/src/test/rustdoc-json/reexport/private_two_names.rs
@@ -1,0 +1,17 @@
+// Test for the ICE in rust/83720
+// A pub-in-private type re-exported under two different names shouldn't cause an error
+
+#![no_core]
+#![feature(no_core)]
+
+// @is private_two_names.json "$.index[*][?(@.name=='style')].kind" \"module\"
+// @is private_two_names.json "$.index[*][?(@.name=='style')].inner.is_stripped" "true"
+mod style {
+    // @has - "$.index[*](?(@.name=='Color'))"
+    pub struct Color;
+}
+
+// @has - "$.index[*][?(@.kind=='import' && @.inner.name=='Color')]"
+pub use style::Color;
+// @has - "$.index[*][?(@.kind=='import' && @.inner.name=='Colour')]"
+pub use style::Color as Colour;

--- a/src/test/rustdoc-json/reexport/rename_private.rs
+++ b/src/test/rustdoc-json/reexport/rename_private.rs
@@ -2,13 +2,13 @@
 
 #![no_core]
 #![feature(no_core)]
-// @!has rename_private.json "$.index[*][?(@.name=='inner')]"
+
+// @is rename_private.json "$.index[*][?(@.name=='inner')].kind" \"module\"
+// @is rename_private.json "$.index[*][?(@.name=='inner')].inner.is_stripped" "true"
 mod inner {
-    // @!has - "$.index[*][?(@.name=='Public')]"
+    // @has - "$.index[*][?(@.name=='Public')]"
     pub struct Public;
 }
 
-// @set newname_id = - "$.index[*][?(@.name=='NewName')].id"
-// @is - "$.index[*][?(@.name=='NewName')].kind" \"struct\"
-// @has - "$.index[*][?(@.name=='rename_private')].inner.items[*]" $newname_id
+// @is - "$.index[*][?(@.kind=='import')].inner.name" \"NewName\"
 pub use inner::Public as NewName;

--- a/src/test/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
+++ b/src/test/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
@@ -1,15 +1,13 @@
-// Regression test for https://github.com/rust-lang/rust/issues/97432.
+// Regression test for <https://github.com/rust-lang/rust/issues/97432>.
 
 #![feature(no_core)]
 #![no_std]
 #![no_core]
 
 // @has same_type_reexported_more_than_once.json
-// @set trait_id = - "$.index[*][?(@.name=='Trait')].id"
-// @has - "$.index[*][?(@.name=='same_type_reexported_more_than_once')].inner.items[*]" $trait_id
+// @has - "$.index[*][?(@.name=='Trait')]"
 pub use inner::Trait;
-// @set reexport_id = - "$.index[*][?(@.name=='Reexport')].id"
-// @has - "$.index[*][?(@.name=='same_type_reexported_more_than_once')].inner.items[*]" $reexport_id
+// @has - "$.index[*].inner[?(@.name=='Reexport')].id"
 pub use inner::Trait as Reexport;
 
 mod inner {

--- a/src/test/rustdoc-json/reexport/simple_private.rs
+++ b/src/test/rustdoc-json/reexport/simple_private.rs
@@ -1,13 +1,15 @@
 // edition:2018
-
 #![no_core]
 #![feature(no_core)]
 
-// @!has simple_private.json "$.index[*][?(@.name=='inner')]"
+// @is simple_private.json "$.index[*][?(@.name=='inner')].kind" \"module\"
+// @is simple_private.json "$.index[*][?(@.name=='inner')].inner.is_stripped" "true"
 mod inner {
     // @set pub_id = - "$.index[*][?(@.name=='Public')].id"
     pub struct Public;
 }
 
-// @has - "$.index[*][?(@.name=='simple_private')].inner.items[*]" $pub_id
+// @is - "$.index[*][?(@.kind=='import')].inner.name" \"Public\"
 pub use inner::Public;
+
+// @has - "$.index[*][?(@.name=='inner')].inner.items[*]" $pub_id

--- a/src/test/rustdoc-json/return_private.rs
+++ b/src/test/rustdoc-json/return_private.rs
@@ -1,0 +1,15 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/96161>.
+// ignore-tidy-linelength
+
+#![feature(no_core)]
+#![no_core]
+
+mod secret {
+    pub struct Secret;
+}
+
+// @is return_private.json "$.index[*][?(@.name=='get_secret')].kind" \"function\"
+// @is return_private.json "$.index[*][?(@.name=='get_secret')].inner.decl.output.inner.name" \"secret::Secret\"
+pub fn get_secret() -> secret::Secret {
+    secret::Secret
+}

--- a/src/test/rustdoc-json/stripped_modules.rs
+++ b/src/test/rustdoc-json/stripped_modules.rs
@@ -1,0 +1,21 @@
+#![no_core]
+#![feature(no_core)]
+
+// @!has stripped_modules.json "$.index[*][?(@.name=='no_pub_inner')]"
+mod no_pub_inner {
+    fn priv_inner() {}
+}
+
+// @!has - "$.index[*][?(@.name=='pub_inner_unreachable')]"
+mod pub_inner_unreachable {
+    // @!has - "$.index[*][?(@.name=='pub_inner_1')]"
+    pub fn pub_inner_1() {}
+}
+
+// @has - "$.index[*][?(@.name=='pub_inner_reachable')]"
+mod pub_inner_reachable {
+    // @has - "$.index[*][?(@.name=='pub_inner_2')]"
+    pub fn pub_inner_2() {}
+}
+
+pub use pub_inner_reachable::pub_inner_2;


### PR DESCRIPTION
Fixes #98007.
Fixes #96161.
Fixes https://github.com/rust-lang/rust/issues/83057.
Fixes https://github.com/rust-lang/rust/issues/83720.

I took over #93518 and applied the comments and added more tests.

There was one thing missing (which is in the second commit): if a non-exported item was used in a public API but not reexported, it was still missing.

cc @CraftSpider @Urgau @Enselic 

r? @notriddle 