### PR TITLE
Revert "Highlight conflicting param-env candidates"

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -541,16 +541,8 @@ pub enum SelectionError<'tcx> {
     ErrorReporting,
     /// Multiple applicable `impl`s where found. The `DefId`s correspond to
     /// all the `impl`s' Items.
-    Ambiguous(Vec<AmbiguousSelection>),
+    Ambiguous(Vec<DefId>),
 }
-
-#[derive(Copy, Clone, Debug)]
-pub enum AmbiguousSelection {
-    Impl(DefId),
-    ParamEnv(Span),
-}
-
-TrivialTypeTraversalAndLiftImpls! { AmbiguousSelection, }
 
 /// When performing resolution, it is typically the case that there
 /// can be one of three outcomes:

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -23,7 +23,7 @@ use rustc_hir::GenericParam;
 use rustc_hir::Item;
 use rustc_hir::Node;
 use rustc_infer::infer::error_reporting::same_type_modulo_infer;
-use rustc_infer::traits::{AmbiguousSelection, TraitEngine};
+use rustc_infer::traits::TraitEngine;
 use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::error::ExpectedFound;
@@ -1402,7 +1402,7 @@ trait InferCtxtPrivExt<'hir, 'tcx> {
     fn annotate_source_of_ambiguity(
         &self,
         err: &mut Diagnostic,
-        impls: &[AmbiguousSelection],
+        impls: &[DefId],
         predicate: ty::Predicate<'tcx>,
     );
 
@@ -2035,14 +2035,6 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                 );
                 match selcx.select_from_obligation(&obligation) {
                     Err(SelectionError::Ambiguous(impls)) if impls.len() > 1 => {
-                        if self.is_tainted_by_errors() && subst.is_none() {
-                            // If `subst.is_none()`, then this is probably two param-env
-                            // candidates or impl candidates that are equal modulo lifetimes.
-                            // Therefore, if we've already emitted an error, just skip this
-                            // one, since it's not particularly actionable.
-                            err.cancel();
-                            return;
-                        }
                         self.annotate_source_of_ambiguity(&mut err, &impls, predicate);
                     }
                     _ => {
@@ -2223,35 +2215,24 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
     fn annotate_source_of_ambiguity(
         &self,
         err: &mut Diagnostic,
-        impls: &[AmbiguousSelection],
+        impls: &[DefId],
         predicate: ty::Predicate<'tcx>,
     ) {
         let mut spans = vec![];
         let mut crates = vec![];
         let mut post = vec![];
-        let mut or_where_clause = false;
-        for ambig in impls {
-            match ambig {
-                AmbiguousSelection::Impl(def_id) => match self.tcx.span_of_impl(*def_id) {
-                    Ok(span) => spans.push(span),
-                    Err(name) => {
-                        crates.push(name);
-                        if let Some(header) = to_pretty_impl_header(self.tcx, *def_id) {
-                            post.push(header);
-                        }
+        for def_id in impls {
+            match self.tcx.span_of_impl(*def_id) {
+                Ok(span) => spans.push(span),
+                Err(name) => {
+                    crates.push(name);
+                    if let Some(header) = to_pretty_impl_header(self.tcx, *def_id) {
+                        post.push(header);
                     }
-                },
-                AmbiguousSelection::ParamEnv(span) => {
-                    or_where_clause = true;
-                    spans.push(*span);
                 }
             }
         }
-        let msg = format!(
-            "multiple `impl`s{} satisfying `{}` found",
-            if or_where_clause { " or `where` clauses" } else { "" },
-            predicate
-        );
+        let msg = format!("multiple `impl`s satisfying `{}` found", predicate);
         let mut crate_names: Vec<_> = crates.iter().map(|n| format!("`{}`", n)).collect();
         crate_names.sort();
         crate_names.dedup();

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -4,13 +4,7 @@ error[E0283]: type annotations needed: cannot satisfy `&'a T: Foo`
 LL |     where &'a T : Foo,
    |                   ^^^
    |
-note: multiple `impl`s or `where` clauses satisfying `&'a T: Foo` found
-  --> $DIR/issue-21974.rs:11:19
-   |
-LL |     where &'a T : Foo,
-   |                   ^^^
-LL |           &'b T : Foo
-   |                   ^^^
+   = note: cannot satisfy `&'a T: Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -4,11 +4,7 @@ error[E0283]: type annotations needed: cannot satisfy `T0: Trait0<'l0>`
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
    |                                                         ^^^^^^^^^^^
    |
-note: multiple `impl`s or `where` clauses satisfying `T0: Trait0<'l0>` found
-  --> $DIR/issue-24424.rs:4:57
-   |
-LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
-   |                                                         ^^^^^^^^^^^       ^^^^^^^^^^^
+   = note: cannot satisfy `T0: Trait0<'l0>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/issue-34979.stderr
+++ b/src/test/ui/lifetimes/issue-34979.stderr
@@ -4,13 +4,7 @@ error[E0283]: type annotations needed: cannot satisfy `&'a (): Foo`
 LL |     &'a (): Foo,
    |             ^^^
    |
-note: multiple `impl`s or `where` clauses satisfying `&'a (): Foo` found
-  --> $DIR/issue-34979.rs:6:13
-   |
-LL |     &'a (): Foo,
-   |             ^^^
-LL |     &'static (): Foo;
-   |                  ^^^
+   = note: cannot satisfy `&'a (): Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-85735.stderr
+++ b/src/test/ui/traits/issue-85735.stderr
@@ -4,14 +4,7 @@ error[E0283]: type annotations needed: cannot satisfy `T: FnMut<(&'a (),)>`
 LL |     T: FnMut(&'a ()),
    |        ^^^^^^^^^^^^^
    |
-note: multiple `impl`s or `where` clauses satisfying `T: FnMut<(&'a (),)>` found
-  --> $DIR/issue-85735.rs:7:8
-   |
-LL |     T: FnMut(&'a ()),
-   |        ^^^^^^^^^^^^^
-LL |
-LL |     T: FnMut(&'b ()),
-   |        ^^^^^^^^^^^^^
+   = note: cannot satisfy `T: FnMut<(&'a (),)>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -4,13 +4,7 @@ error[E0283]: type annotations needed: cannot satisfy `&'a T: Foo`
 LL |     where &'a T : Foo,
    |                   ^^^
    |
-note: multiple `impl`s or `where` clauses satisfying `&'a T: Foo` found
-  --> $DIR/issue-40294.rs:6:19
-   |
-LL |     where &'a T : Foo,
-   |                   ^^^
-LL |           &'b T : Foo
-   |                   ^^^
+   = note: cannot satisfy `&'a T: Foo`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This reverts #98794, commit 08135254dcf22be0d5661ea8f75e703b29a83514.

Seems to have caused an incremental compilation bug. The root cause of the incr comp bug is somewhat unrelated but is triggered by this PR, so I don't feel comfortable with having this PR in the codebase until it can be investigated further. Fixes #99233.