### PR TITLE
Use `impl`'s generics when suggesting fix on bad `impl Copy`

### DIFF
--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.fixed
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.fixed
@@ -1,0 +1,19 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Wrapper<T>(T);
+
+struct OnlyCopyIfDisplay<T>(std::marker::PhantomData<T>);
+
+impl<T: std::fmt::Display> Clone for OnlyCopyIfDisplay<T> {
+    fn clone(&self) -> Self {
+        OnlyCopyIfDisplay(std::marker::PhantomData)
+    }
+}
+
+impl<T: std::fmt::Display> Copy for OnlyCopyIfDisplay<T> {}
+
+impl<S: std::fmt::Display> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
+//~^ ERROR the trait `Copy` may not be implemented for this type
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.rs
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.rs
@@ -1,0 +1,19 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Wrapper<T>(T);
+
+struct OnlyCopyIfDisplay<T>(std::marker::PhantomData<T>);
+
+impl<T: std::fmt::Display> Clone for OnlyCopyIfDisplay<T> {
+    fn clone(&self) -> Self {
+        OnlyCopyIfDisplay(std::marker::PhantomData)
+    }
+}
+
+impl<T: std::fmt::Display> Copy for OnlyCopyIfDisplay<T> {}
+
+impl<S> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
+//~^ ERROR the trait `Copy` may not be implemented for this type
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
@@ -1,0 +1,22 @@
+error[E0204]: the trait `Copy` may not be implemented for this type
+  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:16:9
+   |
+LL | struct Wrapper<T>(T);
+   |                   - this field does not implement `Copy`
+...
+LL | impl<S> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
+   |         ^^^^
+   |
+note: the `Copy` impl for `OnlyCopyIfDisplay<S>` requires that `S: std::fmt::Display`
+  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:4:19
+   |
+LL | struct Wrapper<T>(T);
+   |                   ^
+help: consider restricting type parameter `S`
+   |
+LL | impl<S: std::fmt::Display> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
+   |       +++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0204`.

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.fixed
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Wrapper<T>(T);
+
+impl<S: Copy> Copy for Wrapper<S> {}
+//~^ ERROR the trait `Copy` may not be implemented for this type
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.rs
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Wrapper<T>(T);
+
+impl<S> Copy for Wrapper<S> {}
+//~^ ERROR the trait `Copy` may not be implemented for this type
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
@@ -1,0 +1,17 @@
+error[E0204]: the trait `Copy` may not be implemented for this type
+  --> $DIR/missing-bound-in-manual-copy-impl.rs:6:9
+   |
+LL | struct Wrapper<T>(T);
+   |                   - this field does not implement `Copy`
+LL |
+LL | impl<S> Copy for Wrapper<S> {}
+   |         ^^^^
+   |
+help: consider restricting type parameter `S`
+   |
+LL | impl<S: Copy> Copy for Wrapper<S> {}
+   |       ++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0204`.


### PR DESCRIPTION
See the UI test for a more complicated example, but we weren't correctly suggesting to add bounds given a manual `impl` whose generics didn't match the struct generics. 

```rust
#[derive(Clone)]
struct Wrapper<T>(T);

impl<S> Copy for Wrapper<S> {} 
```

Coincidentally this fix didn't cause any regressions for `derive(Copy)` impls, I think because those use the same spans in the impl generics as the struct generics, so the machinery still applies the same change.