### PR TITLE
Update invalid atomic ordering lint

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -247,11 +247,6 @@ lint-atomic-ordering-invalid = `{$method}`'s failure ordering may not be `Releas
     .label = invalid failure ordering
     .help = consider using `Acquire` or `Relaxed` failure ordering instead
 
-lint-atomic-ordering-invalid-fail-success = `{$method}`'s success ordering must be at least as strong as its failure ordering
-    .fail-label = `{$fail_ordering}` failure ordering
-    .success-label = `{$success_ordering}` success ordering
-    .suggestion = consider using `{$success_suggestion}` success ordering instead
-
 lint-unused-op = unused {$op} that must be used
     .label = the {$op} produces a value
     .suggestion = use `let _ = ...` to ignore the resulting value

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
@@ -9,11 +9,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Relaxed);
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Relaxed);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Relaxed);
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Relaxed);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Relaxed);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Acquire);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::SeqCst);
@@ -41,22 +47,4 @@ fn main() {
     //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
     //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
-
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
@@ -1,5 +1,5 @@
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:22:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:24:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:26:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:32:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:38:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:44:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                                |
-   |                                                `Release` success ordering
-   |                                                help: consider using `AcqRel` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Release` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:52:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Relaxed` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:54:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                                |
-   |                                                `Relaxed` success ordering
-   |                                                help: consider using `Acquire` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:58:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Acquire` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:60:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `AcqRel` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
@@ -7,11 +7,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Relaxed);
-    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Relaxed);
+    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Relaxed);
-    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Relaxed);
+    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Relaxed);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Acquire);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::SeqCst);
@@ -39,22 +45,4 @@ fn main() {
     //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
     //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
-
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
@@ -1,5 +1,5 @@
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:20:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:22:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:24:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:30:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:36:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:42:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                      |
-   |                                      `Release` success ordering
-   |                                      help: consider using `AcqRel` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Release` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:50:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Relaxed` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:52:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                      |
-   |                                      `Relaxed` success ordering
-   |                                      help: consider using `Acquire` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:56:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Acquire` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:58:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `AcqRel` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
@@ -7,11 +7,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| Some(old + 1));
-    let _ = x.fetch_update(Ordering::Acquire, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::Acquire, Ordering::Relaxed, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Acquire, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::Release, Ordering::Relaxed, |old| Some(old + 1));
-    let _ = x.fetch_update(Ordering::AcqRel, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::AcqRel, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Acquire, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |old| Some(old + 1));
@@ -40,21 +46,4 @@ fn main() {
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
     //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
 
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
@@ -1,5 +1,5 @@
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:20:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:22:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:24:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:30:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:36:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:42:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                            |
-   |                            `Release` success ordering
-   |                            help: consider using `AcqRel` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Release` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:50:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Relaxed` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:52:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                            |
-   |                            `Relaxed` success ordering
-   |                            help: consider using `Acquire` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:56:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Acquire` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:58:28
-   |
-LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `AcqRel` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
The restriction that success ordering must be at least as strong as its
failure ordering in compare-exchange operations was lifted in #98383.