### PR TITLE
Be more precise when suggesting removal of parens on unit ctor

### DIFF
--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -211,6 +211,10 @@ pub fn path_to_string(segment: &hir::Path<'_>) -> String {
     to_string(NO_ANN, |s| s.print_path(segment, false))
 }
 
+pub fn qpath_to_string(segment: &hir::QPath<'_>) -> String {
+    to_string(NO_ANN, |s| s.print_qpath(segment, false))
+}
+
 pub fn fn_to_string(
     decl: &hir::FnDecl<'_>,
     header: hir::FnHeader,

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -397,7 +397,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         = self.typeck_results.borrow().qpath_res(qpath, callee_expr.hir_id)
                     // Only suggest removing parens if there are no arguments
                     && arg_exprs.is_empty()
-                    && let Ok(path) = self.tcx.sess.source_map().span_to_snippet(callee_expr.span)
                 {
                     let descr = match kind {
                         def::CtorOf::Struct => "struct",
@@ -406,7 +405,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let removal_span =
                         callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
                     unit_variant =
-                        Some((removal_span, descr, path));
+                        Some((removal_span, descr, rustc_hir_pretty::qpath_to_string(qpath)));
                 }
 
                 let callee_ty = self.resolve_vars_if_possible(callee_ty);

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -4,7 +4,7 @@ use crate::type_error_struct;
 
 use rustc_errors::{struct_span_err, Applicability, Diagnostic};
 use rustc_hir as hir;
-use rustc_hir::def::{Namespace, Res};
+use rustc_hir::def::{self, Namespace, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_infer::{
     infer,
@@ -390,17 +390,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (fn_sig, Some(def_id))
             }
             ty::FnPtr(sig) => (sig, None),
-            ref t => {
+            _ => {
                 let mut unit_variant = None;
-                let mut removal_span = call_expr.span;
-                if let ty::Adt(adt_def, ..) = t
-                    && adt_def.is_enum()
-                    && let hir::ExprKind::Call(expr, _) = call_expr.kind
+                if let hir::ExprKind::Path(qpath) = &callee_expr.kind
+                    && let Res::Def(def::DefKind::Ctor(kind, def::CtorKind::Const), _)
+                        = self.typeck_results.borrow().qpath_res(qpath, callee_expr.hir_id)
+                    // Only suggest removing parens if there are no arguments
+                    && arg_exprs.is_empty()
+                    && let Ok(path) = self.tcx.sess.source_map().span_to_snippet(callee_expr.span)
                 {
-                    removal_span =
-                        expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
+                    let descr = match kind {
+                        def::CtorOf::Struct => "struct",
+                        def::CtorOf::Variant => "enum variant",
+                    };
+                    let removal_span =
+                        callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
                     unit_variant =
-                        self.tcx.sess.source_map().span_to_snippet(expr.span).ok();
+                        Some((removal_span, descr, path));
                 }
 
                 let callee_ty = self.resolve_vars_if_possible(callee_ty);
@@ -410,8 +416,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     callee_ty,
                     E0618,
                     "expected function, found {}",
-                    match unit_variant {
-                        Some(ref path) => format!("enum variant `{path}`"),
+                    match &unit_variant {
+                        Some((_, kind, path)) => format!("{kind} `{path}`"),
                         None => format!("`{callee_ty}`"),
                     }
                 );
@@ -423,11 +429,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     callee_expr.span,
                 );
 
-                if let Some(ref path) = unit_variant {
+                if let Some((removal_span, kind, path)) = &unit_variant {
                     err.span_suggestion_verbose(
-                        removal_span,
+                        *removal_span,
                         &format!(
-                            "`{path}` is a unit variant, you need to write it without the parentheses",
+                            "`{path}` is a unit {kind}, and does not take parentheses to be constructed",
                         ),
                         "",
                         Applicability::MachineApplicable,
@@ -470,7 +476,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let Some(span) = self.tcx.hir().res_span(def) {
                     let callee_ty = callee_ty.to_string();
                     let label = match (unit_variant, inner_callee_path) {
-                        (Some(path), _) => Some(format!("`{path}` defined here")),
+                        (Some((_, kind, path)), _) => Some(format!("{kind} `{path}` defined here")),
                         (_, Some(hir::QPath::Resolved(_, path))) => self
                             .tcx
                             .sess

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -531,7 +531,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 tcx.ty_error()
             }
             Res::Def(DefKind::Ctor(_, CtorKind::Fictive), _) => {
-                report_unexpected_variant_res(tcx, res, expr.span);
+                report_unexpected_variant_res(tcx, res, qpath, expr.span);
                 tcx.ty_error()
             }
             _ => self.instantiate_value_path(segs, opt_ty, res, expr.span, expr.hir_id).0,

--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -863,17 +863,14 @@ fn bad_non_zero_sized_fields<'tcx>(
     err.emit();
 }
 
-fn report_unexpected_variant_res(tcx: TyCtxt<'_>, res: Res, span: Span) {
+fn report_unexpected_variant_res(tcx: TyCtxt<'_>, res: Res, qpath: &hir::QPath<'_>, span: Span) {
     struct_span_err!(
         tcx.sess,
         span,
         E0533,
-        "expected unit struct, unit variant or constant, found {}{}",
+        "expected unit struct, unit variant or constant, found {} `{}`",
         res.descr(),
-        tcx.sess
-            .source_map()
-            .span_to_snippet(span)
-            .map_or_else(|_| String::new(), |s| format!(" `{s}`",)),
+        rustc_hir_pretty::qpath_to_string(qpath),
     )
     .emit();
 }

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -183,7 +183,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PatKind::TupleStruct(ref qpath, subpats, ddpos) => {
                 self.check_pat_tuple_struct(pat, qpath, subpats, ddpos, expected, def_bm, ti)
             }
-            PatKind::Path(_) => self.check_pat_path(pat, path_res.unwrap(), expected, ti),
+            PatKind::Path(ref qpath) => {
+                self.check_pat_path(pat, qpath, path_res.unwrap(), expected, ti)
+            }
             PatKind::Struct(ref qpath, fields, has_rest_pat) => {
                 self.check_pat_struct(pat, qpath, fields, has_rest_pat, expected, def_bm, ti)
             }
@@ -800,6 +802,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn check_pat_path<'b>(
         &self,
         pat: &Pat<'_>,
+        qpath: &hir::QPath<'_>,
         path_resolution: (Res, Option<Ty<'tcx>>, &'b [hir::PathSegment<'b>]),
         expected: Ty<'tcx>,
         ti: TopInfo<'tcx>,
@@ -814,7 +817,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return tcx.ty_error();
             }
             Res::Def(DefKind::AssocFn | DefKind::Ctor(_, CtorKind::Fictive | CtorKind::Fn), _) => {
-                report_unexpected_variant_res(tcx, res, pat.span);
+                report_unexpected_variant_res(tcx, res, qpath, pat.span);
                 return tcx.ty_error();
             }
             Res::SelfCtor(..)

--- a/src/test/ui/empty/empty-struct-unit-expr.rs
+++ b/src/test/ui/empty/empty-struct-unit-expr.rs
@@ -12,10 +12,10 @@ enum E {
 }
 
 fn main() {
-    let e2 = Empty2(); //~ ERROR expected function, found `Empty2`
+    let e2 = Empty2(); //~ ERROR expected function, found struct `Empty2`
     let e4 = E::Empty4();
     //~^ ERROR expected function, found enum variant `E::Empty4` [E0618]
-    let xe2 = XEmpty2(); //~ ERROR expected function, found `empty_struct::XEmpty2`
+    let xe2 = XEmpty2(); //~ ERROR expected function, found struct `XEmpty2`
     let xe4 = XE::XEmpty4();
     //~^ ERROR expected function, found enum variant `XE::XEmpty4` [E0618]
 }

--- a/src/test/ui/empty/empty-struct-unit-expr.stderr
+++ b/src/test/ui/empty/empty-struct-unit-expr.stderr
@@ -1,38 +1,50 @@
-error[E0618]: expected function, found `Empty2`
+error[E0618]: expected function, found struct `Empty2`
   --> $DIR/empty-struct-unit-expr.rs:15:14
    |
 LL | struct Empty2;
-   | ------------- `Empty2` defined here
+   | ------------- struct `Empty2` defined here
 ...
 LL |     let e2 = Empty2();
    |              ^^^^^^--
    |              |
    |              call expression requires function
+   |
+help: `Empty2` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let e2 = Empty2();
+LL +     let e2 = Empty2;
+   |
 
 error[E0618]: expected function, found enum variant `E::Empty4`
   --> $DIR/empty-struct-unit-expr.rs:16:14
    |
 LL |     Empty4
-   |     ------ `E::Empty4` defined here
+   |     ------ enum variant `E::Empty4` defined here
 ...
 LL |     let e4 = E::Empty4();
    |              ^^^^^^^^^--
    |              |
    |              call expression requires function
    |
-help: `E::Empty4` is a unit variant, you need to write it without the parentheses
+help: `E::Empty4` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let e4 = E::Empty4();
 LL +     let e4 = E::Empty4;
    |
 
-error[E0618]: expected function, found `empty_struct::XEmpty2`
+error[E0618]: expected function, found struct `XEmpty2`
   --> $DIR/empty-struct-unit-expr.rs:18:15
    |
 LL |     let xe2 = XEmpty2();
    |               ^^^^^^^--
    |               |
    |               call expression requires function
+   |
+help: `XEmpty2` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let xe2 = XEmpty2();
+LL +     let xe2 = XEmpty2;
+   |
 
 error[E0618]: expected function, found enum variant `XE::XEmpty4`
   --> $DIR/empty-struct-unit-expr.rs:19:15
@@ -42,7 +54,7 @@ LL |     let xe4 = XE::XEmpty4();
    |               |
    |               call expression requires function
    |
-help: `XE::XEmpty4` is a unit variant, you need to write it without the parentheses
+help: `XE::XEmpty4` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let xe4 = XE::XEmpty4();
 LL +     let xe4 = XE::XEmpty4;

--- a/src/test/ui/error-codes/E0618.stderr
+++ b/src/test/ui/error-codes/E0618.stderr
@@ -2,14 +2,14 @@ error[E0618]: expected function, found enum variant `X::Entry`
   --> $DIR/E0618.rs:6:5
    |
 LL |     Entry,
-   |     ----- `X::Entry` defined here
+   |     ----- enum variant `X::Entry` defined here
 ...
 LL |     X::Entry();
    |     ^^^^^^^^--
    |     |
    |     call expression requires function
    |
-help: `X::Entry` is a unit variant, you need to write it without the parentheses
+help: `X::Entry` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     X::Entry();
 LL +     X::Entry;

--- a/src/test/ui/issues/issue-20714.rs
+++ b/src/test/ui/issues/issue-20714.rs
@@ -1,5 +1,5 @@
 struct G;
 
 fn main() {
-    let g = G(); //~ ERROR: expected function, found `G`
+    let g = G(); //~ ERROR: expected function, found struct `G`
 }

--- a/src/test/ui/issues/issue-20714.stderr
+++ b/src/test/ui/issues/issue-20714.stderr
@@ -1,13 +1,19 @@
-error[E0618]: expected function, found `G`
+error[E0618]: expected function, found struct `G`
   --> $DIR/issue-20714.rs:4:13
    |
 LL | struct G;
-   | -------- `G` defined here
+   | -------- struct `G` defined here
 ...
 LL |     let g = G();
    |             ^--
    |             |
    |             call expression requires function
+   |
+help: `G` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let g = G();
+LL +     let g = G;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21701.rs
+++ b/src/test/ui/issues/issue-21701.rs
@@ -7,7 +7,7 @@ struct Bar;
 
 pub fn some_func() {
     let f = Bar();
-//~^ ERROR: expected function, found `Bar`
+//~^ ERROR: expected function, found struct `Bar`
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-21701.stderr
+++ b/src/test/ui/issues/issue-21701.stderr
@@ -8,16 +8,22 @@ LL |     let y = t();
    |             |
    |             call expression requires function
 
-error[E0618]: expected function, found `Bar`
+error[E0618]: expected function, found struct `Bar`
   --> $DIR/issue-21701.rs:9:13
    |
 LL | struct Bar;
-   | ---------- `Bar` defined here
+   | ---------- struct `Bar` defined here
 ...
 LL |     let f = Bar();
    |             ^^^--
    |             |
    |             call expression requires function
+   |
+help: `Bar` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let f = Bar();
+LL +     let f = Bar;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/methods/method-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-path-in-pattern.stderr
@@ -4,13 +4,13 @@ error[E0533]: expected unit struct, unit variant or constant, found associated f
 LL |         Foo::bar => {}
    |         ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:19:9
    |
 LL |         <Foo>::bar => {}
    |         ^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<Foo>::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:23:9
    |
 LL |         <Foo>::trait_bar => {}
@@ -22,7 +22,7 @@ error[E0533]: expected unit struct, unit variant or constant, found associated f
 LL |     if let Foo::bar = 0u32 {}
    |            ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:28:12
    |
 LL |     if let <Foo>::bar = 0u32 {}

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<S as Tr>::A::f::<u8>`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `<<S as Tr>::A>::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -336,14 +336,14 @@ error[E0618]: expected function, found enum variant `Z::Unit`
   --> $DIR/privacy-enum-ctor.rs:31:17
    |
 LL |             Unit,
-   |             ---- `Z::Unit` defined here
+   |             ---- enum variant `Z::Unit` defined here
 ...
 LL |         let _ = Z::Unit();
    |                 ^^^^^^^--
    |                 |
    |                 call expression requires function
    |
-help: `Z::Unit` is a unit variant, you need to write it without the parentheses
+help: `Z::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -         let _ = Z::Unit();
 LL +         let _ = Z::Unit;
@@ -371,14 +371,14 @@ error[E0618]: expected function, found enum variant `m::E::Unit`
   --> $DIR/privacy-enum-ctor.rs:47:16
    |
 LL |         Unit,
-   |         ---- `m::E::Unit` defined here
+   |         ---- enum variant `m::E::Unit` defined here
 ...
 LL |     let _: E = m::E::Unit();
    |                ^^^^^^^^^^--
    |                |
    |                call expression requires function
    |
-help: `m::E::Unit` is a unit variant, you need to write it without the parentheses
+help: `m::E::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let _: E = m::E::Unit();
 LL +     let _: E = m::E::Unit;
@@ -406,14 +406,14 @@ error[E0618]: expected function, found enum variant `E::Unit`
   --> $DIR/privacy-enum-ctor.rs:55:16
    |
 LL |         Unit,
-   |         ---- `E::Unit` defined here
+   |         ---- enum variant `E::Unit` defined here
 ...
 LL |     let _: E = E::Unit();
    |                ^^^^^^^--
    |                |
    |                call expression requires function
    |
-help: `E::Unit` is a unit variant, you need to write it without the parentheses
+help: `E::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let _: E = E::Unit();
 LL +     let _: E = E::Unit;

--- a/src/test/ui/suggestions/issue-99240-2.rs
+++ b/src/test/ui/suggestions/issue-99240-2.rs
@@ -1,0 +1,10 @@
+enum Enum {
+    Unit,
+}
+type Alias = Enum;
+
+fn main() {
+    Alias::
+    Unit();
+    //~^^ ERROR expected function, found enum variant `Alias::Unit`
+}

--- a/src/test/ui/suggestions/issue-99240-2.stderr
+++ b/src/test/ui/suggestions/issue-99240-2.stderr
@@ -1,0 +1,24 @@
+error[E0618]: expected function, found enum variant `Alias::Unit`
+  --> $DIR/issue-99240-2.rs:7:5
+   |
+LL |        Unit,
+   |        ---- enum variant `Alias::Unit` defined here
+...
+LL |        Alias::
+   |   _____^
+   |  |_____|
+   | ||
+LL | ||     Unit();
+   | ||________^_- call expression requires function
+   | |_________|
+   | 
+   |
+help: `Alias::Unit` is a unit enum variant, and does not take parentheses to be constructed
+   |
+LL -     Unit();
+LL +     Unit;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/src/test/ui/suggestions/issue-99240.rs
+++ b/src/test/ui/suggestions/issue-99240.rs
@@ -1,0 +1,6 @@
+fn fmt(it: &(std::cell::Cell<Option<impl FnOnce()>>,)) {
+    (it.0.take())()
+    //~^ ERROR expected function
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-99240.stderr
+++ b/src/test/ui/suggestions/issue-99240.stderr
@@ -1,0 +1,11 @@
+error[E0618]: expected function, found `Option<impl FnOnce()>`
+  --> $DIR/issue-99240.rs:2:5
+   |
+LL |     (it.0.take())()
+   |     ^^^^^^^^^^^^^--
+   |     |
+   |     call expression requires function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -20,14 +20,14 @@ error[E0618]: expected function, found enum variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:15:5
    |
 LL | enum Enum { Braced {}, Unit, Tuple() }
-   |                        ---- `Alias::Unit` defined here
+   |                        ---- enum variant `Alias::Unit` defined here
 ...
 LL |     Alias::Unit();
    |     ^^^^^^^^^^^--
    |     |
    |     call expression requires function
    |
-help: `Alias::Unit` is a unit variant, you need to write it without the parentheses
+help: `Alias::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     Alias::Unit();
 LL +     Alias::Unit;


### PR DESCRIPTION
* Fixes #99240 by only suggesting to remove parens on path exprs, not arbitrary expressions with enum type
* Generalizes by suggesting removal of parens on unit struct, too, because why not?