### PR TITLE
Htmldocck: Substitute the doc channel when blessing

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -440,6 +440,7 @@ def check_snapshot(snapshot_name, actual_tree, normalize_to_text):
 
         if bless:
             with open(snapshot_path, 'w') as snapshot_file:
+                actual_str = actual_str.replace(channel, "{{channel}}")
                 snapshot_file.write(actual_str)
         else:
             print('--- expected ---\n')


### PR DESCRIPTION
Since #84942, the snippet `{{channel}}` gets substituted with the concrete “doc channel” (e.g. `https://doc.rust-lang.org/nightly`) when snapshot files are checked against the actual rustdoc output.

However, when you `--bless` rustdoc tests, htmldocck just dumps the concrete channel into the snapshot file and
you have to manually do a find-and-replace after blessing to uphold what #84942 set out to fix.

I admit it's a bit fragile to blindly replace URLs like this but I guess it's not too bad in practice.
Feel free to close this PR if you don't think that this is a good idea.

@rustbot label T-rustdoc A-testsuite