### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -70,11 +70,14 @@ pub use std::alloc::Global;
 /// # Examples
 ///
 /// ```
-/// use std::alloc::{alloc, dealloc, Layout};
+/// use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
 ///
 /// unsafe {
 ///     let layout = Layout::new::<u16>();
 ///     let ptr = alloc(layout);
+///     if ptr.is_null() {
+///         handle_alloc_error(layout);
+///     }
 ///
 ///     *(ptr as *mut u16) = 42;
 ///     assert_eq!(*(ptr as *mut u16), 42);

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1040,6 +1040,8 @@ pub fn copy<T: Copy>(x: &T) -> T {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_transmute_copy", issue = "83165")]
 pub const unsafe fn transmute_copy<T, U>(src: &T) -> U {
+    assert!(size_of::<T>() >= size_of::<U>(), "cannot transmute_copy if U is larger than T");
+
     // If U has a higher alignment requirement, src might not be suitably aligned.
     if align_of::<U>() > align_of::<T>() {
         // SAFETY: `src` is a reference which is guaranteed to be valid for reads.

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1535,13 +1535,14 @@ fn read_large_dir() {
     }
 }
 
+/// Test the fallback for getting the metadata of files like hiberfil.sys that
+/// Windows holds a special lock on, preventing normal means of querying
+/// metadata. See #96980.
 #[test]
 #[cfg(windows)]
 fn hiberfil_sys() {
-    // Get the system drive, which is usually `C:`.
-    let mut hiberfil = crate::env::var("SystemDrive").unwrap();
-    hiberfil.push_str(r"\hiberfil.sys");
+    let hiberfil = r"C:\hiberfil.sys";
 
-    fs::metadata(&hiberfil).unwrap();
-    fs::symlink_metadata(&hiberfil).unwrap();
+    fs::metadata(hiberfil).unwrap();
+    fs::symlink_metadata(hiberfil).unwrap();
 }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1534,3 +1534,14 @@ fn read_large_dir() {
         entry.unwrap();
     }
 }
+
+#[test]
+#[cfg(windows)]
+fn hiberfil_sys() {
+    // Get the system drive, which is usually `C:`.
+    let mut hiberfil = crate::env::var("SystemDrive").unwrap();
+    hiberfil.push_str(r"\hiberfil.sys");
+
+    fs::metadata(&hiberfil).unwrap();
+    fs::symlink_metadata(&hiberfil).unwrap();
+}

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1541,8 +1541,10 @@ fn read_large_dir() {
 #[test]
 #[cfg(windows)]
 fn hiberfil_sys() {
-    let hiberfil = r"C:\hiberfil.sys";
+    let hiberfil = Path::new(r"C:\hiberfil.sys");
 
-    fs::metadata(hiberfil).unwrap();
+    assert_eq!(true, hiberfil.try_exists().unwrap());
     fs::symlink_metadata(hiberfil).unwrap();
+    fs::metadata(hiberfil).unwrap();
+    assert_eq!(true, hiberfil.exists());
 }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -1150,22 +1150,73 @@ pub fn link(_original: &Path, _link: &Path) -> io::Result<()> {
 }
 
 pub fn stat(path: &Path) -> io::Result<FileAttr> {
-    let mut opts = OpenOptions::new();
-    // No read or write permissions are necessary
-    opts.access_mode(0);
-    // This flag is so we can open directories too
-    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS);
-    let file = File::open(path, &opts)?;
-    file.file_attr()
+    metadata(path, ReparsePoint::Follow)
 }
 
 pub fn lstat(path: &Path) -> io::Result<FileAttr> {
+    metadata(path, ReparsePoint::Open)
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReparsePoint {
+    Follow = 0,
+    Open = c::FILE_FLAG_OPEN_REPARSE_POINT,
+}
+impl ReparsePoint {
+    fn as_flag(self) -> u32 {
+        self as u32
+    }
+}
+
+fn metadata(path: &Path, reparse: ReparsePoint) -> io::Result<FileAttr> {
     let mut opts = OpenOptions::new();
     // No read or write permissions are necessary
     opts.access_mode(0);
-    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS | c::FILE_FLAG_OPEN_REPARSE_POINT);
-    let file = File::open(path, &opts)?;
-    file.file_attr()
+    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS | reparse.as_flag());
+
+    // Attempt to open the file normally.
+    // If that fails with `ERROR_SHARING_VIOLATION` then retry using `FindFirstFileW`.
+    // If the fallback fails for any reason we return the original error.
+    match File::open(path, &opts) {
+        Ok(file) => file.file_attr(),
+        Err(e) if e.raw_os_error() == Some(c::ERROR_SHARING_VIOLATION as _) => {
+            // `ERROR_SHARING_VIOLATION` will almost never be returned.
+            // Usually if a file is locked you can still read some metadata.
+            // However, there are special system files, such as
+            // `C:\hiberfil.sys`, that are locked in a way that denies even that.
+            unsafe {
+                let path = maybe_verbatim(path)?;
+
+                // `FindFirstFileW` accepts wildcard file names.
+                // Fortunately wildcards are not valid file names and
+                // `ERROR_SHARING_VIOLATION` means the file exists (but is locked)
+                // therefore it's safe to assume the file name given does not
+                // include wildcards.
+                let mut wfd = mem::zeroed();
+                let handle = c::FindFirstFileW(path.as_ptr(), &mut wfd);
+
+                if handle == c::INVALID_HANDLE_VALUE {
+                    // This can fail if the user does not have read access to the
+                    // directory.
+                    Err(e)
+                } else {
+                    // We no longer need the find handle.
+                    c::FindClose(handle);
+
+                    // `FindFirstFileW` reads the cached file information from the
+                    // directory. The downside is that this metadata may be outdated.
+                    let attrs = FileAttr::from(wfd);
+                    if reparse == ReparsePoint::Follow && attrs.file_type().is_symlink() {
+                        Err(e)
+                    } else {
+                        Ok(attrs)
+                    }
+                }
+            }
+        }
+        Err(e) => Err(e),
+    }
 }
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -155,22 +155,7 @@ impl DirEntry {
     }
 
     pub fn metadata(&self) -> io::Result<FileAttr> {
-        Ok(FileAttr {
-            attributes: self.data.dwFileAttributes,
-            creation_time: self.data.ftCreationTime,
-            last_access_time: self.data.ftLastAccessTime,
-            last_write_time: self.data.ftLastWriteTime,
-            file_size: ((self.data.nFileSizeHigh as u64) << 32) | (self.data.nFileSizeLow as u64),
-            reparse_tag: if self.data.dwFileAttributes & c::FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-                // reserved unless this is a reparse point
-                self.data.dwReserved0
-            } else {
-                0
-            },
-            volume_serial_number: None,
-            number_of_links: None,
-            file_index: None,
-        })
+        Ok(self.data.into())
     }
 }
 
