### PR TITLE
Fix item-info color

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1069,6 +1069,10 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-weight: normal;
 }
 
+.stab a {
+	color: inherit;
+}
+
 .stab .emoji {
 	font-size: 1.25rem;
 	margin-right: 0.3rem;

--- a/src/test/rustdoc-gui/item-info.goml
+++ b/src/test/rustdoc-gui/item-info.goml
@@ -30,3 +30,29 @@ compare-elements-css: (
     "#main-content > .item-info .stab:nth-of-type(2)",
     ["height"],
 )
+
+// Now checking the text color and the links color.
+show-text: true
+local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"}
+goto: file://|DOC_PATH|/lib2/trait.Trait.html
+
+assert-css: (".item-info .stab", {"color": "rgb(221, 221, 221)"}, ALL)
+assert-css: (".item-info .stab strong", {"color": "rgb(221, 221, 221)"}, ALL)
+assert-css: (".item-info .stab span", {"color": "rgb(221, 221, 221)"}, ALL)
+assert-css: (".item-info .stab a", {"color": "rgb(221, 221, 221)"}, ALL)
+
+local-storage: {"rustdoc-theme": "ayu"}
+reload:
+
+assert-css: (".item-info .stab", {"color": "rgb(197, 197, 197)"}, ALL)
+assert-css: (".item-info .stab strong", {"color": "rgb(197, 197, 197)"}, ALL)
+assert-css: (".item-info .stab span", {"color": "rgb(197, 197, 197)"}, ALL)
+assert-css: (".item-info .stab a", {"color": "rgb(197, 197, 197)"}, ALL)
+
+local-storage: {"rustdoc-theme": "light"}
+reload:
+
+assert-css: (".item-info .stab", {"color": "rgb(0, 0, 0)"}, ALL)
+assert-css: (".item-info .stab strong", {"color": "rgb(0, 0, 0)"}, ALL)
+assert-css: (".item-info .stab span", {"color": "rgb(0, 0, 0)"}, ALL)
+assert-css: (".item-info .stab a", {"color": "rgb(0, 0, 0)"}, ALL)


### PR DESCRIPTION
Part of #98341 (the final fix is #93896).

Since the links are already underlined, no need to change their color too. Instead it now uses the text color directly.

Here are some screenshots of the result:

![Screenshot from 2022-07-26 15-16-28](https://user-images.githubusercontent.com/3050060/181015373-51899ff1-5f77-4d45-b484-059a9d398c80.png)
![Screenshot from 2022-07-26 15-16-33](https://user-images.githubusercontent.com/3050060/181015378-5b220e0a-ff77-4e4c-b49c-4faf157f5625.png)
![Screenshot from 2022-07-26 15-16-39](https://user-images.githubusercontent.com/3050060/181015379-2c6af9e2-d88c-4b3e-9c97-4a1aaad51ec4.png)

Online demo available [here](https://rustdoc.crud.net/imperio/item-info-color/lib2/trait.Trait.html).

cc @jplatte @jsha 
r? @notriddle 