### PR TITLE
adapt assembly/static-relocation-model test for LLVM change

### DIFF
--- a/src/test/assembly/static-relocation-model.rs
+++ b/src/test/assembly/static-relocation-model.rs
@@ -36,7 +36,8 @@ extern "C" {
 }
 
 // CHECK-LABEL: banana:
-// x64: movb   chaenomeles{{(\(%[a-z0-9]+\))?}}, %{{[a-z0-9]+}}
+// On the next line LLVM 14 produces a `movb`, whereas LLVM 15+ produces a `movzbl`.
+// x64: {{movb|movzbl}}   chaenomeles{{(\(%[a-z0-9]+\))?}}, %{{[a-z0-9]+}}
 // A64:      adrp    [[REG:[a-z0-9]+]], chaenomeles
 // A64-NEXT: ldrb    {{[a-z0-9]+}}, {{\[}}[[REG]], :lo12:chaenomeles]
 #[no_mangle]
@@ -47,7 +48,7 @@ pub fn banana() -> u8 {
 }
 
 // CHECK-LABEL: peach:
-// x64: movb    banana{{(\(%[a-z0-9]+\))?}}, %{{[a-z0-9]+}}
+// x64: {{movb|movzbl}}    banana{{(\(%[a-z0-9]+\))?}}, %{{[a-z0-9]+}}
 // A64:      adrp    [[REG2:[a-z0-9]+]], banana
 // A64-NEXT: ldrb    {{[a-z0-9]+}}, {{\[}}[[REG2]], :lo12:banana]
 #[no_mangle]
@@ -59,7 +60,7 @@ pub fn peach() -> u8 {
 
 // CHECK-LABEL: mango:
 // x64:      movq    EXOCHORDA{{(\(%[a-z0-9]+\))?}}, %[[REG:[a-z0-9]+]]
-// x64-NEXT: movb    (%[[REG]]), %{{[a-z0-9]+}}
+// x64-NEXT: {{movb|movzbl}}   (%[[REG]]), %{{[a-z0-9]+}}
 // A64:      adrp    [[REG2:[a-z0-9]+]], EXOCHORDA
 // A64-NEXT: ldr     {{[a-z0-9]+}}, {{\[}}[[REG2]], :lo12:EXOCHORDA]
 #[no_mangle]


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/commit/f0dd12ec5c0169ba5b4363b62d59511181cf954a LLVM emits `movzbl` instead. Adapted this test case accordingly.

Discovered in our experimental rust + llvm at head ci:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/12104#0182195b-8791-4f88-853c-bb23a1e4b54c