### PR TITLE
Document memory orderings of `thread::{park, unpark}`

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -891,8 +891,8 @@ pub fn sleep(dur: Duration) {
 /// performs the corresponding `Acquire` operation. Calls to `unpark` for the same
 /// thread form a [release sequence].
 ///
-/// Note that being unblocked does not imply synchronization with a call to `unpark`,
-/// the wakeup could also be spurious. For example, a valid, but inefficient,
+/// Note that being unblocked does not imply a call was made to `unpark`, because
+/// wakeups can also be spurious. For example, a valid, but inefficient,
 /// implementation could have `park` and `unpark` return immediately without doing anything.
 ///
 /// # Examples

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -880,7 +880,7 @@ pub fn sleep(dur: Duration) {
 /// * It can be implemented very efficiently on many platforms.
 ///
 /// # Memory Orderings
-/// 
+///
 /// Calls to `park` _synchronize-with_ calls to `unpark`, meaning that memory
 /// operations performed before a call to `unpark` are made visible to the thread that
 /// consumes the token and returns from `park`. Note that all `park` and `unpark`
@@ -890,7 +890,7 @@ pub fn sleep(dur: Duration) {
 /// In atomic ordering terms, `unpark` performs a `Release` operation and `park`
 /// performs the corresponding `Acquire` operation. Calls to `unpark` for the same
 /// thread form a [release sequence].
-/// 
+///
 /// Notice that being unblocked does not imply any synchronization with someone that
 /// unparked this thread, it could also be spurious. For example, it would be a valid,
 /// but inefficient, implementation to make both park and unpark return immediately

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -891,10 +891,9 @@ pub fn sleep(dur: Duration) {
 /// performs the corresponding `Acquire` operation. Calls to `unpark` for the same
 /// thread form a [release sequence].
 ///
-/// Notice that being unblocked does not imply any synchronization with someone that
-/// unparked this thread, it could also be spurious. For example, it would be a valid,
-/// but inefficient, implementation to make both park and unpark return immediately
-/// without doing anything.
+/// Note that being unblocked does not imply synchronization with a call to `unpark`,
+/// the wakeup could also be spurious. For example, a valid, but inefficient,
+/// implementation could have `park` and `unpark` return immediately without doing anything.
 ///
 /// # Examples
 ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -893,7 +893,8 @@ pub fn sleep(dur: Duration) {
 ///
 /// Note that being unblocked does not imply a call was made to `unpark`, because
 /// wakeups can also be spurious. For example, a valid, but inefficient,
-/// implementation could have `park` and `unpark` return immediately without doing anything.
+/// implementation could have `park` and `unpark` return immediately without doing anything,
+/// making *all* wakeups spurious.
 ///
 /// # Examples
 ///
@@ -908,7 +909,7 @@ pub fn sleep(dur: Duration) {
 /// let parked_thread = thread::spawn(move || {
 ///     // We want to wait until the flag is set. We *could* just spin, but using
 ///     // park/unpark is more efficient.
-///     while !flag2.load(Ordering::Acquire) {
+///     while !flag2.load(Ordering::Relaxed) {
 ///         println!("Parking thread");
 ///         thread::park();
 ///         // We *could* get here spuriously, i.e., way before the 10ms below are over!
@@ -925,7 +926,7 @@ pub fn sleep(dur: Duration) {
 /// // There is no race condition here, if `unpark`
 /// // happens first, `park` will return immediately.
 /// // Hence there is no risk of a deadlock.
-/// flag.store(true, Ordering::Release);
+/// flag.store(true, Ordering::Relaxed);
 /// println!("Unpark the thread");
 /// parked_thread.thread().unpark();
 ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -879,7 +879,7 @@ pub fn sleep(dur: Duration) {
 ///
 /// * It can be implemented very efficiently on many platforms.
 ///
-/// # Memory Orderings
+/// # Memory Ordering
 ///
 /// Calls to `park` _synchronize-with_ calls to `unpark`, meaning that memory
 /// operations performed before a call to `unpark` are made visible to the thread that


### PR DESCRIPTION
Document `thread::park/unpark` as having acquire/release synchronization. Without that guarantee, even the example in the documentation can deadlock:

```rust
let flag = Arc::new(AtomicBool::new(false));

let t2 = thread::spawn(move || {
    while !flag.load(Ordering::Acquire) {
        thread::park();
    }
});

flag.store(true, Ordering::Release);
t2.thread().unpark();

// t1: flag.store(true)
// t1: thread.unpark()
// t2: flag.load() == false

// t2 now parks, is immediately unblocked but never
// acquires the flag, and thus spins forever 
```

Multiple calls to `unpark` should also maintain a release sequence to make sure operations released by previous `unpark`s are not lost:

```rust
let a = Arc::new(AtomicBool::new(false));
let b = Arc::new(AtomicBool::new(false));

let t2 = thread::spawn(move || {
    while !a.load(Ordering::Acquire) || !b.load(Ordering::Acquire) {
        thread::park();
    }
});

thread::spawn(move || {
    a.store(true, Ordering::Release);
    t2.thread().unpark();
});

b.store(true, Ordering::Release);
t2.thread().unpark();

// t1: a.store(true)
// t1: t2.unpark()
// t3: b.store(true)
// t3: t2.unpark()

// t2 now parks, is immediately unblocked but never
// acquires the store of `a`, only the store of `b` which
// was released by the most recent unpark, and thus spins forever 
```

This is of course a contrived example, but is reasonable to rely upon in real code.

Note that all implementations of park/unpark already comply with the rules, it's just undocumented.