### PR TITLE
Fix source code sidebar tree auto-expand

### DIFF
--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -33,7 +33,7 @@ function createDirEntry(elem, parent, fullPath, hasFoundFile) {
     folders.className = "folders";
     if (elem.dirs) {
         for (const dir of elem.dirs) {
-            if (createDirEntry(dir, folders, fullPath, hasFoundFile)) {
+            if (createDirEntry(dir, folders, fullPath, false)) {
                 dirEntry.open = true;
                 hasFoundFile = true;
             }

--- a/src/test/rustdoc-gui/sidebar-source-code.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code.goml
@@ -16,15 +16,27 @@ click: (10, 10)
 wait-for: "html:not(.expanded)"
 assert: "nav.sidebar"
 
+// Checking that only the path to the current file is "open".
+goto: file://|DOC_PATH|/src/lib2/another_folder/sub_mod/mod.rs.html
+// First we expand the sidebar again.
+click: (10, 10)
+// We wait for the sidebar to be expanded.
+wait-for-css: (".source-sidebar-expanded nav.sidebar", {"width": "300px"})
+assert: "//*[@class='dir-entry' and @open]/*[text()='lib2']"
+assert: "//*[@class='dir-entry' and @open]/*[text()='another_folder']"
+assert: "//*[@class='dir-entry' and @open]/*[text()='sub_mod']"
+// Only "another_folder" should be "open" in "lib2".
+assert: "//*[@class='dir-entry' and not(@open)]/*[text()='another_mod']"
+// All other trees should be collapsed.
+assert-count: ("//*[@id='source-sidebar']/details[not(text()='lib2') and not(@open)]", 5)
+
 // We now switch to mobile mode.
 size: (600, 600)
-// We check that the sidebar has the expected width (0).
-assert-css: ("nav.sidebar", {"width": "0px"})
-// We expand the sidebar.
-click: "#sidebar-toggle"
-assert-css: (".source-sidebar-expanded nav.sidebar", {"width": "600px"})
+wait-for-css: (".source-sidebar-expanded nav.sidebar", {"width": "600px"})
 // We collapse the sidebar.
 click: (10, 10)
+// We check that the sidebar has the expected width (0).
+assert-css: ("nav.sidebar", {"width": "0px"})
 // We ensure that the class has been removed.
 assert-false: ".source-sidebar-expanded"
 assert: "nav.sidebar"

--- a/src/test/rustdoc-gui/src/lib2/another_folder/mod.rs
+++ b/src/test/rustdoc-gui/src/lib2/another_folder/mod.rs
@@ -1,0 +1,3 @@
+pub fn another_fn() {}
+
+pub mod sub_mod;

--- a/src/test/rustdoc-gui/src/lib2/another_folder/sub_mod/mod.rs
+++ b/src/test/rustdoc-gui/src/lib2/another_folder/sub_mod/mod.rs
@@ -1,0 +1,1 @@
+pub fn subsubsub() {}

--- a/src/test/rustdoc-gui/src/lib2/another_mod/mod.rs
+++ b/src/test/rustdoc-gui/src/lib2/another_mod/mod.rs
@@ -1,0 +1,1 @@
+pub fn tadam() {}

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -2,6 +2,9 @@
 
 #![feature(doc_cfg)]
 
+pub mod another_folder;
+pub mod another_mod;
+
 pub mod module {
     pub mod sub_module {
         pub mod sub_sub_module {


### PR DESCRIPTION
Here is the bug:

![Screenshot from 2022-07-17 13-32-00](https://user-images.githubusercontent.com/3050060/179397712-bfb1c279-0ed2-4cb5-aef5-05741921bcc3.png)

It was happening because as soon as we found the file (from the URL), every item following it was then opened, even if it wasn't supposed to.

The GUI test ensures that it doesn't happen by adding two nested levels and ensuring only this path is "open".

r? @notriddle 