### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -299,6 +299,10 @@ pub fn from_fn_attrs<'ll, 'tcx>(
     }
     if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::NAKED) {
         to_add.push(AttributeKind::Naked.create_attr(cx.llcx));
+        // HACK(jubilee): "indirect branch tracking" works by attaching prologues to functions.
+        // And it is a module-level attribute, so the alternative is pulling naked functions into new LLVM modules.
+        // Otherwise LLVM's "naked" functions come with endbr prefixes per https://github.com/rust-lang/rust/issues/98768
+        to_add.push(AttributeKind::NoCfCheck.create_attr(cx.llcx));
     }
     if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::ALLOCATOR) {
         // apply to return place instead of function (unlike all other attributes applied in this function)

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -303,6 +303,8 @@ pub fn from_fn_attrs<'ll, 'tcx>(
         // And it is a module-level attribute, so the alternative is pulling naked functions into new LLVM modules.
         // Otherwise LLVM's "naked" functions come with endbr prefixes per https://github.com/rust-lang/rust/issues/98768
         to_add.push(AttributeKind::NoCfCheck.create_attr(cx.llcx));
+        // Need this for AArch64.
+        to_add.push(llvm::CreateAttrStringValue(cx.llcx, "branch-target-enforcement", "false"));
     }
     if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::ALLOCATOR) {
         // apply to return place instead of function (unlike all other attributes applied in this function)

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -191,6 +191,7 @@ pub enum AttributeKind {
     StackProtect = 32,
     NoUndef = 33,
     SanitizeMemTag = 34,
+    NoCfCheck = 35,
 }
 
 /// LLVMIntPredicate

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -473,6 +473,9 @@ macro_rules! make_value_visitor {
                         // The second `Box` field is the allocator, which we recursively check for validity
                         // like in regular structs.
                         self.visit_field(v, 1, &alloc)?;
+
+                        // We visited all parts of this one.
+                        return Ok(());
                     }
                     _ => {},
                 };

