### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -1,7 +1,7 @@
 //! The entry point of the NLL borrow checker.
 
 use rustc_data_structures::vec_map::VecMap;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
 use rustc_infer::infer::InferCtxt;
 use rustc_middle::mir::{create_dump_file, dump_enabled, dump_mir, PassWhere};
@@ -44,7 +44,7 @@ pub type PoloniusOutput = Output<RustcFacts>;
 /// closure requirements to propagate, and any generated errors.
 pub(crate) struct NllOutput<'tcx> {
     pub regioncx: RegionInferenceContext<'tcx>,
-    pub opaque_type_values: VecMap<DefId, OpaqueHiddenType<'tcx>>,
+    pub opaque_type_values: VecMap<LocalDefId, OpaqueHiddenType<'tcx>>,
     pub polonius_input: Option<Box<AllFacts>>,
     pub polonius_output: Option<Rc<PoloniusOutput>>,
     pub opt_closure_req: Option<ClosureRegionRequirements<'tcx>>,
@@ -373,7 +373,7 @@ pub(super) fn dump_annotation<'a, 'tcx>(
     body: &Body<'tcx>,
     regioncx: &RegionInferenceContext<'tcx>,
     closure_region_requirements: &Option<ClosureRegionRequirements<'_>>,
-    opaque_type_values: &VecMap<DefId, OpaqueHiddenType<'tcx>>,
+    opaque_type_values: &VecMap<LocalDefId, OpaqueHiddenType<'tcx>>,
     errors: &mut crate::error::BorrowckErrors<'tcx>,
 ) {
     let tcx = infcx.tcx;

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -492,6 +492,7 @@ E0785: include_str!("./error_codes/E0785.md"),
 E0786: include_str!("./error_codes/E0786.md"),
 E0787: include_str!("./error_codes/E0787.md"),
 E0788: include_str!("./error_codes/E0788.md"),
+E0789: include_str!("./error_codes/E0789.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/compiler/rustc_error_codes/src/error_codes/E0283.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0283.md
@@ -3,48 +3,31 @@ An implementation cannot be chosen unambiguously because of lack of information.
 Erroneous code example:
 
 ```compile_fail,E0283
-trait Generator {
-    fn create() -> u32;
-}
+struct Foo;
 
-struct Impl;
-
-impl Generator for Impl {
-    fn create() -> u32 { 1 }
-}
-
-struct AnotherImpl;
-
-impl Generator for AnotherImpl {
-    fn create() -> u32 { 2 }
+impl Into<u32> for Foo {
+    fn into(self) -> u32 { 1 }
 }
 
 fn main() {
-    let cont: u32 = Generator::create();
-    // error, impossible to choose one of Generator trait implementation
-    // Should it be Impl or AnotherImpl, maybe something else?
+    let foo = Foo;
+    let bar: u32 = foo.into() * 1u32;
 }
 ```
 
 This error can be solved by adding type annotations that provide the missing
-information to the compiler. In this case, the solution is to use a concrete
-type:
+information to the compiler. In this case, the solution is to specify the
+fully-qualified method:
 
 ```
-trait Generator {
-    fn create() -> u32;
-}
+struct Foo;
 
-struct AnotherImpl;
-
-impl Generator for AnotherImpl {
-    fn create() -> u32 { 2 }
+impl Into<u32> for Foo {
+    fn into(self) -> u32 { 1 }
 }
 
 fn main() {
-    let gen1 = AnotherImpl::create();
-
-    // if there are multiple methods with same name (different traits)
-    let gen2 = <AnotherImpl as Generator>::create();
+    let foo = Foo;
+    let bar: u32 = <Foo as Into<u32>>::into(foo) * 1u32;
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0283.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0283.md
@@ -9,15 +9,13 @@ impl Into<u32> for Foo {
     fn into(self) -> u32 { 1 }
 }
 
-fn main() {
-    let foo = Foo;
-    let bar: u32 = foo.into() * 1u32;
-}
+let foo = Foo;
+let bar: u32 = foo.into() * 1u32;
 ```
 
 This error can be solved by adding type annotations that provide the missing
 information to the compiler. In this case, the solution is to specify the
-fully-qualified method:
+trait's type parameter:
 
 ```
 struct Foo;
@@ -26,8 +24,6 @@ impl Into<u32> for Foo {
     fn into(self) -> u32 { 1 }
 }
 
-fn main() {
-    let foo = Foo;
-    let bar: u32 = <Foo as Into<u32>>::into(foo) * 1u32;
-}
+let foo = Foo;
+let bar: u32 = Into::<u32>::into(foo) * 1u32;
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0789.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0789.md
@@ -1,0 +1,51 @@
+You need to specify a specific implementation of the trait in order to call the
+method.
+
+Erroneous code example:
+
+```compile_fail,E0789
+trait Generator {
+    fn create() -> u32;
+}
+
+struct Impl;
+
+impl Generator for Impl {
+    fn create() -> u32 { 1 }
+}
+
+struct AnotherImpl;
+
+impl Generator for AnotherImpl {
+    fn create() -> u32 { 2 }
+}
+
+fn main() {
+    let cont: u32 = Generator::create();
+    // error, impossible to choose one of Generator trait implementation
+    // Should it be Impl or AnotherImpl, maybe something else?
+}
+```
+
+This error can be solved by adding type annotations that provide the missing
+information to the compiler. In this case, the solution is to use a concrete
+type:
+
+```
+trait Generator {
+    fn create() -> u32;
+}
+
+struct AnotherImpl;
+
+impl Generator for AnotherImpl {
+    fn create() -> u32 { 2 }
+}
+
+fn main() {
+    let gen1 = AnotherImpl::create();
+
+    // if there are multiple methods with same name (different traits)
+    let gen2 = <AnotherImpl as Generator>::create();
+}
+```

--- a/compiler/rustc_error_codes/src/error_codes/E0789.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0789.md
@@ -20,11 +20,9 @@ impl Generator for AnotherImpl {
     fn create() -> u32 { 2 }
 }
 
-fn main() {
-    let cont: u32 = Generator::create();
-    // error, impossible to choose one of Generator trait implementation
-    // Should it be Impl or AnotherImpl, maybe something else?
-}
+let cont: u32 = Generator::create();
+// error, impossible to choose one of Generator trait implementation
+// Should it be Impl or AnotherImpl, maybe something else?
 ```
 
 This error can be solved by adding type annotations that provide the missing
@@ -42,10 +40,8 @@ impl Generator for AnotherImpl {
     fn create() -> u32 { 2 }
 }
 
-fn main() {
-    let gen1 = AnotherImpl::create();
+let gen1 = AnotherImpl::create();
 
-    // if there are multiple methods with same name (different traits)
-    let gen2 = <AnotherImpl as Generator>::create();
-}
+// if there are multiple methods with same name (different traits)
+let gen2 = <AnotherImpl as Generator>::create();
 ```

--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -247,11 +247,6 @@ lint-atomic-ordering-invalid = `{$method}`'s failure ordering may not be `Releas
     .label = invalid failure ordering
     .help = consider using `Acquire` or `Relaxed` failure ordering instead
 
-lint-atomic-ordering-invalid-fail-success = `{$method}`'s success ordering must be at least as strong as its failure ordering
-    .fail-label = `{$fail_ordering}` failure ordering
-    .success-label = `{$success_ordering}` success ordering
-    .suggestion = consider using `{$success_suggestion}` success ordering instead
-
 lint-unused-op = unused {$op} that must be used
     .label = the {$op} produces a value
     .suggestion = use `let _ = ...` to ignore the resulting value

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -399,11 +399,11 @@ pub trait Emitter {
     ) {
         // Check for spans in macros, before `fix_multispans_in_extern_macros`
         // has a chance to replace them.
-        let has_macro_spans = iter::once(&*span)
+        let has_macro_spans: Vec<_> = iter::once(&*span)
             .chain(children.iter().map(|child| &child.span))
             .flat_map(|span| span.primary_spans())
             .flat_map(|sp| sp.macro_backtrace())
-            .find_map(|expn_data| {
+            .filter_map(|expn_data| {
                 match expn_data.kind {
                     ExpnKind::Root => None,
 
@@ -413,7 +413,8 @@ pub trait Emitter {
 
                     ExpnKind::Macro(macro_kind, name) => Some((macro_kind, name)),
                 }
-            });
+            })
+            .collect();
 
         if !backtrace {
             self.fix_multispans_in_extern_macros(source_map, span, children);
@@ -422,11 +423,22 @@ pub trait Emitter {
         self.render_multispans_macro_backtrace(span, children, backtrace);
 
         if !backtrace {
-            if let Some((macro_kind, name)) = has_macro_spans {
-                let descr = macro_kind.descr();
+            if let Some((macro_kind, name)) = has_macro_spans.first() {
+                // Mark the actual macro this originates from
+                let and_then = if let Some((macro_kind, last_name)) = has_macro_spans.last()
+                    && last_name != name
+                {
+                    let descr = macro_kind.descr();
+                    format!(
+                        " which comes from the expansion of the {descr} `{last_name}`",
+                    )
+                } else {
+                    "".to_string()
+                };
 
+                let descr = macro_kind.descr();
                 let msg = format!(
-                    "this {level} originates in the {descr} `{name}` \
+                    "this {level} originates in the {descr} `{name}`{and_then} \
                     (in Nightly builds, run with -Z macro-backtrace for more info)",
                 );
 

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(drain_filter)]
 #![feature(backtrace)]
 #![feature(if_let_guard)]
+#![cfg_attr(bootstrap, feature(let_chains))]
 #![feature(let_else)]
 #![feature(never_type)]
 #![feature(adt_const_params)]

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -153,7 +153,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
             .opaque_type_storage
             .take_opaque_types()
             .into_iter()
-            .map(|(k, v)| (self.tcx.mk_opaque(k.def_id, k.substs), v.hidden_type.ty))
+            .map(|(k, v)| (self.tcx.mk_opaque(k.def_id.to_def_id(), k.substs), v.hidden_type.ty))
             .collect()
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -938,7 +938,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     #[instrument(skip(self), level = "debug")]
     pub fn member_constraint(
         &self,
-        opaque_type_def_id: DefId,
+        opaque_type_def_id: LocalDefId,
         definition_span: Span,
         hidden_ty: Ty<'tcx>,
         region: ty::Region<'tcx>,

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::intern::Interned;
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::undo_log::UndoLogs;
 use rustc_data_structures::unify as ut;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::infer::unify_key::{RegionVidKey, UnifiedRegion};
 use rustc_middle::ty::ReStatic;
@@ -533,7 +533,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
 
     pub fn member_constraint(
         &mut self,
-        opaque_type_def_id: DefId,
+        opaque_type_def_id: LocalDefId,
         definition_span: Span,
         hidden_ty: Ty<'tcx>,
         member_region: ty::Region<'tcx>,

--- a/compiler/rustc_middle/src/infer/mod.rs
+++ b/compiler/rustc_middle/src/infer/mod.rs
@@ -4,7 +4,7 @@ pub mod unify_key;
 use crate::ty::Region;
 use crate::ty::Ty;
 use rustc_data_structures::sync::Lrc;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::LocalDefId;
 use rustc_span::Span;
 
 /// Requires that `region` must be equal to one of the regions in `choice_regions`.
@@ -16,7 +16,7 @@ use rustc_span::Span;
 #[derive(Debug, Clone, HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct MemberConstraint<'tcx> {
     /// The `DefId` of the opaque type causing this constraint: used for error reporting.
-    pub opaque_type_def_id: DefId,
+    pub opaque_type_def_id: LocalDefId,
 
     /// The span where the hidden type was instantiated.
     pub definition_span: Span,

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -235,7 +235,7 @@ pub struct BorrowCheckResult<'tcx> {
     /// All the opaque types that are restricted to concrete types
     /// by this function. Unlike the value in `TypeckResults`, this has
     /// unerased regions.
-    pub concrete_opaque_types: VecMap<DefId, OpaqueHiddenType<'tcx>>,
+    pub concrete_opaque_types: VecMap<LocalDefId, OpaqueHiddenType<'tcx>>,
     pub closure_requirements: Option<ClosureRegionRequirements<'tcx>>,
     pub used_mut_upvars: SmallVec<[Field; 8]>,
     pub tainted_by_errors: Option<ErrorGuaranteed>,

--- a/compiler/rustc_middle/src/ty/closure.rs
+++ b/compiler/rustc_middle/src/ty/closure.rs
@@ -182,7 +182,11 @@ impl<'tcx> CapturedPlace<'tcx> {
                         .unwrap();
                     }
                     ty => {
-                        bug!("Unexpected type {:?} for `Field` projection", ty)
+                        span_bug!(
+                            self.get_capture_kind_span(tcx),
+                            "Unexpected type {:?} for `Field` projection",
+                            ty
+                        )
                     }
                 },
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -542,7 +542,7 @@ pub struct TypeckResults<'tcx> {
     /// even if they are only set in dead code (which doesn't show up in MIR).
     /// For type-alias-impl-trait, this map is only used to prevent query cycles,
     /// so the hidden types are all `None`.
-    pub concrete_opaque_types: VecMap<DefId, Option<Ty<'tcx>>>,
+    pub concrete_opaque_types: VecMap<LocalDefId, Option<Ty<'tcx>>>,
 
     /// Tracks the minimum captures required for a closure;
     /// see `MinCaptureInformationMap` for more details.

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1108,8 +1108,7 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, HashStable, TyEncodable, TyDecodable, Lift)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub struct OpaqueTypeKey<'tcx> {
-    // FIXME(oli-obk): make this a LocalDefId
-    pub def_id: DefId,
+    pub def_id: LocalDefId,
     pub substs: SubstsRef<'tcx>,
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1707,13 +1707,6 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
-    pub fn expect_opaque_type(self) -> ty::OpaqueTypeKey<'tcx> {
-        match *self.kind() {
-            Opaque(def_id, substs) => ty::OpaqueTypeKey { def_id, substs },
-            _ => bug!("`expect_opaque_type` called on non-opaque type: {}", self),
-        }
-    }
-
     pub fn simd_size_and_type(self, tcx: TyCtxt<'tcx>) -> (u64, Ty<'tcx>) {
         match self.kind() {
             Adt(def, substs) => {

--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -74,6 +74,10 @@ impl TraitImpls {
     pub fn blanket_impls(&self) -> &[DefId] {
         self.blanket_impls.as_slice()
     }
+
+    pub fn non_blanket_impls(&self) -> &FxIndexMap<SimplifiedType, Vec<DefId>> {
+        &self.non_blanket_impls
+    }
 }
 
 impl<'tcx> TraitDef {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2093,6 +2093,98 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                         );
                     }
                 }
+
+                if let (Some(body_id), Some(ty::subst::GenericArgKind::Type(_))) =
+                    (body_id, subst.map(|subst| subst.unpack()))
+                {
+                    struct FindExprBySpan<'hir> {
+                        span: Span,
+                        result: Option<&'hir hir::Expr<'hir>>,
+                    }
+
+                    impl<'v> hir::intravisit::Visitor<'v> for FindExprBySpan<'v> {
+                        fn visit_expr(&mut self, ex: &'v hir::Expr<'v>) {
+                            if self.span == ex.span {
+                                self.result = Some(ex);
+                            } else {
+                                hir::intravisit::walk_expr(self, ex);
+                            }
+                        }
+                    }
+
+                    let mut expr_finder = FindExprBySpan { span, result: None };
+
+                    expr_finder.visit_expr(&self.tcx.hir().body(body_id).value);
+
+                    if let Some(hir::Expr {
+                        kind: hir::ExprKind::Path(hir::QPath::Resolved(None, path)), .. }
+                    ) = expr_finder.result
+                        && let [
+                            ..,
+                            trait_path_segment @ hir::PathSegment {
+                                res: Some(rustc_hir::def::Res::Def(rustc_hir::def::DefKind::Trait, trait_id)),
+                                ..
+                            },
+                            hir::PathSegment {
+                                ident: assoc_item_name,
+                                res: Some(rustc_hir::def::Res::Def(_, item_id)),
+                                ..
+                            }
+                        ] = path.segments
+                        && data.trait_ref.def_id == *trait_id
+                        && self.tcx.trait_of_item(item_id) == Some(*trait_id)
+                        && !self.is_tainted_by_errors()
+                    {
+                        let (verb, noun) = match self.tcx.associated_item(item_id).kind {
+                            ty::AssocKind::Const => ("refer to the", "constant"),
+                            ty::AssocKind::Fn => ("call", "function"),
+                            ty::AssocKind::Type => ("refer to the", "type"), // this is already covered by E0223, but this single match arm doesn't hurt here
+                        };
+
+                        // Replace the more general E0283 with a more specific error
+                        err.cancel();
+                        err = self.tcx.sess.struct_span_err_with_code(
+                            span,
+                            &format!(
+                                "cannot {verb} associated {noun} on trait without specifying the corresponding `impl` type",
+                             ),
+                            rustc_errors::error_code!(E0789),
+                        );
+
+                        if let Some(local_def_id) = data.trait_ref.def_id.as_local()
+                            && let Some(hir::Node::Item(hir::Item { ident: trait_name, kind: hir::ItemKind::Trait(_, _, _, _, trait_item_refs), .. })) = self.tcx.hir().find_by_def_id(local_def_id)
+                            && let Some(method_ref) = trait_item_refs.iter().find(|item_ref| item_ref.ident == *assoc_item_name) {
+                            err.span_label(method_ref.span, format!("`{}::{}` defined here", trait_name, assoc_item_name));
+                        }
+
+                        err.span_label(span, format!("cannot {verb} associated {noun} of trait"));
+
+                        let trait_impls = self.tcx.trait_impls_of(data.trait_ref.def_id);
+
+                        if trait_impls.blanket_impls().is_empty()
+                            && let Some((impl_ty, _)) = trait_impls.non_blanket_impls().iter().next()
+                            && let Some(impl_def_id) = impl_ty.def() {
+                            let message = if trait_impls.non_blanket_impls().len() == 1 {
+                                "use the fully-qualified path to the only available implementation".to_string()
+                            } else {
+                                format!(
+                                    "use a fully-qualified path to a specific available implementation ({} found)",
+                                    trait_impls.non_blanket_impls().len()
+                                )
+                            };
+
+                            err.multipart_suggestion(
+                                message,
+                                vec![
+                                    (trait_path_segment.ident.span.shrink_to_lo(), format!("<{} as ", self.tcx.def_path(impl_def_id).to_string_no_crate_verbose())),
+                                    (trait_path_segment.ident.span.shrink_to_hi(), format!(">"))
+                                ],
+                                Applicability::MaybeIncorrect
+                            );
+                        }
+                    }
+                };
+
                 err
             }
 

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -295,6 +295,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
     /// This is called much less often than `needs_process_obligation`, so we
     /// never inline it.
     #[inline(never)]
+    #[instrument(level = "debug", skip(self, pending_obligation))]
     fn process_obligation(
         &mut self,
         pending_obligation: &mut PendingPredicateObligation<'tcx>,
@@ -303,7 +304,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
 
         let obligation = &mut pending_obligation.obligation;
 
-        debug!(?obligation, "process_obligation pre-resolve");
+        debug!(?obligation, "pre-resolve");
 
         if obligation.predicate.has_infer_types_or_consts() {
             obligation.predicate =
@@ -311,8 +312,6 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
         }
 
         let obligation = &pending_obligation.obligation;
-
-        debug!(?obligation, ?obligation.cause, "process_obligation");
 
         let infcx = self.selcx.infcx();
 

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -1513,7 +1513,7 @@ pub fn check_type_bounds<'tcx>(
                         value.hidden_type.span,
                         tcx.hir().local_def_id_to_hir_id(impl_ty.def_id.expect_local()),
                     ),
-                    tcx.mk_opaque(key.def_id, key.substs),
+                    tcx.mk_opaque(key.def_id.to_def_id(), key.substs),
                     value.hidden_type.ty,
                     TypeError::Mismatch,
                 )

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -763,12 +763,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // src/test/ui/impl-trait/hidden-type-is-opaque-2.rs for examples that hit this path.
         if formal_ret.has_infer_types() {
             for ty in ret_ty.walk() {
-                if let ty::subst::GenericArgKind::Type(ty) = ty.unpack() {
-                    if let ty::Opaque(def_id, _) = *ty.kind() {
-                        if self.infcx.opaque_type_origin(def_id, DUMMY_SP).is_some() {
-                            return None;
-                        }
-                    }
+                if let ty::subst::GenericArgKind::Type(ty) = ty.unpack()
+                    && let ty::Opaque(def_id, _) = *ty.kind()
+                    && let Some(def_id) = def_id.as_local()
+                    && self.infcx.opaque_type_origin(def_id, DUMMY_SP).is_some() {
+                    return None;
                 }
             }
         }

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -4,6 +4,7 @@
 
 use crate::check::FnCtxt;
 
+use hir::def_id::LocalDefId;
 use rustc_data_structures::stable_map::FxHashMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
@@ -509,13 +510,13 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 hir::OpaqueTyOrigin::FnReturn(_) | hir::OpaqueTyOrigin::AsyncFn(_) => {
                     let ty = self.resolve(decl.hidden_type.ty, &decl.hidden_type.span);
                     struct RecursionChecker {
-                        def_id: DefId,
+                        def_id: LocalDefId,
                     }
                     impl<'tcx> ty::TypeVisitor<'tcx> for RecursionChecker {
                         type BreakTy = ();
                         fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
                             if let ty::Opaque(def_id, _) = *t.kind() {
-                                if def_id == self.def_id {
+                                if def_id == self.def_id.to_def_id() {
                                     return ControlFlow::Break(());
                                 }
                             }

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -33,7 +33,7 @@ where
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
         if unlikely(self.n > 0) {
-            self.iter.nth(crate::mem::take(&mut self.n) - 1);
+            self.iter.nth(crate::mem::take(&mut self.n) - 1)?;
         }
         self.iter.next()
     }

--- a/library/core/tests/iter/adapters/skip.rs
+++ b/library/core/tests/iter/adapters/skip.rs
@@ -196,5 +196,8 @@ fn test_skip_nth_back() {
 #[test]
 fn test_skip_non_fused() {
     let non_fused = Unfuse::new(0..10);
+
+    // `Skip` would previously exhaust the iterator in this `next` call and then erroneously try to
+    // advance it further. `Unfuse` tests that this doesn't happen by panicking in that scenario.
     let _ = non_fused.skip(20).next();
 }

--- a/library/core/tests/iter/adapters/skip.rs
+++ b/library/core/tests/iter/adapters/skip.rs
@@ -1,5 +1,7 @@
 use core::iter::*;
 
+use super::Unfuse;
+
 #[test]
 fn test_iterator_skip() {
     let xs = [0, 1, 2, 3, 5, 13, 15, 16, 17, 19, 20, 30];
@@ -189,4 +191,10 @@ fn test_skip_nth_back() {
     let mut it = xs.iter();
     it.by_ref().skip(2).nth_back(10);
     assert_eq!(it.next_back(), Some(&1));
+}
+
+#[test]
+fn test_skip_non_fused() {
+    let non_fused = Unfuse::new(0..10);
+    let _ = non_fused.skip(20).next();
 }

--- a/src/test/debuginfo/basic-types-globals-lto.rs
+++ b/src/test/debuginfo/basic-types-globals-lto.rs
@@ -14,7 +14,7 @@
 // gdbr-command:print I
 // gdb-check:$2 = -1
 // gdbg-command:print 'basic_types_globals::C'
-// gdbr-command:print C
+// gdbr-command:print/d C
 // gdbg-check:$3 = 97
 // gdbr-check:$3 = 97
 // gdbg-command:print/d 'basic_types_globals::I8'

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -13,7 +13,7 @@
 // gdbr-command:print I
 // gdb-check:$2 = -1
 // gdbg-command:print 'basic_types_globals::C'
-// gdbr-command:print C
+// gdbr-command:print/d C
 // gdbg-check:$3 = 97
 // gdbr-check:$3 = 97
 // gdbg-command:print/d 'basic_types_globals::I8'

--- a/src/test/ui/associated-consts/issue-63496.rs
+++ b/src/test/ui/associated-consts/issue-63496.rs
@@ -2,8 +2,8 @@ trait A {
     const C: usize;
 
     fn f() -> ([u8; A::C], [u8; A::C]);
-    //~^ ERROR: type annotations needed
-    //~| ERROR: type annotations needed
+    //~^ ERROR: E0789
+    //~| ERROR: E0789
 }
 
 fn main() {}

--- a/src/test/ui/associated-consts/issue-63496.stderr
+++ b/src/test/ui/associated-consts/issue-63496.stderr
@@ -1,27 +1,21 @@
-error[E0283]: type annotations needed
+error[E0789]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
   --> $DIR/issue-63496.rs:4:21
    |
+LL |     const C: usize;
+   |     --------------- `A::C` defined here
+LL |
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
-   |                     ^^^^
-   |                     |
-   |                     cannot infer type
-   |                     help: use the fully qualified path to an implementation: `<Type as A>::C`
-   |
-   = note: cannot satisfy `_: A`
-   = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+   |                     ^^^^ cannot refer to the associated constant of trait
 
-error[E0283]: type annotations needed
+error[E0789]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
   --> $DIR/issue-63496.rs:4:33
    |
+LL |     const C: usize;
+   |     --------------- `A::C` defined here
+LL |
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
-   |                                 ^^^^
-   |                                 |
-   |                                 cannot infer type
-   |                                 help: use the fully qualified path to an implementation: `<Type as A>::C`
-   |
-   = note: cannot satisfy `_: A`
-   = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+   |                                 ^^^^ cannot refer to the associated constant of trait
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0789`.

--- a/src/test/ui/associated-item/issue-48027.rs
+++ b/src/test/ui/associated-item/issue-48027.rs
@@ -1,6 +1,6 @@
 trait Bar {
     const X: usize;
-    fn return_n(&self) -> [u8; Bar::X]; //~ ERROR: type annotations needed
+    fn return_n(&self) -> [u8; Bar::X]; //~ ERROR: E0789
 }
 
 impl dyn Bar {} //~ ERROR: the trait `Bar` cannot be made into an object

--- a/src/test/ui/associated-item/issue-48027.stderr
+++ b/src/test/ui/associated-item/issue-48027.stderr
@@ -13,19 +13,15 @@ LL |     const X: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `X` to another trait
 
-error[E0283]: type annotations needed
+error[E0789]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
   --> $DIR/issue-48027.rs:3:32
    |
+LL |     const X: usize;
+   |     --------------- `Bar::X` defined here
 LL |     fn return_n(&self) -> [u8; Bar::X];
-   |                                ^^^^^^
-   |                                |
-   |                                cannot infer type
-   |                                help: use the fully qualified path to an implementation: `<Type as Bar>::X`
-   |
-   = note: cannot satisfy `_: Bar`
-   = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+   |                                ^^^^^^ cannot refer to the associated constant of trait
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0038, E0283.
+Some errors have detailed explanations: E0038, E0789.
 For more information about an error, try `rustc --explain E0038`.

--- a/src/test/ui/associated-types/associated-types-unconstrained.rs
+++ b/src/test/ui/associated-types/associated-types-unconstrained.rs
@@ -12,5 +12,5 @@ impl Foo for isize {
 
 pub fn main() {
     let x: isize = Foo::bar();
-    //~^ ERROR type annotations needed
+    //~^ ERROR E0789
 }

--- a/src/test/ui/associated-types/associated-types-unconstrained.stderr
+++ b/src/test/ui/associated-types/associated-types-unconstrained.stderr
@@ -1,11 +1,12 @@
-error[E0283]: type annotations needed
+error[E0789]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/associated-types-unconstrained.rs:14:20
    |
+LL |     fn bar() -> isize;
+   |     ------------------ `Foo::bar` defined here
+...
 LL |     let x: isize = Foo::bar();
-   |                    ^^^^^^^^ cannot infer type
-   |
-   = note: cannot satisfy `_: Foo`
+   |                    ^^^^^^^^ cannot call associated function of trait
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0789`.

--- a/src/test/ui/borrowck/borrowck-and-init.stderr
+++ b/src/test/ui/borrowck/borrowck-and-init.stderr
@@ -9,7 +9,7 @@ LL |     println!("{}", false && { i = 5; true });
 LL |     println!("{}", i);
    |                    ^ `i` used here but it is possibly-uninitialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-break-uninit-2.stderr
+++ b/src/test/ui/borrowck/borrowck-break-uninit-2.stderr
@@ -7,7 +7,7 @@ LL |     let x: isize;
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-break-uninit.stderr
+++ b/src/test/ui/borrowck/borrowck-break-uninit.stderr
@@ -7,7 +7,7 @@ LL |     let x: isize;
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-or-init.stderr
+++ b/src/test/ui/borrowck/borrowck-or-init.stderr
@@ -9,7 +9,7 @@ LL |     println!("{}", false || { i = 5; true });
 LL |     println!("{}", i);
    |                    ^ `i` used here but it is possibly-uninitialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-while-break.stderr
+++ b/src/test/ui/borrowck/borrowck-while-break.stderr
@@ -9,7 +9,7 @@ LL |     while cond {
 LL |     println!("{}", v);
    |                    ^ `v` used here but it is possibly-uninitialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-24267-flow-exit.stderr
+++ b/src/test/ui/borrowck/issue-24267-flow-exit.stderr
@@ -7,7 +7,7 @@ LL |     loop { x = break; }
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/issue-24267-flow-exit.rs:18:20
@@ -18,7 +18,7 @@ LL |     for _ in 0..10 { x = continue; }
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/issue-64453.stderr
+++ b/src/test/ui/borrowck/issue-64453.stderr
@@ -5,7 +5,7 @@ LL | static settings_dir: String = format!("");
    |                               ^^^^^^^^^^^
    |
    = help: add `#![feature(const_fmt_arguments_new)]` to the crate attributes to enable
-   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const fn `format` in statics
   --> $DIR/issue-64453.rs:4:31

--- a/src/test/ui/borrowck/issue-81899.stderr
+++ b/src/test/ui/borrowck/issue-81899.stderr
@@ -10,7 +10,7 @@ LL |     panic!()
    |     the evaluated program panicked at 'explicit panic', $DIR/issue-81899.rs:12:5
    |     inside `f::<[closure@$DIR/issue-81899.rs:4:31: 4:34]>` at $SRC_DIR/std/src/panic.rs:LL:COL
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/issue-81899.rs:4:23

--- a/src/test/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/src/test/ui/borrowck/issue-88434-minimal-example.stderr
@@ -10,7 +10,7 @@ LL |     panic!()
    |     the evaluated program panicked at 'explicit panic', $DIR/issue-88434-minimal-example.rs:11:5
    |     inside `f::<[closure@$DIR/issue-88434-minimal-example.rs:3:25: 3:28]>` at $SRC_DIR/std/src/panic.rs:LL:COL
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/issue-88434-minimal-example.rs:3:21

--- a/src/test/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/src/test/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -10,7 +10,7 @@ LL |     panic!()
    |     the evaluated program panicked at 'explicit panic', $DIR/issue-88434-removal-index-should-be-less.rs:11:5
    |     inside `f::<[closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31: 3:34]>` at $SRC_DIR/std/src/panic.rs:LL:COL
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/issue-88434-removal-index-should-be-less.rs:3:23

--- a/src/test/ui/borrowck/move-error-snippets.stderr
+++ b/src/test/ui/borrowck/move-error-snippets.stderr
@@ -12,7 +12,7 @@ LL |         let a = $c;
 LL | sss!();
    | ------ in this macro invocation
    |
-   = note: this error originates in the macro `aaa` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `aaa` which comes from the expansion of the macro `sss` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/arrays.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/arrays.stderr
@@ -82,7 +82,7 @@ LL |     println!("{}", arr[3]);
 LL |     c();
    |     - mutable borrow later used here
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0502]: cannot borrow `arr` as immutable because it is also borrowed as mutable
   --> $DIR/arrays.rs:73:24

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/box.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/box.stderr
@@ -26,7 +26,7 @@ LL |
 LL |     c();
    |     - mutable borrow later used here
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0506]: cannot assign to `e.0.0.m.x` because it is borrowed
   --> $DIR/box.rs:55:5

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -9,7 +9,7 @@ LL |         println!("{}", foo.x);
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 
@@ -25,5 +25,5 @@ LL |         println!("{}", foo.x);
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
@@ -14,7 +14,7 @@ LL |
 LL |     c();
    |     - mutable borrow later used here
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -4,7 +4,7 @@ error: requires at least a format string argument
 LL |     format!();
    |     ^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `,`, found `1`
   --> $DIR/bad-format-args.rs:3:16

--- a/src/test/ui/codemap_tests/tab_3.stderr
+++ b/src/test/ui/codemap_tests/tab_3.stderr
@@ -14,7 +14,7 @@ note: this function takes ownership of the receiver `self`, which moves `some_ve
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/src/test/ui/consts/const-eval/conditional_array_execution.stderr
@@ -26,7 +26,7 @@ LL |     println!("{}", FOO);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error; 2 warnings emitted
 
@@ -60,5 +60,5 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/const_panic.stderr
+++ b/src/test/ui/consts/const-eval/const_panic.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Z: () = std::panic!("cheese");
    |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:6:15
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:9:16
@@ -12,7 +12,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Z2: () = std::panic!();
    |                ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:9:16
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:12:15
@@ -20,7 +20,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Y: () = std::unreachable!();
    |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:12:15
    |
-   = note: this error originates in the macro `$crate::panic::unreachable_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:15:15
@@ -36,7 +36,7 @@ error[E0080]: evaluation of constant value failed
 LL | const W: () = std::panic!(MSG);
    |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:18:15
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:21:16
@@ -44,7 +44,7 @@ error[E0080]: evaluation of constant value failed
 LL | const W2: () = std::panic!("{}", MSG);
    |                ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:21:16
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:24:20
@@ -52,7 +52,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Z_CORE: () = core::panic!("cheese");
    |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:24:20
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:27:21
@@ -60,7 +60,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Z2_CORE: () = core::panic!();
    |                     ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:27:21
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:30:20
@@ -68,7 +68,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Y_CORE: () = core::unreachable!();
    |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:30:20
    |
-   = note: this error originates in the macro `$crate::panic::unreachable_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:33:20
@@ -84,7 +84,7 @@ error[E0080]: evaluation of constant value failed
 LL | const W_CORE: () = core::panic!(MSG);
    |                    ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:36:20
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:39:21
@@ -92,7 +92,7 @@ error[E0080]: evaluation of constant value failed
 LL | const W2_CORE: () = core::panic!("{}", MSG);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:39:21
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/consts/const-eval/const_panic_2021.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_2021.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation of constant value failed
 LL | const A: () = std::panic!("blåhaj");
    |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'blåhaj', $DIR/const_panic_2021.rs:6:15
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:9:15
@@ -12,7 +12,7 @@ error[E0080]: evaluation of constant value failed
 LL | const B: () = std::panic!();
    |               ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:9:15
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:12:15
@@ -20,7 +20,7 @@ error[E0080]: evaluation of constant value failed
 LL | const C: () = std::unreachable!();
    |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:12:15
    |
-   = note: this error originates in the macro `$crate::panic::unreachable_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:15:15
@@ -36,7 +36,7 @@ error[E0080]: evaluation of constant value failed
 LL | const E: () = std::panic!("{}", MSG);
    |               ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:18:15
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:21:20
@@ -44,7 +44,7 @@ error[E0080]: evaluation of constant value failed
 LL | const A_CORE: () = core::panic!("shark");
    |                    ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'shark', $DIR/const_panic_2021.rs:21:20
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:24:20
@@ -52,7 +52,7 @@ error[E0080]: evaluation of constant value failed
 LL | const B_CORE: () = core::panic!();
    |                    ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:24:20
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:27:20
@@ -60,7 +60,7 @@ error[E0080]: evaluation of constant value failed
 LL | const C_CORE: () = core::unreachable!();
    |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:27:20
    |
-   = note: this error originates in the macro `$crate::panic::unreachable_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:30:20
@@ -76,7 +76,7 @@ error[E0080]: evaluation of constant value failed
 LL | const E_CORE: () = core::panic!("{}", MSG);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:33:20
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Z: () = panic!("cheese");
    |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:8:15
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:11:15
@@ -12,7 +12,7 @@ error[E0080]: evaluation of constant value failed
 LL | const Y: () = unreachable!();
    |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:11:15
    |
-   = note: this error originates in the macro `$crate::panic::unreachable_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:14:15

--- a/src/test/ui/consts/const-eval/format.stderr
+++ b/src/test/ui/consts/const-eval/format.stderr
@@ -5,7 +5,7 @@ LL |     panic!("{:?}", 0);
    |                    ^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `$crate::const_format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const formatting macro in constant functions
   --> $DIR/format.rs:11:22
@@ -14,7 +14,7 @@ LL |     println!("{:?}", 0);
    |                      ^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `Arguments::<'a>::new_v1` is not yet stable as a const fn
   --> $DIR/format.rs:11:5
@@ -23,7 +23,7 @@ LL |     println!("{:?}", 0);
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(const_fmt_arguments_new)]` to the crate attributes to enable
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const fn `_print` in constant functions
   --> $DIR/format.rs:11:5
@@ -52,7 +52,7 @@ LL |     panic!("{:?}", 0);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in the macro `$crate::const_format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: erroneous constant used
   --> $DIR/format.rs:11:14
@@ -71,7 +71,7 @@ LL |     println!("{:?}", 0);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 
@@ -97,7 +97,7 @@ LL |     panic!("{:?}", 0);
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in the macro `$crate::const_format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 error: erroneous constant used
@@ -120,5 +120,5 @@ LL |     println!("{:?}", 0);
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/issue-43197.stderr
+++ b/src/test/ui/consts/const-eval/issue-43197.stderr
@@ -35,7 +35,7 @@ LL |     println!("{} {}", X, Y);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-43197.rs:16:26
@@ -51,7 +51,7 @@ LL |     println!("{} {}", X, Y);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors; 4 warnings emitted
 
@@ -100,7 +100,7 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 warning: erroneous constant used
@@ -116,5 +116,5 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/issue-44578.stderr
+++ b/src/test/ui/consts/const-eval/issue-44578.stderr
@@ -36,5 +36,5 @@ LL | #![allow(const_err)]
    |          ^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/issue-85907.stderr
+++ b/src/test/ui/consts/const-eval/issue-85907.stderr
@@ -4,7 +4,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL |     panic!(123);
    |     ^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation of constant value failed
 LL |     const VOID: ! = panic!();
    |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:10:21
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
   --> $DIR/panic-assoc-never-type.rs:15:13

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation of constant value failed
 LL | const VOID: ! = panic!();
    |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:5:17
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/unwind-abort.stderr
+++ b/src/test/ui/consts/const-eval/unwind-abort.stderr
@@ -10,7 +10,7 @@ LL |     panic!()
 LL | const _: () = foo();
    |               ----- inside `_` at $DIR/unwind-abort.rs:7:15
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-float-bits-reject-conv.stderr
+++ b/src/test/ui/consts/const-float-bits-reject-conv.stderr
@@ -25,7 +25,7 @@ LL |     called_in_const.call_once(arg)
 LL |     const MASKED_NAN1: u32 = f32::NAN.to_bits() ^ 0x002A_AAAA;
    |                              ------------------ inside `f32::MASKED_NAN1` at $DIR/const-float-bits-reject-conv.rs:27:30
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/num/f32.rs:LL:COL
@@ -54,7 +54,7 @@ LL |     called_in_const.call_once(arg)
 LL |     const MASKED_NAN2: u32 = f32::NAN.to_bits() ^ 0x0055_5555;
    |                              ------------------ inside `f32::MASKED_NAN2` at $DIR/const-float-bits-reject-conv.rs:28:30
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const-float-bits-reject-conv.rs:30:34
@@ -132,7 +132,7 @@ LL |     called_in_const.call_once(arg)
 LL |     const MASKED_NAN1: u64 = f64::NAN.to_bits() ^ 0x000A_AAAA_AAAA_AAAA;
    |                              ------------------ inside `f64::MASKED_NAN1` at $DIR/const-float-bits-reject-conv.rs:54:30
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/num/f64.rs:LL:COL
@@ -161,7 +161,7 @@ LL |     called_in_const.call_once(arg)
 LL |     const MASKED_NAN2: u64 = f64::NAN.to_bits() ^ 0x0005_5555_5555_5555;
    |                              ------------------ inside `f64::MASKED_NAN2` at $DIR/const-float-bits-reject-conv.rs:55:30
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const-float-bits-reject-conv.rs:57:34

--- a/src/test/ui/consts/issue-32829.stderr
+++ b/src/test/ui/consts/issue-32829.stderr
@@ -4,7 +4,7 @@ error[E0080]: could not evaluate static initializer
 LL | static S : u64 = { { panic!("foo"); 0 } };
    |                      ^^^^^^^^^^^^^ the evaluated program panicked at 'foo', $DIR/issue-32829.rs:1:22
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-66693-panic-in-array-len.stderr
+++ b/src/test/ui/consts/issue-66693-panic-in-array-len.stderr
@@ -4,7 +4,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL |     let _ = [0i32; panic!(2f32)];
    |                    ^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693-panic-in-array-len.rs:10:21
@@ -12,7 +12,7 @@ error[E0080]: evaluation of constant value failed
 LL |     let _ = [false; panic!()];
    |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693-panic-in-array-len.rs:10:21
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/issue-66693.stderr
+++ b/src/test/ui/consts/issue-66693.stderr
@@ -4,7 +4,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL | const _: () = panic!(1);
    |               ^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:7:19
@@ -12,7 +12,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL | static _FOO: () = panic!(true);
    |                   ^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:11:5
@@ -20,7 +20,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL |     panic!(&1);
    |     ^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: erroneous constant used
   --> $DIR/issue-66693.rs:11:12

--- a/src/test/ui/consts/issue-76064.stderr
+++ b/src/test/ui/consts/issue-76064.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation of constant value failed
 LL | struct Bug([u8; panic!("panic")]);
    |                 ^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic', $DIR/issue-76064.rs:1:17
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
+++ b/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
@@ -4,7 +4,7 @@ error: 1 positional argument in format string, but no arguments were given
 LL |     myprintln!("{}");
    |     ^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat` which comes from the expansion of the macro `myprintln` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0283.rs
+++ b/src/test/ui/error-codes/E0283.rs
@@ -27,7 +27,7 @@ impl Generator for AnotherImpl {
 }
 
 fn main() {
-    let cont: u32 = Generator::create(); //~ ERROR E0283
+    let cont: u32 = Generator::create(); //~ ERROR E0789
 }
 
 fn buzz() {

--- a/src/test/ui/error-codes/E0283.stderr
+++ b/src/test/ui/error-codes/E0283.stderr
@@ -1,10 +1,16 @@
-error[E0283]: type annotations needed
+error[E0789]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/E0283.rs:30:21
    |
+LL |     fn create() -> u32;
+   |     ------------------- `Generator::create` defined here
+...
 LL |     let cont: u32 = Generator::create();
-   |                     ^^^^^^^^^^^^^^^^^ cannot infer type
+   |                     ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
-   = note: cannot satisfy `_: Generator`
+help: use a fully-qualified path to a specific available implementation (2 found)
+   |
+LL |     let cont: u32 = <::Impl as Generator>::create();
+   |                     ++++++++++          +
 
 error[E0283]: type annotations needed
   --> $DIR/E0283.rs:35:24
@@ -27,4 +33,5 @@ LL |     let bar = <Impl as Into<T>>::into(foo_impl) * 1u32;
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0283`.
+Some errors have detailed explanations: E0283, E0789.
+For more information about an error, try `rustc --explain E0283`.

--- a/src/test/ui/error-codes/E0789.rs
+++ b/src/test/ui/error-codes/E0789.rs
@@ -1,0 +1,53 @@
+mod inner {
+    pub trait MyTrait {
+        const MY_ASSOC_CONST: ();
+
+        fn my_fn();
+    }
+
+    pub struct MyStruct;
+
+    impl MyTrait for MyStruct {
+        const MY_ASSOC_CONST: () = ();
+
+        fn my_fn() {}
+    }
+
+    fn call() {
+        MyTrait::my_fn(); //~ ERROR E0789
+    }
+
+    fn use_const() {
+        let _ = MyTrait::MY_ASSOC_CONST; //~ ERROR E0789
+    }
+}
+
+fn call_inner() {
+    inner::MyTrait::my_fn(); //~ ERROR E0789
+}
+
+fn use_const_inner() {
+    let _ = inner::MyTrait::MY_ASSOC_CONST; //~ ERROR E0789
+}
+
+trait MyTrait2 {
+    fn my_fn();
+}
+
+struct Impl1;
+
+impl MyTrait2 for Impl1 {
+    fn my_fn() {}
+}
+
+struct Impl2;
+
+impl MyTrait2 for Impl2 {
+    fn my_fn() {}
+}
+
+fn call_multiple_impls() {
+    MyTrait2::my_fn(); //~ ERROR E0789
+}
+
+fn main() {}

--- a/src/test/ui/error-codes/E0789.stderr
+++ b/src/test/ui/error-codes/E0789.stderr
@@ -1,0 +1,73 @@
+error[E0789]: cannot call associated function on trait without specifying the corresponding `impl` type
+  --> $DIR/E0789.rs:17:9
+   |
+LL |         fn my_fn();
+   |         ----------- `MyTrait::my_fn` defined here
+...
+LL |         MyTrait::my_fn();
+   |         ^^^^^^^^^^^^^^ cannot call associated function of trait
+   |
+help: use the fully-qualified path to the only available implementation
+   |
+LL |         <::inner::MyStruct as MyTrait>::my_fn();
+   |         +++++++++++++++++++++        +
+
+error[E0789]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
+  --> $DIR/E0789.rs:21:17
+   |
+LL |         const MY_ASSOC_CONST: ();
+   |         ------------------------- `MyTrait::MY_ASSOC_CONST` defined here
+...
+LL |         let _ = MyTrait::MY_ASSOC_CONST;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ cannot refer to the associated constant of trait
+   |
+help: use the fully-qualified path to the only available implementation
+   |
+LL |         let _ = <::inner::MyStruct as MyTrait>::MY_ASSOC_CONST;
+   |                 +++++++++++++++++++++        +
+
+error[E0789]: cannot call associated function on trait without specifying the corresponding `impl` type
+  --> $DIR/E0789.rs:26:5
+   |
+LL |         fn my_fn();
+   |         ----------- `MyTrait::my_fn` defined here
+...
+LL |     inner::MyTrait::my_fn();
+   |     ^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |
+help: use the fully-qualified path to the only available implementation
+   |
+LL |     inner::<::inner::MyStruct as MyTrait>::my_fn();
+   |            +++++++++++++++++++++        +
+
+error[E0789]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
+  --> $DIR/E0789.rs:30:13
+   |
+LL |         const MY_ASSOC_CONST: ();
+   |         ------------------------- `MyTrait::MY_ASSOC_CONST` defined here
+...
+LL |     let _ = inner::MyTrait::MY_ASSOC_CONST;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot refer to the associated constant of trait
+   |
+help: use the fully-qualified path to the only available implementation
+   |
+LL |     let _ = inner::<::inner::MyStruct as MyTrait>::MY_ASSOC_CONST;
+   |                    +++++++++++++++++++++        +
+
+error[E0789]: cannot call associated function on trait without specifying the corresponding `impl` type
+  --> $DIR/E0789.rs:50:5
+   |
+LL |     fn my_fn();
+   |     ----------- `MyTrait2::my_fn` defined here
+...
+LL |     MyTrait2::my_fn();
+   |     ^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |
+help: use a fully-qualified path to a specific available implementation (2 found)
+   |
+LL |     <::Impl1 as MyTrait2>::my_fn();
+   |     +++++++++++         +
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0789`.

--- a/src/test/ui/expr/if/if-let.stderr
+++ b/src/test/ui/expr/if/if-let.stderr
@@ -27,7 +27,7 @@ LL | |     });
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
-   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` which comes from the expansion of the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:26:8

--- a/src/test/ui/fmt/ifmt-bad-arg.stderr
+++ b/src/test/ui/fmt/ifmt-bad-arg.stderr
@@ -308,7 +308,7 @@ note: associated function defined here
    |
 LL |     pub fn from_usize(x: &usize) -> ArgumentV1<'_> {
    |            ^^^^^^^^^^
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/ifmt-bad-arg.rs:81:35
@@ -326,7 +326,7 @@ note: associated function defined here
    |
 LL |     pub fn from_usize(x: &usize) -> ArgumentV1<'_> {
    |            ^^^^^^^^^^
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 36 previous errors
 

--- a/src/test/ui/fmt/ifmt-unimpl.stderr
+++ b/src/test/ui/fmt/ifmt-unimpl.stderr
@@ -20,7 +20,7 @@ note: required by a bound in `ArgumentV1::<'a>::new_upper_hex`
    |
 LL |     arg_new!(new_upper_hex, UpperHex);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ArgumentV1::<'a>::new_upper_hex`
-   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `arg_new` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/for-loop-while/while-let-2.stderr
+++ b/src/test/ui/for-loop-while/while-let-2.stderr
@@ -27,7 +27,7 @@ LL | |     });
    |
    = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it
-   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` which comes from the expansion of the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `while let` pattern
   --> $DIR/while-let-2.rs:27:11

--- a/src/test/ui/generator/yield-while-ref-reborrowed.stderr
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.stderr
@@ -11,7 +11,7 @@ LL |     println!("{}", x);
 LL |     Pin::new(&mut b).resume(());
    |              ------ first borrow later used here
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-88287.rs
+++ b/src/test/ui/generic-associated-types/issue-88287.rs
@@ -1,4 +1,3 @@
-// check-pass
 // edition:2018
 
 #![feature(generic_associated_types)]
@@ -34,6 +33,7 @@ where
 
     fn search<'c>(&'c self, _client: &'c ()) -> Self::Future<'c, Self, Criteria> {
         async move { todo!() }
+        //~^ ERROR: the size for values of type `A` cannot be known at compilation time
     }
 }
 

--- a/src/test/ui/generic-associated-types/issue-88287.stderr
+++ b/src/test/ui/generic-associated-types/issue-88287.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the size for values of type `A` cannot be known at compilation time
+  --> $DIR/issue-88287.rs:35:9
+   |
+LL | type SearchFutureTy<'f, A, B: 'f>
+   |                         - this type parameter needs to be `std::marker::Sized`
+...
+LL |         async move { todo!() }
+   |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `<T as SearchableResourceExt<Criteria>>`
+  --> $DIR/issue-88287.rs:25:6
+   |
+LL | impl<T, Criteria> SearchableResourceExt<Criteria> for T
+   |      ^ required by this bound in `<T as SearchableResourceExt<Criteria>>`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL -     A: SearchableResource<B> + ?Sized + 'f,
+LL +     A: SearchableResource<B> + 'f,
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     T: SearchableResource<Criteria> + ?Sized,
+   |                                     ++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/internal/internal-unstable.stderr
+++ b/src/test/ui/internal/internal-unstable.stderr
@@ -40,7 +40,7 @@ LL |     bar!(internal_unstable::unstable());
    |     ----------------------------------- in this macro invocation
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
-   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` which comes from the expansion of the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-16966.stderr
+++ b/src/test/ui/issues/issue-16966.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     panic!(std::default::Default::default());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `M` declared on the function `begin_panic`
    |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider specifying the generic argument
   --> $SRC_DIR/std/src/panic.rs:LL:COL
    |

--- a/src/test/ui/issues/issue-42796.stderr
+++ b/src/test/ui/issues/issue-42796.stderr
@@ -9,7 +9,7 @@ LL |     let mut s_copy = s;
 LL |     println!("{}", s);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47646.stderr
+++ b/src/test/ui/issues/issue-47646.stderr
@@ -13,7 +13,7 @@ LL |             println!("{:?}", heap);
 LL |     };
    |      - ... and the mutable borrow might be used here, when that temporary is dropped and runs the destructor for type `(Option<PeekMut<'_, i32>>, ())`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-54954.rs
+++ b/src/test/ui/issues/issue-54954.rs
@@ -1,5 +1,5 @@
 const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
-//~^ ERROR type annotations needed
+//~^ ERROR E0789
 
 trait Tt {
     const fn const_val<T: Sized>() -> usize {

--- a/src/test/ui/issues/issue-54954.stderr
+++ b/src/test/ui/issues/issue-54954.stderr
@@ -4,13 +4,17 @@ error[E0379]: functions in traits cannot be declared const
 LL |     const fn const_val<T: Sized>() -> usize {
    |     ^^^^^ functions in traits cannot be const
 
-error[E0283]: type annotations needed
+error[E0789]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/issue-54954.rs:1:24
    |
-LL | const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-   |
-   = note: cannot satisfy `_: Tt`
+LL |   const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+...
+LL | /     const fn const_val<T: Sized>() -> usize {
+LL | |
+LL | |         core::mem::size_of::<T>()
+LL | |     }
+   | |_____- `Tt::const_val` defined here
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-54954.rs:11:15
@@ -26,5 +30,5 @@ LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0080, E0283, E0379.
+Some errors have detailed explanations: E0080, E0379, E0789.
 For more information about an error, try `rustc --explain E0080`.

--- a/src/test/ui/issues/issue-58022.rs
+++ b/src/test/ui/issues/issue-58022.rs
@@ -2,7 +2,7 @@ pub trait Foo: Sized {
     const SIZE: usize;
 
     fn new(slice: &[u8; Foo::SIZE]) -> Self;
-    //~^ ERROR: type annotations needed
+    //~^ ERROR: E0789
 }
 
 pub struct Bar<T: ?Sized>(T);

--- a/src/test/ui/issues/issue-58022.stderr
+++ b/src/test/ui/issues/issue-58022.stderr
@@ -4,19 +4,16 @@ error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo
 LL |         Foo(Box::new(*slice))
    |         ^^^ not a function, tuple struct or tuple variant
 
-error[E0283]: type annotations needed
+error[E0789]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
   --> $DIR/issue-58022.rs:4:25
    |
+LL |     const SIZE: usize;
+   |     ------------------ `Foo::SIZE` defined here
+LL |
 LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
-   |                         ^^^^^^^^^
-   |                         |
-   |                         cannot infer type
-   |                         help: use the fully qualified path to an implementation: `<Type as Foo>::SIZE`
-   |
-   = note: cannot satisfy `_: Foo`
-   = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+   |                         ^^^^^^^^^ cannot refer to the associated constant of trait
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0283, E0423.
-For more information about an error, try `rustc --explain E0283`.
+Some errors have detailed explanations: E0423, E0789.
+For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/issues/issue-69455.stderr
+++ b/src/test/ui/issues/issue-69455.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     println!("{}", 23u64.test(xs.iter().sum()));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the associated function `new_display`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider specifying the generic argument
    |
 LL |     println!("{}", 23u64.test(xs.iter().sum())::<T>);

--- a/src/test/ui/lifetimes/issue-76168-hr-outlives-2.rs
+++ b/src/test/ui/lifetimes/issue-76168-hr-outlives-2.rs
@@ -1,0 +1,22 @@
+// edition:2018
+// check-pass
+
+trait Trait<Input> {
+    type Output;
+}
+
+async fn walk<F>(filter: F)
+where
+    for<'a> F: Trait<&'a u32> + 'a,
+    for<'a> <F as Trait<&'a u32>>::Output: 'a,
+{
+}
+
+async fn walk2<F: 'static>(filter: F)
+where
+    for<'a> F: Trait<&'a u32> + 'a,
+    for<'a> <F as Trait<&'a u32>>::Output: 'a,
+{
+}
+
+fn main() {}

--- a/src/test/ui/limits/issue-55878.stderr
+++ b/src/test/ui/limits/issue-55878.stderr
@@ -18,7 +18,7 @@ LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 
@@ -33,5 +33,5 @@ LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
@@ -9,11 +9,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Relaxed);
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Relaxed);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Relaxed);
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Relaxed);
+    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Relaxed);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Acquire);
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::SeqCst);
@@ -41,22 +47,4 @@ fn main() {
     //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
     //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
-
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
@@ -1,5 +1,5 @@
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:22:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:24:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:26:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:32:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:38:67
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:44:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering:
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:66
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                                |
-   |                                                `Release` success ordering
-   |                                                help: consider using `AcqRel` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Release` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:52:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Relaxed` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:54:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                                |
-   |                                                `Relaxed` success ordering
-   |                                                help: consider using `Acquire` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:58:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `Acquire` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:60:48
-   |
-LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                                |
-   |                                                `AcqRel` success ordering
-   |                                                help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
@@ -7,11 +7,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Relaxed);
-    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Relaxed);
+    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Relaxed);
-    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Relaxed);
+    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Acquire);
+    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Relaxed);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Acquire);
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::SeqCst);
@@ -39,22 +45,4 @@ fn main() {
     //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
     //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
-
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
-    let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
@@ -1,5 +1,5 @@
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:20:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:22:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:24:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:30:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:36:57
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:42:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:56
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                      |
-   |                                      `Release` success ordering
-   |                                      help: consider using `AcqRel` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Release` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:50:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Relaxed` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:52:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                                      |
-   |                                      `Relaxed` success ordering
-   |                                      help: consider using `Acquire` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:56:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `Acquire` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:58:38
-   |
-LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                                      |
-   |                                      `AcqRel` success ordering
-   |                                      help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
@@ -7,11 +7,17 @@ fn main() {
 
     // Allowed ordering combos
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| Some(old + 1));
-    let _ = x.fetch_update(Ordering::Acquire, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::Acquire, Ordering::Relaxed, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Acquire, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::Release, Ordering::Relaxed, |old| Some(old + 1));
-    let _ = x.fetch_update(Ordering::AcqRel, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::AcqRel, Ordering::Acquire, |old| Some(old + 1));
+    let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Acquire, |old| Some(old + 1));
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |old| Some(old + 1));
@@ -40,21 +46,4 @@ fn main() {
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
     //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
 
-    // Release success order forbids failure order of Acquire or SeqCst
-    let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-
-    // Relaxed success order also forbids failure order of Acquire or SeqCst
-    let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-
-    // Acquire/AcqRel forbids failure order of SeqCst
-    let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
-    let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
@@ -1,5 +1,5 @@
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:20:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:22:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:24:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:30:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:36:47
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:42:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,66 +72,12 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:46
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                            |
-   |                            `Release` success ordering
-   |                            help: consider using `AcqRel` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Release` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:50:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Relaxed` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:52:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
-   |                            |
-   |                            `Relaxed` success ordering
-   |                            help: consider using `Acquire` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:56:28
-   |
-LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `Acquire` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:58:28
-   |
-LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
-   |                            |
-   |                            `AcqRel` success ordering
-   |                            help: consider using `SeqCst` success ordering instead
-
-error: aborting due to 16 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/liveness/liveness-move-in-while.stderr
+++ b/src/test/ui/liveness/liveness-move-in-while.stderr
@@ -29,7 +29,7 @@ LL |         println!("{}", y);
 LL |         while true { while true { while true { x = y; x.clone(); } } }
    |                                                    - value moved here, in previous iteration of loop
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error; 3 warnings emitted
 

--- a/src/test/ui/liveness/liveness-use-after-move.stderr
+++ b/src/test/ui/liveness/liveness-use-after-move.stderr
@@ -9,7 +9,7 @@ LL |
 LL |     println!("{}", *x);
    |                    ^^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-use-after-send.stderr
+++ b/src/test/ui/liveness/liveness-use-after-send.stderr
@@ -8,7 +8,7 @@ LL |     send(ch, message);
 LL |     println!("{}", message);
    |                    ^^^^^^^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/loops/loop-proper-liveness.stderr
+++ b/src/test/ui/loops/loop-proper-liveness.stderr
@@ -7,7 +7,7 @@ LL |     let x: i32;
 LL |     println!("{:?}", x);
    |                      ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macro_backtrace/main.default.stderr
+++ b/src/test/ui/macro_backtrace/main.default.stderr
@@ -18,7 +18,7 @@ LL |     () => { syntax error };
 LL |     ping!();
    |     ------- in this macro invocation
    |
-   = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pong` which comes from the expansion of the macro `ping` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:10:20
@@ -29,7 +29,7 @@ LL |     () => { syntax error };
 LL |     deep!();
    |     ------- in this macro invocation
    |
-   = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pong` which comes from the expansion of the macro `deep` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/macros/format-parse-errors.stderr
+++ b/src/test/ui/macros/format-parse-errors.stderr
@@ -4,7 +4,7 @@ error: requires at least a format string argument
 LL |     format!();
    |     ^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
   --> $DIR/format-parse-errors.rs:5:13

--- a/src/test/ui/macros/macro-backtrace-nested.stderr
+++ b/src/test/ui/macros/macro-backtrace-nested.stderr
@@ -7,7 +7,7 @@ LL |     () => (fake)
 LL |     1 + call_nested_expr!();
    |         ------------------- in this macro invocation
    |
-   = note: this error originates in the macro `nested_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `nested_expr` which comes from the expansion of the macro `call_nested_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `fake` in this scope
   --> $DIR/macro-backtrace-nested.rs:5:12
@@ -18,7 +18,7 @@ LL |     () => (fake)
 LL |     call_nested_expr_sum!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in the macro `nested_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `nested_expr` which comes from the expansion of the macro `call_nested_expr_sum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macro-backtrace-println.stderr
+++ b/src/test/ui/macros/macro-backtrace-println.stderr
@@ -7,7 +7,7 @@ LL |     ($fmt:expr) => (myprint!(concat!($fmt, "\n")));
 LL |     myprintln!("{}");
    |     ---------------- in this macro invocation
    |
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat` which comes from the expansion of the macro `myprintln` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-local-data-key-priv.stderr
+++ b/src/test/ui/macros/macro-local-data-key-priv.stderr
@@ -9,7 +9,7 @@ note: the constant `baz` is defined here
    |
 LL |     thread_local!(static baz: f64 = 0.0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/restricted-shadowing-legacy.stderr
+++ b/src/test/ui/macros/restricted-shadowing-legacy.stderr
@@ -24,7 +24,7 @@ LL |         macro_rules! m { () => {} }
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:139:42
@@ -52,7 +52,7 @@ LL |         macro_rules! m { () => {} }
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:148:9
@@ -136,7 +136,7 @@ LL |         macro_rules! m { () => { Wrong } }
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:218:42
@@ -164,7 +164,7 @@ LL |         macro_rules! m { () => { Wrong } }
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:232:9
@@ -220,7 +220,7 @@ LL |             macro_rules! m { () => {} }
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/macros/restricted-shadowing-modern.stderr
+++ b/src/test/ui/macros/restricted-shadowing-modern.stderr
@@ -24,7 +24,7 @@ LL |         macro m() {}
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:147:33
@@ -52,7 +52,7 @@ LL |         macro m() {}
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:156:13
@@ -136,7 +136,7 @@ LL |         macro m() { Wrong }
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:233:33
@@ -164,7 +164,7 @@ LL |         macro m() { Wrong }
 ...
 LL | include!();
    | ---------- in this macro invocation
-   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` which comes from the expansion of the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/macros/unreachable-format-args.edition_2015.stderr
+++ b/src/test/ui/macros/unreachable-format-args.edition_2015.stderr
@@ -6,7 +6,7 @@ LL |     unreachable!("x is {x} and y is {y}", y = 0);
    |
    = note: did you intend to capture a variable `x` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `$crate::concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::concat` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-capture-clause-bad.stderr
+++ b/src/test/ui/moves/moves-based-on-type-capture-clause-bad.stderr
@@ -11,7 +11,7 @@ LL |     });
 LL |     println!("{}", x);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/no-debug.stderr
