### PR TITLE
Support `x --keep-stage 0 check`

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -623,15 +623,6 @@ Arguments:
             }
         };
 
-        if let Subcommand::Check { .. } = &cmd {
-            if matches.opt_str("keep-stage").is_some()
-                || matches.opt_str("keep-stage-std").is_some()
-            {
-                eprintln!("--keep-stage not yet supported for x.py check");
-                crate::detail_exit(1);
-            }
-        }
-
         Flags {
             verbose: matches.opt_count("verbose"),
             stage: matches.opt_str("stage").map(|j| j.parse().expect("`stage` should be a number")),


### PR DESCRIPTION
Stage 1 check has been supported since https://github.com/rust-lang/rust/pull/81064.
 https://github.com/rust-lang/rust/pull/81064 changed the error message for this, but I don't think there's any reason we should prevent using it.
I tested locally and `keep-stage` works fine.

r? @Mark-Simulacrum