### PR TITLE
Add some comments to the docs issue template to clarify

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -4,13 +4,28 @@ about: Create a report for a documentation problem.
 labels: A-docs
 ---
 <!--
+
 Thank you for finding a documentation problem! 📚
 
 Documentation problems might be grammatical issues, typos, or unclear wording, please provide details regarding the documentation including where it is present.
+
+Note: If your issue is for one of these, please use their dedicated issue tracker instead:
+
+- The Rust Book: https://github.com/rust-lang/book/issues
+- Rust by Example: https://github.com/rust-lang/rust-by-example/issues
+- The Edition Guide: https://github.com/rust-lang/edition-guide/issues
+- The Cargo Book: https://github.com/rust-lang/cargo/issues
+- The Clippy Book: https://github.com/rust-lang/rust-clippy/issues
+- The Reference: https://github.com/rust-lang/reference/issues
+- The Rustonomicon: https://github.com/rust-lang/nomicon/issues
+- The Embedded Book: https://github.com/rust-embedded/book/issues
+
+All other documentation issues should be filed here.
+
+Or, if you find an issue related to rustdoc (e.g. doctest, rustdoc UI), please use the bug report or blank issue template instead.
 
 -->
 
 ### Location
 
 ### Summary
-


### PR DESCRIPTION
Newcomers may not know that some docs have their own repositories (e.g. the book, the reference), or that the documentation and rustdoc are different.
Actually, this template was used to report an issue related to the book: https://github.com/rust-lang/rust/issues/99699
This adds some comments to clarify the above things. I'm not sure if the current wording is the best, any suggestion would be helpful!

Signed-off-by: Yuki Okushi <jtitor@2k36.org>