### PR TITLE
Don't overwrite CodegenFnAttrs when adding used compiler/linker

### DIFF
--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2843,7 +2843,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
                     let is_like_elf = !(tcx.sess.target.is_like_osx
                         || tcx.sess.target.is_like_windows
                         || tcx.sess.target.is_like_wasm);
-                    codegen_fn_attrs.flags = if is_like_elf {
+                    codegen_fn_attrs.flags |= if is_like_elf {
                         CodegenFnAttrFlags::USED
                     } else {
                         CodegenFnAttrFlags::USED_LINKER


### PR DESCRIPTION
Pointed out by @tmiasko in https://github.com/rust-lang/rust/pull/93718#discussion_r928259163. Probably a better fix than https://github.com/rust-lang/rust/pull/99674 for https://github.com/rust-lang/rust/issues/99596, assuming it does fix the latter.

I don't have the ability to write a regression test for this at the moment, and am quite surprised this didn't cause other failures. The old code is clearly wrong though, but I'm not picky as to which of these is better to go with.