### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -274,10 +274,12 @@ impl<'a> PostExpansionVisitor<'a> {
                 );
             }
             abi => {
-                self.sess.parse_sess.span_diagnostic.delay_span_bug(
-                    span,
-                    &format!("unrecognized ABI not caught in lowering: {}", abi),
-                );
+                if self.sess.opts.pretty.map_or(true, |ppm| ppm.needs_hir()) {
+                    self.sess.parse_sess.span_diagnostic.delay_span_bug(
+                        span,
+                        &format!("unrecognized ABI not caught in lowering: {}", abi),
+                    );
+                }
             }
         }
     }

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -1,7 +1,7 @@
 //! The entry point of the NLL borrow checker.
 
 use rustc_data_structures::vec_map::VecMap;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
 use rustc_infer::infer::InferCtxt;
 use rustc_middle::mir::{create_dump_file, dump_enabled, dump_mir, PassWhere};
@@ -44,7 +44,7 @@ pub type PoloniusOutput = Output<RustcFacts>;
 /// closure requirements to propagate, and any generated errors.
 pub(crate) struct NllOutput<'tcx> {
     pub regioncx: RegionInferenceContext<'tcx>,
-    pub opaque_type_values: VecMap<DefId, OpaqueHiddenType<'tcx>>,
+    pub opaque_type_values: VecMap<LocalDefId, OpaqueHiddenType<'tcx>>,
     pub polonius_input: Option<Box<AllFacts>>,
     pub polonius_output: Option<Rc<PoloniusOutput>>,
     pub opt_closure_req: Option<ClosureRegionRequirements<'tcx>>,
