### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -247,11 +247,6 @@ lint-atomic-ordering-invalid = `{$method}`'s failure ordering may not be `Releas
     .label = invalid failure ordering
     .help = consider using `Acquire` or `Relaxed` failure ordering instead
 
-lint-atomic-ordering-invalid-fail-success = `{$method}`'s success ordering must be at least as strong as its failure ordering
-    .fail-label = `{$fail_ordering}` failure ordering
-    .success-label = `{$success_ordering}` success ordering
-    .suggestion = consider using `{$success_suggestion}` success ordering instead
-
 lint-unused-op = unused {$op} that must be used
     .label = the {$op} produces a value
     .suggestion = use `let _ = ...` to ignore the resulting value

--- a/compiler/rustc_middle/src/ty/closure.rs
+++ b/compiler/rustc_middle/src/ty/closure.rs
@@ -182,7 +182,11 @@ impl<'tcx> CapturedPlace<'tcx> {
                         .unwrap();
                     }
                     ty => {
-                        bug!("Unexpected type {:?} for `Field` projection", ty)
+                        span_bug!(
+                            self.get_capture_kind_span(tcx),
+                            "Unexpected type {:?} for `Field` projection",
+                            ty
+                        )
                     }
                 },
 

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -431,9 +431,9 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 let lhs = &self.thir[lhs];
                 if let ty::Adt(adt_def, _) = lhs.ty.kind() && adt_def.is_union() {
                     if let Some((assigned_ty, assignment_span)) = self.assignment_info {
-                        if assigned_ty.needs_drop(self.tcx, self.tcx.param_env(adt_def.did())) {
+                        if assigned_ty.needs_drop(self.tcx, self.param_env) {
                             // This would be unsafe, but should be outright impossible since we reject such unions.
-                            self.tcx.sess.delay_span_bug(assignment_span, "union fields that need dropping should be impossible");
+                            self.tcx.sess.delay_span_bug(assignment_span, format!("union fields that need dropping should be impossible: {assigned_ty}"));
                         }
                     } else {
                         self.requires_unsafe(expr.span, AccessToUnionField);

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -219,14 +219,11 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
                     // We have to check the actual type of the assignment, as that determines if the
                     // old value is being dropped.
                     let assigned_ty = place.ty(&self.body.local_decls, self.tcx).ty;
-                    if assigned_ty.needs_drop(
-                        self.tcx,
-                        self.tcx.param_env(base_ty.ty_adt_def().unwrap().did()),
-                    ) {
+                    if assigned_ty.needs_drop(self.tcx, self.param_env) {
                         // This would be unsafe, but should be outright impossible since we reject such unions.
                         self.tcx.sess.delay_span_bug(
                             self.source_info.span,
-                            "union fields that need dropping should be impossible",
+                            format!("union fields that need dropping should be impossible: {assigned_ty}")
                         );
                     }
                 } else {

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -519,12 +519,14 @@ unsafe impl const SliceIndex<str> for ops::RangeToInclusive<usize> {
 ///     type Err = ParseIntError;
 ///
 ///     fn from_str(s: &str) -> Result<Self, Self::Err> {
-///         let coords: Vec<&str> = s.trim_matches(|p| p == '(' || p == ')' )
-///                                  .split(',')
-///                                  .collect();
+///         let (x, y) = s
+///             .strip_prefix('(')
+///             .and_then(|s| s.strip_suffix(')'))
+///             .and_then(|s| s.split_once(','))
+///             .unwrap();
 ///
-///         let x_fromstr = coords[0].parse::<i32>()?;
-///         let y_fromstr = coords[1].parse::<i32>()?;
+///         let x_fromstr = x.parse::<i32>()?;
+///         let y_fromstr = y.parse::<i32>()?;
 ///
 ///         Ok(Point { x: x_fromstr, y: y_fromstr })
 ///     }

--- a/library/core/src/task/mod.rs
+++ b/library/core/src/task/mod.rs
@@ -11,7 +11,7 @@ mod wake;
 pub use self::wake::{Context, RawWaker, RawWakerVTable, Waker};
 
 mod ready;
-#[unstable(feature = "ready_macro", issue = "70922")]
+#[stable(feature = "ready_macro", since = "1.64.0")]
 pub use ready::ready;
 #[unstable(feature = "poll_ready", issue = "89780")]
 pub use ready::Ready;

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -13,8 +13,6 @@ use core::task::Poll;
 /// # Examples
 ///
 /// ```
-/// #![feature(ready_macro)]
-///
 /// use std::task::{ready, Context, Poll};
 /// use std::future::{self, Future};
 /// use std::pin::Pin;
@@ -34,7 +32,6 @@ use core::task::Poll;
 /// The `ready!` call expands to:
 ///
 /// ```
-/// # #![feature(ready_macro)]
 /// # use std::task::{Context, Poll};
 /// # use std::future::{self, Future};
 /// # use std::pin::Pin;
@@ -53,7 +50,7 @@ use core::task::Poll;
 ///     # Poll::Ready(())
 /// # }
 /// ```
-#[unstable(feature = "ready_macro", issue = "70922")]
+#[stable(feature = "ready_macro", since = "1.64.0")]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro ready($e:expr) {
     match $e {

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -474,7 +474,7 @@ impl fmt::Debug for ChildStderr {
 ///             .expect("failed to execute process")
 /// };
 ///
-/// let hello = output.stdout;
+/// assert_eq!(String::from_utf8_lossy(&output.stdout), "hello\n");
 /// ```
 ///
 /// `Command` can be reused to spawn multiple processes. The builder methods

--- a/src/test/debuginfo/basic-types-globals-lto.rs
+++ b/src/test/debuginfo/basic-types-globals-lto.rs
@@ -14,7 +14,7 @@
 // gdbr-command:print I
 // gdb-check:$2 = -1
 // gdbg-command:print 'basic_types_globals::C'
-// gdbr-command:print C
+// gdbr-command:print/d C
 // gdbg-check:$3 = 97
 // gdbr-check:$3 = 97
 // gdbg-command:print/d 'basic_types_globals::I8'

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -13,7 +13,7 @@
 // gdbr-command:print I
 // gdb-check:$2 = -1
 // gdbg-command:print 'basic_types_globals::C'
-// gdbr-command:print C
+// gdbr-command:print/d C
 // gdbg-check:$3 = 97
 // gdbr-check:$3 = 97
 // gdbg-command:print/d 'basic_types_globals::I8'

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
@@ -9,11 +9,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Relaxed);
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Relaxed);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Relaxed);
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Relaxed);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Relaxed);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Acquire);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::SeqCst);
@@ -41,22 +47,4 @@ fn main() {
     //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
     //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
-
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
@@ -1,5 +1,5 @@
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:22:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:24:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:26:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:32:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:38:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:44:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                                |
-   |                                                `Release` success ordering
-   |                                                help: consider using `AcqRel` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Release` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:52:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Relaxed` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:54:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                                |
-   |                                                `Relaxed` success ordering
-   |                                                help: consider using `Acquire` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:58:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Acquire` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:60:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `AcqRel` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
@@ -7,11 +7,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Relaxed);
-    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Relaxed);
+    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Relaxed);
-    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Relaxed);
+    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Relaxed);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Acquire);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::SeqCst);
@@ -39,22 +45,4 @@ fn main() {
     //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
     //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
-
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
@@ -1,5 +1,5 @@
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:20:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:22:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:24:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:30:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:36:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:42:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                      |
-   |                                      `Release` success ordering
-   |                                      help: consider using `AcqRel` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Release` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:50:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Relaxed` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:52:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                      |
-   |                                      `Relaxed` success ordering
-   |                                      help: consider using `Acquire` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:56:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Acquire` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:58:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `AcqRel` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
@@ -7,11 +7,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| Some(old + 1));
-    let _ = x.fetch_update(Ordering::Acquire, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::Acquire, Ordering::Relaxed, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Acquire, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::Release, Ordering::Relaxed, |old| Some(old + 1));
-    let _ = x.fetch_update(Ordering::AcqRel, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::AcqRel, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Acquire, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |old| Some(old + 1));
@@ -40,21 +46,4 @@ fn main() {
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
     //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
 
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
@@ -1,5 +1,5 @@
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:20:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:22:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:24:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:30:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:36:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:42:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                            |
-   |                            `Release` success ordering
-   |                            help: consider using `AcqRel` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Release` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:50:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Relaxed` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:52:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                            |
-   |                            `Relaxed` success ordering
-   |                            help: consider using `Acquire` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:56:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Acquire` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:58:28
-   |
-LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `AcqRel` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/union/issue-99375.rs
+++ b/src/test/ui/union/issue-99375.rs
@@ -1,0 +1,21 @@
+// check-pass
+
+union URes<R: Copy> {
+    uninit: (),
+    init: R,
+}
+
+struct Params<F, R: Copy> {
+    function: F,
+    result: URes<R>,
+}
+
+unsafe extern "C" fn do_call<F, R>(params: *mut Params<F, R>)
+where
+    R: Copy,
+    F: Fn() -> R,
+{
+    (*params).result.init = ((*params).function)();
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #99214 (docs: show how to stringify the output of Command)
 - #99335 (Use split_once in FromStr docs)
 - #99384 (use body's param-env when checking if type needs drop)
 - #99392 (Fix debuginfo tests.)
 - #99404 (Use span_bug for unexpected field projection type)
 - #99410 (Update invalid atomic ordering lint)
 - #99419 (Stabilize `core::task::ready!`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99214,99335,99384,99392,99404,99410,99419)
<!-- homu-ignore:end -->