### PR TITLE
Use `typeck_results` to get accurate qpath res for arg mismatch error

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -443,17 +443,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Next, let's construct the error
         let (error_span, full_call_span, ctor_of) = match &call_expr.kind {
             hir::ExprKind::Call(
-                hir::Expr {
-                    span,
-                    kind:
-                        hir::ExprKind::Path(hir::QPath::Resolved(
-                            _,
-                            hir::Path { res: Res::Def(DefKind::Ctor(of, _), _), .. },
-                        )),
-                    ..
-                },
+                hir::Expr { hir_id, span, kind: hir::ExprKind::Path(qpath), .. },
                 _,
-            ) => (call_span, *span, Some(of)),
+            ) => {
+                if let Res::Def(DefKind::Ctor(of, _), _) =
+                    self.typeck_results.borrow().qpath_res(qpath, *hir_id)
+                {
+                    (call_span, *span, Some(of))
+                } else {
+                    (call_span, *span, None)
+                }
+            }
             hir::ExprKind::Call(hir::Expr { span, .. }, _) => (call_span, *span, None),
             hir::ExprKind::MethodCall(path_segment, _, span) => {
                 let ident_span = path_segment.ident.span;

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -7,7 +7,7 @@ LL |     fn ts_variant() {
 LL |         Self::TSVariant(());
    |         --------------- ^^ expected type parameter `T`, found `()`
    |         |
-   |         arguments to this function are incorrect
+   |         arguments to this enum variant are incorrect
    |
    = note: expected type parameter `T`
                    found unit type `()`
@@ -55,7 +55,7 @@ LL | impl<T> Enum<T> {
 LL |         Self::<()>::TSVariant(());
    |         --------------------- ^^ expected type parameter `T`, found `()`
    |         |
-   |         arguments to this function are incorrect
+   |         arguments to this enum variant are incorrect
    |
    = note: expected type parameter `T`
                    found unit type `()`

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.rs
@@ -18,6 +18,6 @@ impl E2 {
 }
 
 fn main() {
-    <E>::V(); //~ ERROR this function takes 1 argument but 0 arguments were supplied
+    <E>::V(); //~ ERROR this enum variant takes 1 argument but 0 arguments were supplied
     let _: u8 = <E2>::V; //~ ERROR mismatched types
 }

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
@@ -1,4 +1,4 @@
-error[E0061]: this function takes 1 argument but 0 arguments were supplied
+error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:21:5
    |
 LL |     <E>::V();


### PR DESCRIPTION
Improves error message from "function"  to actually what we're calling (e.g. enum variant constrcutor) in a few cases :smile_cat: 