### PR TITLE
const_eval: Consider array length constant even if array is not

### DIFF
--- a/src/test/ui/const_prop/issue-98444-const-index-out-of-bounds.rs
+++ b/src/test/ui/const_prop/issue-98444-const-index-out-of-bounds.rs
@@ -1,0 +1,8 @@
+// build-fail
+// Need to use build-fail because check doesn't run constant propagation.
+
+fn main() {
+    let xs: [i32; 5] = [1, 2, 3, 4, 5];
+    let _ = &xs;
+    let _ = xs[7]; //~ ERROR this operation will panic at runtime
+}

--- a/src/test/ui/const_prop/issue-98444-const-index-out-of-bounds.stderr
+++ b/src/test/ui/const_prop/issue-98444-const-index-out-of-bounds.stderr
@@ -1,0 +1,10 @@
+error: this operation will panic at runtime
+  --> $DIR/issue-98444-const-index-out-of-bounds.rs:7:13
+   |
+LL |     let _ = xs[7];
+   |             ^^^^^ index out of bounds: the length is 5 but the index is 7
+   |
+   = note: `#[deny(unconditional_panic)]` on by default
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/issue-65348.rs
+++ b/src/test/ui/consts/issue-65348.rs
@@ -1,4 +1,5 @@
 // check-pass
+#![allow(unconditional_panic)]
 
 struct Generic<T>(T);
 


### PR DESCRIPTION
Fixes #98444.