### PR TITLE
update few deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -934,11 +934,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difference"
@@ -1690,9 +1690,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1849,9 +1849,9 @@ checksum = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 
 [[package]]
 name = "ignore"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
  "crossbeam-utils",
  "globset",
@@ -1899,12 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
-dependencies = [
- "unindent",
-]
+checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
 
 [[package]]
 name = "installer"
@@ -2627,15 +2624,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.18.0+1.1.1n"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]
@@ -3260,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3280,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remote-test-client"
@@ -5694,12 +5691,6 @@ checksum = "496a3d395ed0c30f411ceace4a91f7d93b148fb5a9b383d5d4cff7850f048d5f"
 dependencies = [
  "diff",
 ]
-
-[[package]]
-name = "unindent"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "unstable-book-gen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3525,6 +3525,7 @@ dependencies = [
  "crossbeam-utils",
  "libc",
  "libz-sys",
+ "memchr",
  "proc-macro2",
  "quote",
  "rand_core 0.5.1",

--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -71,7 +71,7 @@ features = [
 ]
 
 [dependencies]
-bstr = { version = "0.2.13", features = ["default"] }
+bstr = { version = "0.2.17", features = ["default"] }
 byteorder = { version = "1", features = ['default', 'std'] }
 clap = { version = "3.1.1", features = ["derive", "clap_derive"]}
 curl-sys = { version = "0.4.13", features = ["http2", "libnghttp2-sys"], optional = true }
@@ -80,7 +80,7 @@ libc = { version = "0.2.79", features = ["align"] }
 # Ensure default features of libz-sys, which are disabled in some scenarios.
 libz-sys = { version = "1.1.2" }
 # same for regex
-regex = { version = "1.5.5" }
+regex = { version = "1.5.6" }
 proc-macro2 = { version = "1", features = ["default"] }
 quote = { version = "1", features = ["default"] }
 rand_core_0_5 = { package = "rand_core", version = "0.5.1", features = ["getrandom", "alloc", "std"] }

--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -79,6 +79,10 @@ crossbeam-utils = { version = "0.8.0", features = ["nightly"] }
 libc = { version = "0.2.79", features = ["align"] }
 # Ensure default features of libz-sys, which are disabled in some scenarios.
 libz-sys = { version = "1.1.2" }
+
+# looks like the only user of deprecated `use_std` feature is `combine`, so this
+# can be removed if/when https://github.com/Marwes/combine/pull/348 be merged and released.
+memchr = { version = "2.5", features = ["std", "use_std"] }
 # same for regex
 regex = { version = "1.5.6" }
 proc-macro2 = { version = "1", features = ["default"] }


### PR DESCRIPTION
Updates few crates:

* openssl-src v111.18.0+1.1.1n -> v111.22.0+1.1.1q: fixes few CVE's (https://www.openssl.org/news/vulnerabilities-1.1.1.html: https://cve.org/CVERecord?id=CVE-2022-1292 https://cve.org/CVERecord?id=CVE-2022-2068 https://cve.org/CVERecord?id=CVE-2022-2097)

* openssl-probe v0.1.2 -> v0.1.5 updates ancient (2017) crate (https://github.com/alexcrichton/openssl-probe/compare/0.1.2...0.1.5). Adds support to search cert for additional platforms.

* indoc v1.0.3 -> v1.0.6 (https://github.com/dtolnay/indoc/compare/1.0.3...1.0.6) Nothing special changed, removes unindent v0.1.7
 
* bstr v0.2.13 -> v0.2.17 (https://github.com/BurntSushi/bstr/compare/0.2.13...0.2.17) Few speedups (https://github.com/BurntSushi/bstr/commit/8e659921312830b91d2a48aafa36fb1a49cba5bc, https://github.com/BurntSushi/bstr/commit/5fcef919adf1b84a960c87126decb0f3ef8c2e61) and bugfix (https://github.com/BurntSushi/bstr/commit/b2111b6bbf2c9a819fb1338aa81bd099874106a1)

* crc32fast v1.2.0 -> v1.3.2 (https://github.com/srijs/rust-crc32fast/compare/v1.2.0...v1.3.2) Speedup debug (https://github.com/srijs/rust-crc32fast/commit/e61ce6a39bbe9da495198a4037292ec299e8970f)

* diff v0.1.12 -> v0.1.13 (https://github.com/utkarshkukreti/diff.rs/compare/0.1.12...0.1.13) Few optimizations (https://github.com/utkarshkukreti/diff.rs/pull/16, https://github.com/utkarshkukreti/diff.rs/commit/0f0aa580f197af7dab9ab905568f70a2387e23bc)
 
* ignore v0.4.17 -> v0.4.18 (it's hard to get usable diff, but most notable perf change is https://github.com/BurntSushi/ripgrep/commit/a28e664abd0d8912e4a2d85039fe282b9d37b994)

* globset v0.4.5 -> v0.4.9

* regex v1.5.5 -> v1.5.6 few bugfixes (https://github.com/rust-lang/regex/blob/1.5.6/CHANGELOG.md#156-2022-05-20). There exist 1.6.0 version, but it's too fresh.