### PR TITLE
Normalize the arg spans to be within the call span

### DIFF
--- a/src/test/ui/inference/deref-suggestion.rs
+++ b/src/test/ui/inference/deref-suggestion.rs
@@ -1,5 +1,5 @@
 macro_rules! borrow {
-    ($x:expr) => { &$x } //~ ERROR mismatched types
+    ($x:expr) => { &$x }
 }
 
 fn foo(_: String) {}
@@ -32,6 +32,7 @@ fn main() {
     foo(&mut "aaa".to_owned());
     //~^ ERROR mismatched types
     foo3(borrow!(0));
+    //~^ ERROR mismatched types
     foo4(&0);
     assert_eq!(3i32, &3i32);
     //~^ ERROR mismatched types

--- a/src/test/ui/inference/deref-suggestion.stderr
+++ b/src/test/ui/inference/deref-suggestion.stderr
@@ -70,13 +70,10 @@ LL +     foo("aaa".to_owned());
    |
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:2:20
+  --> $DIR/deref-suggestion.rs:34:10
    |
-LL |     ($x:expr) => { &$x }
-   |                    ^^^ expected `u32`, found `&{integer}`
-...
 LL |     foo3(borrow!(0));
-   |     ---- ---------- in this macro invocation
+   |     ---- ^^^^^^^^^^ expected `u32`, found `&{integer}`
    |     |
    |     arguments to this function are incorrect
    |
@@ -85,10 +82,9 @@ note: function defined here
    |
 LL | fn foo3(_: u32) {}
    |    ^^^^ ------
-   = note: this error originates in the macro `borrow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:36:5
+  --> $DIR/deref-suggestion.rs:37:5
    |
 LL |     assert_eq!(3i32, &3i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `&i32`
@@ -96,7 +92,7 @@ LL |     assert_eq!(3i32, &3i32);
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:39:17
+  --> $DIR/deref-suggestion.rs:40:17
    |
 LL |     let s = S { u };
    |                 ^
@@ -105,7 +101,7 @@ LL |     let s = S { u };
    |                 help: consider borrowing here: `u: &u`
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:41:20
+  --> $DIR/deref-suggestion.rs:42:20
    |
 LL |     let s = S { u: u };
    |                    ^
@@ -114,7 +110,7 @@ LL |     let s = S { u: u };
    |                    help: consider borrowing here: `&u`
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:44:17
+  --> $DIR/deref-suggestion.rs:45:17
    |
 LL |     let r = R { i };
    |                 ^ expected `u32`, found `&{integer}`
@@ -125,7 +121,7 @@ LL |     let r = R { i: *i };
    |                 ++++
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:46:20
+  --> $DIR/deref-suggestion.rs:47:20
    |
 LL |     let r = R { i: i };
    |                    ^ expected `u32`, found `&{integer}`
@@ -136,7 +132,7 @@ LL |     let r = R { i: *i };
    |                    +
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:55:9
+  --> $DIR/deref-suggestion.rs:56:9
    |
 LL |         b
    |         ^ expected `i32`, found `&{integer}`
@@ -147,7 +143,7 @@ LL |         *b
    |         +
 
 error[E0308]: mismatched types
-  --> $DIR/deref-suggestion.rs:63:9
+  --> $DIR/deref-suggestion.rs:64:9
    |
 LL |         b
    |         ^ expected `i32`, found `&{integer}`
@@ -158,7 +154,7 @@ LL |         *b
    |         +
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/deref-suggestion.rs:68:12
+  --> $DIR/deref-suggestion.rs:69:12
    |
 LL |        let val = if true {
    |   _______________-


### PR DESCRIPTION
Makes more sense to point out the arg's span, and not the expression inside the macro