### PR TITLE
UnreachableProp: Preserve unreachable branches for multiple targets

### DIFF
--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -38,7 +38,19 @@ impl MirPass<'_> for UnreachablePropagation {
             }
         }
 
+        // We do want do keep some unreachable blocks, but make them empty.
+        for bb in unreachable_blocks {
+            if !tcx.consider_optimizing(|| {
+                format!("UnreachablePropagation {:?} ", body.source.def_id())
+            }) {
+                break;
+            }
+
+            body.basic_blocks_mut()[bb].statements.clear();
+        }
+
         let replaced = !replacements.is_empty();
+
         for (bb, terminator_kind) in replacements {
             if !tcx.consider_optimizing(|| {
                 format!("UnreachablePropagation {:?} ", body.source.def_id())
@@ -57,42 +69,55 @@ impl MirPass<'_> for UnreachablePropagation {
 
 fn remove_successors<'tcx, F>(
     terminator_kind: &TerminatorKind<'tcx>,
-    predicate: F,
+    is_unreachable: F,
 ) -> Option<TerminatorKind<'tcx>>
 where
     F: Fn(BasicBlock) -> bool,
 {
-    let terminator = match *terminator_kind {
-        TerminatorKind::Goto { target } if predicate(target) => TerminatorKind::Unreachable,
-        TerminatorKind::SwitchInt { ref discr, switch_ty, ref targets } => {
+    let terminator = match terminator_kind {
+        // This will unconditionally run into an unreachable and is therefore unreachable as well.
+        TerminatorKind::Goto { target } if is_unreachable(*target) => TerminatorKind::Unreachable,
+        TerminatorKind::SwitchInt { targets, discr, switch_ty } => {
             let otherwise = targets.otherwise();
 
-            let original_targets_len = targets.iter().len() + 1;
-            let (mut values, mut targets): (Vec<_>, Vec<_>) =
-                targets.iter().filter(|(_, bb)| !predicate(*bb)).unzip();
-
-            if !predicate(otherwise) {
-                targets.push(otherwise);
-            } else {
-                values.pop();
-            }
-
-            let retained_targets_len = targets.len();
-
-            if targets.is_empty() {
+            // If all targets are unreachable, we can be unreachable as well.
+            if targets.all_targets().iter().all(|bb| is_unreachable(*bb)) {
                 TerminatorKind::Unreachable
-            } else if targets.len() == 1 {
-                TerminatorKind::Goto { target: targets[0] }
-            } else if original_targets_len != retained_targets_len {
+            } else if is_unreachable(otherwise) {
+                // If there are multiple targets, don't delete unreachable branches (like an unreachable otherwise)
+                // unless otherwise is unrachable, in which case deleting a normal branch causes it to be merged with
+                // the otherwise, keeping its unreachable.
+                // This looses information about reachability causing worse codegen.
+                // For example (see src/test/codegen/match-optimizes-away.rs)
+                //
+                // pub enum Two { A, B }
+                // pub fn identity(x: Two) -> Two {
+                //     match x {
+                //         Two::A => Two::A,
+                //         Two::B => Two::B,
+                //     }
+                // }
+                //
+                // This generates a `switchInt() -> [0: 0, 1: 1, otherwise: unreachable]`, which allows us or LLVM to
+                // turn it into just `x` later. Without the unreachable, such a transformation would be illegal.
+                // If the otherwise branch is unreachable, we can delete all other unreacahble targets, as they will
+                // still point to the unreachable and therefore not lose reachability information.
+                let reachable_iter = targets.iter().filter(|(_, bb)| !is_unreachable(*bb));
+
+                let new_targets = SwitchTargets::new(reachable_iter, otherwise);
+
+                // No unreachable branches were removed.
+                if new_targets.all_targets().len() == targets.all_targets().len() {
+                    return None;
+                }
+
                 TerminatorKind::SwitchInt {
                     discr: discr.clone(),
-                    switch_ty,
-                    targets: SwitchTargets::new(
-                        values.iter().copied().zip(targets.iter().copied()),
-                        *targets.last().unwrap(),
-                    ),
+                    switch_ty: *switch_ty,
+                    targets: new_targets,
                 }
             } else {
+                // If the otherwise branch is reachable, we don't want to delete any unreachable branches.
                 return None;
             }
         }

--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -12,9 +12,8 @@ pub struct UnreachablePropagation;
 
 impl MirPass<'_> for UnreachablePropagation {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        // Enable only under -Zmir-opt-level=4 as in some cases (check the deeply-nested-opt
-        // perf benchmark) LLVM may spend quite a lot of time optimizing the generated code.
-        sess.mir_opt_level() >= 4
+        // Enable only under -Zmir-opt-level=2 as this can make programs less debuggable.
+        sess.mir_opt_level() >= 2
     }
 
     fn run_pass<'tcx>(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -55,7 +55,7 @@
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
           _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
-          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:+1:17: +1:30
+          goto -> bb3;                     // scope 0 at $DIR/issue-73223.rs:+1:17: +1:30
       }
   
       bb1: {
@@ -66,6 +66,10 @@
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+      }
+  
+      bb3: {
           StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:+2:20: +2:21
@@ -108,10 +112,10 @@
           StorageDead(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _15 = Not(move _16);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _15) -> [false: bb4, otherwise: bb3]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _15) -> [false: bb5, otherwise: bb4]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb3: {
+      bb4: {
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           Deinit(_20);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -141,7 +145,7 @@
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
       }
   
-      bb4: {
+      bb5: {
           nop;                             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -55,7 +55,7 @@
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
           _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
-          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:+1:17: +1:30
+          goto -> bb3;                     // scope 0 at $DIR/issue-73223.rs:+1:17: +1:30
       }
   
       bb1: {
@@ -66,6 +66,10 @@
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+      }
+  
+      bb3: {
           StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:+2:20: +2:21
@@ -108,10 +112,10 @@
           StorageDead(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _15 = Not(move _16);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _15) -> [false: bb4, otherwise: bb3]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _15) -> [false: bb5, otherwise: bb4]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb3: {
+      bb4: {
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           Deinit(_20);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -141,7 +145,7 @@
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
       }
   
-      bb4: {
+      bb5: {
           nop;                             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
@@ -8,20 +8,24 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
           _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          unreachable;                     // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
       }
   
       bb3: {
+          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
@@ -8,20 +8,24 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
           _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          unreachable;                     // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
       }
   
       bb3: {
+          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
@@ -8,20 +8,24 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
           _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          unreachable;                     // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
       }
   
       bb3: {
+          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
@@ -8,20 +8,24 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
           _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          unreachable;                     // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
       }
   
       bb3: {
+          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb4;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -57,7 +57,7 @@
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
           StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
@@ -74,6 +74,10 @@
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+      }
+  
+      bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
@@ -97,7 +101,7 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
-      bb3: {
+      bb4: {
           StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -115,16 +119,16 @@
           StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 -         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 +         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-+         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-      }
-  
-      bb4: {
-          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(const 1_isize) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
       bb5: {
+          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+      }
+  
+      bb6: {
           StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -137,9 +141,9 @@
           StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 -         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 +         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-+         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(const 0_isize) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -57,15 +57,15 @@
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
           StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
--         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         switchInt(move _10) -> [0_isize: bb7, 1_isize: bb5, otherwise: bb6]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
 -         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 -         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 -         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
--         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 -     }
 - 
 -     bb2: {
@@ -83,6 +83,11 @@
   
 -     bb3: {
 +     bb2: {
+          unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+      }
+  
+-     bb4: {
++     bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
@@ -106,8 +111,8 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
--     bb4: {
-+     bb3: {
+-     bb5: {
++     bb4: {
           StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -126,16 +131,16 @@
 +         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-      }
-  
--     bb5: {
-+     bb4: {
-          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
 -     bb6: {
 +     bb5: {
+          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+      }
+  
+-     bb7: {
++     bb6: {
           StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -149,7 +154,7 @@
 +         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
@@ -30,7 +30,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
           _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
+          switchInt(move _3) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
       }
   
       bb1: {
@@ -44,12 +44,16 @@
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:43: +8:44
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
 -         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
+-         switchInt(move _8) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
 +         _8 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
-+         switchInt(const 1_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         switchInt(const 1_isize) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
+      }
+  
+      bb3: {
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
           _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
@@ -60,21 +64,25 @@
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
 -         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
+-         switchInt(move _8) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
 +         _8 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
-+         switchInt(const 0_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         switchInt(const 0_isize) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
-      bb3: {
+      bb4: {
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+          goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
       }
   
-      bb4: {
+      bb5: {
+          unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+      }
+  
+      bb6: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
@@ -84,10 +92,10 @@
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+          goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
       }
   
-      bb5: {
+      bb7: {
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
       }

--- a/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
@@ -27,7 +27,7 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
         _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
-        switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
+        switchInt(move _3) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
     }
 
     bb1: {
@@ -37,10 +37,14 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
         discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
         StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+        goto -> bb4;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
     }
 
     bb2: {
+        unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
+    }
+
+    bb3: {
         StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
         _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
         StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
@@ -59,10 +63,10 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
         StorageDead(_8);                 // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
         StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+        goto -> bb4;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
     }
 
-    bb3: {
+    bb4: {
         StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
         return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
     }

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -30,7 +30,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
           _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
+          switchInt(move _3) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
       }
   
       bb1: {
@@ -43,12 +43,16 @@
           discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:43: +8:44
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
+-         goto -> bb4;                     // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
 +         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         switchInt(move _8) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
+      }
+  
+      bb3: {
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
           _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
@@ -58,28 +62,33 @@
           discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
+-         goto -> bb4;                     // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
 -     }
 - 
--     bb3: {
+-     bb4: {
           _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
--         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
+-         switchInt(move _8) -> [0_isize: bb7, 1_isize: bb5, otherwise: bb6]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         switchInt(move _8) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
--     bb4: {
-+     bb3: {
+-     bb5: {
++     bb4: {
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+-         goto -> bb8;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
++         goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
       }
   
--     bb5: {
-+     bb4: {
+-     bb6: {
++     bb5: {
+          unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+      }
+  
+-     bb7: {
++     bb6: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
@@ -89,12 +98,12 @@
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+-         goto -> bb8;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
++         goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
       }
   
--     bb6: {
-+     bb5: {
+-     bb8: {
++     bb7: {
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
       }

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
@@ -16,23 +16,27 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:11: +1:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:5: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:5: +1:12
       }
   
       bb1: {
           ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
           Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
           discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:26: +3:27
+          goto -> bb4;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:26: +3:27
       }
   
       bb2: {
-          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          unreachable;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:11: +1:12
       }
   
       bb3: {
+          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          goto -> bb4;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:2: +5:2
       }
   }

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
@@ -16,23 +16,27 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:11: +1:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:5: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:5: +1:12
       }
   
       bb1: {
           ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
           Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
           discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:26: +3:27
+          goto -> bb4;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:26: +3:27
       }
   
       bb2: {
-          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          unreachable;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:11: +1:12
       }
   
       bb3: {
+          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          goto -> bb4;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:2: +5:2
       }
   }

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -50,7 +50,7 @@
 +         nop;                             // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
-          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
+          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
       }
   
       bb1: {
@@ -80,6 +80,10 @@
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+      }
+  
+      bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
           nop;                             // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
           StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -41,7 +41,7 @@
           _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
-          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
+          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
       }
   
       bb1: {
@@ -61,6 +61,10 @@
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+      }
+  
+      bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
           _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
           StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -40,7 +40,7 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
-        switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
+        switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
     }
 
     bb1: {
@@ -60,6 +60,10 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
     }
 
     bb2: {
+        unreachable;                     // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+    }
+
+    bb3: {
         StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
         StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -30,7 +30,7 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
     bb0: {
         _2 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
         _3 = discriminant(_2);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
-        switchInt(move _3) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
+        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
     }
 
     bb1: {
@@ -41,6 +41,10 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
     }
 
     bb2: {
+        unreachable;                     // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+    }
+
+    bb3: {
         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
         StorageLive(_5);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50
         StorageLive(_6);                 // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49

--- a/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals.after.mir
@@ -11,8 +11,6 @@ fn process_never(_1: *const !) -> () {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+1:8: +1:14
-        StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+2:1: +2:2
         unreachable;                     // scope 0 at $DIR/uninhabited-enum.rs:+0:39: +2:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -18,6 +18,10 @@ fn main() -> () {
         Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
         _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+        switchInt(move _3) -> [2_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
+    }
+
+    bb1: {
         StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
         _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
                                          // mir::Constant
@@ -32,10 +36,14 @@ fn main() -> () {
         Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
         discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
         _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
-        switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
+        switchInt(move _8) -> [4_isize: bb5, 5_isize: bb3, otherwise: bb4]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
     }
 
-    bb1: {
+    bb2: {
+        unreachable;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+    }
+
+    bb3: {
         StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
         _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
                                          // mir::Constant
@@ -43,18 +51,22 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
         StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
-        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
+        goto -> bb6;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
     }
 
-    bb2: {
+    bb4: {
+        unreachable;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+    }
+
+    bb5: {
         _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
+        goto -> bb6;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
     }
 
-    bb3: {
+    bb6: {
         StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
         StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
         _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +11:2

--- a/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -19,8 +19,8 @@
           Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
           discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
           _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
--         switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
-+         switchInt(move _3) -> bb1;       // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
+-         switchInt(move _3) -> [0_isize: bb3, 1_isize: bb4, 2_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
++         switchInt(move _3) -> [2_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
       }
   
       bb1: {
@@ -31,18 +31,22 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
           StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:23: +4:24
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:23: +4:24
+          goto -> bb5;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:23: +4:24
       }
   
       bb2: {
+          unreachable;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+      }
+  
+      bb3: {
           _1 = const "A(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:+2:24: +2:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:21:24: 21:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+2:24: +2:34
+          goto -> bb5;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+2:24: +2:34
       }
   
-      bb3: {
+      bb4: {
           StorageLive(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
           _4 = const "B(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
                                            // mir::Constant
@@ -50,10 +54,10 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _1 = &(*_4);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
           StorageDead(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:33: +3:34
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:33: +3:34
+          goto -> bb5;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:33: +3:34
       }
   
-      bb4: {
+      bb5: {
           StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+5:6: +5:7
           StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+5:6: +5:7
           StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +10:6
@@ -61,10 +65,10 @@
           Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
           discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
           _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
-          switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
+          switchInt(move _8) -> [4_isize: bb8, 5_isize: bb6, otherwise: bb7]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
       }
   
-      bb5: {
+      bb6: {
           StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
           _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
                                            // mir::Constant
@@ -72,18 +76,22 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
           StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
-          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
+          goto -> bb9;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
       }
   
-      bb6: {
+      bb7: {
+          unreachable;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+      }
+  
+      bb8: {
           _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
+          goto -> bb9;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
       }
   
-      bb7: {
+      bb9: {
           StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
           StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
           _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +11:2

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -32,7 +32,7 @@ fn main() -> () {
         StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
         _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
         _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
-        switchInt(move _5) -> [2_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
+        switchInt(move _5) -> [2_isize: bb3, 3_isize: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
     }
 
     bb1: {
@@ -43,10 +43,14 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
         StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
-        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
+        goto -> bb4;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
     }
 
     bb2: {
+        unreachable;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+    }
+
+    bb3: {
         StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
         _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
                                          // mir::Constant
@@ -54,18 +58,18 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
         StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
-        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
+        goto -> bb4;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
     }
 
-    bb3: {
+    bb4: {
         StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
         StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
         StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
         _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
-        switchInt(move _10) -> [2_isize: bb5, otherwise: bb4]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
+        switchInt(move _10) -> [2_isize: bb7, 3_isize: bb5, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
     }
 
-    bb4: {
+    bb5: {
         StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
         _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
                                          // mir::Constant
@@ -73,10 +77,14 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
         StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
-        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
+        goto -> bb8;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
     }
 
-    bb5: {
+    bb6: {
+        unreachable;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
+    }
+
+    bb7: {
         StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
         _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
                                          // mir::Constant
@@ -84,10 +92,10 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
         StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
-        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
+        goto -> bb8;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
     }
 
-    bb6: {
+    bb8: {
         StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+15:6: +15:7
         _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +16:2
         StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:1: +16:2

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -33,8 +33,8 @@
           StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
           _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
           _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
--         switchInt(move _5) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
-+         switchInt(move _5) -> [2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
+-         switchInt(move _5) -> [0_isize: bb3, 1_isize: bb4, 2_isize: bb5, 3_isize: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
++         switchInt(move _5) -> [2_isize: bb5, 3_isize: bb1, otherwise: bb2]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
       }
   
       bb1: {
@@ -45,18 +45,22 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
           StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
+          goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
       }
   
       bb2: {
+          unreachable;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+      }
+  
+      bb3: {
           _3 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:+4:24: +4:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+4:24: +4:34
+          goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+4:24: +4:34
       }
   
-      bb3: {
+      bb4: {
           StorageLive(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
           _6 = const "B(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
                                            // mir::Constant
@@ -64,10 +68,10 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _3 = &(*_6);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
           StorageDead(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:33: +5:34
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:33: +5:34
+          goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:33: +5:34
       }
   
-      bb4: {
+      bb5: {
           StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
           _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
                                            // mir::Constant
@@ -75,19 +79,19 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
           StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
+          goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
       }
   
-      bb5: {
+      bb6: {
           StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
           StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
           StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
           _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
--         switchInt(move _10) -> [0_isize: bb7, 1_isize: bb8, 2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
-+         switchInt(move _10) -> [2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
+-         switchInt(move _10) -> [0_isize: bb9, 1_isize: bb10, 2_isize: bb11, 3_isize: bb7, otherwise: bb8]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
++         switchInt(move _10) -> [2_isize: bb11, 3_isize: bb7, otherwise: bb8]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
       }
   
-      bb6: {
+      bb7: {
           StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
           _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
                                            // mir::Constant
@@ -95,18 +99,22 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
           StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
+          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
       }
   
-      bb7: {
+      bb8: {
+          unreachable;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
+      }
+  
+      bb9: {
           _9 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
+          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
       }
   
-      bb8: {
+      bb10: {
           StorageLive(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
           _11 = const "B(Empty)";          // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
                                            // mir::Constant
@@ -114,10 +122,10 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_11);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
           StorageDead(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
+          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
       }
   
-      bb9: {
+      bb11: {
           StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
           _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
                                            // mir::Constant
@@ -125,10 +133,10 @@
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
           StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
+          goto -> bb12;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
       }
   
-      bb10: {
+      bb12: {
           StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+15:6: +15:7
           _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +16:2
           StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:1: +16:2

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -28,7 +28,7 @@
       bb1: {
           _2 = discriminant(_1);           // scope 1 at $DIR/unreachable.rs:+1:12: +1:20
 -         switchInt(move _2) -> [1_isize: bb2, otherwise: bb6]; // scope 1 at $DIR/unreachable.rs:+1:12: +1:20
-+         goto -> bb2;                     // scope 1 at $DIR/unreachable.rs:+1:12: +1:20
++         switchInt(move _2) -> [1_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/unreachable.rs:+1:12: +1:20
       }
   
       bb2: {
@@ -39,9 +39,10 @@
 -         StorageLive(_6);                 // scope 2 at $DIR/unreachable.rs:+4:12: +4:16
 -         _6 = const true;                 // scope 2 at $DIR/unreachable.rs:+4:12: +4:16
 -         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable.rs:+4:12: +4:16
--     }
-- 
--     bb3: {
++         unreachable;                     // scope 2 at $DIR/unreachable.rs:+4:12: +4:16
+      }
+  
+      bb3: {
 -         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:+5:13: +5:20
 -         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:+4:17: +6:10
 -         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:+4:9: +8:10

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -29,8 +29,7 @@
   
       bb1: {
           _3 = discriminant(_2);           // scope 2 at $DIR/unreachable_diverging.rs:+2:12: +2:22
--         switchInt(move _3) -> [1_isize: bb2, otherwise: bb6]; // scope 2 at $DIR/unreachable_diverging.rs:+2:12: +2:22
-+         switchInt(move _3) -> [1_isize: bb2, otherwise: bb5]; // scope 2 at $DIR/unreachable_diverging.rs:+2:12: +2:22
+          switchInt(move _3) -> [1_isize: bb2, otherwise: bb6]; // scope 2 at $DIR/unreachable_diverging.rs:+2:12: +2:22
       }
   
       bb2: {
@@ -39,13 +38,11 @@
           StorageLive(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:+3:9: +5:10
           StorageLive(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
           _6 = _1;                         // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
--         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
-+         goto -> bb3;                     // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
+          switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
       }
   
       bb3: {
--         _5 = loop_forever() -> bb5;      // scope 2 at $DIR/unreachable_diverging.rs:+4:13: +4:27
-+         _5 = loop_forever() -> bb4;      // scope 2 at $DIR/unreachable_diverging.rs:+4:13: +4:27
+          _5 = loop_forever() -> bb5;      // scope 2 at $DIR/unreachable_diverging.rs:+4:13: +4:27
                                            // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:16:13: 16:25
                                            // + literal: Const { ty: fn() {loop_forever}, val: Value(<ZST>) }
@@ -54,17 +51,17 @@
       bb4: {
 -         _5 = const ();                   // scope 2 at $DIR/unreachable_diverging.rs:+5:10: +5:10
 -         goto -> bb5;                     // scope 2 at $DIR/unreachable_diverging.rs:+3:9: +5:10
--     }
-- 
--     bb5: {
-          StorageDead(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:+5:9: +5:10
-          StorageDead(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:+5:9: +5:10
-          StorageLive(_7);                 // scope 2 at $DIR/unreachable_diverging.rs:+6:9: +6:22
++         unreachable;                     // scope 2 at $DIR/unreachable_diverging.rs:+3:9: +5:10
+      }
+  
+      bb5: {
+-         StorageDead(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:+5:9: +5:10
+-         StorageDead(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:+5:9: +5:10
+-         StorageLive(_7);                 // scope 2 at $DIR/unreachable_diverging.rs:+6:9: +6:22
           unreachable;                     // scope 2 at $DIR/unreachable_diverging.rs:+6:15: +6:19
       }
   
--     bb6: {
-+     bb5: {
+      bb6: {
           _0 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:+7:6: +7:6
           StorageDead(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:+8:1: +8:2
           StorageDead(_2);                 // scope 0 at $DIR/unreachable_diverging.rs:+8:1: +8:2


### PR DESCRIPTION
Before, UnreachablePropagation removed all unreachable branches. This was a pessimization, as it removed information about reachability that was used later in the optimization pipeline.

For example, this code
```rust
pub enum Two { A, B }
pub fn identity(x: Two) -> Two {
    match x {
        Two::A => Two::A,
        Two::B => Two::B,
    }
}
```

basically has `switchInt() -> [0: 0, 1: 1, otherwise: unreachable]` for the match. This allows it to be transformed into a simple `x`. If we remove the unreachable branch, the transformation becomes illegal.

This was the problem keeping `UnreachablePropagation` from being enabled, so we can enable it now.

Something similar already happened in #77800, but it did not show a perf improvement there. Let's try it again anyways!

Fixes #68105, although that issue has been fixed for a long time (see #77680).