### PR TITLE
Revert "Mark atomics as unsupported on thumbv6m"

### DIFF
--- a/compiler/rustc_target/src/spec/thumbv6m_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/thumbv6m_none_eabi.rs
@@ -14,9 +14,8 @@ pub fn target() -> Target {
             // The ARMv6-M architecture doesn't support unaligned loads/stores so we disable them
             // with +strict-align.
             features: "+strict-align".into(),
-            // There are no atomic instructions available in the instruction set of the ARMv6-M
+            // There are no atomic CAS instructions available in the instruction set of the ARMv6-M
             // architecture
-            max_atomic_width: Some(0),
             atomic_cas: false,
             ..super::thumb_base::opts()
         },


### PR DESCRIPTION
This is a breaking change for the `thumbv6m` target. See #99668 for discussion on how we can proceed forward from here.

This reverts commit 75146102197c7f35e6c38cb402b2bc1065858c54.

cc @nikic 