### PR TITLE
Fix #95079 unhelpful error when missing move in nested closure

### DIFF
--- a/src/test/ui/borrowck/borrowck-describe-lvalue.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.stderr
@@ -36,6 +36,10 @@ LL | |                 }
    |
    = note: `FnMut` closures only have access to their captured variables while they are executing...
    = note: ...therefore, they cannot allow references to captured variables to escape
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |                move || {
+   |                ++++
 
 error[E0503]: cannot use `f.x` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:37:9

--- a/src/test/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.stderr
+++ b/src/test/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.stderr
@@ -10,6 +10,10 @@ LL |         || f() // The `nested` closure
    |         ^^^^^^ returning this value requires that `'1` must outlive `'2`
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |         move || f() // The `nested` closure
+   |         ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-95079-missing-move-in-nested-closure.rs
+++ b/src/test/ui/borrowck/issue-95079-missing-move-in-nested-closure.rs
@@ -1,0 +1,14 @@
+fn foo1(s: &str) -> impl Iterator<Item = String> + '_ {
+    None.into_iter()
+        .flat_map(move |()| s.chars().map(|c| format!("{}{}", c, s)))
+        //~^ ERROR captured variable cannot escape `FnMut` closure body
+        //~| HELP consider adding 'move' keyword before the nested closure
+}
+
+fn foo2(s: &str) -> impl Sized + '_ {
+    move |()| s.chars().map(|c| format!("{}{}", c, s))
+    //~^ ERROR lifetime may not live long enough
+    //~| HELP consider adding 'move' keyword before the nested closure
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/issue-95079-missing-move-in-nested-closure.stderr
+++ b/src/test/ui/borrowck/issue-95079-missing-move-in-nested-closure.stderr
@@ -1,0 +1,37 @@
+error: captured variable cannot escape `FnMut` closure body
+  --> $DIR/issue-95079-missing-move-in-nested-closure.rs:3:29
+   |
+LL | fn foo1(s: &str) -> impl Iterator<Item = String> + '_ {
+   |         - variable defined here
+LL |     None.into_iter()
+LL |         .flat_map(move |()| s.chars().map(|c| format!("{}{}", c, s)))
+   |                           - -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                           | |
+   |                           | returns a reference to a captured variable which escapes the closure body
+   |                           | variable captured here
+   |                           inferred to be a `FnMut` closure
+   |
+   = note: `FnMut` closures only have access to their captured variables while they are executing...
+   = note: ...therefore, they cannot allow references to captured variables to escape
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |         .flat_map(move |()| s.chars().map(move |c| format!("{}{}", c, s)))
+   |                                           ++++
+
+error: lifetime may not live long enough
+  --> $DIR/issue-95079-missing-move-in-nested-closure.rs:9:15
+   |
+LL |     move |()| s.chars().map(|c| format!("{}{}", c, s))
+   |     --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+   |     |       |
+   |     |       return type of closure `Map<Chars<'_>, [closure@$DIR/issue-95079-missing-move-in-nested-closure.rs:9:29: 9:32]>` contains a lifetime `'2`
+   |     lifetime `'1` represents this closure's body
+   |
+   = note: closure implements `Fn`, so references to captured variables can't escape the closure
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |     move |()| s.chars().map(move |c| format!("{}{}", c, s))
+   |                             ++++
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/issues/issue-40510-3.stderr
+++ b/src/test/ui/issues/issue-40510-3.stderr
@@ -14,6 +14,10 @@ LL | |         }
    |
    = note: `FnMut` closures only have access to their captured variables while they are executing...
    = note: ...therefore, they cannot allow references to captured variables to escape
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |         move || {
+   |         ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-49824.stderr
+++ b/src/test/ui/issues/issue-49824.stderr
@@ -14,6 +14,10 @@ LL | |         }
    |
    = note: `FnMut` closures only have access to their captured variables while they are executing...
    = note: ...therefore, they cannot allow references to captured variables to escape
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |         move || {
+   |         ++++
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #95079 by adding help for missing move in nested closure