+++ b/src/test/ui/on-unimplemented/no-debug.stderr
@@ -6,7 +6,7 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |
    = help: the trait `Debug` is not implemented for `Foo`
    = note: add `#[derive(Debug)]` to `Foo` or manually `impl Debug for Foo`
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Foo` with `#[derive(Debug)]`
    |
 LL | #[derive(Debug)]
@@ -19,7 +19,7 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |                                ^^^ `Bar` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `Bar`
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Foo` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:23
@@ -29,7 +29,7 @@ LL |     println!("{} {}", Foo, Bar);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Foo`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Bar` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:28
@@ -39,7 +39,7 @@ LL |     println!("{} {}", Foo, Bar);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Bar`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/macro/pub-item-macro.stderr
+++ b/src/test/ui/parser/macro/pub-item-macro.stderr
@@ -24,7 +24,7 @@ LL |         static x: u32 = 0;
 ...
 LL |     pub_x!();
    |     -------- in this macro invocation
-   = note: this error originates in the macro `priv_x` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_x` which comes from the expansion of the macro `pub_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/mixed-site-span.stderr
+++ b/src/test/ui/proc-macro/mixed-site-span.stderr
@@ -26,7 +26,7 @@ error[E0412]: cannot find type `ItemUse` in crate `$crate`
 LL | pass_dollar_crate!();
    | ^^^^^^^^^^^^^^^^^^^^ not found in `$crate`
    |