@@ -877,6 +862,26 @@ impl FileAttr {
 
     pub fn file_index(&self) -> Option<u64> {
         self.file_index
+    }
+}
+impl From<c::WIN32_FIND_DATAW> for FileAttr {
+    fn from(wfd: c::WIN32_FIND_DATAW) -> Self {
+        FileAttr {
+            attributes: wfd.dwFileAttributes,
+            creation_time: wfd.ftCreationTime,
+            last_access_time: wfd.ftLastAccessTime,
+            last_write_time: wfd.ftLastWriteTime,
+            file_size: ((wfd.nFileSizeHigh as u64) << 32) | (wfd.nFileSizeLow as u64),
+            reparse_tag: if wfd.dwFileAttributes & c::FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                // reserved unless this is a reparse point
+                wfd.dwReserved0
+            } else {
+                0
+            },
+            volume_serial_number: None,
+            number_of_links: None,
+            file_index: None,
+        }
     }
 }
 

--- a/src/test/ui/asm/issue-96797.rs
+++ b/src/test/ui/asm/issue-96797.rs
@@ -1,0 +1,23 @@
+// build-pass
+// compile-flags: -O
+// min-llvm-version: 14.0.5
+
+// regression test for #96797
+
+#![feature(asm_sym)]
+
+use std::arch::global_asm;
+
+#[no_mangle]
+fn my_func() {}
+
+global_asm!("call_foobar: jmp {}", sym foobar);
+
+fn foobar() {}
+
+fn main() {
+    extern "Rust" {
+        fn call_foobar();
+    }
+    unsafe { call_foobar() };
+}

--- a/src/test/ui/hrtb/issue-95230.rs
+++ b/src/test/ui/hrtb/issue-95230.rs
@@ -1,0 +1,7 @@
+// check-pass
+
+pub struct Bar
+where
+    for<'a> &'a mut Self:;
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #98839 (Add assertion that `transmute_copy`'s U is not larger than T)
 - #98916 (Windows: Use `FindFirstFileW` for getting the metadata of locked system files)
 - #99059 (Add test for #96797)
 - #99198 (add missing null ptr check in alloc example)
 - #99394 (Add regression test for #95230)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98839,98916,99059,99198,99394)
<!-- homu-ignore:end -->