### PR TITLE
Mark stabilized intrinsics with `rustc_allowed_through_unstable_modules`

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -63,6 +63,7 @@ use crate::mem;
 use crate::sync::atomic::{self, AtomicBool, AtomicI32, AtomicIsize, AtomicU32, Ordering};
 
 #[stable(feature = "drop_in_place", since = "1.8.0")]
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[deprecated(note = "no longer an intrinsic - use `ptr::drop_in_place` directly", since = "1.52.0")]
 #[inline]
 pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
@@ -2435,6 +2436,7 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// [`Vec::append`]: ../../std/vec/struct.Vec.html#method.append
 #[doc(alias = "memcpy")]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
 #[inline]
 pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
@@ -2520,6 +2522,7 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 /// ```
 #[doc(alias = "memmove")]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
 #[inline]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
@@ -2609,6 +2612,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
 /// ```
 #[doc(alias = "memset")]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
 #[inline]
 pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {

--- a/src/test/ui/stability-attribute/issue-99286-stable-intrinsics.rs
+++ b/src/test/ui/stability-attribute/issue-99286-stable-intrinsics.rs
@@ -1,0 +1,17 @@
+// check-pass
+//
+// Regression test for issue #99286
+// Tests that stabilized intrinsics are accessible
+// through 'std::intrinsics', even though the module
+// is unstable.
+
+#![allow(unused_imports)]
+#![allow(deprecated)]
+
+use std::intrinsics::drop_in_place as _;
+use std::intrinsics::copy_nonoverlapping as _;
+use std::intrinsics::copy as _;
+use std::intrinsics::write_bytes as _;
+use std::intrinsics::{drop_in_place, copy_nonoverlapping, copy, write_bytes};
+
+fn main() {}


### PR DESCRIPTION
Fixes #99286

PR #95956 accidentally made these intrinsics unstable when
accessed through the unstable path segment 'std::intrinsics'