@@ -373,7 +373,7 @@ pub(super) fn dump_annotation<'a, 'tcx>(
     body: &Body<'tcx>,
     regioncx: &RegionInferenceContext<'tcx>,
     closure_region_requirements: &Option<ClosureRegionRequirements<'_>>,
-    opaque_type_values: &VecMap<DefId, OpaqueHiddenType<'tcx>>,
+    opaque_type_values: &VecMap<LocalDefId, OpaqueHiddenType<'tcx>>,
     errors: &mut crate::error::BorrowckErrors<'tcx>,
 ) {
     let tcx = infcx.tcx;

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -211,6 +211,10 @@ pub fn path_to_string(segment: &hir::Path<'_>) -> String {
     to_string(NO_ANN, |s| s.print_path(segment, false))
 }
 
+pub fn qpath_to_string(segment: &hir::QPath<'_>) -> String {
+    to_string(NO_ANN, |s| s.print_qpath(segment, false))
+}
+
 pub fn fn_to_string(
     decl: &hir::FnDecl<'_>,
     header: hir::FnHeader,

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -153,7 +153,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
             .opaque_type_storage
             .take_opaque_types()
             .into_iter()
-            .map(|(k, v)| (self.tcx.mk_opaque(k.def_id, k.substs), v.hidden_type.ty))
+            .map(|(k, v)| (self.tcx.mk_opaque(k.def_id.to_def_id(), k.substs), v.hidden_type.ty))
             .collect()
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -938,7 +938,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     #[instrument(skip(self), level = "debug")]
     pub fn member_constraint(
         &self,
-        opaque_type_def_id: DefId,
+        opaque_type_def_id: LocalDefId,
         definition_span: Span,
         hidden_ty: Ty<'tcx>,
         region: ty::Region<'tcx>,

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::intern::Interned;
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::undo_log::UndoLogs;
 use rustc_data_structures::unify as ut;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::infer::unify_key::{RegionVidKey, UnifiedRegion};
 use rustc_middle::ty::ReStatic;
@@ -533,7 +533,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
 
     pub fn member_constraint(
         &mut self,
-        opaque_type_def_id: DefId,
+        opaque_type_def_id: LocalDefId,
         definition_span: Span,
         hidden_ty: Ty<'tcx>,
         member_region: ty::Region<'tcx>,

--- a/compiler/rustc_middle/src/infer/mod.rs
+++ b/compiler/rustc_middle/src/infer/mod.rs
@@ -4,7 +4,7 @@ pub mod unify_key;
 use crate::ty::Region;
 use crate::ty::Ty;
 use rustc_data_structures::sync::Lrc;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::LocalDefId;
 use rustc_span::Span;
 
 /// Requires that `region` must be equal to one of the regions in `choice_regions`.
@@ -16,7 +16,7 @@ use rustc_span::Span;
 #[derive(Debug, Clone, HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct MemberConstraint<'tcx> {
     /// The `DefId` of the opaque type causing this constraint: used for error reporting.
-    pub opaque_type_def_id: DefId,
+    pub opaque_type_def_id: LocalDefId,
 
     /// The span where the hidden type was instantiated.
     pub definition_span: Span,

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -235,7 +235,7 @@ pub struct BorrowCheckResult<'tcx> {
     /// All the opaque types that are restricted to concrete types
     /// by this function. Unlike the value in `TypeckResults`, this has
     /// unerased regions.
-    pub concrete_opaque_types: VecMap<DefId, OpaqueHiddenType<'tcx>>,
+    pub concrete_opaque_types: VecMap<LocalDefId, OpaqueHiddenType<'tcx>>,
     pub closure_requirements: Option<ClosureRegionRequirements<'tcx>>,
     pub used_mut_upvars: SmallVec<[Field; 8]>,
     pub tainted_by_errors: Option<ErrorGuaranteed>,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -542,7 +542,7 @@ pub struct TypeckResults<'tcx> {
     /// even if they are only set in dead code (which doesn't show up in MIR).
     /// For type-alias-impl-trait, this map is only used to prevent query cycles,
     /// so the hidden types are all `None`.
-    pub concrete_opaque_types: VecMap<DefId, Option<Ty<'tcx>>>,
+    pub concrete_opaque_types: VecMap<LocalDefId, Option<Ty<'tcx>>>,
 
     /// Tracks the minimum captures required for a closure;
     /// see `MinCaptureInformationMap` for more details.

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1108,8 +1108,7 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, HashStable, TyEncodable, TyDecodable, Lift)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub struct OpaqueTypeKey<'tcx> {
-    // FIXME(oli-obk): make this a LocalDefId
-    pub def_id: DefId,
+    pub def_id: LocalDefId,
     pub substs: SubstsRef<'tcx>,
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1707,13 +1707,6 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
-    pub fn expect_opaque_type(self) -> ty::OpaqueTypeKey<'tcx> {
-        match *self.kind() {
-            Opaque(def_id, substs) => ty::OpaqueTypeKey { def_id, substs },
-            _ => bug!("`expect_opaque_type` called on non-opaque type: {}", self),
-        }
-    }
-
     pub fn simd_size_and_type(self, tcx: TyCtxt<'tcx>) -> (u64, Ty<'tcx>) {
         match self.kind() {
             Adt(def, substs) => {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2707,6 +2707,14 @@ impl PpMode {
             | MirCFG => true,
         }
     }
+    pub fn needs_hir(&self) -> bool {
+        use PpMode::*;
+        match *self {
+            Source(_) | AstTree(_) => false,
+
+            Hir(_) | HirTree | ThirTree | Mir | MirCFG => true,
+        }
+    }
 
     pub fn needs_analysis(&self) -> bool {
         use PpMode::*;

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -397,7 +397,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         = self.typeck_results.borrow().qpath_res(qpath, callee_expr.hir_id)
                     // Only suggest removing parens if there are no arguments
                     && arg_exprs.is_empty()
-                    && let Ok(path) = self.tcx.sess.source_map().span_to_snippet(callee_expr.span)
                 {
                     let descr = match kind {
                         def::CtorOf::Struct => "struct",
@@ -406,7 +405,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let removal_span =
                         callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
                     unit_variant =
-                        Some((removal_span, descr, path));
+                        Some((removal_span, descr, rustc_hir_pretty::qpath_to_string(qpath)));
                 }
 
                 let callee_ty = self.resolve_vars_if_possible(callee_ty);

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -4,7 +4,7 @@ use crate::type_error_struct;
 
 use rustc_errors::{struct_span_err, Applicability, Diagnostic};
 use rustc_hir as hir;
-use rustc_hir::def::{Namespace, Res};
+use rustc_hir::def::{self, Namespace, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_infer::{
     infer,
@@ -390,17 +390,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (fn_sig, Some(def_id))
             }
             ty::FnPtr(sig) => (sig, None),
-            ref t => {
+            _ => {
                 let mut unit_variant = None;
-                let mut removal_span = call_expr.span;
-                if let ty::Adt(adt_def, ..) = t
-                    && adt_def.is_enum()
-                    && let hir::ExprKind::Call(expr, _) = call_expr.kind
+                if let hir::ExprKind::Path(qpath) = &callee_expr.kind
+                    && let Res::Def(def::DefKind::Ctor(kind, def::CtorKind::Const), _)
+                        = self.typeck_results.borrow().qpath_res(qpath, callee_expr.hir_id)
+                    // Only suggest removing parens if there are no arguments
+                    && arg_exprs.is_empty()
+                    && let Ok(path) = self.tcx.sess.source_map().span_to_snippet(callee_expr.span)
                 {
-                    removal_span =
-                        expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
+                    let descr = match kind {
+                        def::CtorOf::Struct => "struct",
+                        def::CtorOf::Variant => "enum variant",
+                    };
+                    let removal_span =
+                        callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
                     unit_variant =
-                        self.tcx.sess.source_map().span_to_snippet(expr.span).ok();
+                        Some((removal_span, descr, path));
                 }
 
                 let callee_ty = self.resolve_vars_if_possible(callee_ty);
@@ -410,8 +416,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     callee_ty,
                     E0618,
                     "expected function, found {}",
-                    match unit_variant {
-                        Some(ref path) => format!("enum variant `{path}`"),
+                    match &unit_variant {
+                        Some((_, kind, path)) => format!("{kind} `{path}`"),
                         None => format!("`{callee_ty}`"),
                     }
                 );
@@ -423,11 +429,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     callee_expr.span,
                 );
 
-                if let Some(ref path) = unit_variant {
+                if let Some((removal_span, kind, path)) = &unit_variant {
                     err.span_suggestion_verbose(
-                        removal_span,
+                        *removal_span,
                         &format!(
-                            "`{path}` is a unit variant, you need to write it without the parentheses",
+                            "`{path}` is a unit {kind}, and does not take parentheses to be constructed",
                         ),
                         "",
                         Applicability::MachineApplicable,
@@ -470,7 +476,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let Some(span) = self.tcx.hir().res_span(def) {
                     let callee_ty = callee_ty.to_string();
                     let label = match (unit_variant, inner_callee_path) {
-                        (Some(path), _) => Some(format!("`{path}` defined here")),
+                        (Some((_, kind, path)), _) => Some(format!("{kind} `{path}` defined here")),
                         (_, Some(hir::QPath::Resolved(_, path))) => self
                             .tcx
                             .sess

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -1505,6 +1505,21 @@ pub fn check_type_bounds<'tcx>(
             &outlives_environment,
         );
 
+        let constraints = infcx.inner.borrow_mut().opaque_type_storage.take_opaque_types();
+        for (key, value) in constraints {
+            infcx
+                .report_mismatched_types(
+                    &ObligationCause::misc(
+                        value.hidden_type.span,
+                        tcx.hir().local_def_id_to_hir_id(impl_ty.def_id.expect_local()),
+                    ),
+                    tcx.mk_opaque(key.def_id, key.substs),
+                    value.hidden_type.ty,
+                    TypeError::Mismatch,
+                )
+                .emit();
+        }
+
         Ok(())
     })
 }

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -531,7 +531,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 tcx.ty_error()
             }
             Res::Def(DefKind::Ctor(_, CtorKind::Fictive), _) => {
-                report_unexpected_variant_res(tcx, res, expr.span);
+                report_unexpected_variant_res(tcx, res, qpath, expr.span);
                 tcx.ty_error()
             }
             _ => self.instantiate_value_path(segs, opt_ty, res, expr.span, expr.hir_id).0,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -763,12 +763,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // src/test/ui/impl-trait/hidden-type-is-opaque-2.rs for examples that hit this path.
         if formal_ret.has_infer_types() {
             for ty in ret_ty.walk() {
-                if let ty::subst::GenericArgKind::Type(ty) = ty.unpack() {
-                    if let ty::Opaque(def_id, _) = *ty.kind() {
-                        if self.infcx.opaque_type_origin(def_id, DUMMY_SP).is_some() {
-                            return None;
-                        }
-                    }
+                if let ty::subst::GenericArgKind::Type(ty) = ty.unpack()
+                    && let ty::Opaque(def_id, _) = *ty.kind()
+                    && let Some(def_id) = def_id.as_local()
+                    && self.infcx.opaque_type_origin(def_id, DUMMY_SP).is_some() {
+                    return None;
                 }
             }
         }

--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -863,17 +863,14 @@ fn bad_non_zero_sized_fields<'tcx>(
     err.emit();
 }
 
-fn report_unexpected_variant_res(tcx: TyCtxt<'_>, res: Res, span: Span) {
+fn report_unexpected_variant_res(tcx: TyCtxt<'_>, res: Res, qpath: &hir::QPath<'_>, span: Span) {
     struct_span_err!(
         tcx.sess,
         span,
         E0533,
-        "expected unit struct, unit variant or constant, found {}{}",
+        "expected unit struct, unit variant or constant, found {} `{}`",
         res.descr(),
-        tcx.sess
-            .source_map()
-            .span_to_snippet(span)
-            .map_or_else(|_| String::new(), |s| format!(" `{s}`",)),
+        rustc_hir_pretty::qpath_to_string(qpath),
     )
     .emit();
 }

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -183,7 +183,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PatKind::TupleStruct(ref qpath, subpats, ddpos) => {
                 self.check_pat_tuple_struct(pat, qpath, subpats, ddpos, expected, def_bm, ti)
             }
-            PatKind::Path(_) => self.check_pat_path(pat, path_res.unwrap(), expected, ti),
+            PatKind::Path(ref qpath) => {
+                self.check_pat_path(pat, qpath, path_res.unwrap(), expected, ti)
+            }
             PatKind::Struct(ref qpath, fields, has_rest_pat) => {
                 self.check_pat_struct(pat, qpath, fields, has_rest_pat, expected, def_bm, ti)
             }
@@ -800,6 +802,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn check_pat_path<'b>(
         &self,
         pat: &Pat<'_>,
+        qpath: &hir::QPath<'_>,
         path_resolution: (Res, Option<Ty<'tcx>>, &'b [hir::PathSegment<'b>]),
         expected: Ty<'tcx>,
         ti: TopInfo<'tcx>,
@@ -814,7 +817,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return tcx.ty_error();
             }
             Res::Def(DefKind::AssocFn | DefKind::Ctor(_, CtorKind::Fictive | CtorKind::Fn), _) => {
-                report_unexpected_variant_res(tcx, res, pat.span);
+                report_unexpected_variant_res(tcx, res, qpath, pat.span);
                 return tcx.ty_error();
             }
             Res::SelfCtor(..)

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -4,6 +4,7 @@
 
 use crate::check::FnCtxt;
 
+use hir::def_id::LocalDefId;
 use rustc_data_structures::stable_map::FxHashMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
@@ -509,13 +510,13 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 hir::OpaqueTyOrigin::FnReturn(_) | hir::OpaqueTyOrigin::AsyncFn(_) => {
                     let ty = self.resolve(decl.hidden_type.ty, &decl.hidden_type.span);
                     struct RecursionChecker {
-                        def_id: DefId,
+                        def_id: LocalDefId,
                     }
                     impl<'tcx> ty::TypeVisitor<'tcx> for RecursionChecker {
                         type BreakTy = ();
                         fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
                             if let ty::Opaque(def_id, _) = *t.kind() {
-                                if def_id == self.def_id {
+                                if def_id == self.def_id.to_def_id() {
                                     return ControlFlow::Break(());
                                 }
                             }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1340,7 +1340,7 @@ impl<T> [T] {
     /// from the `remainder` function of the iterator.
     ///
     /// Due to each chunk having exactly `chunk_size` elements, the compiler can often optimize the
-    /// resulting code better than in the case of [`chunks`].
+    /// resulting code better than in the case of [`rchunks`].
     ///
     /// See [`rchunks`] for a variant of this iterator that also returns the remainder as a smaller
     /// chunk, and [`chunks_exact`] for the same iterator but starting at the beginning of the

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -581,8 +581,7 @@ impl AtomicBool {
     /// `failure` describes the required ordering for the load operation that takes place when
     /// the comparison fails. Using [`Acquire`] as success ordering makes the store part
     /// of this operation [`Relaxed`], and using [`Release`] makes the successful load
-    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
-    /// and must be equivalent to or weaker than the success ordering.
+    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`].
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
@@ -640,8 +639,7 @@ impl AtomicBool {
     /// `failure` describes the required ordering for the load operation that takes place when
     /// the comparison fails. Using [`Acquire`] as success ordering makes the store part
     /// of this operation [`Relaxed`], and using [`Release`] makes the successful load
-    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
-    /// and must be equivalent to or weaker than the success ordering.
+    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`].
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
@@ -905,8 +903,7 @@ impl AtomicBool {
     /// Using [`Acquire`] as success ordering makes the store part of this
     /// operation [`Relaxed`], and using [`Release`] makes the final successful
     /// load [`Relaxed`]. The (failed) load ordering can only be [`SeqCst`],
-    /// [`Acquire`] or [`Relaxed`] and must be equivalent to or weaker than the
-    /// success ordering.
+    /// [`Acquire`] or [`Relaxed`].
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
@@ -1265,8 +1262,7 @@ impl<T> AtomicPtr<T> {
     /// `failure` describes the required ordering for the load operation that takes place when
     /// the comparison fails. Using [`Acquire`] as success ordering makes the store part
     /// of this operation [`Relaxed`], and using [`Release`] makes the successful load
-    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
-    /// and must be equivalent to or weaker than the success ordering.
+    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`].
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on pointers.
@@ -1311,8 +1307,7 @@ impl<T> AtomicPtr<T> {
     /// `failure` describes the required ordering for the load operation that takes place when
     /// the comparison fails. Using [`Acquire`] as success ordering makes the store part
     /// of this operation [`Relaxed`], and using [`Release`] makes the successful load
-    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
-    /// and must be equivalent to or weaker than the success ordering.
+    /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`].
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on pointers.
@@ -1368,8 +1363,7 @@ impl<T> AtomicPtr<T> {
     /// Using [`Acquire`] as success ordering makes the store part of this
     /// operation [`Relaxed`], and using [`Release`] makes the final successful
     /// load [`Relaxed`]. The (failed) load ordering can only be [`SeqCst`],
-    /// [`Acquire`] or [`Relaxed`] and must be equivalent to or weaker than the
-    /// success ordering.
+    /// [`Acquire`] or [`Relaxed`].
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on pointers.
@@ -1850,8 +1844,7 @@ macro_rules! atomic_int {
             /// `failure` describes the required ordering for the load operation that takes place when
             /// the comparison fails. Using [`Acquire`] as success ordering makes the store part
             /// of this operation [`Relaxed`], and using [`Release`] makes the successful load
-            /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
-            /// and must be equivalent to or weaker than the success ordering.
+            /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
             #[doc = concat!("[`", $s_int_type, "`].")]
@@ -1902,8 +1895,7 @@ macro_rules! atomic_int {
             /// `failure` describes the required ordering for the load operation that takes place when
             /// the comparison fails. Using [`Acquire`] as success ordering makes the store part
             /// of this operation [`Relaxed`], and using [`Release`] makes the successful load
-            /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
-            /// and must be equivalent to or weaker than the success ordering.
+            /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
             #[doc = concat!("[`", $s_int_type, "`].")]
@@ -2140,8 +2132,7 @@ macro_rules! atomic_int {
             ///
             /// Using [`Acquire`] as success ordering makes the store part
             /// of this operation [`Relaxed`], and using [`Release`] makes the final successful load
-            /// [`Relaxed`]. The (failed) load ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
-            /// and must be equivalent to or weaker than the success ordering.
+            /// [`Relaxed`]. The (failed) load ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
             #[doc = concat!("[`", $s_int_type, "`].")]
@@ -2658,23 +2649,22 @@ unsafe fn atomic_compare_exchange<T: Copy>(
     let (val, ok) = unsafe {
         match (success, failure) {
             (Relaxed, Relaxed) => intrinsics::atomic_cxchg_relaxed_relaxed(dst, old, new),
-            //(Relaxed, Acquire) => intrinsics::atomic_cxchg_relaxed_acquire(dst, old, new),
-            //(Relaxed, SeqCst) => intrinsics::atomic_cxchg_relaxed_seqcst(dst, old, new),
+            (Relaxed, Acquire) => intrinsics::atomic_cxchg_relaxed_acquire(dst, old, new),
+            (Relaxed, SeqCst) => intrinsics::atomic_cxchg_relaxed_seqcst(dst, old, new),
             (Acquire, Relaxed) => intrinsics::atomic_cxchg_acquire_relaxed(dst, old, new),
             (Acquire, Acquire) => intrinsics::atomic_cxchg_acquire_acquire(dst, old, new),
-            //(Acquire, SeqCst) => intrinsics::atomic_cxchg_acquire_seqcst(dst, old, new),
+            (Acquire, SeqCst) => intrinsics::atomic_cxchg_acquire_seqcst(dst, old, new),
             (Release, Relaxed) => intrinsics::atomic_cxchg_release_relaxed(dst, old, new),
-            //(Release, Acquire) => intrinsics::atomic_cxchg_release_acquire(dst, old, new),
-            //(Release, SeqCst) => intrinsics::atomic_cxchg_release_seqcst(dst, old, new),
+            (Release, Acquire) => intrinsics::atomic_cxchg_release_acquire(dst, old, new),
+            (Release, SeqCst) => intrinsics::atomic_cxchg_release_seqcst(dst, old, new),
             (AcqRel, Relaxed) => intrinsics::atomic_cxchg_acqrel_relaxed(dst, old, new),
             (AcqRel, Acquire) => intrinsics::atomic_cxchg_acqrel_acquire(dst, old, new),
-            //(AcqRel, SeqCst) => intrinsics::atomic_cxchg_acqrel_seqcst(dst, old, new),
+            (AcqRel, SeqCst) => intrinsics::atomic_cxchg_acqrel_seqcst(dst, old, new),
             (SeqCst, Relaxed) => intrinsics::atomic_cxchg_seqcst_relaxed(dst, old, new),
             (SeqCst, Acquire) => intrinsics::atomic_cxchg_seqcst_acquire(dst, old, new),
             (SeqCst, SeqCst) => intrinsics::atomic_cxchg_seqcst_seqcst(dst, old, new),
             (_, AcqRel) => panic!("there is no such thing as an acquire-release failure ordering"),
             (_, Release) => panic!("there is no such thing as a release failure ordering"),
-            _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
     if ok { Ok(val) } else { Err(val) }
@@ -2693,23 +2683,22 @@ unsafe fn atomic_compare_exchange_weak<T: Copy>(
     let (val, ok) = unsafe {
         match (success, failure) {
             (Relaxed, Relaxed) => intrinsics::atomic_cxchgweak_relaxed_relaxed(dst, old, new),
-            //(Relaxed, Acquire) => intrinsics::atomic_cxchgweak_relaxed_acquire(dst, old, new),
-            //(Relaxed, SeqCst) => intrinsics::atomic_cxchgweak_relaxed_seqcst(dst, old, new),
+            (Relaxed, Acquire) => intrinsics::atomic_cxchgweak_relaxed_acquire(dst, old, new),
+            (Relaxed, SeqCst) => intrinsics::atomic_cxchgweak_relaxed_seqcst(dst, old, new),
             (Acquire, Relaxed) => intrinsics::atomic_cxchgweak_acquire_relaxed(dst, old, new),
             (Acquire, Acquire) => intrinsics::atomic_cxchgweak_acquire_acquire(dst, old, new),
-            //(Acquire, SeqCst) => intrinsics::atomic_cxchgweak_acquire_seqcst(dst, old, new),
+            (Acquire, SeqCst) => intrinsics::atomic_cxchgweak_acquire_seqcst(dst, old, new),
             (Release, Relaxed) => intrinsics::atomic_cxchgweak_release_relaxed(dst, old, new),
-            //(Release, Acquire) => intrinsics::atomic_cxchgweak_release_acquire(dst, old, new),
-            //(Release, SeqCst) => intrinsics::atomic_cxchgweak_release_seqcst(dst, old, new),
+            (Release, Acquire) => intrinsics::atomic_cxchgweak_release_acquire(dst, old, new),
+            (Release, SeqCst) => intrinsics::atomic_cxchgweak_release_seqcst(dst, old, new),
             (AcqRel, Relaxed) => intrinsics::atomic_cxchgweak_acqrel_relaxed(dst, old, new),
             (AcqRel, Acquire) => intrinsics::atomic_cxchgweak_acqrel_acquire(dst, old, new),
-            //(AcqRel, SeqCst) => intrinsics::atomic_cxchgweak_acqrel_seqcst(dst, old, new),
+            (AcqRel, SeqCst) => intrinsics::atomic_cxchgweak_acqrel_seqcst(dst, old, new),
             (SeqCst, Relaxed) => intrinsics::atomic_cxchgweak_seqcst_relaxed(dst, old, new),
             (SeqCst, Acquire) => intrinsics::atomic_cxchgweak_seqcst_acquire(dst, old, new),
             (SeqCst, SeqCst) => intrinsics::atomic_cxchgweak_seqcst_seqcst(dst, old, new),
             (_, AcqRel) => panic!("there is no such thing as an acquire-release failure ordering"),
             (_, Release) => panic!("there is no such thing as a release failure ordering"),
-            _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
     if ok { Ok(val) } else { Err(val) }

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -2649,22 +2649,30 @@ unsafe fn atomic_compare_exchange<T: Copy>(
     let (val, ok) = unsafe {
         match (success, failure) {
             (Relaxed, Relaxed) => intrinsics::atomic_cxchg_relaxed_relaxed(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Relaxed, Acquire) => intrinsics::atomic_cxchg_relaxed_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Relaxed, SeqCst) => intrinsics::atomic_cxchg_relaxed_seqcst(dst, old, new),
             (Acquire, Relaxed) => intrinsics::atomic_cxchg_acquire_relaxed(dst, old, new),
             (Acquire, Acquire) => intrinsics::atomic_cxchg_acquire_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Acquire, SeqCst) => intrinsics::atomic_cxchg_acquire_seqcst(dst, old, new),
             (Release, Relaxed) => intrinsics::atomic_cxchg_release_relaxed(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Release, Acquire) => intrinsics::atomic_cxchg_release_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Release, SeqCst) => intrinsics::atomic_cxchg_release_seqcst(dst, old, new),
             (AcqRel, Relaxed) => intrinsics::atomic_cxchg_acqrel_relaxed(dst, old, new),
             (AcqRel, Acquire) => intrinsics::atomic_cxchg_acqrel_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (AcqRel, SeqCst) => intrinsics::atomic_cxchg_acqrel_seqcst(dst, old, new),
             (SeqCst, Relaxed) => intrinsics::atomic_cxchg_seqcst_relaxed(dst, old, new),
             (SeqCst, Acquire) => intrinsics::atomic_cxchg_seqcst_acquire(dst, old, new),
             (SeqCst, SeqCst) => intrinsics::atomic_cxchg_seqcst_seqcst(dst, old, new),
             (_, AcqRel) => panic!("there is no such thing as an acquire-release failure ordering"),
             (_, Release) => panic!("there is no such thing as a release failure ordering"),
+            #[cfg(bootstrap)]
+            _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
     if ok { Ok(val) } else { Err(val) }
@@ -2683,22 +2691,30 @@ unsafe fn atomic_compare_exchange_weak<T: Copy>(
     let (val, ok) = unsafe {
         match (success, failure) {
             (Relaxed, Relaxed) => intrinsics::atomic_cxchgweak_relaxed_relaxed(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Relaxed, Acquire) => intrinsics::atomic_cxchgweak_relaxed_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Relaxed, SeqCst) => intrinsics::atomic_cxchgweak_relaxed_seqcst(dst, old, new),
             (Acquire, Relaxed) => intrinsics::atomic_cxchgweak_acquire_relaxed(dst, old, new),
             (Acquire, Acquire) => intrinsics::atomic_cxchgweak_acquire_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Acquire, SeqCst) => intrinsics::atomic_cxchgweak_acquire_seqcst(dst, old, new),
             (Release, Relaxed) => intrinsics::atomic_cxchgweak_release_relaxed(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Release, Acquire) => intrinsics::atomic_cxchgweak_release_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (Release, SeqCst) => intrinsics::atomic_cxchgweak_release_seqcst(dst, old, new),
             (AcqRel, Relaxed) => intrinsics::atomic_cxchgweak_acqrel_relaxed(dst, old, new),
             (AcqRel, Acquire) => intrinsics::atomic_cxchgweak_acqrel_acquire(dst, old, new),
+            #[cfg(not(bootstrap))]
             (AcqRel, SeqCst) => intrinsics::atomic_cxchgweak_acqrel_seqcst(dst, old, new),
             (SeqCst, Relaxed) => intrinsics::atomic_cxchgweak_seqcst_relaxed(dst, old, new),
             (SeqCst, Acquire) => intrinsics::atomic_cxchgweak_seqcst_acquire(dst, old, new),
             (SeqCst, SeqCst) => intrinsics::atomic_cxchgweak_seqcst_seqcst(dst, old, new),
             (_, AcqRel) => panic!("there is no such thing as an acquire-release failure ordering"),
             (_, Release) => panic!("there is no such thing as a release failure ordering"),
+            #[cfg(bootstrap)]
+            _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
     if ok { Ok(val) } else { Err(val) }

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -33,7 +33,7 @@ function createDirEntry(elem, parent, fullPath, hasFoundFile) {
     folders.className = "folders";
     if (elem.dirs) {
         for (const dir of elem.dirs) {
-            if (createDirEntry(dir, folders, fullPath, hasFoundFile)) {
+            if (createDirEntry(dir, folders, fullPath, false)) {
                 dirEntry.open = true;
                 hasFoundFile = true;
             }

--- a/src/test/rustdoc-gui/sidebar-source-code.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code.goml
@@ -16,15 +16,27 @@ click: (10, 10)
 wait-for: "html:not(.expanded)"
 assert: "nav.sidebar"
 
+// Checking that only the path to the current file is "open".
+goto: file://|DOC_PATH|/src/lib2/another_folder/sub_mod/mod.rs.html
+// First we expand the sidebar again.
+click: (10, 10)
+// We wait for the sidebar to be expanded.
+wait-for-css: (".source-sidebar-expanded nav.sidebar", {"width": "300px"})
+assert: "//*[@class='dir-entry' and @open]/*[text()='lib2']"
+assert: "//*[@class='dir-entry' and @open]/*[text()='another_folder']"
+assert: "//*[@class='dir-entry' and @open]/*[text()='sub_mod']"
+// Only "another_folder" should be "open" in "lib2".
+assert: "//*[@class='dir-entry' and not(@open)]/*[text()='another_mod']"
+// All other trees should be collapsed.
+assert-count: ("//*[@id='source-sidebar']/details[not(text()='lib2') and not(@open)]", 5)
+
 // We now switch to mobile mode.
 size: (600, 600)
-// We check that the sidebar has the expected width (0).
-assert-css: ("nav.sidebar", {"width": "0px"})
-// We expand the sidebar.
-click: "#sidebar-toggle"
-assert-css: (".source-sidebar-expanded nav.sidebar", {"width": "600px"})
+wait-for-css: (".source-sidebar-expanded nav.sidebar", {"width": "600px"})
 // We collapse the sidebar.
 click: (10, 10)
+// We check that the sidebar has the expected width (0).
+assert-css: ("nav.sidebar", {"width": "0px"})
 // We ensure that the class has been removed.
 assert-false: ".source-sidebar-expanded"
 assert: "nav.sidebar"

--- a/src/test/rustdoc-gui/src/lib2/another_folder/mod.rs
+++ b/src/test/rustdoc-gui/src/lib2/another_folder/mod.rs
@@ -1,0 +1,3 @@
+pub fn another_fn() {}
+
+pub mod sub_mod;

--- a/src/test/rustdoc-gui/src/lib2/another_folder/sub_mod/mod.rs
+++ b/src/test/rustdoc-gui/src/lib2/another_folder/sub_mod/mod.rs
@@ -1,0 +1,1 @@
+pub fn subsubsub() {}

--- a/src/test/rustdoc-gui/src/lib2/another_mod/mod.rs
+++ b/src/test/rustdoc-gui/src/lib2/another_mod/mod.rs
@@ -1,0 +1,1 @@
+pub fn tadam() {}

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -2,6 +2,9 @@
 
 #![feature(doc_cfg)]
 
+pub mod another_folder;
+pub mod another_mod;
+
 pub mod module {
     pub mod sub_module {
         pub mod sub_sub_module {

--- a/src/test/ui/codemap_tests/unicode.expanded.stdout
+++ b/src/test/ui/codemap_tests/unicode.expanded.stdout
@@ -1,0 +1,13 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// revisions: normal expanded
+//[expanded] check-pass
+//[expanded]compile-flags: -Zunpretty=expanded
+
+extern "路濫狼á́́" fn foo() {}
+
+fn main() {}

--- a/src/test/ui/codemap_tests/unicode.normal.stderr
+++ b/src/test/ui/codemap_tests/unicode.normal.stderr
@@ -1,5 +1,5 @@
 error[E0703]: invalid ABI: found `路濫狼á́́`
-  --> $DIR/unicode.rs:1:8
+  --> $DIR/unicode.rs:5:8
    |
 LL | extern "路濫狼á́́" fn foo() {}
    |        ^^^^^^^^^ invalid ABI

--- a/src/test/ui/codemap_tests/unicode.rs
+++ b/src/test/ui/codemap_tests/unicode.rs
@@ -1,3 +1,7 @@
-extern "路濫狼á́́" fn foo() {} //~ ERROR invalid ABI
+// revisions: normal expanded
+//[expanded] check-pass
+//[expanded]compile-flags: -Zunpretty=expanded
+
+extern "路濫狼á́́" fn foo() {} //[normal]~ ERROR invalid ABI
 
 fn main() { }

--- a/src/test/ui/empty/empty-struct-unit-expr.rs
+++ b/src/test/ui/empty/empty-struct-unit-expr.rs
@@ -12,10 +12,10 @@ enum E {
 }
 
 fn main() {
-    let e2 = Empty2(); //~ ERROR expected function, found `Empty2`
+    let e2 = Empty2(); //~ ERROR expected function, found struct `Empty2`
     let e4 = E::Empty4();
     //~^ ERROR expected function, found enum variant `E::Empty4` [E0618]
-    let xe2 = XEmpty2(); //~ ERROR expected function, found `empty_struct::XEmpty2`
+    let xe2 = XEmpty2(); //~ ERROR expected function, found struct `XEmpty2`
     let xe4 = XE::XEmpty4();
     //~^ ERROR expected function, found enum variant `XE::XEmpty4` [E0618]
 }

--- a/src/test/ui/empty/empty-struct-unit-expr.stderr
+++ b/src/test/ui/empty/empty-struct-unit-expr.stderr
@@ -1,38 +1,50 @@
-error[E0618]: expected function, found `Empty2`
+error[E0618]: expected function, found struct `Empty2`
   --> $DIR/empty-struct-unit-expr.rs:15:14
    |
 LL | struct Empty2;
-   | ------------- `Empty2` defined here
+   | ------------- struct `Empty2` defined here
 ...
 LL |     let e2 = Empty2();
    |              ^^^^^^--
    |              |
    |              call expression requires function
+   |
+help: `Empty2` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let e2 = Empty2();
+LL +     let e2 = Empty2;
+   |
 
 error[E0618]: expected function, found enum variant `E::Empty4`
   --> $DIR/empty-struct-unit-expr.rs:16:14
    |
 LL |     Empty4
-   |     ------ `E::Empty4` defined here
+   |     ------ enum variant `E::Empty4` defined here
 ...
 LL |     let e4 = E::Empty4();
    |              ^^^^^^^^^--
    |              |
    |              call expression requires function
    |
-help: `E::Empty4` is a unit variant, you need to write it without the parentheses
+help: `E::Empty4` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let e4 = E::Empty4();
 LL +     let e4 = E::Empty4;
    |
 
-error[E0618]: expected function, found `empty_struct::XEmpty2`
+error[E0618]: expected function, found struct `XEmpty2`
   --> $DIR/empty-struct-unit-expr.rs:18:15
    |
 LL |     let xe2 = XEmpty2();
    |               ^^^^^^^--
    |               |
    |               call expression requires function
+   |
+help: `XEmpty2` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let xe2 = XEmpty2();
+LL +     let xe2 = XEmpty2;
+   |
 
 error[E0618]: expected function, found enum variant `XE::XEmpty4`
   --> $DIR/empty-struct-unit-expr.rs:19:15
@@ -42,7 +54,7 @@ LL |     let xe4 = XE::XEmpty4();
    |               |
    |               call expression requires function
    |
-help: `XE::XEmpty4` is a unit variant, you need to write it without the parentheses
+help: `XE::XEmpty4` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let xe4 = XE::XEmpty4();
 LL +     let xe4 = XE::XEmpty4;

--- a/src/test/ui/error-codes/E0618.stderr
+++ b/src/test/ui/error-codes/E0618.stderr
@@ -2,14 +2,14 @@ error[E0618]: expected function, found enum variant `X::Entry`
   --> $DIR/E0618.rs:6:5
    |
 LL |     Entry,
-   |     ----- `X::Entry` defined here
+   |     ----- enum variant `X::Entry` defined here
 ...
 LL |     X::Entry();
    |     ^^^^^^^^--
    |     |
    |     call expression requires function
    |
-help: `X::Entry` is a unit variant, you need to write it without the parentheses
+help: `X::Entry` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     X::Entry();
 LL +     X::Entry;

--- a/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.rs
+++ b/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.rs
@@ -1,0 +1,26 @@
+#![feature(type_alias_impl_trait)]
+
+struct Concrete;
+
+type Tait = impl Sized;
+
+impl Foo for Concrete {
+    type Item = Concrete;
+    //~^ mismatched types
+}
+
+impl Bar for Concrete {
+    type Other = Tait;
+}
+
+trait Foo {
+    type Item: Bar<Other = Self>;
+}
+
+trait Bar {
+    type Other;
+}
+
+fn tait() -> Tait {}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.stderr
+++ b/src/test/ui/impl-trait/issues/issue-99348-impl-compatibility.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-99348-impl-compatibility.rs:8:17
+   |
+LL | type Tait = impl Sized;
+   |             ---------- the expected opaque type
+...
+LL |     type Item = Concrete;
+   |                 ^^^^^^^^ types differ
+   |
+   = note: expected opaque type `Tait`
+                   found struct `Concrete`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-20714.rs
+++ b/src/test/ui/issues/issue-20714.rs
@@ -1,5 +1,5 @@
 struct G;
 
 fn main() {
-    let g = G(); //~ ERROR: expected function, found `G`
+    let g = G(); //~ ERROR: expected function, found struct `G`
 }

--- a/src/test/ui/issues/issue-20714.stderr
+++ b/src/test/ui/issues/issue-20714.stderr
@@ -1,13 +1,19 @@
-error[E0618]: expected function, found `G`
+error[E0618]: expected function, found struct `G`
   --> $DIR/issue-20714.rs:4:13
    |
 LL | struct G;
-   | -------- `G` defined here
+   | -------- struct `G` defined here
 ...
 LL |     let g = G();
    |             ^--
    |             |
    |             call expression requires function
+   |
+help: `G` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let g = G();
+LL +     let g = G;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21701.rs
+++ b/src/test/ui/issues/issue-21701.rs
@@ -7,7 +7,7 @@ struct Bar;
 
 pub fn some_func() {
     let f = Bar();
-//~^ ERROR: expected function, found `Bar`
+//~^ ERROR: expected function, found struct `Bar`
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-21701.stderr
+++ b/src/test/ui/issues/issue-21701.stderr
@@ -8,16 +8,22 @@ LL |     let y = t();
    |             |
    |             call expression requires function
 
-error[E0618]: expected function, found `Bar`
+error[E0618]: expected function, found struct `Bar`
   --> $DIR/issue-21701.rs:9:13
    |
 LL | struct Bar;
-   | ---------- `Bar` defined here
+   | ---------- struct `Bar` defined here
 ...
 LL |     let f = Bar();
    |             ^^^--
    |             |
    |             call expression requires function
+   |
+help: `Bar` is a unit struct, and does not take parentheses to be constructed
+   |
+LL -     let f = Bar();
+LL +     let f = Bar;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/methods/method-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-path-in-pattern.stderr
@@ -4,13 +4,13 @@ error[E0533]: expected unit struct, unit variant or constant, found associated f
 LL |         Foo::bar => {}
    |         ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:19:9
    |
 LL |         <Foo>::bar => {}
    |         ^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<Foo>::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:23:9
    |
 LL |         <Foo>::trait_bar => {}
@@ -22,7 +22,7 @@ error[E0533]: expected unit struct, unit variant or constant, found associated f
 LL |     if let Foo::bar = 0u32 {}
    |            ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:28:12
    |
 LL |     if let <Foo>::bar = 0u32 {}

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct, unit variant or constant, found associated function `<S as Tr>::A::f::<u8>`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `<<S as Tr>::A>::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -336,14 +336,14 @@ error[E0618]: expected function, found enum variant `Z::Unit`
   --> $DIR/privacy-enum-ctor.rs:31:17
    |
 LL |             Unit,
-   |             ---- `Z::Unit` defined here
+   |             ---- enum variant `Z::Unit` defined here
 ...
 LL |         let _ = Z::Unit();
    |                 ^^^^^^^--
    |                 |
    |                 call expression requires function
    |
-help: `Z::Unit` is a unit variant, you need to write it without the parentheses
+help: `Z::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -         let _ = Z::Unit();
 LL +         let _ = Z::Unit;
@@ -371,14 +371,14 @@ error[E0618]: expected function, found enum variant `m::E::Unit`
   --> $DIR/privacy-enum-ctor.rs:47:16
    |
 LL |         Unit,
-   |         ---- `m::E::Unit` defined here
+   |         ---- enum variant `m::E::Unit` defined here
 ...
 LL |     let _: E = m::E::Unit();
    |                ^^^^^^^^^^--
    |                |
    |                call expression requires function
    |
-help: `m::E::Unit` is a unit variant, you need to write it without the parentheses
+help: `m::E::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let _: E = m::E::Unit();
 LL +     let _: E = m::E::Unit;
@@ -406,14 +406,14 @@ error[E0618]: expected function, found enum variant `E::Unit`
   --> $DIR/privacy-enum-ctor.rs:55:16
    |
 LL |         Unit,
-   |         ---- `E::Unit` defined here
+   |         ---- enum variant `E::Unit` defined here
 ...
 LL |     let _: E = E::Unit();
    |                ^^^^^^^--
    |                |
    |                call expression requires function
    |
-help: `E::Unit` is a unit variant, you need to write it without the parentheses
+help: `E::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     let _: E = E::Unit();
 LL +     let _: E = E::Unit;

--- a/src/test/ui/suggestions/issue-99240-2.rs
+++ b/src/test/ui/suggestions/issue-99240-2.rs
@@ -1,0 +1,10 @@
+enum Enum {
+    Unit,
+}
+type Alias = Enum;
+
+fn main() {
+    Alias::
+    Unit();
+    //~^^ ERROR expected function, found enum variant `Alias::Unit`
+}

--- a/src/test/ui/suggestions/issue-99240-2.stderr
+++ b/src/test/ui/suggestions/issue-99240-2.stderr
@@ -1,0 +1,24 @@
+error[E0618]: expected function, found enum variant `Alias::Unit`
+  --> $DIR/issue-99240-2.rs:7:5
+   |
+LL |        Unit,
+   |        ---- enum variant `Alias::Unit` defined here
+...
+LL |        Alias::
+   |   _____^
+   |  |_____|
+   | ||
+LL | ||     Unit();
+   | ||________^_- call expression requires function
+   | |_________|
+   | 
+   |
+help: `Alias::Unit` is a unit enum variant, and does not take parentheses to be constructed
+   |
+LL -     Unit();
+LL +     Unit;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/src/test/ui/suggestions/issue-99240.rs
+++ b/src/test/ui/suggestions/issue-99240.rs
@@ -1,0 +1,6 @@
+fn fmt(it: &(std::cell::Cell<Option<impl FnOnce()>>,)) {
+    (it.0.take())()
+    //~^ ERROR expected function
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-99240.stderr
+++ b/src/test/ui/suggestions/issue-99240.stderr
@@ -1,0 +1,11 @@
+error[E0618]: expected function, found `Option<impl FnOnce()>`
+  --> $DIR/issue-99240.rs:2:5
+   |
+LL |     (it.0.take())()
+   |     ^^^^^^^^^^^^^--
+   |     |
+   |     call expression requires function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -20,14 +20,14 @@ error[E0618]: expected function, found enum variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:15:5
    |
 LL | enum Enum { Braced {}, Unit, Tuple() }
-   |                        ---- `Alias::Unit` defined here
+   |                        ---- enum variant `Alias::Unit` defined here
 ...
 LL |     Alias::Unit();
    |     ^^^^^^^^^^^--
    |     |
    |     call expression requires function
    |
-help: `Alias::Unit` is a unit variant, you need to write it without the parentheses
+help: `Alias::Unit` is a unit enum variant, and does not take parentheses to be constructed
    |
 LL -     Alias::Unit();
 LL +     Alias::Unit;


### PR DESCRIPTION
Successful merges:

 - #98383 (Remove restrictions on compare-exchange memory ordering.)
 - #99347 (Use `LocalDefId` in `OpaqueTypeKey`)
 - #99350 (Be more precise when suggesting removal of parens on unit ctor)
 - #99356 (Do not constraint TAITs when checking impl/trait item compatibility)
 - #99360 (Do not ICE when we have `-Zunpretty=expanded` with invalid ABI)
 - #99373 (Fix source code sidebar tree auto-expand)
 - #99374 (Fix doc for `rchunks_exact`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98383,99347,99350,99356,99360,99373,99374)
<!-- homu-ignore:end -->