### PR TITLE
Use non-relocatable code in nofile-limit.rs test

### DIFF
--- a/src/test/ui/process/nofile-limit.rs
+++ b/src/test/ui/process/nofile-limit.rs
@@ -6,7 +6,7 @@
 // dont-check-compiler-stderr
 // only-linux
 // no-prefer-dynamic
-// compile-flags: -Ctarget-feature=+crt-static -Crpath=no
+// compile-flags: -Ctarget-feature=+crt-static -Crpath=no -Crelocation-model=static
 #![feature(exit_status_error)]
 #![feature(rustc_private)]
 extern crate libc;


### PR DESCRIPTION
To avoid using static-pie which is not essential to the test but which
was reported to cause problems on Void Linux where glibc is build
without support for static-pie.