### PR TITLE
Correctly handle path stability for 'use tree' items

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -533,7 +533,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     let ident = *ident;
                     let mut path = path.clone();
                     for seg in &mut path.segments {
-                        seg.id = self.next_node_id();
+                        // Give the cloned segment the same resolution information
+                        // as the old one (this is needed for stability checking).
+                        let new_id = self.next_node_id();
+                        self.resolver.clone_res(seg.id, new_id);
+                        seg.id = new_id;
                     }
                     let span = path.span;
 
@@ -602,7 +606,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                     // Give the segments new node-ids since they are being cloned.
                     for seg in &mut prefix.segments {
-                        seg.id = self.next_node_id();
+                        // Give the cloned segment the same resolution information
+                        // as the old one (this is needed for stability checking).
+                        let new_id = self.next_node_id();
+                        self.resolver.clone_res(seg.id, new_id);
+                        seg.id = new_id;
                     }
 
                     // Each `use` import is an item and thus are owners of the

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -155,6 +155,10 @@ trait ResolverAstLoweringExt {
     fn legacy_const_generic_args(&self, expr: &Expr) -> Option<Vec<usize>>;
     fn get_partial_res(&self, id: NodeId) -> Option<PartialRes>;
     fn get_import_res(&self, id: NodeId) -> PerNS<Option<Res<NodeId>>>;
+    // Clones the resolution (if any) on 'source' and applies it
+    // to 'target'. Used when desugaring a `UseTreeKind::Nested` to
+    // multiple `UseTreeKind::Simple`s
+    fn clone_res(&mut self, source: NodeId, target: NodeId);
     fn get_label_res(&self, id: NodeId) -> Option<NodeId>;
     fn get_lifetime_res(&self, id: NodeId) -> Option<LifetimeRes>;
     fn take_extra_lifetime_params(&mut self, id: NodeId) -> Vec<(Ident, NodeId, LifetimeRes)>;
@@ -190,6 +194,12 @@ impl ResolverAstLoweringExt for ResolverAstLowering {
         }
 
         None
+    }
+
+    fn clone_res(&mut self, source: NodeId, target: NodeId) {
+        if let Some(res) = self.partial_res_map.get(&source) {
+            self.partial_res_map.insert(target, *res);
+        }
     }
 
     /// Obtains resolution for a `NodeId` with a single resolution.

--- a/src/test/ui/lint/lint-output-format.rs
+++ b/src/test/ui/lint/lint-output-format.rs
@@ -5,6 +5,7 @@
 
 extern crate lint_output_format; //~ ERROR use of unstable library feature
 use lint_output_format::{foo, bar}; //~ ERROR use of unstable library feature
+//~| ERROR use of unstable library feature
 
 fn main() {
     let _x = foo();

--- a/src/test/ui/lint/lint-output-format.stderr
+++ b/src/test/ui/lint/lint-output-format.stderr
@@ -7,6 +7,14 @@ LL | extern crate lint_output_format;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
+  --> $DIR/lint-output-format.rs:7:26
+   |
+LL | use lint_output_format::{foo, bar};
+   |                          ^^^
+   |
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-output-format.rs:7:31
    |
 LL | use lint_output_format::{foo, bar};
@@ -15,13 +23,13 @@ LL | use lint_output_format::{foo, bar};
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-output-format.rs:11:14
+  --> $DIR/lint-output-format.rs:12:14
    |
 LL |     let _y = bar();
    |              ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/stable-in-unstable.rs
+++ b/src/test/ui/stability-attribute/stable-in-unstable.rs
@@ -44,3 +44,11 @@ mod isolated5 {
 
     impl stable_in_unstable_std::old_stable_module::OldTrait for LocalType {}
 }
+
+mod isolated6 {
+    use stable_in_unstable_core::new_unstable_module::{OldTrait}; //~ ERROR use of unstable library feature 'unstable_test_feature'
+}
+
+mod isolated7 {
+    use stable_in_unstable_core::new_unstable_module::*; //~ ERROR use of unstable library feature 'unstable_test_feature'
+}

--- a/src/test/ui/stability-attribute/stable-in-unstable.stderr
+++ b/src/test/ui/stability-attribute/stable-in-unstable.stderr
@@ -34,6 +34,24 @@ LL |     impl stable_in_unstable_core::new_unstable_module::OldTrait for LocalTy
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
-error: aborting due to 4 previous errors
+error[E0658]: use of unstable library feature 'unstable_test_feature'
+  --> $DIR/stable-in-unstable.rs:49:56
+   |
+LL |     use stable_in_unstable_core::new_unstable_module::{OldTrait};
+   |                                                        ^^^^^^^^
+   |
+   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_test_feature'
+  --> $DIR/stable-in-unstable.rs:53:9
+   |
+LL |     use stable_in_unstable_core::new_unstable_module::*;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
PR #95956 started checking the stability of path segments.
However, this was not applied to 'use tree' items
(e.g. 'use some::path::{ItemOne, ItemTwo}') due to the way
that we desugar these items in HIR lowering.

This PR modifies 'use tree' lowering to preserve resolution
information, which is needed by stability checking.