-   = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `proc_macro_rules` which comes from the expansion of the macro `pass_dollar_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -7,7 +7,7 @@ LL |     three!($a, $b);
 LL |     one!("hello", "world");
    |     ---------------------- in this macro invocation
    |
-   = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `two` which comes from the expansion of the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: second final: "world"
   --> $DIR/parent-source-spans.rs:16:16
@@ -18,7 +18,7 @@ LL |     three!($a, $b);
 LL |     one!("hello", "world");
    |     ---------------------- in this macro invocation
    |
-   = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `two` which comes from the expansion of the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: first parent: "hello"
   --> $DIR/parent-source-spans.rs:10:5
@@ -150,7 +150,7 @@ LL |     one!("hello", "world");
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     -- similarly named tuple variant `Ok` defined here
    |
-   = note: this error originates in the macro `parent_source_spans` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
@@ -166,7 +166,7 @@ LL |     two!("yay", "rust");
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     -- similarly named tuple variant `Ok` defined here
    |
-   = note: this error originates in the macro `parent_source_spans` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
@@ -182,7 +182,7 @@ LL |     three!("hip", "hop");
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     -- similarly named tuple variant `Ok` defined here
    |
-   = note: this error originates in the macro `parent_source_spans` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `three` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 21 previous errors
 

--- a/src/test/ui/proc-macro/weird-hygiene.stderr
+++ b/src/test/ui/proc-macro/weird-hygiene.stderr
@@ -7,7 +7,7 @@ LL |             Value = (stringify!($tokens + hidden_ident), 1).1
 LL |     other!(50);
    |     ---------- in this macro invocation
    |
-   = note: this error originates in the macro `inner` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `inner` which comes from the expansion of the macro `other` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `hidden_ident` in this scope
   --> $DIR/weird-hygiene.rs:34:13

--- a/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -6,7 +6,7 @@ LL |     let _: NotDebug = dbg!(NotDebug);
    |
    = help: the trait `Debug` is not implemented for `NotDebug`
    = note: add `#[derive(Debug)]` to `NotDebug` or manually `impl Debug for NotDebug`
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NotDebug` with `#[derive(Debug)]`
    |
 LL | #[derive(Debug)]

