### PR TITLE
Update mdbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13cdad8057b09a519c6c63e6d7c93ea854f5d7fbfe284df864d5e1140d215a2d"
+checksum = "23f3e133c6d515528745ffd3b9f0c7d975ae039f0b6abb099f2168daa2afb4f9"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -9,6 +9,6 @@ clap = "3.1.1"
 env_logger = "0.7.1"
 
 [dependencies.mdbook]
-version = "0.4.18"
+version = "0.4.21"
 default-features = false
 features = ["search"]


### PR DESCRIPTION
This updates mdbook from 0.4.20 to 0.4.21
Changelog: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0421

This contains a single fix that prevents mdbook from compiling on nightly (due to #99413). This will be necessary to keep everything working after the next master bootstrap switch.
