### PR TITLE
Mark atomics as unsupported on thumbv6m

### DIFF
--- a/compiler/rustc_target/src/spec/thumbv6m_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/thumbv6m_none_eabi.rs
@@ -14,8 +14,9 @@ pub fn target() -> Target {
             // The ARMv6-M architecture doesn't support unaligned loads/stores so we disable them
             // with +strict-align.
             features: "+strict-align".into(),
-            // There are no atomic CAS instructions available in the instruction set of the ARMv6-M
+            // There are no atomic instructions available in the instruction set of the ARMv6-M
             // architecture
+            max_atomic_width: Some(0),
             atomic_cas: false,
             ..super::thumb_base::opts()
         },


### PR DESCRIPTION
The thumbv6m target does not support atomics. Historically, LLVM
had a bug where atomic load/stores for this target were emitted
as plain load/stores rather than as libatomic calls. This was
fixed in https://reviews.llvm.org/D120026, which will be part of
LLVM 15. As we require that "atomic support" does not use libatomic,
we need to indicate that this target does not have native atomics.