--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -84,6 +84,7 @@ enum LLVMRustAttribute {
   StackProtect = 32,
   NoUndef = 33,
   SanitizeMemTag = 34,
+  NoCfCheck = 35,
 };
 
 typedef struct OpaqueRustString *RustStringRef;

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -176,6 +176,8 @@ static Attribute::AttrKind fromRust(LLVMRustAttribute Kind) {
     return Attribute::NoAlias;
   case NoCapture:
     return Attribute::NoCapture;
+  case NoCfCheck:
+    return Attribute::NoCfCheck;
   case NoInline:
     return Attribute::NoInline;
   case NonNull:

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -443,17 +443,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Next, let's construct the error
         let (error_span, full_call_span, ctor_of) = match &call_expr.kind {
             hir::ExprKind::Call(
-                hir::Expr {
-                    span,
-                    kind:
-                        hir::ExprKind::Path(hir::QPath::Resolved(
-                            _,
-                            hir::Path { res: Res::Def(DefKind::Ctor(of, _), _), .. },
-                        )),
-                    ..
-                },
+                hir::Expr { hir_id, span, kind: hir::ExprKind::Path(qpath), .. },
                 _,
-            ) => (call_span, *span, Some(of)),
+            ) => {
+                if let Res::Def(DefKind::Ctor(of, _), _) =
+                    self.typeck_results.borrow().qpath_res(qpath, *hir_id)
+                {
+                    (call_span, *span, Some(of))
+                } else {
+                    (call_span, *span, None)
+                }
+            }
             hir::ExprKind::Call(hir::Expr { span, .. }, _) => (call_span, *span, None),
             hir::ExprKind::MethodCall(path_segment, _, span) => {
                 let ident_span = path_segment.ident.span;

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -70,11 +70,14 @@ pub use std::alloc::Global;
 /// # Examples
 ///
 /// ```
-/// use std::alloc::{alloc, dealloc, Layout};
+/// use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
 ///
 /// unsafe {
 ///     let layout = Layout::new::<u16>();
 ///     let ptr = alloc(layout);
+///     if ptr.is_null() {
+///         handle_alloc_error(layout);
+///     }
 ///
 ///     *(ptr as *mut u16) = 42;
 ///     assert_eq!(*(ptr as *mut u16), 42);

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1040,6 +1040,8 @@ pub fn copy<T: Copy>(x: &T) -> T {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_transmute_copy", issue = "83165")]
 pub const unsafe fn transmute_copy<T, U>(src: &T) -> U {
+    assert!(size_of::<T>() >= size_of::<U>(), "cannot transmute_copy if U is larger than T");
+
     // If U has a higher alignment requirement, src might not be suitably aligned.
     if align_of::<U>() > align_of::<T>() {
         // SAFETY: `src` is a reference which is guaranteed to be valid for reads.

--- a/src/test/assembly/aarch64-naked-fn-no-bti-prolog.rs
+++ b/src/test/assembly/aarch64-naked-fn-no-bti-prolog.rs
@@ -1,0 +1,21 @@
+// compile-flags: -C no-prepopulate-passes -Zbranch-protection=bti
+// assembly-output: emit-asm
+// needs-asm-support
+// only-aarch64
+
+#![crate_type = "lib"]
+#![feature(naked_functions)]
+use std::arch::asm;
+
+// The problem at hand: Rust has adopted a fairly strict meaning for "naked functions",
+// meaning "no prologue whatsoever, no, really, not one instruction."
+// Unfortunately, aarch64's "branch target identification" works via hints at landing sites.
+// LLVM implements this via making sure of that, even for functions with the naked attribute.
+// So, we must emit an appropriate instruction instead!
+#[no_mangle]
+#[naked]
+pub unsafe extern "C" fn _hlt() -> ! {
+    // CHECK-NOT: hint #34
+    // CHECK: hlt #0x1
+    asm!("hlt #1", options(noreturn))
+}

--- a/src/test/assembly/x86_64-naked-fn-no-cet-prolog.rs
+++ b/src/test/assembly/x86_64-naked-fn-no-cet-prolog.rs
@@ -1,0 +1,24 @@
+// compile-flags: -C no-prepopulate-passes -Zcf-protection=full
+// assembly-output: emit-asm
+// needs-asm-support
+// only-x86_64
+
+#![crate_type = "lib"]
+#![feature(naked_functions)]
+use std::arch::asm;
+
+// The problem at hand: Rust has adopted a fairly strict meaning for "naked functions",
+// meaning "no prologue whatsoever, no, really, not one instruction."
+// Unfortunately, x86's control-flow enforcement, specifically indirect branch protection,
+// works by using an instruction for each possible landing site,
+// and LLVM implements this via making sure of that.
+#[no_mangle]
+#[naked]
+pub unsafe extern "sysv64" fn will_halt() -> ! {
+    // CHECK-NOT: endbr{{32|64}}
+    // CHECK: hlt
+    asm!("hlt", options(noreturn))
+}
+
+// what about aarch64?
+// "branch-protection"=false

--- a/src/test/codegen/naked-noinline.rs
+++ b/src/test/codegen/naked-noinline.rs
@@ -28,4 +28,4 @@ pub unsafe fn g() {
     f();
 }
 
-// CHECK: attributes [[ATTR]] = { naked noinline{{.*}} }
+// CHECK: attributes [[ATTR]] = { naked{{.*}}noinline{{.*}} }

--- a/src/test/rustdoc/auxiliary/issue-99221-aux.rs
+++ b/src/test/rustdoc/auxiliary/issue-99221-aux.rs
@@ -1,0 +1,20 @@
+pub struct Option;
+impl Option {
+    pub fn unwrap(self) {}
+}
+
+mod macros {
+    use crate::Option;
+    /// [`Option::unwrap`]
+    #[macro_export]
+    macro_rules! print {
+        () => ()
+    }
+}
+
+mod structs {
+    use crate::Option;
+    /// [`Option::unwrap`]
+    pub struct Print;
+}
+pub use structs::Print;

--- a/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name-submodule.rs
+++ b/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name-submodule.rs
@@ -1,0 +1,19 @@
+// aux-build:issue-99221-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99221_aux;
+
+pub use issue_99221_aux::*;
+
+// @count foo/index.html '//a[@class="macro"]' 1
+
+mod inner {
+    #[macro_export]
+    macro_rules! print {
+        () => ()
+    }
+}

--- a/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name.rs
+++ b/src/test/rustdoc/issue-99221-multiple-macro-rules-w-same-name.rs
@@ -1,0 +1,17 @@
+// aux-build:issue-99221-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99221_aux;
+
+pub use issue_99221_aux::*;
+
+// @count foo/index.html '//a[@class="macro"]' 1
+
+#[macro_export]
+macro_rules! print {
+    () => ()
+}

--- a/src/test/rustdoc/issue-99221-multiple-structs-w-same-name.rs
+++ b/src/test/rustdoc/issue-99221-multiple-structs-w-same-name.rs
@@ -1,0 +1,14 @@
+// aux-build:issue-99221-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99221_aux;
+
+pub use issue_99221_aux::*;
+
+// @count foo/index.html '//a[@class="struct"][@title="foo::Print struct"]' 1
+
+pub struct Print;

--- a/src/test/ui/hrtb/issue-95230.rs
+++ b/src/test/ui/hrtb/issue-95230.rs
@@ -1,0 +1,7 @@
+// check-pass
+
+pub struct Bar
+where
+    for<'a> &'a mut Self:;
+
+fn main() {}

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -7,7 +7,7 @@ LL |     fn ts_variant() {
 LL |         Self::TSVariant(());
    |         --------------- ^^ expected type parameter `T`, found `()`
    |         |
-   |         arguments to this function are incorrect
+   |         arguments to this enum variant are incorrect
    |
    = note: expected type parameter `T`
                    found unit type `()`
@@ -55,7 +55,7 @@ LL | impl<T> Enum<T> {
 LL |         Self::<()>::TSVariant(());
    |         --------------------- ^^ expected type parameter `T`, found `()`
    |         |
-   |         arguments to this function are incorrect
+   |         arguments to this enum variant are incorrect
    |
    = note: expected type parameter `T`
                    found unit type `()`

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.rs
@@ -18,6 +18,6 @@ impl E2 {
 }
 
 fn main() {
-    <E>::V(); //~ ERROR this function takes 1 argument but 0 arguments were supplied
+    <E>::V(); //~ ERROR this enum variant takes 1 argument but 0 arguments were supplied
     let _: u8 = <E2>::V; //~ ERROR mismatched types
 }

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
@@ -1,4 +1,4 @@
-error[E0061]: this function takes 1 argument but 0 arguments were supplied
+error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:21:5
    |
 LL |     <E>::V();


### PR DESCRIPTION
Successful merges:

 - #98839 (Add assertion that `transmute_copy`'s U is not larger than T)
 - #98998 (Remove branch target prologues from `#[naked] fn`)
 - #99198 (add missing null ptr check in alloc example)
 - #99344 (rustdoc: avoid inlining items with duplicate `(type, name)`)
 - #99351 (Use `typeck_results` to get accurate qpath res for arg mismatch error)
 - #99378 (interpret/visitor: add missing early return)
 - #99394 (Add regression test for #95230)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98839,98998,99198,99344,99351,99378,99394)
<!-- homu-ignore:end -->