### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1727,7 +1727,7 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
     }
 
     fn print_const(self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
-        self.pretty_print_const(ct, true)
+        self.pretty_print_const(ct, false)
     }
 
     fn path_crate(mut self, cnum: CrateNum) -> Result<Self::Path, Self::Error> {

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -185,14 +185,20 @@ pub fn is_const_evaluatable<'cx, 'tcx>(
         }
         let concrete = infcx.const_eval_resolve(param_env, uv.expand(), Some(span));
         match concrete {
-            Err(ErrorHandled::TooGeneric) => Err(if !uv.has_infer_types_or_consts() {
+            Err(ErrorHandled::TooGeneric) => Err(if uv.has_infer_types_or_consts() {
+                NotConstEvaluatable::MentionsInfer
+            } else if uv.has_param_types_or_consts() {
                 infcx
                     .tcx
                     .sess
                     .delay_span_bug(span, &format!("unexpected `TooGeneric` for {:?}", uv));
                 NotConstEvaluatable::MentionsParam
             } else {
-                NotConstEvaluatable::MentionsInfer
+                let guar = infcx.tcx.sess.delay_span_bug(
+                    span,
+                    format!("Missing value for constant, but no error reported?"),
+                );
+                NotConstEvaluatable::Error(guar)
             }),
             Err(ErrorHandled::Linted) => {
                 let reported = infcx
@@ -240,8 +246,11 @@ pub fn is_const_evaluatable<'cx, 'tcx>(
 
             Err(ErrorHandled::TooGeneric) => Err(if uv.has_infer_types_or_consts() {
                 NotConstEvaluatable::MentionsInfer
-                } else {
+                } else if uv.has_param_types_or_consts() {
                 NotConstEvaluatable::MentionsParam
+            } else {
+                let guar = infcx.tcx.sess.delay_span_bug(span, format!("Missing value for constant, but no error reported?"));
+                NotConstEvaluatable::Error(guar)
             }),
             Err(ErrorHandled::Linted) => {
                 let reported =

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -280,6 +280,11 @@ fn resolve_associated_item<'tcx>(
                 return Ok(None);
             }
 
+            // If the item does not have a value, then we cannot return an instance.
+            if !leaf_def.item.defaultness.has_value() {
+                return Ok(None);
+            }
+
             let substs = tcx.erase_regions(substs);
 
             // Check if we just resolved an associated `const` declaration from

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -195,6 +195,41 @@ impl<B, C> ControlFlow<B, C> {
             ControlFlow::Break(x) => ControlFlow::Break(f(x)),
         }
     }
+
+    /// Converts the `ControlFlow` into an `Option` which is `Some` if the
+    /// `ControlFlow` was `Continue` and `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(control_flow_enum)]
+    /// use std::ops::ControlFlow;
+    ///
+    /// assert_eq!(ControlFlow::<i32, String>::Break(3).continue_value(), None);
+    /// assert_eq!(ControlFlow::<String, i32>::Continue(3).continue_value(), Some(3));
+    /// ```
+    #[inline]
+    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
+    pub fn continue_value(self) -> Option<C> {
+        match self {
+            ControlFlow::Continue(x) => Some(x),
+            ControlFlow::Break(..) => None,
+        }
+    }
+
+    /// Maps `ControlFlow<B, C>` to `ControlFlow<B, T>` by applying a function
+    /// to the continue value in case it exists.
+    #[inline]
+    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
+    pub fn map_continue<T, F>(self, f: F) -> ControlFlow<B, T>
+    where
+        F: FnOnce(C) -> T,
+    {
+        match self {
+            ControlFlow::Continue(x) => ControlFlow::Continue(f(x)),
+            ControlFlow::Break(x) => ControlFlow::Break(x),
+        }
+    }
 }
 
 /// These are used only as part of implementing the iterator adapters.

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -356,7 +356,7 @@ impl From<OwnedFd> for crate::net::UdpSocket {
     }
 }
 
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "asfd_ptrs", since = "1.64.0")]
 /// This impl allows implementing traits that require `AsFd` on Arc.
 /// ```
 /// # #[cfg(any(unix, target_os = "wasi"))] mod group_cfg {
@@ -379,7 +379,7 @@ impl<T: AsFd> AsFd for crate::sync::Arc<T> {
     }
 }
 
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "asfd_ptrs", since = "1.64.0")]
 impl<T: AsFd> AsFd for Box<T> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {

--- a/library/std/src/sys/unix/futex.rs
+++ b/library/std/src/sys/unix/futex.rs
@@ -240,17 +240,22 @@ pub fn futex_wake_all(futex: &AtomicU32) {
 }
 
 #[cfg(target_os = "fuchsia")]
-mod zircon {
-    type zx_time_t = i64;
-    type zx_futex_t = crate::sync::atomic::AtomicU32;
-    type zx_handle_t = u32;
-    type zx_status_t = i32;
+pub mod zircon {
+    pub type zx_futex_t = crate::sync::atomic::AtomicU32;
+    pub type zx_handle_t = u32;
+    pub type zx_status_t = i32;
+    pub type zx_time_t = i64;
 
     pub const ZX_HANDLE_INVALID: zx_handle_t = 0;
-    pub const ZX_ERR_TIMED_OUT: zx_status_t = -21;
+
     pub const ZX_TIME_INFINITE: zx_time_t = zx_time_t::MAX;
 
+    pub const ZX_OK: zx_status_t = 0;
+    pub const ZX_ERR_BAD_STATE: zx_status_t = -20;
+    pub const ZX_ERR_TIMED_OUT: zx_status_t = -21;
+
     extern "C" {
+        pub fn zx_clock_get_monotonic() -> zx_time_t;
         pub fn zx_futex_wait(
             value_ptr: *const zx_futex_t,
             current_value: zx_futex_t,
@@ -258,7 +263,8 @@ mod zircon {
             deadline: zx_time_t,
         ) -> zx_status_t;
         pub fn zx_futex_wake(value_ptr: *const zx_futex_t, wake_count: u32) -> zx_status_t;
-        pub fn zx_clock_get_monotonic() -> zx_time_t;
+        pub fn zx_futex_wake_single_owner(value_ptr: *const zx_futex_t) -> zx_status_t;
+        pub fn zx_thread_self() -> zx_handle_t;
     }
 }
 
@@ -286,4 +292,9 @@ pub fn futex_wait(futex: &AtomicU32, expected: u32, timeout: Option<Duration>) -
 pub fn futex_wake(futex: &AtomicU32) -> bool {
     unsafe { zircon::zx_futex_wake(futex, 1) };
     false
+}
+
+#[cfg(target_os = "fuchsia")]
+pub fn futex_wake_all(futex: &AtomicU32) {
+    unsafe { zircon::zx_futex_wake(futex, u32::MAX) };
 }

--- a/library/std/src/sys/unix/futex.rs
+++ b/library/std/src/sys/unix/futex.rs
@@ -267,7 +267,6 @@ pub mod zircon {
         ) -> zx_status_t;
         pub fn zx_futex_wake(value_ptr: *const zx_futex_t, wake_count: u32) -> zx_status_t;
         pub fn zx_futex_wake_single_owner(value_ptr: *const zx_futex_t) -> zx_status_t;
-        pub fn zx_nanosleep(deadline: zx_time_t) -> zx_status_t;
         pub fn zx_thread_self() -> zx_handle_t;
     }
 }

--- a/library/std/src/sys/unix/futex.rs
+++ b/library/std/src/sys/unix/futex.rs
@@ -251,6 +251,9 @@ pub mod zircon {
     pub const ZX_TIME_INFINITE: zx_time_t = zx_time_t::MAX;
 
     pub const ZX_OK: zx_status_t = 0;
+    pub const ZX_ERR_INVALID_ARGS: zx_status_t = -10;
+    pub const ZX_ERR_BAD_HANDLE: zx_status_t = -11;
+    pub const ZX_ERR_WRONG_TYPE: zx_status_t = -12;
     pub const ZX_ERR_BAD_STATE: zx_status_t = -20;
     pub const ZX_ERR_TIMED_OUT: zx_status_t = -21;
 
@@ -264,6 +267,7 @@ pub mod zircon {
         ) -> zx_status_t;
         pub fn zx_futex_wake(value_ptr: *const zx_futex_t, wake_count: u32) -> zx_status_t;
         pub fn zx_futex_wake_single_owner(value_ptr: *const zx_futex_t) -> zx_status_t;
+        pub fn zx_nanosleep(deadline: zx_time_t) -> zx_status_t;
         pub fn zx_thread_self() -> zx_handle_t;
     }
 }

