### PR TITLE
interpret/visitor: add missing early return

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -473,6 +473,9 @@ macro_rules! make_value_visitor {
                         // The second `Box` field is the allocator, which we recursively check for validity
                         // like in regular structs.
                         self.visit_field(v, 1, &alloc)?;
+
+                        // We visited all parts of this one.
+                        return Ok(());
                     }
                     _ => {},
                 };


### PR DESCRIPTION
I forgot to add this when adding the special `Box` handling branch.

r? @oli-obk 