### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/thumbv6m_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/thumbv6m_none_eabi.rs
@@ -14,8 +14,9 @@ pub fn target() -> Target {
             // The ARMv6-M architecture doesn't support unaligned loads/stores so we disable them
             // with +strict-align.
             features: "+strict-align".into(),
-            // There are no atomic CAS instructions available in the instruction set of the ARMv6-M
+            // There are no atomic instructions available in the instruction set of the ARMv6-M
             // architecture
+            max_atomic_width: Some(0),
             atomic_cas: false,
             ..super::thumb_base::opts()
         },

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -185,14 +185,20 @@ pub fn is_const_evaluatable<'cx, 'tcx>(
         }
         let concrete = infcx.const_eval_resolve(param_env, uv.expand(), Some(span));
         match concrete {
-            Err(ErrorHandled::TooGeneric) => Err(if !uv.has_infer_types_or_consts() {
+            Err(ErrorHandled::TooGeneric) => Err(if uv.has_infer_types_or_consts() {
+                NotConstEvaluatable::MentionsInfer
+            } else if uv.has_param_types_or_consts() {
                 infcx
                     .tcx
                     .sess
                     .delay_span_bug(span, &format!("unexpected `TooGeneric` for {:?}", uv));
                 NotConstEvaluatable::MentionsParam
             } else {
-                NotConstEvaluatable::MentionsInfer
+                let guar = infcx.tcx.sess.delay_span_bug(
+                    span,
+                    format!("Missing value for constant, but no error reported?"),
+                );
+                NotConstEvaluatable::Error(guar)
             }),
             Err(ErrorHandled::Linted) => {
                 let reported = infcx
@@ -240,8 +246,11 @@ pub fn is_const_evaluatable<'cx, 'tcx>(
 
             Err(ErrorHandled::TooGeneric) => Err(if uv.has_infer_types_or_consts() {
                 NotConstEvaluatable::MentionsInfer
-                } else {
+                } else if uv.has_param_types_or_consts() {
                 NotConstEvaluatable::MentionsParam
+            } else {
+                let guar = infcx.tcx.sess.delay_span_bug(span, format!("Missing value for constant, but no error reported?"));
+                NotConstEvaluatable::Error(guar)
             }),
             Err(ErrorHandled::Linted) => {
                 let reported =

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -280,6 +280,11 @@ fn resolve_associated_item<'tcx>(
                 return Ok(None);
             }
 
+            // If the item does not have a value, then we cannot return an instance.
+            if !leaf_def.item.defaultness.has_value() {
+                return Ok(None);
+            }
+
             let substs = tcx.erase_regions(substs);
 
             // Check if we just resolved an associated `const` declaration from

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -137,7 +137,7 @@ impl ConsoleTestState {
 // List the tests to console, and optionally to logfile. Filters are honored.
 pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<()> {
     let mut output = match term::stdout() {
-        None => OutputLocation::Raw(io::stdout()),
+        None => OutputLocation::Raw(io::stdout().lock()),
         Some(t) => OutputLocation::Pretty(t),
     };
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -121,7 +121,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 unsafety: hir::Unsafety::Normal,
                 generics: new_generics,
                 trait_: Some(trait_ref.clean(self.cx)),
-                for_: ty.clean(self.cx),
+                for_: clean_middle_ty(ty, self.cx, None),
                 items: Vec::new(),
                 polarity,
                 kind: ImplKind::Auto,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -116,14 +116,14 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             // FIXME(eddyb) compute both `trait_` and `for_` from
                             // the post-inference `trait_ref`, as it's more accurate.
                             trait_: Some(trait_ref.0.clean(cx)),
-                            for_: ty.0.clean(cx),
+                            for_: clean_middle_ty(ty.0, cx, None),
                             items: cx.tcx
                                 .associated_items(impl_def_id)
                                 .in_definition_order()
                                 .map(|x| x.clean(cx))
                                 .collect::<Vec<_>>(),
                             polarity: ty::ImplPolarity::Positive,
-                            kind: ImplKind::Blanket(Box::new(trait_ref.0.self_ty().clean(cx))),
+                            kind: ImplKind::Blanket(Box::new(clean_middle_ty(trait_ref.0.self_ty(), cx, None))),
                         })),
                         cfg: None,
                     });

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -2,8 +2,9 @@ use crate::clean::auto_trait::AutoTraitFinder;
 use crate::clean::blanket_impl::BlanketImplFinder;
 use crate::clean::render_macro_matchers::render_macro_matcher;
 use crate::clean::{
-    inline, Clean, Crate, ExternalCrate, Generic, GenericArg, GenericArgs, ImportSource, Item,
-    ItemKind, Lifetime, Path, PathSegment, Primitive, PrimitiveType, Type, TypeBinding, Visibility,
+    clean_middle_ty, inline, Clean, Crate, ExternalCrate, Generic, GenericArg, GenericArgs,
+    ImportSource, Item, ItemKind, Lifetime, Path, PathSegment, Primitive, PrimitiveType, Type,
+    TypeBinding, Visibility,
 };
 use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
@@ -91,7 +92,7 @@ pub(crate) fn substs_to_args<'tcx>(
             skip_first = false;
             None
         }
-        GenericArgKind::Type(ty) => Some(GenericArg::Type(ty.clean(cx))),
+        GenericArgKind::Type(ty) => Some(GenericArg::Type(clean_middle_ty(ty, cx, None))),
         GenericArgKind::Const(ct) => Some(GenericArg::Const(Box::new(ct.clean(cx)))),
     }));
     ret_val
