### PR TITLE
Add UI to help with advanced search requests

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1446,6 +1446,7 @@ fn init_id_map() -> FxHashMap<Cow<'static, str>, usize> {
     map.insert("not-displayed".into(), 1);
     map.insert("alternative-display".into(), 1);
     map.insert("search".into(), 1);
+    map.insert("search-helper".into(), 1);
     // This is the list of IDs used in HTML generated in Rust (including the ones
     // used in tera template files).
     map.insert("mainThemeStyle".into(), 1);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -946,7 +946,7 @@ table,
 	font-weight: 500;
 	margin-bottom: 20px;
 }
-#crate-search {
+#crate-search, #search-helper select {
 	min-width: 115px;
 	margin-top: 5px;
 	padding-left: 0.3125em;
@@ -971,7 +971,7 @@ table,
 .search-container {
 	margin-top: 4px;
 }
-.search-input {
+.search-input, #search-helper input:not([type="checkbox"]), #search-helper button {
 	/* Override Normalize.css: it has a rule that sets
 	   -webkit-appearance: textfield for search inputs. That
 	   causes rounded corners and no border on iOS Safari. */
@@ -988,6 +988,45 @@ table,
 	font-size: 1rem;
 	transition: border-color 300ms ease;
 	width: 100%;
+}
+
+#search-helper {
+	margin-top: 6px;
+}
+#search-helper summary {
+	font-size: 1.15rem;
+}
+#search-helper select {
+	padding-top: 4px;
+	padding-bottom: 4px;
+	margin-bottom: 5px;
+}
+#search-helper .end-buttons {
+	padding-top: 5px;
+}
+#search-helper select, #search-helper button, #search-helper summary {
+	cursor: pointer;
+}
+#search-helper > *:not(input) {
+	width: 100%;
+}
+#search-helper .search-buttons {
+	display: flex;
+}
+#search-helper .search-returned, #search-helper .search-arguments {
+	margin: 15px 0;
+}
+#search-helper .search-arguments > *, #search-helper .search-returned > *, #search-helper .search-buttons {
+	margin-top: 5px;
+}
+#search-helper .search-buttons button:not(:last-of-type) {
+	margin-right: 5px;
+}
+#search-helper .generics {
+	padding-left: 14px;
+}
+#search-helper .search-literal, #search-helper .search-literal > * {
+	cursor: pointer;
 }
 
 .search-results {
@@ -2110,7 +2149,7 @@ in storage.js plus the media query with (min-width: 701px)
 		width: 50%;
 	}
 
-	#crate-search {
+	#crate-search, #search-helper select {
 		border-radius: 4px;
 	}
 

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -182,14 +182,18 @@ details.rustdoc-toggle > summary::before {
 	filter: invert(100%);
 }
 
-#crate-search, .search-input {
+#crate-search, .search-input, #search-helper input, #search-helper button, #search-helper select {
 	background-color: #141920;
+}
+
+#crate-search {
 	/* Without the `!important`, the border-color is ignored for `<select>`... */
 	border-color: #424c57 !important;
 }
 
-.search-input {
+.search-input, #search-helper input, #search-helper button, #search-helper select {
 	color: #ffffff;
+	border-color: #424c57;
 }
 
 .module-item .stab,
@@ -486,7 +490,8 @@ kbd {
 }
 
 #settings-menu > a:hover, #settings-menu > a:focus,
-#help-button > button:hover, #help-button > button:focus {
+#help-button > button:hover, #help-button > button:focus,
+#search-helper button:focus, #search-helper button:hover {
 	border-color: #e0e0e0;
 }
 

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -156,18 +156,21 @@ details.rustdoc-toggle > summary::before {
 	filter: invert(100%);
 }
 
-#crate-search, .search-input {
+#crate-search, .search-input, #search-helper input, #search-helper button, #search-helper select {
 	color: #111;
 	background-color: #f0f0f0;
+}
+
+#crate-search {
 	/* Without the `!important`, the border-color is ignored for `<select>`... */
 	border-color: #f0f0f0 !important;
 }
 
-.search-input {
+.search-input, .search-input, #search-helper input, #search-helper button {
 	border-color: #e0e0e0;
 }
 
-.search-input:focus {
+.search-input:focus, #search-helper input:focus {
 	border-color: #008dfd;
 }
 
@@ -325,7 +328,8 @@ kbd {
 }
 
 #settings-menu > a:hover, #settings-menu > a:focus,
-#help-button > button:hover, #help-button > button:focus {
+#help-button > button:hover, #help-button > button:focus,
+#search-helper button:focus, #search-helper button:hover {
 	border-color: #ffb900;
 }
 

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -144,13 +144,16 @@ details.rustdoc-toggle > summary::before {
 	color: #999;
 }
 
-#crate-search, .search-input {
+#crate-search, .search-input, #search-helper input, #search-helper button, #search-helper select {
 	background-color: white;
+}
+
+#crate-search {
 	/* Without the `!important`, the border-color is ignored for `<select>`... */
 	border-color: #e0e0e0 !important;
 }
 
-.search-input:focus {
+.search-input:focus, #search-helper input:focus {
 	border-color: #66afe9;
 }
 
@@ -308,7 +311,8 @@ kbd {
 }
 
 #settings-menu > a:hover, #settings-menu > a:focus,
-#help-button > button:hover, #help-button > button:focus {
+#help-button > button:hover, #help-button > button:focus,
+#search-helper button:focus, #search-helper button:hover {
 	border-color: #717171;
 }
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/99321.

This is for now a very early POC. The idea would be to provide help writing search requests for more advanced ones because the syntax might not be obvious for everyone.

Here what it currently looks like:

![image](https://user-images.githubusercontent.com/3050060/179766428-460ee15c-1f76-4b4a-bf62-5e4766493665.png)

You can test it [here](https://rustdoc.crud.net/imperio/advanced-search-ui/foo/index.html?search=test).

To be noted: the "advanced search helper" appears when `search.js` is loaded, so when you focused on the search input or when you directly arrive on a search results page.

r? @rust-lang/rustdoc 