### PR TITLE
Fix a numerical underflow in tuple wrap suggestion

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -575,6 +575,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // If so, we might have just forgotten to wrap some args in a tuple.
             if let Some(ty::Tuple(tys)) =
                 formal_and_expected_inputs.get(mismatch_idx.into()).map(|tys| tys.1.kind())
+                // If the tuple is unit, we're not actually wrapping any arguments.
+                && !tys.is_empty()
                 && provided_arg_tys.len() == formal_and_expected_inputs.len() - 1 + tys.len()
             {
                 // Wrap up the N provided arguments starting at this position in a tuple.

--- a/src/test/ui/argument-suggestions/issue-99482.rs
+++ b/src/test/ui/argument-suggestions/issue-99482.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let f = |_: (), f: fn()| f;
+    let _f = f(main);
+    //~^ ERROR this function takes 2 arguments but 1 argument was supplied
+}

--- a/src/test/ui/argument-suggestions/issue-99482.stderr
+++ b/src/test/ui/argument-suggestions/issue-99482.stderr
@@ -1,0 +1,19 @@
+error[E0057]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/issue-99482.rs:3:14
+   |
+LL |     let _f = f(main);
+   |              ^ ---- an argument of type `()` is missing
+   |
+note: closure defined here
+  --> $DIR/issue-99482.rs:2:13
+   |
+LL |     let f = |_: (), f: fn()| f;
+   |             ^^^^^^^^^^^^^^^^
+help: provide the argument
+   |
+LL |     let _f = f((), main);
+   |              ~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0057`.


### PR DESCRIPTION
Fixes #99482

I'm a clown, I rewrote the arg mismatch algo to use well-typed indices to avoid things like this, but then I added my own indexing bug, lol.