### PR TITLE
Forbid $crate in macro patterns

### DIFF
--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -221,6 +221,9 @@ fn parse_tree(
                     let (ident, is_raw) = token.ident().unwrap();
                     let span = ident.span.with_lo(span.lo());
                     if ident.name == kw::Crate && !is_raw {
+                        if parsing_patterns {
+                            span_dollar_dollar_or_metavar_in_the_lhs_err(sess, &token);
+                        }
                         TokenTree::token(token::Ident(kw::DollarCrate, is_raw), span)
                     } else {
                         TokenTree::MetaVar(span, ident)
@@ -359,6 +362,6 @@ fn span_dollar_dollar_or_metavar_in_the_lhs_err<'sess>(sess: &'sess ParseSess, t
         .span_err(token.span, &format!("unexpected token: {}", pprust::token_to_string(token)));
     sess.span_diagnostic.span_note_without_error(
         token.span,
-        "`$$` and meta-variable expressions are not allowed inside macro parameter definitions",
+        "`$$`, `$crate`, and meta-variable expressions are not allowed inside macro parameter definitions",
     );
 }

--- a/src/test/ui/macros/rfc-3086-metavar-expr/syntax-errors.rs
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/syntax-errors.rs
@@ -55,6 +55,12 @@ macro_rules! dollar_dollar_in_the_lhs {
     };
 }
 