@@ -110,7 +111,7 @@ fn external_generic_args<'tcx>(
         let inputs =
             // The trait's first substitution is the one after self, if there is one.
             match substs.iter().nth(if has_self { 1 } else { 0 }).unwrap().expect_ty().kind() {
-                ty::Tuple(tys) => tys.iter().map(|t| t.clean(cx)).collect::<Vec<_>>().into(),
+                ty::Tuple(tys) => tys.iter().map(|t| clean_middle_ty(t, cx, None)).collect::<Vec<_>>().into(),
                 _ => return GenericArgs::AngleBracketed { args: args.into(), bindings: bindings.into() },
             };
         let output = None;

--- a/src/test/ui-fulldeps/gated-plugin.rs
+++ b/src/test/ui-fulldeps/gated-plugin.rs
@@ -1,4 +1,5 @@
 // aux-build:empty-plugin.rs
+// ignore-stage1
 
 #![plugin(empty_plugin)]
 //~^ ERROR compiler plugins are deprecated

--- a/src/test/ui-fulldeps/gated-plugin.stderr
+++ b/src/test/ui-fulldeps/gated-plugin.stderr
@@ -1,5 +1,5 @@
 error[E0658]: compiler plugins are deprecated
-  --> $DIR/gated-plugin.rs:3:1
+  --> $DIR/gated-plugin.rs:4:1
    |
 LL | #![plugin(empty_plugin)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![plugin(empty_plugin)]
    = help: add `#![feature(plugin)]` to the crate attributes to enable
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/gated-plugin.rs:3:1
+  --> $DIR/gated-plugin.rs:4:1
    |
 LL | #![plugin(empty_plugin)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version

--- a/src/test/ui-fulldeps/multiple-plugins.rs
+++ b/src/test/ui-fulldeps/multiple-plugins.rs
@@ -1,6 +1,7 @@
 // run-pass
 // aux-build:multiple-plugins-1.rs
 // aux-build:multiple-plugins-2.rs
+// ignore-stage1
 
 // Check that the plugin registrar of multiple plugins doesn't conflict
 

--- a/src/test/ui-fulldeps/multiple-plugins.stderr
+++ b/src/test/ui-fulldeps/multiple-plugins.stderr
@@ -1,5 +1,5 @@
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/multiple-plugins.rs:8:1
+  --> $DIR/multiple-plugins.rs:9:1
    |
 LL | #![plugin(multiple_plugins_1)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
@@ -7,7 +7,7 @@ LL | #![plugin(multiple_plugins_1)]
    = note: `#[warn(deprecated)]` on by default
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/multiple-plugins.rs:9:1
+  --> $DIR/multiple-plugins.rs:10:1
    |
 LL | #![plugin(multiple_plugins_2)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version

--- a/src/test/ui/argument-suggestions/issue-98894.rs
+++ b/src/test/ui/argument-suggestions/issue-98894.rs
@@ -1,0 +1,4 @@
+fn main() {
+    (|_, ()| ())(if true {} else {return;});
+    //~^ ERROR this function takes 2 arguments but 1 argument was supplied
+}

--- a/src/test/ui/argument-suggestions/issue-98894.stderr
+++ b/src/test/ui/argument-suggestions/issue-98894.stderr
@@ -1,0 +1,19 @@
+error[E0057]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/issue-98894.rs:2:5
+   |
+LL |     (|_, ()| ())(if true {} else {return;});
+   |     ^^^^^^^^^^^^--------------------------- an argument of type `()` is missing
+   |
+note: closure defined here
+  --> $DIR/issue-98894.rs:2:6
+   |
+LL |     (|_, ()| ())(if true {} else {return;});
+   |      ^^^^^^^
+help: provide the argument
+   |
+LL |     (|_, ()| ())(if true {} else {return;}, ());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0057`.

--- a/src/test/ui/argument-suggestions/issue-98897.rs
+++ b/src/test/ui/argument-suggestions/issue-98897.rs
@@ -1,0 +1,4 @@
+fn main() {
+    (|_, ()| ())([return, ()]);
+    //~^ ERROR this function takes 2 arguments but 1 argument was supplied
+}

--- a/src/test/ui/argument-suggestions/issue-98897.stderr
+++ b/src/test/ui/argument-suggestions/issue-98897.stderr
@@ -1,0 +1,19 @@
+error[E0057]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/issue-98897.rs:2:5
+   |
+LL |     (|_, ()| ())([return, ()]);
+   |     ^^^^^^^^^^^^-------------- an argument of type `()` is missing
+   |
+note: closure defined here
+  --> $DIR/issue-98897.rs:2:6
+   |
+LL |     (|_, ()| ())([return, ()]);
+   |      ^^^^^^^
+help: provide the argument
+   |
+LL |     (|_, ()| ())([return, ()], ());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0057`.

