### PR TITLE
Deeply deny fn and raw ptrs in const generics

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -226,7 +226,7 @@ impl Qualif for CustomEq {
         // because that component may be part of an enum variant (e.g.,
         // `Option::<NonStructuralMatchTy>::Some`), in which case some values of this type may be
         // structural-match (`Option::None`).
-        traits::search_for_structural_match_violation(cx.body.span, cx.tcx, ty, false).is_some()
+        traits::search_for_structural_match_violation(cx.body.span, cx.tcx, ty).is_some()
     }
 
     fn in_adt_inherently<'tcx>(

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -226,7 +226,7 @@ impl Qualif for CustomEq {
         // because that component may be part of an enum variant (e.g.,
         // `Option::<NonStructuralMatchTy>::Some`), in which case some values of this type may be
         // structural-match (`Option::None`).
-        traits::search_for_structural_match_violation(cx.body.span, cx.tcx, ty, true).is_some()
+        traits::search_for_structural_match_violation(cx.body.span, cx.tcx, ty, false).is_some()
     }
 
     fn in_adt_inherently<'tcx>(

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -203,7 +203,7 @@ impl<'tcx> Const<'tcx> {
     pub fn to_valtree(self) -> ty::ValTree<'tcx> {
         match self.kind() {
             ty::ConstKind::Value(valtree) => valtree,
-            _ => bug!("expected ConstKind::Value"),
+            _ => bug!("expected ConstKind::Value, got {:?}", self.kind()),
         }
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -120,37 +120,35 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
     }
 
     fn search_for_structural_match_violation(&self, ty: Ty<'tcx>) -> Option<String> {
-        traits::search_for_structural_match_violation(self.span, self.tcx(), ty, false).map(
-            |non_sm_ty| {
-                with_no_trimmed_paths!(match non_sm_ty.kind() {
-                    ty::Adt(adt, _) => self.adt_derive_msg(*adt),
-                    ty::Dynamic(..) => {
-                        "trait objects cannot be used in patterns".to_string()
-                    }
-                    ty::Opaque(..) => {
-                        "opaque types cannot be used in patterns".to_string()
-                    }
-                    ty::Closure(..) => {
-                        "closures cannot be used in patterns".to_string()
-                    }
-                    ty::Generator(..) | ty::GeneratorWitness(..) => {
-                        "generators cannot be used in patterns".to_string()
-                    }
-                    ty::Float(..) => {
-                        "floating-point numbers cannot be used in patterns".to_string()
-                    }
-                    ty::FnPtr(..) => {
-                        "function pointers cannot be used in patterns".to_string()
-                    }
-                    ty::RawPtr(..) => {
-                        "raw pointers cannot be used in patterns".to_string()
-                    }
-                    _ => {
-                        bug!("use of a value of `{non_sm_ty}` inside a pattern")
-                    }
-                })
-            },
-        )
+        traits::search_for_structural_match_violation(self.span, self.tcx(), ty).map(|non_sm_ty| {
+            with_no_trimmed_paths!(match non_sm_ty.kind() {
+                ty::Adt(adt, _) => self.adt_derive_msg(*adt),
+                ty::Dynamic(..) => {
+                    "trait objects cannot be used in patterns".to_string()
+                }
+                ty::Opaque(..) => {
+                    "opaque types cannot be used in patterns".to_string()
+                }
+                ty::Closure(..) => {
+                    "closures cannot be used in patterns".to_string()
+                }
+                ty::Generator(..) | ty::GeneratorWitness(..) => {
+                    "generators cannot be used in patterns".to_string()
+                }
+                ty::Float(..) => {
+                    "floating-point numbers cannot be used in patterns".to_string()
+                }
+                ty::FnPtr(..) => {
+                    "function pointers cannot be used in patterns".to_string()
+                }
+                ty::RawPtr(..) => {
+                    "raw pointers cannot be used in patterns".to_string()
+                }
+                _ => {
+                    bug!("use of a value of `{non_sm_ty}` inside a pattern")
+                }
+            })
+        })
     }
 
     fn type_marked_structural(&self, ty: Ty<'tcx>) -> bool {

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -120,7 +120,7 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
     }
 
     fn search_for_structural_match_violation(&self, ty: Ty<'tcx>) -> Option<String> {
-        traits::search_for_structural_match_violation(self.span, self.tcx(), ty, true).map(
+        traits::search_for_structural_match_violation(self.span, self.tcx(), ty, false).map(
             |non_sm_ty| {
                 with_no_trimmed_paths!(match non_sm_ty.kind {
                     traits::NonStructuralMatchTyKind::Adt(adt) => self.adt_derive_msg(adt),
@@ -138,6 +138,12 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                     }
                     traits::NonStructuralMatchTyKind::Float => {
                         "floating-point numbers cannot be used in patterns".to_string()
+                    }
+                    traits::NonStructuralMatchTyKind::FnPtr => {
+                        "function pointers cannot be used in patterns".to_string()
+                    }
+                    traits::NonStructuralMatchTyKind::RawPtr => {
+                        "raw pointers cannot be used in patterns".to_string()
                     }
                     traits::NonStructuralMatchTyKind::Param => {
                         bug!("use of a constant whose type is a parameter inside a pattern")

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -122,37 +122,31 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
     fn search_for_structural_match_violation(&self, ty: Ty<'tcx>) -> Option<String> {
         traits::search_for_structural_match_violation(self.span, self.tcx(), ty, false).map(
             |non_sm_ty| {
-                with_no_trimmed_paths!(match non_sm_ty.kind {
-                    traits::NonStructuralMatchTyKind::Adt(adt) => self.adt_derive_msg(adt),
-                    traits::NonStructuralMatchTyKind::Dynamic => {
+                with_no_trimmed_paths!(match non_sm_ty.kind() {
+                    ty::Adt(adt, _) => self.adt_derive_msg(*adt),
+                    ty::Dynamic(..) => {
                         "trait objects cannot be used in patterns".to_string()
                     }
-                    traits::NonStructuralMatchTyKind::Opaque => {
+                    ty::Opaque(..) => {
                         "opaque types cannot be used in patterns".to_string()
                     }
-                    traits::NonStructuralMatchTyKind::Closure => {
+                    ty::Closure(..) => {
                         "closures cannot be used in patterns".to_string()
                     }
-                    traits::NonStructuralMatchTyKind::Generator => {
+                    ty::Generator(..) | ty::GeneratorWitness(..) => {
                         "generators cannot be used in patterns".to_string()
                     }
-                    traits::NonStructuralMatchTyKind::Float => {
+                    ty::Float(..) => {
                         "floating-point numbers cannot be used in patterns".to_string()
                     }
-                    traits::NonStructuralMatchTyKind::FnPtr => {
+                    ty::FnPtr(..) => {
                         "function pointers cannot be used in patterns".to_string()
                     }
-                    traits::NonStructuralMatchTyKind::RawPtr => {
+                    ty::RawPtr(..) => {
                         "raw pointers cannot be used in patterns".to_string()
                     }
-                    traits::NonStructuralMatchTyKind::Param => {
-                        bug!("use of a constant whose type is a parameter inside a pattern")
-                    }
-                    traits::NonStructuralMatchTyKind::Projection => {
-                        bug!("use of a constant whose type is a projection inside a pattern")
-                    }
-                    traits::NonStructuralMatchTyKind::Foreign => {
-                        bug!("use of a value of a foreign type inside a pattern")
+                    _ => {
+                        bug!("use of a value of `{non_sm_ty}` inside a pattern")
                     }
                 })
             },

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -60,7 +60,9 @@ pub use self::select::{EvaluationResult, IntercrateAmbiguityCause, OverflowError
 pub use self::specialize::specialization_graph::FutureCompatOverlapError;
 pub use self::specialize::specialization_graph::FutureCompatOverlapErrorKind;
 pub use self::specialize::{specialization_graph, translate_substs, OverlapError};
-pub use self::structural_match::search_for_structural_match_violation;
+pub use self::structural_match::{
+    search_for_adt_const_param_violation, search_for_structural_match_violation,
+};
 pub use self::util::{
     elaborate_obligations, elaborate_predicates, elaborate_predicates_with_span,
     elaborate_trait_ref, elaborate_trait_refs,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -61,7 +61,6 @@ pub use self::specialize::specialization_graph::FutureCompatOverlapError;
 pub use self::specialize::specialization_graph::FutureCompatOverlapErrorKind;
 pub use self::specialize::{specialization_graph, translate_substs, OverlapError};
 pub use self::structural_match::search_for_structural_match_violation;
-pub use self::structural_match::{NonStructuralMatchTy, NonStructuralMatchTyKind};
 pub use self::util::{
     elaborate_obligations, elaborate_predicates, elaborate_predicates_with_span,
     elaborate_trait_ref, elaborate_trait_refs,

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -849,7 +849,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) {
 
             if tcx.features().adt_const_params {
                 if let Some(non_structural_match_ty) =
-                    traits::search_for_structural_match_violation(param.span, tcx, ty, true)
+                    traits::search_for_adt_const_param_violation(param.span, tcx, ty)
                 {
                     // We use the same error code in both branches, because this is really the same
                     // issue: we just special-case the message for type parameters to make it

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -848,29 +848,13 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) {
             let ty = tcx.type_of(tcx.hir().local_def_id(param.hir_id));
 
             if tcx.features().adt_const_params {
-                let err = match ty.peel_refs().kind() {
-                    ty::FnPtr(_) => Some("function pointers"),
-                    ty::RawPtr(_) => Some("raw pointers"),
-                    _ => None,
-                };
-
-                if let Some(unsupported_type) = err {
-                    tcx.sess.span_err(
-                        hir_ty.span,
-                        &format!(
-                            "using {} as const generic parameters is forbidden",
-                            unsupported_type
-                        ),
-                    );
-                }
-
                 if let Some(non_structural_match_ty) =
-                    traits::search_for_structural_match_violation(param.span, tcx, ty, false)
+                    traits::search_for_structural_match_violation(param.span, tcx, ty, true)
                 {
                     // We use the same error code in both branches, because this is really the same
                     // issue: we just special-case the message for type parameters to make it
                     // clearer.
-                    match ty.peel_refs().kind() {
+                    match non_structural_match_ty.ty.kind() {
                         ty::Param(_) => {
                             // Const parameters may not have type parameters as their types,
                             // because we cannot be sure that the type parameter derives `PartialEq`
@@ -900,6 +884,24 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) {
                                 "`{ty}` is forbidden as the type of a const generic parameter",
                             )
                             .note("floats do not derive `Eq` or `Ord`, which are required for const parameters")
+                            .emit();
+                        }
+                        ty::FnPtr(_) => {
+                            struct_span_err!(
+                                tcx.sess,
+                                hir_ty.span,
+                                E0741,
+                                "using function pointers as const generic parameters is forbidden",
+                            )
+                            .emit();
+                        }
+                        ty::RawPtr(_) => {
+                            struct_span_err!(
+                                tcx.sess,
+                                hir_ty.span,
+                                E0741,
+                                "using raw pointers as const generic parameters is forbidden",
+                            )
                             .emit();
                         }
                         _ => {

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -854,7 +854,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) {
                     // We use the same error code in both branches, because this is really the same
                     // issue: we just special-case the message for type parameters to make it
                     // clearer.
-                    match non_structural_match_ty.ty.kind() {
+                    match non_structural_match_ty.kind() {
                         ty::Param(_) => {
                             // Const parameters may not have type parameters as their types,
                             // because we cannot be sure that the type parameter derives `PartialEq`
@@ -911,10 +911,10 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) {
                                 E0741,
                                 "`{}` must be annotated with `#[derive(PartialEq, Eq)]` to be used as \
                                 the type of a const parameter",
-                                non_structural_match_ty.ty,
+                                non_structural_match_ty,
                             );
 
-                            if ty == non_structural_match_ty.ty {
+                            if ty == non_structural_match_ty {
                                 diag.span_label(
                                     hir_ty.span,
                                     format!("`{ty}` doesn't derive both `PartialEq` and `Eq`"),

--- a/src/test/ui/const-generics/fn-const-param-infer.full.stderr
+++ b/src/test/ui/const-generics/fn-const-param-infer.full.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error[E0741]: using function pointers as const generic parameters is forbidden
   --> $DIR/fn-const-param-infer.rs:6:25
    |
 LL | struct Checked<const F: fn(usize) -> bool>;
@@ -6,3 +6,4 @@ LL | struct Checked<const F: fn(usize) -> bool>;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/issues/issue-71381.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-71381.full.stderr
@@ -10,13 +10,13 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
 
-error: using function pointers as const generic parameters is forbidden
+error[E0741]: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71381.rs:14:61
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using function pointers as const generic parameters is forbidden
+error[E0741]: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71381.rs:23:19
    |
 LL |         const FN: unsafe extern "C" fn(Args),
@@ -24,4 +24,5 @@ LL |         const FN: unsafe extern "C" fn(Args),
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0770`.
+Some errors have detailed explanations: E0741, E0770.
+For more information about an error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/issues/issue-71382.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-71382.full.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error[E0741]: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71382.rs:16:23
    |
 LL |     fn test<const FN: fn()>(&self) {
@@ -6,3 +6,4 @@ LL |     fn test<const FN: fn()>(&self) {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/issues/issue-71611.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-71611.full.stderr
@@ -4,7 +4,7 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
 
-error: using function pointers as const generic parameters is forbidden
+error[E0741]: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71611.rs:5:21
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
@@ -12,4 +12,5 @@ LL | fn func<A, const F: fn(inner: A)>(outer: A) {
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0770`.
+Some errors have detailed explanations: E0741, E0770.
+For more information about an error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/issues/issue-72352.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-72352.full.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error[E0741]: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-72352.rs:7:42
    |
 LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {
@@ -6,3 +6,4 @@ LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/issues/issue-99641.rs
+++ b/src/test/ui/const-generics/issues/issue-99641.rs
@@ -1,0 +1,18 @@
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+fn main() {
+    pub struct Color<const WHITE: (fn(),)>;
+    //~^ ERROR using function pointers
+
+    impl<const WHITE: (fn(),)> Color<WHITE> {
+        //~^ ERROR using function pointers
+        pub fn new() -> Self {
+            Color::<WHITE>
+        }
+    }
+
+    pub const D65: (fn(),) = (|| {},);
+
+    Color::<D65>::new();
+}

--- a/src/test/ui/const-generics/issues/issue-99641.stderr
+++ b/src/test/ui/const-generics/issues/issue-99641.stderr
@@ -1,14 +1,14 @@
 error[E0741]: using function pointers as const generic parameters is forbidden
-  --> $DIR/fn-const-param-call.rs:11:25
+  --> $DIR/issue-99641.rs:5:35
    |
-LL | struct Wrapper<const F: fn() -> u32>;
-   |                         ^^^^^^^^^^^
+LL |     pub struct Color<const WHITE: (fn(),)>;
+   |                                   ^^^^^^^
 
 error[E0741]: using function pointers as const generic parameters is forbidden
-  --> $DIR/fn-const-param-call.rs:13:15
+  --> $DIR/issue-99641.rs:8:23
    |
-LL | impl<const F: fn() -> u32> Wrapper<F> {
-   |               ^^^^^^^^^^^
+LL |     impl<const WHITE: (fn(),)> Color<WHITE> {
+   |                       ^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/raw-ptr-const-param-deref.full.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param-deref.full.stderr
@@ -1,10 +1,10 @@
-error: using raw pointers as const generic parameters is forbidden
+error[E0741]: using raw pointers as const generic parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:9:23
    |
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
 
-error: using raw pointers as const generic parameters is forbidden
+error[E0741]: using raw pointers as const generic parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:11:15
    |
 LL | impl<const P: *const u32> Const<P> {
@@ -12,3 +12,4 @@ LL | impl<const P: *const u32> Const<P> {
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/raw-ptr-const-param.full.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param.full.stderr
@@ -1,4 +1,4 @@
-error: using raw pointers as const generic parameters is forbidden
+error[E0741]: using raw pointers as const generic parameters is forbidden
   --> $DIR/raw-ptr-const-param.rs:6:23
    |
 LL | struct Const<const P: *const u32>;
@@ -6,3 +6,4 @@ LL | struct Const<const P: *const u32>;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/consts/refs_check_const_eq-issue-88384.rs
+++ b/src/test/ui/consts/refs_check_const_eq-issue-88384.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 #![feature(fn_traits)]
 #![feature(adt_const_params)]
 //~^ WARNING the feature `adt_const_params` is incomplete
@@ -10,8 +8,10 @@ struct CompileTimeSettings{
 }
 
 struct Foo<const T: CompileTimeSettings>;
+//~^ ERROR using function pointers as const generic parameters is forbidden
 
 impl<const T: CompileTimeSettings> Foo<T> {
+    //~^ ERROR using function pointers as const generic parameters is forbidden
     fn call_hooks(){
     }
 }

--- a/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
+++ b/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
@@ -1,5 +1,5 @@
 warning: the feature `adt_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/refs_check_const_eq-issue-88384.rs:4:12
+  --> $DIR/refs_check_const_eq-issue-88384.rs:2:12
    |
 LL | #![feature(adt_const_params)]
    |            ^^^^^^^^^^^^^^^^
@@ -7,5 +7,18 @@ LL | #![feature(adt_const_params)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
 
-warning: 1 warning emitted
+error[E0741]: using function pointers as const generic parameters is forbidden
+  --> $DIR/refs_check_const_eq-issue-88384.rs:10:21
+   |
+LL | struct Foo<const T: CompileTimeSettings>;
+   |                     ^^^^^^^^^^^^^^^^^^^
 
+error[E0741]: using function pointers as const generic parameters is forbidden
+  --> $DIR/refs_check_const_eq-issue-88384.rs:13:15
+   |
+LL | impl<const T: CompileTimeSettings> Foo<T> {
+   |               ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0741`.


### PR DESCRIPTION
I think this is right -- just because we wrap a fn ptr in a wrapper type does not mean we should allow it in a const parameter.

We now reject both of these in the same way:

```
#![feature(adt_const_params)]

#[derive(Eq, PartialEq)]
struct Wrapper();

fn foo<const W: Wrapper>() {}

fn foo2<const F: fn()>() {}
```

This does regress one test (`src/test/ui/consts/refs_check_const_eq-issue-88384.stderr`), but I'm not sure it should've passed in the first place.

cc: @b-naber who introduced that test^
fixes #99641