--- a/src/test/ui/suggestions/bound-suggestions.stderr
+++ b/src/test/ui/suggestions/bound-suggestions.stderr
@@ -4,7 +4,7 @@ error[E0277]: `impl Sized` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
@@ -16,7 +16,7 @@ error[E0277]: `T` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
@@ -28,7 +28,7 @@ error[E0277]: `T` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
@@ -40,7 +40,7 @@ error[E0277]: `Y` doesn't implement `Debug`
 LL |     println!("{:?} {:?}", x, y);
    |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `Y`
    |
 LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
@@ -52,7 +52,7 @@ error[E0277]: `X` doesn't implement `Debug`
 LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
@@ -64,7 +64,7 @@ error[E0277]: `X` doesn't implement `Debug`
 LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -6,7 +6,7 @@ LL | |         "abc"
 LL | |     };
    | |_____^ expected `&str`, found struct `String`
    |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format` which comes from the expansion of the macro `intrinsic_match` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-97760.stderr
+++ b/src/test/ui/suggestions/issue-97760.stderr
@@ -6,7 +6,7 @@ LL |         println!("{x}");
    |
    = help: the trait `std::fmt::Display` is not implemented for `<impl IntoIterator as IntoIterator>::Item`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL ~ pub fn print_values<I: IntoIterator>(values: &I)

--- a/src/test/ui/suggestions/path-display.stderr
+++ b/src/test/ui/suggestions/path-display.stderr
@@ -6,7 +6,7 @@ LL |     println!("{}", path);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Path`
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `PathBuf` doesn't implement `std::fmt::Display`
   --> $DIR/path-display.rs:9:20
