### PR TITLE
add suggestion when there is a impl of external trait on pointer with wrong coherence rules

### DIFF
--- a/src/test/ui/errors/issue-99572-impl-trait-on-pointer.rs
+++ b/src/test/ui/errors/issue-99572-impl-trait-on-pointer.rs
@@ -1,0 +1,25 @@
+// Emit additional suggestion to correct the trait implementation
+// on a pointer
+use std::{fmt, marker};
+
+struct LocalType;
+
+impl fmt::Display for *mut LocalType {
+//~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
+//~| NOTE impl doesn't use only types from inside the current crate
+//~| NOTE `*mut LocalType` is not defined in the current crate because raw pointers are always foreign
+//~| NOTE define and implement a trait or new type instead
+//~| HELP consider introducing a new wrapper type
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "This not compile")
+    }
+}
+
+impl<T> marker::Copy for *mut T {
+//~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
+//~| NOTE impl doesn't use only types from inside the current crate
+//~| NOTE `*mut T` is not defined in the current crate because raw pointers are always foreign
+//~| NOTE define and implement a trait or new type instead
+}
+
+fn main() {}

--- a/src/test/ui/errors/issue-99572-impl-trait-on-pointer.stderr
+++ b/src/test/ui/errors/issue-99572-impl-trait-on-pointer.stderr
@@ -1,0 +1,31 @@
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/issue-99572-impl-trait-on-pointer.rs:7:1
+   |
+LL | impl fmt::Display for *mut LocalType {
+   | ^^^^^^^^^^^^^^^^^^^^^^--------------
+   | |                     |
+   | |                     `*mut LocalType` is not defined in the current crate because raw pointers are always foreign
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+help: consider introducing a new wrapper type
+   |
+LL + struct WrapperType(*mut LocalType);
+LL + 
+LL ~ impl fmt::Display for WrapperType {
+   |
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/issue-99572-impl-trait-on-pointer.rs:18:1
+   |
+LL | impl<T> marker::Copy for *mut T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^------
+   | |                        |
+   | |                        `*mut T` is not defined in the current crate because raw pointers are always foreign
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0117`.


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/99572

This will try to improve the node in the error message by suggesting a general solution because the solution, in this case, is application depended.

I'm not super happy regarding the code quality, but I'm happy to have feedback on it.

@rustbot r? @compiler-errors 