### PR TITLE
Generate correct suggestion with named arguments used positionally

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -656,7 +656,7 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
                     let span = arg_spans.next().unwrap_or(template_sp);
 
                     let operand_idx = match arg.position {
-                        parse::ArgumentIs(idx) | parse::ArgumentImplicitlyIs(idx) => {
+                        parse::ArgumentIs(idx, _) | parse::ArgumentImplicitlyIs(idx) => {
                             if idx >= args.operands.len()
                                 || named_pos.contains_key(&idx)
                                 || args.reg_args.contains(&idx)

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -861,10 +861,10 @@ pub trait LintContext: Sized {
                     if let Some(positional_arg) = positional_arg {
                         let msg = format!("this formatting argument uses named argument `{}` by position", name);
                         db.span_label(positional_arg, msg);
-                            db.span_suggestion_verbose(
+                        db.span_suggestion_verbose(
                             positional_arg,
                             "use the named argument by name to avoid ambiguity",
-                            format!("{{{}}}", name),
+                            name,
                             Applicability::MaybeIncorrect,
                         );
                     }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -467,7 +467,7 @@ pub enum BuiltinLintDiagnostics {
         /// If true, the lifetime will be fully elided.
         use_span: Option<(Span, bool)>,
     },
-    NamedArgumentUsedPositionally(Option<Span>, Span, Symbol),
+    NamedArgumentUsedPositionally(Option<Span>, Span, String),
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -104,8 +104,8 @@ pub struct FormatSpec<'a> {
 pub enum Position<'a> {
     /// The argument is implied to be located at an index
     ArgumentImplicitlyIs(usize),
-    /// The argument is located at a specific index given in the format
-    ArgumentIs(usize),
+    /// The argument is located at a specific index given in the format,
+    ArgumentIs(usize, Option<InnerSpan>),
     /// The argument has a name.
     ArgumentNamed(&'a str, InnerSpan),
 }
@@ -113,7 +113,7 @@ pub enum Position<'a> {
 impl Position<'_> {
     pub fn index(&self) -> Option<usize> {
         match self {
-            ArgumentIs(i) | ArgumentImplicitlyIs(i) => Some(*i),
+            ArgumentIs(i, ..) | ArgumentImplicitlyIs(i) => Some(*i),
             _ => None,
         }
     }
@@ -502,8 +502,15 @@ impl<'a> Parser<'a> {
     /// Returns `Some(parsed_position)` if the position is not implicitly
     /// consuming a macro argument, `None` if it's the case.
     fn position(&mut self) -> Option<Position<'a>> {
+        let start_position = self.cur.peek().map(|item| item.0);
         if let Some(i) = self.integer() {
-            Some(ArgumentIs(i))
+            let inner_span = start_position.and_then(|start| {
+                self.cur
+                    .peek()
+                    .cloned()
+                    .and_then(|item| Some(self.to_span_index(start).to(self.to_span_index(item.0))))
+            });
+            Some(ArgumentIs(i, inner_span))
         } else {
             match self.cur.peek() {
                 Some(&(start, c)) if rustc_lexer::is_id_start(c) => {
@@ -574,6 +581,10 @@ impl<'a> Parser<'a> {
             // no '0' flag and '0$' as the width instead.
             if let Some(end) = self.consume_pos('$') {
                 spec.width = CountIsParam(0);
+
+                if let Some((pos, _)) = self.cur.peek().cloned() {
+                    spec.width_span = Some(self.to_span_index(pos - 2).to(self.to_span_index(pos)));
+                }
                 havewidth = true;
                 spec.width_span = Some(self.to_span_index(end - 1).to(self.to_span_index(end + 1)));
             } else {
@@ -586,6 +597,7 @@ impl<'a> Parser<'a> {
             spec.width = w;
             spec.width_span = sp;
         }
+
         if let Some(start) = self.consume_pos('.') {
             if let Some(end) = self.consume_pos('*') {
                 // Resolve `CountIsNextParam`.

--- a/compiler/rustc_parse_format/src/tests.rs
+++ b/compiler/rustc_parse_format/src/tests.rs
@@ -62,18 +62,30 @@ fn format_nothing() {
 }
 #[test]
 fn format_position() {
-    same("{3}", &[NextArgument(Argument { position: ArgumentIs(3), format: fmtdflt() })]);
+    same(
+        "{3}",
+        &[NextArgument(Argument {
+            position: ArgumentIs(3, Some(InnerSpan { start: 2, end: 3 })),
+            format: fmtdflt(),
+        })],
+    );
 }
 #[test]
 fn format_position_nothing_else() {
-    same("{3:}", &[NextArgument(Argument { position: ArgumentIs(3), format: fmtdflt() })]);
+    same(
+        "{3:}",
+        &[NextArgument(Argument {
+            position: ArgumentIs(3, Some(InnerSpan { start: 2, end: 3 })),
+            format: fmtdflt(),
+        })],
+    );
 }
 #[test]
 fn format_type() {
     same(
         "{3:x}",
         &[NextArgument(Argument {
-            position: ArgumentIs(3),
+            position: ArgumentIs(3, Some(InnerSpan { start: 2, end: 3 })),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
@@ -93,7 +105,7 @@ fn format_align_fill() {
     same(
         "{3:>}",
         &[NextArgument(Argument {
-            position: ArgumentIs(3),
+            position: ArgumentIs(3, Some(InnerSpan { start: 2, end: 3 })),
             format: FormatSpec {
                 fill: None,
                 align: AlignRight,
@@ -110,7 +122,7 @@ fn format_align_fill() {
     same(
         "{3:0<}",
         &[NextArgument(Argument {
-            position: ArgumentIs(3),
+            position: ArgumentIs(3, Some(InnerSpan { start: 2, end: 3 })),
             format: FormatSpec {
                 fill: Some('0'),
                 align: AlignLeft,
@@ -127,7 +139,7 @@ fn format_align_fill() {
     same(
         "{3:*<abcd}",
         &[NextArgument(Argument {
-            position: ArgumentIs(3),
+            position: ArgumentIs(3, Some(InnerSpan { start: 2, end: 3 })),
             format: FormatSpec {
                 fill: Some('*'),
                 align: AlignLeft,
@@ -181,7 +193,7 @@ fn format_counts() {
     same(
         "{1:0$.10x}",
         &[NextArgument(Argument {
-            position: ArgumentIs(1),
+            position: ArgumentIs(1, Some(InnerSpan { start: 2, end: 3 })),
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
@@ -291,7 +303,7 @@ fn format_mixture() {
         &[
             String("abcd "),
             NextArgument(Argument {
-                position: ArgumentIs(3),
+                position: ArgumentIs(3, Some(InnerSpan { start: 7, end: 8 })),
                 format: FormatSpec {
                     fill: None,
                     align: AlignUnknown,

--- a/compiler/rustc_trait_selection/src/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/on_unimplemented.rs
@@ -337,7 +337,7 @@ impl<'tcx> OnUnimplementedFormatString {
                         }
                     }
                     // `{:1}` and `{}` are not to be used
-                    Position::ArgumentIs(_) | Position::ArgumentImplicitlyIs(_) => {
+                    Position::ArgumentIs(..) | Position::ArgumentImplicitlyIs(_) => {
                         let reported = struct_span_err!(
                             tcx.sess,
                             span,

--- a/src/test/ui/macros/issue-98466.stderr
+++ b/src/test/ui/macros/issue-98466.stderr
@@ -2,80 +2,80 @@ warning: named argument `_x` is not used by name
   --> $DIR/issue-98466.rs:7:26
    |
 LL |     println!("_x is {}", _x = 5);
-   |                     --   ^^ this named argument is only referred to by position in formatting string
-   |                     |
-   |                     this formatting argument uses named argument `_x` by position
+   |                      -   ^^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `_x` by position
    |
    = note: `#[warn(named_arguments_used_positionally)]` on by default
 help: use the named argument by name to avoid ambiguity
    |
 LL |     println!("_x is {_x}", _x = 5);
-   |                     ~~~~
+   |                      ++
 
 warning: named argument `y` is not used by name
   --> $DIR/issue-98466.rs:10:26
    |
 LL |     println!("_x is {}", y = _x);
-   |                     --   ^ this named argument is only referred to by position in formatting string
-   |                     |
-   |                     this formatting argument uses named argument `y` by position
+   |                      -   ^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `y` by position
    |
 help: use the named argument by name to avoid ambiguity
    |
 LL |     println!("_x is {y}", y = _x);
-   |                     ~~~
+   |                      +
 
 warning: named argument `y` is not used by name
   --> $DIR/issue-98466.rs:13:83
    |
 LL |     println!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
-   |                                                                        --         ^ this named argument is only referred to by position in formatting string
-   |                                                                        |
-   |                                                                        this formatting argument uses named argument `y` by position
+   |                                                                         -         ^ this named argument is only referred to by position in formatting string
+   |                                                                         |
+   |                                                                         this formatting argument uses named argument `y` by position
    |
 help: use the named argument by name to avoid ambiguity
    |
 LL |     println!("first positional arg {}, second positional arg {}, _x is {y}", 1, 2, y = _x);
-   |                                                                        ~~~
+   |                                                                         +
 
 warning: named argument `_x` is not used by name
   --> $DIR/issue-98466.rs:19:34
    |
 LL |     let _f = format!("_x is {}", _x = 5);
-   |                             --   ^^ this named argument is only referred to by position in formatting string
-   |                             |
-   |                             this formatting argument uses named argument `_x` by position
+   |                              -   ^^ this named argument is only referred to by position in formatting string
+   |                              |
+   |                              this formatting argument uses named argument `_x` by position
    |
 help: use the named argument by name to avoid ambiguity
    |
 LL |     let _f = format!("_x is {_x}", _x = 5);
-   |                             ~~~~
+   |                              ++
 
 warning: named argument `y` is not used by name
   --> $DIR/issue-98466.rs:22:34
    |
 LL |     let _f = format!("_x is {}", y = _x);
-   |                             --   ^ this named argument is only referred to by position in formatting string
-   |                             |
-   |                             this formatting argument uses named argument `y` by position
+   |                              -   ^ this named argument is only referred to by position in formatting string
+   |                              |
+   |                              this formatting argument uses named argument `y` by position
    |
 help: use the named argument by name to avoid ambiguity
    |
 LL |     let _f = format!("_x is {y}", y = _x);
-   |                             ~~~
+   |                              +
 
 warning: named argument `y` is not used by name
   --> $DIR/issue-98466.rs:25:91
    |
 LL |     let _f = format!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
-   |                                                                                --         ^ this named argument is only referred to by position in formatting string
-   |                                                                                |
-   |                                                                                this formatting argument uses named argument `y` by position
+   |                                                                                 -         ^ this named argument is only referred to by position in formatting string
+   |                                                                                 |
+   |                                                                                 this formatting argument uses named argument `y` by position
    |
 help: use the named argument by name to avoid ambiguity
    |
 LL |     let _f = format!("first positional arg {}, second positional arg {}, _x is {y}", 1, 2, y = _x);
-   |                                                                                ~~~
+   |                                                                                 +
 
 warning: 6 warnings emitted
 

--- a/src/test/ui/macros/issue-99265.fixed
+++ b/src/test/ui/macros/issue-99265.fixed
@@ -1,0 +1,139 @@
+// check-pass
+// run-rustfix
+
+fn main() {
+    println!("{b} {a}", a=1, b=2);
+    //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("{} {a} {b} {c} {d}", 0, a=1, b=2, c=3, d=4);
+    //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `b` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `c` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `d` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {:width$}!", "x", width = 5);
+    //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {f:width$.precision$}!", f = 0.02f32, width = 5, precision = 2);
+    //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+    //~| WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {f:width$.precision$}!", f = 0.02f32, width = 5, precision = 2);
+    //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+    //~| WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!(
+        "{}, Hello {f:width$.precision$} {g:width2$.precision2$}! {f}",
+        //~^ HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        1,
+        f = 0.02f32,
+        //~^ WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+        //~| WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+        width = 5,
+        //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+        precision = 2,
+        //~^ WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+        g = 0.02f32,
+        //~^ WARNING named argument `g` is not used by name [named_arguments_used_positionally]
+        width2 = 5,
+        //~^ WARNING named argument `width2` is not used by name [named_arguments_used_positionally
+        precision2 = 2
+        //~^ WARNING named argument `precision2` is not used by name [named_arguments_used_positionally]
+    );
+
+    println!("Hello {f:0.1}!", f = 0.02f32);
+    //~^ WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {f:0.1}!", f = 0.02f32);
+    //~^ WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {f:width$.precision$}!", f = 0.02f32, width = 5, precision = 2);
+
+    let width = 5;
+    let precision = 2;
+    println!("Hello {f:width$.precision$}!", f = 0.02f32);
+
+    let val = 5;
+    println!("{v:v$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("{v:v$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("{v:v$.v$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("{v:v$.v$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("{a} {a} {a}", a = 1);
+    //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("aaaaaaaaaaaaaaa\
+                {a:b$.c$}",
+             //~^ HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             a = 1.0, b = 1, c = 2,
+             //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `b` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `c` is not used by name [named_arguments_used_positionally]
+    );
+
+    println!("aaaaaaaaaaaaaaa\
+                {a:b$.c$}",
+             //~^ HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             a = 1.0, b = 1, c = 2,
+             //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `b` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `c` is not used by name [named_arguments_used_positionally]
+    );
+
+    println!("{{{x:width$.precision$}}}", x = 1.0, width = 3, precision = 2);
+    //~^ WARNING named argument `x` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `width` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+}

--- a/src/test/ui/macros/issue-99265.rs
+++ b/src/test/ui/macros/issue-99265.rs
@@ -1,0 +1,139 @@
+// check-pass
+// run-rustfix
+
+fn main() {
+    println!("{b} {}", a=1, b=2);
+    //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("{} {} {} {} {}", 0, a=1, b=2, c=3, d=4);
+    //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `b` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `c` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `d` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {:1$}!", "x", width = 5);
+    //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+    //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+    //~| WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {0:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+    //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+    //~| WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!(
+        "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+        //~^ HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        //~| HELP use the named argument by name to avoid ambiguity
+        1,
+        f = 0.02f32,
+        //~^ WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+        //~| WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+        width = 5,
+        //~^ WARNING named argument `width` is not used by name [named_arguments_used_positionally
+        precision = 2,
+        //~^ WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+        g = 0.02f32,
+        //~^ WARNING named argument `g` is not used by name [named_arguments_used_positionally]
+        width2 = 5,
+        //~^ WARNING named argument `width2` is not used by name [named_arguments_used_positionally
+        precision2 = 2
+        //~^ WARNING named argument `precision2` is not used by name [named_arguments_used_positionally]
+    );
+
+    println!("Hello {:0.1}!", f = 0.02f32);
+    //~^ WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {0:0.1}!", f = 0.02f32);
+    //~^ WARNING named argument `f` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("Hello {f:width$.precision$}!", f = 0.02f32, width = 5, precision = 2);
+
+    let width = 5;
+    let precision = 2;
+    println!("Hello {f:width$.precision$}!", f = 0.02f32);
+
+    let val = 5;
+    println!("{:0$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("{0:0$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("{:0$.0$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("{0:0$.0$}", v = val);
+    //~^ WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `v` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("{} {a} {0}", a = 1);
+    //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    println!("aaaaaaaaaaaaaaa\
+                {:1$.2$}",
+             //~^ HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             a = 1.0, b = 1, c = 2,
+             //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `b` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `c` is not used by name [named_arguments_used_positionally]
+    );
+
+    println!("aaaaaaaaaaaaaaa\
+                {0:1$.2$}",
+             //~^ HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             //~| HELP use the named argument by name to avoid ambiguity
+             a = 1.0, b = 1, c = 2,
+             //~^ WARNING named argument `a` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `b` is not used by name [named_arguments_used_positionally]
+             //~| WARNING named argument `c` is not used by name [named_arguments_used_positionally]
+    );
+
+    println!("{{{:1$.2$}}}", x = 1.0, width = 3, precision = 2);
+    //~^ WARNING named argument `x` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `width` is not used by name [named_arguments_used_positionally]
+    //~| WARNING named argument `precision` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| HELP use the named argument by name to avoid ambiguity
+}

--- a/src/test/ui/macros/issue-99265.stderr
+++ b/src/test/ui/macros/issue-99265.stderr
@@ -1,0 +1,562 @@
+warning: named argument `a` is not used by name
+  --> $DIR/issue-99265.rs:5:24
+   |
+LL |     println!("{b} {}", a=1, b=2);
+   |                    -   ^ this named argument is only referred to by position in formatting string
+   |                    |
+   |                    this formatting argument uses named argument `a` by position
+   |
+   = note: `#[warn(named_arguments_used_positionally)]` on by default
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{b} {a}", a=1, b=2);
+   |                    +
+
+warning: named argument `a` is not used by name
+  --> $DIR/issue-99265.rs:9:35
+   |
+LL |     println!("{} {} {} {} {}", 0, a=1, b=2, c=3, d=4);
+   |                   -               ^ this named argument is only referred to by position in formatting string
+   |                   |
+   |                   this formatting argument uses named argument `a` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{} {a} {} {} {}", 0, a=1, b=2, c=3, d=4);
+   |                   +
+
+warning: named argument `b` is not used by name
+  --> $DIR/issue-99265.rs:9:40
+   |
+LL |     println!("{} {} {} {} {}", 0, a=1, b=2, c=3, d=4);
+   |                      -                 ^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `b` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{} {} {b} {} {}", 0, a=1, b=2, c=3, d=4);
+   |                      +
+
+warning: named argument `c` is not used by name
+  --> $DIR/issue-99265.rs:9:45
+   |
+LL |     println!("{} {} {} {} {}", 0, a=1, b=2, c=3, d=4);
+   |                         -                   ^ this named argument is only referred to by position in formatting string
+   |                         |
+   |                         this formatting argument uses named argument `c` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{} {} {} {c} {}", 0, a=1, b=2, c=3, d=4);
+   |                         +
+
+warning: named argument `d` is not used by name
+  --> $DIR/issue-99265.rs:9:50
+   |
+LL |     println!("{} {} {} {} {}", 0, a=1, b=2, c=3, d=4);
+   |                            -                     ^ this named argument is only referred to by position in formatting string
+   |                            |
+   |                            this formatting argument uses named argument `d` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{} {} {} {} {d}", 0, a=1, b=2, c=3, d=4);
+   |                            +
+
+warning: named argument `width` is not used by name
+  --> $DIR/issue-99265.rs:19:35
+   |
+LL |     println!("Hello {:1$}!", "x", width = 5);
+   |                       --          ^^^^^ this named argument is only referred to by position in formatting string
+   |                       |
+   |                       this formatting argument uses named argument `width$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {:width$}!", "x", width = 5);
+   |                       ~~~~~~
+
+warning: named argument `width` is not used by name
+  --> $DIR/issue-99265.rs:23:46
+   |
+LL |     println!("Hello {:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                       --                     ^^^^^ this named argument is only referred to by position in formatting string
+   |                       |
+   |                       this formatting argument uses named argument `width$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {:width$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                       ~~~~~~
+
+warning: named argument `precision` is not used by name
+  --> $DIR/issue-99265.rs:23:57
+   |
+LL |     println!("Hello {:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                          --                             ^^^^^^^^^ this named argument is only referred to by position in formatting string
+   |                          |
+   |                          this formatting argument uses named argument `precision$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {:1$.precision$}!", f = 0.02f32, width = 5, precision = 2);
+   |                          ~~~~~~~~~~
+
+warning: named argument `f` is not used by name
+  --> $DIR/issue-99265.rs:23:33
+   |
+LL |     println!("Hello {:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                      -          ^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `f` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {f:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                      +
+
+warning: named argument `width` is not used by name
+  --> $DIR/issue-99265.rs:31:47
+   |
+LL |     println!("Hello {0:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                        --                     ^^^^^ this named argument is only referred to by position in formatting string
+   |                        |
+   |                        this formatting argument uses named argument `width$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {0:width$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                        ~~~~~~
+
+warning: named argument `precision` is not used by name
+  --> $DIR/issue-99265.rs:31:58
+   |
+LL |     println!("Hello {0:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                           --                             ^^^^^^^^^ this named argument is only referred to by position in formatting string
+   |                           |
+   |                           this formatting argument uses named argument `precision$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {0:1$.precision$}!", f = 0.02f32, width = 5, precision = 2);
+   |                           ~~~~~~~~~~
+
+warning: named argument `f` is not used by name
+  --> $DIR/issue-99265.rs:31:34
+   |
+LL |     println!("Hello {0:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                      -           ^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `f` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {f:1$.2$}!", f = 0.02f32, width = 5, precision = 2);
+   |                      ~
+
+warning: named argument `width` is not used by name
+  --> $DIR/issue-99265.rs:52:9
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+   |                       -- this formatting argument uses named argument `width$` by position
+...
+LL |         width = 5,
+   |         ^^^^^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |         "{}, Hello {1:width$.3$} {4:5$.6$}! {1}",
+   |                       ~~~~~~
+
+warning: named argument `precision` is not used by name
+  --> $DIR/issue-99265.rs:54:9
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+   |                          -- this formatting argument uses named argument `precision$` by position
+...
+LL |         precision = 2,
+   |         ^^^^^^^^^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |         "{}, Hello {1:2$.precision$} {4:5$.6$}! {1}",
+   |                          ~~~~~~~~~~
+
+warning: named argument `f` is not used by name
+  --> $DIR/issue-99265.rs:49:9
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+   |                     - this formatting argument uses named argument `f` by position
+...
+LL |         f = 0.02f32,
+   |         ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |         "{}, Hello {f:2$.3$} {4:5$.6$}! {1}",
+   |                     ~
+
+warning: named argument `width2` is not used by name
+  --> $DIR/issue-99265.rs:58:9
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+   |                                 -- this formatting argument uses named argument `width2$` by position
+...
+LL |         width2 = 5,
+   |         ^^^^^^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |         "{}, Hello {1:2$.3$} {4:width2$.6$}! {1}",
+   |                                 ~~~~~~~
+
+warning: named argument `precision2` is not used by name
+  --> $DIR/issue-99265.rs:60:9
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+   |                                    -- this formatting argument uses named argument `precision2$` by position
+...
+LL |         precision2 = 2
+   |         ^^^^^^^^^^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.precision2$}! {1}",
+   |                                    ~~~~~~~~~~~
+
+warning: named argument `g` is not used by name
+  --> $DIR/issue-99265.rs:56:9
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+   |                               - this formatting argument uses named argument `g` by position
+...
+LL |         g = 0.02f32,
+   |         ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |         "{}, Hello {1:2$.3$} {g:5$.6$}! {1}",
+   |                               ~
+
+warning: named argument `f` is not used by name
+  --> $DIR/issue-99265.rs:49:9
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {1}",
+   |                                          - this formatting argument uses named argument `f` by position
+...
+LL |         f = 0.02f32,
+   |         ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |         "{}, Hello {1:2$.3$} {4:5$.6$}! {f}",
+   |                                          ~
+
+warning: named argument `f` is not used by name
+  --> $DIR/issue-99265.rs:64:31
+   |
+LL |     println!("Hello {:0.1}!", f = 0.02f32);
+   |                      -        ^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `f` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {f:0.1}!", f = 0.02f32);
+   |                      +
+
+warning: named argument `f` is not used by name
+  --> $DIR/issue-99265.rs:68:32
+   |
+LL |     println!("Hello {0:0.1}!", f = 0.02f32);
+   |                      -         ^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `f` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("Hello {f:0.1}!", f = 0.02f32);
+   |                      ~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:79:23
+   |
+LL |     println!("{:0$}", v = val);
+   |                 --    ^ this named argument is only referred to by position in formatting string
+   |                 |
+   |                 this formatting argument uses named argument `v$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{:v$}", v = val);
+   |                 ~~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:79:23
+   |
+LL |     println!("{:0$}", v = val);
+   |                -      ^ this named argument is only referred to by position in formatting string
+   |                |
+   |                this formatting argument uses named argument `v` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{v:0$}", v = val);
+   |                +
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:84:24
+   |
+LL |     println!("{0:0$}", v = val);
+   |                  --    ^ this named argument is only referred to by position in formatting string
+   |                  |
+   |                  this formatting argument uses named argument `v$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{0:v$}", v = val);
+   |                  ~~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:84:24
+   |
+LL |     println!("{0:0$}", v = val);
+   |                -       ^ this named argument is only referred to by position in formatting string
+   |                |
+   |                this formatting argument uses named argument `v` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{v:0$}", v = val);
+   |                ~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:89:26
+   |
+LL |     println!("{:0$.0$}", v = val);
+   |                 --       ^ this named argument is only referred to by position in formatting string
+   |                 |
+   |                 this formatting argument uses named argument `v$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{:v$.0$}", v = val);
+   |                 ~~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:89:26
+   |
+LL |     println!("{:0$.0$}", v = val);
+   |                    --    ^ this named argument is only referred to by position in formatting string
+   |                    |
+   |                    this formatting argument uses named argument `v$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{:0$.v$}", v = val);
+   |                    ~~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:89:26
+   |
+LL |     println!("{:0$.0$}", v = val);
+   |                -         ^ this named argument is only referred to by position in formatting string
+   |                |
+   |                this formatting argument uses named argument `v` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{v:0$.0$}", v = val);
+   |                +
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:96:27
+   |
+LL |     println!("{0:0$.0$}", v = val);
+   |                  --       ^ this named argument is only referred to by position in formatting string
+   |                  |
+   |                  this formatting argument uses named argument `v$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{0:v$.0$}", v = val);
+   |                  ~~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:96:27
+   |
+LL |     println!("{0:0$.0$}", v = val);
+   |                     --    ^ this named argument is only referred to by position in formatting string
+   |                     |
+   |                     this formatting argument uses named argument `v$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{0:0$.v$}", v = val);
+   |                     ~~
+
+warning: named argument `v` is not used by name
+  --> $DIR/issue-99265.rs:96:27
+   |
+LL |     println!("{0:0$.0$}", v = val);
+   |                -          ^ this named argument is only referred to by position in formatting string
+   |                |
+   |                this formatting argument uses named argument `v` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{v:0$.0$}", v = val);
+   |                ~
+
+warning: named argument `a` is not used by name
+  --> $DIR/issue-99265.rs:104:28
+   |
+LL |     println!("{} {a} {0}", a = 1);
+   |                -           ^ this named argument is only referred to by position in formatting string
+   |                |
+   |                this formatting argument uses named argument `a` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{a} {a} {0}", a = 1);
+   |                +
+
+warning: named argument `a` is not used by name
+  --> $DIR/issue-99265.rs:104:28
+   |
+LL |     println!("{} {a} {0}", a = 1);
+   |                       -    ^ this named argument is only referred to by position in formatting string
+   |                       |
+   |                       this formatting argument uses named argument `a` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{} {a} {a}", a = 1);
+   |                       ~
+
+warning: named argument `b` is not used by name
+  --> $DIR/issue-99265.rs:115:23
+   |
+LL |                 {:1$.2$}",
+   |                   -- this formatting argument uses named argument `b$` by position
+...
+LL |              a = 1.0, b = 1, c = 2,
+   |                       ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |                 {:b$.2$}",
+   |                   ~~
+
+warning: named argument `c` is not used by name
+  --> $DIR/issue-99265.rs:115:30
+   |
+LL |                 {:1$.2$}",
+   |                      -- this formatting argument uses named argument `c$` by position
+...
+LL |              a = 1.0, b = 1, c = 2,
+   |                              ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |                 {:1$.c$}",
+   |                      ~~
+
+warning: named argument `a` is not used by name
+  --> $DIR/issue-99265.rs:115:14
+   |
+LL |                 {:1$.2$}",
+   |                  - this formatting argument uses named argument `a` by position
+...
+LL |              a = 1.0, b = 1, c = 2,
+   |              ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |                 {a:1$.2$}",
+   |                  +
+
+warning: named argument `b` is not used by name
+  --> $DIR/issue-99265.rs:126:23
+   |
+LL |                 {0:1$.2$}",
+   |                    -- this formatting argument uses named argument `b$` by position
+...
+LL |              a = 1.0, b = 1, c = 2,
+   |                       ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |                 {0:b$.2$}",
+   |                    ~~
+
+warning: named argument `c` is not used by name
+  --> $DIR/issue-99265.rs:126:30
+   |
+LL |                 {0:1$.2$}",
+   |                       -- this formatting argument uses named argument `c$` by position
+...
+LL |              a = 1.0, b = 1, c = 2,
+   |                              ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |                 {0:1$.c$}",
+   |                       ~~
+
+warning: named argument `a` is not used by name
+  --> $DIR/issue-99265.rs:126:14
+   |
+LL |                 {0:1$.2$}",
+   |                  - this formatting argument uses named argument `a` by position
+...
+LL |              a = 1.0, b = 1, c = 2,
+   |              ^ this named argument is only referred to by position in formatting string
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |                 {a:1$.2$}",
+   |                  ~
+
+warning: named argument `width` is not used by name
+  --> $DIR/issue-99265.rs:132:39
+   |
+LL |     println!("{{{:1$.2$}}}", x = 1.0, width = 3, precision = 2);
+   |                   --                  ^^^^^ this named argument is only referred to by position in formatting string
+   |                   |
+   |                   this formatting argument uses named argument `width$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{{{:width$.2$}}}", x = 1.0, width = 3, precision = 2);
+   |                   ~~~~~~
+
+warning: named argument `precision` is not used by name
+  --> $DIR/issue-99265.rs:132:50
+   |
+LL |     println!("{{{:1$.2$}}}", x = 1.0, width = 3, precision = 2);
+   |                      --                          ^^^^^^^^^ this named argument is only referred to by position in formatting string
+   |                      |
+   |                      this formatting argument uses named argument `precision$` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{{{:1$.precision$}}}", x = 1.0, width = 3, precision = 2);
+   |                      ~~~~~~~~~~
+
+warning: named argument `x` is not used by name
+  --> $DIR/issue-99265.rs:132:30
+   |
+LL |     println!("{{{:1$.2$}}}", x = 1.0, width = 3, precision = 2);
+   |                  -           ^ this named argument is only referred to by position in formatting string
+   |                  |
+   |                  this formatting argument uses named argument `x` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("{{{x:1$.2$}}}", x = 1.0, width = 3, precision = 2);
+   |                  +
+
+warning: 42 warnings emitted
+

--- a/src/tools/clippy/clippy_lints/src/write.rs
+++ b/src/tools/clippy/clippy_lints/src/write.rs
@@ -441,7 +441,7 @@ impl SimpleFormatArgs {
         };
 
         match arg.position {
-            ArgumentIs(n) | ArgumentImplicitlyIs(n) => {
+            ArgumentIs(n, _) | ArgumentImplicitlyIs(n) => {
                 if self.unnamed.len() <= n {
                     // Use a dummy span to mark all unseen arguments.
                     self.unnamed.resize_with(n, || vec![DUMMY_SP]);


### PR DESCRIPTION
Address issue #99265 by checking each positionally used argument
to see if the argument is named and adding a lint to use the name
instead. This way, when named arguments are used positionally in a
different order than their argument order, the suggested lint is
correct.

For example:
```
println!("{b} {}", a=1, b=2);
```
This will now generate the suggestion:
```
println!("{b} {a}", a=1, b=2);
```

Additionally, this check now also correctly replaces or inserts
only where the positional argument is (or would be if implicit).
Also, width and precision are replaced with their argument names
when they exists.

Since the issues were so closely related, this fix for issue #99265
also fixes issue #99266.

Fixes #99265
Fixes #99266