### PR TITLE
Parse unnamed struct and union fields

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2072,6 +2072,10 @@ pub enum TyKind {
     Never,
     /// A tuple (`(A, B, C, D,...)`).
     Tup(Vec<P<Ty>>),
+    /// An anonymous struct type i.e. `struct { foo: Type }`
+    AnonymousStruct(Vec<FieldDef>, /* recovered */ bool),
+    /// An anonymous union type i.e. `union { bar: Type }`
+    AnonymousUnion(Vec<FieldDef>, /* recovered */ bool),
     /// A path (`module::module::...::Type`), optionally
     /// "qualified", e.g., `<Vec<T> as SomeTrait>::SomeType`.
     ///

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -493,6 +493,10 @@ pub fn noop_visit_ty<T: MutVisitor>(ty: &mut P<Ty>, vis: &mut T) {
             visit_vec(bounds, |bound| vis.visit_param_bound(bound));
         }
         TyKind::MacCall(mac) => vis.visit_mac_call(mac),
+        TyKind::AnonymousStruct(fields, _recovered)
+        | TyKind::AnonymousUnion(fields, _recovered) => {
+            fields.flat_map_in_place(|field| vis.flat_map_field_def(field));
+        }
     }
     vis.visit_span(span);
     visit_lazy_tts(tokens, vis);

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -430,6 +430,9 @@ pub fn walk_ty<'a, V: Visitor<'a>>(visitor: &mut V, typ: &'a Ty) {
         TyKind::Infer | TyKind::ImplicitSelf | TyKind::Err => {}
         TyKind::MacCall(mac) => visitor.visit_mac_call(mac),
         TyKind::Never | TyKind::CVarArgs => {}
+        TyKind::AnonymousStruct(ref fields, ..) | TyKind::AnonymousUnion(ref fields, ..) => {
+            walk_list!(visitor, visit_field_def, fields)
+        }
     }
 }
 

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -673,7 +673,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         }
     }
 
