### PR TITLE
Fix bad suggestions when initializing enum as struct

### DIFF
--- a/src/test/ui/hygiene/globs.stderr
+++ b/src/test/ui/hygiene/globs.stderr
@@ -37,8 +37,6 @@ LL | n!(f);
 LL |         n!(f);
    |            ^ not found in this scope
    |
-   = note: consider importing this function:
-           foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `f` in this scope
@@ -50,8 +48,6 @@ LL | n!(f);
 LL |                 f
    |                 ^ not found in this scope
    |
-   = note: consider importing this function:
-           foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/resolve/issue-3907.stderr
+++ b/src/test/ui/resolve/issue-3907.stderr
@@ -8,10 +8,6 @@ help: you might have meant to use `#![feature(trait_alias)]` instead of a `type`
    |
 LL | trait Foo = dyn issue_3907::Foo;
    |
-help: consider importing this trait instead
-   |
-LL | use issue_3907::Foo;
-   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -3,11 +3,6 @@ error[E0404]: expected trait, found type parameter `Add`
    |
 LL | impl<T: Clone, Add> Add for Foo<T> {
    |                     ^^^ not a trait
-   |
-help: consider importing this trait instead
-   |
-LL | use std::ops::Add;
-   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/init-enum-as-struct.rs
+++ b/src/test/ui/suggestions/init-enum-as-struct.rs
@@ -1,0 +1,23 @@
+pub type Foos = i32;
+
+pub enum Foo {
+    A,
+    B,
+    C,
+}
+
+mod module0 {
+    pub struct Foo {
+        a: i32,
+    }
+}
+mod module1 {
+    pub struct Foo {}
+}
+mod module2 {
+    pub enum Foo {}
+}
+
+fn main() {
+    let foo = Foo { b: 0 }; //~ expected struct, variant or union type, found enum `Foo`
+}

--- a/src/test/ui/suggestions/init-enum-as-struct.stderr
+++ b/src/test/ui/suggestions/init-enum-as-struct.stderr
@@ -1,0 +1,12 @@
+error[E0574]: expected struct, variant or union type, found enum `Foo`
+  --> $DIR/init-enum-as-struct.rs:22:15
+   |
+LL | pub type Foos = i32;
+   | -------------------- similarly named type alias `Foos` defined here
+...
+LL |     let foo = Foo { b: 0 };
+   |               ^^^ help: a type alias with a similar name exists: `Foos`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0574`.


### PR DESCRIPTION
Fix bad suggestions by adding a new heuristic where we assume correct
intent when there's an exact match on an in-scope identifier.