### PR TITLE
Resolve $crate at the expansion-local crate

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -27,7 +27,7 @@ use rustc_span::edition::Edition;
 use rustc_span::hygiene::Transparency;
 use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::{kw, sym, Ident, MacroRulesNormalizedIdent};
-use rustc_span::Span;
+use rustc_span::{HashStableContext, Span};
 
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
@@ -381,6 +381,7 @@ pub fn compile_declarative_macro(
     features: &Features,
     def: &ast::Item,
     edition: Edition,
+    ctx: impl HashStableContext,
 ) -> (SyntaxExtension, Vec<(usize, Span)>) {
     debug!("compile_declarative_macro: {:?}", def);
     let mk_syn_ext = |expander| {
@@ -487,6 +488,7 @@ pub fn compile_declarative_macro(
                         def.id,
                         features,
                         edition,
+                        ctx.clone(),
                     )
                     .pop()
                     .unwrap();
@@ -511,6 +513,7 @@ pub fn compile_declarative_macro(
                         def.id,
                         features,
                         edition,
+                        ctx.clone(),
                     )
                     .pop()
                     .unwrap();

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1722,13 +1722,6 @@ impl<'a> Resolver<'a> {
         debug!("resolve_crate_root({:?})", ident);
         let mut ctxt = ident.span.ctxt();
         let mark = if ident.name == kw::DollarCrate {
-            // When resolving `$crate` from a `macro_rules!` invoked in a `macro`,
-            // we don't want to pretend that the `macro_rules!` definition is in the `macro`
-            // as described in `SyntaxContext::apply_mark`, so we ignore prepended opaque marks.
-            // FIXME: This is only a guess and it doesn't work correctly for `macro_rules!`
-            // definitions actually produced by `macro` and `macro` definitions produced by
-            // `macro_rules!`, but at least such configurations are not stable yet.
-            ctxt = ctxt.normalize_to_macro_rules();
             debug!(
                 "resolve_crate_root: marks={:?}",
                 ctxt.marks().into_iter().map(|(i, t)| (i.expn_data(), t)).collect::<Vec<_>>()

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -875,6 +875,7 @@ impl<'a> Resolver<'a> {
             self.session.features_untracked(),
             item,
             edition,
+            self.create_stable_hashing_context(),
         );
 
         if let Some(builtin_name) = result.builtin_name {

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2025,7 +2025,7 @@ impl InnerSpan {
 ///
 /// This is a hack to allow using the [`HashStable_Generic`] derive macro
 /// instead of implementing everything in rustc_middle.
-pub trait HashStableContext {
+pub trait HashStableContext: Clone {
     fn def_path_hash(&self, def_id: DefId) -> DefPathHash;
     fn hash_spans(&self) -> bool;
     /// Accesses `sess.opts.unstable_opts.incremental_ignore_spans` since

--- a/src/test/ui/proc-macro/auxiliary/dollar-dollar-crate-external.rs
+++ b/src/test/ui/proc-macro/auxiliary/dollar-dollar-crate-external.rs
@@ -1,0 +1,12 @@
+#![feature(macro_metavar_expr)]
+
+#[macro_export]
+macro_rules! define_macro {
+    ($m:ident => $item:ident) => {
+        macro_rules! $m {
+            () => {
+                $$crate::$item
+            };
+        }
+    };
+}

--- a/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
@@ -2,79 +2,79 @@ PRINT-BANG INPUT (DISPLAY): struct M($crate :: S) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/dollar-crate-issue-57089.rs:17:13: 17:19 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:17:13: 17:19 (#6),
     },
     Ident {
         ident: "M",
-        span: $DIR/dollar-crate-issue-57089.rs:17:20: 17:21 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:17:20: 17:21 (#6),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/dollar-crate-issue-57089.rs:17:22: 17:28 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:17:22: 17:28 (#7),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/dollar-crate-issue-57089.rs:17:28: 17:30 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:17:28: 17:30 (#6),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/dollar-crate-issue-57089.rs:17:28: 17:30 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:17:28: 17:30 (#6),
             },
             Ident {
                 ident: "S",
-                span: $DIR/dollar-crate-issue-57089.rs:17:30: 17:31 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:17:30: 17:31 (#6),
             },
         ],
-        span: $DIR/dollar-crate-issue-57089.rs:17:21: 17:32 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:17:21: 17:32 (#6),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/dollar-crate-issue-57089.rs:17:32: 17:33 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:17:32: 17:33 (#6),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/dollar-crate-issue-57089.rs:21:9: 21:15 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:21:9: 21:15 (#6),
     },
     Ident {
         ident: "A",
-        span: $DIR/dollar-crate-issue-57089.rs:21:16: 21:17 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:21:16: 21:17 (#6),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/dollar-crate-issue-57089.rs:21:18: 21:24 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:21:18: 21:24 (#8),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/dollar-crate-issue-57089.rs:21:24: 21:26 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:21:24: 21:26 (#6),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/dollar-crate-issue-57089.rs:21:24: 21:26 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:21:24: 21:26 (#6),
             },
             Ident {
                 ident: "S",
-                span: $DIR/dollar-crate-issue-57089.rs:21:26: 21:27 (#4),
+                span: $DIR/dollar-crate-issue-57089.rs:21:26: 21:27 (#6),
             },
         ],
-        span: $DIR/dollar-crate-issue-57089.rs:21:17: 21:28 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:21:17: 21:28 (#6),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/dollar-crate-issue-57089.rs:21:28: 21:29 (#4),
+        span: $DIR/dollar-crate-issue-57089.rs:21:28: 21:29 (#6),
     },
 ]

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -2,109 +2,109 @@ PRINT-ATTR INPUT (DISPLAY): struct A(identity! ($crate :: S)) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/dollar-crate-issue-62325.rs:19:5: 19:11 (#4),
+        span: $DIR/dollar-crate-issue-62325.rs:19:5: 19:11 (#5),
     },
     Ident {
         ident: "A",
-        span: $DIR/dollar-crate-issue-62325.rs:19:12: 19:13 (#4),
+        span: $DIR/dollar-crate-issue-62325.rs:19:12: 19:13 (#5),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "identity",
-                span: $DIR/dollar-crate-issue-62325.rs:19:14: 19:22 (#4),
+                span: $DIR/dollar-crate-issue-62325.rs:19:14: 19:22 (#5),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/dollar-crate-issue-62325.rs:19:22: 19:23 (#4),
+                span: $DIR/dollar-crate-issue-62325.rs:19:22: 19:23 (#5),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "$crate",
-                        span: $DIR/dollar-crate-issue-62325.rs:19:24: 19:30 (#4),
+                        span: $DIR/dollar-crate-issue-62325.rs:19:24: 19:30 (#6),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/dollar-crate-issue-62325.rs:19:30: 19:32 (#4),
+                        span: $DIR/dollar-crate-issue-62325.rs:19:30: 19:32 (#5),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/dollar-crate-issue-62325.rs:19:30: 19:32 (#4),
+                        span: $DIR/dollar-crate-issue-62325.rs:19:30: 19:32 (#5),
                     },
                     Ident {
                         ident: "S",
-                        span: $DIR/dollar-crate-issue-62325.rs:19:32: 19:33 (#4),
+                        span: $DIR/dollar-crate-issue-62325.rs:19:32: 19:33 (#5),
                     },
                 ],
-                span: $DIR/dollar-crate-issue-62325.rs:19:23: 19:34 (#4),
+                span: $DIR/dollar-crate-issue-62325.rs:19:23: 19:34 (#5),
             },
         ],
-        span: $DIR/dollar-crate-issue-62325.rs:19:13: 19:35 (#4),
+        span: $DIR/dollar-crate-issue-62325.rs:19:13: 19:35 (#5),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/dollar-crate-issue-62325.rs:19:35: 19:36 (#4),
+        span: $DIR/dollar-crate-issue-62325.rs:19:35: 19:36 (#5),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct B(identity! ($crate :: S)) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#15),
     },
     Ident {
         ident: "B",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#15),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "identity",
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#15),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#15),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "$crate",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#16),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:32 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:32 (#15),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:32 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:32 (#15),
                     },
                     Ident {
                         ident: "S",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#15),
                     },
                 ],
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#15),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#15),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#15),
     },
 ]

--- a/src/test/ui/proc-macro/dollar-crate-issue-99035.rs
+++ b/src/test/ui/proc-macro/dollar-crate-issue-99035.rs
@@ -1,0 +1,25 @@
+// check-pass
+// edition:2018
+// compile-flags: -Z span-debug
+// aux-build:test-macros.rs
+// aux-build:dollar-dollar-crate-external.rs
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+extern crate dollar_dollar_crate_external;
+
+struct S;
+
+mod namespace {
+    use dollar_dollar_crate_external::define_macro;
+
+    define_macro!(m => S);
+
+    #[print_attr]
+    const _: crate::S = m!();
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/dollar-crate-issue-99035.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-99035.stdout
@@ -1,0 +1,58 @@
+PRINT-ATTR INPUT (DISPLAY): const _ : crate :: S = m! () ;
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "const",
+        span: $DIR/dollar-crate-issue-99035.rs:22:5: 22:10 (#0),
+    },
+    Ident {
+        ident: "_",
+        span: $DIR/dollar-crate-issue-99035.rs:22:11: 22:12 (#0),
+    },
+    Punct {
+        ch: ':',
+        spacing: Alone,
+        span: $DIR/dollar-crate-issue-99035.rs:22:12: 22:13 (#0),
+    },
+    Ident {
+        ident: "crate",
+        span: $DIR/dollar-crate-issue-99035.rs:22:14: 22:19 (#0),
+    },
+    Punct {
+        ch: ':',
+        spacing: Joint,
+        span: $DIR/dollar-crate-issue-99035.rs:22:19: 22:21 (#0),
+    },
+    Punct {
+        ch: ':',
+        spacing: Alone,
+        span: $DIR/dollar-crate-issue-99035.rs:22:19: 22:21 (#0),
+    },
+    Ident {
+        ident: "S",
+        span: $DIR/dollar-crate-issue-99035.rs:22:21: 22:22 (#0),
+    },
+    Punct {
+        ch: '=',
+        spacing: Alone,
+        span: $DIR/dollar-crate-issue-99035.rs:22:23: 22:24 (#0),
+    },
+    Ident {
+        ident: "m",
+        span: $DIR/dollar-crate-issue-99035.rs:22:25: 22:26 (#0),
+    },
+    Punct {
+        ch: '!',
+        spacing: Alone,
+        span: $DIR/dollar-crate-issue-99035.rs:22:26: 22:27 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/dollar-crate-issue-99035.rs:22:27: 22:29 (#0),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: $DIR/dollar-crate-issue-99035.rs:22:29: 22:30 (#0),
+    },
+]

--- a/src/test/ui/proc-macro/dollar-crate.stdout
+++ b/src/test/ui/proc-macro/dollar-crate.stdout
@@ -2,239 +2,239 @@ PRINT-BANG INPUT (DISPLAY): struct M($crate :: S) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/dollar-crate.rs:20:17: 20:23 (#4),
+        span: $DIR/dollar-crate.rs:20:17: 20:23 (#7),
     },
     Ident {
         ident: "M",
-        span: $DIR/dollar-crate.rs:20:24: 20:25 (#4),
+        span: $DIR/dollar-crate.rs:20:24: 20:25 (#7),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/dollar-crate.rs:20:26: 20:32 (#4),
+                span: $DIR/dollar-crate.rs:20:26: 20:32 (#8),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/dollar-crate.rs:20:32: 20:34 (#4),
+                span: $DIR/dollar-crate.rs:20:32: 20:34 (#7),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/dollar-crate.rs:20:32: 20:34 (#4),
+                span: $DIR/dollar-crate.rs:20:32: 20:34 (#7),
             },
             Ident {
                 ident: "S",
-                span: $DIR/dollar-crate.rs:20:34: 20:35 (#4),
+                span: $DIR/dollar-crate.rs:20:34: 20:35 (#7),
             },
         ],
-        span: $DIR/dollar-crate.rs:20:25: 20:36 (#4),
+        span: $DIR/dollar-crate.rs:20:25: 20:36 (#7),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/dollar-crate.rs:20:36: 20:37 (#4),
+        span: $DIR/dollar-crate.rs:20:36: 20:37 (#7),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/dollar-crate.rs:24:13: 24:19 (#4),
+        span: $DIR/dollar-crate.rs:24:13: 24:19 (#7),
     },
     Ident {
         ident: "A",
-        span: $DIR/dollar-crate.rs:24:20: 24:21 (#4),
+        span: $DIR/dollar-crate.rs:24:20: 24:21 (#7),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/dollar-crate.rs:24:22: 24:28 (#4),
+                span: $DIR/dollar-crate.rs:24:22: 24:28 (#9),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/dollar-crate.rs:24:28: 24:30 (#4),
+                span: $DIR/dollar-crate.rs:24:28: 24:30 (#7),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/dollar-crate.rs:24:28: 24:30 (#4),
+                span: $DIR/dollar-crate.rs:24:28: 24:30 (#7),
             },
             Ident {
                 ident: "S",
-                span: $DIR/dollar-crate.rs:24:30: 24:31 (#4),
+                span: $DIR/dollar-crate.rs:24:30: 24:31 (#7),
             },
         ],
-        span: $DIR/dollar-crate.rs:24:21: 24:32 (#4),
+        span: $DIR/dollar-crate.rs:24:21: 24:32 (#7),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/dollar-crate.rs:24:32: 24:33 (#4),
+        span: $DIR/dollar-crate.rs:24:32: 24:33 (#7),
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D($crate :: S) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/dollar-crate.rs:27:13: 27:19 (#4),
+        span: $DIR/dollar-crate.rs:27:13: 27:19 (#7),
     },
     Ident {
         ident: "D",
-        span: $DIR/dollar-crate.rs:27:20: 27:21 (#4),
+        span: $DIR/dollar-crate.rs:27:20: 27:21 (#7),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/dollar-crate.rs:27:22: 27:28 (#4),
+                span: $DIR/dollar-crate.rs:27:22: 27:28 (#10),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/dollar-crate.rs:27:28: 27:30 (#4),
+                span: $DIR/dollar-crate.rs:27:28: 27:30 (#7),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/dollar-crate.rs:27:28: 27:30 (#4),
+                span: $DIR/dollar-crate.rs:27:28: 27:30 (#7),
             },
             Ident {
                 ident: "S",
-                span: $DIR/dollar-crate.rs:27:30: 27:31 (#4),
+                span: $DIR/dollar-crate.rs:27:30: 27:31 (#7),
             },
         ],
-        span: $DIR/dollar-crate.rs:27:21: 27:32 (#4),
+        span: $DIR/dollar-crate.rs:27:21: 27:32 (#7),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/dollar-crate.rs:27:32: 27:33 (#4),
+        span: $DIR/dollar-crate.rs:27:32: 27:33 (#7),
     },
 ]
 PRINT-BANG INPUT (DISPLAY): struct M($crate :: S) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#24),
     },
     Ident {
         ident: "M",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#24),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#25),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:30 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:30 (#24),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:30 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:30 (#24),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#24),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#24),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#24),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#24),
     },
     Ident {
         ident: "A",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#24),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#26),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:26 (#24),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:26 (#24),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#24),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#24),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#24),
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D($crate :: S) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#24),
     },
     Ident {
         ident: "D",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#24),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#27),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:26 (#24),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:26 (#24),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#24),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#24),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#24),
     },
 ]

--- a/src/test/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.stdout
@@ -1,6 +1,6 @@
-Def site: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#5)
-Input: TokenStream [Ident { ident: "$crate", span: $DIR/meta-macro-hygiene.rs:24:37: 24:43 (#4) }, Punct { ch: ':', spacing: Joint, span: $DIR/meta-macro-hygiene.rs:24:43: 24:45 (#4) }, Punct { ch: ':', spacing: Alone, span: $DIR/meta-macro-hygiene.rs:24:43: 24:45 (#4) }, Ident { ident: "dummy", span: $DIR/meta-macro-hygiene.rs:24:45: 24:50 (#4) }, Punct { ch: '!', spacing: Alone, span: $DIR/meta-macro-hygiene.rs:24:50: 24:51 (#4) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: $DIR/meta-macro-hygiene.rs:24:51: 24:53 (#4) }]
-Respanned: TokenStream [Ident { ident: "$crate", span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#5) }, Punct { ch: ':', spacing: Joint, span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#5) }, Punct { ch: ':', spacing: Alone, span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#5) }, Ident { ident: "dummy", span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#5) }, Punct { ch: '!', spacing: Alone, span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#5) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#5) }]
+Def site: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#7)
+Input: TokenStream [Ident { ident: "$crate", span: $DIR/meta-macro-hygiene.rs:24:37: 24:43 (#6) }, Punct { ch: ':', spacing: Joint, span: $DIR/meta-macro-hygiene.rs:24:43: 24:45 (#5) }, Punct { ch: ':', spacing: Alone, span: $DIR/meta-macro-hygiene.rs:24:43: 24:45 (#5) }, Ident { ident: "dummy", span: $DIR/meta-macro-hygiene.rs:24:45: 24:50 (#5) }, Punct { ch: '!', spacing: Alone, span: $DIR/meta-macro-hygiene.rs:24:50: 24:51 (#5) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: $DIR/meta-macro-hygiene.rs:24:51: 24:53 (#5) }]
+Respanned: TokenStream [Ident { ident: "$crate", span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#7) }, Punct { ch: ':', spacing: Joint, span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#7) }, Punct { ch: ':', spacing: Alone, span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#7) }, Ident { ident: "dummy", span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#7) }, Punct { ch: '!', spacing: Alone, span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#7) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: $DIR/auxiliary/make-macro.rs:7:9: 7:56 (#7) }]
 #![feature /* 0#0 */(prelude_import)]
 // aux-build:make-macro.rs
 // aux-build:meta-macro.rs
@@ -47,8 +47,9 @@ Expansions:
 crate0::{{expn0}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Root
 crate0::{{expn1}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: AstPass(StdImports)
 crate0::{{expn2}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Bang, "produce_it")
-crate0::{{expn3}}: parent: crate0::{{expn2}}, call_site_ctxt: #4, def_site_ctxt: #0, kind: Macro(Bang, "meta_macro::print_def_site")
-crate0::{{expn4}}: parent: crate0::{{expn3}}, call_site_ctxt: #5, def_site_ctxt: #0, kind: Macro(Bang, "$crate::dummy")
+crate0::{{expn3}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Root
+crate0::{{expn4}}: parent: crate0::{{expn2}}, call_site_ctxt: #5, def_site_ctxt: #0, kind: Macro(Bang, "meta_macro::print_def_site")
+crate0::{{expn5}}: parent: crate0::{{expn4}}, call_site_ctxt: #7, def_site_ctxt: #0, kind: Macro(Bang, "$crate::dummy")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Bang, "include")
@@ -59,11 +60,13 @@ SyntaxContexts:
 #1: parent: #0, outer_mark: (crate0::{{expn1}}, Opaque)
 #2: parent: #0, outer_mark: (crate0::{{expn1}}, Transparent)
 #3: parent: #0, outer_mark: (crate2::{{expn1}}, Opaque)
-#4: parent: #0, outer_mark: (crate0::{{expn2}}, SemiTransparent)
-#5: parent: #0, outer_mark: (crate0::{{expn3}}, Opaque)
-#6: parent: #4, outer_mark: (crate0::{{expn3}}, Transparent)
-#7: parent: #0, outer_mark: (crate0::{{expn3}}, SemiTransparent)
-#8: parent: #0, outer_mark: (crate0::{{expn4}}, Opaque)
-#9: parent: #5, outer_mark: (crate0::{{expn4}}, Transparent)
-#10: parent: #5, outer_mark: (crate0::{{expn4}}, SemiTransparent)
+#4: parent: #0, outer_mark: (crate0::{{expn3}}, Transparent)
+#5: parent: #0, outer_mark: (crate0::{{expn2}}, SemiTransparent)
+#6: parent: #4, outer_mark: (crate0::{{expn2}}, SemiTransparent)
+#7: parent: #0, outer_mark: (crate0::{{expn4}}, Opaque)
+#8: parent: #5, outer_mark: (crate0::{{expn4}}, Transparent)
+#9: parent: #0, outer_mark: (crate0::{{expn4}}, SemiTransparent)
+#10: parent: #0, outer_mark: (crate0::{{expn5}}, Opaque)
+#11: parent: #7, outer_mark: (crate0::{{expn5}}, Transparent)
+#12: parent: #7, outer_mark: (crate0::{{expn5}}, SemiTransparent)
 */


### PR DESCRIPTION
Fixes #99035. The glued `$crate` token now gets the resolution context of the local crate when gluing `$crate` into a single token. This is almost certainly what is intended by a macro author.

This does change the behavior of stable code. Specifically, previously `$crate` would resolve to the crate of the `crate` token, and if a macro uses a tt binder that expands to `$`, it is possible for it to replicate the behavior made much more accessible by `$$crate`.

However, this behavior really isn't all that desirable. If a `crate` token is passed in, it already resolves to its local crate, so turning it into a `$crate` token is a resolution no-op. If a `macro_rules!` definition wants a def-site `crate`, it can just write `$crate`. The current behavior of `$crate` becoming a def-site version of the `crate` token is not useful; `$crate` resolving to the gluing crate is.

Except... it looks like this is allowing proc-macro-hacked proc-macros to use `$crate` to refer to the declaration crate...