### PR TITLE
Do not constraint TAITs when checking impl/trait item compatibility

### DIFF
--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -1505,6 +1505,21 @@ pub fn check_type_bounds<'tcx>(
             &outlives_environment,
         );
 
+        let constraints = infcx.inner.borrow_mut().opaque_type_storage.take_opaque_types();
+        for (key, value) in constraints {
+            infcx
+                .report_mismatched_types(
+                    &ObligationCause::misc(
+                        value.hidden_type.span,
+                        tcx.hir().local_def_id_to_hir_id(impl_ty.def_id.expect_local()),
+                    ),
+                    tcx.mk_opaque(key.def_id, key.substs),
+                    value.hidden_type.ty,
+                    TypeError::Mismatch,
+                )
+                .emit();
+        }
+
         Ok(())
     })
 }

--- a/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.rs
+++ b/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.rs
@@ -1,0 +1,26 @@
+#![feature(type_alias_impl_trait)]
+
+struct Concrete;
+
+type Tait = impl Sized;
+
+impl Foo for Concrete {
+    type Item = Concrete;
+    //~^ mismatched types
+}
+
+impl Bar for Concrete {
+    type Other = Tait;
+}
+
+trait Foo {
+    type Item: Bar<Other = Self>;
+}
+
+trait Bar {
+    type Other;
+}
+
+fn tait() -> Tait {}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.stderr
+++ b/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-99348-impl-compatibility.rs:8:17
+   |
+LL | type Tait = impl Sized;
+   |             ---------- the expected opaque type
+...
+LL |     type Item = Concrete;
+   |                 ^^^^^^^^ types differ
+   |
+   = note: expected opaque type `Tait`
+                   found struct `Concrete`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Check out the UI test for the example. 

Open to other approaches to fix this issue -- ideally we _would_ be able to collect this opaque type constraint in a way to use it in `find_opaque_ty_constraints`, so we can report a better mismatch error in the incompatible case, and just allow it in the compatible case. But that seems like a bigger refactor, so I wouldn't want to start it unless someone else thought it was a good idea.

cc #99348
r? @oli-obk