### PR TITLE
remove useless `#[allow]` in a test

### DIFF
--- a/src/test/ui/issues/issue-30371.rs
+++ b/src/test/ui/issues/issue-30371.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(unreachable_code)]
-#![allow(unused_mut)] // rust-lang/rust#54586
 #![deny(unused_variables)]
 
 fn main() {


### PR DESCRIPTION
The mentioned issue, https://github.com/rust-lang/rust/issues/54586 was fixed 4 years ago :)