@@ -16,7 +16,7 @@ LL |     println!("{}", path);
    |
    = help: the trait `std::fmt::Display` is not implemented for `PathBuf`
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/static-method-generic-inference.rs
+++ b/src/test/ui/traits/static-method-generic-inference.rs
@@ -22,7 +22,7 @@ mod base {
 
 pub fn foo() {
     let _f: base::Foo = base::HasNew::new();
-    //~^ ERROR type annotations needed
+    //~^ ERROR E0789
 }
 
 fn main() { }

--- a/src/test/ui/traits/static-method-generic-inference.stderr
+++ b/src/test/ui/traits/static-method-generic-inference.stderr
@@ -1,11 +1,17 @@
-error[E0283]: type annotations needed
+error[E0789]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/static-method-generic-inference.rs:24:25
    |
+LL |         fn new() -> T;
+   |         -------------- `HasNew::new` defined here
+...
 LL |     let _f: base::Foo = base::HasNew::new();
-   |                         ^^^^^^^^^^^^^^^^^ cannot infer type
+   |                         ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
-   = note: cannot satisfy `_: HasNew<Foo>`
+help: use the fully-qualified path to the only available implementation
+   |
+LL |     let _f: base::Foo = base::<::base::Foo as HasNew>::new();
+   |                               +++++++++++++++       +
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0789`.

--- a/src/test/ui/try-block/try-block-maybe-bad-lifetime.stderr
+++ b/src/test/ui/try-block/try-block-maybe-bad-lifetime.stderr
@@ -22,7 +22,7 @@ LL |         };
 LL |         println!("{}", x);
    |                        ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0506]: cannot assign to `i` because it is borrowed
   --> $DIR/try-block-maybe-bad-lifetime.rs:40:9

--- a/src/test/ui/type-alias-impl-trait/future.rs
+++ b/src/test/ui/type-alias-impl-trait/future.rs
@@ -1,0 +1,22 @@
+#![feature(type_alias_impl_trait)]
+
+// edition:2021
+// compile-flags: --crate-type=lib
+
+use std::future::Future;
+
+trait Bar {
+    fn bar(&self);
+}
+
+type FooFuture<B> = impl Future<Output = ()>;
+
+fn foo<B: Bar>(bar: B) -> FooFuture<B> {
+    async move { bar.bar() }
+    //~^ ERROR: the trait bound `B: Bar` is not satisfied
+}
+
+pub fn mainish(ctx: &mut std::task::Context) {
+    let boom: FooFuture<u32> = unsafe { core::mem::zeroed() };
+    Box::pin(boom).as_mut().poll(ctx);
+}

--- a/src/test/ui/type-alias-impl-trait/future.stderr
+++ b/src/test/ui/type-alias-impl-trait/future.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `B: Bar` is not satisfied
+  --> $DIR/future.rs:15:5
+   |
+LL |     async move { bar.bar() }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `B`
+   |
+note: required by a bound in `foo`
+  --> $DIR/future.rs:14:11
+   |
+LL | fn foo<B: Bar>(bar: B) -> FooFuture<B> {
+   |           ^^^ required by this bound in `foo`
+help: consider restricting type parameter `B`
+   |
+LL | type FooFuture<B: Bar> = impl Future<Output = ()>;
+   |                 +++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/nested.stderr
+++ b/src/test/ui/type-alias-impl-trait/nested.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}", bar());
    |                      ^^^^^ `Bar` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `Bar`
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -10,7 +10,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
    |                   help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: this error originates in the macro `$crate::__rust_force_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__rust_force_expr` which comes from the expansion of the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-after-move-based-on-type.stderr
+++ b/src/test/ui/use/use-after-move-based-on-type.stderr
@@ -8,7 +8,7 @@ LL |     let _y = x;
 LL |     println!("{}", x);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/walk-struct-literal-with.stderr
+++ b/src/test/ui/walk-struct-literal-with.stderr
@@ -13,7 +13,7 @@ note: this function takes ownership of the receiver `self`, which moves `start`
    |
 LL |     fn make_string_bar(mut self) -> Mine{
    |                            ^^^^
-   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui/diverging_sub_expression.stderr
+++ b/src/tools/clippy/tests/ui/diverging_sub_expression.stderr
@@ -36,7 +36,7 @@ error: sub-expression diverges
 LL |                 _ => true || panic!("boo"),
    |                              ^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: sub-expression diverges
   --> $DIR/diverging_sub_expression.rs:38:26

--- a/src/tools/clippy/tests/ui/fallible_impl_from.stderr
+++ b/src/tools/clippy/tests/ui/fallible_impl_from.stderr
@@ -38,7 +38,7 @@ note: potential failure(s)
    |
 LL |             panic!();
    |             ^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
   --> $DIR/fallible_impl_from.rs:35:1
@@ -65,7 +65,7 @@ LL |         } else if s.parse::<u32>().unwrap() != 42 {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
    |             ^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
   --> $DIR/fallible_impl_from.rs:53:1
@@ -87,7 +87,7 @@ LL |         if s.parse::<u32>().ok().unwrap() != 42 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
    |             ^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/issue-7447.stderr
+++ b/src/tools/clippy/tests/ui/issue-7447.stderr
@@ -5,7 +5,7 @@ LL |     byte_view(panic!());
    |               ^^^^^^^^
    |
    = note: `-D clippy::diverging-sub-expression` implied by `-D warnings`
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: sub-expression diverges
   --> $DIR/issue-7447.rs:24:19
@@ -13,7 +13,7 @@ error: sub-expression diverges
 LL |     group_entries(panic!());
    |                   ^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #97183 (wf-check generators)
 - #98028 (Add E0789 as more specific variant of E0283)
 - #98320 (Mention first and last macro in backtrace)
 - #99347 (Use `LocalDefId` in `OpaqueTypeKey`)
 - #99392 (Fix debuginfo tests.)
 - #99404 (Use span_bug for unexpected field projection type)
 - #99410 (Update invalid atomic ordering lint)
 - #99434 (Fix `Skip::next` for non-fused inner iterators)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97183,98028,98320,99347,99392,99404,99410,99434)
<!-- homu-ignore:end -->