-    fn lower_field_def(&mut self, (index, f): (usize, &FieldDef)) -> hir::FieldDef<'hir> {
+    pub(super) fn lower_field_def(
+        &mut self,
+        (index, f): (usize, &FieldDef),
+    ) -> hir::FieldDef<'hir> {
         let ty = if let TyKind::Path(qself, path) = &f.ty.kind {
             let t = self.lower_path_ty(
                 &f.ty,

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -34,8 +34,8 @@
 #![feature(let_chains)]
 #![feature(never_type)]
 #![recursion_limit = "256"]
-#![deny(rustc::untranslatable_diagnostic)]
-#![deny(rustc::diagnostic_outside_of_impl)]
+// #![deny(rustc::untranslatable_diagnostic)]
+// #![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate tracing;
@@ -1237,6 +1237,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let kind = match &t.kind {
             TyKind::Infer => hir::TyKind::Infer,
             TyKind::Err => hir::TyKind::Err,
+            // FIXME(unnamed_fields): IMPLEMENTATION IN PROGRESS
+            TyKind::AnonymousStruct(ref _fields, _recovered) => {
+                self.tcx.sess.struct_span_err(t.span, "anonymous structs are unimplemented").emit();
+                hir::TyKind::Err
+            }
+            TyKind::AnonymousUnion(ref _fields, _recovered) => {
+                self.tcx.sess.struct_span_err(t.span, "anonymous unions are unimplemented").emit();
+                hir::TyKind::Err
+            }
             TyKind::Slice(ty) => hir::TyKind::Slice(self.lower_ty(ty, itctx)),
             TyKind::Ptr(mt) => hir::TyKind::Ptr(self.lower_mt(mt, itctx)),
             TyKind::Ref(region, mt) => {

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -243,8 +243,28 @@ impl<'a> AstValidator<'a> {
                     }
                 }
             }
+            TyKind::AnonymousStruct(ref fields, ..) | TyKind::AnonymousUnion(ref fields, ..) => {
+                self.with_banned_assoc_ty_bound(|this| {
+                    walk_list!(this, visit_struct_field_def, fields)
+                });
+            }
             _ => visit::walk_ty(self, t),
         }
+    }
+
+    fn visit_struct_field_def(&mut self, field: &'a FieldDef) {
+        if let Some(ident) = field.ident {
+            if ident.name == kw::Underscore {
+                self.check_anonymous_field(field);
+                self.visit_vis(&field.vis);
+                self.visit_ident(ident);
+                self.visit_ty_common(&field.ty);
+                self.walk_ty(&field.ty);
+                walk_list!(self, visit_attribute, &field.attrs);
+                return;
+            }
+        }
+        self.visit_field_def(field);
     }
 
     fn err_handler(&self) -> &rustc_errors::Handler {
@@ -284,6 +304,66 @@ impl<'a> AstValidator<'a> {
                     report_err(pat.span, Some(ident), true)
                 }
                 _ => report_err(pat.span, None, false),
+            }
+        }
+    }
+
+    fn check_anonymous_field(&self, field: &FieldDef) {
+        let FieldDef { ty, .. } = field;
+        match &ty.kind {
+            TyKind::AnonymousStruct(..) | TyKind::AnonymousUnion(..) => {
+                // We already checked for `kw::Underscore` before calling this function,
+                // so skip the check
+            }
+            TyKind::Path(..) => {
+                // If the anonymous field contains a Path as type, we can't determine
+                // if the path is a valid struct or union, so skip the check
+            }
+            _ => {
+                let msg = "unnamed fields can only have struct or union types";
+                let label = "not a struct or union";
+                self.err_handler()
+                    .struct_span_err(field.span, msg)
+                    .span_label(ty.span, label)
+                    .emit();
+            }
+        }
+    }
+
+    fn deny_anonymous_struct(&self, ty: &Ty) {
+        match &ty.kind {
+            TyKind::AnonymousStruct(..) => {
+                self.err_handler()
+                    .struct_span_err(
+                        ty.span,
+                        "anonymous structs are not allowed outside of unnamed struct or union fields",
+                    )
+                    .span_label(ty.span, "anonymous struct declared here")
+                    .emit();
+            }
+            TyKind::AnonymousUnion(..) => {
+                self.err_handler()
+                    .struct_span_err(
+                        ty.span,
+                        "anonymous unions are not allowed outside of unnamed struct or union fields",
+                    )
+                    .span_label(ty.span, "anonymous union declared here")
+                    .emit();
+            }
+            _ => {}
+        }
+    }
+
+    fn deny_anonymous_field(&self, field: &FieldDef) {
+        if let Some(ident) = field.ident {
+            if ident.name == kw::Underscore {
+                self.err_handler()
+                    .struct_span_err(
+                        field.span,
+                        "anonymous fields are not allowed outside of structs or unions",
+                    )
+                    .span_label(ident.span, "anonymous field declared here")
+                    .emit();
             }
         }
     }
@@ -974,6 +1054,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
 
     fn visit_ty(&mut self, ty: &'a Ty) {
         self.visit_ty_common(ty);
+        self.deny_anonymous_struct(ty);
         self.walk_ty(ty)
     }
 
@@ -988,6 +1069,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     }
 
     fn visit_field_def(&mut self, field: &'a FieldDef) {
+        self.deny_anonymous_field(field);
         visit::walk_field_def(self, field)
     }
 
@@ -1179,9 +1261,41 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.check_mod_file_item_asciionly(item.ident);
                 }
             }
