### PR TITLE
Register opaque types even when equated with infer variables

### DIFF
--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -184,16 +184,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         } else if let Some(res) = process(b, a) {
             res
         } else {
-            // Rerun equality check, but this time error out due to
-            // different types.
-            match self.at(cause, param_env).define_opaque_types(false).eq(a, b) {
-                Ok(_) => span_bug!(
-                    cause.span,
-                    "opaque types are never equal to anything but themselves: {:#?}",
-                    (a.kind(), b.kind())
-                ),
-                Err(e) => Err(e),
-            }
+            self.at(cause, param_env).define_opaque_types(false).eq(a, b)
         }
     }
 

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -90,7 +90,7 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
                 // Shouldn't have any LBR here, so we can safely put
                 // this under a binder below without fear of accidental
                 // capture.
-                assert!(!a.has_escaping_bound_vars());
+            assert!(!a.has_escaping_bound_vars());
                 assert!(!b.has_escaping_bound_vars());
 
                 // can't make progress on `A <: B` if both A and B are


### PR DESCRIPTION
**note:** This doesn't work, but it does fix #99536. Just putting this code up for other people's eyes.

The issue this attempts to solve here is that when we [`Equate::tys`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/relate/trait.TypeRelation.html#tymethod.tys) on an inference variable and an opaque type, we end up just storing the opaque type in the type variable table, instead of [handling](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#method.handle_opaque_type) the opaque type as we should be doing.

Thoughts on this? cc @oli-obk in particular. I'd like to work towards a real working solution if possible, if this approach has any merit.