### PR TITLE
use body's param-env when checking if type needs drop

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -431,9 +431,9 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 let lhs = &self.thir[lhs];
                 if let ty::Adt(adt_def, _) = lhs.ty.kind() && adt_def.is_union() {
                     if let Some((assigned_ty, assignment_span)) = self.assignment_info {
-                        if assigned_ty.needs_drop(self.tcx, self.tcx.param_env(adt_def.did())) {
+                        if assigned_ty.needs_drop(self.tcx, self.param_env) {
                             // This would be unsafe, but should be outright impossible since we reject such unions.
-                            self.tcx.sess.delay_span_bug(assignment_span, "union fields that need dropping should be impossible");
+                            self.tcx.sess.delay_span_bug(assignment_span, format!("union fields that need dropping should be impossible: {assigned_ty}"));
                         }
                     } else {
                         self.requires_unsafe(expr.span, AccessToUnionField);

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -219,14 +219,11 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
                     // We have to check the actual type of the assignment, as that determines if the
                     // old value is being dropped.
                     let assigned_ty = place.ty(&self.body.local_decls, self.tcx).ty;
-                    if assigned_ty.needs_drop(
-                        self.tcx,
-                        self.tcx.param_env(base_ty.ty_adt_def().unwrap().did()),
-                    ) {
+                    if assigned_ty.needs_drop(self.tcx, self.param_env) {
                         // This would be unsafe, but should be outright impossible since we reject such unions.
                         self.tcx.sess.delay_span_bug(
                             self.source_info.span,
-                            "union fields that need dropping should be impossible",
+                            format!("union fields that need dropping should be impossible: {assigned_ty}")
                         );
                     }
                 } else {

--- a/src/test/ui/union/issue-99375.rs
+++ b/src/test/ui/union/issue-99375.rs
@@ -1,0 +1,21 @@
+// check-pass
+
+union URes<R: Copy> {
+    uninit: (),
+    init: R,
+}
+
+struct Params<F, R: Copy> {
+    function: F,
+    result: URes<R>,
+}
+
+unsafe extern "C" fn do_call<F, R>(params: *mut Params<F, R>)
+where
+    R: Copy,
+    F: Fn() -> R,
+{
+    (*params).result.init = ((*params).function)();
+}
+
+fn main() {}


### PR DESCRIPTION
The type comes from the body, so we should be using the body's param-env, as opposed to the ADT's param env, because we know less in the latter compared to the former.

Fixes #99375