### PR TITLE
Remove let-chain close brace check.

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2356,10 +2356,7 @@ impl<'a> Parser<'a> {
         let is_in_a_let_chains_context_but_nested_in_other_expr = self.let_expr_allowed
             && !matches!(
                 self.prev_token.kind,
-                TokenKind::AndAnd
-                    | TokenKind::CloseDelim(Delimiter::Brace)
-                    | TokenKind::Ident(kw::If, _)
-                    | TokenKind::Ident(kw::While, _)
+                TokenKind::AndAnd | TokenKind::Ident(kw::If, _) | TokenKind::Ident(kw::While, _)
             );
         if !self.let_expr_allowed || is_in_a_let_chains_context_but_nested_in_other_expr {
             self.struct_span_err(self.token.span, "expected expression, found `let` statement")


### PR DESCRIPTION
#98633 added some checks to forbid let-expressions that aren't in a let chain. This check looks at the preceding token to determine if it is a valid let-chain position. One of those tokens it checks is the close brace `}`. However, to my understanding, it is not possible for a let chain to be preceded by a close brace. This PR removes the check to avoid any confusion.

This is a followup to the discussion at https://github.com/rust-lang/rust/pull/98633#pullrequestreview-1030962803. It wasn't clear what issues the original PR ran into, but I have run the full set of CI tests and nothing failed.  I also can't conceive of a situation where this would be possible.  This doesn't reject any valid code, I'm just removing it to avoid confusion to anyone looking at this code in the future.
