### PR TITLE
Lock stdout once when listing tests

### DIFF
--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -137,7 +137,7 @@ impl ConsoleTestState {
 // List the tests to console, and optionally to logfile. Filters are honored.
 pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<()> {
     let mut output = match term::stdout() {
-        None => OutputLocation::Raw(io::stdout()),
+        None => OutputLocation::Raw(io::stdout().lock()),
         Some(t) => OutputLocation::Pretty(t),
     };
 


### PR DESCRIPTION
This is a marginal optimization for normal operation, but for `cargo miri nextest list` (which is invoked by `cargo miri nextest run`) this knocks the startup time on `regex` down from 87 seconds to 17 seconds. Still slow, but a nice 5x improvement.