### PR TITLE
Fix debuginfo tests.

### DIFF
--- a/src/test/debuginfo/basic-types-globals-lto.rs
+++ b/src/test/debuginfo/basic-types-globals-lto.rs
@@ -14,7 +14,7 @@
 // gdbr-command:print I
 // gdb-check:$2 = -1
 // gdbg-command:print 'basic_types_globals::C'
-// gdbr-command:print C
+// gdbr-command:print/d C
 // gdbg-check:$3 = 97
 // gdbr-check:$3 = 97
 // gdbg-command:print/d 'basic_types_globals::I8'

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -13,7 +13,7 @@
 // gdbr-command:print I
 // gdb-check:$2 = -1
 // gdbg-command:print 'basic_types_globals::C'
-// gdbr-command:print C
+// gdbr-command:print/d C
 // gdbg-check:$3 = 97
 // gdbr-check:$3 = 97
 // gdbg-command:print/d 'basic_types_globals::I8'


### PR DESCRIPTION
This is needed for my Ubuntu 22.04 box due to a slight change in gdb
output. The fix is similar to the fix in #95063.