### PR TITLE
Update cc-rs to 1.0.73 for compiler + bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,9 +512,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -8,7 +8,7 @@ test = false
 
 [dependencies]
 bitflags = "1.2.1"
-cc = "1.0.69"
+cc = "1.0.73"
 itertools = "0.10.1"
 tracing = "0.1"
 libc = "0.2.50"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -11,4 +11,4 @@ emscripten = []
 libc = "0.2.73"
 
 [build-dependencies]
-cc = "1.0.69"
+cc = "1.0.73"

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -40,7 +40,7 @@ fd-lock = "3.0.6"
 filetime = "0.2"
 num_cpus = "1.0"
 getopts = "0.2.19"
-cc = "1.0.69"
+cc = "1.0.73"
 libc = "0.2"
 hex = "0.4"
 serde = { version = "1.0.8", features = ["derive"] }


### PR DESCRIPTION
WARNING: This may be considered a breaking change due to https://github.com/rust-lang/cc-rs/commit/8858713ea1592d171f8c860ce7382a2ec5ee0a44 - specifically, `cc-rs` now correctly detects that it's running in a Visual Studio Command Prompt and will use the ambient `LIB` path rather than trying to auto-detect it.

Other improvements that may be valuable for the Rust Compiler:
* Support for Visual Studio 2022 https://github.com/rust-lang/cc-rs/commit/e643cc14c497007a73fbf347d295a15cde6cd70f
* Support for detecting the Windows SDK from environment variables https://github.com/rust-lang/cc-rs/commit/030baede12f079793cc50d6f90b677b889c49fcd