### PR TITLE
Erase regions before comparing signatures of foreign fns.

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2858,9 +2858,10 @@ impl ClashingExternDeclarations {
                             let a_poly_sig = a.fn_sig(tcx);
                             let b_poly_sig = b.fn_sig(tcx);
 
-                            // As we don't compare regions, skip_binder is fine.
-                            let a_sig = a_poly_sig.skip_binder();
-                            let b_sig = b_poly_sig.skip_binder();
+                            // We don't compare regions, but leaving bound regions around ICEs, so
+                            // we erase them.
+                            let a_sig = tcx.erase_late_bound_regions(a_poly_sig);
+                            let b_sig = tcx.erase_late_bound_regions(b_poly_sig);
 
                             (a_sig.abi, a_sig.unsafety, a_sig.c_variadic)
                                 == (b_sig.abi, b_sig.unsafety, b_sig.c_variadic)

--- a/src/test/ui/foreign/issue-99276-same-type-lifetimes.rs
+++ b/src/test/ui/foreign/issue-99276-same-type-lifetimes.rs
@@ -1,0 +1,24 @@
+// Check that we do not ICE when structurally comparing types with lifetimes present.
+// check-pass
+
+pub struct Record<'a> {
+    pub args: &'a [(usize, &'a str)],
+}
+
+mod a {
+    extern "Rust" {
+        fn foo<'a, 'b>(record: &'a super::Record<'b>);
+
+        fn bar<'a, 'b>(record: &'a super::Record<'b>);
+    }
+}
+
+mod b {
+    extern "Rust" {
+        fn foo<'a, 'b>(record: &'a super::Record<'b>);
+
+        fn bar<'a, 'b>(record: &'a super::Record<'b>);
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/99276

The version with explicit lifetimes is probably tracked in another bug, but I could not find it.