### PR TITLE
Allow ?-converting from Result<T, E> in functions returning Option<Result<T, E>>

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2306,6 +2306,19 @@ impl<T> const ops::FromResidual for Option<T> {
     }
 }
 
+#[unstable(feature = "try_trait_v2", issue = "84277")]
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
+impl<T, E, F: ~const From<E>> const ops::FromResidual<Result<convert::Infallible, E>>
+    for Option<Result<T, F>>
+{
+    #[inline]
+    fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
+        match residual {
+            Err(e) => Some(Err(From::from(e))),
+        }
+    }
+}
+
 #[unstable(feature = "try_trait_v2_yeet", issue = "96374")]
 impl<T> ops::FromResidual<ops::Yeet<()>> for Option<T> {
     #[inline]

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -553,3 +553,14 @@ fn zip_unzip_roundtrip() {
     let a = z.unzip();
     assert_eq!(a, (x, y));
 }
+
+#[test]
+fn from_residual_option_result() {
+    fn test<F: FnOnce() -> Result<u8, u16>>(f: F) -> Option<Result<u8, u32>> {
+        let x: u8 = f()?;
+        Some(Ok(x * 2))
+    }
+
+    assert_eq!(test(|| Ok(2)), Some(Ok(4)));
+    assert_eq!(test(|| Err(2)), Some(Err(2)));
+}

--- a/src/test/ui/try-trait/bad-interconversion.stderr
+++ b/src/test/ui/try-trait/bad-interconversion.stderr
@@ -62,6 +62,7 @@ LL | | }
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `Option<u16>`
    = help: the following other types implement trait `FromResidual<R>`:
+             <Option<Result<T, F>> as FromResidual<Result<Infallible, E>>>
              <Option<T> as FromResidual<Yeet<()>>>
              <Option<T> as FromResidual>
 
@@ -77,6 +78,7 @@ LL | | }
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Option<u64>`
    = help: the following other types implement trait `FromResidual<R>`:
+             <Option<Result<T, F>> as FromResidual<Result<Infallible, E>>>
              <Option<T> as FromResidual<Yeet<()>>>
              <Option<T> as FromResidual>
 

--- a/src/test/ui/try-trait/option-to-result.stderr
+++ b/src/test/ui/try-trait/option-to-result.stderr
@@ -27,6 +27,7 @@ LL | | }
    |
    = help: the trait `FromResidual<Result<Infallible, i32>>` is not implemented for `Option<i32>`
    = help: the following other types implement trait `FromResidual<R>`:
+             <Option<Result<T, F>> as FromResidual<Result<Infallible, E>>>
              <Option<T> as FromResidual<Yeet<()>>>
              <Option<T> as FromResidual>
 


### PR DESCRIPTION
This PR adds implementation `FromResidual<Result<Infallible, E>> for Option<Result<T, E>>`, allowing to use `?` operator on `Result<_, E>` in functions returning `Option<Result<T, E>>`.

Interestingly, this is already the case for `Poll<Option<Result<T, E>>>`, so this implementation seems to be accidentally missing and not deliberately left out.

This is particularly useful for `Iterator` implementations where `Item = Result<T, E>`.

This implementation is `const` when underlying `From<_>` impl is `const`. This is not the case for `Poll<_>` implementations and I’m not sure why. Should I add missing `const` to `Poll<_>` impls or there’s a reason for that?