### PR TITLE
Fix flakyness of GUI tests

### DIFF
--- a/src/test/rustdoc-gui/escape-key.goml
+++ b/src/test/rustdoc-gui/escape-key.goml
@@ -3,6 +3,8 @@
 goto: file://|DOC_PATH|/test_docs/index.html
 // First, we check that the search results are hidden when the Escape key is pressed.
 write: (".search-input", "test")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 wait-for: "#search h1" // The search element is empty before the first search 
 // Check that the currently displayed element is search.
 wait-for: "#alternative-display #search"

--- a/src/test/rustdoc-gui/search-filter.goml
+++ b/src/test/rustdoc-gui/search-filter.goml
@@ -2,6 +2,8 @@
 goto: file://|DOC_PATH|/test_docs/index.html
 show-text: true
 write: (".search-input", "test")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-text: ("#results .externcrate", "test_docs")

--- a/src/test/rustdoc-gui/search-reexport.goml
+++ b/src/test/rustdoc-gui/search-reexport.goml
@@ -7,6 +7,8 @@ reload:
 assert-text: ("//*[@id='reexport.TheStdReexport']", "pub use ::std as TheStdReexport;")
 assert-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgba(0, 0, 0, 0)"})
 write: (".search-input", "TheStdReexport")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 wait-for: "//a[@class='result-import']"
 assert-attribute: (
     "//a[@class='result-import']",
@@ -18,6 +20,8 @@ click: "//a[@class='result-import']"
 wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgb(73, 74, 61)"})
 
 // We now check that the alias is working as well on the reexport.
+// To be SURE that the search will be run.
+press-key: 'Enter'
 write: (".search-input", "AliasForTheStdReexport")
 wait-for: "//a[@class='result-import']"
 assert-text: (

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -89,6 +89,8 @@ show-text: true
 // We reload the page so the local storage settings are being used.
 reload:
 write: (".search-input", "thisisanalias")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 // Checking that the colors for the alias element are the ones expected.

--- a/src/test/rustdoc-gui/search-result-display.goml
+++ b/src/test/rustdoc-gui/search-result-display.goml
@@ -2,6 +2,8 @@
 goto: file://|DOC_PATH|/test_docs/index.html
 size: (900, 1000)
 write: (".search-input", "test")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 wait-for: "#search-settings"
 // The width is returned by "getComputedStyle" which returns the exact number instead of the
 // CSS rule which is "50%"...

--- a/src/test/rustdoc-gui/search-result-keyword.goml
+++ b/src/test/rustdoc-gui/search-result-keyword.goml
@@ -1,6 +1,8 @@
 // Checks that the "keyword" results have the expected text alongside them.
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "CookieMonster")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 // Note: The two next assert commands could be merged as one but readability would be

--- a/src/test/rustdoc-gui/search-tab-change-title-fn-sig.goml
+++ b/src/test/rustdoc-gui/search-tab-change-title-fn-sig.goml
@@ -2,6 +2,8 @@
 // First, try a search-by-name
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "Foo")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})
@@ -22,6 +24,8 @@ wait-for-attribute: ("#titles > button:nth-of-type(3)", {"class": "selected"})
 // Now try search-by-return
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "-> String")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})
@@ -42,6 +46,8 @@ wait-for-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})
 // Try with a search-by-return with no results
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "-> Something")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})
@@ -50,6 +56,8 @@ assert-text: ("#titles > button:nth-of-type(1)", "In Function Return Types", STA
 // Try with a search-by-parameter
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "usize pattern")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})
@@ -58,6 +66,8 @@ assert-text: ("#titles > button:nth-of-type(1)", "In Function Parameters", START
 // Try with a search-by-parameter-and-return
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "pattern -> str")
+// To be SURE that the search will be run.
+press-key: 'Enter'
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})

--- a/src/test/rustdoc-gui/settings.goml
+++ b/src/test/rustdoc-gui/settings.goml
@@ -20,6 +20,8 @@ wait-for-css: ("#settings", {"display": "none"})
 // Let's click on it when the search results are displayed.
 focus: ".search-input"
 write: "test"
+// To be SURE that the search will be run.
+press-key: 'Enter'
 wait-for: "#alternative-display #search"
 click: "#settings-menu"
 wait-for-css: ("#settings", {"display": "block"})


### PR DESCRIPTION
Fixes #98163.

All flaky tests seemed to be linked to the search. Since the search JS is loaded when we focus the search input, I think it's possible that we enter faster than the JS is actually loaded. The solution for that would be to do it in two steps: first we write into the search input (`browser-ui-test` adds a small sleep time after such commands) and then we press enter to be sure that it wasn't missed.

cc @JohnTitor 
r? @Dylan-DPC 