### PR TITLE
Re-enable submodule archive downloads.

### DIFF
--- a/src/ci/scripts/checkout-submodules.sh
+++ b/src/ci/scripts/checkout-submodules.sh
@@ -36,10 +36,7 @@ function fetch_github_commit_archive {
     rm $cached
 }
 
-# Archive downloads are temporarily disabled due to sudden 504
-# gateway timeout errors.
-# included="src/llvm-project src/doc/book src/doc/rust-by-example"
-included=""
+included="src/llvm-project src/doc/book src/doc/rust-by-example"
 modules="$(git config --file .gitmodules --get-regexp '\.path$' | cut -d' ' -f2)"
 modules=($modules)
 use_git=""
@@ -63,9 +60,9 @@ done
 retry sh -c "git submodule deinit -f $use_git && \
     git submodule sync && \
     git submodule update -j 16 --init --recursive --depth 1 $use_git"
-# STATUS=0
-# for pid in ${bg_pids[*]}
-# do
-#     wait $pid || STATUS=1
-# done
-# exit ${STATUS}
+STATUS=0
+for pid in ${bg_pids[*]}
+do
+    wait $pid || STATUS=1
+done
+exit ${STATUS}


### PR DESCRIPTION
This is effectively a revert of #98423 (though it keeps the `--depth 1` flag since that is still helpful).

GitHub has indicated that they have been working on the original issue, and my testing shows that the llvm-project archive download now succeeds 100% of the time.

This should save about a minute on every job.
