### PR TITLE
Fix some broken link fragments.

### DIFF
--- a/src/doc/rustdoc/src/deprecated-features.md
+++ b/src/doc/rustdoc/src/deprecated-features.md
@@ -10,4 +10,4 @@ change in any release.
 
 In the past the most common use case for customizing passes was to omit the `strip-private` pass.
 You can do this more easily, and without risk of the pass being changed, by passing
-[`--document-private-items`](./unstable-features.md#--document-private-items).
+[`--document-private-items`](command-line-arguments.md#--document-private-items-show-items-that-are-not-public).

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -466,7 +466,7 @@ Note that the third item is the crate root, which in this case is undocumented.
 and is also accepted on stable toolchains.
 
 It can also be used with `--show-coverage`. Take a look at its
-[documentation](#--show-coverage-get-statistics-about-code-documentation-coverage) for more
+[documentation](#--show-coverage-calculate-the-percentage-of-items-with-documentation) for more
 information.
 
 ### `--enable-per-target-ignores`: allow `ignore-foo` style filters for doctests

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -348,11 +348,6 @@ impl Checker {
                     return;
                 }
 
-                // These appear to be broken in mdbook right now?
-                if fragment.starts_with('-') {
-                    return;
-                }
-
                 parse_ids(&mut target_ids.borrow_mut(), &pretty_path, target_source, report);
 
                 if target_ids.borrow().contains(*fragment) {


### PR DESCRIPTION
An exception for link fragments starting with `-` was added in #49590. However, it is not clear what issues were encountered at the time. Perhaps those were fixed in the meantime.

This removes the exception, and fixes a couple of broken links that were skipped due to it.
