### PR TITLE
[perf experiment] Don't emit noalias for box when compiling rustc itself

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1403,6 +1403,7 @@ impl<'a> Builder<'a> {
                 cargo.args(s.split_whitespace());
             }
             rustflags.env("RUSTFLAGS_NOT_BOOTSTRAP");
+            rustflags.arg("-Zbox-noalias=no");
         } else {
             if let Ok(s) = env::var("CARGOFLAGS_BOOTSTRAP") {
                 cargo.args(s.split_whitespace());


### PR DESCRIPTION
This compiles rustc without noalias on box to evaluate the performance impact of such a change on a large scale project like rustc.

Only add it for stage1 compiling stage2, since beta doesn't have the flag yet and stage2 is running the benchmarks. 

Most importantly, this does NOT change the emitting of noalias when compiling crates other than rustc, to avoid perf impacts from LLVM having to process less attributes like in #98017.

r? @RalfJung