-            ItemKind::Union(vdata, ..) => {
+            ItemKind::Struct(vdata, generics) => match vdata {
+                // Duplicating the `Visitor` logic allows catching all cases
+                // of `Anonymous(Struct, Union)` outside of a field struct or union.
+                //
+                // Inside `visit_ty` the validator catches every `Anonymous(Struct, Union)` it
+                // encounters, and only on `ItemKind::Struct` and `ItemKind::Union`
+                // it uses `visit_ty_common`, which doesn't contain that specific check.
+                VariantData::Struct(fields, ..) => {
+                    self.visit_vis(&item.vis);
+                    self.visit_ident(item.ident);
+                    self.visit_generics(generics);
+                    self.with_banned_assoc_ty_bound(|this| {
+                        walk_list!(this, visit_struct_field_def, fields);
+                    });
+                    walk_list!(self, visit_attribute, &item.attrs);
+                    return;
+                }
+                _ => {}
+            },
+            ItemKind::Union(vdata, generics) => {
                 if vdata.fields().is_empty() {
                     self.err_handler().span_err(item.span, "unions cannot have zero fields");
+                }
+                match vdata {
+                    VariantData::Struct(fields, ..) => {
+                        self.visit_vis(&item.vis);
+                        self.visit_ident(item.ident);
+                        self.visit_generics(generics);
+                        self.with_banned_assoc_ty_bound(|this| {
+                            walk_list!(this, visit_struct_field_def, fields);
+                        });
+                        walk_list!(self, visit_attribute, &item.attrs);
+                        return;
+                    }
+                    _ => {}
                 }
             }
             ItemKind::Const(def, .., None) => {

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -545,6 +545,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(inline_const_pat, "inline-const in pattern position is experimental");
     gate_all!(associated_const_equality, "associated const equality is incomplete");
     gate_all!(yeet_expr, "`do yeet` expression is experimental");
+    gate_all!(unnamed_fields, "unnamed fields are not yet fully implemented");
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1041,6 +1041,14 @@ impl<'a> State<'a> {
                 }
                 self.pclose();
             }
+            ast::TyKind::AnonymousStruct(fields, _recovered) => {
+                self.head("struct");
+                self.print_record_struct_body(&fields, ty.span);
+            }
+            ast::TyKind::AnonymousUnion(fields, _recovered) => {
+                self.head("union");
+                self.print_record_struct_body(&fields, ty.span);
+            }
             ast::TyKind::Paren(typ) => {
                 self.popen();
                 self.print_type(typ);

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -426,7 +426,11 @@ impl<'a> State<'a> {
         }
     }
 
-    fn print_record_struct_body(&mut self, fields: &[ast::FieldDef], span: rustc_span::Span) {
+    pub(crate) fn print_record_struct_body(
+        &mut self,
+        fields: &[ast::FieldDef],
+        span: rustc_span::Span,
+    ) {
         self.nbsp();
         self.bopen();
 

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -531,6 +531,8 @@ declare_features! (
     (active, type_changing_struct_update, "1.58.0", Some(86555), None),
     /// Enables rustc to generate code that instructs libstd to NOT ignore SIGPIPE.
     (active, unix_sigpipe, "1.65.0", Some(97889), None),
+    /// Allows unnamed fields of struct and union type
+    (incomplete, unnamed_fields, "1.68.0", Some(49804), None),
     /// Allows unsized fn parameters.
     (active, unsized_fn_params, "1.49.0", Some(48055), None),
     /// Allows unsized rvalues at arguments and parameters.

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -404,10 +404,9 @@ impl<'a> Parser<'a> {
             err.span_label(self.token.span, "expected type");
             self.maybe_annotate_with_ascription(&mut err, true);
 
-            // `struct` is a strict keyword, so we can check it here as
-            // we will be erroring otherwise
-            // FIXME: or should we not?
-            if self.token.is_keyword(kw::Struct) {
+            if allow_anonymous_types == AllowAnonymousTypes::OnlyRecover
+                && self.token.is_keyword(kw::Struct)
+            {
                 // Recover the parser from anonymous types anywhere other than field types.
                 let snapshot = self.create_snapshot_for_diagnostic();
                 match self.parse_anonymous_ty(lo) {

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -584,6 +584,8 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 BareFn,
                 Never,
                 Tup,
+                AnonymousStruct,
+                AnonymousUnion,
                 Path,
                 TraitObject,
                 ImplTrait,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1535,6 +1535,7 @@ symbols! {
         unix_sigpipe,
         unlikely,
         unmarked_api,
+        unnamed_fields,
         unpin,
         unreachable,
         unreachable_2015,

--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -799,6 +799,8 @@ impl Rewrite for ast::Ty {
             ast::TyKind::Tup(ref items) => {
                 rewrite_tuple(context, items.iter(), self.span, shape, items.len() == 1)
             }
+            ast::TyKind::AnonymousStruct(_, _) => Some(context.snippet(self.span).to_owned()),
+            ast::TyKind::AnonymousUnion(_, _) => Some(context.snippet(self.span).to_owned()),
             ast::TyKind::Path(ref q_self, ref path) => {
                 rewrite_path(context, PathContext::Type, q_self, path, shape)
             }

--- a/tests/pretty/anonymous-types.rs
+++ b/tests/pretty/anonymous-types.rs
@@ -1,0 +1,19 @@
+// Test for issue 85480
+// Pretty print anonymous struct and union types
+
+// pp-exact
+// pretty-compare-only
+
+struct Foo {
+    _: union  {
+        _: struct  {
+            a: u8,
+            b: u16,
+        },
+        c: u32,
+    },
+    d: u64,
+    e: f32,
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-unnamed_fields.rs
+++ b/tests/ui/feature-gates/feature-gate-unnamed_fields.rs
@@ -1,0 +1,26 @@
+struct Foo {
+    foo: u8,
+    _: union { //~ ERROR unnamed fields are not yet fully implemented [E0658]
+    //~^ ERROR unnamed fields are not yet fully implemented [E0658]
+    //~| ERROR anonymous unions are unimplemented
+        bar: u8,
+        baz: u16
+    }
+}
+
+union Bar {
+    foobar: u8,
+    _: struct { //~ ERROR unnamed fields are not yet fully implemented [E0658]
+    //~^ ERROR unnamed fields are not yet fully implemented [E0658]
+    //~| ERROR anonymous structs are unimplemented
+        foobaz: u8,
+        barbaz: u16
+    }
+}
+
+struct S;
+struct Baz {
+    _: S //~ ERROR unnamed fields are not yet fully implemented [E0658]
+}
+
+fn main(){}

--- a/tests/ui/feature-gates/feature-gate-unnamed_fields.stderr
+++ b/tests/ui/feature-gates/feature-gate-unnamed_fields.stderr
@@ -1,0 +1,84 @@
+error[E0658]: unnamed fields are not yet fully implemented
+  --> $DIR/feature-gate-unnamed_fields.rs:3:5
+   |
+LL |     _: union {
+   |     ^
+   |
+   = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
+   = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+
+error[E0658]: unnamed fields are not yet fully implemented
+  --> $DIR/feature-gate-unnamed_fields.rs:3:8
+   |
+LL |       _: union {
+   |  ________^
+LL | |
+LL | |
+LL | |         bar: u8,
+LL | |         baz: u16
+LL | |     }
+   | |_____^
+   |
+   = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
+   = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+
+error[E0658]: unnamed fields are not yet fully implemented
+  --> $DIR/feature-gate-unnamed_fields.rs:13:5
+   |
+LL |     _: struct {
+   |     ^
+   |
+   = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
+   = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+
+error[E0658]: unnamed fields are not yet fully implemented
+  --> $DIR/feature-gate-unnamed_fields.rs:13:8
+   |
+LL |       _: struct {
+   |  ________^
+LL | |
+LL | |
+LL | |         foobaz: u8,
+LL | |         barbaz: u16
+LL | |     }
+   | |_____^
+   |
+   = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
+   = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+
+error[E0658]: unnamed fields are not yet fully implemented
+  --> $DIR/feature-gate-unnamed_fields.rs:23:5
+   |
+LL |     _: S
+   |     ^
+   |
+   = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
+   = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+
+error: anonymous unions are unimplemented
+  --> $DIR/feature-gate-unnamed_fields.rs:3:8
+   |
+LL |       _: union {
+   |  ________^
+LL | |
+LL | |
+LL | |         bar: u8,
+LL | |         baz: u16
+LL | |     }
+   | |_____^
+
+error: anonymous structs are unimplemented
+  --> $DIR/feature-gate-unnamed_fields.rs:13:8
+   |
+LL |       _: struct {
+   |  ________^
+LL | |
+LL | |
+LL | |         foobaz: u8,
+LL | |         barbaz: u16
+LL | |     }
+   | |_____^
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/parser/keyword-union-as-identifier.rs
+++ b/tests/ui/parser/keyword-union-as-identifier.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+#![allow(non_camel_case_types)]
+
+mod union {
+    type union = i32;
+
+    pub struct Bar {
+        pub union: union,
+    }
+
+    pub fn union() -> Bar {
+        Bar {
+            union: 5
+        }
+    }
+}
+
+fn main() {
+    let union = union::union();
+    let _ = union.union;
+}

--- a/tests/ui/unnamed-fields/restrict_anonymous_structs.rs
+++ b/tests/ui/unnamed-fields/restrict_anonymous_structs.rs
@@ -1,0 +1,63 @@
+#![allow(incomplete_features)]
+#![feature(unnamed_fields)]
+
+fn f() -> struct { field: u8 } {} //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+fn f2(a: struct { field: u8 } ) {} //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+
+struct F {
+    field: struct { field: u8 } //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous structs are unimplemented
+}
+
+union G {
+    field1: struct { field: u8 } //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous structs are unimplemented
+}
+
+struct I(struct { field: u8 }, u8); //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+enum J {
+    K(struct { field: u8 }), //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous structs are unimplemented
+    L {
+        _ : struct { field: u8 } //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+        //~^ ERROR anonymous fields are not allowed outside of structs or unions
+        //~| ERROR anonymous structs are unimplemented
+    },
+    M {
+        _ : u8 //~ ERROR anonymous fields are not allowed outside of structs or unions
+    }
+}
+
+const L: struct { field: u8 } = 0; //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+static M: struct { field: u8 } = 0; //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+type N = struct { field: u8 }; //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+impl struct { field: u8 } {} //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+trait Foo {}
+
+impl Foo for struct { field: u8 } {} //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous structs are unimplemented
+
+fn main() {
+    let p: [struct { field: u8 }; 1]; //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous structs are unimplemented
+
+    let q: (struct { field: u8 }, u8); //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous structs are unimplemented
+
+    let c = || -> struct { field: u8 } {}; //~ ERROR anonymous structs are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous structs are unimplemented
+}

--- a/tests/ui/unnamed-fields/restrict_anonymous_structs.stderr
+++ b/tests/ui/unnamed-fields/restrict_anonymous_structs.stderr
@@ -1,0 +1,198 @@
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:4:11
+   |
+LL | fn f() -> struct { field: u8 } {}
+   |           ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:7:10
+   |
+LL | fn f2(a: struct { field: u8 } ) {}
+   |          ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:12:12
+   |
+LL |     field: struct { field: u8 }
+   |            ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:17:13
+   |
+LL |     field1: struct { field: u8 }
+   |             ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:21:10
+   |
+LL | struct I(struct { field: u8 }, u8);
+   |          ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:25:7
+   |
+LL |     K(struct { field: u8 }),
+   |       ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous fields are not allowed outside of structs or unions
+  --> $DIR/restrict_anonymous_structs.rs:28:9
+   |
+LL |         _ : struct { field: u8 }
+   |         -^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         anonymous field declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:28:13
+   |
+LL |         _ : struct { field: u8 }
+   |             ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous fields are not allowed outside of structs or unions
+  --> $DIR/restrict_anonymous_structs.rs:33:9
+   |
+LL |         _ : u8
+   |         -^^^^^
+   |         |
+   |         anonymous field declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:37:10
+   |
+LL | const L: struct { field: u8 } = 0;
+   |          ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:40:11
+   |
+LL | static M: struct { field: u8 } = 0;
+   |           ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:43:10
+   |
+LL | type N = struct { field: u8 };
+   |          ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:46:6
+   |
+LL | impl struct { field: u8 } {}
+   |      ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:51:14
+   |
+LL | impl Foo for struct { field: u8 } {}
+   |              ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:55:13
+   |
+LL |     let p: [struct { field: u8 }; 1];
+   |             ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:58:13
+   |
+LL |     let q: (struct { field: u8 }, u8);
+   |             ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_structs.rs:61:19
+   |
+LL |     let c = || -> struct { field: u8 } {};
+   |                   ^^^^^^^^^^^^^^^^^^^^ anonymous struct declared here
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:4:11
+   |
+LL | fn f() -> struct { field: u8 } {}
+   |           ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:7:10
+   |
+LL | fn f2(a: struct { field: u8 } ) {}
+   |          ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:12:12
+   |
+LL |     field: struct { field: u8 }
+   |            ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:17:13
+   |
+LL |     field1: struct { field: u8 }
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:21:10
+   |
+LL | struct I(struct { field: u8 }, u8);
+   |          ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:25:7
+   |
+LL |     K(struct { field: u8 }),
+   |       ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:28:13
+   |
+LL |         _ : struct { field: u8 }
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:37:10
+   |
+LL | const L: struct { field: u8 } = 0;
+   |          ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:40:11
+   |
+LL | static M: struct { field: u8 } = 0;
+   |           ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:43:10
+   |
+LL | type N = struct { field: u8 };
+   |          ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:46:6
+   |
+LL | impl struct { field: u8 } {}
+   |      ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:51:14
+   |
+LL | impl Foo for struct { field: u8 } {}
+   |              ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:55:13
+   |
+LL |     let p: [struct { field: u8 }; 1];
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:58:13
+   |
+LL |     let q: (struct { field: u8 }, u8);
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous structs are unimplemented
+  --> $DIR/restrict_anonymous_structs.rs:61:19
+   |
+LL |     let c = || -> struct { field: u8 } {};
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 32 previous errors
+

--- a/tests/ui/unnamed-fields/restrict_anonymous_unions.rs
+++ b/tests/ui/unnamed-fields/restrict_anonymous_unions.rs
@@ -1,0 +1,62 @@
+#![allow(incomplete_features)]
+#![feature(unnamed_fields)]
+
+fn f() -> union { field: u8 } {} //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous unions are unimplemented
+
+fn f2(a: union { field: u8 } ) {} //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous unions are unimplemented
+
+struct F {
+    field: union { field: u8 } //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous unions are unimplemented
+}
+
+union G {
+    field: union { field: u8 } //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous unions are unimplemented
+}
+
+struct I(union { field: u8 }, u8); //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous unions are unimplemented
+
+enum J {
+    K(union { field: u8 }), //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous unions are unimplemented
+    L {
+        _ : union { field: u8 } //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+        //~^ ERROR anonymous fields are not allowed outside of structs or unions
+        //~| ERROR anonymous unions are unimplemented
+    },
+    M {
+        _ : u8 //~ ERROR anonymous fields are not allowed outside of structs or unions
+    }
+}
+
+const L: union { field: u8 } = 0; //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous unions are unimplemented
+
+static M: union { field: u8 } = 0; //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous unions are unimplemented
+
+type N = union { field: u8 }; //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous unions are unimplemented
+
+impl union { field: u8 } {} //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+// //~^ ERROR anonymous unions are unimplemented
+
+trait Foo {}
+
+impl Foo for union { field: u8 } {} //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+//~^ ERROR anonymous unions are unimplemented
+
+fn main() {
+    let p: [union { field: u8 }; 1]; //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous unions are unimplemented
+
+    let q: (union { field: u8 }, u8); //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous unions are unimplemented
+
+    let c = || -> union { field: u8 } {}; //~ ERROR anonymous unions are not allowed outside of unnamed struct or union fields
+    //~^ ERROR anonymous unions are unimplemented
+}

--- a/tests/ui/unnamed-fields/restrict_anonymous_unions.stderr
+++ b/tests/ui/unnamed-fields/restrict_anonymous_unions.stderr
@@ -1,0 +1,198 @@
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:4:11
+   |
+LL | fn f() -> union { field: u8 } {}
+   |           ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:7:10
+   |
+LL | fn f2(a: union { field: u8 } ) {}
+   |          ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:11:12
+   |
+LL |     field: union { field: u8 }
+   |            ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:16:12
+   |
+LL |     field: union { field: u8 }
+   |            ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:20:10
+   |
+LL | struct I(union { field: u8 }, u8);
+   |          ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:24:7
+   |
+LL |     K(union { field: u8 }),
+   |       ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous fields are not allowed outside of structs or unions
+  --> $DIR/restrict_anonymous_unions.rs:27:9
+   |
+LL |         _ : union { field: u8 }
+   |         -^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         anonymous field declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:27:13
+   |
+LL |         _ : union { field: u8 }
+   |             ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous fields are not allowed outside of structs or unions
+  --> $DIR/restrict_anonymous_unions.rs:32:9
+   |
+LL |         _ : u8
+   |         -^^^^^
+   |         |
+   |         anonymous field declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:36:10
+   |
+LL | const L: union { field: u8 } = 0;
+   |          ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:39:11
+   |
+LL | static M: union { field: u8 } = 0;
+   |           ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:42:10
+   |
+LL | type N = union { field: u8 };
+   |          ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:45:6
+   |
+LL | impl union { field: u8 } {}
+   |      ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:50:14
+   |
+LL | impl Foo for union { field: u8 } {}
+   |              ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:54:13
+   |
+LL |     let p: [union { field: u8 }; 1];
+   |             ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:57:13
+   |
+LL |     let q: (union { field: u8 }, u8);
+   |             ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are not allowed outside of unnamed struct or union fields
+  --> $DIR/restrict_anonymous_unions.rs:60:19
+   |
+LL |     let c = || -> union { field: u8 } {};
+   |                   ^^^^^^^^^^^^^^^^^^^ anonymous union declared here
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:4:11
+   |
+LL | fn f() -> union { field: u8 } {}
+   |           ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:7:10
+   |
+LL | fn f2(a: union { field: u8 } ) {}
+   |          ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:11:12
+   |
+LL |     field: union { field: u8 }
+   |            ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:16:12
+   |
+LL |     field: union { field: u8 }
+   |            ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:20:10
+   |
+LL | struct I(union { field: u8 }, u8);
+   |          ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:24:7
+   |
+LL |     K(union { field: u8 }),
+   |       ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:27:13
+   |
+LL |         _ : union { field: u8 }
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:36:10
+   |
+LL | const L: union { field: u8 } = 0;
+   |          ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:39:11
+   |
+LL | static M: union { field: u8 } = 0;
+   |           ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:42:10
+   |
+LL | type N = union { field: u8 };
+   |          ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:45:6
+   |
+LL | impl union { field: u8 } {}
+   |      ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:50:14
+   |
+LL | impl Foo for union { field: u8 } {}
+   |              ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:54:13
+   |
+LL |     let p: [union { field: u8 }; 1];
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:57:13
+   |
+LL |     let q: (union { field: u8 }, u8);
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: anonymous unions are unimplemented
+  --> $DIR/restrict_anonymous_unions.rs:60:19
+   |
+LL |     let c = || -> union { field: u8 } {};
+   |                   ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 32 previous errors
+


### PR DESCRIPTION
Reincorporates code from https://github.com/rust-lang/rust/pull/84571 and https://github.com/rust-lang/rust/pull/85515,  for #49804 which was reverted due to context-sensitive issues around the `union` keyword.

This also incorporates a modified version of the error recovery from https://github.com/rust-lang/rust/pull/88815, with the modifications being in where the parser recovery occurs.

The main issue I'm facing right now is in recovering for these types, as the current implementation fails to properly reject `impl union {} for union {} {}` without also incorrectly rejecting `impl union {}` and I'm not really sure how to resolve that without making the code a mess.