### PR TITLE
Display raw pointer as *{mut,const} T instead of *-ptr in errors

### DIFF
--- a/src/test/ui/asm/type-check-1.stderr
+++ b/src/test/ui/asm/type-check-1.stderr
@@ -106,7 +106,7 @@ error[E0308]: mismatched types
   --> $DIR/type-check-1.rs:60:26
    |
 LL |         asm!("{}", const 0 as *mut u8);
-   |                          ^^^^^^^^^^^^ expected integer, found *-ptr
+   |                          ^^^^^^^^^^^^ expected integer, found `*mut u8`
    |
    = note:     expected type `{integer}`
            found raw pointer `*mut u8`
@@ -133,7 +133,7 @@ error[E0308]: mismatched types
   --> $DIR/type-check-1.rs:78:25
    |
 LL | global_asm!("{}", const 0 as *mut u8);
-   |                         ^^^^^^^^^^^^ expected integer, found *-ptr
+   |                         ^^^^^^^^^^^^ expected integer, found `*mut u8`
    |
    = note:     expected type `{integer}`
            found raw pointer `*mut u8`

--- a/src/test/ui/dst/dst-bad-coercions.stderr
+++ b/src/test/ui/dst/dst-bad-coercions.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/dst-bad-coercions.rs:14:17
    |
 LL |     let y: &S = x;
-   |            --   ^ expected `&S`, found *-ptr
+   |            --   ^ expected `&S`, found `*const S`
    |            |
    |            expected due to this
    |
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
   --> $DIR/dst-bad-coercions.rs:15:21
    |
 LL |     let y: &dyn T = x;
-   |            ------   ^ expected `&dyn T`, found *-ptr
+   |            ------   ^ expected `&dyn T`, found `*const S`
    |            |
    |            expected due to this
    |
@@ -24,7 +24,7 @@ error[E0308]: mismatched types
   --> $DIR/dst-bad-coercions.rs:19:17
    |
 LL |     let y: &S = x;
-   |            --   ^ expected `&S`, found *-ptr
+   |            --   ^ expected `&S`, found `*mut S`
    |            |
    |            expected due to this
    |
@@ -35,7 +35,7 @@ error[E0308]: mismatched types
   --> $DIR/dst-bad-coercions.rs:20:21
    |
 LL |     let y: &dyn T = x;
-   |            ------   ^ expected `&dyn T`, found *-ptr
+   |            ------   ^ expected `&dyn T`, found `*mut S`
    |            |
    |            expected due to this
    |

--- a/src/test/ui/mismatched_types/issue-19109.stderr
+++ b/src/test/ui/mismatched_types/issue-19109.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn function(t: &mut dyn Trait) {
    |                                - help: try adding a return type: `-> *mut dyn Trait`
 LL |     t as *mut dyn Trait
-   |     ^^^^^^^^^^^^^^^^^^^ expected `()`, found *-ptr
+   |     ^^^^^^^^^^^^^^^^^^^ expected `()`, found `*mut dyn Trait`
    |
    = note: expected unit type `()`
             found raw pointer `*mut dyn Trait`


### PR DESCRIPTION
The `*-ptr` is rather confusing, and we have the full information for properly displaying the information.