--- a/library/std/src/sys/unix/locks/fuchsia_mutex.rs
+++ b/library/std/src/sys/unix/locks/fuchsia_mutex.rs
@@ -42,9 +42,9 @@ use crate::sync::atomic::{
     Ordering::{Acquire, Relaxed, Release},
 };
 use crate::sys::futex::zircon::{
-    zx_futex_wait, zx_futex_wake_single_owner, zx_handle_t, zx_nanosleep, zx_thread_self,
-    ZX_ERR_BAD_HANDLE, ZX_ERR_BAD_STATE, ZX_ERR_INVALID_ARGS, ZX_ERR_TIMED_OUT, ZX_ERR_WRONG_TYPE,
-    ZX_OK, ZX_TIME_INFINITE, ZX_TIME_INFINITE,
+    zx_futex_wait, zx_futex_wake_single_owner, zx_handle_t, zx_thread_self, ZX_ERR_BAD_HANDLE,
+    ZX_ERR_BAD_STATE, ZX_ERR_INVALID_ARGS, ZX_ERR_TIMED_OUT, ZX_ERR_WRONG_TYPE, ZX_OK,
+    ZX_TIME_INFINITE, ZX_TIME_INFINITE,
 };
 
 // The lowest two bits of a `zx_handle_t` are always set, so the lowest bit is used to mark the
@@ -122,18 +122,18 @@ impl Mutex {
                         ZX_TIME_INFINITE,
                     ) {
                         ZX_OK | ZX_ERR_BAD_STATE | ZX_ERR_TIMED_OUT => (),
-                        // Either the current thread is trying to lock a mutex it has already locked,
-                        // or the previous owner did not unlock the mutex before exiting. Since it is
-                        // not possible to reliably detect which is the case, the current thread is
-                        // deadlocked. This makes debugging these cases quite a bit harder, but encourages
-                        // portable programming, since all other platforms do the same.
-                        //
-                        // Note that if the thread handle is reused, an arbitrary thread's priority could
-                        // be boosted by the wait, but there is currently no way to prevent that.
-                        ZX_ERR_INVALID_ARGS | ZX_ERR_BAD_HANDLE | ZX_ERR_WRONG_TYPE => loop {
-                            zx_nanosleep(ZX_TIME_INFINITE);
-                        },
-                        error => unreachable!("unexpected error code in futex wait: {error}"),
+                        // Note that if a thread handle is reused after its associated thread
+                        // exits without unlocking the mutex, an arbitrary thread's priority
+                        // could be boosted by the wait, but there is currently no way to
+                        // prevent that.
+                        ZX_ERR_INVALID_ARGS | ZX_ERR_BAD_HANDLE | ZX_ERR_WRONG_TYPE => {
+                            panic!(
+                                "either the current thread is trying to lock a mutex it has
+                                already locked, or the previous uowner did not unlock the mutex
+                                before exiting"
+                            )
+                        }
+                        error => panic!("unexpected error in zx_futex_wait: {error}"),
                     }
                 }
             }

