### PR TITLE
99522 more semicolon hint

### DIFF
--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -140,6 +140,8 @@ pub enum TyKind<I: Interner> {
     Never,
 
     /// A tuple type. For example, `(i32, bool)`.
+    ///
+    /// The unit type `()` is defined as a tuple of length 0.
     Tuple(I::ListTy),
 
     /// The projection of an associated type. For example,


### PR DESCRIPTION
This change works perfectly well for the code in `main` but it suggests an erroneous change for `test_error` and I don't know how to fix it.

```rust
fn main() {
    for _ in 0..1 {
        true
    }
}

fn test_error(v: &[&[&[i32]]]) -> bool {
    for a in v {
        for b in *a {
            b.iter().fold(true, |acc, x| acc && (*x < 1000))
        }
    }
    true
}
```

Suggestions:

```
error[E0308]: mismatched types
 --> src/main.rs:3:9
  |
3 |         true
  |         ^^^^ expected `()`, found `bool`
  |
help: consider using a semicolon at the end of the expression
  |
3 |         true;
  |             +

error[E0308]: mismatched types
    --> src/main.rs:10:27
     |
10   |             b.iter().fold(true, |acc, x| acc && (*x < 1000))
     |                      ---- ^^^^ expected `()`, found `bool`
     |                      |
     |                      arguments to this function are incorrect
     |
note: associated function defined here
    --> /Users/alexis/repos/tp/rust/library/core/src/iter/traits/iterator.rs:2407:8
     |
2407 |     fn fold<B, F>(mut self, init: B, mut f: F) -> B
     |        ^^^^
help: consider using a semicolon at the end of the expression
     |
10   |             b.iter().fold(true;, |acc, x| acc && (*x < 1000))
     |                               +

error[E0308]: mismatched types
  --> src/main.rs:10:13
   |
10 |             b.iter().fold(true, |acc, x| acc && (*x < 1000))
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `bool`
   |
help: consider using a semicolon at the end of the expression
   |
10 |             b.iter().fold(true, |acc, x| acc && (*x < 1000));
   |                                                             +
help: consider using a semicolon here
   |
10 |             b.iter().fold(true, |acc, x| acc && (*x < 1000));
   |                                                             +
help: you might have meant to return this value
   |
10 |             return b.iter().fold(true, |acc, x| acc && (*x < 1000));
   |             ++++++                                                 +
```