### PR TITLE
rustdoc: avoid inlining items with duplicate `(type, name)`

### DIFF
--- a/src/test/rustdoc/auxiliary/issue-99221-aux.rs
+++ b/src/test/rustdoc/auxiliary/issue-99221-aux.rs
@@ -1,0 +1,20 @@
+pub struct Option;
+impl Option {
+    pub fn unwrap(self) {}
+}
+
+mod macros {
+    use crate::Option;
+    /// [`Option::unwrap`]
+    #[macro_export]
+    macro_rules! print {
+        () => ()
+    }
+}
+
+mod structs {
+    use crate::Option;
+    /// [`Option::unwrap`]
+    pub struct Print;
+}
+pub use structs::Print;

--- a/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name-submodule.rs
+++ b/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name-submodule.rs
@@ -1,0 +1,19 @@
+// aux-build:issue-99221-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99221_aux;
+
+pub use issue_99221_aux::*;
+
+// @count foo/index.html '//a[@class="macro"]' 1
+
+mod inner {
+    #[macro_export]
+    macro_rules! print {
+        () => ()
+    }
+}

--- a/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name.rs
+++ b/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name.rs
@@ -1,0 +1,17 @@
+// aux-build:issue-99221-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99221_aux;
+
+pub use issue_99221_aux::*;
+
+// @count foo/index.html '//a[@class="macro"]' 1
+
+#[macro_export]
+macro_rules! print {
+    () => ()
+}

--- a/src/test/rustdoc/issue-99221-multiple-structs-w-same-name.rs
+++ b/src/test/rustdoc/issue-99221-multiple-structs-w-same-name.rs
@@ -1,0 +1,14 @@
+// aux-build:issue-99221-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99221_aux;
+
+pub use issue_99221_aux::*;
+
+// @count foo/index.html '//a[@class="struct"][@title="foo::Print struct"]' 1
+
+pub struct Print;


### PR DESCRIPTION
Fixes #99221