--- a/src/test/ui/const-generics/issues/issue-86530.rs
+++ b/src/test/ui/const-generics/issues/issue-86530.rs
@@ -15,7 +15,6 @@ where
 fn unit_literals() {
     z(" ");
     //~^ ERROR: the trait bound `&str: X` is not satisfied
-    //~| ERROR: unconstrained generic constant
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/issues/issue-86530.stderr
+++ b/src/test/ui/const-generics/issues/issue-86530.stderr
@@ -15,22 +15,6 @@ LL | where
 LL |     T: X,
    |        ^ required by this bound in `z`
 
-error: unconstrained generic constant
-  --> $DIR/issue-86530.rs:16:5
-   |
-LL |     z(" ");
-   |     ^
-   |
-   = help: try adding a `where` bound using this expression: `where [(); T::Y]:`
-note: required by a bound in `z`
-  --> $DIR/issue-86530.rs:11:10
-   |
-LL | fn z<T>(t: T)
-   |    - required by a bound in this
-...
-LL |     [(); T::Y]: ,
-   |          ^^^^ required by this bound in `z`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/issues/issue-98629.rs
+++ b/src/test/ui/const-generics/issues/issue-98629.rs
@@ -1,0 +1,15 @@
+#![feature(const_trait_impl)]
+
+trait Trait {
+    const N: usize;
+}
+
+impl const Trait for i32 {}
+//~^ ERROR not all trait items implemented, missing: `N`
+
+fn f()
+where
+    [(); <i32 as Trait>::N]:,
+{}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-98629.stderr
+++ b/src/test/ui/const-generics/issues/issue-98629.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `N`
+  --> $DIR/issue-98629.rs:7:1
+   |
+LL |     const N: usize;
+   |     -------------- `N` from trait
+...
+LL | impl const Trait for i32 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ missing `N` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/src/test/ui/issues/issue-77919.rs
+++ b/src/test/ui/issues/issue-77919.rs
@@ -1,6 +1,5 @@
 fn main() {
     [1; <Multiply<Five, Five>>::VAL];
-    //~^ ERROR: constant expression depends on a generic parameter
 }
 trait TypeVal<T> {
     const VAL: T;

--- a/src/test/ui/issues/issue-77919.stderr
+++ b/src/test/ui/issues/issue-77919.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `PhantomData` in this scope
-  --> $DIR/issue-77919.rs:10:9
+  --> $DIR/issue-77919.rs:9:9
    |
 LL |     _n: PhantomData,
    |         ^^^^^^^^^^^ not found in this scope
@@ -10,7 +10,7 @@ LL | use std::marker::PhantomData;
    |
 
 error[E0412]: cannot find type `VAL` in this scope
-  --> $DIR/issue-77919.rs:12:63
+  --> $DIR/issue-77919.rs:11:63
    |
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          -                                                    ^^^ not found in this scope
@@ -18,7 +18,7 @@ LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          help: you might be missing a type parameter: `, VAL`
 
 error[E0046]: not all trait items implemented, missing: `VAL`
-  --> $DIR/issue-77919.rs:12:1
+  --> $DIR/issue-77919.rs:11:1
    |
 LL |     const VAL: T;
    |     ------------ `VAL` from trait
@@ -26,15 +26,7 @@ LL |     const VAL: T;
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
-error: constant expression depends on a generic parameter
-  --> $DIR/issue-77919.rs:2:9
-   |
-LL |     [1; <Multiply<Five, Five>>::VAL];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this may fail depending on what value the parameter takes
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0046, E0412.
 For more information about an error, try `rustc --explain E0046`.

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -30,15 +30,7 @@ LL |     const VAL: T;
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
-error: constant expression depends on a generic parameter
-  --> $DIR/ice-6252.rs:13:9
-   |
-LL |     [1; <Multiply<Five, Five>>::VAL];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this may fail depending on what value the parameter takes
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0046, E0412.
 For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
Successful merges:

 - #99298 (Make `ui-fulldeps/gated-plugins` and `ui-fulldeps/multiple-plugins` tests stage 2 only)
 - #99396 (Add some additional double-adjustment regression tests)
 - #99449 (Do not resolve associated const when there is no provided value)
 - #99595 (Mark atomics as unsupported on thumbv6m)
 - #99627 (Lock stdout once when listing tests)
 - #99638 (Remove Clean trait implementation for hir::Ty and middle::Ty)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99298,99396,99449,99595,99627,99638)
<!-- homu-ignore:end -->