### PR TITLE
[beta] Do not call `check_expr` twice in `check_compatible`

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -303,12 +303,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let provided_arg: &hir::Expr<'tcx> = &provided_args[input_idx];
             let expectation = Expectation::rvalue_hint(self, expected_input_ty);
-            // FIXME: check that this is safe; I don't believe this commits any of the obligations, but I can't be sure.
-            //
-            //   I had another method of "soft" type checking before,
-            //   but it was failing to find the type of some expressions (like "")
-            //   so I prodded this method and made it pub(super) so I could call it, and it seems to work well.
-            let checked_ty = self.check_expr_kind(provided_arg, expectation);
+            let already_checked_ty = self.typeck_results.borrow().expr_ty_adjusted_opt(provided_arg);
+            let checked_ty = already_checked_ty.unwrap_or_else(|| self.check_expr(provided_arg));
 
             let coerced_ty = expectation.only_has_type(self).unwrap_or(formal_input_ty);
             let can_coerce = self.can_coerce(checked_ty, coerced_ty);

--- a/src/test/ui/argument-suggestions/issue-98894.rs
+++ b/src/test/ui/argument-suggestions/issue-98894.rs
@@ -1,0 +1,4 @@
+fn main() {
+    (|_, ()| ())(if true {} else {return;});
+    //~^ ERROR this function takes 2 arguments but 1 argument was supplied
+}

--- a/src/test/ui/argument-suggestions/issue-98894.stderr
+++ b/src/test/ui/argument-suggestions/issue-98894.stderr
@@ -1,0 +1,19 @@
+error[E0057]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/issue-98894.rs:2:5
+   |
+LL |     (|_, ()| ())(if true {} else {return;});
+   |     ^^^^^^^^^^^^--------------------------- an argument of type `()` is missing
+   |
+note: closure defined here
+  --> $DIR/issue-98894.rs:2:6
+   |
+LL |     (|_, ()| ())(if true {} else {return;});
+   |      ^^^^^^^
+help: provide the argument
+   |
+LL |     (|_, ()| ())(if true {} else {return;}, ());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0057`.

--- a/src/test/ui/argument-suggestions/issue-98897.rs
+++ b/src/test/ui/argument-suggestions/issue-98897.rs
@@ -1,0 +1,4 @@
+fn main() {
+    (|_, ()| ())([return, ()]);
+    //~^ ERROR this function takes 2 arguments but 1 argument was supplied
+}

--- a/src/test/ui/argument-suggestions/issue-98897.stderr
+++ b/src/test/ui/argument-suggestions/issue-98897.stderr
@@ -1,0 +1,19 @@
+error[E0057]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/issue-98897.rs:2:5
+   |
+LL |     (|_, ()| ())([return, ()]);
+   |     ^^^^^^^^^^^^-------------- an argument of type `()` is missing
+   |
+note: closure defined here
+  --> $DIR/issue-98897.rs:2:6
+   |
+LL |     (|_, ()| ())([return, ()]);
+   |      ^^^^^^^
+help: provide the argument
+   |
+LL |     (|_, ()| ())([return, ()], ());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0057`.

--- a/src/test/ui/issues/issue-3044.rs
+++ b/src/test/ui/issues/issue-3044.rs
@@ -2,6 +2,5 @@ fn main() {
     let needlesArr: Vec<char> = vec!['a', 'f'];
     needlesArr.iter().fold(|x, y| {
     });
-    //~^^ ERROR mismatched types
-    //~| ERROR this function takes 2 arguments but 1 argument was supplied
+    //~^^ ERROR this function takes 2 arguments but 1 argument was supplied
 }

--- a/src/test/ui/issues/issue-3044.stderr
+++ b/src/test/ui/issues/issue-3044.stderr
@@ -1,14 +1,3 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-3044.rs:3:35
-   |
-LL |       needlesArr.iter().fold(|x, y| {
-   |  ___________________________________^
-LL | |     });
-   | |_____^ expected closure, found `()`
-   |
-   = note: expected closure `[closure@$DIR/issue-3044.rs:3:28: 4:6]`
-            found unit type `()`
-
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-3044.rs:3:23
    |
@@ -28,7 +17,6 @@ LL ~     needlesArr.iter().fold(|x, y| {
 LL ~     }, /* value */);
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0061, E0308.
-For more information about an error, try `rustc --explain E0061`.
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
This fixes #98894 and #98897 on the beta branch, since my original fix #98785 does not [merge cleanly onto beta](https://github.com/rust-lang/rust/pull/98785#issuecomment-1185980986).

Should I nominate this for beta backport again, since it's basically a different fix compared to the one that was approved? Regardless, it's actually a slightly smaller change than #98785.