### PR TITLE
Remove erroneous E0133 code from an error message.

### DIFF
--- a/compiler/rustc_mir_transform/src/check_packed_ref.rs
+++ b/compiler/rustc_mir_transform/src/check_packed_ref.rs
@@ -42,7 +42,7 @@ fn unsafe_derive_on_repr_packed(tcx: TyCtxt<'_>, def_id: LocalDefId) {
             "that does not derive `Copy`"
         };
         let message = format!(
-            "`{}` can't be derived on this `#[repr(packed)]` struct {} (error E0133)",
+            "`{}` can't be derived on this `#[repr(packed)]` struct {}",
             tcx.item_name(tcx.trait_id_of_impl(def_id.to_def_id()).expect("derived trait name")),
             extra
         );

--- a/src/test/ui/derives/deriving-with-repr-packed.stderr
+++ b/src/test/ui/derives/deriving-with-repr-packed.stderr
@@ -1,4 +1,4 @@
-error: `Clone` can't be derived on this `#[repr(packed)]` struct with type or const parameters (error E0133)
+error: `Clone` can't be derived on this `#[repr(packed)]` struct with type or const parameters
   --> $DIR/deriving-with-repr-packed.rs:11:16
    |
 LL | #[derive(Copy, Clone, Default, PartialEq, Eq)]
@@ -13,7 +13,7 @@ LL | #![deny(unaligned_references)]
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `PartialEq` can't be derived on this `#[repr(packed)]` struct with type or const parameters (error E0133)
+error: `PartialEq` can't be derived on this `#[repr(packed)]` struct with type or const parameters
   --> $DIR/deriving-with-repr-packed.rs:11:32
    |
 LL | #[derive(Copy, Clone, Default, PartialEq, Eq)]
@@ -23,7 +23,7 @@ LL | #[derive(Copy, Clone, Default, PartialEq, Eq)]
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `Hash` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy` (error E0133)
+error: `Hash` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy`
   --> $DIR/deriving-with-repr-packed.rs:19:19
    |
 LL | #[derive(Default, Hash)]
@@ -33,7 +33,7 @@ LL | #[derive(Default, Hash)]
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `Debug` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy` (error E0133)
+error: `Debug` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy`
   --> $DIR/deriving-with-repr-packed.rs:39:10
    |
 LL | #[derive(Debug, Default)]
@@ -46,7 +46,7 @@ LL | #[derive(Debug, Default)]
 error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: `Clone` can't be derived on this `#[repr(packed)]` struct with type or const parameters (error E0133)
+error: `Clone` can't be derived on this `#[repr(packed)]` struct with type or const parameters
   --> $DIR/deriving-with-repr-packed.rs:11:16
    |
 LL | #[derive(Copy, Clone, Default, PartialEq, Eq)]
@@ -62,7 +62,7 @@ LL | #![deny(unaligned_references)]
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
-error: `PartialEq` can't be derived on this `#[repr(packed)]` struct with type or const parameters (error E0133)
+error: `PartialEq` can't be derived on this `#[repr(packed)]` struct with type or const parameters
   --> $DIR/deriving-with-repr-packed.rs:11:32
    |
 LL | #[derive(Copy, Clone, Default, PartialEq, Eq)]
@@ -78,7 +78,7 @@ LL | #![deny(unaligned_references)]
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
-error: `Hash` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy` (error E0133)
+error: `Hash` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy`
   --> $DIR/deriving-with-repr-packed.rs:19:19
    |
 LL | #[derive(Default, Hash)]
@@ -94,7 +94,7 @@ LL | #![deny(unaligned_references)]
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
-error: `Debug` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy` (error E0133)
+error: `Debug` can't be derived on this `#[repr(packed)]` struct that does not derive `Copy`
   --> $DIR/deriving-with-repr-packed.rs:39:10
    |
 LL | #[derive(Debug, Default)]


### PR DESCRIPTION
This error message is about `derive` and `packed`, but E0133 is for
"Unsafe code was used outside of an unsafe function or block".

r? @estebank