### PR TITLE
Remove implicit names and values from `--cfg` in `--check-cfg`

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -117,7 +117,6 @@ pub fn create_session(
 
     let mut check_cfg = config::to_crate_check_config(check_cfg);
     check_cfg.fill_well_known();
-    check_cfg.fill_actual(&cfg);
 
     sess.parse_sess.config = cfg;
     sess.parse_sess.check_config = check_cfg;

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1157,20 +1157,6 @@ impl CrateCheckConfig {
         self.fill_well_known_names();
         self.fill_well_known_values();
     }
-
-    /// Fills a `CrateCheckConfig` with configuration names and values that are actually active.
-    pub fn fill_actual(&mut self, cfg: &CrateConfig) {
-        for &(k, v) in cfg {
-            if let Some(names_valid) = &mut self.names_valid {
-                names_valid.insert(k);
-            }
-            if let Some(v) = v {
-                self.values_valid.entry(k).and_modify(|values| {
-                    values.insert(v);
-                });
-            }
-        }
-    }
 }
 
 pub fn build_configuration(sess: &Session, mut user_cfg: CrateConfig) -> CrateConfig {

--- a/src/doc/unstable-book/src/compiler-flags/check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/check-cfg.md
@@ -18,6 +18,9 @@ check cfg specification is parsed using the Rust metadata syntax, just as the `-
 These two options are independent. `names` checks only the namespace of condition names
 while `values` checks only the namespace of the values of list-valued conditions.
 
+NOTE: No implicit expectation is added when using `--cfg` for both forms. Users are expected to
+pass all expected names and values using `names(...)` and `values(...)`.
+
 ## The `names(...)` form
 
 The `names(...)` form enables checking the names. This form uses a named list:
@@ -52,27 +55,6 @@ Note that `--check-cfg 'names()'` is _not_ equivalent to omitting the option ent
 The first form enables checking condition names, while specifying that there are no valid
 condition names (outside of the set of well-known names defined by `rustc`). Omitting the
 `--check-cfg 'names(...)'` option does not enable checking condition names.
-
-Conditions that are enabled are implicitly valid; it is unnecessary (but legal) to specify a
-condition name as both enabled and valid. For example, the following invocations are equivalent:
-
-```bash
-# condition names will be checked, and 'has_time_travel' is valid
-rustc --cfg 'has_time_travel' --check-cfg 'names()'
-
-# condition names will be checked, and 'has_time_travel' is valid
-rustc --cfg 'has_time_travel' --check-cfg 'names(has_time_travel)'
-```
-
-In contrast, the following two invocations are _not_ equivalent:
-
-```bash
-# condition names will not be checked (because there is no --check-cfg names(...))
-rustc --cfg 'has_time_travel'
-
-# condition names will be checked, and 'has_time_travel' is both valid and enabled.
-rustc --cfg 'has_time_travel' --check-cfg 'names(has_time_travel)'
-```
 
 ## The `values(...)` form
 
@@ -149,7 +131,7 @@ fn tame_lion() {}
 ```bash
 # This turns on checking for condition names, but not values, such as 'feature' values.
 rustc --check-cfg 'names(is_embedded, has_feathers)' \
-      --cfg has_feathers --cfg 'feature = "zapping"' -Z unstable-options
+      --cfg has_feathers -Z unstable-options
 ```
 
 ```rust
@@ -159,13 +141,14 @@ fn do_embedded() {}
 #[cfg(has_feathers)]        // This is expected as "has_feathers" was provided in names()
 fn do_features() {}
 
+#[cfg(has_feathers = "zapping")] // This is expected as "has_feathers" was provided in names()
+                                 // and because no value checking was enable for "has_feathers"
+                                 // no warning is emited for the value "zapping"
+fn do_zapping() {}
+
 #[cfg(has_mumble_frotz)]    // This is UNEXPECTED because names checking is enable and
                             // "has_mumble_frotz" was not provided in names()
 fn do_mumble_frotz() {}
-
-#[cfg(feature = "lasers")]  // This doesn't raise a warning, because values checking for "feature"
-                            // was never used
-fn shoot_lasers() {}
 ```
 
 ### Example: Checking feature values, but not condition names

--- a/src/test/ui/check-cfg/invalid-cfg-value.rs
+++ b/src/test/ui/check-cfg/invalid-cfg-value.rs
@@ -12,6 +12,7 @@ pub fn f() {}
 pub fn g() {}
 
 #[cfg(feature = "rand")]
+//~^ WARNING unexpected `cfg` condition value
 pub fn h() {}
 
 pub fn main() {}

--- a/src/test/ui/check-cfg/invalid-cfg-value.stderr
+++ b/src/test/ui/check-cfg/invalid-cfg-value.stderr
@@ -5,7 +5,15 @@ LL | #[cfg(feature = "sedre")]
    |       ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unexpected_cfgs)]` on by default
-   = note: expected values for `feature` are: full, rand, serde
+   = note: expected values for `feature` are: full, serde
 
-warning: 1 warning emitted
+warning: unexpected `cfg` condition value
+  --> $DIR/invalid-cfg-value.rs:14:7
+   |
+LL | #[cfg(feature = "rand")]
+   |       ^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: full, serde
+
+warning: 2 warnings emitted
 

--- a/src/test/ui/check-cfg/mix.rs
+++ b/src/test/ui/check-cfg/mix.rs
@@ -1,6 +1,6 @@
-// This test checks the combination of well known names, their activation via names(), the usage of
-// partial values() with a --cfg and test that we also correctly lint on the `cfg!` macro and
-// `cfg_attr` attribute.
+// This test checks the combination of well known names, their activation via names(),
+// the usage of values(), and that no implicit is done with --cfg while also testing that
+// we correctly lint on the `cfg!` macro and `cfg_attr` attribute.
 //
 // check-pass
 // compile-flags: --check-cfg=names() --check-cfg=values(feature,"foo") --cfg feature="bar" -Z unstable-options
@@ -16,6 +16,7 @@ fn do_windows_stuff() {}
 fn use_foo() {}
 
 #[cfg(feature = "bar")]
+//~^ WARNING unexpected `cfg` condition value
 fn use_bar() {}
 
 #[cfg(feature = "zebra")]
@@ -35,6 +36,7 @@ fn test_cfg_macro() {
     //~^ WARNING unexpected `cfg` condition name
     cfg!(feature = "foo");
     cfg!(feature = "bar");
+    //~^ WARNING unexpected `cfg` condition value
     cfg!(feature = "zebra");
     //~^ WARNING unexpected `cfg` condition value
     cfg!(xxx = "foo");

--- a/src/test/ui/check-cfg/mix.stderr
+++ b/src/test/ui/check-cfg/mix.stderr
@@ -7,21 +7,29 @@ LL | #[cfg(widnows)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value
-  --> $DIR/mix.rs:21:7
+  --> $DIR/mix.rs:18:7
+   |
+LL | #[cfg(feature = "bar")]
+   |       ^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: foo
+
+warning: unexpected `cfg` condition value
+  --> $DIR/mix.rs:22:7
    |
 LL | #[cfg(feature = "zebra")]
    |       ^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:25:12
+  --> $DIR/mix.rs:26:12
    |
 LL | #[cfg_attr(uu, test)]
    |            ^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:34:10
+  --> $DIR/mix.rs:35:10
    |
 LL |     cfg!(widnows);
    |          ^^^^^^^ help: did you mean: `windows`
@@ -29,132 +37,138 @@ LL |     cfg!(widnows);
 warning: unexpected `cfg` condition value
   --> $DIR/mix.rs:38:10
    |
+LL |     cfg!(feature = "bar");
+   |          ^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: foo
+
+warning: unexpected `cfg` condition value
+  --> $DIR/mix.rs:40:10
+   |
 LL |     cfg!(feature = "zebra");
    |          ^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:40:10
+  --> $DIR/mix.rs:42:10
    |
 LL |     cfg!(xxx = "foo");
    |          ^^^^^^^^^^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:42:10
+  --> $DIR/mix.rs:44:10
    |
 LL |     cfg!(xxx);
    |          ^^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:44:14
+  --> $DIR/mix.rs:46:14
    |
 LL |     cfg!(any(xxx, windows));
    |              ^^^
 
 warning: unexpected `cfg` condition value
-  --> $DIR/mix.rs:46:14
+  --> $DIR/mix.rs:48:14
    |
 LL |     cfg!(any(feature = "bad", windows));
-   |              ^^^^^^^^^^-----
-   |                        |
-   |                        help: did you mean: `"bar"`
+   |              ^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:48:23
+  --> $DIR/mix.rs:50:23
    |
 LL |     cfg!(any(windows, xxx));
    |                       ^^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:50:20
+  --> $DIR/mix.rs:52:20
    |
 LL |     cfg!(all(unix, xxx));
    |                    ^^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:52:14
+  --> $DIR/mix.rs:54:14
    |
 LL |     cfg!(all(aa, bb));
    |              ^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:52:18
+  --> $DIR/mix.rs:54:18
    |
 LL |     cfg!(all(aa, bb));
    |                  ^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:55:14
+  --> $DIR/mix.rs:57:14
    |
 LL |     cfg!(any(aa, bb));
    |              ^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:55:18
+  --> $DIR/mix.rs:57:18
    |
 LL |     cfg!(any(aa, bb));
    |                  ^^
 
 warning: unexpected `cfg` condition value
-  --> $DIR/mix.rs:58:20
+  --> $DIR/mix.rs:60:20
    |
 LL |     cfg!(any(unix, feature = "zebra"));
    |                    ^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:60:14
+  --> $DIR/mix.rs:62:14
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |              ^^^
 
 warning: unexpected `cfg` condition value
-  --> $DIR/mix.rs:60:19
+  --> $DIR/mix.rs:62:19
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |                   ^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:63:14
+  --> $DIR/mix.rs:65:14
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |              ^^^
 
 warning: unexpected `cfg` condition name
-  --> $DIR/mix.rs:63:25
+  --> $DIR/mix.rs:65:25
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |                         ^^^
 
 warning: unexpected `cfg` condition value
-  --> $DIR/mix.rs:66:14
+  --> $DIR/mix.rs:68:14
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |              ^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
 warning: unexpected `cfg` condition value
-  --> $DIR/mix.rs:66:33
+  --> $DIR/mix.rs:68:33
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |                                 ^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
 warning: unexpected `cfg` condition value
-  --> $DIR/mix.rs:66:52
+  --> $DIR/mix.rs:68:52
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |                                                    ^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `feature` are: bar, foo
+   = note: expected values for `feature` are: foo
 
-warning: 23 warnings emitted
+warning: 25 warnings emitted
 


### PR DESCRIPTION
This PR remove the implicit names and values from `--cfg` in `--check-cfg` because the behavior is quite surprising but also because it's really easy to inadvertently really on the implicitness and when the `--cfg` is not set anymore to have an unexpected warning from an unexpected condition that pass with the implicitness.

This change in behavior will also enable us to warn when an unexpected `--cfg` is passed, ex: the user wrote `--cfg=unstabl` instead of `--cfg=unstable`. The implementation of the warning will be done in a follow-up PR.

cc @petrochenkov