### PR TITLE
Stabilize `core::task::ready!`

### DIFF
--- a/library/core/src/task/mod.rs
+++ b/library/core/src/task/mod.rs
@@ -11,7 +11,7 @@ mod wake;
 pub use self::wake::{Context, RawWaker, RawWakerVTable, Waker};
 
 mod ready;
-#[unstable(feature = "ready_macro", issue = "70922")]
+#[stable(feature = "ready_macro", since = "1.64.0")]
 pub use ready::ready;
 #[unstable(feature = "poll_ready", issue = "89780")]
 pub use ready::Ready;

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -13,8 +13,6 @@ use core::task::Poll;
 /// # Examples
 ///
 /// ```
-/// #![feature(ready_macro)]
-///
 /// use std::task::{ready, Context, Poll};
 /// use std::future::{self, Future};
 /// use std::pin::Pin;
@@ -34,7 +32,6 @@ use core::task::Poll;
 /// The `ready!` call expands to:
 ///
 /// ```
-/// # #![feature(ready_macro)]
 /// # use std::task::{Context, Poll};
 /// # use std::future::{self, Future};
 /// # use std::pin::Pin;
@@ -53,7 +50,7 @@ use core::task::Poll;
 ///     # Poll::Ready(())
 /// # }
 /// ```
-#[unstable(feature = "ready_macro", issue = "70922")]
+#[stable(feature = "ready_macro", since = "1.64.0")]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro ready($e:expr) {
     match $e {


### PR DESCRIPTION
This stabilizes `core::task::ready!` for Rust 1.64. The FCP for stabilization was just completed here https://github.com/rust-lang/rust/issues/70922#issuecomment-1186231855. Thanks!

Closes #70922

cc/ @rust-lang/libs-api 