--- a/library/std/src/sys/unix/locks/fuchsia_mutex.rs
+++ b/library/std/src/sys/unix/locks/fuchsia_mutex.rs
@@ -129,7 +129,7 @@ impl Mutex {
                         ZX_ERR_INVALID_ARGS | ZX_ERR_BAD_HANDLE | ZX_ERR_WRONG_TYPE => {
                             panic!(
                                 "either the current thread is trying to lock a mutex it has
-                                already locked, or the previous uowner did not unlock the mutex
+                                already locked, or the previous owner did not unlock the mutex
                                 before exiting"
                             )
                         }

--- a/library/std/src/sys/unix/locks/fuchsia_mutex.rs
+++ b/library/std/src/sys/unix/locks/fuchsia_mutex.rs
@@ -1,0 +1,158 @@
+//! A priority inheriting mutex for Fuchsia.
+//!
+//! This is a port of the [mutex in Fuchsia's libsync]. Contrary to the original,
+//! it does not abort the process when reentrant locking is detected, but deadlocks.
+//!
+//! Priority inheritance is achieved by storing the owning thread's handle in an
+//! atomic variable. Fuchsia's futex operations support setting an owner thread
+//! for a futex, which can boost that thread's priority while the futex is waited
+//! upon.
+//!
+//! libsync is licenced under the following BSD-style licence:
+//!
+//! Copyright 2016 The Fuchsia Authors.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions are
+//! met:
+//!
+//!    * Redistributions of source code must retain the above copyright
+//!      notice, this list of conditions and the following disclaimer.
+//!    * Redistributions in binary form must reproduce the above
+//!      copyright notice, this list of conditions and the following
+//!      disclaimer in the documentation and/or other materials provided
+//!      with the distribution.
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+//! A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+//! OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+//! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//! DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+//! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//!
+//! [mutex in Fuchsia's libsync]: https://cs.opensource.google/fuchsia/fuchsia/+/main:zircon/system/ulib/sync/mutex.c
+
+use crate::sync::atomic::{
+    AtomicU32,
+    Ordering::{Acquire, Relaxed, Release},
+};
+use crate::sys::futex::zircon::{
+    zx_futex_wait, zx_futex_wake_single_owner, zx_handle_t, zx_thread_self, ZX_ERR_BAD_STATE,
+    ZX_OK, ZX_TIME_INFINITE,
+};
+
+// The lowest two bits of a `zx_handle_t` are always set, so the lowest bit is used to mark the
+// mutex as contested by clearing it.
+const CONTESTED_BIT: u32 = 1;
+// This can never be a valid `zx_handle_t`.
+const UNLOCKED: u32 = 0;
+
+pub type MovableMutex = Mutex;
+
+pub struct Mutex {
+    futex: AtomicU32,
+}
+
+#[inline]
+fn to_state(owner: zx_handle_t) -> u32 {
+    owner
+}
+
+#[inline]
+fn to_owner(state: u32) -> zx_handle_t {
+    state | CONTESTED_BIT
+}
+
+#[inline]
+fn is_contested(state: u32) -> bool {
+    state & CONTESTED_BIT == 0
+}
+
+#[inline]
+fn mark_contested(state: u32) -> u32 {
+    state & !CONTESTED_BIT
+}
+
+impl Mutex {
+    #[inline]
+    pub const fn new() -> Mutex {
+        Mutex { futex: AtomicU32::new(UNLOCKED) }
+    }
+
+    #[inline]
+    pub unsafe fn init(&mut self) {}
+
+    #[inline]
+    pub unsafe fn try_lock(&self) -> bool {
+        let thread_self = zx_thread_self();
+        self.futex.compare_exchange(UNLOCKED, to_state(thread_self), Acquire, Relaxed).is_ok()
+    }
+
+    #[inline]
+    pub unsafe fn lock(&self) {
+        let thread_self = zx_thread_self();
+        if let Err(state) =
+            self.futex.compare_exchange(UNLOCKED, to_state(thread_self), Acquire, Relaxed)
+        {
+            self.lock_contested(state, thread_self);
+        }
+    }
+
+    #[cold]
+    fn lock_contested(&self, mut state: u32, thread_self: zx_handle_t) {
+        let owned_state = mark_contested(to_state(thread_self));
+        loop {
+            // Mark the mutex as contested if it is not already.
+            let contested = mark_contested(state);
+            if is_contested(state)
+                || self.futex.compare_exchange(state, contested, Relaxed, Relaxed).is_ok()
+            {
+                // The mutex has been marked as contested, wait for the state to change.
+                unsafe {
+                    match zx_futex_wait(
+                        &self.futex,
+                        AtomicU32::new(contested),
+                        to_owner(state),
+                        ZX_TIME_INFINITE,
+                    ) {
+                        ZX_OK | ZX_ERR_BAD_STATE => (),
+                        // Deadlock even in the case of reentrant locking, as leaking a guard
+                        // could lead to the same condition if the thread id is reused, but
+                        // panicking is not expected in that situation. This makes things
+                        // quite a bit harder to debug, but encourages portable programming.
+                        _ if to_owner(state) == thread_self => loop {},
+                        error => panic!("futex operation failed with error code {error}"),
+                    }
+                }
+            }
+
+            // The state has changed or a wakeup occured, try to lock the mutex.
+            match self.futex.compare_exchange(UNLOCKED, owned_state, Acquire, Relaxed) {
+                Ok(_) => return,
+                Err(updated) => state = updated,
+            }
+        }
+    }
+
+    #[inline]
+    pub unsafe fn unlock(&self) {
+        if is_contested(self.futex.swap(UNLOCKED, Release)) {
+            // The woken thread will mark the mutex as contested again,
+            // and return here, waking until there are no waiters left,
+            // in which case this is a noop.
+            self.wake();
+        }
+    }
+
+    #[cold]
+    fn wake(&self) {
+        unsafe {
+            zx_futex_wake_single_owner(&self.futex);
+        }
+    }
+}

--- a/library/std/src/sys/unix/locks/futex_condvar.rs
+++ b/library/std/src/sys/unix/locks/futex_condvar.rs
@@ -1,0 +1,58 @@
+use super::Mutex;
+use crate::sync::atomic::{AtomicU32, Ordering::Relaxed};
+use crate::sys::futex::{futex_wait, futex_wake, futex_wake_all};
+use crate::time::Duration;
+
+pub type MovableCondvar = Condvar;
+
+pub struct Condvar {
+    // The value of this atomic is simply incremented on every notification.
+    // This is used by `.wait()` to not miss any notifications after
+    // unlocking the mutex and before waiting for notifications.
+    futex: AtomicU32,
+}
+
+impl Condvar {
+    #[inline]
+    pub const fn new() -> Self {
+        Self { futex: AtomicU32::new(0) }
+    }
+
+    // All the memory orderings here are `Relaxed`,
+    // because synchronization is done by unlocking and locking the mutex.
+
+    pub unsafe fn notify_one(&self) {
+        self.futex.fetch_add(1, Relaxed);
+        futex_wake(&self.futex);
+    }
+
+    pub unsafe fn notify_all(&self) {
+        self.futex.fetch_add(1, Relaxed);
+        futex_wake_all(&self.futex);
+    }
+
+    pub unsafe fn wait(&self, mutex: &Mutex) {
+        self.wait_optional_timeout(mutex, None);
+    }
+
+    pub unsafe fn wait_timeout(&self, mutex: &Mutex, timeout: Duration) -> bool {
+        self.wait_optional_timeout(mutex, Some(timeout))
+    }
+
+    unsafe fn wait_optional_timeout(&self, mutex: &Mutex, timeout: Option<Duration>) -> bool {
+        // Examine the notification counter _before_ we unlock the mutex.
+        let futex_value = self.futex.load(Relaxed);
+
+        // Unlock the mutex before going to sleep.
+        mutex.unlock();
+
+        // Wait, but only if there hasn't been any
+        // notification since we unlocked the mutex.
+        let r = futex_wait(&self.futex, futex_value, timeout);
+
+        // Lock the mutex again.
+        mutex.lock();
+
+        r
+    }
+}

--- a/library/std/src/sys/unix/locks/futex_mutex.rs
+++ b/library/std/src/sys/unix/locks/futex_mutex.rs
@@ -2,11 +2,9 @@ use crate::sync::atomic::{
     AtomicU32,
     Ordering::{Acquire, Relaxed, Release},
 };
-use crate::sys::futex::{futex_wait, futex_wake, futex_wake_all};
-use crate::time::Duration;
+use crate::sys::futex::{futex_wait, futex_wake};
 
 pub type MovableMutex = Mutex;
-pub type MovableCondvar = Condvar;
 
 pub struct Mutex {
     /// 0: unlocked
@@ -99,57 +97,5 @@ impl Mutex {
     #[cold]
     fn wake(&self) {
         futex_wake(&self.futex);
-    }
-}
-
-pub struct Condvar {
-    // The value of this atomic is simply incremented on every notification.
-    // This is used by `.wait()` to not miss any notifications after
-    // unlocking the mutex and before waiting for notifications.
-    futex: AtomicU32,
-}
-
-impl Condvar {
-    #[inline]
-    pub const fn new() -> Self {
-        Self { futex: AtomicU32::new(0) }
-    }
-
-    // All the memory orderings here are `Relaxed`,
-    // because synchronization is done by unlocking and locking the mutex.
-
-    pub unsafe fn notify_one(&self) {
-        self.futex.fetch_add(1, Relaxed);
-        futex_wake(&self.futex);
-    }
-
-    pub unsafe fn notify_all(&self) {
-        self.futex.fetch_add(1, Relaxed);
-        futex_wake_all(&self.futex);
-    }
-
-    pub unsafe fn wait(&self, mutex: &Mutex) {
-        self.wait_optional_timeout(mutex, None);
-    }
-
-    pub unsafe fn wait_timeout(&self, mutex: &Mutex, timeout: Duration) -> bool {
-        self.wait_optional_timeout(mutex, Some(timeout))
-    }
-
-    unsafe fn wait_optional_timeout(&self, mutex: &Mutex, timeout: Option<Duration>) -> bool {
-        // Examine the notification counter _before_ we unlock the mutex.
-        let futex_value = self.futex.load(Relaxed);
-
-        // Unlock the mutex before going to sleep.
-        mutex.unlock();
-
-        // Wait, but only if there hasn't been any
-        // notification since we unlocked the mutex.
-        let r = futex_wait(&self.futex, futex_value, timeout);
-
-        // Lock the mutex again.
-        mutex.lock();
-
-        r
     }
 }

--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -7,10 +7,19 @@ cfg_if::cfg_if! {
         target_os = "openbsd",
         target_os = "dragonfly",
     ))] {
-        mod futex;
+        mod futex_mutex;
         mod futex_rwlock;
-        pub(crate) use futex::{Mutex, MovableMutex, MovableCondvar};
+        mod futex_condvar;
+        pub(crate) use futex_mutex::{Mutex, MovableMutex};
         pub(crate) use futex_rwlock::{RwLock, MovableRwLock};
+        pub(crate) use futex_condvar::MovableCondvar;
+    } else if #[cfg(target_os = "fuchsia")] {
+        mod fuchsia_mutex;
+        mod futex_rwlock;
+        mod futex_condvar;
+        pub(crate) use fuchsia_mutex::{Mutex, MovableMutex};
+        pub(crate) use futex_rwlock::{RwLock, MovableRwLock};
+        pub(crate) use futex_condvar::MovableCondvar;
     } else {
         mod pthread_mutex;
         mod pthread_rwlock;

--- a/src/test/rustdoc/const-generics/add-impl.rs
+++ b/src/test/rustdoc/const-generics/add-impl.rs
@@ -7,7 +7,7 @@ pub struct Simd<T, const WIDTH: usize> {
     inner: T,
 }
 
-// @has foo/struct.Simd.html '//div[@id="trait-implementations-list"]//h3[@class="code-header in-band"]' 'impl Add<Simd<u8, 16_usize>> for Simd<u8, 16>'
+// @has foo/struct.Simd.html '//div[@id="trait-implementations-list"]//h3[@class="code-header in-band"]' 'impl Add<Simd<u8, 16>> for Simd<u8, 16>'
 impl Add for Simd<u8, 16> {
     type Output = Self;
 

--- a/src/test/rustdoc/const-generics/const-generic-defaults.rs
+++ b/src/test/rustdoc/const-generics/const-generic-defaults.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
 
 // @has foo/struct.Foo.html '//pre[@class="rust struct"]' \
-//      'pub struct Foo<const M: usize = 10_usize, const N: usize = M, T = i32>(_);'
+//      'pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>(_);'
 pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>(T);

--- a/src/test/rustdoc/const-generics/const-generics-docs.rs
+++ b/src/test/rustdoc/const-generics/const-generics-docs.rs
@@ -19,8 +19,8 @@ pub use extern_crate::WTrait;
 
 // @has foo/trait.Trait.html '//pre[@class="rust trait"]' \
 //      'pub trait Trait<const N: usize>'
-// @has - '//*[@id="impl-Trait%3C1_usize%3E-for-u8"]//h3[@class="code-header in-band"]' 'impl Trait<1_usize> for u8'
-// @has - '//*[@id="impl-Trait%3C2_usize%3E-for-u8"]//h3[@class="code-header in-band"]' 'impl Trait<2_usize> for u8'
+// @has - '//*[@id="impl-Trait%3C1%3E-for-u8"]//h3[@class="code-header in-band"]' 'impl Trait<1> for u8'
+// @has - '//*[@id="impl-Trait%3C2%3E-for-u8"]//h3[@class="code-header in-band"]' 'impl Trait<2> for u8'
 // @has - '//*[@id="impl-Trait%3C{1%20+%202}%3E-for-u8"]//h3[@class="code-header in-band"]' 'impl Trait<{1 + 2}> for u8'
 // @has - '//*[@id="impl-Trait%3CN%3E-for-%5Bu8%3B%20N%5D"]//h3[@class="code-header in-band"]' \
 //      'impl<const N: usize> Trait<N> for [u8; N]'

--- a/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value_self.rs
+++ b/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value_self.rs
@@ -44,11 +44,11 @@ struct WithParameters<T, const N: usize, M = u32> {
 }
 
 impl<T> WithParameters<T, 1> {
-    fn with_ref(&self) {} //~ ERROR passing `WithParameters<T, 1_usize>` by reference
+    fn with_ref(&self) {} //~ ERROR passing `WithParameters<T, 1>` by reference
 }
 
 impl<T> WithParameters<T, 1, u8> {
-    fn with_ref(&self) {} //~ ERROR passing `WithParameters<T, 1_usize, u8>` by reference
+    fn with_ref(&self) {} //~ ERROR passing `WithParameters<T, 1, u8>` by reference
 }
 
 fn main() {}

--- a/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value_self.stderr
+++ b/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value_self.stderr
@@ -22,13 +22,13 @@ error: passing `Foo` by reference
 LL |     fn with_ref(&self) {}
    |                 ^^^^^ help: try passing by value: `Foo`
 
-error: passing `WithParameters<T, 1_usize>` by reference
+error: passing `WithParameters<T, 1>` by reference
   --> $DIR/rustc_pass_by_value_self.rs:47:17
    |
 LL |     fn with_ref(&self) {}
    |                 ^^^^^ help: try passing by value: `WithParameters<T, 1>`
 
-error: passing `WithParameters<T, 1_usize, u8>` by reference
+error: passing `WithParameters<T, 1, u8>` by reference
   --> $DIR/rustc_pass_by_value_self.rs:51:17
    |
 LL |     fn with_ref(&self) {}

--- a/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value_self.stderr
+++ b/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value_self.stderr
@@ -26,13 +26,13 @@ error: passing `WithParameters<T, 1_usize>` by reference
   --> $DIR/rustc_pass_by_value_self.rs:47:17
    |
 LL |     fn with_ref(&self) {}
-   |                 ^^^^^ help: try passing by value: `WithParameters<T, 1_usize>`
+   |                 ^^^^^ help: try passing by value: `WithParameters<T, 1>`
 
 error: passing `WithParameters<T, 1_usize, u8>` by reference
   --> $DIR/rustc_pass_by_value_self.rs:51:17
    |
 LL |     fn with_ref(&self) {}
-   |                 ^^^^^ help: try passing by value: `WithParameters<T, 1_usize, u8>`
+   |                 ^^^^^ help: try passing by value: `WithParameters<T, 1, u8>`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
+++ b/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/match_arr_unknown_len.rs:3:9
    |
 LL |         [1, 2] => true,
-   |         ^^^^^^ expected `2_usize`, found `N`
+   |         ^^^^^^ expected `2`, found `N`
    |
    = note: expected array `[u32; 2]`
               found array `[u32; N]`

--- a/src/test/ui/const-generics/associated-type-bound-fail.stderr
+++ b/src/test/ui/const-generics/associated-type-bound-fail.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `u16: Bar<N>` is not satisfied
 LL |     type Assoc = u16;
    |                  ^^^ the trait `Bar<N>` is not implemented for `u16`
    |
-   = help: the trait `Bar<3_usize>` is implemented for `u16`
+   = help: the trait `Bar<3>` is implemented for `u16`
 note: required by a bound in `Foo::Assoc`
   --> $DIR/associated-type-bound-fail.rs:4:17
    |

--- a/src/test/ui/const-generics/defaults/generic-expr-default-concrete.stderr
+++ b/src/test/ui/const-generics/defaults/generic-expr-default-concrete.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/generic-expr-default-concrete.rs:10:5
    |
 LL |     Foo::<10, 12>
-   |     ^^^^^^^^^^^^^ expected `11_usize`, found `12_usize`
+   |     ^^^^^^^^^^^^^ expected `11`, found `12`
    |
-   = note: expected type `11_usize`
-              found type `12_usize`
+   = note: expected type `11`
+              found type `12`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/mismatch.rs
+++ b/src/test/ui/const-generics/defaults/mismatch.rs
@@ -1,22 +1,22 @@
-pub struct Example<const N: usize=13>;
-pub struct Example2<T=u32, const N: usize=13>(T);
-pub struct Example3<const N: usize=13, T=u32>(T);
-pub struct Example4<const N: usize=13, const M: usize=4>;
+pub struct Example<const N: usize = 13>;
+pub struct Example2<T = u32, const N: usize = 13>(T);
+pub struct Example3<const N: usize = 13, T = u32>(T);
+pub struct Example4<const N: usize = 13, const M: usize = 4>;
 
 fn main() {
-    let e: Example::<13> = ();
+    let e: Example<13> = ();
     //~^ Error: mismatched types
     //~| expected struct `Example`
-    let e: Example2::<u32, 13> = ();
+    let e: Example2<u32, 13> = ();
     //~^ Error: mismatched types
     //~| expected struct `Example2`
-    let e: Example3::<13, u32> = ();
+    let e: Example3<13, u32> = ();
     //~^ Error: mismatched types
     //~| expected struct `Example3`
-    let e: Example3::<7> = ();
+    let e: Example3<7> = ();
     //~^ Error: mismatched types
-    //~| expected struct `Example3<7_usize>`
-    let e: Example4::<7> = ();
+    //~| expected struct `Example3<7>`
+    let e: Example4<7> = ();
     //~^ Error: mismatched types
-    //~| expected struct `Example4<7_usize>`
+    //~| expected struct `Example4<7>`
 }

--- a/src/test/ui/const-generics/defaults/mismatch.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:7:28
+  --> $DIR/mismatch.rs:7:26
    |
-LL |     let e: Example::<13> = ();
-   |            -------------   ^^ expected struct `Example`, found `()`
+LL |     let e: Example<13> = ();
+   |            -----------   ^^ expected struct `Example`, found `()`
    |            |
    |            expected due to this
    |
@@ -10,10 +10,10 @@ LL |     let e: Example::<13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:10:34
+  --> $DIR/mismatch.rs:10:32
    |
-LL |     let e: Example2::<u32, 13> = ();
-   |            -------------------   ^^ expected struct `Example2`, found `()`
+LL |     let e: Example2<u32, 13> = ();
+   |            -----------------   ^^ expected struct `Example2`, found `()`
    |            |
    |            expected due to this
    |
@@ -21,10 +21,10 @@ LL |     let e: Example2::<u32, 13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:13:34
+  --> $DIR/mismatch.rs:13:32
    |
-LL |     let e: Example3::<13, u32> = ();
-   |            -------------------   ^^ expected struct `Example3`, found `()`
+LL |     let e: Example3<13, u32> = ();
+   |            -----------------   ^^ expected struct `Example3`, found `()`
    |            |
    |            expected due to this
    |
@@ -32,25 +32,25 @@ LL |     let e: Example3::<13, u32> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:16:28
+  --> $DIR/mismatch.rs:16:26
    |
-LL |     let e: Example3::<7> = ();
-   |            -------------   ^^ expected struct `Example3`, found `()`
+LL |     let e: Example3<7> = ();
+   |            -----------   ^^ expected struct `Example3`, found `()`
    |            |
    |            expected due to this
    |
-   = note: expected struct `Example3<7_usize>`
+   = note: expected struct `Example3<7>`
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:19:28
+  --> $DIR/mismatch.rs:19:26
    |
-LL |     let e: Example4::<7> = ();
-   |            -------------   ^^ expected struct `Example4`, found `()`
+LL |     let e: Example4<7> = ();
+   |            -----------   ^^ expected struct `Example4`, found `()`
    |            |
    |            expected due to this
    |
-   = note: expected struct `Example4<7_usize>`
+   = note: expected struct `Example4<7>`
            found unit type `()`
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/const-generics/defaults/rp_impl_trait_fail.rs
+++ b/src/test/ui/const-generics/defaults/rp_impl_trait_fail.rs
@@ -4,15 +4,14 @@ trait Trait {}
 impl<const N: u32> Trait for Uwu<N> {}
 
 fn rawr() -> impl Trait {
-    //~^ error: the trait bound `Uwu<10_u32, 12_u32>: Trait` is not satisfied
+    //~^ error: the trait bound `Uwu<10, 12>: Trait` is not satisfied
     Uwu::<10, 12>
 }
 
-trait Traitor<const N: u8 = 1, const M: u8 = N> { }
+trait Traitor<const N: u8 = 1, const M: u8 = N> {}
 
 impl<const N: u8> Traitor<N, 2> for u32 {}
 impl Traitor<1, 2> for u64 {}
-
 
 fn uwu<const N: u8>() -> impl Traitor<N> {
     //~^ error: the trait bound `u32: Traitor<N>` is not satisfied

--- a/src/test/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/src/test/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -1,16 +1,16 @@
-error[E0277]: the trait bound `Uwu<10_u32, 12_u32>: Trait` is not satisfied
+error[E0277]: the trait bound `Uwu<10, 12>: Trait` is not satisfied
   --> $DIR/rp_impl_trait_fail.rs:6:14
    |
 LL | fn rawr() -> impl Trait {
-   |              ^^^^^^^^^^ the trait `Trait` is not implemented for `Uwu<10_u32, 12_u32>`
+   |              ^^^^^^^^^^ the trait `Trait` is not implemented for `Uwu<10, 12>`
 LL |
 LL |     Uwu::<10, 12>
-   |     ------------- return type was inferred to be `Uwu<10_u32, 12_u32>` here
+   |     ------------- return type was inferred to be `Uwu<10, 12>` here
    |
    = help: the trait `Trait` is implemented for `Uwu<N>`
 
 error[E0277]: the trait bound `u32: Traitor<N>` is not satisfied
-  --> $DIR/rp_impl_trait_fail.rs:17:26
+  --> $DIR/rp_impl_trait_fail.rs:16:26
    |
 LL | fn uwu<const N: u8>() -> impl Traitor<N> {
    |                          ^^^^^^^^^^^^^^^ the trait `Traitor<N>` is not implemented for `u32`
@@ -19,11 +19,11 @@ LL |     1_u32
    |     ----- return type was inferred to be `u32` here
    |
    = help: the following other types implement trait `Traitor<N, M>`:
-             <u32 as Traitor<N, 2_u8>>
-             <u64 as Traitor<1_u8, 2_u8>>
+             <u32 as Traitor<N, 2>>
+             <u64 as Traitor<1, 2>>
 
 error[E0277]: the trait bound `u64: Traitor` is not satisfied
-  --> $DIR/rp_impl_trait_fail.rs:22:13
+  --> $DIR/rp_impl_trait_fail.rs:21:13
    |
 LL | fn owo() -> impl Traitor {
    |             ^^^^^^^^^^^^ the trait `Traitor` is not implemented for `u64`
@@ -32,8 +32,8 @@ LL |     1_u64
    |     ----- return type was inferred to be `u64` here
    |
    = help: the following other types implement trait `Traitor<N, M>`:
-             <u32 as Traitor<N, 2_u8>>
-             <u64 as Traitor<1_u8, 2_u8>>
+             <u32 as Traitor<N, 2>>
+             <u64 as Traitor<1, 2>>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/defaults/trait_objects_fail.rs
+++ b/src/test/ui/const-generics/defaults/trait_objects_fail.rs
@@ -16,7 +16,7 @@ trait Traitor<const N: u8 = 1, const M: u8 = N> {
     }
 }
 
-impl Traitor<2, 3> for bool { }
+impl Traitor<2, 3> for bool {}
 
 fn bar<const N: u8>(arg: &dyn Traitor<N>) -> u8 {
     arg.owo()
@@ -26,5 +26,5 @@ fn main() {
     foo(&10_u32);
     //~^ error: the trait bound `u32: Trait` is not satisfied
     bar(&true);
-    //~^ error: the trait bound `bool: Traitor<{_: u8}>` is not satisfied
+    //~^ error: the trait bound `bool: Traitor<_>` is not satisfied
 }

--- a/src/test/ui/const-generics/defaults/trait_objects_fail.stderr
+++ b/src/test/ui/const-generics/defaults/trait_objects_fail.stderr
@@ -6,19 +6,19 @@ LL |     foo(&10_u32);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Trait<2_u8>` is implemented for `u32`
+   = help: the trait `Trait<2>` is implemented for `u32`
    = note: required for the cast from `u32` to the object type `dyn Trait`
 
-error[E0277]: the trait bound `bool: Traitor<{_: u8}>` is not satisfied
+error[E0277]: the trait bound `bool: Traitor<_>` is not satisfied
   --> $DIR/trait_objects_fail.rs:28:9
    |
 LL |     bar(&true);
-   |     --- ^^^^^ the trait `Traitor<{_: u8}>` is not implemented for `bool`
+   |     --- ^^^^^ the trait `Traitor<_>` is not implemented for `bool`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Traitor<2_u8, 3_u8>` is implemented for `bool`
-   = note: required for the cast from `bool` to the object type `dyn Traitor<{_: u8}>`
+   = help: the trait `Traitor<2, 3>` is implemented for `bool`
+   = note: required for the cast from `bool` to the object type `dyn Traitor<_>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/defaults/wfness.rs
+++ b/src/test/ui/const-generics/defaults/wfness.rs
@@ -3,16 +3,20 @@ struct Ooopsies<const N: u8 = { u8::MAX + 1 }>;
 
 trait Trait<const N: u8> {}
 impl Trait<3> for () {}
-struct WhereClause<const N: u8 = 2> where (): Trait<N>;
-//~^ error: the trait bound `(): Trait<2_u8>` is not satisfied
+struct WhereClause<const N: u8 = 2>
+where
+    (): Trait<N>;
+//~^ error: the trait bound `(): Trait<2>` is not satisfied
 
 trait Traitor<T, const N: u8> {}
-struct WhereClauseTooGeneric<T = u32, const N: u8 = 2>(T) where (): Traitor<T, N>;
+struct WhereClauseTooGeneric<T = u32, const N: u8 = 2>(T)
+where
+    (): Traitor<T, N>;
 
 // no error on struct def
 struct DependentDefaultWfness<const N: u8 = 1, T = WhereClause<N>>(T);
 fn foo() -> DependentDefaultWfness {
-    //~^ error: the trait bound `(): Trait<1_u8>` is not satisfied
+    //~^ error: the trait bound `(): Trait<1>` is not satisfied
     loop {}
 }
 

--- a/src/test/ui/const-generics/defaults/wfness.stderr
+++ b/src/test/ui/const-generics/defaults/wfness.stderr
@@ -4,26 +4,29 @@ error[E0080]: evaluation of constant value failed
 LL | struct Ooopsies<const N: u8 = { u8::MAX + 1 }>;
    |                                 ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
 
-error[E0277]: the trait bound `(): Trait<2_u8>` is not satisfied
-  --> $DIR/wfness.rs:6:47
+error[E0277]: the trait bound `(): Trait<2>` is not satisfied
+  --> $DIR/wfness.rs:8:9
    |
-LL | struct WhereClause<const N: u8 = 2> where (): Trait<N>;
-   |                                               ^^^^^^^^ the trait `Trait<2_u8>` is not implemented for `()`
+LL |     (): Trait<N>;
+   |         ^^^^^^^^ the trait `Trait<2>` is not implemented for `()`
    |
-   = help: the trait `Trait<3_u8>` is implemented for `()`
+   = help: the trait `Trait<3>` is implemented for `()`
 
-error[E0277]: the trait bound `(): Trait<1_u8>` is not satisfied
-  --> $DIR/wfness.rs:14:13
+error[E0277]: the trait bound `(): Trait<1>` is not satisfied
+  --> $DIR/wfness.rs:18:13
    |
 LL | fn foo() -> DependentDefaultWfness {
-   |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<1_u8>` is not implemented for `()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<1>` is not implemented for `()`
    |
-   = help: the trait `Trait<3_u8>` is implemented for `()`
+   = help: the trait `Trait<3>` is implemented for `()`
 note: required by a bound in `WhereClause`
-  --> $DIR/wfness.rs:6:47
+  --> $DIR/wfness.rs:8:9
    |
-LL | struct WhereClause<const N: u8 = 2> where (): Trait<N>;
-   |                                               ^^^^^^^^ required by this bound in `WhereClause`
+LL | struct WhereClause<const N: u8 = 2>
+   |        ----------- required by a bound in this
+LL | where
+LL |     (): Trait<N>;
+   |         ^^^^^^^^ required by this bound in `WhereClause`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/different_generic_args.full.stderr
+++ b/src/test/ui/const-generics/different_generic_args.full.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/different_generic_args.rs:11:9
    |
 LL |     u = ConstUsize::<4> {};
-   |         ^^^^^^^^^^^^^^^^^^ expected `3_usize`, found `4_usize`
+   |         ^^^^^^^^^^^^^^^^^^ expected `3`, found `4`
    |
-   = note: expected struct `ConstUsize<3_usize>`
-              found struct `ConstUsize<4_usize>`
+   = note: expected struct `ConstUsize<3>`
+              found struct `ConstUsize<4>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/different_generic_args.min.stderr
+++ b/src/test/ui/const-generics/different_generic_args.min.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/different_generic_args.rs:11:9
    |
 LL |     u = ConstUsize::<4> {};
-   |         ^^^^^^^^^^^^^^^^^^ expected `3_usize`, found `4_usize`
+   |         ^^^^^^^^^^^^^^^^^^ expected `3`, found `4`
    |
-   = note: expected struct `ConstUsize<3_usize>`
-              found struct `ConstUsize<4_usize>`
+   = note: expected struct `ConstUsize<3>`
+              found struct `ConstUsize<4>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/different_generic_args_array.stderr
+++ b/src/test/ui/const-generics/different_generic_args_array.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/different_generic_args_array.rs:9:9
    |
 LL |     x = Const::<{ [4] }> {};
-   |         ^^^^^^^^^^^^^^^^^^^ expected `[3_usize]`, found `[4_usize]`
+   |         ^^^^^^^^^^^^^^^^^^^ expected `[3]`, found `[4]`
    |
-   = note: expected struct `Const<[3_usize]>`
-              found struct `Const<[4_usize]>`
+   = note: expected struct `Const<[3]>`
+              found struct `Const<[4]>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/exhaustive-value.stderr
+++ b/src/test/ui/const-generics/exhaustive-value.stderr
@@ -5,14 +5,14 @@ LL |     <() as Foo<N>>::test()
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `Foo<N>` is not implemented for `()`
    |
    = help: the following other types implement trait `Foo<N>`:
-             <() as Foo<0_u8>>
-             <() as Foo<100_u8>>
-             <() as Foo<101_u8>>
-             <() as Foo<102_u8>>
-             <() as Foo<103_u8>>
-             <() as Foo<104_u8>>
-             <() as Foo<105_u8>>
-             <() as Foo<106_u8>>
+             <() as Foo<0>>
+             <() as Foo<100>>
+             <() as Foo<101>>
+             <() as Foo<102>>
+             <() as Foo<103>>
+             <() as Foo<104>>
+             <() as Foo<105>>
+             <() as Foo<106>>
            and 248 others
 
 error: aborting due to previous error

--- a/src/test/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/src/test/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -14,7 +14,7 @@ LL | fn ty_fn() -> Bar<i32, _> {
    |               ---------^-
    |               |        |
    |               |        not allowed in type signatures
-   |               help: replace with the correct return type: `Bar<i32, 3_usize>`
+   |               help: replace with the correct return type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/in-signature.rs:17:25
@@ -24,7 +24,7 @@ LL | fn ty_fn_mixed() -> Bar<_, _> {
    |                     |   |  |
    |                     |   |  not allowed in type signatures
    |                     |   not allowed in type signatures
-   |                     help: replace with the correct return type: `Bar<i32, 3_usize>`
+   |                     help: replace with the correct return type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/in-signature.rs:22:15
@@ -45,7 +45,7 @@ LL | const TY_CT: Bar<i32, _> = Bar::<i32, 3>(0);
    |              ^^^^^^^^^^^
    |              |
    |              not allowed in type signatures
-   |              help: replace with the correct type: `Bar<i32, 3_usize>`
+   |              help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/in-signature.rs:28:19
@@ -54,7 +54,7 @@ LL | static TY_STATIC: Bar<i32, _> = Bar::<i32, 3>(0);
    |                   ^^^^^^^^^^^
    |                   |
    |                   not allowed in type signatures
-   |                   help: replace with the correct type: `Bar<i32, 3_usize>`
+   |                   help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/in-signature.rs:30:20
@@ -63,7 +63,7 @@ LL | const TY_CT_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
    |                    ^^^^^^^^^
    |                    |
    |                    not allowed in type signatures
-   |                    help: replace with the correct type: `Bar<i32, 3_usize>`
+   |                    help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/in-signature.rs:32:25
@@ -72,7 +72,7 @@ LL | static TY_STATIC_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
    |                         ^^^^^^^^^
    |                         |
    |                         not allowed in type signatures
-   |                         help: replace with the correct type: `Bar<i32, 3_usize>`
+   |                         help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/in-signature.rs:35:21

--- a/src/test/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
@@ -56,19 +56,19 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:23:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<13, { 12 as u128 }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12_u128`, found `13_u128`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12`, found `13`
    |
-   = note: expected type `12_u128`
-              found type `13_u128`
+   = note: expected type `12`
+              found type `13`
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:25:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<14, 13>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13_u128`, found `14_u128`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13`, found `14`
    |
-   = note: expected type `13_u128`
-              found type `14_u128`
+   = note: expected type `13`
+              found type `14`
 
 error: unconstrained generic constant
   --> $DIR/abstract-const-as-cast-3.rs:35:5
@@ -128,19 +128,19 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:41:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<13, { 12 as u128 }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12_u128`, found `13_u128`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12`, found `13`
    |
-   = note: expected type `12_u128`
-              found type `13_u128`
+   = note: expected type `12`
+              found type `13`
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:43:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<14, 13>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13_u128`, found `14_u128`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13`, found `14`
    |
-   = note: expected type `13_u128`
-              found type `14_u128`
+   = note: expected type `13`
+              found type `14`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/const-generics/generic_const_exprs/from-sig-fail.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/from-sig-fail.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 
 fn test<const N: usize>() -> [u8; N - 1] {
-    //~^ ERROR evaluation of `test::<0_usize>::{constant#0}` failed
+    //~^ ERROR evaluation of `test::<0>::{constant#0}` failed
     todo!()
 }
 

--- a/src/test/ui/const-generics/generic_const_exprs/from-sig-fail.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/from-sig-fail.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation of `test::<0_usize>::{constant#0}` failed
+error[E0080]: evaluation of `test::<0>::{constant#0}` failed
   --> $DIR/from-sig-fail.rs:4:35
    |
 LL | fn test<const N: usize>() -> [u8; N - 1] {

--- a/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
@@ -4,14 +4,14 @@ error[E0423]: expected value, found type parameter `T`
 LL | impl<T> Bar<T> for [u8; T] {}
    |                         ^ not a value
 
-error[E0599]: the function or associated item `foo` exists for struct `Foo<{_: usize}>`, but its trait bounds were not satisfied
+error[E0599]: the function or associated item `foo` exists for struct `Foo<_>`, but its trait bounds were not satisfied
   --> $DIR/issue-69654.rs:17:10
    |
 LL | struct Foo<const N: usize> {}
    | -------------------------- function or associated item `foo` not found for this struct
 ...
 LL |     Foo::foo();
-   |          ^^^ function or associated item cannot be called on `Foo<{_: usize}>` due to unsatisfied trait bounds
+   |          ^^^ function or associated item cannot be called on `Foo<_>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `[u8; _]: Bar<[(); _]>`

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -34,21 +34,21 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    = help: const parameters may only be used as standalone arguments, i.e. `J`
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
+error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8>: True`
   --> $DIR/issue-72787.rs:21:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
    |                          ^^^^
    |
-   = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
+   = note: cannot satisfy `IsLessOrEqual<I, 8>: True`
 
-error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
+error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8>: True`
   --> $DIR/issue-72787.rs:21:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
    |                          ^^^^
    |
-   = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
+   = note: cannot satisfy `IsLessOrEqual<I, 8>: True`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/const-generics/generic_const_exprs/simple_fail.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/simple_fail.rs
@@ -2,10 +2,13 @@
 #![allow(incomplete_features)]
 
 type Arr<const N: usize> = [u8; N - 1];
-//~^ ERROR evaluation of `Arr::<0_usize>::{constant#0}` failed
+//~^ ERROR evaluation of `Arr::<0>::{constant#0}` failed
 
-fn test<const N: usize>() -> Arr<N> where [u8; N - 1]: Sized {
-//~^ ERROR evaluation of `test::<0_usize>::{constant#0}` failed
+fn test<const N: usize>() -> Arr<N>
+where
+    [u8; N - 1]: Sized,
+    //~^ ERROR evaluation of `test::<0>::{constant#0}` failed
+{
     todo!()
 }
 

--- a/src/test/ui/const-generics/generic_const_exprs/simple_fail.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/simple_fail.stderr
@@ -1,10 +1,10 @@
-error[E0080]: evaluation of `test::<0_usize>::{constant#0}` failed
-  --> $DIR/simple_fail.rs:7:48
+error[E0080]: evaluation of `test::<0>::{constant#0}` failed
+  --> $DIR/simple_fail.rs:9:10
    |
-LL | fn test<const N: usize>() -> Arr<N> where [u8; N - 1]: Sized {
-   |                                                ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+LL |     [u8; N - 1]: Sized,
+   |          ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
 
-error[E0080]: evaluation of `Arr::<0_usize>::{constant#0}` failed
+error[E0080]: evaluation of `Arr::<0>::{constant#0}` failed
   --> $DIR/simple_fail.rs:4:33
    |
 LL | type Arr<const N: usize> = [u8; N - 1];

--- a/src/test/ui/const-generics/infer/one-param-uninferred.stderr
+++ b/src/test/ui/const-generics/infer/one-param-uninferred.stderr
@@ -6,8 +6,8 @@ LL |     let _: [u8; 17] = foo();
    |
 help: consider specifying the generic arguments
    |
-LL |     let _: [u8; 17] = foo::<17_usize, M>();
-   |                          +++++++++++++++
+LL |     let _: [u8; 17] = foo::<17, M>();
+   |                          +++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issue-66451.stderr
+++ b/src/test/ui/const-generics/issue-66451.stderr
@@ -8,12 +8,12 @@ LL | |             value: 3,
 LL | |             nested: &Bar(5),
 LL | |         }
 LL | |     }> = x;
-   | |      -   ^ expected `Foo { value: 3_i32, nested: &Bar::<i32>(5_i32) }`, found `Foo { value: 3_i32, nested: &Bar::<i32>(4_i32) }`
+   | |      -   ^ expected `Foo { value: 3, nested: &Bar::<i32>(5) }`, found `Foo { value: 3, nested: &Bar::<i32>(4) }`
    | |______|
    |        expected due to this
    |
-   = note: expected struct `Test<Foo { value: 3_i32, nested: &Bar::<i32>(5_i32) }>`
-              found struct `Test<Foo { value: 3_i32, nested: &Bar::<i32>(4_i32) }>`
+   = note: expected struct `Test<Foo { value: 3, nested: &Bar::<i32>(5) }>`
+              found struct `Test<Foo { value: 3, nested: &Bar::<i32>(4) }>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-86530.rs
+++ b/src/test/ui/const-generics/issues/issue-86530.rs
@@ -15,7 +15,6 @@ where
 fn unit_literals() {
     z(" ");
     //~^ ERROR: the trait bound `&str: X` is not satisfied
-    //~| ERROR: unconstrained generic constant
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/issues/issue-86530.stderr
+++ b/src/test/ui/const-generics/issues/issue-86530.stderr
@@ -15,22 +15,6 @@ LL | where
 LL |     T: X,
    |        ^ required by this bound in `z`
 
-error: unconstrained generic constant
-  --> $DIR/issue-86530.rs:16:5
-   |
-LL |     z(" ");
-   |     ^
-   |
-   = help: try adding a `where` bound using this expression: `where [(); T::Y]:`
-note: required by a bound in `z`
-  --> $DIR/issue-86530.rs:11:10
-   |
-LL | fn z<T>(t: T)
-   |    - required by a bound in this
-...
-LL |     [(); T::Y]: ,
-   |          ^^^^ required by this bound in `z`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/issues/issue-98629.rs
+++ b/src/test/ui/const-generics/issues/issue-98629.rs
@@ -1,0 +1,15 @@
+#![feature(const_trait_impl)]
+
+trait Trait {
+    const N: usize;
+}
+
+impl const Trait for i32 {}
+//~^ ERROR not all trait items implemented, missing: `N`
+
+fn f()
+where
+    [(); <i32 as Trait>::N]:,
+{}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-98629.stderr
+++ b/src/test/ui/const-generics/issues/issue-98629.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `N`
+  --> $DIR/issue-98629.rs:7:1
+   |
+LL |     const N: usize;
+   |     -------------- `N` from trait
+...
+LL | impl const Trait for i32 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ missing `N` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/src/test/ui/const-generics/nested-type.full.stderr
+++ b/src/test/ui/const-generics/nested-type.full.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `Foo::{constant#0}::Foo::<17_usize>::value` in constants
+error[E0015]: cannot call non-const fn `Foo::{constant#0}::Foo::<17>::value` in constants
   --> $DIR/nested-type.rs:15:5
    |
 LL |     Foo::<17>::value()

--- a/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `A<{_: usize}>: Bar<{_: usize}>` is not satisfied
+error[E0277]: the trait bound `A<_>: Bar<_>` is not satisfied
   --> $DIR/unused-substs-1.rs:12:13
    |
 LL |     let _ = A;
-   |             ^ the trait `Bar<{_: usize}>` is not implemented for `A<{_: usize}>`
+   |             ^ the trait `Bar<_>` is not implemented for `A<_>`
    |
-   = help: the trait `Bar<N>` is implemented for `A<7_usize>`
+   = help: the trait `Bar<N>` is implemented for `A<7>`
 note: required by a bound in `A`
   --> $DIR/unused-substs-1.rs:9:11
    |

--- a/src/test/ui/const-generics/types-mismatch-const-args.full.stderr
+++ b/src/test/ui/const-generics/types-mismatch-const-args.full.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:14:41
    |
 LL |     let _: A<'a, u32, {2u32}, {3u32}> = A::<'a, u32, {2u32 + 2u32}, {3u32}> { data: PhantomData };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `2_u32`, found `4_u32`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `2`, found `4`
    |
-   = note: expected type `2_u32`
-              found type `4_u32`
+   = note: expected type `2`
+              found type `4`
 
 error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:16:41
@@ -26,8 +26,8 @@ LL |     let _: A<'a, u16, {4u32}, {3u32}> = A::<'b, u32, {2u32}, {3u32}> { data
    |            |
    |            expected due to this
    |
-   = note: expected struct `A<'a, u16, 4_u32, _>`
-              found struct `A<'b, u32, 2_u32, _>`
+   = note: expected struct `A<'a, u16, 4, _>`
+              found struct `A<'b, u32, 2, _>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/types-mismatch-const-args.min.stderr
+++ b/src/test/ui/const-generics/types-mismatch-const-args.min.stderr
@@ -2,12 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:14:41
    |
 LL |     let _: A<'a, u32, {2u32}, {3u32}> = A::<'a, u32, {2u32 + 2u32}, {3u32}> { data: PhantomData };
-   |            --------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `2_u32`, found `4_u32`
+   |            --------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `2`, found `4`
    |            |
    |            expected due to this
    |
-   = note: expected struct `A<'_, _, 2_u32, _>`
-              found struct `A<'_, _, 4_u32, _>`
+   = note: expected struct `A<'_, _, 2, _>`
+              found struct `A<'_, _, 4, _>`
 
 error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:16:41
@@ -28,8 +28,8 @@ LL |     let _: A<'a, u16, {4u32}, {3u32}> = A::<'b, u32, {2u32}, {3u32}> { data
    |            |
    |            expected due to this
    |
-   = note: expected struct `A<'a, u16, 4_u32, _>`
-              found struct `A<'b, u32, 2_u32, _>`
+   = note: expected struct `A<'a, u16, 4, _>`
+              found struct `A<'b, u32, 2, _>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/issue-85155.stderr
+++ b/src/test/ui/consts/const-eval/issue-85155.stderr
@@ -1,10 +1,10 @@
-error[E0080]: evaluation of `post_monomorphization_error::ValidateConstImm::<2_i32, 0_i32, 1_i32>::VALID` failed
+error[E0080]: evaluation of `post_monomorphization_error::ValidateConstImm::<2, 0, 1>::VALID` failed
   --> $DIR/auxiliary/post_monomorphization_error.rs:7:17
    |
 LL |         let _ = 1 / ((IMM >= MIN && IMM <= MAX) as usize);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to divide `1_usize` by zero
 
-note: the above error was encountered while instantiating `fn post_monomorphization_error::stdarch_intrinsic::<2_i32>`
+note: the above error was encountered while instantiating `fn post_monomorphization_error::stdarch_intrinsic::<2>`
   --> $DIR/issue-85155.rs:19:5
    |
 LL |     post_monomorphization_error::stdarch_intrinsic::<2>();

--- a/src/test/ui/dropck/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/dropck/reject-specialized-drops-8142.stderr
@@ -104,7 +104,7 @@ error[E0366]: `Drop` impls cannot be specialized
 LL | impl              Drop for X<3>           { fn drop(&mut self) { } } // REJECT
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `3_usize` is not a generic parameter
+   = note: `3` is not a generic parameter
 note: use the same sequence of generic lifetime, type and const parameters as the struct definition
   --> $DIR/reject-specialized-drops-8142.rs:17:1
    |

--- a/src/test/ui/inline-const/const-expr-generic-err.stderr
+++ b/src/test/ui/inline-const/const-expr-generic-err.stderr
@@ -12,13 +12,13 @@ note: the above error was encountered while instantiating `fn foo::<i32>`
 LL |     foo::<i32>();
    |     ^^^^^^^^^^^^
 
-error[E0080]: evaluation of `bar::<0_usize>::{constant#0}` failed
+error[E0080]: evaluation of `bar::<0>::{constant#0}` failed
   --> $DIR/const-expr-generic-err.rs:9:13
    |
 LL |     const { N - 1 }
    |             ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
 
-note: the above error was encountered while instantiating `fn bar::<0_usize>`
+note: the above error was encountered while instantiating `fn bar::<0>`
   --> $DIR/const-expr-generic-err.rs:14:5
    |
 LL |     bar::<0>();

--- a/src/test/ui/issues/issue-77919.rs
+++ b/src/test/ui/issues/issue-77919.rs
@@ -1,6 +1,5 @@
 fn main() {
     [1; <Multiply<Five, Five>>::VAL];
-    //~^ ERROR: constant expression depends on a generic parameter
 }
 trait TypeVal<T> {
     const VAL: T;

--- a/src/test/ui/issues/issue-77919.stderr
+++ b/src/test/ui/issues/issue-77919.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `PhantomData` in this scope
-  --> $DIR/issue-77919.rs:10:9
+  --> $DIR/issue-77919.rs:9:9
    |
 LL |     _n: PhantomData,
    |         ^^^^^^^^^^^ not found in this scope
@@ -10,7 +10,7 @@ LL | use std::marker::PhantomData;
    |
 
 error[E0412]: cannot find type `VAL` in this scope
-  --> $DIR/issue-77919.rs:12:63
+  --> $DIR/issue-77919.rs:11:63
    |
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          -                                                    ^^^ not found in this scope
@@ -18,7 +18,7 @@ LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          help: you might be missing a type parameter: `, VAL`
 
 error[E0046]: not all trait items implemented, missing: `VAL`
-  --> $DIR/issue-77919.rs:12:1
+  --> $DIR/issue-77919.rs:11:1
    |
 LL |     const VAL: T;
    |     ------------ `VAL` from trait
@@ -26,15 +26,7 @@ LL |     const VAL: T;
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
-error: constant expression depends on a generic parameter
-  --> $DIR/issue-77919.rs:2:9
-   |
-LL |     [1; <Multiply<Five, Five>>::VAL];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this may fail depending on what value the parameter takes
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0046, E0412.
 For more information about an error, try `rustc --explain E0046`.

--- a/src/test/ui/lint/function-item-references.stderr
+++ b/src/test/ui/lint/function-item-references.stderr
@@ -116,7 +116,7 @@ warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:118:22
    |
 LL |     println!("{:p}", &take_generic_array::<u32, 4>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_array` to obtain a function pointer: `take_generic_array::<u32, 4_usize> as fn(_)`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_array` to obtain a function pointer: `take_generic_array::<u32, 4> as fn(_)`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:120:22
@@ -128,7 +128,7 @@ warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:122:22
    |
 LL |     println!("{:p}", &multiple_generic_arrays::<u32, f32, 4, 8>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `multiple_generic_arrays` to obtain a function pointer: `multiple_generic_arrays::<u32, f32, 4_usize, 8_usize> as fn(_, _)`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `multiple_generic_arrays` to obtain a function pointer: `multiple_generic_arrays::<u32, f32, 4, 8> as fn(_, _)`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:124:22

--- a/src/test/ui/methods/method-not-found-generic-arg-elision.rs
+++ b/src/test/ui/methods/method-not-found-generic-arg-elision.rs
@@ -61,13 +61,13 @@ impl Other {
     fn other(&self) {}
 }
 
-struct Struct<T>{
-    _phatom: PhantomData<T>
+struct Struct<T> {
+    _phatom: PhantomData<T>,
 }
 
 impl<T> Default for Struct<T> {
     fn default() -> Self {
-        Self{ _phatom: PhantomData }
+        Self { _phatom: PhantomData }
     }
 }
 
@@ -76,9 +76,9 @@ impl<T: Clone + Copy + PartialEq + Eq + PartialOrd + Ord> Struct<T> {
 }
 
 fn main() {
-    let point_f64 = Point{ x: 1_f64, y: 1_f64};
+    let point_f64 = Point { x: 1_f64, y: 1_f64 };
     let d = point_f64.distance();
-    let point_i32 = Point{ x: 1_i32, y: 1_i32};
+    let point_i32 = Point { x: 1_i32, y: 1_i32 };
     let d = point_i32.distance();
     //~^ ERROR no method named `distance` found for struct `Point<i32>
     let d = point_i32.other();
@@ -92,9 +92,9 @@ fn main() {
     wrapper.other();
     //~^ ERROR no method named `other` found for struct `Wrapper
     let boolean = true;
-    let wrapper = Wrapper2::<'_, _, 3> {x: &boolean};
+    let wrapper = Wrapper2::<'_, _, 3> { x: &boolean };
     wrapper.method();
-    //~^ ERROR no method named `method` found for struct `Wrapper2<'_, bool, 3_usize>
+    //~^ ERROR no method named `method` found for struct `Wrapper2<'_, bool, 3>
     wrapper.other();
     //~^ ERROR no method named `other` found for struct `Wrapper2
     let a = vec![1, 2, 3];

--- a/src/test/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/src/test/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -50,14 +50,14 @@ LL | struct Wrapper<T>(T);
 LL |     wrapper.other();
    |             ^^^^^ method not found in `Wrapper<bool>`
 
-error[E0599]: no method named `method` found for struct `Wrapper2<'_, bool, 3_usize>` in the current scope
+error[E0599]: no method named `method` found for struct `Wrapper2<'_, bool, 3>` in the current scope
   --> $DIR/method-not-found-generic-arg-elision.rs:96:13
    |
 LL | struct Wrapper2<'a, T, const C: usize> {
    | -------------------------------------- method `method` not found for this struct
 ...
 LL |     wrapper.method();
-   |             ^^^^^^ method not found in `Wrapper2<'_, bool, 3_usize>`
+   |             ^^^^^^ method not found in `Wrapper2<'_, bool, 3>`
    |
    = note: the method was found for
            - `Wrapper2<'a, i8, C>`
@@ -71,7 +71,7 @@ LL | struct Wrapper2<'a, T, const C: usize> {
    | -------------------------------------- method `other` not found for this struct
 ...
 LL |     wrapper.other();
-   |             ^^^^^ method not found in `Wrapper2<'_, bool, 3_usize>`
+   |             ^^^^^ method not found in `Wrapper2<'_, bool, 3>`
 
 error[E0599]: no method named `not_found` found for struct `Vec<{integer}>` in the current scope
   --> $DIR/method-not-found-generic-arg-elision.rs:101:7
@@ -82,7 +82,7 @@ LL |     a.not_found();
 error[E0599]: the method `method` exists for struct `Struct<f64>`, but its trait bounds were not satisfied
   --> $DIR/method-not-found-generic-arg-elision.rs:104:7
    |
-LL | struct Struct<T>{
+LL | struct Struct<T> {
    | ---------------- method `method` not found for this struct
 ...
 LL |     s.method();

--- a/src/test/ui/simd/intrinsic/generic-shuffle.stderr
+++ b/src/test/ui/simd/intrinsic/generic-shuffle.stderr
@@ -1,10 +1,10 @@
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `Simd<u32, 4_usize>` with length 4
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `Simd<u32, 4>` with length 4
   --> $DIR/generic-shuffle.rs:24:31
    |
 LL |         let _: Simd<u32, 4> = simd_shuffle(v, v, I);
    |                               ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `u32` (element of input `Simd<u32, 4_usize>`), found `Simd<f32, 2_usize>` with element type `f32`
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `u32` (element of input `Simd<u32, 4>`), found `Simd<f32, 2>` with element type `f32`
   --> $DIR/generic-shuffle.rs:27:31
    |
 LL |         let _: Simd<f32, 2> = simd_shuffle(v, v, I);

--- a/src/test/ui/simd/libm_no_std_cant_float.stderr
+++ b/src/test/ui/simd/libm_no_std_cant_float.stderr
@@ -2,37 +2,37 @@ error[E0599]: no method named `ceil` found for struct `Simd` in the current scop
   --> $DIR/libm_no_std_cant_float.rs:14:17
    |
 LL |     let _xc = x.ceil();
-   |                 ^^^^ method not found in `Simd<f32, 4_usize>`
+   |                 ^^^^ method not found in `Simd<f32, 4>`
 
 error[E0599]: no method named `floor` found for struct `Simd` in the current scope
   --> $DIR/libm_no_std_cant_float.rs:15:17
    |
 LL |     let _xf = x.floor();
-   |                 ^^^^^ method not found in `Simd<f32, 4_usize>`
+   |                 ^^^^^ method not found in `Simd<f32, 4>`
 
 error[E0599]: no method named `round` found for struct `Simd` in the current scope
   --> $DIR/libm_no_std_cant_float.rs:16:17
    |
 LL |     let _xr = x.round();
-   |                 ^^^^^ method not found in `Simd<f32, 4_usize>`
+   |                 ^^^^^ method not found in `Simd<f32, 4>`
 
 error[E0599]: no method named `trunc` found for struct `Simd` in the current scope
   --> $DIR/libm_no_std_cant_float.rs:17:17
    |
 LL |     let _xt = x.trunc();
-   |                 ^^^^^ method not found in `Simd<f32, 4_usize>`
+   |                 ^^^^^ method not found in `Simd<f32, 4>`
 
 error[E0599]: no method named `mul_add` found for struct `Simd` in the current scope
   --> $DIR/libm_no_std_cant_float.rs:18:19
    |
 LL |     let _xfma = x.mul_add(x, x);
-   |                   ^^^^^^^ method not found in `Simd<f32, 4_usize>`
+   |                   ^^^^^^^ method not found in `Simd<f32, 4>`
 
 error[E0599]: no method named `sqrt` found for struct `Simd` in the current scope
   --> $DIR/libm_no_std_cant_float.rs:19:20
    |
 LL |     let _xsqrt = x.sqrt();
-   |                    ^^^^ method not found in `Simd<f32, 4_usize>`
+   |                    ^^^^ method not found in `Simd<f32, 4>`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/simd/type-generic-monomorphisation-empty.rs
+++ b/src/test/ui/simd/type-generic-monomorphisation-empty.rs
@@ -2,7 +2,7 @@
 
 #![feature(repr_simd, platform_intrinsics)]
 
-// error-pattern:monomorphising SIMD type `Simd<0_usize>` of zero length
+// error-pattern:monomorphising SIMD type `Simd<0>` of zero length
 
 #[repr(simd)]
 struct Simd<const N: usize>([f32; N]);

--- a/src/test/ui/simd/type-generic-monomorphisation-empty.stderr
+++ b/src/test/ui/simd/type-generic-monomorphisation-empty.stderr
@@ -1,4 +1,4 @@
-error: monomorphising SIMD type `Simd<0_usize>` of zero length
+error: monomorphising SIMD type `Simd<0>` of zero length
 
 error: aborting due to previous error
 

--- a/src/test/ui/simd/type-generic-monomorphisation-oversized.rs
+++ b/src/test/ui/simd/type-generic-monomorphisation-oversized.rs
@@ -2,7 +2,7 @@
 
 #![feature(repr_simd, platform_intrinsics)]
 
-// error-pattern:monomorphising SIMD type `Simd<65536_usize>` of length greater than 32768
+// error-pattern:monomorphising SIMD type `Simd<65536>` of length greater than 32768
 
 #[repr(simd)]
 struct Simd<const N: usize>([f32; N]);

--- a/src/test/ui/simd/type-generic-monomorphisation-oversized.stderr
+++ b/src/test/ui/simd/type-generic-monomorphisation-oversized.stderr
@@ -1,4 +1,4 @@
-error: monomorphising SIMD type `Simd<65536_usize>` of length greater than 32768
+error: monomorphising SIMD type `Simd<65536>` of length greater than 32768
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
@@ -25,7 +25,7 @@ error: non-defining opaque type use in defining scope
 LL |     7u32
    |     ^^^^
    |
-note: used non-generic constant `123_usize` for generic parameter
+note: used non-generic constant `123` for generic parameter
   --> $DIR/generic_nondefining_use.rs:11:15
    |
 LL | type OneConst<const X: usize> = impl Debug;


### PR DESCRIPTION
Successful merges:

 - #98707 (std: use futex-based locks on Fuchsia)
 - #99393 (feat: omit suffixes in const generics (e.g. `1_i32`))
 - #99449 (Do not resolve associated const when there is no provided value)
 - #99454 (Add map_continue and continue_value combinators to ControlFlow)
 - #99523 (Fix the stable version of `AsFd for Arc<T>` and `Box<T>`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98707,99393,99449,99454,99523)
<!-- homu-ignore:end -->