### PR TITLE
rustdoc: avoid inlining modules with duplicate names

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -51,19 +51,22 @@ pub(crate) trait Clean<'tcx, T> {
 impl<'tcx> Clean<'tcx, Item> for DocModule<'tcx> {
     fn clean(&self, cx: &mut DocContext<'tcx>) -> Item {
         let mut items: Vec<Item> = vec![];
+        let mut inserted = FxHashSet::default();
         items.extend(
             self.foreigns
                 .iter()
                 .map(|(item, renamed)| clean_maybe_renamed_foreign_item(cx, item, *renamed)),
         );
-        items.extend(self.mods.iter().map(|x| x.clean(cx)));
+        items.extend(self.mods.iter().map(|x| {
+            inserted.insert((ItemType::Module, x.name));
+            x.clean(cx)
+        }));
 
         // Split up imports from all other items.
         //
         // This covers the case where somebody does an import which should pull in an item,
         // but there's already an item with the same namespace and same name. Rust gives
         // priority to the not-imported one, so we should, too.
-        let mut inserted = FxHashSet::default();
         items.extend(self.items.iter().flat_map(|(item, renamed)| {
             // First, lower everything other than imports.
             if matches!(item.kind, hir::ItemKind::Use(..)) {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -52,11 +52,13 @@ impl<'tcx> Clean<'tcx, Item> for DocModule<'tcx> {
     fn clean(&self, cx: &mut DocContext<'tcx>) -> Item {
         let mut items: Vec<Item> = vec![];
         let mut inserted = FxHashSet::default();
-        items.extend(
-            self.foreigns
-                .iter()
-                .map(|(item, renamed)| clean_maybe_renamed_foreign_item(cx, item, *renamed)),
-        );
+        items.extend(self.foreigns.iter().map(|(item, renamed)| {
+            let item = clean_maybe_renamed_foreign_item(cx, item, *renamed);
+            if let Some(name) = item.name {
+                inserted.insert((item.type_(), name));
+            }
+            item
+        }));
         items.extend(self.mods.iter().map(|x| {
             inserted.insert((ItemType::Module, x.name));
             x.clean(cx)

--- a/src/test/rustdoc/auxiliary/issue-99734-aux.rs
+++ b/src/test/rustdoc/auxiliary/issue-99734-aux.rs
@@ -1,0 +1,7 @@
+pub struct Option;
+impl Option {
+    pub fn unwrap(self) {}
+}
+
+/// [`Option::unwrap`]
+pub mod task {}

--- a/src/test/rustdoc/auxiliary/issue-99734-aux.rs
+++ b/src/test/rustdoc/auxiliary/issue-99734-aux.rs
@@ -5,3 +5,7 @@ impl Option {
 
 /// [`Option::unwrap`]
 pub mod task {}
+
+extern "C" {
+    pub fn main() -> std::ffi::c_int;
+}

--- a/src/test/rustdoc/issue-99734-multiple-foreigns-w-same-name.rs
+++ b/src/test/rustdoc/issue-99734-multiple-foreigns-w-same-name.rs
@@ -1,0 +1,16 @@
+// aux-build:issue-99734-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99734_aux;
+
+pub use issue_99734_aux::*;
+
+// @count foo/index.html '//a[@class="fn"][@title="foo::main fn"]' 1
+
+extern "C" {
+    pub fn main() -> std::ffi::c_int;
+}

--- a/src/test/rustdoc/issue-99734-multiple-mods-w-same-name.rs
+++ b/src/test/rustdoc/issue-99734-multiple-mods-w-same-name.rs
@@ -1,0 +1,14 @@
+// aux-build:issue-99734-aux.rs
+// build-aux-docs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate issue_99734_aux;
+
+pub use issue_99734_aux::*;
+
+// @count foo/index.html '//a[@class="mod"][@title="foo::task mod"]' 1
+
+pub mod task {}


### PR DESCRIPTION
Fixes rust-lang/rust#99734