### PR TITLE
Fix item info pos and height

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1111,7 +1111,14 @@ table,
 }
 
 .item-info .stab {
-	display: inline-block;
+	width: fit-content;
+	/* This min-height is needed to unify the height of the stab elements because some of them
+	   have emojis.
+	*/
+	min-height: 36px;
+	display: flex;
+	align-items: center;
+	white-space: pre-wrap;
 }
 .stab {
 	padding: 3px;
@@ -1121,6 +1128,7 @@ table,
 }
 .stab p {
 	display: inline;
+	margin: 0;
 }
 
 .stab .emoji {

--- a/src/test/rustdoc-gui/item-info-width.goml
+++ b/src/test/rustdoc-gui/item-info-width.goml
@@ -1,8 +1,0 @@
-// This test ensures that the item information don't take 100% of the width if unnecessary.
-goto: file://|DOC_PATH|/lib2/struct.Foo.html
-// We set a fixed size so there is no chance of "random" resize.
-size: (1100, 800)
-// We check that ".item-info" is bigger than its content.
-assert-css: (".item-info", {"width": "790px"})
-assert-css: (".item-info .stab", {"width": "289px"})
-assert-position: (".item-info .stab", {"x": 295})

--- a/src/test/rustdoc-gui/item-info.goml
+++ b/src/test/rustdoc-gui/item-info.goml
@@ -1,0 +1,32 @@
+// This test ensures a few things for item info elements.
+goto: file://|DOC_PATH|/lib2/struct.Foo.html
+// Ensuring that the item information don't take 100% of the width if unnecessary.
+// We set a fixed size so there is no chance of "random" resize.
+size: (1100, 800)
+// We check that ".item-info" is bigger than its content.
+assert-css: (".item-info", {"width": "790px"})
+assert-css: (".item-info .stab", {"width": "289px"})
+assert-position: (".item-info .stab", {"x": 295})
+
+// Now we ensure that they're not rendered on the same line.
+goto: file://|DOC_PATH|/lib2/trait.Trait.html
+// We first ensure that there are two item info on the trait.
+assert-count: ("#main-content > .item-info .stab", 2)
+// They should not have the same `y` position!
+compare-elements-position-false: (
+    "#main-content > .item-info .stab:nth-of-type(1)",
+    "#main-content > .item-info .stab:nth-of-type(2)",
+    ("y"),
+)
+// But they should have the same `x` position.
+compare-elements-position: (
+    "#main-content > .item-info .stab:nth-of-type(1)",
+    "#main-content > .item-info .stab:nth-of-type(2)",
+    ("x"),
+)
+// They are supposed to have the same height too.
+compare-elements-css: (
+    "#main-content > .item-info .stab:nth-of-type(1)",
+    "#main-content > .item-info .stab:nth-of-type(2)",
+    ["height"],
+)

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -30,10 +30,13 @@ impl Foo {
     pub fn a_method(&self) {}
 }
 
+#[doc(cfg(feature = "foo-method"))]
+#[deprecated = "Whatever [`Foo::a_method`](#method.a_method)"]
 pub trait Trait {
     type X;
     const Y: u32;
 
+    #[deprecated = "Whatever [`Foo`](#tadam)"]
     fn foo() {}
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/98266.
Fixes https://github.com/rust-lang/rust/issues/98343.

You can test it [here](https://rustdoc.crud.net/imperio/fix-item-info-pos-and-height/lib2/trait.Trait.html).

Here is a screenshot of the result:

![Screenshot from 2022-07-26 21-55-53](https://user-images.githubusercontent.com/3050060/181100624-18b8b045-5c25-4c7c-9c44-97d55d29b675.png)

r? @jsha 