### PR TITLE
rustdoc: do not allocate String when writing path full name

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2175,8 +2175,8 @@ impl Path {
     pub(crate) fn whole_name(&self) -> String {
         self.segments
             .iter()
-            .map(|s| if s.name == kw::PathRoot { String::new() } else { s.name.to_string() })
-            .intersperse("::".into())
+            .map(|s| if s.name == kw::PathRoot { "" } else { s.name.as_str() })
+            .intersperse("::")
             .collect()
     }
 


### PR DESCRIPTION
No idea if this makes any perf difference, but it just seems like premature pessimisation to use String when str will do.