+macro_rules! dollar_crate_in_the_lhs {
+    ( $crate $a:ident ) => {
+    //~^ ERROR unexpected token: crate
+    };
+}
+
 macro_rules! extra_garbage_after_metavar {
     ( $( $i:ident ),* ) => {
         ${count() a b c}

--- a/src/test/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -16,182 +16,194 @@ error: unexpected token: $
 LL |     ( $$ $a:ident ) => {
    |        ^
 
-note: `$$` and meta-variable expressions are not allowed inside macro parameter definitions
+note: `$$`, `$crate`, and meta-variable expressions are not allowed inside macro parameter definitions
   --> $DIR/syntax-errors.rs:53:8
    |
 LL |     ( $$ $a:ident ) => {
    |        ^
 
+error: unexpected token: crate
+  --> $DIR/syntax-errors.rs:59:8
+   |
+LL |     ( $crate $a:ident ) => {
+   |        ^^^^^
+
+note: `$$`, `$crate`, and meta-variable expressions are not allowed inside macro parameter definitions
+  --> $DIR/syntax-errors.rs:59:8
+   |
+LL |     ( $crate $a:ident ) => {
+   |        ^^^^^
+
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:60:19
+  --> $DIR/syntax-errors.rs:66:19
    |
 LL |         ${count() a b c}
    |                   ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:60:19
+  --> $DIR/syntax-errors.rs:66:19
    |
 LL |         ${count() a b c}
    |                   ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:63:19
+  --> $DIR/syntax-errors.rs:69:19
    |
 LL |         ${count(i a b c)}
    |                   ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:63:19
+  --> $DIR/syntax-errors.rs:69:19
    |
 LL |         ${count(i a b c)}
    |                   ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:65:22
+  --> $DIR/syntax-errors.rs:71:22
    |
 LL |         ${count(i, 1 a b c)}
    |                      ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:65:22
+  --> $DIR/syntax-errors.rs:71:22
    |
 LL |         ${count(i, 1 a b c)}
    |                      ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:67:20
+  --> $DIR/syntax-errors.rs:73:20
    |
 LL |         ${count(i) a b c}
    |                    ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:67:20
+  --> $DIR/syntax-errors.rs:73:20
    |
 LL |         ${count(i) a b c}
    |                    ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:70:21
+  --> $DIR/syntax-errors.rs:76:21
    |
 LL |         ${ignore(i) a b c}
    |                     ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:70:21
+  --> $DIR/syntax-errors.rs:76:21
    |
 LL |         ${ignore(i) a b c}
    |                     ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:72:20
+  --> $DIR/syntax-errors.rs:78:20
    |
 LL |         ${ignore(i a b c)}
    |                    ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:72:20
+  --> $DIR/syntax-errors.rs:78:20
    |
 LL |         ${ignore(i a b c)}
    |                    ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:75:19
+  --> $DIR/syntax-errors.rs:81:19
    |
 LL |         ${index() a b c}
    |                   ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:75:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:77:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:77:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:80:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:80:19
+  --> $DIR/syntax-errors.rs:81:19
    |
 LL |         ${index() a b c}
    |                   ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:82:19
+  --> $DIR/syntax-errors.rs:83:19
    |
 LL |         ${index(1 a b c)}
    |                   ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:82:19
+  --> $DIR/syntax-errors.rs:83:19
+   |
+LL |         ${index(1 a b c)}
+   |                   ^
+
+error: unexpected token: a
+  --> $DIR/syntax-errors.rs:86:19
+   |
+LL |         ${index() a b c}
+   |                   ^
+   |
+note: meta-variable expression must not have trailing tokens
+  --> $DIR/syntax-errors.rs:86:19
+   |
+LL |         ${index() a b c}
+   |                   ^
+
+error: unexpected token: a
+  --> $DIR/syntax-errors.rs:88:19
+   |
+LL |         ${index(1 a b c)}
+   |                   ^
+   |
+note: meta-variable expression must not have trailing tokens
+  --> $DIR/syntax-errors.rs:88:19
    |
 LL |         ${index(1 a b c)}
    |                   ^
 
 error: meta-variable expression depth must be a literal
-  --> $DIR/syntax-errors.rs:89:33
+  --> $DIR/syntax-errors.rs:95:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(IDX) } };
    |                                 ^^^^^
 
 error: unexpected token: {
-  --> $DIR/syntax-errors.rs:95:8
+  --> $DIR/syntax-errors.rs:101:8
    |
 LL |     ( ${ length() } ) => {
    |        ^^^^^^^^^^^^
 
-note: `$$` and meta-variable expressions are not allowed inside macro parameter definitions
-  --> $DIR/syntax-errors.rs:95:8
+note: `$$`, `$crate`, and meta-variable expressions are not allowed inside macro parameter definitions
+  --> $DIR/syntax-errors.rs:101:8
    |
 LL |     ( ${ length() } ) => {
    |        ^^^^^^^^^^^^
 
 error: expected one of: `*`, `+`, or `?`
-  --> $DIR/syntax-errors.rs:95:8
+  --> $DIR/syntax-errors.rs:101:8
    |
 LL |     ( ${ length() } ) => {
    |        ^^^^^^^^^^^^
 
 error: expected identifier
-  --> $DIR/syntax-errors.rs:102:33
+  --> $DIR/syntax-errors.rs:108:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ ignore() } };
    |                                 ^^^^^^
 
 error: only unsuffixes integer literals are supported in meta-variable expressions
-  --> $DIR/syntax-errors.rs:108:33
+  --> $DIR/syntax-errors.rs:114:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(1u32) } };
    |                                 ^^^^^
 
 error: meta-variable expression parameter must be wrapped in parentheses
-  --> $DIR/syntax-errors.rs:114:33
+  --> $DIR/syntax-errors.rs:120:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
    |                                 ^^^^^
 
 error: expected identifier
-  --> $DIR/syntax-errors.rs:120:31
+  --> $DIR/syntax-errors.rs:126:31
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };
    |                               ^^^^^^
 
 error: unrecognized meta-variable expression
-  --> $DIR/syntax-errors.rs:140:33
+  --> $DIR/syntax-errors.rs:146:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and length
@@ -231,7 +243,7 @@ LL |     ( $( $i:ident ),* ) => { count($i) };
    |                                    ^^
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:60:9
+  --> $DIR/syntax-errors.rs:66:9
    |
 LL |         ${count() a b c}
    |         ^ expected expression
@@ -242,7 +254,7 @@ LL |     extra_garbage_after_metavar!(a);
    = note: this error originates in the macro `extra_garbage_after_metavar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:89:30
+  --> $DIR/syntax-errors.rs:95:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(IDX) } };
    |                              ^ expected expression
@@ -253,7 +265,7 @@ LL |     metavar_depth_is_not_literal!(a);
    = note: this error originates in the macro `metavar_depth_is_not_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:102:30
+  --> $DIR/syntax-errors.rs:108:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ ignore() } };
    |                              ^ expected expression
@@ -264,7 +276,7 @@ LL |     metavar_token_without_ident!(a);
    = note: this error originates in the macro `metavar_token_without_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:108:30
+  --> $DIR/syntax-errors.rs:114:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(1u32) } };
    |                              ^ expected expression
@@ -275,7 +287,7 @@ LL |     metavar_with_literal_suffix!(a);
    = note: this error originates in the macro `metavar_with_literal_suffix` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:114:30
+  --> $DIR/syntax-errors.rs:120:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
    |                              ^ expected expression
@@ -286,7 +298,7 @@ LL |     metavar_without_parens!(a);
    = note: this error originates in the macro `metavar_without_parens` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:120:30
+  --> $DIR/syntax-errors.rs:126:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };
    |                              ^ expected expression
@@ -297,19 +309,19 @@ LL |     open_brackets_without_tokens!(a);
    = note: this error originates in the macro `open_brackets_without_tokens` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: variable `foo` is not recognized in meta-variable expression
-  --> $DIR/syntax-errors.rs:127:17
+  --> $DIR/syntax-errors.rs:133:17
    |
 LL |         ${count(foo)}
    |                 ^^^
 
 error: variable `bar` is not recognized in meta-variable expression
-  --> $DIR/syntax-errors.rs:134:18
+  --> $DIR/syntax-errors.rs:140:18
    |
 LL |         ${ignore(bar)}
    |                  ^^^
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:140:30
+  --> $DIR/syntax-errors.rs:146:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |                              ^ expected expression
@@ -375,11 +387,11 @@ LL |     no_curly__rhs_dollar__no_round!(a);
    = note: this error originates in the macro `no_curly__rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `a` in this scope
-  --> $DIR/syntax-errors.rs:153:37
+  --> $DIR/syntax-errors.rs:159:37
    |
 LL |     no_curly__rhs_dollar__no_round!(a);
    |                                     ^ not found in this scope
 
-error: aborting due to 40 previous errors
+error: aborting due to 41 previous errors
 
 For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes #99037. This currently implements a hard error because it was convenient to reuse the existing error for other disallowed metavars in the macro pattern, but should maybe be a forward-compat lint instead. Or maybe a clean crater run would justify just landing this directly as a hard error.