### PR TITLE
Do not ICE when we have `-Zunpretty=expanded` with invalid ABI

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -274,10 +274,12 @@ impl<'a> PostExpansionVisitor<'a> {
                 );
             }
             abi => {
-                self.sess.parse_sess.span_diagnostic.delay_span_bug(
-                    span,
-                    &format!("unrecognized ABI not caught in lowering: {}", abi),
-                );
+                if self.sess.opts.pretty.map_or(true, |ppm| ppm.needs_hir()) {
+                    self.sess.parse_sess.span_diagnostic.delay_span_bug(
+                        span,
+                        &format!("unrecognized ABI not caught in lowering: {}", abi),
+                    );
+                }
             }
         }
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2707,6 +2707,14 @@ impl PpMode {
             | MirCFG => true,
         }
     }
+    pub fn needs_hir(&self) -> bool {
+        use PpMode::*;
+        match *self {
+            Source(_) | AstTree(_) => false,
+
+            Hir(_) | HirTree | ThirTree | Mir | MirCFG => true,
+        }
+    }
 
     pub fn needs_analysis(&self) -> bool {
         use PpMode::*;

--- a/src/test/ui/codemap_tests/unicode.expanded.stdout
+++ b/src/test/ui/codemap_tests/unicode.expanded.stdout
@@ -1,0 +1,13 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// revisions: normal expanded
+//[expanded] check-pass
+//[expanded]compile-flags: -Zunpretty=expanded
+
+extern "路濫狼á́́" fn foo() {}
+
+fn main() {}

--- a/src/test/ui/codemap_tests/unicode.normal.stderr
+++ b/src/test/ui/codemap_tests/unicode.normal.stderr
@@ -1,5 +1,5 @@
 error[E0703]: invalid ABI: found `路濫狼á́́`
-  --> $DIR/unicode.rs:1:8
+  --> $DIR/unicode.rs:5:8
    |
 LL | extern "路濫狼á́́" fn foo() {}
    |        ^^^^^^^^^ invalid ABI

--- a/src/test/ui/codemap_tests/unicode.rs
+++ b/src/test/ui/codemap_tests/unicode.rs
@@ -1,3 +1,7 @@
-extern "路濫狼á́́" fn foo() {} //~ ERROR invalid ABI
+// revisions: normal expanded
+//[expanded] check-pass
+//[expanded]compile-flags: -Zunpretty=expanded
+
+extern "路濫狼á́́" fn foo() {} //[normal]~ ERROR invalid ABI
 
 fn main() { }


### PR DESCRIPTION
Fixes #99331