### PR TITLE
only run --all-targets in stage0 for Std

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -140,7 +140,10 @@ impl Step for Std {
             cargo_subcommand(builder.kind),
         );
 
-        cargo.arg("--all-targets");
+        if compiler.stage == 0 {
+            cargo.arg("--all-targets");
+        }
+
         std_cargo(builder, target, compiler.stage, &mut cargo);
 
         // Explicitly pass -p for all dependencies krates -- this will force cargo

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -140,6 +140,9 @@ impl Step for Std {
             cargo_subcommand(builder.kind),
         );
 
+        // If we're not in stage 0, tests and examples will fail to compile
+        // from `core` definitions being loaded from two different `libcore`
+        // .rmeta and .rlib files.
         if compiler.stage == 0 {
             cargo.arg("--all-targets");
         }


### PR DESCRIPTION
Repro'd the issue with `python3 x.py check --stage 1 library/std` and tested the fix with the same command.

r? @jyn514 

I tried to implement [this solution](https://github.com/rust-lang/rust/issues/98720#issuecomment-1184435462), but didn't have any luck. I don't think I fully understood what needed to be done. However, I would love to be mentored on it since it would be a more correct solution, and I can learn more about how bootstrap works.