### PR TITLE
Use line numbers relative to the function in mir-opt tests

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -670,6 +670,7 @@ fn test_unstable_options_tracking_hash() {
     untracked!(ls, true);
     untracked!(macro_backtrace, true);
     untracked!(meta_stats, true);
+    untracked!(mir_pretty_relative_line_numbers, true);
     untracked!(nll_facts, true);
     untracked!(no_analysis, true);
     untracked!(no_interleave_lints, true);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1379,6 +1379,8 @@ options! {
         "use like `-Zmir-enable-passes=+DestProp,-InstCombine`. Forces the specified passes to be \
         enabled, overriding all other checks. Passes that are not specified are enabled or \
         disabled by other flags as usual."),
+    mir_pretty_relative_line_numbers: bool = (false, parse_bool, [UNTRACKED],
+        "use line numbers relative to the function in mir pretty printing"),
     #[cfg_attr(not(bootstrap), rustc_lint_opt_deny_field_access("use `Session::mir_opt_level` instead of this field"))]
     mir_opt_level: Option<usize> = (None, parse_opt_number, [TRACKED],
         "MIR optimization level (0-4; default: 1 in non optimized builds and 2 in optimized builds)"),

--- a/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
@@ -2,28 +2,28 @@
 + // MIR for `encode` after SimplifyBranchSame
   
   fn encode(_1: Type) -> Type {
-      debug v => _1;                       // in scope 0 at $DIR/76803_regression.rs:10:15: 10:16
-      let mut _0: Type;                    // return place in scope 0 at $DIR/76803_regression.rs:10:27: 10:31
-      let mut _2: isize;                   // in scope 0 at $DIR/76803_regression.rs:12:9: 12:16
+      debug v => _1;                       // in scope 0 at $DIR/76803_regression.rs:+0:15: +0:16
+      let mut _0: Type;                    // return place in scope 0 at $DIR/76803_regression.rs:+0:27: +0:31
+      let mut _2: isize;                   // in scope 0 at $DIR/76803_regression.rs:+2:9: +2:16
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/76803_regression.rs:11:11: 11:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:11:5: 11:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/76803_regression.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = move _1;                    // scope 0 at $DIR/76803_regression.rs:13:14: 13:15
-          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:13:14: 13:15
+          _0 = move _1;                    // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
+          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:+3:14: +3:15
       }
   
       bb2: {
-          Deinit(_0);                      // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
-          discriminant(_0) = 1;            // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
-          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
+          Deinit(_0);                      // scope 0 at $DIR/76803_regression.rs:+2:20: +2:27
+          discriminant(_0) = 1;            // scope 0 at $DIR/76803_regression.rs:+2:20: +2:27
+          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:+2:20: +2:27
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/76803_regression.rs:15:2: 15:2
+          return;                          // scope 0 at $DIR/76803_regression.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/address_of.address_of_reborrow.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/address_of.address_of_reborrow.SimplifyCfg-initial.after.mir
@@ -33,83 +33,83 @@
 | 29: user_ty: Canonical { max_universe: U0, variables: [], value: Ty(*mut [i32]) }, span: $DIR/address-of.rs:36:12: 36:22, inferred_ty: *mut [i32]
 |
 fn address_of_reborrow() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/address-of.rs:3:26: 3:26
-    let _1: &[i32; 10];                  // in scope 0 at $DIR/address-of.rs:4:9: 4:10
-    let _2: [i32; 10];                   // in scope 0 at $DIR/address-of.rs:4:14: 4:21
-    let mut _4: [i32; 10];               // in scope 0 at $DIR/address-of.rs:5:22: 5:29
-    let _5: *const [i32; 10];            // in scope 0 at $DIR/address-of.rs:7:5: 7:18
-    let mut _6: *const [i32; 10];        // in scope 0 at $DIR/address-of.rs:7:5: 7:18
-    let _7: *const [i32; 10];            // in scope 0 at $DIR/address-of.rs:8:5: 8:26
-    let _8: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:9:5: 9:25
-    let mut _9: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:9:5: 9:25
-    let mut _10: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:9:5: 9:6
-    let _11: *const [i32];               // in scope 0 at $DIR/address-of.rs:10:5: 10:22
-    let mut _12: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:10:5: 10:6
-    let _13: *const i32;                 // in scope 0 at $DIR/address-of.rs:11:5: 11:20
-    let mut _14: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:11:5: 11:6
-    let mut _18: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:15:30: 15:31
-    let mut _20: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:16:27: 16:28
-    let _21: *const [i32; 10];           // in scope 0 at $DIR/address-of.rs:18:5: 18:18
-    let mut _22: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:18:5: 18:18
-    let _23: *const [i32; 10];           // in scope 0 at $DIR/address-of.rs:19:5: 19:26
-    let _24: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:20:5: 20:25
-    let mut _25: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:20:5: 20:25
-    let mut _26: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:20:5: 20:6
-    let _27: *const [i32];               // in scope 0 at $DIR/address-of.rs:21:5: 21:22
-    let mut _28: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:21:5: 21:6
-    let mut _32: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:25:30: 25:31
-    let mut _34: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:26:27: 26:28
-    let _35: *mut [i32; 10];             // in scope 0 at $DIR/address-of.rs:28:5: 28:16
-    let mut _36: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:28:5: 28:16
-    let _37: *mut [i32; 10];             // in scope 0 at $DIR/address-of.rs:29:5: 29:24
-    let _38: *mut dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:30:5: 30:23
-    let mut _39: *mut dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:30:5: 30:23
-    let mut _40: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:30:5: 30:6
-    let _41: *mut [i32];                 // in scope 0 at $DIR/address-of.rs:31:5: 31:20
-    let mut _42: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:31:5: 31:6
-    let mut _46: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:35:28: 35:29
-    let mut _48: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:36:25: 36:26
+    let mut _0: ();                      // return place in scope 0 at $DIR/address-of.rs:+0:26: +0:26
+    let _1: &[i32; 10];                  // in scope 0 at $DIR/address-of.rs:+1:9: +1:10
+    let _2: [i32; 10];                   // in scope 0 at $DIR/address-of.rs:+1:14: +1:21
+    let mut _4: [i32; 10];               // in scope 0 at $DIR/address-of.rs:+2:22: +2:29
+    let _5: *const [i32; 10];            // in scope 0 at $DIR/address-of.rs:+4:5: +4:18
+    let mut _6: *const [i32; 10];        // in scope 0 at $DIR/address-of.rs:+4:5: +4:18
+    let _7: *const [i32; 10];            // in scope 0 at $DIR/address-of.rs:+5:5: +5:26
+    let _8: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:+6:5: +6:25
+    let mut _9: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:+6:5: +6:25
+    let mut _10: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+6:5: +6:6
+    let _11: *const [i32];               // in scope 0 at $DIR/address-of.rs:+7:5: +7:22
+    let mut _12: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+7:5: +7:6
+    let _13: *const i32;                 // in scope 0 at $DIR/address-of.rs:+8:5: +8:20
+    let mut _14: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+8:5: +8:6
+    let mut _18: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+12:30: +12:31
+    let mut _20: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+13:27: +13:28
+    let _21: *const [i32; 10];           // in scope 0 at $DIR/address-of.rs:+15:5: +15:18
+    let mut _22: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+15:5: +15:18
+    let _23: *const [i32; 10];           // in scope 0 at $DIR/address-of.rs:+16:5: +16:26
+    let _24: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:+17:5: +17:25
+    let mut _25: *const dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:+17:5: +17:25
+    let mut _26: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+17:5: +17:6
+    let _27: *const [i32];               // in scope 0 at $DIR/address-of.rs:+18:5: +18:22
+    let mut _28: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+18:5: +18:6
+    let mut _32: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+22:30: +22:31
+    let mut _34: *const [i32; 10];       // in scope 0 at $DIR/address-of.rs:+23:27: +23:28
+    let _35: *mut [i32; 10];             // in scope 0 at $DIR/address-of.rs:+25:5: +25:16
+    let mut _36: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:+25:5: +25:16
+    let _37: *mut [i32; 10];             // in scope 0 at $DIR/address-of.rs:+26:5: +26:24
+    let _38: *mut dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:+27:5: +27:23
+    let mut _39: *mut dyn std::marker::Send; // in scope 0 at $DIR/address-of.rs:+27:5: +27:23
+    let mut _40: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:+27:5: +27:6
+    let _41: *mut [i32];                 // in scope 0 at $DIR/address-of.rs:+28:5: +28:20
+    let mut _42: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:+28:5: +28:6
+    let mut _46: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:+32:28: +32:29
+    let mut _48: *mut [i32; 10];         // in scope 0 at $DIR/address-of.rs:+33:25: +33:26
     scope 1 {
-        debug y => _1;                   // in scope 1 at $DIR/address-of.rs:4:9: 4:10
-        let mut _3: &mut [i32; 10];      // in scope 1 at $DIR/address-of.rs:5:9: 5:14
+        debug y => _1;                   // in scope 1 at $DIR/address-of.rs:+1:9: +1:10
+        let mut _3: &mut [i32; 10];      // in scope 1 at $DIR/address-of.rs:+2:9: +2:14
         scope 2 {
-            debug z => _3;               // in scope 2 at $DIR/address-of.rs:5:9: 5:14
-            let _15: *const [i32; 10] as UserTypeProjection { base: UserType(2), projs: [] }; // in scope 2 at $DIR/address-of.rs:13:9: 13:10
+            debug z => _3;               // in scope 2 at $DIR/address-of.rs:+2:9: +2:14
+            let _15: *const [i32; 10] as UserTypeProjection { base: UserType(2), projs: [] }; // in scope 2 at $DIR/address-of.rs:+10:9: +10:10
             scope 3 {
-                debug p => _15;          // in scope 3 at $DIR/address-of.rs:13:9: 13:10
-                let _16: *const [i32; 10] as UserTypeProjection { base: UserType(4), projs: [] }; // in scope 3 at $DIR/address-of.rs:14:9: 14:10
+                debug p => _15;          // in scope 3 at $DIR/address-of.rs:+10:9: +10:10
+                let _16: *const [i32; 10] as UserTypeProjection { base: UserType(4), projs: [] }; // in scope 3 at $DIR/address-of.rs:+11:9: +11:10
                 scope 4 {
-                    debug p => _16;      // in scope 4 at $DIR/address-of.rs:14:9: 14:10
-                    let _17: *const dyn std::marker::Send as UserTypeProjection { base: UserType(6), projs: [] }; // in scope 4 at $DIR/address-of.rs:15:9: 15:10
+                    debug p => _16;      // in scope 4 at $DIR/address-of.rs:+11:9: +11:10
+                    let _17: *const dyn std::marker::Send as UserTypeProjection { base: UserType(6), projs: [] }; // in scope 4 at $DIR/address-of.rs:+12:9: +12:10
                     scope 5 {
-                        debug p => _17;  // in scope 5 at $DIR/address-of.rs:15:9: 15:10
-                        let _19: *const [i32] as UserTypeProjection { base: UserType(8), projs: [] }; // in scope 5 at $DIR/address-of.rs:16:9: 16:10
+                        debug p => _17;  // in scope 5 at $DIR/address-of.rs:+12:9: +12:10
+                        let _19: *const [i32] as UserTypeProjection { base: UserType(8), projs: [] }; // in scope 5 at $DIR/address-of.rs:+13:9: +13:10
                         scope 6 {
-                            debug p => _19; // in scope 6 at $DIR/address-of.rs:16:9: 16:10
-                            let _29: *const [i32; 10] as UserTypeProjection { base: UserType(12), projs: [] }; // in scope 6 at $DIR/address-of.rs:23:9: 23:10
+                            debug p => _19; // in scope 6 at $DIR/address-of.rs:+13:9: +13:10
+                            let _29: *const [i32; 10] as UserTypeProjection { base: UserType(12), projs: [] }; // in scope 6 at $DIR/address-of.rs:+20:9: +20:10
                             scope 7 {
-                                debug p => _29; // in scope 7 at $DIR/address-of.rs:23:9: 23:10
-                                let _30: *const [i32; 10] as UserTypeProjection { base: UserType(14), projs: [] }; // in scope 7 at $DIR/address-of.rs:24:9: 24:10
+                                debug p => _29; // in scope 7 at $DIR/address-of.rs:+20:9: +20:10
+                                let _30: *const [i32; 10] as UserTypeProjection { base: UserType(14), projs: [] }; // in scope 7 at $DIR/address-of.rs:+21:9: +21:10
                                 scope 8 {
-                                    debug p => _30; // in scope 8 at $DIR/address-of.rs:24:9: 24:10
-                                    let _31: *const dyn std::marker::Send as UserTypeProjection { base: UserType(16), projs: [] }; // in scope 8 at $DIR/address-of.rs:25:9: 25:10
+                                    debug p => _30; // in scope 8 at $DIR/address-of.rs:+21:9: +21:10
+                                    let _31: *const dyn std::marker::Send as UserTypeProjection { base: UserType(16), projs: [] }; // in scope 8 at $DIR/address-of.rs:+22:9: +22:10
                                     scope 9 {
-                                        debug p => _31; // in scope 9 at $DIR/address-of.rs:25:9: 25:10
-                                        let _33: *const [i32] as UserTypeProjection { base: UserType(18), projs: [] }; // in scope 9 at $DIR/address-of.rs:26:9: 26:10
+                                        debug p => _31; // in scope 9 at $DIR/address-of.rs:+22:9: +22:10
+                                        let _33: *const [i32] as UserTypeProjection { base: UserType(18), projs: [] }; // in scope 9 at $DIR/address-of.rs:+23:9: +23:10
                                         scope 10 {
-                                            debug p => _33; // in scope 10 at $DIR/address-of.rs:26:9: 26:10
-                                            let _43: *mut [i32; 10] as UserTypeProjection { base: UserType(22), projs: [] }; // in scope 10 at $DIR/address-of.rs:33:9: 33:10
+                                            debug p => _33; // in scope 10 at $DIR/address-of.rs:+23:9: +23:10
+                                            let _43: *mut [i32; 10] as UserTypeProjection { base: UserType(22), projs: [] }; // in scope 10 at $DIR/address-of.rs:+30:9: +30:10
                                             scope 11 {
-                                                debug p => _43; // in scope 11 at $DIR/address-of.rs:33:9: 33:10
-                                                let _44: *mut [i32; 10] as UserTypeProjection { base: UserType(24), projs: [] }; // in scope 11 at $DIR/address-of.rs:34:9: 34:10
+                                                debug p => _43; // in scope 11 at $DIR/address-of.rs:+30:9: +30:10
+                                                let _44: *mut [i32; 10] as UserTypeProjection { base: UserType(24), projs: [] }; // in scope 11 at $DIR/address-of.rs:+31:9: +31:10
                                                 scope 12 {
-                                                    debug p => _44; // in scope 12 at $DIR/address-of.rs:34:9: 34:10
-                                                    let _45: *mut dyn std::marker::Send as UserTypeProjection { base: UserType(26), projs: [] }; // in scope 12 at $DIR/address-of.rs:35:9: 35:10
+                                                    debug p => _44; // in scope 12 at $DIR/address-of.rs:+31:9: +31:10
+                                                    let _45: *mut dyn std::marker::Send as UserTypeProjection { base: UserType(26), projs: [] }; // in scope 12 at $DIR/address-of.rs:+32:9: +32:10
                                                     scope 13 {
-                                                        debug p => _45; // in scope 13 at $DIR/address-of.rs:35:9: 35:10
-                                                        let _47: *mut [i32] as UserTypeProjection { base: UserType(28), projs: [] }; // in scope 13 at $DIR/address-of.rs:36:9: 36:10
+                                                        debug p => _45; // in scope 13 at $DIR/address-of.rs:+32:9: +32:10
+                                                        let _47: *mut [i32] as UserTypeProjection { base: UserType(28), projs: [] }; // in scope 13 at $DIR/address-of.rs:+33:9: +33:10
                                                         scope 14 {
-                                                            debug p => _47; // in scope 14 at $DIR/address-of.rs:36:9: 36:10
+                                                            debug p => _47; // in scope 14 at $DIR/address-of.rs:+33:9: +33:10
                                                         }
                                                     }
                                                 }
@@ -126,183 +126,183 @@ fn address_of_reborrow() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/address-of.rs:4:9: 4:10
-        StorageLive(_2);                 // scope 0 at $DIR/address-of.rs:4:14: 4:21
-        _2 = [const 0_i32; 10];          // scope 0 at $DIR/address-of.rs:4:14: 4:21
-        _1 = &_2;                        // scope 0 at $DIR/address-of.rs:4:13: 4:21
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/address-of.rs:4:9: 4:10
-        StorageLive(_3);                 // scope 1 at $DIR/address-of.rs:5:9: 5:14
-        StorageLive(_4);                 // scope 1 at $DIR/address-of.rs:5:22: 5:29
-        _4 = [const 0_i32; 10];          // scope 1 at $DIR/address-of.rs:5:22: 5:29
-        _3 = &mut _4;                    // scope 1 at $DIR/address-of.rs:5:17: 5:29
-        FakeRead(ForLet(None), _3);      // scope 1 at $DIR/address-of.rs:5:9: 5:14
-        StorageLive(_5);                 // scope 2 at $DIR/address-of.rs:7:5: 7:18
-        StorageLive(_6);                 // scope 2 at $DIR/address-of.rs:7:5: 7:18
-        _6 = &raw const (*_1);           // scope 2 at $DIR/address-of.rs:7:5: 7:6
-        AscribeUserType(_6, o, UserTypeProjection { base: UserType(0), projs: [] }); // scope 2 at $DIR/address-of.rs:7:5: 7:18
-        _5 = _6;                         // scope 2 at $DIR/address-of.rs:7:5: 7:18
-        StorageDead(_6);                 // scope 2 at $DIR/address-of.rs:7:18: 7:19
-        StorageDead(_5);                 // scope 2 at $DIR/address-of.rs:7:18: 7:19
-        StorageLive(_7);                 // scope 2 at $DIR/address-of.rs:8:5: 8:26
-        _7 = &raw const (*_1);           // scope 2 at $DIR/address-of.rs:8:5: 8:6
-        StorageDead(_7);                 // scope 2 at $DIR/address-of.rs:8:26: 8:27
-        StorageLive(_8);                 // scope 2 at $DIR/address-of.rs:9:5: 9:25
-        StorageLive(_9);                 // scope 2 at $DIR/address-of.rs:9:5: 9:25
-        StorageLive(_10);                // scope 2 at $DIR/address-of.rs:9:5: 9:6
-        _10 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:9:5: 9:6
-        _9 = move _10 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 2 at $DIR/address-of.rs:9:5: 9:6
-        StorageDead(_10);                // scope 2 at $DIR/address-of.rs:9:5: 9:6
-        AscribeUserType(_9, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 2 at $DIR/address-of.rs:9:5: 9:25
-        _8 = _9;                         // scope 2 at $DIR/address-of.rs:9:5: 9:25
-        StorageDead(_9);                 // scope 2 at $DIR/address-of.rs:9:25: 9:26
-        StorageDead(_8);                 // scope 2 at $DIR/address-of.rs:9:25: 9:26
-        StorageLive(_11);                // scope 2 at $DIR/address-of.rs:10:5: 10:22
-        StorageLive(_12);                // scope 2 at $DIR/address-of.rs:10:5: 10:6
-        _12 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:10:5: 10:6
-        _11 = move _12 as *const [i32] (Pointer(Unsize)); // scope 2 at $DIR/address-of.rs:10:5: 10:6
-        StorageDead(_12);                // scope 2 at $DIR/address-of.rs:10:5: 10:6
-        StorageDead(_11);                // scope 2 at $DIR/address-of.rs:10:22: 10:23
-        StorageLive(_13);                // scope 2 at $DIR/address-of.rs:11:5: 11:20
-        StorageLive(_14);                // scope 2 at $DIR/address-of.rs:11:5: 11:6
-        _14 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:11:5: 11:6
-        _13 = move _14 as *const i32 (Pointer(ArrayToPointer)); // scope 2 at $DIR/address-of.rs:11:5: 11:20
-        StorageDead(_14);                // scope 2 at $DIR/address-of.rs:11:19: 11:20
-        StorageDead(_13);                // scope 2 at $DIR/address-of.rs:11:20: 11:21
-        StorageLive(_15);                // scope 2 at $DIR/address-of.rs:13:9: 13:10
-        _15 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:13:23: 13:24
-        FakeRead(ForLet(None), _15);     // scope 2 at $DIR/address-of.rs:13:9: 13:10
-        AscribeUserType(_15, o, UserTypeProjection { base: UserType(3), projs: [] }); // scope 2 at $DIR/address-of.rs:13:12: 13:20
-        StorageLive(_16);                // scope 3 at $DIR/address-of.rs:14:9: 14:10
-        _16 = &raw const (*_1);          // scope 3 at $DIR/address-of.rs:14:31: 14:32
-        FakeRead(ForLet(None), _16);     // scope 3 at $DIR/address-of.rs:14:9: 14:10
-        AscribeUserType(_16, o, UserTypeProjection { base: UserType(5), projs: [] }); // scope 3 at $DIR/address-of.rs:14:12: 14:28
-        StorageLive(_17);                // scope 4 at $DIR/address-of.rs:15:9: 15:10
-        StorageLive(_18);                // scope 4 at $DIR/address-of.rs:15:30: 15:31
-        _18 = &raw const (*_1);          // scope 4 at $DIR/address-of.rs:15:30: 15:31
-        _17 = move _18 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 4 at $DIR/address-of.rs:15:30: 15:31
-        StorageDead(_18);                // scope 4 at $DIR/address-of.rs:15:30: 15:31
-        FakeRead(ForLet(None), _17);     // scope 4 at $DIR/address-of.rs:15:9: 15:10
-        AscribeUserType(_17, o, UserTypeProjection { base: UserType(7), projs: [] }); // scope 4 at $DIR/address-of.rs:15:12: 15:27
-        StorageLive(_19);                // scope 5 at $DIR/address-of.rs:16:9: 16:10
-        StorageLive(_20);                // scope 5 at $DIR/address-of.rs:16:27: 16:28
-        _20 = &raw const (*_1);          // scope 5 at $DIR/address-of.rs:16:27: 16:28
-        _19 = move _20 as *const [i32] (Pointer(Unsize)); // scope 5 at $DIR/address-of.rs:16:27: 16:28
-        StorageDead(_20);                // scope 5 at $DIR/address-of.rs:16:27: 16:28
-        FakeRead(ForLet(None), _19);     // scope 5 at $DIR/address-of.rs:16:9: 16:10
-        AscribeUserType(_19, o, UserTypeProjection { base: UserType(9), projs: [] }); // scope 5 at $DIR/address-of.rs:16:12: 16:24
-        StorageLive(_21);                // scope 6 at $DIR/address-of.rs:18:5: 18:18
-        StorageLive(_22);                // scope 6 at $DIR/address-of.rs:18:5: 18:18
-        _22 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:18:5: 18:6
-        AscribeUserType(_22, o, UserTypeProjection { base: UserType(10), projs: [] }); // scope 6 at $DIR/address-of.rs:18:5: 18:18
-        _21 = _22;                       // scope 6 at $DIR/address-of.rs:18:5: 18:18
-        StorageDead(_22);                // scope 6 at $DIR/address-of.rs:18:18: 18:19
-        StorageDead(_21);                // scope 6 at $DIR/address-of.rs:18:18: 18:19
-        StorageLive(_23);                // scope 6 at $DIR/address-of.rs:19:5: 19:26
-        _23 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:19:5: 19:6
-        StorageDead(_23);                // scope 6 at $DIR/address-of.rs:19:26: 19:27
-        StorageLive(_24);                // scope 6 at $DIR/address-of.rs:20:5: 20:25
-        StorageLive(_25);                // scope 6 at $DIR/address-of.rs:20:5: 20:25
-        StorageLive(_26);                // scope 6 at $DIR/address-of.rs:20:5: 20:6
-        _26 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:20:5: 20:6
-        _25 = move _26 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 6 at $DIR/address-of.rs:20:5: 20:6
-        StorageDead(_26);                // scope 6 at $DIR/address-of.rs:20:5: 20:6
-        AscribeUserType(_25, o, UserTypeProjection { base: UserType(11), projs: [] }); // scope 6 at $DIR/address-of.rs:20:5: 20:25
-        _24 = _25;                       // scope 6 at $DIR/address-of.rs:20:5: 20:25
-        StorageDead(_25);                // scope 6 at $DIR/address-of.rs:20:25: 20:26
-        StorageDead(_24);                // scope 6 at $DIR/address-of.rs:20:25: 20:26
-        StorageLive(_27);                // scope 6 at $DIR/address-of.rs:21:5: 21:22
-        StorageLive(_28);                // scope 6 at $DIR/address-of.rs:21:5: 21:6
-        _28 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:21:5: 21:6
-        _27 = move _28 as *const [i32] (Pointer(Unsize)); // scope 6 at $DIR/address-of.rs:21:5: 21:6
-        StorageDead(_28);                // scope 6 at $DIR/address-of.rs:21:5: 21:6
-        StorageDead(_27);                // scope 6 at $DIR/address-of.rs:21:22: 21:23
-        StorageLive(_29);                // scope 6 at $DIR/address-of.rs:23:9: 23:10
-        _29 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:23:23: 23:24
-        FakeRead(ForLet(None), _29);     // scope 6 at $DIR/address-of.rs:23:9: 23:10
-        AscribeUserType(_29, o, UserTypeProjection { base: UserType(13), projs: [] }); // scope 6 at $DIR/address-of.rs:23:12: 23:20
-        StorageLive(_30);                // scope 7 at $DIR/address-of.rs:24:9: 24:10
-        _30 = &raw const (*_3);          // scope 7 at $DIR/address-of.rs:24:31: 24:32
-        FakeRead(ForLet(None), _30);     // scope 7 at $DIR/address-of.rs:24:9: 24:10
-        AscribeUserType(_30, o, UserTypeProjection { base: UserType(15), projs: [] }); // scope 7 at $DIR/address-of.rs:24:12: 24:28
-        StorageLive(_31);                // scope 8 at $DIR/address-of.rs:25:9: 25:10
-        StorageLive(_32);                // scope 8 at $DIR/address-of.rs:25:30: 25:31
-        _32 = &raw const (*_3);          // scope 8 at $DIR/address-of.rs:25:30: 25:31
-        _31 = move _32 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 8 at $DIR/address-of.rs:25:30: 25:31
-        StorageDead(_32);                // scope 8 at $DIR/address-of.rs:25:30: 25:31
-        FakeRead(ForLet(None), _31);     // scope 8 at $DIR/address-of.rs:25:9: 25:10
-        AscribeUserType(_31, o, UserTypeProjection { base: UserType(17), projs: [] }); // scope 8 at $DIR/address-of.rs:25:12: 25:27
-        StorageLive(_33);                // scope 9 at $DIR/address-of.rs:26:9: 26:10
-        StorageLive(_34);                // scope 9 at $DIR/address-of.rs:26:27: 26:28
-        _34 = &raw const (*_3);          // scope 9 at $DIR/address-of.rs:26:27: 26:28
-        _33 = move _34 as *const [i32] (Pointer(Unsize)); // scope 9 at $DIR/address-of.rs:26:27: 26:28
-        StorageDead(_34);                // scope 9 at $DIR/address-of.rs:26:27: 26:28
-        FakeRead(ForLet(None), _33);     // scope 9 at $DIR/address-of.rs:26:9: 26:10
-        AscribeUserType(_33, o, UserTypeProjection { base: UserType(19), projs: [] }); // scope 9 at $DIR/address-of.rs:26:12: 26:24
-        StorageLive(_35);                // scope 10 at $DIR/address-of.rs:28:5: 28:16
-        StorageLive(_36);                // scope 10 at $DIR/address-of.rs:28:5: 28:16
-        _36 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:28:5: 28:6
-        AscribeUserType(_36, o, UserTypeProjection { base: UserType(20), projs: [] }); // scope 10 at $DIR/address-of.rs:28:5: 28:16
-        _35 = _36;                       // scope 10 at $DIR/address-of.rs:28:5: 28:16
-        StorageDead(_36);                // scope 10 at $DIR/address-of.rs:28:16: 28:17
-        StorageDead(_35);                // scope 10 at $DIR/address-of.rs:28:16: 28:17
-        StorageLive(_37);                // scope 10 at $DIR/address-of.rs:29:5: 29:24
-        _37 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:29:5: 29:6
-        StorageDead(_37);                // scope 10 at $DIR/address-of.rs:29:24: 29:25
-        StorageLive(_38);                // scope 10 at $DIR/address-of.rs:30:5: 30:23
-        StorageLive(_39);                // scope 10 at $DIR/address-of.rs:30:5: 30:23
-        StorageLive(_40);                // scope 10 at $DIR/address-of.rs:30:5: 30:6
-        _40 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:30:5: 30:6
-        _39 = move _40 as *mut dyn std::marker::Send (Pointer(Unsize)); // scope 10 at $DIR/address-of.rs:30:5: 30:6
-        StorageDead(_40);                // scope 10 at $DIR/address-of.rs:30:5: 30:6
-        AscribeUserType(_39, o, UserTypeProjection { base: UserType(21), projs: [] }); // scope 10 at $DIR/address-of.rs:30:5: 30:23
-        _38 = _39;                       // scope 10 at $DIR/address-of.rs:30:5: 30:23
-        StorageDead(_39);                // scope 10 at $DIR/address-of.rs:30:23: 30:24
-        StorageDead(_38);                // scope 10 at $DIR/address-of.rs:30:23: 30:24
-        StorageLive(_41);                // scope 10 at $DIR/address-of.rs:31:5: 31:20
-        StorageLive(_42);                // scope 10 at $DIR/address-of.rs:31:5: 31:6
-        _42 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:31:5: 31:6
-        _41 = move _42 as *mut [i32] (Pointer(Unsize)); // scope 10 at $DIR/address-of.rs:31:5: 31:6
-        StorageDead(_42);                // scope 10 at $DIR/address-of.rs:31:5: 31:6
-        StorageDead(_41);                // scope 10 at $DIR/address-of.rs:31:20: 31:21
-        StorageLive(_43);                // scope 10 at $DIR/address-of.rs:33:9: 33:10
-        _43 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:33:21: 33:22
-        FakeRead(ForLet(None), _43);     // scope 10 at $DIR/address-of.rs:33:9: 33:10
-        AscribeUserType(_43, o, UserTypeProjection { base: UserType(23), projs: [] }); // scope 10 at $DIR/address-of.rs:33:12: 33:18
-        StorageLive(_44);                // scope 11 at $DIR/address-of.rs:34:9: 34:10
-        _44 = &raw mut (*_3);            // scope 11 at $DIR/address-of.rs:34:29: 34:30
-        FakeRead(ForLet(None), _44);     // scope 11 at $DIR/address-of.rs:34:9: 34:10
-        AscribeUserType(_44, o, UserTypeProjection { base: UserType(25), projs: [] }); // scope 11 at $DIR/address-of.rs:34:12: 34:26
-        StorageLive(_45);                // scope 12 at $DIR/address-of.rs:35:9: 35:10
-        StorageLive(_46);                // scope 12 at $DIR/address-of.rs:35:28: 35:29
-        _46 = &raw mut (*_3);            // scope 12 at $DIR/address-of.rs:35:28: 35:29
-        _45 = move _46 as *mut dyn std::marker::Send (Pointer(Unsize)); // scope 12 at $DIR/address-of.rs:35:28: 35:29
-        StorageDead(_46);                // scope 12 at $DIR/address-of.rs:35:28: 35:29
-        FakeRead(ForLet(None), _45);     // scope 12 at $DIR/address-of.rs:35:9: 35:10
-        AscribeUserType(_45, o, UserTypeProjection { base: UserType(27), projs: [] }); // scope 12 at $DIR/address-of.rs:35:12: 35:25
-        StorageLive(_47);                // scope 13 at $DIR/address-of.rs:36:9: 36:10
-        StorageLive(_48);                // scope 13 at $DIR/address-of.rs:36:25: 36:26
-        _48 = &raw mut (*_3);            // scope 13 at $DIR/address-of.rs:36:25: 36:26
-        _47 = move _48 as *mut [i32] (Pointer(Unsize)); // scope 13 at $DIR/address-of.rs:36:25: 36:26
-        StorageDead(_48);                // scope 13 at $DIR/address-of.rs:36:25: 36:26
-        FakeRead(ForLet(None), _47);     // scope 13 at $DIR/address-of.rs:36:9: 36:10
-        AscribeUserType(_47, o, UserTypeProjection { base: UserType(29), projs: [] }); // scope 13 at $DIR/address-of.rs:36:12: 36:22
-        _0 = const ();                   // scope 0 at $DIR/address-of.rs:3:26: 37:2
-        StorageDead(_47);                // scope 13 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_45);                // scope 12 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_44);                // scope 11 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_43);                // scope 10 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_33);                // scope 9 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_31);                // scope 8 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_30);                // scope 7 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_29);                // scope 6 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_19);                // scope 5 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_17);                // scope 4 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_16);                // scope 3 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_15);                // scope 2 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_4);                 // scope 1 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_3);                 // scope 1 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_2);                 // scope 0 at $DIR/address-of.rs:37:1: 37:2
-        StorageDead(_1);                 // scope 0 at $DIR/address-of.rs:37:1: 37:2
-        return;                          // scope 0 at $DIR/address-of.rs:37:2: 37:2
+        StorageLive(_1);                 // scope 0 at $DIR/address-of.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 0 at $DIR/address-of.rs:+1:14: +1:21
+        _2 = [const 0_i32; 10];          // scope 0 at $DIR/address-of.rs:+1:14: +1:21
+        _1 = &_2;                        // scope 0 at $DIR/address-of.rs:+1:13: +1:21
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/address-of.rs:+1:9: +1:10
+        StorageLive(_3);                 // scope 1 at $DIR/address-of.rs:+2:9: +2:14
+        StorageLive(_4);                 // scope 1 at $DIR/address-of.rs:+2:22: +2:29
+        _4 = [const 0_i32; 10];          // scope 1 at $DIR/address-of.rs:+2:22: +2:29
+        _3 = &mut _4;                    // scope 1 at $DIR/address-of.rs:+2:17: +2:29
+        FakeRead(ForLet(None), _3);      // scope 1 at $DIR/address-of.rs:+2:9: +2:14
+        StorageLive(_5);                 // scope 2 at $DIR/address-of.rs:+4:5: +4:18
+        StorageLive(_6);                 // scope 2 at $DIR/address-of.rs:+4:5: +4:18
+        _6 = &raw const (*_1);           // scope 2 at $DIR/address-of.rs:+4:5: +4:6
+        AscribeUserType(_6, o, UserTypeProjection { base: UserType(0), projs: [] }); // scope 2 at $DIR/address-of.rs:+4:5: +4:18
+        _5 = _6;                         // scope 2 at $DIR/address-of.rs:+4:5: +4:18
+        StorageDead(_6);                 // scope 2 at $DIR/address-of.rs:+4:18: +4:19
+        StorageDead(_5);                 // scope 2 at $DIR/address-of.rs:+4:18: +4:19
+        StorageLive(_7);                 // scope 2 at $DIR/address-of.rs:+5:5: +5:26
+        _7 = &raw const (*_1);           // scope 2 at $DIR/address-of.rs:+5:5: +5:6
+        StorageDead(_7);                 // scope 2 at $DIR/address-of.rs:+5:26: +5:27
+        StorageLive(_8);                 // scope 2 at $DIR/address-of.rs:+6:5: +6:25
+        StorageLive(_9);                 // scope 2 at $DIR/address-of.rs:+6:5: +6:25
+        StorageLive(_10);                // scope 2 at $DIR/address-of.rs:+6:5: +6:6
+        _10 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:+6:5: +6:6
+        _9 = move _10 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 2 at $DIR/address-of.rs:+6:5: +6:6
+        StorageDead(_10);                // scope 2 at $DIR/address-of.rs:+6:5: +6:6
+        AscribeUserType(_9, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 2 at $DIR/address-of.rs:+6:5: +6:25
+        _8 = _9;                         // scope 2 at $DIR/address-of.rs:+6:5: +6:25
+        StorageDead(_9);                 // scope 2 at $DIR/address-of.rs:+6:25: +6:26
+        StorageDead(_8);                 // scope 2 at $DIR/address-of.rs:+6:25: +6:26
+        StorageLive(_11);                // scope 2 at $DIR/address-of.rs:+7:5: +7:22
+        StorageLive(_12);                // scope 2 at $DIR/address-of.rs:+7:5: +7:6
+        _12 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:+7:5: +7:6
+        _11 = move _12 as *const [i32] (Pointer(Unsize)); // scope 2 at $DIR/address-of.rs:+7:5: +7:6
+        StorageDead(_12);                // scope 2 at $DIR/address-of.rs:+7:5: +7:6
+        StorageDead(_11);                // scope 2 at $DIR/address-of.rs:+7:22: +7:23
+        StorageLive(_13);                // scope 2 at $DIR/address-of.rs:+8:5: +8:20
+        StorageLive(_14);                // scope 2 at $DIR/address-of.rs:+8:5: +8:6
+        _14 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:+8:5: +8:6
+        _13 = move _14 as *const i32 (Pointer(ArrayToPointer)); // scope 2 at $DIR/address-of.rs:+8:5: +8:20
+        StorageDead(_14);                // scope 2 at $DIR/address-of.rs:+8:19: +8:20
+        StorageDead(_13);                // scope 2 at $DIR/address-of.rs:+8:20: +8:21
+        StorageLive(_15);                // scope 2 at $DIR/address-of.rs:+10:9: +10:10
+        _15 = &raw const (*_1);          // scope 2 at $DIR/address-of.rs:+10:23: +10:24
+        FakeRead(ForLet(None), _15);     // scope 2 at $DIR/address-of.rs:+10:9: +10:10
+        AscribeUserType(_15, o, UserTypeProjection { base: UserType(3), projs: [] }); // scope 2 at $DIR/address-of.rs:+10:12: +10:20
+        StorageLive(_16);                // scope 3 at $DIR/address-of.rs:+11:9: +11:10
+        _16 = &raw const (*_1);          // scope 3 at $DIR/address-of.rs:+11:31: +11:32
+        FakeRead(ForLet(None), _16);     // scope 3 at $DIR/address-of.rs:+11:9: +11:10
+        AscribeUserType(_16, o, UserTypeProjection { base: UserType(5), projs: [] }); // scope 3 at $DIR/address-of.rs:+11:12: +11:28
+        StorageLive(_17);                // scope 4 at $DIR/address-of.rs:+12:9: +12:10
+        StorageLive(_18);                // scope 4 at $DIR/address-of.rs:+12:30: +12:31
+        _18 = &raw const (*_1);          // scope 4 at $DIR/address-of.rs:+12:30: +12:31
+        _17 = move _18 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 4 at $DIR/address-of.rs:+12:30: +12:31
+        StorageDead(_18);                // scope 4 at $DIR/address-of.rs:+12:30: +12:31
+        FakeRead(ForLet(None), _17);     // scope 4 at $DIR/address-of.rs:+12:9: +12:10
+        AscribeUserType(_17, o, UserTypeProjection { base: UserType(7), projs: [] }); // scope 4 at $DIR/address-of.rs:+12:12: +12:27
+        StorageLive(_19);                // scope 5 at $DIR/address-of.rs:+13:9: +13:10
+        StorageLive(_20);                // scope 5 at $DIR/address-of.rs:+13:27: +13:28
+        _20 = &raw const (*_1);          // scope 5 at $DIR/address-of.rs:+13:27: +13:28
+        _19 = move _20 as *const [i32] (Pointer(Unsize)); // scope 5 at $DIR/address-of.rs:+13:27: +13:28
+        StorageDead(_20);                // scope 5 at $DIR/address-of.rs:+13:27: +13:28
+        FakeRead(ForLet(None), _19);     // scope 5 at $DIR/address-of.rs:+13:9: +13:10
+        AscribeUserType(_19, o, UserTypeProjection { base: UserType(9), projs: [] }); // scope 5 at $DIR/address-of.rs:+13:12: +13:24
+        StorageLive(_21);                // scope 6 at $DIR/address-of.rs:+15:5: +15:18
+        StorageLive(_22);                // scope 6 at $DIR/address-of.rs:+15:5: +15:18
+        _22 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:+15:5: +15:6
+        AscribeUserType(_22, o, UserTypeProjection { base: UserType(10), projs: [] }); // scope 6 at $DIR/address-of.rs:+15:5: +15:18
+        _21 = _22;                       // scope 6 at $DIR/address-of.rs:+15:5: +15:18
+        StorageDead(_22);                // scope 6 at $DIR/address-of.rs:+15:18: +15:19
+        StorageDead(_21);                // scope 6 at $DIR/address-of.rs:+15:18: +15:19
+        StorageLive(_23);                // scope 6 at $DIR/address-of.rs:+16:5: +16:26
+        _23 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:+16:5: +16:6
+        StorageDead(_23);                // scope 6 at $DIR/address-of.rs:+16:26: +16:27
+        StorageLive(_24);                // scope 6 at $DIR/address-of.rs:+17:5: +17:25
+        StorageLive(_25);                // scope 6 at $DIR/address-of.rs:+17:5: +17:25
+        StorageLive(_26);                // scope 6 at $DIR/address-of.rs:+17:5: +17:6
+        _26 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:+17:5: +17:6
+        _25 = move _26 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 6 at $DIR/address-of.rs:+17:5: +17:6
+        StorageDead(_26);                // scope 6 at $DIR/address-of.rs:+17:5: +17:6
+        AscribeUserType(_25, o, UserTypeProjection { base: UserType(11), projs: [] }); // scope 6 at $DIR/address-of.rs:+17:5: +17:25
+        _24 = _25;                       // scope 6 at $DIR/address-of.rs:+17:5: +17:25
+        StorageDead(_25);                // scope 6 at $DIR/address-of.rs:+17:25: +17:26
+        StorageDead(_24);                // scope 6 at $DIR/address-of.rs:+17:25: +17:26
+        StorageLive(_27);                // scope 6 at $DIR/address-of.rs:+18:5: +18:22
+        StorageLive(_28);                // scope 6 at $DIR/address-of.rs:+18:5: +18:6
+        _28 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:+18:5: +18:6
+        _27 = move _28 as *const [i32] (Pointer(Unsize)); // scope 6 at $DIR/address-of.rs:+18:5: +18:6
+        StorageDead(_28);                // scope 6 at $DIR/address-of.rs:+18:5: +18:6
+        StorageDead(_27);                // scope 6 at $DIR/address-of.rs:+18:22: +18:23
+        StorageLive(_29);                // scope 6 at $DIR/address-of.rs:+20:9: +20:10
+        _29 = &raw const (*_3);          // scope 6 at $DIR/address-of.rs:+20:23: +20:24
+        FakeRead(ForLet(None), _29);     // scope 6 at $DIR/address-of.rs:+20:9: +20:10
+        AscribeUserType(_29, o, UserTypeProjection { base: UserType(13), projs: [] }); // scope 6 at $DIR/address-of.rs:+20:12: +20:20
+        StorageLive(_30);                // scope 7 at $DIR/address-of.rs:+21:9: +21:10
+        _30 = &raw const (*_3);          // scope 7 at $DIR/address-of.rs:+21:31: +21:32
+        FakeRead(ForLet(None), _30);     // scope 7 at $DIR/address-of.rs:+21:9: +21:10
+        AscribeUserType(_30, o, UserTypeProjection { base: UserType(15), projs: [] }); // scope 7 at $DIR/address-of.rs:+21:12: +21:28
+        StorageLive(_31);                // scope 8 at $DIR/address-of.rs:+22:9: +22:10
+        StorageLive(_32);                // scope 8 at $DIR/address-of.rs:+22:30: +22:31
+        _32 = &raw const (*_3);          // scope 8 at $DIR/address-of.rs:+22:30: +22:31
+        _31 = move _32 as *const dyn std::marker::Send (Pointer(Unsize)); // scope 8 at $DIR/address-of.rs:+22:30: +22:31
+        StorageDead(_32);                // scope 8 at $DIR/address-of.rs:+22:30: +22:31
+        FakeRead(ForLet(None), _31);     // scope 8 at $DIR/address-of.rs:+22:9: +22:10
+        AscribeUserType(_31, o, UserTypeProjection { base: UserType(17), projs: [] }); // scope 8 at $DIR/address-of.rs:+22:12: +22:27
+        StorageLive(_33);                // scope 9 at $DIR/address-of.rs:+23:9: +23:10
+        StorageLive(_34);                // scope 9 at $DIR/address-of.rs:+23:27: +23:28
+        _34 = &raw const (*_3);          // scope 9 at $DIR/address-of.rs:+23:27: +23:28
+        _33 = move _34 as *const [i32] (Pointer(Unsize)); // scope 9 at $DIR/address-of.rs:+23:27: +23:28
+        StorageDead(_34);                // scope 9 at $DIR/address-of.rs:+23:27: +23:28
+        FakeRead(ForLet(None), _33);     // scope 9 at $DIR/address-of.rs:+23:9: +23:10
+        AscribeUserType(_33, o, UserTypeProjection { base: UserType(19), projs: [] }); // scope 9 at $DIR/address-of.rs:+23:12: +23:24
+        StorageLive(_35);                // scope 10 at $DIR/address-of.rs:+25:5: +25:16
+        StorageLive(_36);                // scope 10 at $DIR/address-of.rs:+25:5: +25:16
+        _36 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:+25:5: +25:6
+        AscribeUserType(_36, o, UserTypeProjection { base: UserType(20), projs: [] }); // scope 10 at $DIR/address-of.rs:+25:5: +25:16
+        _35 = _36;                       // scope 10 at $DIR/address-of.rs:+25:5: +25:16
+        StorageDead(_36);                // scope 10 at $DIR/address-of.rs:+25:16: +25:17
+        StorageDead(_35);                // scope 10 at $DIR/address-of.rs:+25:16: +25:17
+        StorageLive(_37);                // scope 10 at $DIR/address-of.rs:+26:5: +26:24
+        _37 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:+26:5: +26:6
+        StorageDead(_37);                // scope 10 at $DIR/address-of.rs:+26:24: +26:25
+        StorageLive(_38);                // scope 10 at $DIR/address-of.rs:+27:5: +27:23
+        StorageLive(_39);                // scope 10 at $DIR/address-of.rs:+27:5: +27:23
+        StorageLive(_40);                // scope 10 at $DIR/address-of.rs:+27:5: +27:6
+        _40 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:+27:5: +27:6
+        _39 = move _40 as *mut dyn std::marker::Send (Pointer(Unsize)); // scope 10 at $DIR/address-of.rs:+27:5: +27:6
+        StorageDead(_40);                // scope 10 at $DIR/address-of.rs:+27:5: +27:6
+        AscribeUserType(_39, o, UserTypeProjection { base: UserType(21), projs: [] }); // scope 10 at $DIR/address-of.rs:+27:5: +27:23
+        _38 = _39;                       // scope 10 at $DIR/address-of.rs:+27:5: +27:23
+        StorageDead(_39);                // scope 10 at $DIR/address-of.rs:+27:23: +27:24
+        StorageDead(_38);                // scope 10 at $DIR/address-of.rs:+27:23: +27:24
+        StorageLive(_41);                // scope 10 at $DIR/address-of.rs:+28:5: +28:20
+        StorageLive(_42);                // scope 10 at $DIR/address-of.rs:+28:5: +28:6
+        _42 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:+28:5: +28:6
+        _41 = move _42 as *mut [i32] (Pointer(Unsize)); // scope 10 at $DIR/address-of.rs:+28:5: +28:6
+        StorageDead(_42);                // scope 10 at $DIR/address-of.rs:+28:5: +28:6
+        StorageDead(_41);                // scope 10 at $DIR/address-of.rs:+28:20: +28:21
+        StorageLive(_43);                // scope 10 at $DIR/address-of.rs:+30:9: +30:10
+        _43 = &raw mut (*_3);            // scope 10 at $DIR/address-of.rs:+30:21: +30:22
+        FakeRead(ForLet(None), _43);     // scope 10 at $DIR/address-of.rs:+30:9: +30:10
+        AscribeUserType(_43, o, UserTypeProjection { base: UserType(23), projs: [] }); // scope 10 at $DIR/address-of.rs:+30:12: +30:18
+        StorageLive(_44);                // scope 11 at $DIR/address-of.rs:+31:9: +31:10
+        _44 = &raw mut (*_3);            // scope 11 at $DIR/address-of.rs:+31:29: +31:30
+        FakeRead(ForLet(None), _44);     // scope 11 at $DIR/address-of.rs:+31:9: +31:10
+        AscribeUserType(_44, o, UserTypeProjection { base: UserType(25), projs: [] }); // scope 11 at $DIR/address-of.rs:+31:12: +31:26
+        StorageLive(_45);                // scope 12 at $DIR/address-of.rs:+32:9: +32:10
+        StorageLive(_46);                // scope 12 at $DIR/address-of.rs:+32:28: +32:29
+        _46 = &raw mut (*_3);            // scope 12 at $DIR/address-of.rs:+32:28: +32:29
+        _45 = move _46 as *mut dyn std::marker::Send (Pointer(Unsize)); // scope 12 at $DIR/address-of.rs:+32:28: +32:29
+        StorageDead(_46);                // scope 12 at $DIR/address-of.rs:+32:28: +32:29
+        FakeRead(ForLet(None), _45);     // scope 12 at $DIR/address-of.rs:+32:9: +32:10
+        AscribeUserType(_45, o, UserTypeProjection { base: UserType(27), projs: [] }); // scope 12 at $DIR/address-of.rs:+32:12: +32:25
+        StorageLive(_47);                // scope 13 at $DIR/address-of.rs:+33:9: +33:10
+        StorageLive(_48);                // scope 13 at $DIR/address-of.rs:+33:25: +33:26
+        _48 = &raw mut (*_3);            // scope 13 at $DIR/address-of.rs:+33:25: +33:26
+        _47 = move _48 as *mut [i32] (Pointer(Unsize)); // scope 13 at $DIR/address-of.rs:+33:25: +33:26
+        StorageDead(_48);                // scope 13 at $DIR/address-of.rs:+33:25: +33:26
+        FakeRead(ForLet(None), _47);     // scope 13 at $DIR/address-of.rs:+33:9: +33:10
+        AscribeUserType(_47, o, UserTypeProjection { base: UserType(29), projs: [] }); // scope 13 at $DIR/address-of.rs:+33:12: +33:22
+        _0 = const ();                   // scope 0 at $DIR/address-of.rs:+0:26: +34:2
+        StorageDead(_47);                // scope 13 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_45);                // scope 12 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_44);                // scope 11 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_43);                // scope 10 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_33);                // scope 9 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_31);                // scope 8 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_30);                // scope 7 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_29);                // scope 6 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_19);                // scope 5 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_17);                // scope 4 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_16);                // scope 3 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_15);                // scope 2 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_4);                 // scope 1 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_3);                 // scope 1 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_2);                 // scope 0 at $DIR/address-of.rs:+34:1: +34:2
+        StorageDead(_1);                 // scope 0 at $DIR/address-of.rs:+34:1: +34:2
+        return;                          // scope 0 at $DIR/address-of.rs:+34:2: +34:2
     }
 }

--- a/src/test/mir-opt/address_of.borrow_and_cast.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/address_of.borrow_and_cast.SimplifyCfg-initial.after.mir
@@ -1,47 +1,47 @@
 // MIR for `borrow_and_cast` after SimplifyCfg-initial
 
 fn borrow_and_cast(_1: i32) -> () {
-    debug x => _1;                       // in scope 0 at $DIR/address-of.rs:41:20: 41:25
-    let mut _0: ();                      // return place in scope 0 at $DIR/address-of.rs:41:32: 41:32
-    let _2: *const i32;                  // in scope 0 at $DIR/address-of.rs:42:9: 42:10
-    let _3: &i32;                        // in scope 0 at $DIR/address-of.rs:42:13: 42:15
-    let _5: &mut i32;                    // in scope 0 at $DIR/address-of.rs:43:13: 43:19
-    let mut _7: &mut i32;                // in scope 0 at $DIR/address-of.rs:44:13: 44:19
+    debug x => _1;                       // in scope 0 at $DIR/address-of.rs:+0:20: +0:25
+    let mut _0: ();                      // return place in scope 0 at $DIR/address-of.rs:+0:32: +0:32
+    let _2: *const i32;                  // in scope 0 at $DIR/address-of.rs:+1:9: +1:10
+    let _3: &i32;                        // in scope 0 at $DIR/address-of.rs:+1:13: +1:15
+    let _5: &mut i32;                    // in scope 0 at $DIR/address-of.rs:+2:13: +2:19
+    let mut _7: &mut i32;                // in scope 0 at $DIR/address-of.rs:+3:13: +3:19
     scope 1 {
-        debug p => _2;                   // in scope 1 at $DIR/address-of.rs:42:9: 42:10
-        let _4: *const i32;              // in scope 1 at $DIR/address-of.rs:43:9: 43:10
+        debug p => _2;                   // in scope 1 at $DIR/address-of.rs:+1:9: +1:10
+        let _4: *const i32;              // in scope 1 at $DIR/address-of.rs:+2:9: +2:10
         scope 2 {
-            debug q => _4;               // in scope 2 at $DIR/address-of.rs:43:9: 43:10
-            let _6: *mut i32;            // in scope 2 at $DIR/address-of.rs:44:9: 44:10
+            debug q => _4;               // in scope 2 at $DIR/address-of.rs:+2:9: +2:10
+            let _6: *mut i32;            // in scope 2 at $DIR/address-of.rs:+3:9: +3:10
             scope 3 {
-                debug r => _6;           // in scope 3 at $DIR/address-of.rs:44:9: 44:10
+                debug r => _6;           // in scope 3 at $DIR/address-of.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/address-of.rs:42:9: 42:10
-        StorageLive(_3);                 // scope 0 at $DIR/address-of.rs:42:13: 42:15
-        _3 = &_1;                        // scope 0 at $DIR/address-of.rs:42:13: 42:15
-        _2 = &raw const (*_3);           // scope 0 at $DIR/address-of.rs:42:13: 42:15
-        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/address-of.rs:42:9: 42:10
-        StorageDead(_3);                 // scope 0 at $DIR/address-of.rs:42:29: 42:30
-        StorageLive(_4);                 // scope 1 at $DIR/address-of.rs:43:9: 43:10
-        StorageLive(_5);                 // scope 1 at $DIR/address-of.rs:43:13: 43:19
-        _5 = &mut _1;                    // scope 1 at $DIR/address-of.rs:43:13: 43:19
-        _4 = &raw const (*_5);           // scope 1 at $DIR/address-of.rs:43:13: 43:19
-        FakeRead(ForLet(None), _4);      // scope 1 at $DIR/address-of.rs:43:9: 43:10
-        StorageDead(_5);                 // scope 1 at $DIR/address-of.rs:43:33: 43:34
-        StorageLive(_6);                 // scope 2 at $DIR/address-of.rs:44:9: 44:10
-        StorageLive(_7);                 // scope 2 at $DIR/address-of.rs:44:13: 44:19
-        _7 = &mut _1;                    // scope 2 at $DIR/address-of.rs:44:13: 44:19
-        _6 = &raw mut (*_7);             // scope 2 at $DIR/address-of.rs:44:13: 44:19
-        FakeRead(ForLet(None), _6);      // scope 2 at $DIR/address-of.rs:44:9: 44:10
-        StorageDead(_7);                 // scope 2 at $DIR/address-of.rs:44:31: 44:32
-        _0 = const ();                   // scope 0 at $DIR/address-of.rs:41:32: 45:2
-        StorageDead(_6);                 // scope 2 at $DIR/address-of.rs:45:1: 45:2
-        StorageDead(_4);                 // scope 1 at $DIR/address-of.rs:45:1: 45:2
-        StorageDead(_2);                 // scope 0 at $DIR/address-of.rs:45:1: 45:2
-        return;                          // scope 0 at $DIR/address-of.rs:45:2: 45:2
+        StorageLive(_2);                 // scope 0 at $DIR/address-of.rs:+1:9: +1:10
+        StorageLive(_3);                 // scope 0 at $DIR/address-of.rs:+1:13: +1:15
+        _3 = &_1;                        // scope 0 at $DIR/address-of.rs:+1:13: +1:15
+        _2 = &raw const (*_3);           // scope 0 at $DIR/address-of.rs:+1:13: +1:15
+        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/address-of.rs:+1:9: +1:10
+        StorageDead(_3);                 // scope 0 at $DIR/address-of.rs:+1:29: +1:30
+        StorageLive(_4);                 // scope 1 at $DIR/address-of.rs:+2:9: +2:10
+        StorageLive(_5);                 // scope 1 at $DIR/address-of.rs:+2:13: +2:19
+        _5 = &mut _1;                    // scope 1 at $DIR/address-of.rs:+2:13: +2:19
+        _4 = &raw const (*_5);           // scope 1 at $DIR/address-of.rs:+2:13: +2:19
+        FakeRead(ForLet(None), _4);      // scope 1 at $DIR/address-of.rs:+2:9: +2:10
+        StorageDead(_5);                 // scope 1 at $DIR/address-of.rs:+2:33: +2:34
+        StorageLive(_6);                 // scope 2 at $DIR/address-of.rs:+3:9: +3:10
+        StorageLive(_7);                 // scope 2 at $DIR/address-of.rs:+3:13: +3:19
+        _7 = &mut _1;                    // scope 2 at $DIR/address-of.rs:+3:13: +3:19
+        _6 = &raw mut (*_7);             // scope 2 at $DIR/address-of.rs:+3:13: +3:19
+        FakeRead(ForLet(None), _6);      // scope 2 at $DIR/address-of.rs:+3:9: +3:10
+        StorageDead(_7);                 // scope 2 at $DIR/address-of.rs:+3:31: +3:32
+        _0 = const ();                   // scope 0 at $DIR/address-of.rs:+0:32: +4:2
+        StorageDead(_6);                 // scope 2 at $DIR/address-of.rs:+4:1: +4:2
+        StorageDead(_4);                 // scope 1 at $DIR/address-of.rs:+4:1: +4:2
+        StorageDead(_2);                 // scope 0 at $DIR/address-of.rs:+4:1: +4:2
+        return;                          // scope 0 at $DIR/address-of.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.32bit.mir
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.32bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after SimplifyCfg-elaborate-drops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/array-index-is-temporary.rs:12:11: 12:11
-    let mut _1: [u32; 3];                // in scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-    let mut _4: &mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-    let mut _5: u32;                     // in scope 0 at $DIR/array-index-is-temporary.rs:16:12: 16:29
-    let mut _6: *mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:16:25: 16:26
-    let _7: usize;                       // in scope 0 at $DIR/array-index-is-temporary.rs:16:7: 16:8
-    let mut _8: usize;                   // in scope 0 at $DIR/array-index-is-temporary.rs:16:5: 16:9
-    let mut _9: bool;                    // in scope 0 at $DIR/array-index-is-temporary.rs:16:5: 16:9
+    let mut _0: ();                      // return place in scope 0 at $DIR/array-index-is-temporary.rs:+0:11: +0:11
+    let mut _1: [u32; 3];                // in scope 0 at $DIR/array-index-is-temporary.rs:+1:9: +1:14
+    let mut _4: &mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+    let mut _5: u32;                     // in scope 0 at $DIR/array-index-is-temporary.rs:+4:12: +4:29
+    let mut _6: *mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:+4:25: +4:26
+    let _7: usize;                       // in scope 0 at $DIR/array-index-is-temporary.rs:+4:7: +4:8
+    let mut _8: usize;                   // in scope 0 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
+    let mut _9: bool;                    // in scope 0 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-        let mut _2: usize;               // in scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
+        debug x => _1;                   // in scope 1 at $DIR/array-index-is-temporary.rs:+1:9: +1:14
+        let mut _2: usize;               // in scope 1 at $DIR/array-index-is-temporary.rs:+2:9: +2:14
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/array-index-is-temporary.rs:14:9: 14:14
-            let _3: *mut usize;          // in scope 2 at $DIR/array-index-is-temporary.rs:15:9: 15:10
+            debug y => _2;               // in scope 2 at $DIR/array-index-is-temporary.rs:+2:9: +2:14
+            let _3: *mut usize;          // in scope 2 at $DIR/array-index-is-temporary.rs:+3:9: +3:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/array-index-is-temporary.rs:15:9: 15:10
+                debug z => _3;           // in scope 3 at $DIR/array-index-is-temporary.rs:+3:9: +3:10
                 scope 4 {
                 }
             }
@@ -24,41 +24,41 @@ fn main() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-        _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
-        StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
-        _2 = const 1_usize;              // scope 1 at $DIR/array-index-is-temporary.rs:14:17: 14:18
-        StorageLive(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:15:9: 15:10
-        StorageLive(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-        _4 = &mut _2;                    // scope 2 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-        _3 = &raw mut (*_4);             // scope 2 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-        StorageDead(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:15:31: 15:32
-        StorageLive(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:12: 16:29
-        StorageLive(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
-        _6 = _3;                         // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
-        _5 = foo(move _6) -> bb1;        // scope 4 at $DIR/array-index-is-temporary.rs:16:21: 16:27
+        StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:+1:9: +1:14
+        _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:+1:17: +1:29
+        StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:+2:9: +2:14
+        _2 = const 1_usize;              // scope 1 at $DIR/array-index-is-temporary.rs:+2:17: +2:18
+        StorageLive(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:+3:9: +3:10
+        StorageLive(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+        _4 = &mut _2;                    // scope 2 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+        _3 = &raw mut (*_4);             // scope 2 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+        StorageDead(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:+3:31: +3:32
+        StorageLive(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:12: +4:29
+        StorageLive(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:+4:25: +4:26
+        _6 = _3;                         // scope 4 at $DIR/array-index-is-temporary.rs:+4:25: +4:26
+        _5 = foo(move _6) -> bb1;        // scope 4 at $DIR/array-index-is-temporary.rs:+4:21: +4:27
                                          // mir::Constant
                                          // + span: $DIR/array-index-is-temporary.rs:16:21: 16:24
                                          // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:26: 16:27
-        StorageLive(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
-        _7 = _2;                         // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
-        _8 = Len(_1);                    // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
-        _9 = Lt(_7, _8);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
-        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
+        StorageDead(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:+4:26: +4:27
+        StorageLive(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:7: +4:8
+        _7 = _2;                         // scope 3 at $DIR/array-index-is-temporary.rs:+4:7: +4:8
+        _8 = Len(_1);                    // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
+        _9 = Lt(_7, _8);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
+        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
     }
 
     bb2: {
-        _1[_7] = move _5;                // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:29
-        StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:28: 16:29
-        StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:29: 16:30
-        _0 = const ();                   // scope 0 at $DIR/array-index-is-temporary.rs:12:11: 17:2
-        StorageDead(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:17:1: 17:2
-        StorageDead(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:17:1: 17:2
-        StorageDead(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:17:1: 17:2
-        return;                          // scope 0 at $DIR/array-index-is-temporary.rs:17:2: 17:2
+        _1[_7] = move _5;                // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:29
+        StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:28: +4:29
+        StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:29: +4:30
+        _0 = const ();                   // scope 0 at $DIR/array-index-is-temporary.rs:+0:11: +5:2
+        StorageDead(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:+5:1: +5:2
+        StorageDead(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:+5:1: +5:2
+        StorageDead(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/array-index-is-temporary.rs:+5:2: +5:2
     }
 }

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after SimplifyCfg-elaborate-drops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/array-index-is-temporary.rs:12:11: 12:11
-    let mut _1: [u32; 3];                // in scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-    let mut _4: &mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-    let mut _5: u32;                     // in scope 0 at $DIR/array-index-is-temporary.rs:16:12: 16:29
-    let mut _6: *mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:16:25: 16:26
-    let _7: usize;                       // in scope 0 at $DIR/array-index-is-temporary.rs:16:7: 16:8
-    let mut _8: usize;                   // in scope 0 at $DIR/array-index-is-temporary.rs:16:5: 16:9
-    let mut _9: bool;                    // in scope 0 at $DIR/array-index-is-temporary.rs:16:5: 16:9
+    let mut _0: ();                      // return place in scope 0 at $DIR/array-index-is-temporary.rs:+0:11: +0:11
+    let mut _1: [u32; 3];                // in scope 0 at $DIR/array-index-is-temporary.rs:+1:9: +1:14
+    let mut _4: &mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+    let mut _5: u32;                     // in scope 0 at $DIR/array-index-is-temporary.rs:+4:12: +4:29
+    let mut _6: *mut usize;              // in scope 0 at $DIR/array-index-is-temporary.rs:+4:25: +4:26
+    let _7: usize;                       // in scope 0 at $DIR/array-index-is-temporary.rs:+4:7: +4:8
+    let mut _8: usize;                   // in scope 0 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
+    let mut _9: bool;                    // in scope 0 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-        let mut _2: usize;               // in scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
+        debug x => _1;                   // in scope 1 at $DIR/array-index-is-temporary.rs:+1:9: +1:14
+        let mut _2: usize;               // in scope 1 at $DIR/array-index-is-temporary.rs:+2:9: +2:14
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/array-index-is-temporary.rs:14:9: 14:14
-            let _3: *mut usize;          // in scope 2 at $DIR/array-index-is-temporary.rs:15:9: 15:10
+            debug y => _2;               // in scope 2 at $DIR/array-index-is-temporary.rs:+2:9: +2:14
+            let _3: *mut usize;          // in scope 2 at $DIR/array-index-is-temporary.rs:+3:9: +3:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/array-index-is-temporary.rs:15:9: 15:10
+                debug z => _3;           // in scope 3 at $DIR/array-index-is-temporary.rs:+3:9: +3:10
                 scope 4 {
                 }
             }
@@ -24,41 +24,41 @@ fn main() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-        _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
-        StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
-        _2 = const 1_usize;              // scope 1 at $DIR/array-index-is-temporary.rs:14:17: 14:18
-        StorageLive(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:15:9: 15:10
-        StorageLive(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-        _4 = &mut _2;                    // scope 2 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-        _3 = &raw mut (*_4);             // scope 2 at $DIR/array-index-is-temporary.rs:15:25: 15:31
-        StorageDead(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:15:31: 15:32
-        StorageLive(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:12: 16:29
-        StorageLive(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
-        _6 = _3;                         // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
-        _5 = foo(move _6) -> bb1;        // scope 4 at $DIR/array-index-is-temporary.rs:16:21: 16:27
+        StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:+1:9: +1:14
+        _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:+1:17: +1:29
+        StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:+2:9: +2:14
+        _2 = const 1_usize;              // scope 1 at $DIR/array-index-is-temporary.rs:+2:17: +2:18
+        StorageLive(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:+3:9: +3:10
+        StorageLive(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+        _4 = &mut _2;                    // scope 2 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+        _3 = &raw mut (*_4);             // scope 2 at $DIR/array-index-is-temporary.rs:+3:25: +3:31
+        StorageDead(_4);                 // scope 2 at $DIR/array-index-is-temporary.rs:+3:31: +3:32
+        StorageLive(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:12: +4:29
+        StorageLive(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:+4:25: +4:26
+        _6 = _3;                         // scope 4 at $DIR/array-index-is-temporary.rs:+4:25: +4:26
+        _5 = foo(move _6) -> bb1;        // scope 4 at $DIR/array-index-is-temporary.rs:+4:21: +4:27
                                          // mir::Constant
                                          // + span: $DIR/array-index-is-temporary.rs:16:21: 16:24
                                          // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:26: 16:27
-        StorageLive(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
-        _7 = _2;                         // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
-        _8 = Len(_1);                    // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
-        _9 = Lt(_7, _8);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
-        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
+        StorageDead(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:+4:26: +4:27
+        StorageLive(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:7: +4:8
+        _7 = _2;                         // scope 3 at $DIR/array-index-is-temporary.rs:+4:7: +4:8
+        _8 = Len(_1);                    // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
+        _9 = Lt(_7, _8);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
+        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:9
     }
 
     bb2: {
-        _1[_7] = move _5;                // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:29
-        StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:28: 16:29
-        StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:29: 16:30
-        _0 = const ();                   // scope 0 at $DIR/array-index-is-temporary.rs:12:11: 17:2
-        StorageDead(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:17:1: 17:2
-        StorageDead(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:17:1: 17:2
-        StorageDead(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:17:1: 17:2
-        return;                          // scope 0 at $DIR/array-index-is-temporary.rs:17:2: 17:2
+        _1[_7] = move _5;                // scope 3 at $DIR/array-index-is-temporary.rs:+4:5: +4:29
+        StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:28: +4:29
+        StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:+4:29: +4:30
+        _0 = const ();                   // scope 0 at $DIR/array-index-is-temporary.rs:+0:11: +5:2
+        StorageDead(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:+5:1: +5:2
+        StorageDead(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:+5:1: +5:2
+        StorageDead(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/array-index-is-temporary.rs:+5:2: +5:2
     }
 }

--- a/src/test/mir-opt/asm_unwind_panic_abort.main.AbortUnwindingCalls.after.mir
+++ b/src/test/mir-opt/asm_unwind_panic_abort.main.AbortUnwindingCalls.after.mir
@@ -1,24 +1,24 @@
 // MIR for `main` after AbortUnwindingCalls
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/asm_unwind_panic_abort.rs:12:11: 12:11
-    let _1: ();                          // in scope 0 at $DIR/asm_unwind_panic_abort.rs:14:9: 14:49
+    let mut _0: ();                      // return place in scope 0 at $DIR/asm_unwind_panic_abort.rs:+0:11: +0:11
+    let _1: ();                          // in scope 0 at $DIR/asm_unwind_panic_abort.rs:+2:9: +2:49
     scope 1 {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 1 at $DIR/asm_unwind_panic_abort.rs:14:9: 14:49
-        _1 = const ();                   // scope 1 at $DIR/asm_unwind_panic_abort.rs:14:9: 14:49
-        asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind: bb2]; // scope 1 at $DIR/asm_unwind_panic_abort.rs:14:9: 14:49
+        StorageLive(_1);                 // scope 1 at $DIR/asm_unwind_panic_abort.rs:+2:9: +2:49
+        _1 = const ();                   // scope 1 at $DIR/asm_unwind_panic_abort.rs:+2:9: +2:49
+        asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind: bb2]; // scope 1 at $DIR/asm_unwind_panic_abort.rs:+2:9: +2:49
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 1 at $DIR/asm_unwind_panic_abort.rs:14:48: 14:49
-        _0 = const ();                   // scope 1 at $DIR/asm_unwind_panic_abort.rs:13:5: 15:6
-        return;                          // scope 0 at $DIR/asm_unwind_panic_abort.rs:16:2: 16:2
+        StorageDead(_1);                 // scope 1 at $DIR/asm_unwind_panic_abort.rs:+2:48: +2:49
+        _0 = const ();                   // scope 1 at $DIR/asm_unwind_panic_abort.rs:+1:5: +3:6
+        return;                          // scope 0 at $DIR/asm_unwind_panic_abort.rs:+4:2: +4:2
     }
 
     bb2 (cleanup): {
-        abort;                           // scope 0 at $DIR/asm_unwind_panic_abort.rs:12:1: 16:2
+        abort;                           // scope 0 at $DIR/asm_unwind_panic_abort.rs:+0:1: +4:2
     }
 }

--- a/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
@@ -5,80 +5,80 @@
 | 1: user_ty: Canonical { max_universe: U0, variables: [], value: Ty(std::option::Option<std::boxed::Box<u32>>) }, span: $DIR/basic_assignment.rs:18:17: 18:33, inferred_ty: std::option::Option<std::boxed::Box<u32>>
 |
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/basic_assignment.rs:10:11: 10:11
-    let _1: bool;                        // in scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
-    let mut _3: bool;                    // in scope 0 at $DIR/basic_assignment.rs:16:16: 16:24
-    let mut _6: std::option::Option<std::boxed::Box<u32>>; // in scope 0 at $DIR/basic_assignment.rs:23:14: 23:20
+    let mut _0: ();                      // return place in scope 0 at $DIR/basic_assignment.rs:+0:11: +0:11
+    let _1: bool;                        // in scope 0 at $DIR/basic_assignment.rs:+1:9: +1:17
+    let mut _3: bool;                    // in scope 0 at $DIR/basic_assignment.rs:+6:16: +6:24
+    let mut _6: std::option::Option<std::boxed::Box<u32>>; // in scope 0 at $DIR/basic_assignment.rs:+13:14: +13:20
     scope 1 {
-        debug nodrop_x => _1;            // in scope 1 at $DIR/basic_assignment.rs:11:9: 11:17
-        let _2: bool;                    // in scope 1 at $DIR/basic_assignment.rs:12:9: 12:17
+        debug nodrop_x => _1;            // in scope 1 at $DIR/basic_assignment.rs:+1:9: +1:17
+        let _2: bool;                    // in scope 1 at $DIR/basic_assignment.rs:+2:9: +2:17
         scope 2 {
-            debug nodrop_y => _2;        // in scope 2 at $DIR/basic_assignment.rs:12:9: 12:17
-            let _4: std::option::Option<std::boxed::Box<u32>> as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 2 at $DIR/basic_assignment.rs:18:9: 18:15
+            debug nodrop_y => _2;        // in scope 2 at $DIR/basic_assignment.rs:+2:9: +2:17
+            let _4: std::option::Option<std::boxed::Box<u32>> as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 2 at $DIR/basic_assignment.rs:+8:9: +8:15
             scope 3 {
-                debug drop_x => _4;      // in scope 3 at $DIR/basic_assignment.rs:18:9: 18:15
-                let _5: std::option::Option<std::boxed::Box<u32>>; // in scope 3 at $DIR/basic_assignment.rs:19:9: 19:15
+                debug drop_x => _4;      // in scope 3 at $DIR/basic_assignment.rs:+8:9: +8:15
+                let _5: std::option::Option<std::boxed::Box<u32>>; // in scope 3 at $DIR/basic_assignment.rs:+9:9: +9:15
                 scope 4 {
-                    debug drop_y => _5;  // in scope 4 at $DIR/basic_assignment.rs:19:9: 19:15
+                    debug drop_y => _5;  // in scope 4 at $DIR/basic_assignment.rs:+9:9: +9:15
                 }
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
-        _1 = const false;                // scope 0 at $DIR/basic_assignment.rs:11:20: 11:25
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
-        StorageLive(_2);                 // scope 1 at $DIR/basic_assignment.rs:12:9: 12:17
-        StorageLive(_3);                 // scope 2 at $DIR/basic_assignment.rs:16:16: 16:24
-        _3 = _1;                         // scope 2 at $DIR/basic_assignment.rs:16:16: 16:24
-        _2 = move _3;                    // scope 2 at $DIR/basic_assignment.rs:16:5: 16:24
-        StorageDead(_3);                 // scope 2 at $DIR/basic_assignment.rs:16:23: 16:24
-        StorageLive(_4);                 // scope 2 at $DIR/basic_assignment.rs:18:9: 18:15
-        _4 = Option::<Box<u32>>::None;   // scope 2 at $DIR/basic_assignment.rs:18:36: 18:40
-        FakeRead(ForLet(None), _4);      // scope 2 at $DIR/basic_assignment.rs:18:9: 18:15
-        AscribeUserType(_4, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 2 at $DIR/basic_assignment.rs:18:17: 18:33
-        StorageLive(_5);                 // scope 3 at $DIR/basic_assignment.rs:19:9: 19:15
-        StorageLive(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
-        _6 = move _4;                    // scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
-        replace(_5 <- move _6) -> [return: bb1, unwind: bb5]; // scope 4 at $DIR/basic_assignment.rs:23:5: 23:11
+        StorageLive(_1);                 // scope 0 at $DIR/basic_assignment.rs:+1:9: +1:17
+        _1 = const false;                // scope 0 at $DIR/basic_assignment.rs:+1:20: +1:25
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/basic_assignment.rs:+1:9: +1:17
+        StorageLive(_2);                 // scope 1 at $DIR/basic_assignment.rs:+2:9: +2:17
+        StorageLive(_3);                 // scope 2 at $DIR/basic_assignment.rs:+6:16: +6:24
+        _3 = _1;                         // scope 2 at $DIR/basic_assignment.rs:+6:16: +6:24
+        _2 = move _3;                    // scope 2 at $DIR/basic_assignment.rs:+6:5: +6:24
+        StorageDead(_3);                 // scope 2 at $DIR/basic_assignment.rs:+6:23: +6:24
+        StorageLive(_4);                 // scope 2 at $DIR/basic_assignment.rs:+8:9: +8:15
+        _4 = Option::<Box<u32>>::None;   // scope 2 at $DIR/basic_assignment.rs:+8:36: +8:40
+        FakeRead(ForLet(None), _4);      // scope 2 at $DIR/basic_assignment.rs:+8:9: +8:15
+        AscribeUserType(_4, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 2 at $DIR/basic_assignment.rs:+8:17: +8:33
+        StorageLive(_5);                 // scope 3 at $DIR/basic_assignment.rs:+9:9: +9:15
+        StorageLive(_6);                 // scope 4 at $DIR/basic_assignment.rs:+13:14: +13:20
+        _6 = move _4;                    // scope 4 at $DIR/basic_assignment.rs:+13:14: +13:20
+        replace(_5 <- move _6) -> [return: bb1, unwind: bb5]; // scope 4 at $DIR/basic_assignment.rs:+13:5: +13:11
     }
 
     bb1: {
-        drop(_6) -> [return: bb2, unwind: bb6]; // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
+        drop(_6) -> [return: bb2, unwind: bb6]; // scope 4 at $DIR/basic_assignment.rs:+13:19: +13:20
     }
 
     bb2: {
-        StorageDead(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
-        _0 = const ();                   // scope 0 at $DIR/basic_assignment.rs:10:11: 24:2
-        drop(_5) -> [return: bb3, unwind: bb7]; // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+        StorageDead(_6);                 // scope 4 at $DIR/basic_assignment.rs:+13:19: +13:20
+        _0 = const ();                   // scope 0 at $DIR/basic_assignment.rs:+0:11: +14:2
+        drop(_5) -> [return: bb3, unwind: bb7]; // scope 3 at $DIR/basic_assignment.rs:+14:1: +14:2
     }
 
     bb3: {
-        StorageDead(_5);                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
-        drop(_4) -> [return: bb4, unwind: bb8]; // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+        StorageDead(_5);                 // scope 3 at $DIR/basic_assignment.rs:+14:1: +14:2
+        drop(_4) -> [return: bb4, unwind: bb8]; // scope 2 at $DIR/basic_assignment.rs:+14:1: +14:2
     }
 
     bb4: {
-        StorageDead(_4);                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
-        StorageDead(_2);                 // scope 1 at $DIR/basic_assignment.rs:24:1: 24:2
-        StorageDead(_1);                 // scope 0 at $DIR/basic_assignment.rs:24:1: 24:2
-        return;                          // scope 0 at $DIR/basic_assignment.rs:24:2: 24:2
+        StorageDead(_4);                 // scope 2 at $DIR/basic_assignment.rs:+14:1: +14:2
+        StorageDead(_2);                 // scope 1 at $DIR/basic_assignment.rs:+14:1: +14:2
+        StorageDead(_1);                 // scope 0 at $DIR/basic_assignment.rs:+14:1: +14:2
+        return;                          // scope 0 at $DIR/basic_assignment.rs:+14:2: +14:2
     }
 
     bb5 (cleanup): {
-        drop(_6) -> bb6;                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
+        drop(_6) -> bb6;                 // scope 4 at $DIR/basic_assignment.rs:+13:19: +13:20
     }
 
     bb6 (cleanup): {
-        drop(_5) -> bb7;                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+        drop(_5) -> bb7;                 // scope 3 at $DIR/basic_assignment.rs:+14:1: +14:2
     }
 
     bb7 (cleanup): {
-        drop(_4) -> bb8;                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+        drop(_4) -> bb8;                 // scope 2 at $DIR/basic_assignment.rs:+14:1: +14:2
     }
 
     bb8 (cleanup): {
-        resume;                          // scope 0 at $DIR/basic_assignment.rs:10:1: 24:2
+        resume;                          // scope 0 at $DIR/basic_assignment.rs:+0:1: +14:2
     }
 }

--- a/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
@@ -2,34 +2,34 @@
 + // MIR for `opt1` after InstCombine
   
   fn opt1(_1: bool) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:2:9: 2:10
-      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:2:21: 2:24
-      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:3:8: 3:17
-      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:3:8: 3:9
+      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:+0:9: +0:10
+      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:+0:21: +0:24
+      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
-          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:3:8: 3:9
-          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:3:8: 3:9
--         _2 = Ne(move _3, const true);    // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:3:16: 3:17
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
+          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
+-         _2 = Ne(move _3, const true);    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
++         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
       }
   
       bb1: {
-          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:3:20: 3:21
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:3:5: 3:34
+          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:20: +1:21
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:3:31: 3:32
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:3:5: 3:34
+          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:31: +1:32
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:3:33: 3:34
-          return;                          // scope 0 at $DIR/bool_compare.rs:4:2: 4:2
+          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:33: +1:34
+          return;                          // scope 0 at $DIR/bool_compare.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
@@ -2,34 +2,34 @@
 + // MIR for `opt2` after InstCombine
   
   fn opt2(_1: bool) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:7:9: 7:10
-      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:7:21: 7:24
-      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:8:8: 8:17
-      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:8:16: 8:17
+      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:+0:9: +0:10
+      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:+0:21: +0:24
+      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
-          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:8:16: 8:17
-          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:8:16: 8:17
--         _2 = Ne(const true, move _3);    // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:8:16: 8:17
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
+          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
+          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
+-         _2 = Ne(const true, move _3);    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
++         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
       }
   
       bb1: {
-          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:8:20: 8:21
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:8:5: 8:34
+          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:20: +1:21
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:8:31: 8:32
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:8:5: 8:34
+          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:31: +1:32
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:8:33: 8:34
-          return;                          // scope 0 at $DIR/bool_compare.rs:9:2: 9:2
+          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:33: +1:34
+          return;                          // scope 0 at $DIR/bool_compare.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
@@ -2,34 +2,34 @@
 + // MIR for `opt3` after InstCombine
   
   fn opt3(_1: bool) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:12:9: 12:10
-      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:12:21: 12:24
-      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:13:8: 13:18
-      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:13:8: 13:9
+      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:+0:9: +0:10
+      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:+0:21: +0:24
+      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
-          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:13:8: 13:9
-          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:13:8: 13:9
--         _2 = Eq(move _3, const false);   // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:13:17: 13:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
+          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
+-         _2 = Eq(move _3, const false);   // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
++         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
       }
   
       bb1: {
-          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:13:21: 13:22
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:13:5: 13:35
+          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:21: +1:22
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:13:32: 13:33
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:13:5: 13:35
+          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:32: +1:33
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:13:34: 13:35
-          return;                          // scope 0 at $DIR/bool_compare.rs:14:2: 14:2
+          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:34: +1:35
+          return;                          // scope 0 at $DIR/bool_compare.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
@@ -2,34 +2,34 @@
 + // MIR for `opt4` after InstCombine
   
   fn opt4(_1: bool) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:17:9: 17:10
-      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:17:21: 17:24
-      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:18:8: 18:18
-      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:18:17: 18:18
+      debug x => _1;                       // in scope 0 at $DIR/bool_compare.rs:+0:9: +0:10
+      let mut _0: u32;                     // return place in scope 0 at $DIR/bool_compare.rs:+0:21: +0:24
+      let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+      let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
-          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:18:17: 18:18
-          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:18:17: 18:18
--         _2 = Eq(const false, move _3);   // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
-+         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:18:17: 18:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
+          StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+          StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
+          _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
+-         _2 = Eq(const false, move _3);   // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
++         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
       }
   
       bb1: {
-          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:18:21: 18:22
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:18:5: 18:35
+          _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:21: +1:22
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:18:32: 18:33
-          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:18:5: 18:35
+          _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:32: +1:33
+          goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:18:34: 18:35
-          return;                          // scope 0 at $DIR/bool_compare.rs:19:2: 19:2
+          StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:+1:34: +1:35
+          return;                          // scope 0 at $DIR/bool_compare.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
@@ -1,80 +1,80 @@
 // MIR for `main` before ElaborateDrops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/box_expr.rs:6:11: 6:11
-    let _1: std::boxed::Box<S>;          // in scope 0 at $DIR/box_expr.rs:7:9: 7:10
-    let mut _2: usize;                   // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
-    let mut _3: usize;                   // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
-    let mut _4: *mut u8;                 // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
-    let mut _5: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
-    let _6: ();                          // in scope 0 at $DIR/box_expr.rs:8:5: 8:12
-    let mut _7: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:8:10: 8:11
+    let mut _0: ();                      // return place in scope 0 at $DIR/box_expr.rs:+0:11: +0:11
+    let _1: std::boxed::Box<S>;          // in scope 0 at $DIR/box_expr.rs:+1:9: +1:10
+    let mut _2: usize;                   // in scope 0 at $DIR/box_expr.rs:+1:13: +1:25
+    let mut _3: usize;                   // in scope 0 at $DIR/box_expr.rs:+1:13: +1:25
+    let mut _4: *mut u8;                 // in scope 0 at $DIR/box_expr.rs:+1:13: +1:25
+    let mut _5: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:+1:13: +1:25
+    let _6: ();                          // in scope 0 at $DIR/box_expr.rs:+2:5: +2:12
+    let mut _7: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:+2:10: +2:11
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/box_expr.rs:7:9: 7:10
+        debug x => _1;                   // in scope 1 at $DIR/box_expr.rs:+1:9: +1:10
     }
     scope 2 {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/box_expr.rs:7:9: 7:10
-        _2 = SizeOf(S);                  // scope 2 at $DIR/box_expr.rs:7:13: 7:25
-        _3 = AlignOf(S);                 // scope 2 at $DIR/box_expr.rs:7:13: 7:25
-        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/box_expr.rs:7:13: 7:25
+        StorageLive(_1);                 // scope 0 at $DIR/box_expr.rs:+1:9: +1:10
+        _2 = SizeOf(S);                  // scope 2 at $DIR/box_expr.rs:+1:13: +1:25
+        _3 = AlignOf(S);                 // scope 2 at $DIR/box_expr.rs:+1:13: +1:25
+        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/box_expr.rs:+1:13: +1:25
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:7:13: 7:25
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageLive(_5);                 // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        _5 = ShallowInitBox(move _4, S); // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        (*_5) = S::new() -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
+        StorageLive(_5);                 // scope 0 at $DIR/box_expr.rs:+1:13: +1:25
+        _5 = ShallowInitBox(move _4, S); // scope 0 at $DIR/box_expr.rs:+1:13: +1:25
+        (*_5) = S::new() -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/box_expr.rs:+1:17: +1:25
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:7:17: 7:23
                                          // + literal: Const { ty: fn() -> S {S::new}, val: Value(<ZST>) }
     }
 
     bb2: {
-        _1 = move _5;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        drop(_5) -> bb3;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+        _1 = move _5;                    // scope 0 at $DIR/box_expr.rs:+1:13: +1:25
+        drop(_5) -> bb3;                 // scope 0 at $DIR/box_expr.rs:+1:24: +1:25
     }
 
     bb3: {
-        StorageDead(_5);                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
-        StorageLive(_6);                 // scope 1 at $DIR/box_expr.rs:8:5: 8:12
-        StorageLive(_7);                 // scope 1 at $DIR/box_expr.rs:8:10: 8:11
-        _7 = move _1;                    // scope 1 at $DIR/box_expr.rs:8:10: 8:11
-        _6 = std::mem::drop::<Box<S>>(move _7) -> [return: bb4, unwind: bb6]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
+        StorageDead(_5);                 // scope 0 at $DIR/box_expr.rs:+1:24: +1:25
+        StorageLive(_6);                 // scope 1 at $DIR/box_expr.rs:+2:5: +2:12
+        StorageLive(_7);                 // scope 1 at $DIR/box_expr.rs:+2:10: +2:11
+        _7 = move _1;                    // scope 1 at $DIR/box_expr.rs:+2:10: +2:11
+        _6 = std::mem::drop::<Box<S>>(move _7) -> [return: bb4, unwind: bb6]; // scope 1 at $DIR/box_expr.rs:+2:5: +2:12
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:8:5: 8:9
                                          // + literal: Const { ty: fn(Box<S>) {std::mem::drop::<Box<S>>}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_7);                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
-        StorageDead(_6);                 // scope 1 at $DIR/box_expr.rs:8:12: 8:13
-        _0 = const ();                   // scope 0 at $DIR/box_expr.rs:6:11: 9:2
-        drop(_1) -> bb5;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        StorageDead(_7);                 // scope 1 at $DIR/box_expr.rs:+2:11: +2:12
+        StorageDead(_6);                 // scope 1 at $DIR/box_expr.rs:+2:12: +2:13
+        _0 = const ();                   // scope 0 at $DIR/box_expr.rs:+0:11: +3:2
+        drop(_1) -> bb5;                 // scope 0 at $DIR/box_expr.rs:+3:1: +3:2
     }
 
     bb5: {
-        StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
-        return;                          // scope 0 at $DIR/box_expr.rs:9:2: 9:2
+        StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/box_expr.rs:+3:2: +3:2
     }
 
     bb6 (cleanup): {
-        drop(_7) -> bb7;                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
+        drop(_7) -> bb7;                 // scope 1 at $DIR/box_expr.rs:+2:11: +2:12
     }
 
     bb7 (cleanup): {
-        drop(_1) -> bb9;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        drop(_1) -> bb9;                 // scope 0 at $DIR/box_expr.rs:+3:1: +3:2
     }
 
     bb8 (cleanup): {
-        drop(_5) -> bb9;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+        drop(_5) -> bb9;                 // scope 0 at $DIR/box_expr.rs:+1:24: +1:25
     }
 
     bb9 (cleanup): {
-        resume;                          // scope 0 at $DIR/box_expr.rs:6:1: 9:2
+        resume;                          // scope 0 at $DIR/box_expr.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/byte_slice.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/byte_slice.main.SimplifyCfg-elaborate-drops.after.mir
@@ -1,28 +1,28 @@
 // MIR for `main` after SimplifyCfg-elaborate-drops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/byte_slice.rs:4:11: 4:11
-    let _1: &[u8; 3];                    // in scope 0 at $DIR/byte_slice.rs:5:9: 5:10
+    let mut _0: ();                      // return place in scope 0 at $DIR/byte_slice.rs:+0:11: +0:11
+    let _1: &[u8; 3];                    // in scope 0 at $DIR/byte_slice.rs:+1:9: +1:10
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/byte_slice.rs:5:9: 5:10
-        let _2: [u8; 2];                 // in scope 1 at $DIR/byte_slice.rs:6:9: 6:10
+        debug x => _1;                   // in scope 1 at $DIR/byte_slice.rs:+1:9: +1:10
+        let _2: [u8; 2];                 // in scope 1 at $DIR/byte_slice.rs:+2:9: +2:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/byte_slice.rs:6:9: 6:10
+            debug y => _2;               // in scope 2 at $DIR/byte_slice.rs:+2:9: +2:10
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/byte_slice.rs:5:9: 5:10
-        _1 = const b"foo";               // scope 0 at $DIR/byte_slice.rs:5:13: 5:19
+        StorageLive(_1);                 // scope 0 at $DIR/byte_slice.rs:+1:9: +1:10
+        _1 = const b"foo";               // scope 0 at $DIR/byte_slice.rs:+1:13: +1:19
                                          // mir::Constant
                                          // + span: $DIR/byte_slice.rs:5:13: 5:19
                                          // + literal: Const { ty: &[u8; 3], val: Value(Scalar(alloc1)) }
-        StorageLive(_2);                 // scope 1 at $DIR/byte_slice.rs:6:9: 6:10
-        _2 = [const 5_u8, const 120_u8]; // scope 1 at $DIR/byte_slice.rs:6:13: 6:24
-        _0 = const ();                   // scope 0 at $DIR/byte_slice.rs:4:11: 7:2
-        StorageDead(_2);                 // scope 1 at $DIR/byte_slice.rs:7:1: 7:2
-        StorageDead(_1);                 // scope 0 at $DIR/byte_slice.rs:7:1: 7:2
-        return;                          // scope 0 at $DIR/byte_slice.rs:7:2: 7:2
+        StorageLive(_2);                 // scope 1 at $DIR/byte_slice.rs:+2:9: +2:10
+        _2 = [const 5_u8, const 120_u8]; // scope 1 at $DIR/byte_slice.rs:+2:13: +2:24
+        _0 = const ();                   // scope 0 at $DIR/byte_slice.rs:+0:11: +3:2
+        StorageDead(_2);                 // scope 1 at $DIR/byte_slice.rs:+3:1: +3:2
+        StorageDead(_1);                 // scope 0 at $DIR/byte_slice.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/byte_slice.rs:+3:2: +3:2
     }
 }
 

--- a/src/test/mir-opt/combine_array_len.norm2.InstCombine.32bit.diff
+++ b/src/test/mir-opt/combine_array_len.norm2.InstCombine.32bit.diff
@@ -2,76 +2,76 @@
 + // MIR for `norm2` after InstCombine
   
   fn norm2(_1: [f32; 2]) -> f32 {
-      debug x => _1;                       // in scope 0 at $DIR/combine_array_len.rs:4:10: 4:11
-      let mut _0: f32;                     // return place in scope 0 at $DIR/combine_array_len.rs:4:26: 4:29
-      let _2: f32;                         // in scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
-      let _3: usize;                       // in scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
-      let mut _4: usize;                   // in scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-      let mut _5: bool;                    // in scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-      let _7: usize;                       // in scope 0 at $DIR/combine_array_len.rs:6:15: 6:16
-      let mut _8: usize;                   // in scope 0 at $DIR/combine_array_len.rs:6:13: 6:17
-      let mut _9: bool;                    // in scope 0 at $DIR/combine_array_len.rs:6:13: 6:17
-      let mut _10: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:5: 7:8
-      let mut _11: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:5: 7:6
-      let mut _12: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:7: 7:8
-      let mut _13: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:11: 7:14
-      let mut _14: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:11: 7:12
-      let mut _15: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:13: 7:14
+      debug x => _1;                       // in scope 0 at $DIR/combine_array_len.rs:+0:10: +0:11
+      let mut _0: f32;                     // return place in scope 0 at $DIR/combine_array_len.rs:+0:26: +0:29
+      let _2: f32;                         // in scope 0 at $DIR/combine_array_len.rs:+1:9: +1:10
+      let _3: usize;                       // in scope 0 at $DIR/combine_array_len.rs:+1:15: +1:16
+      let mut _4: usize;                   // in scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+      let mut _5: bool;                    // in scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+      let _7: usize;                       // in scope 0 at $DIR/combine_array_len.rs:+2:15: +2:16
+      let mut _8: usize;                   // in scope 0 at $DIR/combine_array_len.rs:+2:13: +2:17
+      let mut _9: bool;                    // in scope 0 at $DIR/combine_array_len.rs:+2:13: +2:17
+      let mut _10: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:5: +3:8
+      let mut _11: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:5: +3:6
+      let mut _12: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:7: +3:8
+      let mut _13: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:11: +3:14
+      let mut _14: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:11: +3:12
+      let mut _15: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:13: +3:14
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/combine_array_len.rs:5:9: 5:10
-          let _6: f32;                     // in scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
+          debug a => _2;                   // in scope 1 at $DIR/combine_array_len.rs:+1:9: +1:10
+          let _6: f32;                     // in scope 1 at $DIR/combine_array_len.rs:+2:9: +2:10
           scope 2 {
-              debug b => _6;               // in scope 2 at $DIR/combine_array_len.rs:6:9: 6:10
+              debug b => _6;               // in scope 2 at $DIR/combine_array_len.rs:+2:9: +2:10
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
-          StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
-          _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
--         _4 = Len(_1);                    // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-+         _4 = const 2_usize;              // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-          _5 = Lt(_3, _4);                 // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-          assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
+          StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:+1:15: +1:16
+          _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:+1:15: +1:16
+-         _4 = Len(_1);                    // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
++         _4 = const 2_usize;              // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+          _5 = Lt(_3, _4);                 // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+          assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
       }
   
       bb1: {
-          _2 = _1[_3];                     // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-          StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:17: 5:18
-          StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
-          StorageLive(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
-          _7 = const 1_usize;              // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
--         _8 = Len(_1);                    // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-+         _8 = const 2_usize;              // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-          _9 = Lt(_7, _8);                 // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
+          _2 = _1[_3];                     // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+          StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:+1:17: +1:18
+          StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:+2:9: +2:10
+          StorageLive(_7);                 // scope 1 at $DIR/combine_array_len.rs:+2:15: +2:16
+          _7 = const 1_usize;              // scope 1 at $DIR/combine_array_len.rs:+2:15: +2:16
+-         _8 = Len(_1);                    // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
++         _8 = const 2_usize;              // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
+          _9 = Lt(_7, _8);                 // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
+          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
       }
   
       bb2: {
-          _6 = _1[_7];                     // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-          StorageDead(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:17: 6:18
-          StorageLive(_10);                // scope 2 at $DIR/combine_array_len.rs:7:5: 7:8
-          StorageLive(_11);                // scope 2 at $DIR/combine_array_len.rs:7:5: 7:6
-          _11 = _2;                        // scope 2 at $DIR/combine_array_len.rs:7:5: 7:6
-          StorageLive(_12);                // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          _12 = _2;                        // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          _10 = Mul(move _11, move _12);   // scope 2 at $DIR/combine_array_len.rs:7:5: 7:8
-          StorageDead(_12);                // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          StorageDead(_11);                // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          StorageLive(_13);                // scope 2 at $DIR/combine_array_len.rs:7:11: 7:14
-          StorageLive(_14);                // scope 2 at $DIR/combine_array_len.rs:7:11: 7:12
-          _14 = _6;                        // scope 2 at $DIR/combine_array_len.rs:7:11: 7:12
-          StorageLive(_15);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          _15 = _6;                        // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          _13 = Mul(move _14, move _15);   // scope 2 at $DIR/combine_array_len.rs:7:11: 7:14
-          StorageDead(_15);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          StorageDead(_14);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          _0 = Add(move _10, move _13);    // scope 2 at $DIR/combine_array_len.rs:7:5: 7:14
-          StorageDead(_13);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          StorageDead(_10);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          StorageDead(_6);                 // scope 1 at $DIR/combine_array_len.rs:8:1: 8:2
-          StorageDead(_2);                 // scope 0 at $DIR/combine_array_len.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/combine_array_len.rs:8:2: 8:2
+          _6 = _1[_7];                     // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
+          StorageDead(_7);                 // scope 1 at $DIR/combine_array_len.rs:+2:17: +2:18
+          StorageLive(_10);                // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:8
+          StorageLive(_11);                // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:6
+          _11 = _2;                        // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:6
+          StorageLive(_12);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          _12 = _2;                        // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          _10 = Mul(move _11, move _12);   // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:8
+          StorageDead(_12);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          StorageDead(_11);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          StorageLive(_13);                // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:14
+          StorageLive(_14);                // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:12
+          _14 = _6;                        // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:12
+          StorageLive(_15);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          _15 = _6;                        // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          _13 = Mul(move _14, move _15);   // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:14
+          StorageDead(_15);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          StorageDead(_14);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          _0 = Add(move _10, move _13);    // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:14
+          StorageDead(_13);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          StorageDead(_10);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          StorageDead(_6);                 // scope 1 at $DIR/combine_array_len.rs:+4:1: +4:2
+          StorageDead(_2);                 // scope 0 at $DIR/combine_array_len.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/combine_array_len.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/combine_array_len.norm2.InstCombine.64bit.diff
+++ b/src/test/mir-opt/combine_array_len.norm2.InstCombine.64bit.diff
@@ -2,76 +2,76 @@
 + // MIR for `norm2` after InstCombine
   
   fn norm2(_1: [f32; 2]) -> f32 {
-      debug x => _1;                       // in scope 0 at $DIR/combine_array_len.rs:4:10: 4:11
-      let mut _0: f32;                     // return place in scope 0 at $DIR/combine_array_len.rs:4:26: 4:29
-      let _2: f32;                         // in scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
-      let _3: usize;                       // in scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
-      let mut _4: usize;                   // in scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-      let mut _5: bool;                    // in scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-      let _7: usize;                       // in scope 0 at $DIR/combine_array_len.rs:6:15: 6:16
-      let mut _8: usize;                   // in scope 0 at $DIR/combine_array_len.rs:6:13: 6:17
-      let mut _9: bool;                    // in scope 0 at $DIR/combine_array_len.rs:6:13: 6:17
-      let mut _10: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:5: 7:8
-      let mut _11: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:5: 7:6
-      let mut _12: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:7: 7:8
-      let mut _13: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:11: 7:14
-      let mut _14: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:11: 7:12
-      let mut _15: f32;                    // in scope 0 at $DIR/combine_array_len.rs:7:13: 7:14
+      debug x => _1;                       // in scope 0 at $DIR/combine_array_len.rs:+0:10: +0:11
+      let mut _0: f32;                     // return place in scope 0 at $DIR/combine_array_len.rs:+0:26: +0:29
+      let _2: f32;                         // in scope 0 at $DIR/combine_array_len.rs:+1:9: +1:10
+      let _3: usize;                       // in scope 0 at $DIR/combine_array_len.rs:+1:15: +1:16
+      let mut _4: usize;                   // in scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+      let mut _5: bool;                    // in scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+      let _7: usize;                       // in scope 0 at $DIR/combine_array_len.rs:+2:15: +2:16
+      let mut _8: usize;                   // in scope 0 at $DIR/combine_array_len.rs:+2:13: +2:17
+      let mut _9: bool;                    // in scope 0 at $DIR/combine_array_len.rs:+2:13: +2:17
+      let mut _10: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:5: +3:8
+      let mut _11: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:5: +3:6
+      let mut _12: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:7: +3:8
+      let mut _13: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:11: +3:14
+      let mut _14: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:11: +3:12
+      let mut _15: f32;                    // in scope 0 at $DIR/combine_array_len.rs:+3:13: +3:14
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/combine_array_len.rs:5:9: 5:10
-          let _6: f32;                     // in scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
+          debug a => _2;                   // in scope 1 at $DIR/combine_array_len.rs:+1:9: +1:10
+          let _6: f32;                     // in scope 1 at $DIR/combine_array_len.rs:+2:9: +2:10
           scope 2 {
-              debug b => _6;               // in scope 2 at $DIR/combine_array_len.rs:6:9: 6:10
+              debug b => _6;               // in scope 2 at $DIR/combine_array_len.rs:+2:9: +2:10
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
-          StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
-          _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
--         _4 = Len(_1);                    // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-+         _4 = const 2_usize;              // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-          _5 = Lt(_3, _4);                 // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-          assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
+          StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:+1:15: +1:16
+          _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:+1:15: +1:16
+-         _4 = Len(_1);                    // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
++         _4 = const 2_usize;              // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+          _5 = Lt(_3, _4);                 // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+          assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
       }
   
       bb1: {
-          _2 = _1[_3];                     // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-          StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:17: 5:18
-          StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
-          StorageLive(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
-          _7 = const 1_usize;              // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
--         _8 = Len(_1);                    // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-+         _8 = const 2_usize;              // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-          _9 = Lt(_7, _8);                 // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
+          _2 = _1[_3];                     // scope 0 at $DIR/combine_array_len.rs:+1:13: +1:17
+          StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:+1:17: +1:18
+          StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:+2:9: +2:10
+          StorageLive(_7);                 // scope 1 at $DIR/combine_array_len.rs:+2:15: +2:16
+          _7 = const 1_usize;              // scope 1 at $DIR/combine_array_len.rs:+2:15: +2:16
+-         _8 = Len(_1);                    // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
++         _8 = const 2_usize;              // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
+          _9 = Lt(_7, _8);                 // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
+          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
       }
   
       bb2: {
-          _6 = _1[_7];                     // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-          StorageDead(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:17: 6:18
-          StorageLive(_10);                // scope 2 at $DIR/combine_array_len.rs:7:5: 7:8
-          StorageLive(_11);                // scope 2 at $DIR/combine_array_len.rs:7:5: 7:6
-          _11 = _2;                        // scope 2 at $DIR/combine_array_len.rs:7:5: 7:6
-          StorageLive(_12);                // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          _12 = _2;                        // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          _10 = Mul(move _11, move _12);   // scope 2 at $DIR/combine_array_len.rs:7:5: 7:8
-          StorageDead(_12);                // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          StorageDead(_11);                // scope 2 at $DIR/combine_array_len.rs:7:7: 7:8
-          StorageLive(_13);                // scope 2 at $DIR/combine_array_len.rs:7:11: 7:14
-          StorageLive(_14);                // scope 2 at $DIR/combine_array_len.rs:7:11: 7:12
-          _14 = _6;                        // scope 2 at $DIR/combine_array_len.rs:7:11: 7:12
-          StorageLive(_15);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          _15 = _6;                        // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          _13 = Mul(move _14, move _15);   // scope 2 at $DIR/combine_array_len.rs:7:11: 7:14
-          StorageDead(_15);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          StorageDead(_14);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          _0 = Add(move _10, move _13);    // scope 2 at $DIR/combine_array_len.rs:7:5: 7:14
-          StorageDead(_13);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          StorageDead(_10);                // scope 2 at $DIR/combine_array_len.rs:7:13: 7:14
-          StorageDead(_6);                 // scope 1 at $DIR/combine_array_len.rs:8:1: 8:2
-          StorageDead(_2);                 // scope 0 at $DIR/combine_array_len.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/combine_array_len.rs:8:2: 8:2
+          _6 = _1[_7];                     // scope 1 at $DIR/combine_array_len.rs:+2:13: +2:17
+          StorageDead(_7);                 // scope 1 at $DIR/combine_array_len.rs:+2:17: +2:18
+          StorageLive(_10);                // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:8
+          StorageLive(_11);                // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:6
+          _11 = _2;                        // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:6
+          StorageLive(_12);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          _12 = _2;                        // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          _10 = Mul(move _11, move _12);   // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:8
+          StorageDead(_12);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          StorageDead(_11);                // scope 2 at $DIR/combine_array_len.rs:+3:7: +3:8
+          StorageLive(_13);                // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:14
+          StorageLive(_14);                // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:12
+          _14 = _6;                        // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:12
+          StorageLive(_15);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          _15 = _6;                        // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          _13 = Mul(move _14, move _15);   // scope 2 at $DIR/combine_array_len.rs:+3:11: +3:14
+          StorageDead(_15);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          StorageDead(_14);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          _0 = Add(move _10, move _13);    // scope 2 at $DIR/combine_array_len.rs:+3:5: +3:14
+          StorageDead(_13);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          StorageDead(_10);                // scope 2 at $DIR/combine_array_len.rs:+3:13: +3:14
+          StorageDead(_6);                 // scope 1 at $DIR/combine_array_len.rs:+4:1: +4:2
+          StorageDead(_2);                 // scope 0 at $DIR/combine_array_len.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/combine_array_len.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
+++ b/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
@@ -2,84 +2,84 @@
 + // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:6:10: 6:15>::clone` after InstCombine
   
   fn <impl at $DIR/combine_clone_of_primitives.rs:6:10: 6:15>::clone(_1: &MyThing<T>) -> MyThing<T> {
-      debug self => _1;                    // in scope 0 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
-      let mut _0: MyThing<T>;              // return place in scope 0 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
-      let mut _2: T;                       // in scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-      let mut _3: &T;                      // in scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-      let _4: &T;                          // in scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-      let mut _5: u64;                     // in scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-      let mut _6: &u64;                    // in scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-      let _7: &u64;                        // in scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-      let mut _8: [f32; 3];                // in scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-      let mut _9: &[f32; 3];               // in scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-      let _10: &[f32; 3];                  // in scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+      debug self => _1;                    // in scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+      let mut _0: MyThing<T>;              // return place in scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+      let mut _2: T;                       // in scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+      let mut _3: &T;                      // in scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+      let _4: &T;                          // in scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+      let mut _5: u64;                     // in scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+      let mut _6: &u64;                    // in scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+      let _7: &u64;                        // in scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+      let mut _8: [f32; 3];                // in scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+      let mut _9: &[f32; 3];               // in scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+      let _10: &[f32; 3];                  // in scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-          StorageLive(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-          StorageLive(_4);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-          _4 = &((*_1).0: T);              // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
--         _3 = &(*_4);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-+         _3 = _4;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-          _2 = <T as Clone>::clone(move _3) -> bb1; // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+          StorageLive(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+          StorageLive(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+          StorageLive(_4);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+          _4 = &((*_1).0: T);              // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+-         _3 = &(*_4);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
++         _3 = _4;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+          _2 = <T as Clone>::clone(move _3) -> bb1; // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
                                            // mir::Constant
                                            // + span: $DIR/combine_clone_of_primitives.rs:8:5: 8:9
                                            // + literal: Const { ty: for<'r> fn(&'r T) -> T {<T as Clone>::clone}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:8: 8:9
-          StorageLive(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-          StorageLive(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-          StorageLive(_7);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-          _7 = &((*_1).1: u64);            // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
--         _6 = &(*_7);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
--         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+          StorageDead(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:8: +2:9
+          StorageLive(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+          StorageLive(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+          StorageLive(_7);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+          _7 = &((*_1).1: u64);            // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+-         _6 = &(*_7);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+-         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
 -                                          // mir::Constant
 -                                          // + span: $DIR/combine_clone_of_primitives.rs:9:5: 9:11
 -                                          // + literal: Const { ty: for<'r> fn(&'r u64) -> u64 {<u64 as Clone>::clone}, val: Value(<ZST>) }
-+         _6 = _7;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-+         _5 = (*_6);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
-+         goto -> bb2;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
++         _6 = _7;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
++         _5 = (*_6);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
++         goto -> bb2;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
       }
   
       bb2: {
-          StorageDead(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:10: 9:11
-          StorageLive(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-          StorageLive(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-          StorageLive(_10);                // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-          _10 = &((*_1).2: [f32; 3]);      // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
--         _9 = &(*_10);                    // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
--         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+          StorageDead(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:10: +3:11
+          StorageLive(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+          StorageLive(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+          StorageLive(_10);                // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+          _10 = &((*_1).2: [f32; 3]);      // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+-         _9 = &(*_10);                    // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+-         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
 -                                          // mir::Constant
 -                                          // + span: $DIR/combine_clone_of_primitives.rs:10:5: 10:16
 -                                          // + literal: Const { ty: for<'r> fn(&'r [f32; 3]) -> [f32; 3] {<[f32; 3] as Clone>::clone}, val: Value(<ZST>) }
-+         _9 = _10;                        // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-+         _8 = (*_9);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
-+         goto -> bb3;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
++         _9 = _10;                        // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
++         _8 = (*_9);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
++         goto -> bb3;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
       }
   
       bb3: {
-          StorageDead(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:15: 10:16
-          Deinit(_0);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
-          (_0.0: T) = move _2;             // scope 0 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
-          (_0.1: u64) = move _5;           // scope 0 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
-          (_0.2: [f32; 3]) = move _8;      // scope 0 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
-          StorageDead(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:6:14: 6:15
-          StorageDead(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:6:14: 6:15
-          StorageDead(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:6:14: 6:15
-          StorageDead(_10);                // scope 0 at $DIR/combine_clone_of_primitives.rs:6:14: 6:15
-          StorageDead(_7);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:6:14: 6:15
-          StorageDead(_4);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:6:14: 6:15
-          return;                          // scope 0 at $DIR/combine_clone_of_primitives.rs:6:15: 6:15
+          StorageDead(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:15: +4:16
+          Deinit(_0);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.0: T) = move _2;             // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.1: u64) = move _5;           // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          (_0.2: [f32; 3]) = move _8;      // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
+          StorageDead(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
+          StorageDead(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
+          StorageDead(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
+          StorageDead(_10);                // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
+          StorageDead(_7);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
+          StorageDead(_4);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
+          return;                          // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:15: +0:15
       }
   
       bb4 (cleanup): {
-          drop(_2) -> bb5;                 // scope 0 at $DIR/combine_clone_of_primitives.rs:6:14: 6:15
+          drop(_2) -> bb5;                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:14: +0:15
       }
   
       bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
+          resume;                          // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
       }
   }
   

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.32bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after ConstProp
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation.rs:7:11: 7:11
-    let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-    let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation.rs:+0:11: +0:11
+    let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+    let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+        StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+        _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
                                          // mir::Constant
                                          // + span: $DIR/const_allocation.rs:8:5: 8:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&str])], val: Value(Scalar(alloc1)) }
-        _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
-        StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
-        nop;                             // scope 0 at $DIR/const_allocation.rs:7:11: 9:2
-        return;                          // scope 0 at $DIR/const_allocation.rs:9:2: 9:2
+        _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+        StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
+        StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
+        nop;                             // scope 0 at $DIR/const_allocation.rs:+0:11: +2:2
+        return;                          // scope 0 at $DIR/const_allocation.rs:+2:2: +2:2
     }
 }
 

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.64bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after ConstProp
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation.rs:7:11: 7:11
-    let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-    let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation.rs:+0:11: +0:11
+    let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+    let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+        StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+        _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
                                          // mir::Constant
                                          // + span: $DIR/const_allocation.rs:8:5: 8:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&str])], val: Value(Scalar(alloc1)) }
-        _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
-        StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
-        nop;                             // scope 0 at $DIR/const_allocation.rs:7:11: 9:2
-        return;                          // scope 0 at $DIR/const_allocation.rs:9:2: 9:2
+        _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:+1:5: +1:8
+        StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
+        StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:+1:8: +1:9
+        nop;                             // scope 0 at $DIR/const_allocation.rs:+0:11: +2:2
+        return;                          // scope 0 at $DIR/const_allocation.rs:+2:2: +2:2
     }
 }
 

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.32bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after ConstProp
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation2.rs:4:11: 4:11
-    let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-    let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation2.rs:+0:11: +0:11
+    let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+    let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+        StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+        _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
                                          // mir::Constant
                                          // + span: $DIR/const_allocation2.rs:5:5: 5:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&u8])], val: Value(Scalar(alloc1)) }
-        _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
-        StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
-        nop;                             // scope 0 at $DIR/const_allocation2.rs:4:11: 6:2
-        return;                          // scope 0 at $DIR/const_allocation2.rs:6:2: 6:2
+        _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+        StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
+        StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
+        nop;                             // scope 0 at $DIR/const_allocation2.rs:+0:11: +2:2
+        return;                          // scope 0 at $DIR/const_allocation2.rs:+2:2: +2:2
     }
 }
 

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.64bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after ConstProp
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation2.rs:4:11: 4:11
-    let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-    let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation2.rs:+0:11: +0:11
+    let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+    let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+        StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+        _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
                                          // mir::Constant
                                          // + span: $DIR/const_allocation2.rs:5:5: 5:8
                                          // + literal: Const { ty: &&[(Option<i32>, &[&u8])], val: Value(Scalar(alloc1)) }
-        _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
-        StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
-        nop;                             // scope 0 at $DIR/const_allocation2.rs:4:11: 6:2
-        return;                          // scope 0 at $DIR/const_allocation2.rs:6:2: 6:2
+        _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:+1:5: +1:8
+        StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
+        StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:+1:8: +1:9
+        nop;                             // scope 0 at $DIR/const_allocation2.rs:+0:11: +2:2
+        return;                          // scope 0 at $DIR/const_allocation2.rs:+2:2: +2:2
     }
 }
 

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.32bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after ConstProp
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation3.rs:4:11: 4:11
-    let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-    let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation3.rs:+0:11: +0:11
+    let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+    let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+        StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+        _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
                                          // mir::Constant
                                          // + span: $DIR/const_allocation3.rs:5:5: 5:8
                                          // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc1)) }
-        _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
-        StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
-        nop;                             // scope 0 at $DIR/const_allocation3.rs:4:11: 6:2
-        return;                          // scope 0 at $DIR/const_allocation3.rs:6:2: 6:2
+        _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+        StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
+        StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
+        nop;                             // scope 0 at $DIR/const_allocation3.rs:+0:11: +2:2
+        return;                          // scope 0 at $DIR/const_allocation3.rs:+2:2: +2:2
     }
 }
 

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.64bit.mir
@@ -1,22 +1,22 @@
 // MIR for `main` after ConstProp
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation3.rs:4:11: 4:11
-    let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-    let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation3.rs:+0:11: +0:11
+    let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+    let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+        StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+        _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
                                          // mir::Constant
                                          // + span: $DIR/const_allocation3.rs:5:5: 5:8
                                          // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc1)) }
-        _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
-        StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
-        nop;                             // scope 0 at $DIR/const_allocation3.rs:4:11: 6:2
-        return;                          // scope 0 at $DIR/const_allocation3.rs:6:2: 6:2
+        _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:+1:5: +1:8
+        StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
+        StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:+1:8: +1:9
+        nop;                             // scope 0 at $DIR/const_allocation3.rs:+0:11: +2:2
+        return;                          // scope 0 at $DIR/const_allocation3.rs:+2:2: +2:2
     }
 }
 

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -2,46 +2,46 @@
 + // MIR for `main` after ConstDebugInfo
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/const_debuginfo.rs:8:11: 8:11
-      let _1: u8;                          // in scope 0 at $DIR/const_debuginfo.rs:9:9: 9:10
-      let mut _5: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:12:15: 12:20
-      let mut _6: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:12:15: 12:16
-      let mut _7: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:12:19: 12:20
-      let mut _8: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:12:23: 12:24
-      let mut _14: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:21:13: 21:16
-      let mut _15: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:21:19: 21:22
+      let mut _0: ();                      // return place in scope 0 at $DIR/const_debuginfo.rs:+0:11: +0:11
+      let _1: u8;                          // in scope 0 at $DIR/const_debuginfo.rs:+1:9: +1:10
+      let mut _5: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:+4:15: +4:20
+      let mut _6: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:+4:15: +4:16
+      let mut _7: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:+4:19: +4:20
+      let mut _8: u8;                      // in scope 0 at $DIR/const_debuginfo.rs:+4:23: +4:24
+      let mut _14: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:+13:13: +13:16
+      let mut _15: u32;                    // in scope 0 at $DIR/const_debuginfo.rs:+13:19: +13:22
       scope 1 {
--         debug x => _1;                   // in scope 1 at $DIR/const_debuginfo.rs:9:9: 9:10
-+         debug x => const 1_u8;           // in scope 1 at $DIR/const_debuginfo.rs:9:9: 9:10
-          let _2: u8;                      // in scope 1 at $DIR/const_debuginfo.rs:10:9: 10:10
+-         debug x => _1;                   // in scope 1 at $DIR/const_debuginfo.rs:+1:9: +1:10
++         debug x => const 1_u8;           // in scope 1 at $DIR/const_debuginfo.rs:+1:9: +1:10
+          let _2: u8;                      // in scope 1 at $DIR/const_debuginfo.rs:+2:9: +2:10
           scope 2 {
--             debug y => _2;               // in scope 2 at $DIR/const_debuginfo.rs:10:9: 10:10
-+             debug y => const 2_u8;       // in scope 2 at $DIR/const_debuginfo.rs:10:9: 10:10
-              let _3: u8;                  // in scope 2 at $DIR/const_debuginfo.rs:11:9: 11:10
+-             debug y => _2;               // in scope 2 at $DIR/const_debuginfo.rs:+2:9: +2:10
++             debug y => const 2_u8;       // in scope 2 at $DIR/const_debuginfo.rs:+2:9: +2:10
+              let _3: u8;                  // in scope 2 at $DIR/const_debuginfo.rs:+3:9: +3:10
               scope 3 {
--                 debug z => _3;           // in scope 3 at $DIR/const_debuginfo.rs:11:9: 11:10
-+                 debug z => const 3_u8;   // in scope 3 at $DIR/const_debuginfo.rs:11:9: 11:10
-                  let _4: u8;              // in scope 3 at $DIR/const_debuginfo.rs:12:9: 12:12
+-                 debug z => _3;           // in scope 3 at $DIR/const_debuginfo.rs:+3:9: +3:10
++                 debug z => const 3_u8;   // in scope 3 at $DIR/const_debuginfo.rs:+3:9: +3:10
+                  let _4: u8;              // in scope 3 at $DIR/const_debuginfo.rs:+4:9: +4:12
                   scope 4 {
--                     debug sum => _4;     // in scope 4 at $DIR/const_debuginfo.rs:12:9: 12:12
-+                     debug sum => const 6_u8; // in scope 4 at $DIR/const_debuginfo.rs:12:9: 12:12
-                      let _9: &str;        // in scope 4 at $DIR/const_debuginfo.rs:14:9: 14:10
+-                     debug sum => _4;     // in scope 4 at $DIR/const_debuginfo.rs:+4:9: +4:12
++                     debug sum => const 6_u8; // in scope 4 at $DIR/const_debuginfo.rs:+4:9: +4:12
+                      let _9: &str;        // in scope 4 at $DIR/const_debuginfo.rs:+6:9: +6:10
                       scope 5 {
--                         debug s => _9;   // in scope 5 at $DIR/const_debuginfo.rs:14:9: 14:10
-+                         debug s => const "hello, world!"; // in scope 5 at $DIR/const_debuginfo.rs:14:9: 14:10
-                          let _10: (bool, bool, u32); // in scope 5 at $DIR/const_debuginfo.rs:16:9: 16:10
+-                         debug s => _9;   // in scope 5 at $DIR/const_debuginfo.rs:+6:9: +6:10
++                         debug s => const "hello, world!"; // in scope 5 at $DIR/const_debuginfo.rs:+6:9: +6:10
+                          let _10: (bool, bool, u32); // in scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
                           scope 6 {
-                              debug f => _10; // in scope 6 at $DIR/const_debuginfo.rs:16:9: 16:10
-                              let _11: std::option::Option<u16>; // in scope 6 at $DIR/const_debuginfo.rs:18:9: 18:10
+                              debug f => _10; // in scope 6 at $DIR/const_debuginfo.rs:+8:9: +8:10
+                              let _11: std::option::Option<u16>; // in scope 6 at $DIR/const_debuginfo.rs:+10:9: +10:10
                               scope 7 {
-                                  debug o => _11; // in scope 7 at $DIR/const_debuginfo.rs:18:9: 18:10
-                                  let _12: Point; // in scope 7 at $DIR/const_debuginfo.rs:20:9: 20:10
+                                  debug o => _11; // in scope 7 at $DIR/const_debuginfo.rs:+10:9: +10:10
+                                  let _12: Point; // in scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
                                   scope 8 {
-                                      debug p => _12; // in scope 8 at $DIR/const_debuginfo.rs:20:9: 20:10
-                                      let _13: u32; // in scope 8 at $DIR/const_debuginfo.rs:21:9: 21:10
+                                      debug p => _12; // in scope 8 at $DIR/const_debuginfo.rs:+12:9: +12:10
+                                      let _13: u32; // in scope 8 at $DIR/const_debuginfo.rs:+13:9: +13:10
                                       scope 9 {
--                                         debug a => _13; // in scope 9 at $DIR/const_debuginfo.rs:21:9: 21:10
-+                                         debug a => const 64_u32; // in scope 9 at $DIR/const_debuginfo.rs:21:9: 21:10
+-                                         debug a => _13; // in scope 9 at $DIR/const_debuginfo.rs:+13:9: +13:10
++                                         debug a => const 64_u32; // in scope 9 at $DIR/const_debuginfo.rs:+13:9: +13:10
                                       }
                                   }
                               }
@@ -53,63 +53,63 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_debuginfo.rs:9:9: 9:10
-          _1 = const 1_u8;                 // scope 0 at $DIR/const_debuginfo.rs:9:13: 9:16
-          StorageLive(_2);                 // scope 1 at $DIR/const_debuginfo.rs:10:9: 10:10
-          _2 = const 2_u8;                 // scope 1 at $DIR/const_debuginfo.rs:10:13: 10:16
-          StorageLive(_3);                 // scope 2 at $DIR/const_debuginfo.rs:11:9: 11:10
-          _3 = const 3_u8;                 // scope 2 at $DIR/const_debuginfo.rs:11:13: 11:16
-          StorageLive(_4);                 // scope 3 at $DIR/const_debuginfo.rs:12:9: 12:12
-          StorageLive(_5);                 // scope 3 at $DIR/const_debuginfo.rs:12:15: 12:20
-          StorageLive(_6);                 // scope 3 at $DIR/const_debuginfo.rs:12:15: 12:16
-          _6 = const 1_u8;                 // scope 3 at $DIR/const_debuginfo.rs:12:15: 12:16
-          StorageLive(_7);                 // scope 3 at $DIR/const_debuginfo.rs:12:19: 12:20
-          _7 = const 2_u8;                 // scope 3 at $DIR/const_debuginfo.rs:12:19: 12:20
-          _5 = const 3_u8;                 // scope 3 at $DIR/const_debuginfo.rs:12:15: 12:20
-          StorageDead(_7);                 // scope 3 at $DIR/const_debuginfo.rs:12:19: 12:20
-          StorageDead(_6);                 // scope 3 at $DIR/const_debuginfo.rs:12:19: 12:20
-          StorageLive(_8);                 // scope 3 at $DIR/const_debuginfo.rs:12:23: 12:24
-          _8 = const 3_u8;                 // scope 3 at $DIR/const_debuginfo.rs:12:23: 12:24
-          _4 = const 6_u8;                 // scope 3 at $DIR/const_debuginfo.rs:12:15: 12:24
-          StorageDead(_8);                 // scope 3 at $DIR/const_debuginfo.rs:12:23: 12:24
-          StorageDead(_5);                 // scope 3 at $DIR/const_debuginfo.rs:12:23: 12:24
-          StorageLive(_9);                 // scope 4 at $DIR/const_debuginfo.rs:14:9: 14:10
-          _9 = const "hello, world!";      // scope 4 at $DIR/const_debuginfo.rs:14:13: 14:28
+          StorageLive(_1);                 // scope 0 at $DIR/const_debuginfo.rs:+1:9: +1:10
+          _1 = const 1_u8;                 // scope 0 at $DIR/const_debuginfo.rs:+1:13: +1:16
+          StorageLive(_2);                 // scope 1 at $DIR/const_debuginfo.rs:+2:9: +2:10
+          _2 = const 2_u8;                 // scope 1 at $DIR/const_debuginfo.rs:+2:13: +2:16
+          StorageLive(_3);                 // scope 2 at $DIR/const_debuginfo.rs:+3:9: +3:10
+          _3 = const 3_u8;                 // scope 2 at $DIR/const_debuginfo.rs:+3:13: +3:16
+          StorageLive(_4);                 // scope 3 at $DIR/const_debuginfo.rs:+4:9: +4:12
+          StorageLive(_5);                 // scope 3 at $DIR/const_debuginfo.rs:+4:15: +4:20
+          StorageLive(_6);                 // scope 3 at $DIR/const_debuginfo.rs:+4:15: +4:16
+          _6 = const 1_u8;                 // scope 3 at $DIR/const_debuginfo.rs:+4:15: +4:16
+          StorageLive(_7);                 // scope 3 at $DIR/const_debuginfo.rs:+4:19: +4:20
+          _7 = const 2_u8;                 // scope 3 at $DIR/const_debuginfo.rs:+4:19: +4:20
+          _5 = const 3_u8;                 // scope 3 at $DIR/const_debuginfo.rs:+4:15: +4:20
+          StorageDead(_7);                 // scope 3 at $DIR/const_debuginfo.rs:+4:19: +4:20
+          StorageDead(_6);                 // scope 3 at $DIR/const_debuginfo.rs:+4:19: +4:20
+          StorageLive(_8);                 // scope 3 at $DIR/const_debuginfo.rs:+4:23: +4:24
+          _8 = const 3_u8;                 // scope 3 at $DIR/const_debuginfo.rs:+4:23: +4:24
+          _4 = const 6_u8;                 // scope 3 at $DIR/const_debuginfo.rs:+4:15: +4:24
+          StorageDead(_8);                 // scope 3 at $DIR/const_debuginfo.rs:+4:23: +4:24
+          StorageDead(_5);                 // scope 3 at $DIR/const_debuginfo.rs:+4:23: +4:24
+          StorageLive(_9);                 // scope 4 at $DIR/const_debuginfo.rs:+6:9: +6:10
+          _9 = const "hello, world!";      // scope 4 at $DIR/const_debuginfo.rs:+6:13: +6:28
                                            // mir::Constant
                                            // + span: $DIR/const_debuginfo.rs:14:13: 14:28
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          StorageLive(_10);                // scope 5 at $DIR/const_debuginfo.rs:16:9: 16:10
-          Deinit(_10);                     // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
-          (_10.0: bool) = const true;      // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
-          (_10.1: bool) = const false;     // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
-          (_10.2: u32) = const 123_u32;    // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
-          StorageLive(_11);                // scope 6 at $DIR/const_debuginfo.rs:18:9: 18:10
-          Deinit(_11);                     // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
-          ((_11 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
-          discriminant(_11) = 1;           // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
-          StorageLive(_12);                // scope 7 at $DIR/const_debuginfo.rs:20:9: 20:10
-          Deinit(_12);                     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35
-          (_12.0: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35
-          (_12.1: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35
-          StorageLive(_13);                // scope 8 at $DIR/const_debuginfo.rs:21:9: 21:10
-          StorageLive(_14);                // scope 8 at $DIR/const_debuginfo.rs:21:13: 21:16
-          _14 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:21:13: 21:16
-          StorageLive(_15);                // scope 8 at $DIR/const_debuginfo.rs:21:19: 21:22
-          _15 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:21:19: 21:22
-          _13 = const 64_u32;              // scope 8 at $DIR/const_debuginfo.rs:21:13: 21:22
-          StorageDead(_15);                // scope 8 at $DIR/const_debuginfo.rs:21:21: 21:22
-          StorageDead(_14);                // scope 8 at $DIR/const_debuginfo.rs:21:21: 21:22
-          nop;                             // scope 0 at $DIR/const_debuginfo.rs:8:11: 22:2
-          StorageDead(_13);                // scope 8 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_12);                // scope 7 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_11);                // scope 6 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_10);                // scope 5 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_9);                 // scope 4 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_4);                 // scope 3 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_3);                 // scope 2 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_2);                 // scope 1 at $DIR/const_debuginfo.rs:22:1: 22:2
-          StorageDead(_1);                 // scope 0 at $DIR/const_debuginfo.rs:22:1: 22:2
-          return;                          // scope 0 at $DIR/const_debuginfo.rs:22:2: 22:2
+          StorageLive(_10);                // scope 5 at $DIR/const_debuginfo.rs:+8:9: +8:10
+          Deinit(_10);                     // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          (_10.0: bool) = const true;      // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          (_10.1: bool) = const false;     // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          (_10.2: u32) = const 123_u32;    // scope 5 at $DIR/const_debuginfo.rs:+8:13: +8:34
+          StorageLive(_11);                // scope 6 at $DIR/const_debuginfo.rs:+10:9: +10:10
+          Deinit(_11);                     // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
+          ((_11 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
+          discriminant(_11) = 1;           // scope 6 at $DIR/const_debuginfo.rs:+10:13: +10:24
+          StorageLive(_12);                // scope 7 at $DIR/const_debuginfo.rs:+12:9: +12:10
+          Deinit(_12);                     // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
+          (_12.0: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
+          (_12.1: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:+12:13: +12:35
+          StorageLive(_13);                // scope 8 at $DIR/const_debuginfo.rs:+13:9: +13:10
+          StorageLive(_14);                // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:16
+          _14 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:16
+          StorageLive(_15);                // scope 8 at $DIR/const_debuginfo.rs:+13:19: +13:22
+          _15 = const 32_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:19: +13:22
+          _13 = const 64_u32;              // scope 8 at $DIR/const_debuginfo.rs:+13:13: +13:22
+          StorageDead(_15);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
+          StorageDead(_14);                // scope 8 at $DIR/const_debuginfo.rs:+13:21: +13:22
+          nop;                             // scope 0 at $DIR/const_debuginfo.rs:+0:11: +14:2
+          StorageDead(_13);                // scope 8 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_12);                // scope 7 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_11);                // scope 6 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_10);                // scope 5 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_9);                 // scope 4 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_4);                 // scope 3 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_3);                 // scope 2 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_2);                 // scope 1 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          StorageDead(_1);                 // scope 0 at $DIR/const_debuginfo.rs:+14:1: +14:2
+          return;                          // scope 0 at $DIR/const_debuginfo.rs:+14:2: +14:2
       }
   }
   

--- a/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -2,25 +2,25 @@
 + // MIR for `issue_77355_opt` after ConstGoto
   
   fn issue_77355_opt(_1: Foo) -> u64 {
-      debug num => _1;                     // in scope 0 at $DIR/const_goto.rs:11:20: 11:23
-      let mut _0: u64;                     // return place in scope 0 at $DIR/const_goto.rs:11:33: 11:36
+      debug num => _1;                     // in scope 0 at $DIR/const_goto.rs:+0:20: +0:23
+      let mut _0: u64;                     // return place in scope 0 at $DIR/const_goto.rs:+0:33: +0:36
 -     let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--     let mut _3: isize;                   // in scope 0 at $DIR/const_goto.rs:12:22: 12:28
-+     let mut _2: isize;                   // in scope 0 at $DIR/const_goto.rs:12:22: 12:28
+-     let mut _3: isize;                   // in scope 0 at $DIR/const_goto.rs:+1:22: +1:28
++     let mut _2: isize;                   // in scope 0 at $DIR/const_goto.rs:+1:22: +1:28
   
       bb0: {
 -         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:17: 12:20
+-         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:+1:17: +1:20
 -         switchInt(move _3) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:17: 12:20
++         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:+1:17: +1:20
 +         switchInt(move _2) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb1: {
 -         _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:12:53: 12:55
-+         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
++         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:+1:53: +1:55
++         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:+1:5: +1:57
       }
   
       bb2: {
@@ -33,20 +33,20 @@
 -     }
 - 
 -     bb4: {
-          _0 = const 23_u64;               // scope 0 at $DIR/const_goto.rs:12:41: 12:43
--         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
-+         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
+          _0 = const 23_u64;               // scope 0 at $DIR/const_goto.rs:+1:41: +1:43
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:+1:5: +1:57
++         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:+1:5: +1:57
       }
   
 -     bb5: {
--         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:12:53: 12:55
--         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
+-         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:+1:53: +1:55
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:+1:5: +1:57
 -     }
 - 
 -     bb6: {
--         StorageDead(_2);                 // scope 0 at $DIR/const_goto.rs:12:56: 12:57
+-         StorageDead(_2);                 // scope 0 at $DIR/const_goto.rs:+1:56: +1:57
 +     bb3: {
-          return;                          // scope 0 at $DIR/const_goto.rs:13:2: 13:2
+          return;                          // scope 0 at $DIR/const_goto.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
@@ -2,50 +2,50 @@
 + // MIR for `f` after ConstGoto
   
   fn f() -> u64 {
-      let mut _0: u64;                     // return place in scope 0 at $DIR/const_goto_const_eval_fail.rs:6:44: 6:47
-      let mut _1: bool;                    // in scope 0 at $DIR/const_goto_const_eval_fail.rs:7:11: 12:6
-      let mut _2: i32;                     // in scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
+      let mut _0: u64;                     // return place in scope 0 at $DIR/const_goto_const_eval_fail.rs:+0:44: +0:47
+      let mut _1: bool;                    // in scope 0 at $DIR/const_goto_const_eval_fail.rs:+1:11: +6:6
+      let mut _2: i32;                     // in scope 0 at $DIR/const_goto_const_eval_fail.rs:+2:15: +2:16
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:11: 12:6
-          StorageLive(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
-          _2 = const A;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
-          switchInt(_2) -> [1_i32: bb2, 2_i32: bb2, 3_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:9: 8:16
+          StorageLive(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:+1:11: +6:6
+          StorageLive(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:+2:15: +2:16
+          _2 = const A;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:+2:15: +2:16
+          switchInt(_2) -> [1_i32: bb2, 2_i32: bb2, 3_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:+2:9: +2:16
       }
   
       bb1: {
-          _1 = const true;                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:10:18: 10:22
-          goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:10:18: 10:22
+          _1 = const true;                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:+4:18: +4:22
+          goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:+4:18: +4:22
       }
   
       bb2: {
-          _1 = const B;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:26: 9:27
--         goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:26: 9:27
-+         switchInt(_1) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 12:6
+          _1 = const B;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:+3:26: +3:27
+-         goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:+3:26: +3:27
++         switchInt(_1) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:+1:5: +6:6
       }
   
       bb3: {
--         switchInt(_1) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 12:6
+-         switchInt(_1) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:+1:5: +6:6
 -     }
 - 
 -     bb4: {
-          _0 = const 2_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
--         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
-+         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
+          _0 = const 2_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:+8:17: +8:18
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:+8:17: +8:18
++         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:+8:17: +8:18
       }
   
 -     bb5: {
 +     bb4: {
-          _0 = const 1_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
--         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
-+         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
+          _0 = const 1_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:+7:18: +7:19
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:+7:18: +7:19
++         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:+7:18: +7:19
       }
   
 -     bb6: {
 +     bb5: {
-          StorageDead(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:1: 16:2
-          StorageDead(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:1: 16:2
-          return;                          // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:2: 16:2
+          StorageDead(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:+10:1: +10:2
+          StorageDead(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:+10:1: +10:2
+          return;                          // scope 0 at $DIR/const_goto_const_eval_fail.rs:+10:2: +10:2
       }
   }
   

--- a/src/test/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
@@ -2,102 +2,102 @@
 + // MIR for `match_nested_if` after ConstGoto
   
   fn match_nested_if() -> bool {
-      let mut _0: bool;                    // return place in scope 0 at $DIR/const_goto_storage.rs:2:25: 2:29
-      let _1: bool;                        // in scope 0 at $DIR/const_goto_storage.rs:3:9: 3:12
--     let mut _2: ();                      // in scope 0 at $DIR/const_goto_storage.rs:3:21: 3:23
--     let mut _3: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:4:15: 8:10
--     let mut _4: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:4:18: 4:76
--     let mut _5: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:4:21: 4:52
--     let mut _6: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
-+     let mut _2: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
+      let mut _0: bool;                    // return place in scope 0 at $DIR/const_goto_storage.rs:+0:25: +0:29
+      let _1: bool;                        // in scope 0 at $DIR/const_goto_storage.rs:+1:9: +1:12
+-     let mut _2: ();                      // in scope 0 at $DIR/const_goto_storage.rs:+1:21: +1:23
+-     let mut _3: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
+-     let mut _4: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
+-     let mut _5: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
+-     let mut _6: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
++     let mut _2: bool;                    // in scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
       scope 1 {
-          debug val => _1;                 // in scope 1 at $DIR/const_goto_storage.rs:3:9: 3:12
+          debug val => _1;                 // in scope 1 at $DIR/const_goto_storage.rs:+1:9: +1:12
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_goto_storage.rs:3:9: 3:12
--         StorageLive(_2);                 // scope 0 at $DIR/const_goto_storage.rs:3:21: 3:23
--         nop;                             // scope 0 at $DIR/const_goto_storage.rs:3:21: 3:23
--         StorageLive(_3);                 // scope 0 at $DIR/const_goto_storage.rs:4:15: 8:10
--         StorageLive(_4);                 // scope 0 at $DIR/const_goto_storage.rs:4:18: 4:76
--         StorageLive(_5);                 // scope 0 at $DIR/const_goto_storage.rs:4:21: 4:52
--         StorageLive(_6);                 // scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
--         _6 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
--         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
-+         StorageLive(_2);                 // scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
-+         _2 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
-+         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:4:24: 4:28
+          StorageLive(_1);                 // scope 0 at $DIR/const_goto_storage.rs:+1:9: +1:12
+-         StorageLive(_2);                 // scope 0 at $DIR/const_goto_storage.rs:+1:21: +1:23
+-         nop;                             // scope 0 at $DIR/const_goto_storage.rs:+1:21: +1:23
+-         StorageLive(_3);                 // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
+-         StorageLive(_4);                 // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
+-         StorageLive(_5);                 // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
+-         StorageLive(_6);                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
+-         _6 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
+-         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
++         StorageLive(_2);                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
++         _2 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
++         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_storage.rs:+2:24: +2:28
       }
   
       bb1: {
--         _5 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:4:31: 4:35
--         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:4:21: 4:52
+-         _5 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+2:31: +2:35
+-         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
 -     }
 - 
 -     bb2: {
--         _5 = const false;                // scope 0 at $DIR/const_goto_storage.rs:4:45: 4:50
--         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:4:21: 4:52
+-         _5 = const false;                // scope 0 at $DIR/const_goto_storage.rs:+2:45: +2:50
+-         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
 -     }
 - 
 -     bb3: {
--         StorageDead(_6);                 // scope 0 at $DIR/const_goto_storage.rs:4:51: 4:52
--         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_storage.rs:4:21: 4:52
+-         StorageDead(_6);                 // scope 0 at $DIR/const_goto_storage.rs:+2:51: +2:52
+-         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
 -     }
 - 
 -     bb4: {
--         _4 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:4:55: 4:59
--         goto -> bb6;                     // scope 0 at $DIR/const_goto_storage.rs:4:18: 4:76
+-         _4 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+2:55: +2:59
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
 -     }
 - 
 -     bb5: {
--         _4 = const false;                // scope 0 at $DIR/const_goto_storage.rs:4:69: 4:74
--         goto -> bb6;                     // scope 0 at $DIR/const_goto_storage.rs:4:18: 4:76
+-         _4 = const false;                // scope 0 at $DIR/const_goto_storage.rs:+2:69: +2:74
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
 -     }
 - 
 -     bb6: {
--         StorageDead(_5);                 // scope 0 at $DIR/const_goto_storage.rs:4:75: 4:76
--         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/const_goto_storage.rs:4:18: 4:76
+-         StorageDead(_5);                 // scope 0 at $DIR/const_goto_storage.rs:+2:75: +2:76
+-         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
 -     }
 - 
 -     bb7: {
--         _3 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:5:13: 5:17
--         goto -> bb9;                     // scope 0 at $DIR/const_goto_storage.rs:4:15: 8:10
+-         _3 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+3:13: +3:17
+-         goto -> bb9;                     // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
 -     }
 - 
 -     bb8: {
--         _3 = const false;                // scope 0 at $DIR/const_goto_storage.rs:7:13: 7:18
--         goto -> bb9;                     // scope 0 at $DIR/const_goto_storage.rs:4:15: 8:10
+-         _3 = const false;                // scope 0 at $DIR/const_goto_storage.rs:+5:13: +5:18
+-         goto -> bb9;                     // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
 -     }
 - 
 -     bb9: {
--         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/const_goto_storage.rs:4:15: 8:10
+-         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
 -     }
 - 
 -     bb10: {
--         StorageDead(_4);                 // scope 0 at $DIR/const_goto_storage.rs:8:9: 8:10
--         StorageDead(_3);                 // scope 0 at $DIR/const_goto_storage.rs:8:9: 8:10
-+         StorageDead(_2);                 // scope 0 at $DIR/const_goto_storage.rs:4:51: 4:52
-          _1 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:10:17: 10:21
--         goto -> bb12;                    // scope 0 at $DIR/const_goto_storage.rs:10:17: 10:21
-+         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:10:17: 10:21
+-         StorageDead(_4);                 // scope 0 at $DIR/const_goto_storage.rs:+6:9: +6:10
+-         StorageDead(_3);                 // scope 0 at $DIR/const_goto_storage.rs:+6:9: +6:10
++         StorageDead(_2);                 // scope 0 at $DIR/const_goto_storage.rs:+2:51: +2:52
+          _1 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+8:17: +8:21
+-         goto -> bb12;                    // scope 0 at $DIR/const_goto_storage.rs:+8:17: +8:21
++         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:+8:17: +8:21
       }
   
 -     bb11: {
--         StorageDead(_4);                 // scope 0 at $DIR/const_goto_storage.rs:8:9: 8:10
--         StorageDead(_3);                 // scope 0 at $DIR/const_goto_storage.rs:8:9: 8:10
+-         StorageDead(_4);                 // scope 0 at $DIR/const_goto_storage.rs:+6:9: +6:10
+-         StorageDead(_3);                 // scope 0 at $DIR/const_goto_storage.rs:+6:9: +6:10
 +     bb2: {
-+         StorageDead(_2);                 // scope 0 at $DIR/const_goto_storage.rs:4:51: 4:52
-          _1 = const false;                // scope 0 at $DIR/const_goto_storage.rs:12:14: 12:19
--         goto -> bb12;                    // scope 0 at $DIR/const_goto_storage.rs:12:14: 12:19
-+         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:12:14: 12:19
++         StorageDead(_2);                 // scope 0 at $DIR/const_goto_storage.rs:+2:51: +2:52
+          _1 = const false;                // scope 0 at $DIR/const_goto_storage.rs:+10:14: +10:19
+-         goto -> bb12;                    // scope 0 at $DIR/const_goto_storage.rs:+10:14: +10:19
++         goto -> bb3;                     // scope 0 at $DIR/const_goto_storage.rs:+10:14: +10:19
       }
   
 -     bb12: {
--         StorageDead(_2);                 // scope 0 at $DIR/const_goto_storage.rs:13:6: 13:7
+-         StorageDead(_2);                 // scope 0 at $DIR/const_goto_storage.rs:+11:6: +11:7
 +     bb3: {
-          _0 = _1;                         // scope 1 at $DIR/const_goto_storage.rs:14:5: 14:8
-          StorageDead(_1);                 // scope 0 at $DIR/const_goto_storage.rs:15:1: 15:2
-          return;                          // scope 0 at $DIR/const_goto_storage.rs:15:2: 15:2
+          _0 = _1;                         // scope 1 at $DIR/const_goto_storage.rs:+12:5: +12:8
+          StorageDead(_1);                 // scope 0 at $DIR/const_goto_storage.rs:+13:1: +13:2
+          return;                          // scope 0 at $DIR/const_goto_storage.rs:+13:2: +13:2
       }
   }
   

--- a/src/test/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -1,20 +1,20 @@
 // MIR for `BAR::promoted[0]` after SimplifyCfg-elaborate-drops
 
 promoted[0] in BAR: &[&i32; 1] = {
-    let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-    let mut _1: [&i32; 1];               // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
-    let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
-    let mut _3: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+    let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+    let mut _1: [&i32; 1];               // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:35
+    let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:34
+    let mut _3: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:33: +0:34
 
     bb0: {
-        _3 = const {alloc1: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+        _3 = const {alloc1: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:+0:33: +0:34
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc1)) }
-        _2 = &(*_3);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
-        _1 = [move _2];                  // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
-        _0 = &_1;                        // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+        _2 = &(*_3);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:34
+        _1 = [move _2];                  // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:35
+        _0 = &_1;                        // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
     }
 }
 

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -2,49 +2,49 @@
 + // MIR for `BAR` after PromoteTemps
   
   static mut BAR: *const &i32 = {
-      let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:9:17: 9:28
-      let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
-      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
-      let _5: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
-+     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+      let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:+0:17: +0:28
+      let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:35
+      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:34
+      let _5: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:33: +0:34
++     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-          StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
--         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
--         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
--         StorageLive(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
--         _5 = const {alloc1: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
-+         _6 = const BAR::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+          StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+          StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+-         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:35
+-         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:34
+-         StorageLive(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:33: +0:34
+-         _5 = const {alloc1: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:+0:33: +0:34
++         _6 = const BAR::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
 -                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc1)) }
--         _4 = &(*_5);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
--         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
--         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+-         _4 = &(*_5);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:34
+-         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:35
+-         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
 +                                          // + span: $DIR/const-promotion-extern-static.rs:9:31: 9:44
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(BAR, [], Some(promoted[0])) }
-+         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-          _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
--         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:34: 9:35
-          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:34: 9:35
-          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
++         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+          _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
+-         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:34: +0:35
+          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:34: +0:35
+          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:9:36: 9:42
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(<ZST>) }
       }
   
       bb1: {
--         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
--         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
-          StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
-          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:28
+-         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
+-         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
+          StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
+          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:28
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
       }
 - }
 - 

--- a/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
@@ -1,17 +1,17 @@
 // MIR for `BOP` 0 mir_map
 
 static BOP: &i32 = {
-    let mut _0: &i32;                    // return place in scope 0 at $DIR/const-promotion-extern-static.rs:16:13: 16:17
-    let _1: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:16:20: 16:23
-    let _2: i32;                         // in scope 0 at $DIR/const-promotion-extern-static.rs:16:21: 16:23
+    let mut _0: &i32;                    // return place in scope 0 at $DIR/const-promotion-extern-static.rs:+0:13: +0:17
+    let _1: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
+    let _2: i32;                         // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:21: +0:23
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:16:20: 16:23
-        StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:16:21: 16:23
-        _2 = const 13_i32;               // scope 0 at $DIR/const-promotion-extern-static.rs:16:21: 16:23
-        _1 = &_2;                        // scope 0 at $DIR/const-promotion-extern-static.rs:16:20: 16:23
-        _0 = &(*_1);                     // scope 0 at $DIR/const-promotion-extern-static.rs:16:20: 16:23
-        StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:16:22: 16:23
-        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:16:1: 16:17
+        StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
+        StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:21: +0:23
+        _2 = const 13_i32;               // scope 0 at $DIR/const-promotion-extern-static.rs:+0:21: +0:23
+        _1 = &_2;                        // scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
+        _0 = &(*_1);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
+        StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:22: +0:23
+        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:17
     }
 }

--- a/src/test/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -1,20 +1,20 @@
 // MIR for `FOO::promoted[0]` after SimplifyCfg-elaborate-drops
 
 promoted[0] in FOO: &[&i32; 1] = {
-    let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-    let mut _1: [&i32; 1];               // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
-    let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
-    let mut _3: *const i32;              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+    let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+    let mut _1: [&i32; 1];               // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:46
+    let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:45
+    let mut _3: *const i32;              // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:42: +0:43
 
     bb0: {
-        _3 = const {alloc3: *const i32}; // scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+        _3 = const {alloc3: *const i32}; // scope 0 at $DIR/const-promotion-extern-static.rs:+0:42: +0:43
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
                                          // + literal: Const { ty: *const i32, val: Value(Scalar(alloc3)) }
-        _2 = &(*_3);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
-        _1 = [move _2];                  // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
-        _0 = &_1;                        // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+        _2 = &(*_3);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:41: +0:43
+        _1 = [move _2];                  // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:46
+        _0 = &_1;                        // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
     }
 }
 

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -2,51 +2,51 @@
 + // MIR for `FOO` after PromoteTemps
   
   static mut FOO: *const &i32 = {
-      let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:13:17: 13:28
-      let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
-      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
-      let _5: *const i32;                  // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
-+     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+      let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:+0:17: +0:28
+      let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:46
+      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:45
+      let _5: *const i32;                  // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:42: +0:43
++     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
       scope 1 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-          StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
--         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
--         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
--         StorageLive(_5);                 // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
--         _5 = const {alloc3: *const i32}; // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
-+         _6 = const FOO::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+          StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+          StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+-         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:46
+-         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:32: +0:45
+-         StorageLive(_5);                 // scope 1 at $DIR/const-promotion-extern-static.rs:+0:42: +0:43
+-         _5 = const {alloc3: *const i32}; // scope 1 at $DIR/const-promotion-extern-static.rs:+0:42: +0:43
++         _6 = const FOO::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
 -                                          // + literal: Const { ty: *const i32, val: Value(Scalar(alloc3)) }
--         _4 = &(*_5);                     // scope 1 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
--         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
--         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+-         _4 = &(*_5);                     // scope 1 at $DIR/const-promotion-extern-static.rs:+0:41: +0:43
+-         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:46
+-         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
 +                                          // + span: $DIR/const-promotion-extern-static.rs:13:31: 13:55
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(FOO, [], Some(promoted[0])) }
-+         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-          _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
--         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:45: 13:46
-          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:45: 13:46
-          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
++         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+          _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
+-         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:45: +0:46
+          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:45: +0:46
+          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:13:47: 13:53
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(<ZST>) }
       }
   
       bb1: {
--         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
--         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
-          StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
-          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:28
+-         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
+-         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
+          StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
+          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:28
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
       }
   }
 - 

--- a/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
@@ -2,31 +2,31 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/aggregate.rs:4:11: 4:11
-      let _1: i32;                         // in scope 0 at $DIR/aggregate.rs:5:9: 5:10
-      let mut _2: i32;                     // in scope 0 at $DIR/aggregate.rs:5:13: 5:24
-      let mut _3: (i32, i32, i32);         // in scope 0 at $DIR/aggregate.rs:5:13: 5:22
+      let mut _0: ();                      // return place in scope 0 at $DIR/aggregate.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/aggregate.rs:+1:9: +1:10
+      let mut _2: i32;                     // in scope 0 at $DIR/aggregate.rs:+1:13: +1:24
+      let mut _3: (i32, i32, i32);         // in scope 0 at $DIR/aggregate.rs:+1:13: +1:22
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/aggregate.rs:5:9: 5:10
+          debug x => _1;                   // in scope 1 at $DIR/aggregate.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/aggregate.rs:5:9: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:24
-          StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          Deinit(_3);                      // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          (_3.0: i32) = const 0_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          (_3.1: i32) = const 1_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          (_3.2: i32) = const 2_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
--         _2 = (_3.1: i32);                // scope 0 at $DIR/aggregate.rs:5:13: 5:24
--         _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/aggregate.rs:5:13: 5:28
-+         _2 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:24
-+         _1 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:28
-          StorageDead(_2);                 // scope 0 at $DIR/aggregate.rs:5:27: 5:28
-          StorageDead(_3);                 // scope 0 at $DIR/aggregate.rs:5:28: 5:29
-          nop;                             // scope 0 at $DIR/aggregate.rs:4:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/aggregate.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/aggregate.rs:6:2: 6:2
+          StorageLive(_1);                 // scope 0 at $DIR/aggregate.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
+          StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+          Deinit(_3);                      // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+          (_3.0: i32) = const 0_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+          (_3.1: i32) = const 1_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+          (_3.2: i32) = const 2_i32;       // scope 0 at $DIR/aggregate.rs:+1:13: +1:22
+-         _2 = (_3.1: i32);                // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
+-         _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/aggregate.rs:+1:13: +1:28
++         _2 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:24
++         _1 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:+1:13: +1:28
+          StorageDead(_2);                 // scope 0 at $DIR/aggregate.rs:+1:27: +1:28
+          StorageDead(_3);                 // scope 0 at $DIR/aggregate.rs:+1:28: +1:29
+          nop;                             // scope 0 at $DIR/aggregate.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/aggregate.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/aggregate.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.32bit.diff
@@ -2,37 +2,37 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/array_index.rs:4:11: 4:11
-      let _1: u32;                         // in scope 0 at $DIR/array_index.rs:5:9: 5:10
-      let mut _2: [u32; 4];                // in scope 0 at $DIR/array_index.rs:5:18: 5:30
-      let _3: usize;                       // in scope 0 at $DIR/array_index.rs:5:31: 5:32
-      let mut _4: usize;                   // in scope 0 at $DIR/array_index.rs:5:18: 5:33
-      let mut _5: bool;                    // in scope 0 at $DIR/array_index.rs:5:18: 5:33
+      let mut _0: ();                      // return place in scope 0 at $DIR/array_index.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/array_index.rs:+1:9: +1:10
+      let mut _2: [u32; 4];                // in scope 0 at $DIR/array_index.rs:+1:18: +1:30
+      let _3: usize;                       // in scope 0 at $DIR/array_index.rs:+1:31: +1:32
+      let mut _4: usize;                   // in scope 0 at $DIR/array_index.rs:+1:18: +1:33
+      let mut _5: bool;                    // in scope 0 at $DIR/array_index.rs:+1:18: +1:33
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/array_index.rs:5:9: 5:10
+          debug x => _1;                   // in scope 1 at $DIR/array_index.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:5:9: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:5:18: 5:30
-          _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
-          StorageLive(_3);                 // scope 0 at $DIR/array_index.rs:5:31: 5:32
-          _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:5:31: 5:32
-          _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:5:18: 5:33
--         _5 = Lt(_3, _4);                 // scope 0 at $DIR/array_index.rs:5:18: 5:33
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         _5 = const true;                 // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> bb1; // scope 0 at $DIR/array_index.rs:5:18: 5:33
+          StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:+1:18: +1:30
+          _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:+1:18: +1:30
+          StorageLive(_3);                 // scope 0 at $DIR/array_index.rs:+1:31: +1:32
+          _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:+1:31: +1:32
+          _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+-         _5 = Lt(_3, _4);                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         _5 = const true;                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
       }
   
       bb1: {
--         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:5:18: 5:33
-          StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
-          StorageDead(_2);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
-          nop;                             // scope 0 at $DIR/array_index.rs:4:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/array_index.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/array_index.rs:6:2: 6:2
+-         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+          StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:+1:33: +1:34
+          StorageDead(_2);                 // scope 0 at $DIR/array_index.rs:+1:33: +1:34
+          nop;                             // scope 0 at $DIR/array_index.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/array_index.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/array_index.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.64bit.diff
@@ -2,37 +2,37 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/array_index.rs:4:11: 4:11
-      let _1: u32;                         // in scope 0 at $DIR/array_index.rs:5:9: 5:10
-      let mut _2: [u32; 4];                // in scope 0 at $DIR/array_index.rs:5:18: 5:30
-      let _3: usize;                       // in scope 0 at $DIR/array_index.rs:5:31: 5:32
-      let mut _4: usize;                   // in scope 0 at $DIR/array_index.rs:5:18: 5:33
-      let mut _5: bool;                    // in scope 0 at $DIR/array_index.rs:5:18: 5:33
+      let mut _0: ();                      // return place in scope 0 at $DIR/array_index.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/array_index.rs:+1:9: +1:10
+      let mut _2: [u32; 4];                // in scope 0 at $DIR/array_index.rs:+1:18: +1:30
+      let _3: usize;                       // in scope 0 at $DIR/array_index.rs:+1:31: +1:32
+      let mut _4: usize;                   // in scope 0 at $DIR/array_index.rs:+1:18: +1:33
+      let mut _5: bool;                    // in scope 0 at $DIR/array_index.rs:+1:18: +1:33
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/array_index.rs:5:9: 5:10
+          debug x => _1;                   // in scope 1 at $DIR/array_index.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:5:9: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:5:18: 5:30
-          _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
-          StorageLive(_3);                 // scope 0 at $DIR/array_index.rs:5:31: 5:32
-          _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:5:31: 5:32
-          _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:5:18: 5:33
--         _5 = Lt(_3, _4);                 // scope 0 at $DIR/array_index.rs:5:18: 5:33
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         _5 = const true;                 // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> bb1; // scope 0 at $DIR/array_index.rs:5:18: 5:33
+          StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:+1:18: +1:30
+          _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:+1:18: +1:30
+          StorageLive(_3);                 // scope 0 at $DIR/array_index.rs:+1:31: +1:32
+          _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:+1:31: +1:32
+          _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+-         _5 = Lt(_3, _4);                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         _5 = const true;                 // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> bb1; // scope 0 at $DIR/array_index.rs:+1:18: +1:33
       }
   
       bb1: {
--         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:5:18: 5:33
-          StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
-          StorageDead(_2);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
-          nop;                             // scope 0 at $DIR/array_index.rs:4:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/array_index.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/array_index.rs:6:2: 6:2
+-         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:+1:18: +1:33
++         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:+1:18: +1:33
+          StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:+1:33: +1:34
+          StorageDead(_2);                 // scope 0 at $DIR/array_index.rs:+1:33: +1:34
+          nop;                             // scope 0 at $DIR/array_index.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/array_index.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/array_index.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
@@ -2,53 +2,53 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_div_by_zero.rs:3:11: 3:11
-      let _1: i32;                         // in scope 0 at $DIR/bad_op_div_by_zero.rs:4:9: 4:10
-      let mut _3: i32;                     // in scope 0 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
-      let mut _4: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-      let mut _5: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-      let mut _6: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-      let mut _7: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_div_by_zero.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/bad_op_div_by_zero.rs:+1:9: +1:10
+      let mut _3: i32;                     // in scope 0 at $DIR/bad_op_div_by_zero.rs:+2:18: +2:19
+      let mut _4: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+      let mut _5: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+      let mut _6: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+      let mut _7: bool;                    // in scope 0 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
       scope 1 {
-          debug y => _1;                   // in scope 1 at $DIR/bad_op_div_by_zero.rs:4:9: 4:10
-          let _2: i32;                     // in scope 1 at $DIR/bad_op_div_by_zero.rs:5:9: 5:11
+          debug y => _1;                   // in scope 1 at $DIR/bad_op_div_by_zero.rs:+1:9: +1:10
+          let _2: i32;                     // in scope 1 at $DIR/bad_op_div_by_zero.rs:+2:9: +2:11
           scope 2 {
-              debug _z => _2;              // in scope 2 at $DIR/bad_op_div_by_zero.rs:5:9: 5:11
+              debug _z => _2;              // in scope 2 at $DIR/bad_op_div_by_zero.rs:+2:9: +2:11
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/bad_op_div_by_zero.rs:4:9: 4:10
-          _1 = const 0_i32;                // scope 0 at $DIR/bad_op_div_by_zero.rs:4:13: 4:14
-          StorageLive(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:9: 5:11
-          StorageLive(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
--         _3 = _1;                         // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
--         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
--         assert(!move _4, "attempt to divide `{}` by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
-+         _4 = const true;                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         assert(!const true, "attempt to divide `{}` by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+          StorageLive(_1);                 // scope 0 at $DIR/bad_op_div_by_zero.rs:+1:9: +1:10
+          _1 = const 0_i32;                // scope 0 at $DIR/bad_op_div_by_zero.rs:+1:13: +1:14
+          StorageLive(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:9: +2:11
+          StorageLive(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:18: +2:19
+-         _3 = _1;                         // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:18: +2:19
+-         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+-         assert(!move _4, "attempt to divide `{}` by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
++         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:18: +2:19
++         _4 = const true;                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
++         assert(!const true, "attempt to divide `{}` by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
       }
   
       bb1: {
--         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
--         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
--         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
--         assert(!move _7, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         _5 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         _6 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         _7 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, const 0_i32) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+-         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+-         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+-         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+-         assert(!move _7, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
++         _5 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
++         _6 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
++         _7 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
++         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, const 0_i32) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
       }
   
       bb2: {
--         _2 = Div(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         _2 = Div(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-          StorageDead(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
-          nop;                             // scope 0 at $DIR/bad_op_div_by_zero.rs:3:11: 6:2
-          StorageDead(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:6:1: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/bad_op_div_by_zero.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/bad_op_div_by_zero.rs:6:2: 6:2
+-         _2 = Div(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
++         _2 = Div(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:14: +2:19
+          StorageDead(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+2:18: +2:19
+          nop;                             // scope 0 at $DIR/bad_op_div_by_zero.rs:+0:11: +3:2
+          StorageDead(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:+3:1: +3:2
+          StorageDead(_1);                 // scope 0 at $DIR/bad_op_div_by_zero.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/bad_op_div_by_zero.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
@@ -2,53 +2,53 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_mod_by_zero.rs:3:11: 3:11
-      let _1: i32;                         // in scope 0 at $DIR/bad_op_mod_by_zero.rs:4:9: 4:10
-      let mut _3: i32;                     // in scope 0 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
-      let mut _4: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-      let mut _5: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-      let mut _6: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-      let mut _7: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_mod_by_zero.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/bad_op_mod_by_zero.rs:+1:9: +1:10
+      let mut _3: i32;                     // in scope 0 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
+      let mut _4: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+      let mut _5: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+      let mut _6: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+      let mut _7: bool;                    // in scope 0 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
       scope 1 {
-          debug y => _1;                   // in scope 1 at $DIR/bad_op_mod_by_zero.rs:4:9: 4:10
-          let _2: i32;                     // in scope 1 at $DIR/bad_op_mod_by_zero.rs:5:9: 5:11
+          debug y => _1;                   // in scope 1 at $DIR/bad_op_mod_by_zero.rs:+1:9: +1:10
+          let _2: i32;                     // in scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:9: +2:11
           scope 2 {
-              debug _z => _2;              // in scope 2 at $DIR/bad_op_mod_by_zero.rs:5:9: 5:11
+              debug _z => _2;              // in scope 2 at $DIR/bad_op_mod_by_zero.rs:+2:9: +2:11
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:4:9: 4:10
-          _1 = const 0_i32;                // scope 0 at $DIR/bad_op_mod_by_zero.rs:4:13: 4:14
-          StorageLive(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:9: 5:11
-          StorageLive(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
--         _3 = _1;                         // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
--         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
--         assert(!move _4, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
-+         _4 = const true;                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         assert(!const true, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+          StorageLive(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:+1:9: +1:10
+          _1 = const 0_i32;                // scope 0 at $DIR/bad_op_mod_by_zero.rs:+1:13: +1:14
+          StorageLive(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:9: +2:11
+          StorageLive(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
+-         _3 = _1;                         // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
+-         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         assert(!move _4, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
++         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
++         _4 = const true;                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
++         assert(!const true, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
       }
   
       bb1: {
--         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
--         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
--         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
--         assert(!move _7, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         _5 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         _6 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         _7 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, const 0_i32) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+-         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+-         assert(!move _7, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
++         _5 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
++         _6 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
++         _7 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
++         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, const 0_i32) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
       }
   
       bb2: {
--         _2 = Rem(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         _2 = Rem(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-          StorageDead(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
-          nop;                             // scope 0 at $DIR/bad_op_mod_by_zero.rs:3:11: 6:2
-          StorageDead(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:6:1: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/bad_op_mod_by_zero.rs:6:2: 6:2
+-         _2 = Rem(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
++         _2 = Rem(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:14: +2:19
+          StorageDead(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+2:18: +2:19
+          nop;                             // scope 0 at $DIR/bad_op_mod_by_zero.rs:+0:11: +3:2
+          StorageDead(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:+3:1: +3:2
+          StorageDead(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/bad_op_mod_by_zero.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
@@ -2,55 +2,55 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:4:11: 4:11
-      let _1: *const [i32];                // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
-      let mut _2: *const [i32; 3];         // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-      let _3: &[i32; 3];                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-      let _4: [i32; 3];                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:26: 5:35
-      let _6: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-      let mut _7: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-      let mut _8: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-      let mut _9: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
+      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+0:11: +0:11
+      let _1: *const [i32];                // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
+      let mut _2: *const [i32; 3];         // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+      let _3: &[i32; 3];                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+      let _4: [i32; 3];                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:26: +1:35
+      let _6: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+      let mut _7: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _8: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _9: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
       scope 1 {
-          debug a => _1;                   // in scope 1 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
+          debug a => _1;                   // in scope 1 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
           scope 2 {
-              let _5: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
+              let _5: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               scope 3 {
-                  debug _b => _5;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
+                  debug _b => _5;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          _9 = const main::promoted[0];    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
+          StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _9 = const main::promoted[0];    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
                                            // mir::Constant
                                            // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
                                            // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
-          _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:34: 5:35
-          StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:35: 5:36
-          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
-          StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-          _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
--         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-+         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
+          _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:34: +1:35
+          StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:35: +1:36
+          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+          StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
       }
   
       bb1: {
-          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-          StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:25: 7:26
-          nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6
-          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:8:5: 8:6
-          StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:2: 9:2
+          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+          StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
+          nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
+          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
+          StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
@@ -2,55 +2,55 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:4:11: 4:11
-      let _1: *const [i32];                // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
-      let mut _2: *const [i32; 3];         // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-      let _3: &[i32; 3];                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-      let _4: [i32; 3];                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:26: 5:35
-      let _6: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-      let mut _7: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-      let mut _8: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-      let mut _9: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
+      let mut _0: ();                      // return place in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+0:11: +0:11
+      let _1: *const [i32];                // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
+      let mut _2: *const [i32; 3];         // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+      let _3: &[i32; 3];                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+      let _4: [i32; 3];                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:26: +1:35
+      let _6: usize;                       // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+      let mut _7: usize;                   // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _8: bool;                    // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+      let mut _9: &[i32; 3];               // in scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
       scope 1 {
-          debug a => _1;                   // in scope 1 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
+          debug a => _1;                   // in scope 1 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
           scope 2 {
-              let _5: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
+              let _5: i32;                 // in scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               scope 3 {
-                  debug _b => _5;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
+                  debug _b => _5;          // in scope 3 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          _9 = const main::promoted[0];    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
+          StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _9 = const main::promoted[0];    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
                                            // mir::Constant
                                            // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
                                            // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
-          _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
-          StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:34: 5:35
-          StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:35: 5:36
-          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
-          StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-          _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
--         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-+         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
+          _3 = _9;                         // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
+          StorageDead(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:34: +1:35
+          StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:35: +1:36
+          StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:13: +3:15
+          StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:23: +3:24
+          _7 = Len((*_1));                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         _8 = Lt(_6, _7);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         _8 = Lt(const 3_usize, _7);      // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
++         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
       }
   
       bb1: {
-          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
-          StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:25: 7:26
-          nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6
-          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:8:5: 8:6
-          StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:2: 9:2
+          _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:18: +3:25
+          StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+3:25: +3:26
+          nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+2:5: +4:6
+          StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:+4:5: +4:6
+          StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/boolean_identities.test.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boolean_identities.test.ConstProp.diff
@@ -2,32 +2,32 @@
 + // MIR for `test` after ConstProp
   
   fn test(_1: bool, _2: bool) -> bool {
-      debug x => _1;                       // in scope 0 at $DIR/boolean_identities.rs:4:13: 4:14
-      debug y => _2;                       // in scope 0 at $DIR/boolean_identities.rs:4:22: 4:23
-      let mut _0: bool;                    // return place in scope 0 at $DIR/boolean_identities.rs:4:34: 4:38
-      let mut _3: bool;                    // in scope 0 at $DIR/boolean_identities.rs:5:5: 5:15
-      let mut _4: bool;                    // in scope 0 at $DIR/boolean_identities.rs:5:6: 5:7
-      let mut _5: bool;                    // in scope 0 at $DIR/boolean_identities.rs:5:18: 5:29
-      let mut _6: bool;                    // in scope 0 at $DIR/boolean_identities.rs:5:19: 5:20
+      debug x => _1;                       // in scope 0 at $DIR/boolean_identities.rs:+0:13: +0:14
+      debug y => _2;                       // in scope 0 at $DIR/boolean_identities.rs:+0:22: +0:23
+      let mut _0: bool;                    // return place in scope 0 at $DIR/boolean_identities.rs:+0:34: +0:38
+      let mut _3: bool;                    // in scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
+      let mut _4: bool;                    // in scope 0 at $DIR/boolean_identities.rs:+1:6: +1:7
+      let mut _5: bool;                    // in scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
+      let mut _6: bool;                    // in scope 0 at $DIR/boolean_identities.rs:+1:19: +1:20
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/boolean_identities.rs:5:5: 5:15
-          StorageLive(_4);                 // scope 0 at $DIR/boolean_identities.rs:5:6: 5:7
-          _4 = _2;                         // scope 0 at $DIR/boolean_identities.rs:5:6: 5:7
--         _3 = BitOr(move _4, const true); // scope 0 at $DIR/boolean_identities.rs:5:5: 5:15
-+         _3 = const true;                 // scope 0 at $DIR/boolean_identities.rs:5:5: 5:15
-          StorageDead(_4);                 // scope 0 at $DIR/boolean_identities.rs:5:14: 5:15
-          StorageLive(_5);                 // scope 0 at $DIR/boolean_identities.rs:5:18: 5:29
-          StorageLive(_6);                 // scope 0 at $DIR/boolean_identities.rs:5:19: 5:20
-          _6 = _1;                         // scope 0 at $DIR/boolean_identities.rs:5:19: 5:20
--         _5 = BitAnd(move _6, const false); // scope 0 at $DIR/boolean_identities.rs:5:18: 5:29
-+         _5 = const false;                // scope 0 at $DIR/boolean_identities.rs:5:18: 5:29
-          StorageDead(_6);                 // scope 0 at $DIR/boolean_identities.rs:5:28: 5:29
--         _0 = BitAnd(move _3, move _5);   // scope 0 at $DIR/boolean_identities.rs:5:5: 5:29
-+         _0 = const false;                // scope 0 at $DIR/boolean_identities.rs:5:5: 5:29
-          StorageDead(_5);                 // scope 0 at $DIR/boolean_identities.rs:5:28: 5:29
-          StorageDead(_3);                 // scope 0 at $DIR/boolean_identities.rs:5:28: 5:29
-          return;                          // scope 0 at $DIR/boolean_identities.rs:6:2: 6:2
+          StorageLive(_3);                 // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
+          StorageLive(_4);                 // scope 0 at $DIR/boolean_identities.rs:+1:6: +1:7
+          _4 = _2;                         // scope 0 at $DIR/boolean_identities.rs:+1:6: +1:7
+-         _3 = BitOr(move _4, const true); // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
++         _3 = const true;                 // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:15
+          StorageDead(_4);                 // scope 0 at $DIR/boolean_identities.rs:+1:14: +1:15
+          StorageLive(_5);                 // scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
+          StorageLive(_6);                 // scope 0 at $DIR/boolean_identities.rs:+1:19: +1:20
+          _6 = _1;                         // scope 0 at $DIR/boolean_identities.rs:+1:19: +1:20
+-         _5 = BitAnd(move _6, const false); // scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
++         _5 = const false;                // scope 0 at $DIR/boolean_identities.rs:+1:18: +1:29
+          StorageDead(_6);                 // scope 0 at $DIR/boolean_identities.rs:+1:28: +1:29
+-         _0 = BitAnd(move _3, move _5);   // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:29
++         _0 = const false;                // scope 0 at $DIR/boolean_identities.rs:+1:5: +1:29
+          StorageDead(_5);                 // scope 0 at $DIR/boolean_identities.rs:+1:28: +1:29
+          StorageDead(_3);                 // scope 0 at $DIR/boolean_identities.rs:+1:28: +1:29
+          return;                          // scope 0 at $DIR/boolean_identities.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -2,66 +2,66 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/boxes.rs:11:11: 11:11
-      let _1: i32;                         // in scope 0 at $DIR/boxes.rs:12:9: 12:10
-      let mut _2: i32;                     // in scope 0 at $DIR/boxes.rs:12:13: 12:22
-      let mut _3: std::boxed::Box<i32>;    // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _4: usize;                   // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _5: usize;                   // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _6: *mut u8;                 // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _8: *const i32;              // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _9: *const i32;              // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _10: *const i32;             // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _11: *const i32;             // in scope 0 at $DIR/boxes.rs:12:14: 12:22
+      let mut _0: ();                      // return place in scope 0 at $DIR/boxes.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/boxes.rs:+1:9: +1:10
+      let mut _2: i32;                     // in scope 0 at $DIR/boxes.rs:+1:13: +1:22
+      let mut _3: std::boxed::Box<i32>;    // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _4: usize;                   // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _5: usize;                   // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _6: *mut u8;                 // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _8: *const i32;              // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _9: *const i32;              // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _10: *const i32;             // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
+      let mut _11: *const i32;             // in scope 0 at $DIR/boxes.rs:+1:14: +1:22
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/boxes.rs:12:9: 12:10
+          debug x => _1;                   // in scope 1 at $DIR/boxes.rs:+1:9: +1:10
       }
       scope 2 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/boxes.rs:12:9: 12:10
-          StorageLive(_2);                 // scope 0 at $DIR/boxes.rs:12:13: 12:22
-          StorageLive(_3);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
--         _4 = SizeOf(i32);                // scope 2 at $DIR/boxes.rs:12:14: 12:22
--         _5 = AlignOf(i32);               // scope 2 at $DIR/boxes.rs:12:14: 12:22
--         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> bb1; // scope 2 at $DIR/boxes.rs:12:14: 12:22
-+         _4 = const 4_usize;              // scope 2 at $DIR/boxes.rs:12:14: 12:22
-+         _5 = const 4_usize;              // scope 2 at $DIR/boxes.rs:12:14: 12:22
-+         _6 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> bb1; // scope 2 at $DIR/boxes.rs:12:14: 12:22
+          StorageLive(_1);                 // scope 0 at $DIR/boxes.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/boxes.rs:+1:13: +1:22
+          StorageLive(_3);                 // scope 0 at $DIR/boxes.rs:+1:14: +1:22
+-         _4 = SizeOf(i32);                // scope 2 at $DIR/boxes.rs:+1:14: +1:22
+-         _5 = AlignOf(i32);               // scope 2 at $DIR/boxes.rs:+1:14: +1:22
+-         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> bb1; // scope 2 at $DIR/boxes.rs:+1:14: +1:22
++         _4 = const 4_usize;              // scope 2 at $DIR/boxes.rs:+1:14: +1:22
++         _5 = const 4_usize;              // scope 2 at $DIR/boxes.rs:+1:14: +1:22
++         _6 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> bb1; // scope 2 at $DIR/boxes.rs:+1:14: +1:22
                                            // mir::Constant
                                            // + span: $DIR/boxes.rs:12:14: 12:22
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_7);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          _7 = ShallowInitBox(move _6, i32); // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          StorageLive(_8);                 // scope 0 at $DIR/boxes.rs:12:19: 12:21
-          _8 = (((_7.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:12:19: 12:21
-          (*_8) = const 42_i32;            // scope 0 at $DIR/boxes.rs:12:19: 12:21
-          StorageDead(_8);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          _3 = move _7;                    // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          StorageDead(_7);                 // scope 0 at $DIR/boxes.rs:12:21: 12:22
-          StorageLive(_9);                 // scope 0 at $DIR/boxes.rs:12:13: 12:22
-          _9 = (((_3.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:12:13: 12:22
-          _2 = (*_9);                      // scope 0 at $DIR/boxes.rs:12:13: 12:22
-          StorageDead(_9);                 // scope 0 at $DIR/boxes.rs:12:13: 12:26
-          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:12:13: 12:26
-          StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:12:25: 12:26
-          drop(_3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
+          StorageLive(_7);                 // scope 0 at $DIR/boxes.rs:+1:14: +1:22
+          _7 = ShallowInitBox(move _6, i32); // scope 0 at $DIR/boxes.rs:+1:14: +1:22
+          StorageLive(_8);                 // scope 0 at $DIR/boxes.rs:+1:19: +1:21
+          _8 = (((_7.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:19: +1:21
+          (*_8) = const 42_i32;            // scope 0 at $DIR/boxes.rs:+1:19: +1:21
+          StorageDead(_8);                 // scope 0 at $DIR/boxes.rs:+1:14: +1:22
+          _3 = move _7;                    // scope 0 at $DIR/boxes.rs:+1:14: +1:22
+          StorageDead(_7);                 // scope 0 at $DIR/boxes.rs:+1:21: +1:22
+          StorageLive(_9);                 // scope 0 at $DIR/boxes.rs:+1:13: +1:22
+          _9 = (((_3.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 0 at $DIR/boxes.rs:+1:13: +1:22
+          _2 = (*_9);                      // scope 0 at $DIR/boxes.rs:+1:13: +1:22
+          StorageDead(_9);                 // scope 0 at $DIR/boxes.rs:+1:13: +1:26
+          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:+1:13: +1:26
+          StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:+1:25: +1:26
+          drop(_3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/boxes.rs:+1:26: +1:27
       }
   
       bb2: {
-          StorageDead(_3);                 // scope 0 at $DIR/boxes.rs:12:26: 12:27
-          nop;                             // scope 0 at $DIR/boxes.rs:11:11: 13:2
-          StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:13:1: 13:2
-          return;                          // scope 0 at $DIR/boxes.rs:13:2: 13:2
+          StorageDead(_3);                 // scope 0 at $DIR/boxes.rs:+1:26: +1:27
+          nop;                             // scope 0 at $DIR/boxes.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/boxes.rs:+2:2: +2:2
       }
   
       bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
+          resume;                          // scope 0 at $DIR/boxes.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
@@ -2,27 +2,27 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/cast.rs:3:11: 3:11
-      let _1: u32;                         // in scope 0 at $DIR/cast.rs:4:9: 4:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/cast.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/cast.rs:+1:9: +1:10
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/cast.rs:4:9: 4:10
-          let _2: u8;                      // in scope 1 at $DIR/cast.rs:6:9: 6:10
+          debug x => _1;                   // in scope 1 at $DIR/cast.rs:+1:9: +1:10
+          let _2: u8;                      // in scope 1 at $DIR/cast.rs:+3:9: +3:10
           scope 2 {
-              debug y => _2;               // in scope 2 at $DIR/cast.rs:6:9: 6:10
+              debug y => _2;               // in scope 2 at $DIR/cast.rs:+3:9: +3:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/cast.rs:4:9: 4:10
--         _1 = const 42_u8 as u32 (Misc);  // scope 0 at $DIR/cast.rs:4:13: 4:24
-+         _1 = const 42_u32;               // scope 0 at $DIR/cast.rs:4:13: 4:24
-          StorageLive(_2);                 // scope 1 at $DIR/cast.rs:6:9: 6:10
--         _2 = const 42_u32 as u8 (Misc);  // scope 1 at $DIR/cast.rs:6:13: 6:24
-+         _2 = const 42_u8;                // scope 1 at $DIR/cast.rs:6:13: 6:24
-          nop;                             // scope 0 at $DIR/cast.rs:3:11: 7:2
-          StorageDead(_2);                 // scope 1 at $DIR/cast.rs:7:1: 7:2
-          StorageDead(_1);                 // scope 0 at $DIR/cast.rs:7:1: 7:2
-          return;                          // scope 0 at $DIR/cast.rs:7:2: 7:2
+          StorageLive(_1);                 // scope 0 at $DIR/cast.rs:+1:9: +1:10
+-         _1 = const 42_u8 as u32 (Misc);  // scope 0 at $DIR/cast.rs:+1:13: +1:24
++         _1 = const 42_u32;               // scope 0 at $DIR/cast.rs:+1:13: +1:24
+          StorageLive(_2);                 // scope 1 at $DIR/cast.rs:+3:9: +3:10
+-         _2 = const 42_u32 as u8 (Misc);  // scope 1 at $DIR/cast.rs:+3:13: +3:24
++         _2 = const 42_u8;                // scope 1 at $DIR/cast.rs:+3:13: +3:24
+          nop;                             // scope 0 at $DIR/cast.rs:+0:11: +4:2
+          StorageDead(_2);                 // scope 1 at $DIR/cast.rs:+4:1: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/cast.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/cast.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
@@ -2,27 +2,27 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/checked_add.rs:4:11: 4:11
-      let _1: u32;                         // in scope 0 at $DIR/checked_add.rs:5:9: 5:10
-      let mut _2: (u32, bool);             // in scope 0 at $DIR/checked_add.rs:5:18: 5:23
+      let mut _0: ();                      // return place in scope 0 at $DIR/checked_add.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/checked_add.rs:+1:9: +1:10
+      let mut _2: (u32, bool);             // in scope 0 at $DIR/checked_add.rs:+1:18: +1:23
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/checked_add.rs:5:9: 5:10
+          debug x => _1;                   // in scope 1 at $DIR/checked_add.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/checked_add.rs:5:9: 5:10
--         _2 = CheckedAdd(const 1_u32, const 1_u32); // scope 0 at $DIR/checked_add.rs:5:18: 5:23
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
-+         _2 = const (2_u32, false);       // scope 0 at $DIR/checked_add.rs:5:18: 5:23
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
+          StorageLive(_1);                 // scope 0 at $DIR/checked_add.rs:+1:9: +1:10
+-         _2 = CheckedAdd(const 1_u32, const 1_u32); // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
++         _2 = const (2_u32, false);       // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
       }
   
       bb1: {
--         _1 = move (_2.0: u32);           // scope 0 at $DIR/checked_add.rs:5:18: 5:23
-+         _1 = const 2_u32;                // scope 0 at $DIR/checked_add.rs:5:18: 5:23
-          nop;                             // scope 0 at $DIR/checked_add.rs:4:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/checked_add.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/checked_add.rs:6:2: 6:2
+-         _1 = move (_2.0: u32);           // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
++         _1 = const 2_u32;                // scope 0 at $DIR/checked_add.rs:+1:18: +1:23
+          nop;                             // scope 0 at $DIR/checked_add.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/checked_add.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/checked_add.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
@@ -2,43 +2,43 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/const_prop_fails_gracefully.rs:5:11: 5:11
-      let _1: usize;                       // in scope 0 at $DIR/const_prop_fails_gracefully.rs:7:9: 7:10
-      let mut _2: *const i32;              // in scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:30
-      let _3: &i32;                        // in scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:16
-      let _4: ();                          // in scope 0 at $DIR/const_prop_fails_gracefully.rs:8:5: 8:12
-      let mut _5: usize;                   // in scope 0 at $DIR/const_prop_fails_gracefully.rs:8:10: 8:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/const_prop_fails_gracefully.rs:+0:11: +0:11
+      let _1: usize;                       // in scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:9: +2:10
+      let mut _2: *const i32;              // in scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:30
+      let _3: &i32;                        // in scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:16
+      let _4: ();                          // in scope 0 at $DIR/const_prop_fails_gracefully.rs:+3:5: +3:12
+      let mut _5: usize;                   // in scope 0 at $DIR/const_prop_fails_gracefully.rs:+3:10: +3:11
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/const_prop_fails_gracefully.rs:7:9: 7:10
+          debug x => _1;                   // in scope 1 at $DIR/const_prop_fails_gracefully.rs:+2:9: +2:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:9: 7:10
-          StorageLive(_2);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:30
-          StorageLive(_3);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:16
-          _3 = const FOO;                  // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:16
+          StorageLive(_1);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:9: +2:10
+          StorageLive(_2);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:30
+          StorageLive(_3);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:16
+          _3 = const FOO;                  // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:16
                                            // mir::Constant
                                            // + span: $DIR/const_prop_fails_gracefully.rs:7:13: 7:16
                                            // + literal: Const { ty: &i32, val: Unevaluated(FOO, [], None) }
-          _2 = &raw const (*_3);           // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:16
-          _1 = move _2 as usize (PointerExposeAddress); // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:39
-          StorageDead(_2);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:38: 7:39
-          StorageDead(_3);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:39: 7:40
-          StorageLive(_4);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:5: 8:12
-          StorageLive(_5);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:10: 8:11
-          _5 = _1;                         // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:10: 8:11
-          _4 = read(move _5) -> bb1;       // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:5: 8:12
+          _2 = &raw const (*_3);           // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:16
+          _1 = move _2 as usize (PointerExposeAddress); // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:39
+          StorageDead(_2);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:38: +2:39
+          StorageDead(_3);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:39: +2:40
+          StorageLive(_4);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:5: +3:12
+          StorageLive(_5);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:10: +3:11
+          _5 = _1;                         // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:10: +3:11
+          _4 = read(move _5) -> bb1;       // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:5: +3:12
                                            // mir::Constant
                                            // + span: $DIR/const_prop_fails_gracefully.rs:8:5: 8:9
                                            // + literal: Const { ty: fn(usize) {read}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_5);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:11: 8:12
-          StorageDead(_4);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:12: 8:13
-          nop;                             // scope 0 at $DIR/const_prop_fails_gracefully.rs:5:11: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/const_prop_fails_gracefully.rs:9:2: 9:2
+          StorageDead(_5);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:11: +3:12
+          StorageDead(_4);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:12: +3:13
+          nop;                             // scope 0 at $DIR/const_prop_fails_gracefully.rs:+0:11: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/const_prop_fails_gracefully.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -2,16 +2,16 @@
 + // MIR for `hello` after ConstProp
   
   fn hello() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/control-flow-simplification.rs:11:14: 11:14
-      let mut _1: bool;                    // in scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
+      let mut _0: ();                      // return place in scope 0 at $DIR/control-flow-simplification.rs:+0:14: +0:14
+      let mut _1: bool;                    // in scope 0 at $DIR/control-flow-simplification.rs:+1:8: +1:21
       let mut _2: !;                       // in scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
--         _1 = const <bool as NeedsDrop>::NEEDS; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
--         switchInt(move _1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
-+         _1 = const false;                // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
-+         switchInt(const false) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
+          StorageLive(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:+1:8: +1:21
+-         _1 = const <bool as NeedsDrop>::NEEDS; // scope 0 at $DIR/control-flow-simplification.rs:+1:8: +1:21
+-         switchInt(move _1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:+1:8: +1:21
++         _1 = const false;                // scope 0 at $DIR/control-flow-simplification.rs:+1:8: +1:21
++         switchInt(const false) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:+1:8: +1:21
       }
   
       bb1: {
@@ -26,9 +26,9 @@
       }
   
       bb2: {
-          nop;                             // scope 0 at $DIR/control-flow-simplification.rs:14:6: 14:6
-          StorageDead(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:14:5: 14:6
-          return;                          // scope 0 at $DIR/control-flow-simplification.rs:15:2: 15:2
+          nop;                             // scope 0 at $DIR/control-flow-simplification.rs:+3:6: +3:6
+          StorageDead(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:+3:5: +3:6
+          return;                          // scope 0 at $DIR/control-flow-simplification.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.PreCodegen.before.mir
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.PreCodegen.before.mir
@@ -1,9 +1,9 @@
 // MIR for `hello` before PreCodegen
 
 fn hello() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/control-flow-simplification.rs:11:14: 11:14
+    let mut _0: ();                      // return place in scope 0 at $DIR/control-flow-simplification.rs:+0:14: +0:14
 
     bb0: {
-        return;                          // scope 0 at $DIR/control-flow-simplification.rs:15:2: 15:2
+        return;                          // scope 0 at $DIR/control-flow-simplification.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
@@ -2,51 +2,51 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/discriminant.rs:10:11: 10:11
-      let _1: i32;                         // in scope 0 at $DIR/discriminant.rs:11:9: 11:10
-      let mut _2: i32;                     // in scope 0 at $DIR/discriminant.rs:11:13: 11:64
-      let mut _3: std::option::Option<bool>; // in scope 0 at $DIR/discriminant.rs:11:34: 11:44
-      let mut _4: isize;                   // in scope 0 at $DIR/discriminant.rs:11:21: 11:31
+      let mut _0: ();                      // return place in scope 0 at $DIR/discriminant.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/discriminant.rs:+1:9: +1:10
+      let mut _2: i32;                     // in scope 0 at $DIR/discriminant.rs:+1:13: +1:64
+      let mut _3: std::option::Option<bool>; // in scope 0 at $DIR/discriminant.rs:+1:34: +1:44
+      let mut _4: isize;                   // in scope 0 at $DIR/discriminant.rs:+1:21: +1:31
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/discriminant.rs:11:9: 11:10
+          debug x => _1;                   // in scope 1 at $DIR/discriminant.rs:+1:9: +1:10
       }
       scope 2 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
-          StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
-          StorageLive(_3);                 // scope 2 at $DIR/discriminant.rs:11:34: 11:44
-          Deinit(_3);                      // scope 2 at $DIR/discriminant.rs:11:34: 11:44
-          ((_3 as Some).0: bool) = const true; // scope 2 at $DIR/discriminant.rs:11:34: 11:44
-          discriminant(_3) = 1;            // scope 2 at $DIR/discriminant.rs:11:34: 11:44
--         _4 = discriminant(_3);           // scope 2 at $DIR/discriminant.rs:11:21: 11:31
--         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:11:21: 11:31
-+         _4 = const 1_isize;              // scope 2 at $DIR/discriminant.rs:11:21: 11:31
-+         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:11:21: 11:31
+          StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:+1:13: +1:64
+          StorageLive(_3);                 // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+          Deinit(_3);                      // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+          ((_3 as Some).0: bool) = const true; // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+          discriminant(_3) = 1;            // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+-         _4 = discriminant(_3);           // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
++         _4 = const 1_isize;              // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
++         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
       }
   
       bb1: {
-          switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 2 at $DIR/discriminant.rs:11:21: 11:31
+          switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
       }
   
       bb2: {
-          _2 = const 42_i32;               // scope 2 at $DIR/discriminant.rs:11:47: 11:49
-          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
+          _2 = const 42_i32;               // scope 2 at $DIR/discriminant.rs:+1:47: +1:49
+          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:+1:13: +1:64
       }
   
       bb3: {
-          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
-          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
+          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:+1:59: +1:61
+          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:+1:13: +1:64
       }
   
       bb4: {
-          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:11:13: 11:68
-          StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:11:67: 11:68
-          StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:11:68: 11:69
-          nop;                             // scope 0 at $DIR/discriminant.rs:10:11: 12:2
-          StorageDead(_1);                 // scope 0 at $DIR/discriminant.rs:12:1: 12:2
-          return;                          // scope 0 at $DIR/discriminant.rs:12:2: 12:2
+          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:+1:13: +1:68
+          StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:+1:67: +1:68
+          StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:+1:68: +1:69
+          nop;                             // scope 0 at $DIR/discriminant.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/discriminant.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/discriminant.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -2,51 +2,51 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/discriminant.rs:10:11: 10:11
-      let _1: i32;                         // in scope 0 at $DIR/discriminant.rs:11:9: 11:10
-      let mut _2: i32;                     // in scope 0 at $DIR/discriminant.rs:11:13: 11:64
-      let mut _3: std::option::Option<bool>; // in scope 0 at $DIR/discriminant.rs:11:34: 11:44
-      let mut _4: isize;                   // in scope 0 at $DIR/discriminant.rs:11:21: 11:31
+      let mut _0: ();                      // return place in scope 0 at $DIR/discriminant.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/discriminant.rs:+1:9: +1:10
+      let mut _2: i32;                     // in scope 0 at $DIR/discriminant.rs:+1:13: +1:64
+      let mut _3: std::option::Option<bool>; // in scope 0 at $DIR/discriminant.rs:+1:34: +1:44
+      let mut _4: isize;                   // in scope 0 at $DIR/discriminant.rs:+1:21: +1:31
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/discriminant.rs:11:9: 11:10
+          debug x => _1;                   // in scope 1 at $DIR/discriminant.rs:+1:9: +1:10
       }
       scope 2 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
-          StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
-          StorageLive(_3);                 // scope 2 at $DIR/discriminant.rs:11:34: 11:44
-          Deinit(_3);                      // scope 2 at $DIR/discriminant.rs:11:34: 11:44
-          ((_3 as Some).0: bool) = const true; // scope 2 at $DIR/discriminant.rs:11:34: 11:44
-          discriminant(_3) = 1;            // scope 2 at $DIR/discriminant.rs:11:34: 11:44
--         _4 = discriminant(_3);           // scope 2 at $DIR/discriminant.rs:11:21: 11:31
--         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:11:21: 11:31
-+         _4 = const 1_isize;              // scope 2 at $DIR/discriminant.rs:11:21: 11:31
-+         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:11:21: 11:31
+          StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:+1:13: +1:64
+          StorageLive(_3);                 // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+          Deinit(_3);                      // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+          ((_3 as Some).0: bool) = const true; // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+          discriminant(_3) = 1;            // scope 2 at $DIR/discriminant.rs:+1:34: +1:44
+-         _4 = discriminant(_3);           // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
++         _4 = const 1_isize;              // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
++         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
       }
   
       bb1: {
-          switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 2 at $DIR/discriminant.rs:11:21: 11:31
+          switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 2 at $DIR/discriminant.rs:+1:21: +1:31
       }
   
       bb2: {
-          _2 = const 42_i32;               // scope 2 at $DIR/discriminant.rs:11:47: 11:49
-          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
+          _2 = const 42_i32;               // scope 2 at $DIR/discriminant.rs:+1:47: +1:49
+          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:+1:13: +1:64
       }
   
       bb3: {
-          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
-          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
+          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:+1:59: +1:61
+          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:+1:13: +1:64
       }
   
       bb4: {
-          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:11:13: 11:68
-          StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:11:67: 11:68
-          StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:11:68: 11:69
-          nop;                             // scope 0 at $DIR/discriminant.rs:10:11: 12:2
-          StorageDead(_1);                 // scope 0 at $DIR/discriminant.rs:12:1: 12:2
-          return;                          // scope 0 at $DIR/discriminant.rs:12:2: 12:2
+          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:+1:13: +1:68
+          StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:+1:67: +1:68
+          StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:+1:68: +1:69
+          nop;                             // scope 0 at $DIR/discriminant.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/discriminant.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/discriminant.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
@@ -2,32 +2,32 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/indirect.rs:4:11: 4:11
-      let _1: u8;                          // in scope 0 at $DIR/indirect.rs:5:9: 5:10
-      let mut _2: u8;                      // in scope 0 at $DIR/indirect.rs:5:13: 5:25
-      let mut _3: (u8, bool);              // in scope 0 at $DIR/indirect.rs:5:13: 5:29
+      let mut _0: ();                      // return place in scope 0 at $DIR/indirect.rs:+0:11: +0:11
+      let _1: u8;                          // in scope 0 at $DIR/indirect.rs:+1:9: +1:10
+      let mut _2: u8;                      // in scope 0 at $DIR/indirect.rs:+1:13: +1:25
+      let mut _3: (u8, bool);              // in scope 0 at $DIR/indirect.rs:+1:13: +1:29
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/indirect.rs:5:9: 5:10
+          debug x => _1;                   // in scope 1 at $DIR/indirect.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/indirect.rs:5:9: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/indirect.rs:5:13: 5:25
--         _2 = const 2_u32 as u8 (Misc);   // scope 0 at $DIR/indirect.rs:5:13: 5:25
--         _3 = CheckedAdd(_2, const 1_u8); // scope 0 at $DIR/indirect.rs:5:13: 5:29
--         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:5:13: 5:29
-+         _2 = const 2_u8;                 // scope 0 at $DIR/indirect.rs:5:13: 5:25
-+         _3 = const (3_u8, false);        // scope 0 at $DIR/indirect.rs:5:13: 5:29
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u8, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:5:13: 5:29
+          StorageLive(_1);                 // scope 0 at $DIR/indirect.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25
+-         _2 = const 2_u32 as u8 (Misc);   // scope 0 at $DIR/indirect.rs:+1:13: +1:25
+-         _3 = CheckedAdd(_2, const 1_u8); // scope 0 at $DIR/indirect.rs:+1:13: +1:29
+-         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
++         _2 = const 2_u8;                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25
++         _3 = const (3_u8, false);        // scope 0 at $DIR/indirect.rs:+1:13: +1:29
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u8, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
       }
   
       bb1: {
--         _1 = move (_3.0: u8);            // scope 0 at $DIR/indirect.rs:5:13: 5:29
-+         _1 = const 3_u8;                 // scope 0 at $DIR/indirect.rs:5:13: 5:29
-          StorageDead(_2);                 // scope 0 at $DIR/indirect.rs:5:28: 5:29
-          nop;                             // scope 0 at $DIR/indirect.rs:4:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/indirect.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/indirect.rs:6:2: 6:2
+-         _1 = move (_3.0: u8);            // scope 0 at $DIR/indirect.rs:+1:13: +1:29
++         _1 = const 3_u8;                 // scope 0 at $DIR/indirect.rs:+1:13: +1:29
+          StorageDead(_2);                 // scope 0 at $DIR/indirect.rs:+1:28: +1:29
+          nop;                             // scope 0 at $DIR/indirect.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/indirect.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/indirect.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -2,24 +2,24 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/invalid_constant.rs:15:11: 15:11
-      let _1: char;                        // in scope 0 at $DIR/invalid_constant.rs:21:9: 21:22
-      let mut _2: main::InvalidChar;       // in scope 0 at $DIR/invalid_constant.rs:21:34: 21:63
-      let mut _4: E;                       // in scope 0 at $DIR/invalid_constant.rs:28:25: 28:59
-      let mut _5: main::InvalidTag;        // in scope 0 at $DIR/invalid_constant.rs:28:34: 28:55
-      let mut _7: Empty;                   // in scope 0 at $DIR/invalid_constant.rs:35:35: 35:73
-      let mut _8: main::NoVariants;        // in scope 0 at $DIR/invalid_constant.rs:35:44: 35:65
+      let mut _0: ();                      // return place in scope 0 at $DIR/invalid_constant.rs:+0:11: +0:11
+      let _1: char;                        // in scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
+      let mut _2: main::InvalidChar;       // in scope 0 at $DIR/invalid_constant.rs:+6:34: +6:63
+      let mut _4: E;                       // in scope 0 at $DIR/invalid_constant.rs:+13:25: +13:59
+      let mut _5: main::InvalidTag;        // in scope 0 at $DIR/invalid_constant.rs:+13:34: +13:55
+      let mut _7: Empty;                   // in scope 0 at $DIR/invalid_constant.rs:+20:35: +20:73
+      let mut _8: main::NoVariants;        // in scope 0 at $DIR/invalid_constant.rs:+20:44: +20:65
       scope 1 {
-          debug _invalid_char => _1;       // in scope 1 at $DIR/invalid_constant.rs:21:9: 21:22
-          let _3: [E; 1];                  // in scope 1 at $DIR/invalid_constant.rs:28:9: 28:21
+          debug _invalid_char => _1;       // in scope 1 at $DIR/invalid_constant.rs:+6:9: +6:22
+          let _3: [E; 1];                  // in scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
           scope 3 {
-              debug _invalid_tag => _3;    // in scope 3 at $DIR/invalid_constant.rs:28:9: 28:21
-              let _6: [Empty; 1];          // in scope 3 at $DIR/invalid_constant.rs:35:9: 35:31
+              debug _invalid_tag => _3;    // in scope 3 at $DIR/invalid_constant.rs:+13:9: +13:21
+              let _6: [Empty; 1];          // in scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
               scope 5 {
-                  debug _enum_without_variants => _6; // in scope 5 at $DIR/invalid_constant.rs:35:9: 35:31
-                  let _9: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:39:9: 39:22
+                  debug _enum_without_variants => _6; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
+                  let _9: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
                   scope 7 {
-                      debug _non_utf8_str => _9; // in scope 7 at $DIR/invalid_constant.rs:39:9: 39:22
+                      debug _non_utf8_str => _9; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
                   }
               }
               scope 6 {
@@ -32,46 +32,46 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/invalid_constant.rs:21:9: 21:22
-          StorageLive(_2);                 // scope 2 at $DIR/invalid_constant.rs:21:34: 21:63
-          Deinit(_2);                      // scope 2 at $DIR/invalid_constant.rs:21:34: 21:63
-          (_2.0: u32) = const 1114113_u32; // scope 2 at $DIR/invalid_constant.rs:21:34: 21:63
--         _1 = (_2.1: char);               // scope 2 at $DIR/invalid_constant.rs:21:34: 21:67
-+         _1 = const {transmute(0x00110001): char}; // scope 2 at $DIR/invalid_constant.rs:21:34: 21:67
-          StorageDead(_2);                 // scope 0 at $DIR/invalid_constant.rs:21:69: 21:70
-          StorageLive(_3);                 // scope 1 at $DIR/invalid_constant.rs:28:9: 28:21
-          StorageLive(_4);                 // scope 1 at $DIR/invalid_constant.rs:28:25: 28:59
-          StorageLive(_5);                 // scope 4 at $DIR/invalid_constant.rs:28:34: 28:55
-          Deinit(_5);                      // scope 4 at $DIR/invalid_constant.rs:28:34: 28:55
-          (_5.0: u32) = const 4_u32;       // scope 4 at $DIR/invalid_constant.rs:28:34: 28:55
--         _4 = (_5.1: E);                  // scope 4 at $DIR/invalid_constant.rs:28:34: 28:57
--         _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:28:24: 28:60
-+         _4 = const Scalar(0x00000004): E; // scope 4 at $DIR/invalid_constant.rs:28:34: 28:57
+          StorageLive(_1);                 // scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
+          StorageLive(_2);                 // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
+          Deinit(_2);                      // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
+          (_2.0: u32) = const 1114113_u32; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
+-         _1 = (_2.1: char);               // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
++         _1 = const {transmute(0x00110001): char}; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
+          StorageDead(_2);                 // scope 0 at $DIR/invalid_constant.rs:+6:69: +6:70
+          StorageLive(_3);                 // scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
+          StorageLive(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:25: +13:59
+          StorageLive(_5);                 // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
+          Deinit(_5);                      // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
+          (_5.0: u32) = const 4_u32;       // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
+-         _4 = (_5.1: E);                  // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
+-         _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
++         _4 = const Scalar(0x00000004): E; // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
 +                                          // mir::Constant
 +                                          // + span: $DIR/invalid_constant.rs:28:34: 28:57
 +                                          // + literal: Const { ty: E, val: Value(Scalar(0x00000004)) }
-+         _3 = [const Scalar(0x00000004): E]; // scope 1 at $DIR/invalid_constant.rs:28:24: 28:60
++         _3 = [const Scalar(0x00000004): E]; // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
 +                                          // mir::Constant
 +                                          // + span: $DIR/invalid_constant.rs:28:24: 28:60
 +                                          // + literal: Const { ty: E, val: Value(Scalar(0x00000004)) }
-          StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:28:59: 28:60
-          StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:28:60: 28:61
-          StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:35:9: 35:31
-          StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:35:35: 35:73
-          StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:35:44: 35:65
-          Deinit(_8);                      // scope 6 at $DIR/invalid_constant.rs:35:44: 35:65
-          (_8.0: u32) = const 0_u32;       // scope 6 at $DIR/invalid_constant.rs:35:44: 35:65
-          nop;                             // scope 6 at $DIR/invalid_constant.rs:35:44: 35:71
-          nop;                             // scope 3 at $DIR/invalid_constant.rs:35:34: 35:74
-          StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:35:73: 35:74
-          StorageDead(_8);                 // scope 3 at $DIR/invalid_constant.rs:35:74: 35:75
-          StorageLive(_9);                 // scope 5 at $DIR/invalid_constant.rs:39:9: 39:22
-          nop;                             // scope 0 at $DIR/invalid_constant.rs:15:11: 42:2
-          StorageDead(_9);                 // scope 5 at $DIR/invalid_constant.rs:42:1: 42:2
-          StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:42:1: 42:2
-          StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:42:1: 42:2
-          StorageDead(_1);                 // scope 0 at $DIR/invalid_constant.rs:42:1: 42:2
-          return;                          // scope 0 at $DIR/invalid_constant.rs:42:2: 42:2
+          StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:59: +13:60
+          StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:+13:60: +13:61
+          StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
+          StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
+          StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
+          Deinit(_8);                      // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
+          (_8.0: u32) = const 0_u32;       // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
+          nop;                             // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
+          nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
+          StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74
+          StorageDead(_8);                 // scope 3 at $DIR/invalid_constant.rs:+20:74: +20:75
+          StorageLive(_9);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+          nop;                             // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
+          StorageDead(_9);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
+          StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
+          StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:+27:1: +27:2
+          StorageDead(_1);                 // scope 0 at $DIR/invalid_constant.rs:+27:1: +27:2
+          return;                          // scope 0 at $DIR/invalid_constant.rs:+27:2: +27:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -2,32 +2,32 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-66971.rs:15:11: 15:11
-      let _1: ();                          // in scope 0 at $DIR/issue-66971.rs:16:5: 16:23
-      let mut _2: ((), u8, u8);            // in scope 0 at $DIR/issue-66971.rs:16:12: 16:22
-      let mut _3: ();                      // in scope 0 at $DIR/issue-66971.rs:16:13: 16:15
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-66971.rs:+0:11: +0:11
+      let _1: ();                          // in scope 0 at $DIR/issue-66971.rs:+1:5: +1:23
+      let mut _2: ((), u8, u8);            // in scope 0 at $DIR/issue-66971.rs:+1:12: +1:22
+      let mut _3: ();                      // in scope 0 at $DIR/issue-66971.rs:+1:13: +1:15
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-66971.rs:16:5: 16:23
-          StorageLive(_2);                 // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
-          StorageLive(_3);                 // scope 0 at $DIR/issue-66971.rs:16:13: 16:15
-          nop;                             // scope 0 at $DIR/issue-66971.rs:16:13: 16:15
-          Deinit(_2);                      // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
-          nop;                             // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
-          (_2.1: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
-          (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
-          StorageDead(_3);                 // scope 0 at $DIR/issue-66971.rs:16:21: 16:22
-          _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue-66971.rs:16:5: 16:23
+          StorageLive(_1);                 // scope 0 at $DIR/issue-66971.rs:+1:5: +1:23
+          StorageLive(_2);                 // scope 0 at $DIR/issue-66971.rs:+1:12: +1:22
+          StorageLive(_3);                 // scope 0 at $DIR/issue-66971.rs:+1:13: +1:15
+          nop;                             // scope 0 at $DIR/issue-66971.rs:+1:13: +1:15
+          Deinit(_2);                      // scope 0 at $DIR/issue-66971.rs:+1:12: +1:22
+          nop;                             // scope 0 at $DIR/issue-66971.rs:+1:12: +1:22
+          (_2.1: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:+1:12: +1:22
+          (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:+1:12: +1:22
+          StorageDead(_3);                 // scope 0 at $DIR/issue-66971.rs:+1:21: +1:22
+          _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue-66971.rs:+1:5: +1:23
                                            // mir::Constant
                                            // + span: $DIR/issue-66971.rs:16:5: 16:11
                                            // + literal: Const { ty: fn(((), u8, u8)) {encode}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/issue-66971.rs:16:22: 16:23
-          StorageDead(_1);                 // scope 0 at $DIR/issue-66971.rs:16:23: 16:24
-          nop;                             // scope 0 at $DIR/issue-66971.rs:15:11: 17:2
-          return;                          // scope 0 at $DIR/issue-66971.rs:17:2: 17:2
+          StorageDead(_2);                 // scope 0 at $DIR/issue-66971.rs:+1:22: +1:23
+          StorageDead(_1);                 // scope 0 at $DIR/issue-66971.rs:+1:23: +1:24
+          nop;                             // scope 0 at $DIR/issue-66971.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/issue-66971.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -2,33 +2,33 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-67019.rs:10:11: 10:11
-      let _1: ();                          // in scope 0 at $DIR/issue-67019.rs:11:5: 11:20
-      let mut _2: ((u8, u8),);             // in scope 0 at $DIR/issue-67019.rs:11:10: 11:19
-      let mut _3: (u8, u8);                // in scope 0 at $DIR/issue-67019.rs:11:11: 11:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-67019.rs:+0:11: +0:11
+      let _1: ();                          // in scope 0 at $DIR/issue-67019.rs:+1:5: +1:20
+      let mut _2: ((u8, u8),);             // in scope 0 at $DIR/issue-67019.rs:+1:10: +1:19
+      let mut _3: (u8, u8);                // in scope 0 at $DIR/issue-67019.rs:+1:11: +1:17
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-67019.rs:11:5: 11:20
-          StorageLive(_2);                 // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
-          StorageLive(_3);                 // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
-          Deinit(_3);                      // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
-          (_3.0: u8) = const 1_u8;         // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
-          (_3.1: u8) = const 2_u8;         // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
-          Deinit(_2);                      // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
--         (_2.0: (u8, u8)) = move _3;      // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
-+         (_2.0: (u8, u8)) = const (1_u8, 2_u8); // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
-          StorageDead(_3);                 // scope 0 at $DIR/issue-67019.rs:11:18: 11:19
-          _1 = test(move _2) -> bb1;       // scope 0 at $DIR/issue-67019.rs:11:5: 11:20
+          StorageLive(_1);                 // scope 0 at $DIR/issue-67019.rs:+1:5: +1:20
+          StorageLive(_2);                 // scope 0 at $DIR/issue-67019.rs:+1:10: +1:19
+          StorageLive(_3);                 // scope 0 at $DIR/issue-67019.rs:+1:11: +1:17
+          Deinit(_3);                      // scope 0 at $DIR/issue-67019.rs:+1:11: +1:17
+          (_3.0: u8) = const 1_u8;         // scope 0 at $DIR/issue-67019.rs:+1:11: +1:17
+          (_3.1: u8) = const 2_u8;         // scope 0 at $DIR/issue-67019.rs:+1:11: +1:17
+          Deinit(_2);                      // scope 0 at $DIR/issue-67019.rs:+1:10: +1:19
+-         (_2.0: (u8, u8)) = move _3;      // scope 0 at $DIR/issue-67019.rs:+1:10: +1:19
++         (_2.0: (u8, u8)) = const (1_u8, 2_u8); // scope 0 at $DIR/issue-67019.rs:+1:10: +1:19
+          StorageDead(_3);                 // scope 0 at $DIR/issue-67019.rs:+1:18: +1:19
+          _1 = test(move _2) -> bb1;       // scope 0 at $DIR/issue-67019.rs:+1:5: +1:20
                                            // mir::Constant
                                            // + span: $DIR/issue-67019.rs:11:5: 11:9
                                            // + literal: Const { ty: fn(((u8, u8),)) {test}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/issue-67019.rs:11:19: 11:20
-          StorageDead(_1);                 // scope 0 at $DIR/issue-67019.rs:11:20: 11:21
-          nop;                             // scope 0 at $DIR/issue-67019.rs:10:11: 12:2
-          return;                          // scope 0 at $DIR/issue-67019.rs:12:2: 12:2
+          StorageDead(_2);                 // scope 0 at $DIR/issue-67019.rs:+1:19: +1:20
+          StorageDead(_1);                 // scope 0 at $DIR/issue-67019.rs:+1:20: +1:21
+          nop;                             // scope 0 at $DIR/issue-67019.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/issue-67019.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
@@ -2,36 +2,36 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/large_array_index.rs:4:11: 4:11
-      let _1: u8;                          // in scope 0 at $DIR/large_array_index.rs:6:9: 6:10
-      let mut _2: [u8; 5000];              // in scope 0 at $DIR/large_array_index.rs:6:17: 6:29
-      let _3: usize;                       // in scope 0 at $DIR/large_array_index.rs:6:30: 6:31
-      let mut _4: usize;                   // in scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-      let mut _5: bool;                    // in scope 0 at $DIR/large_array_index.rs:6:17: 6:32
+      let mut _0: ();                      // return place in scope 0 at $DIR/large_array_index.rs:+0:11: +0:11
+      let _1: u8;                          // in scope 0 at $DIR/large_array_index.rs:+2:9: +2:10
+      let mut _2: [u8; 5000];              // in scope 0 at $DIR/large_array_index.rs:+2:17: +2:29
+      let _3: usize;                       // in scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
+      let mut _4: usize;                   // in scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+      let mut _5: bool;                    // in scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/large_array_index.rs:6:9: 6:10
+          debug x => _1;                   // in scope 1 at $DIR/large_array_index.rs:+2:9: +2:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/large_array_index.rs:6:9: 6:10
-          StorageLive(_2);                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
-          _2 = [const 0_u8; 5000];         // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
-          StorageLive(_3);                 // scope 0 at $DIR/large_array_index.rs:6:30: 6:31
-          _3 = const 2_usize;              // scope 0 at $DIR/large_array_index.rs:6:30: 6:31
-          _4 = const 5000_usize;           // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
--         _5 = Lt(_3, _4);                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-+         _5 = const true;                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
+          StorageLive(_1);                 // scope 0 at $DIR/large_array_index.rs:+2:9: +2:10
+          StorageLive(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:29
+          _2 = [const 0_u8; 5000];         // scope 0 at $DIR/large_array_index.rs:+2:17: +2:29
+          StorageLive(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
+          _3 = const 2_usize;              // scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
+          _4 = const 5000_usize;           // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         _5 = Lt(_3, _4);                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
++         _5 = const true;                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
       }
   
       bb1: {
-          _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-          StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
-          StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
-          nop;                             // scope 0 at $DIR/large_array_index.rs:4:11: 7:2
-          StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:7:1: 7:2
-          return;                          // scope 0 at $DIR/large_array_index.rs:7:2: 7:2
+          _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+          StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
+          StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
+          nop;                             // scope 0 at $DIR/large_array_index.rs:+0:11: +3:2
+          StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/large_array_index.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
@@ -2,36 +2,36 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/large_array_index.rs:4:11: 4:11
-      let _1: u8;                          // in scope 0 at $DIR/large_array_index.rs:6:9: 6:10
-      let mut _2: [u8; 5000];              // in scope 0 at $DIR/large_array_index.rs:6:17: 6:29
-      let _3: usize;                       // in scope 0 at $DIR/large_array_index.rs:6:30: 6:31
-      let mut _4: usize;                   // in scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-      let mut _5: bool;                    // in scope 0 at $DIR/large_array_index.rs:6:17: 6:32
+      let mut _0: ();                      // return place in scope 0 at $DIR/large_array_index.rs:+0:11: +0:11
+      let _1: u8;                          // in scope 0 at $DIR/large_array_index.rs:+2:9: +2:10
+      let mut _2: [u8; 5000];              // in scope 0 at $DIR/large_array_index.rs:+2:17: +2:29
+      let _3: usize;                       // in scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
+      let mut _4: usize;                   // in scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+      let mut _5: bool;                    // in scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/large_array_index.rs:6:9: 6:10
+          debug x => _1;                   // in scope 1 at $DIR/large_array_index.rs:+2:9: +2:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/large_array_index.rs:6:9: 6:10
-          StorageLive(_2);                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
-          _2 = [const 0_u8; 5000];         // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
-          StorageLive(_3);                 // scope 0 at $DIR/large_array_index.rs:6:30: 6:31
-          _3 = const 2_usize;              // scope 0 at $DIR/large_array_index.rs:6:30: 6:31
-          _4 = const 5000_usize;           // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
--         _5 = Lt(_3, _4);                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-+         _5 = const true;                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
+          StorageLive(_1);                 // scope 0 at $DIR/large_array_index.rs:+2:9: +2:10
+          StorageLive(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:29
+          _2 = [const 0_u8; 5000];         // scope 0 at $DIR/large_array_index.rs:+2:17: +2:29
+          StorageLive(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
+          _3 = const 2_usize;              // scope 0 at $DIR/large_array_index.rs:+2:30: +2:31
+          _4 = const 5000_usize;           // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         _5 = Lt(_3, _4);                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
++         _5 = const true;                 // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
       }
   
       bb1: {
-          _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
-          StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
-          StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
-          nop;                             // scope 0 at $DIR/large_array_index.rs:4:11: 7:2
-          StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:7:1: 7:2
-          return;                          // scope 0 at $DIR/large_array_index.rs:7:2: 7:2
+          _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:+2:17: +2:32
+          StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
+          StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:+2:32: +2:33
+          nop;                             // scope 0 at $DIR/large_array_index.rs:+0:11: +3:2
+          StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/large_array_index.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/mult_by_zero.test.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mult_by_zero.test.ConstProp.diff
@@ -2,17 +2,17 @@
 + // MIR for `test` after ConstProp
   
   fn test(_1: i32) -> i32 {
-      debug x => _1;                       // in scope 0 at $DIR/mult_by_zero.rs:4:9: 4:10
-      let mut _0: i32;                     // return place in scope 0 at $DIR/mult_by_zero.rs:4:21: 4:24
-      let mut _2: i32;                     // in scope 0 at $DIR/mult_by_zero.rs:5:3: 5:4
+      debug x => _1;                       // in scope 0 at $DIR/mult_by_zero.rs:+0:9: +0:10
+      let mut _0: i32;                     // return place in scope 0 at $DIR/mult_by_zero.rs:+0:21: +0:24
+      let mut _2: i32;                     // in scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:4
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/mult_by_zero.rs:5:3: 5:4
-          _2 = _1;                         // scope 0 at $DIR/mult_by_zero.rs:5:3: 5:4
--         _0 = Mul(move _2, const 0_i32);  // scope 0 at $DIR/mult_by_zero.rs:5:3: 5:8
-+         _0 = const 0_i32;                // scope 0 at $DIR/mult_by_zero.rs:5:3: 5:8
-          StorageDead(_2);                 // scope 0 at $DIR/mult_by_zero.rs:5:7: 5:8
-          return;                          // scope 0 at $DIR/mult_by_zero.rs:6:2: 6:2
+          StorageLive(_2);                 // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:4
+          _2 = _1;                         // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:4
+-         _0 = Mul(move _2, const 0_i32);  // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:8
++         _0 = const 0_i32;                // scope 0 at $DIR/mult_by_zero.rs:+1:3: +1:8
+          StorageDead(_2);                 // scope 0 at $DIR/mult_by_zero.rs:+1:7: +1:8
+          return;                          // scope 0 at $DIR/mult_by_zero.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
@@ -2,27 +2,27 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable.rs:4:11: 4:11
-      let mut _1: i32;                     // in scope 0 at $DIR/mutable_variable.rs:5:9: 5:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable.rs:+0:11: +0:11
+      let mut _1: i32;                     // in scope 0 at $DIR/mutable_variable.rs:+1:9: +1:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/mutable_variable.rs:5:9: 5:14
-          let _2: i32;                     // in scope 1 at $DIR/mutable_variable.rs:7:9: 7:10
+          debug x => _1;                   // in scope 1 at $DIR/mutable_variable.rs:+1:9: +1:14
+          let _2: i32;                     // in scope 1 at $DIR/mutable_variable.rs:+3:9: +3:10
           scope 2 {
-              debug y => _2;               // in scope 2 at $DIR/mutable_variable.rs:7:9: 7:10
+              debug y => _2;               // in scope 2 at $DIR/mutable_variable.rs:+3:9: +3:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable.rs:5:9: 5:14
-          _1 = const 42_i32;               // scope 0 at $DIR/mutable_variable.rs:5:17: 5:19
-          _1 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:6:5: 6:11
-          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable.rs:7:9: 7:10
--         _2 = _1;                         // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14
-+         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14
-          nop;                             // scope 0 at $DIR/mutable_variable.rs:4:11: 8:2
-          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable.rs:8:1: 8:2
-          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/mutable_variable.rs:8:2: 8:2
+          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable.rs:+1:9: +1:14
+          _1 = const 42_i32;               // scope 0 at $DIR/mutable_variable.rs:+1:17: +1:19
+          _1 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:+2:5: +2:11
+          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable.rs:+3:9: +3:10
+-         _2 = _1;                         // scope 1 at $DIR/mutable_variable.rs:+3:13: +3:14
++         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:+3:13: +3:14
+          nop;                             // scope 0 at $DIR/mutable_variable.rs:+0:11: +4:2
+          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable.rs:+4:1: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/mutable_variable.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
@@ -2,29 +2,29 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_aggregate.rs:4:11: 4:11
-      let mut _1: (i32, i32);              // in scope 0 at $DIR/mutable_variable_aggregate.rs:5:9: 5:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_aggregate.rs:+0:11: +0:11
+      let mut _1: (i32, i32);              // in scope 0 at $DIR/mutable_variable_aggregate.rs:+1:9: +1:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_aggregate.rs:5:9: 5:14
-          let _2: (i32, i32);              // in scope 1 at $DIR/mutable_variable_aggregate.rs:7:9: 7:10
+          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_aggregate.rs:+1:9: +1:14
+          let _2: (i32, i32);              // in scope 1 at $DIR/mutable_variable_aggregate.rs:+3:9: +3:10
           scope 2 {
-              debug y => _2;               // in scope 2 at $DIR/mutable_variable_aggregate.rs:7:9: 7:10
+              debug y => _2;               // in scope 2 at $DIR/mutable_variable_aggregate.rs:+3:9: +3:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:5:9: 5:14
-          Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
-          (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
-          (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
-          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate.rs:6:5: 6:13
-          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:7:9: 7:10
--         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14
-+         _2 = const (42_i32, 99_i32);     // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14
-          nop;                             // scope 0 at $DIR/mutable_variable_aggregate.rs:4:11: 8:2
-          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:8:1: 8:2
-          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/mutable_variable_aggregate.rs:8:2: 8:2
+          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:9: +1:14
+          Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
+          (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
+          (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:+1:17: +1:25
+          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate.rs:+2:5: +2:13
+          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:9: +3:10
+-         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:13: +3:14
++         _2 = const (42_i32, 99_i32);     // scope 1 at $DIR/mutable_variable_aggregate.rs:+3:13: +3:14
+          nop;                             // scope 0 at $DIR/mutable_variable_aggregate.rs:+0:11: +4:2
+          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:+4:1: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/mutable_variable_aggregate.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
@@ -2,35 +2,35 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:4:11: 4:11
-      let mut _1: (i32, i32);              // in scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:9: 5:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+0:11: +0:11
+      let mut _1: (i32, i32);              // in scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:9: +1:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:9: 5:14
-          let _2: &mut (i32, i32);         // in scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:6:9: 6:10
+          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:9: +1:14
+          let _2: &mut (i32, i32);         // in scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+2:9: +2:10
           scope 2 {
-              debug z => _2;               // in scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:6:9: 6:10
-              let _3: (i32, i32);          // in scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:8:9: 8:10
+              debug z => _2;               // in scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+2:9: +2:10
+              let _3: (i32, i32);          // in scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:9: +4:10
               scope 3 {
-                  debug y => _3;           // in scope 3 at $DIR/mutable_variable_aggregate_mut_ref.rs:8:9: 8:10
+                  debug y => _3;           // in scope 3 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:9: +4:10
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:9: 5:14
-          Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
-          (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
-          (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
-          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:6:9: 6:10
-          _2 = &mut _1;                    // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:6:13: 6:19
-          ((*_2).1: i32) = const 99_i32;   // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:7:5: 7:13
-          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:8:9: 8:10
-          _3 = _1;                         // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:8:13: 8:14
-          nop;                             // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:4:11: 9:2
-          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:9:1: 9:2
-          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:9:2: 9:2
+          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:9: +1:14
+          Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
+          (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
+          (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+1:17: +1:25
+          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+2:9: +2:10
+          _2 = &mut _1;                    // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+2:13: +2:19
+          ((*_2).1: i32) = const 99_i32;   // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+3:5: +3:13
+          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:9: +4:10
+          _3 = _1;                         // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+4:13: +4:14
+          nop;                             // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+0:11: +5:2
+          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:+5:1: +5:2
+          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:+5:1: +5:2
+          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
@@ -2,34 +2,34 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:4:11: 4:11
-      let mut _1: (i32, i32);              // in scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:5:9: 5:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+0:11: +0:11
+      let mut _1: (i32, i32);              // in scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+1:9: +1:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:5:9: 5:14
-          let _2: i32;                     // in scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:9: 8:10
+          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+1:9: +1:14
+          let _2: i32;                     // in scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:9: +4:10
           scope 2 {
-              debug y => _2;               // in scope 2 at $DIR/mutable_variable_aggregate_partial_read.rs:8:9: 8:10
+              debug y => _2;               // in scope 2 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:9: +4:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:5:9: 5:14
-          _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:5:29: 5:34
+          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+1:9: +1:14
+          _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+1:29: +1:34
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_aggregate_partial_read.rs:5:29: 5:32
                                            // + literal: Const { ty: fn() -> (i32, i32) {foo}, val: Value(<ZST>) }
       }
   
       bb1: {
-          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:6:5: 6:13
-          (_1.0: i32) = const 42_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:7:5: 7:13
-          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:9: 8:10
--         _2 = (_1.1: i32);                // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:13: 8:16
-+         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:13: 8:16
-          nop;                             // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:4:11: 9:2
-          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:9:2: 9:2
+          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+2:5: +2:13
+          (_1.0: i32) = const 42_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+3:5: +3:13
+          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:9: +4:10
+-         _2 = (_1.1: i32);                // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:13: +4:16
++         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+4:13: +4:16
+          nop;                             // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+0:11: +5:2
+          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:+5:1: +5:2
+          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
@@ -2,43 +2,43 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_no_prop.rs:6:11: 6:11
-      let mut _1: u32;                     // in scope 0 at $DIR/mutable_variable_no_prop.rs:7:9: 7:14
-      let _2: ();                          // in scope 0 at $DIR/mutable_variable_no_prop.rs:8:5: 10:6
-      let mut _3: u32;                     // in scope 0 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
-      let mut _4: *mut u32;                // in scope 0 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_no_prop.rs:+0:11: +0:11
+      let mut _1: u32;                     // in scope 0 at $DIR/mutable_variable_no_prop.rs:+1:9: +1:14
+      let _2: ();                          // in scope 0 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6
+      let mut _3: u32;                     // in scope 0 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+      let mut _4: *mut u32;                // in scope 0 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_no_prop.rs:7:9: 7:14
-          let _5: u32;                     // in scope 1 at $DIR/mutable_variable_no_prop.rs:11:9: 11:10
+          debug x => _1;                   // in scope 1 at $DIR/mutable_variable_no_prop.rs:+1:9: +1:14
+          let _5: u32;                     // in scope 1 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
           scope 2 {
           }
           scope 3 {
-              debug y => _5;               // in scope 3 at $DIR/mutable_variable_no_prop.rs:11:9: 11:10
+              debug y => _5;               // in scope 3 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:7:9: 7:14
-          _1 = const 42_u32;               // scope 0 at $DIR/mutable_variable_no_prop.rs:7:17: 7:19
-          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:8:5: 10:6
-          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
-          StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
-          _4 = const {alloc1: *mut u32};   // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
+          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:+1:9: +1:14
+          _1 = const 42_u32;               // scope 0 at $DIR/mutable_variable_no_prop.rs:+1:17: +1:19
+          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6
+          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+          StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+          _4 = const {alloc1: *mut u32};   // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_no_prop.rs:9:13: 9:19
                                            // + literal: Const { ty: *mut u32, val: Value(Scalar(alloc1)) }
-          _3 = (*_4);                      // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
-          _1 = move _3;                    // scope 2 at $DIR/mutable_variable_no_prop.rs:9:9: 9:19
-          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:18: 9:19
-          StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:19: 9:20
-          nop;                             // scope 2 at $DIR/mutable_variable_no_prop.rs:8:5: 10:6
-          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:10:5: 10:6
-          StorageLive(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:11:9: 11:10
-          _5 = _1;                         // scope 1 at $DIR/mutable_variable_no_prop.rs:11:13: 11:14
-          nop;                             // scope 0 at $DIR/mutable_variable_no_prop.rs:6:11: 12:2
-          StorageDead(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:12:1: 12:2
-          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:12:1: 12:2
-          return;                          // scope 0 at $DIR/mutable_variable_no_prop.rs:12:2: 12:2
+          _3 = (*_4);                      // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:13: +3:19
+          _1 = move _3;                    // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:9: +3:19
+          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:18: +3:19
+          StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:+3:19: +3:20
+          nop;                             // scope 2 at $DIR/mutable_variable_no_prop.rs:+2:5: +4:6
+          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+4:5: +4:6
+          StorageLive(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:9: +5:10
+          _5 = _1;                         // scope 1 at $DIR/mutable_variable_no_prop.rs:+5:13: +5:14
+          nop;                             // scope 0 at $DIR/mutable_variable_no_prop.rs:+0:11: +6:2
+          StorageDead(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:+6:1: +6:2
+          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/mutable_variable_no_prop.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -2,52 +2,52 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_unprop_assign.rs:4:11: 4:11
-      let _1: i32;                         // in scope 0 at $DIR/mutable_variable_unprop_assign.rs:5:9: 5:10
-      let mut _3: i32;                     // in scope 0 at $DIR/mutable_variable_unprop_assign.rs:7:11: 7:12
+      let mut _0: ();                      // return place in scope 0 at $DIR/mutable_variable_unprop_assign.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/mutable_variable_unprop_assign.rs:+1:9: +1:10
+      let mut _3: i32;                     // in scope 0 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
       scope 1 {
-          debug a => _1;                   // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:5:9: 5:10
-          let mut _2: (i32, i32);          // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:9: 6:14
+          debug a => _1;                   // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:+1:9: +1:10
+          let mut _2: (i32, i32);          // in scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
           scope 2 {
-              debug x => _2;               // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:6:9: 6:14
-              let _4: i32;                 // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:8:9: 8:10
+              debug x => _2;               // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
+              let _4: i32;                 // in scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
               scope 3 {
-                  debug y => _4;           // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:8:9: 8:10
-                  let _5: i32;             // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:9:9: 9:10
+                  debug y => _4;           // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
+                  let _5: i32;             // in scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
                   scope 4 {
-                      debug z => _5;       // in scope 4 at $DIR/mutable_variable_unprop_assign.rs:9:9: 9:10
+                      debug z => _5;       // in scope 4 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_unprop_assign.rs:5:9: 5:10
-          _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_unprop_assign.rs:5:13: 5:18
+          StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+1:9: +1:10
+          _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+1:13: +1:18
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_unprop_assign.rs:5:13: 5:16
                                            // + literal: Const { ty: fn() -> i32 {foo}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:9: 6:14
-          Deinit(_2);                      // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
-          (_2.0: i32) = const 1_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
-          (_2.1: i32) = const 2_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
-          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:7:11: 7:12
-          _3 = _1;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:7:11: 7:12
-          (_2.1: i32) = move _3;           // scope 2 at $DIR/mutable_variable_unprop_assign.rs:7:5: 7:12
-          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:7:11: 7:12
-          StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:8:9: 8:10
-          _4 = (_2.1: i32);                // scope 2 at $DIR/mutable_variable_unprop_assign.rs:8:13: 8:16
-          StorageLive(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:9:9: 9:10
-          _5 = (_2.0: i32);                // scope 3 at $DIR/mutable_variable_unprop_assign.rs:9:13: 9:16
-          nop;                             // scope 0 at $DIR/mutable_variable_unprop_assign.rs:4:11: 10:2
-          StorageDead(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:10:1: 10:2
-          StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:10:1: 10:2
-          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:10:1: 10:2
-          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_unprop_assign.rs:10:1: 10:2
-          return;                          // scope 0 at $DIR/mutable_variable_unprop_assign.rs:10:2: 10:2
+          StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:9: +2:14
+          Deinit(_2);                      // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
+          (_2.0: i32) = const 1_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
+          (_2.1: i32) = const 2_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+2:29: +2:35
+          StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
+          _3 = _1;                         // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
+          (_2.1: i32) = move _3;           // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:5: +3:12
+          StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+3:11: +3:12
+          StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:9: +4:10
+          _4 = (_2.1: i32);                // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+4:13: +4:16
+          StorageLive(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:9: +5:10
+          _5 = (_2.0: i32);                // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+5:13: +5:16
+          nop;                             // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+0:11: +6:2
+          StorageDead(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
+          StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
+          StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
+          StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
@@ -2,67 +2,67 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:11:11: 11:11
-      let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-      let mut _2: (i32, bool);             // in scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-      let mut _4: [i32; 6];                // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-      let _5: usize;                       // in scope 0 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-      let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-      let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-      let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+      let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+      let mut _2: (i32, bool);             // in scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+      let mut _4: [i32; 6];                // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
+      let _5: usize;                       // in scope 0 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
+      let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+      let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+      let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-          let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
+          debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+          let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           scope 2 {
-              debug y => _3;               // in scope 2 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-              let _8: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+              debug y => _3;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+              let _8: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
               scope 3 {
-                  debug z => _8;           // in scope 3 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+                  debug z => _8;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
--         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+          StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+-         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
++         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
--         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-          StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-          StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-          _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-          _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
--         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
--         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         _7 = const true;                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
+-         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
++         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+          StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
+          _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
+          StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
+          _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
+          _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+-         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
++         _7 = const true;                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       }
   
       bb2: {
--         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-          StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
--         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-+         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
-          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-          StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
+-         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
++         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+          StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
+          StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
+          StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+-         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
++         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
+          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
+          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +4:2
+          StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+          StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -2,67 +2,67 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:11:11: 11:11
-      let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-      let mut _2: (i32, bool);             // in scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-      let mut _4: [i32; 6];                // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-      let _5: usize;                       // in scope 0 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-      let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-      let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-      let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+      let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+      let mut _2: (i32, bool);             // in scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+      let mut _4: [i32; 6];                // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
+      let _5: usize;                       // in scope 0 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
+      let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+      let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+      let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-          let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
+          debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+          let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
           scope 2 {
-              debug y => _3;               // in scope 2 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-              let _8: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+              debug y => _3;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+              let _8: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
               scope 3 {
-                  debug z => _8;           // in scope 3 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+                  debug z => _8;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
--         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+          StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+-         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
++         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
       }
   
       bb1: {
--         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-          StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-          StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-          _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-          _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
--         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
--         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         _7 = const true;                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
+-         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
++         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:+1:13: +1:18
+          StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+          StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
+          _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:31
+          StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
+          _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:32: +2:33
+          _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+-         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
++         _7 = const true;                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
       }
   
       bb2: {
--         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-          StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
--         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-+         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
-          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-          StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
+-         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
++         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:+2:13: +2:34
+          StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
+          StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:34: +2:35
+          StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+          (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:36
+-         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
++         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:+3:13: +3:38
+          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:38: +3:39
+          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +4:2
+          StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+          StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.32bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.32bit.mir
@@ -1,27 +1,27 @@
 // MIR for `main` after SimplifyLocals
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:11:11: 11:11
-    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
+    let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
+    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
+        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-            let _3: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+            let _3: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-        StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-        StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
+        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+        StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+        StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+        return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
@@ -1,27 +1,27 @@
 // MIR for `main` after SimplifyLocals
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:11:11: 11:11
-    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
+    let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
+    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
+        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-            let _3: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+            let _3: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-        StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-        StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
+        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+        StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+        StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
+        return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
@@ -2,43 +2,43 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/read_immutable_static.rs:6:11: 6:11
-      let _1: u8;                          // in scope 0 at $DIR/read_immutable_static.rs:7:9: 7:10
-      let mut _2: u8;                      // in scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-      let mut _3: &u8;                     // in scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-      let mut _4: u8;                      // in scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
-      let mut _5: &u8;                     // in scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
+      let mut _0: ();                      // return place in scope 0 at $DIR/read_immutable_static.rs:+0:11: +0:11
+      let _1: u8;                          // in scope 0 at $DIR/read_immutable_static.rs:+1:9: +1:10
+      let mut _2: u8;                      // in scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:16
+      let mut _3: &u8;                     // in scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:16
+      let mut _4: u8;                      // in scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
+      let mut _5: &u8;                     // in scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/read_immutable_static.rs:7:9: 7:10
+          debug x => _1;                   // in scope 1 at $DIR/read_immutable_static.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/read_immutable_static.rs:7:9: 7:10
-          StorageLive(_2);                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-          StorageLive(_3);                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-          _3 = const {alloc1: &u8};        // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
+          StorageLive(_1);                 // scope 0 at $DIR/read_immutable_static.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:16
+          StorageLive(_3);                 // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:16
+          _3 = const {alloc1: &u8};        // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:16
                                            // mir::Constant
                                            // + span: $DIR/read_immutable_static.rs:7:13: 7:16
                                            // + literal: Const { ty: &u8, val: Value(Scalar(alloc1)) }
--         _2 = (*_3);                      // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-+         _2 = const 2_u8;                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-          StorageLive(_4);                 // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
-          StorageLive(_5);                 // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
-          _5 = const {alloc1: &u8};        // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
+-         _2 = (*_3);                      // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:16
++         _2 = const 2_u8;                 // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:16
+          StorageLive(_4);                 // scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
+          StorageLive(_5);                 // scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
+          _5 = const {alloc1: &u8};        // scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
                                            // mir::Constant
                                            // + span: $DIR/read_immutable_static.rs:7:19: 7:22
                                            // + literal: Const { ty: &u8, val: Value(Scalar(alloc1)) }
--         _4 = (*_5);                      // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
--         _1 = Add(move _2, move _4);      // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:22
-+         _4 = const 2_u8;                 // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
-+         _1 = const 4_u8;                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:22
-          StorageDead(_4);                 // scope 0 at $DIR/read_immutable_static.rs:7:21: 7:22
-          StorageDead(_2);                 // scope 0 at $DIR/read_immutable_static.rs:7:21: 7:22
-          StorageDead(_5);                 // scope 0 at $DIR/read_immutable_static.rs:7:22: 7:23
-          StorageDead(_3);                 // scope 0 at $DIR/read_immutable_static.rs:7:22: 7:23
-          nop;                             // scope 0 at $DIR/read_immutable_static.rs:6:11: 8:2
-          StorageDead(_1);                 // scope 0 at $DIR/read_immutable_static.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/read_immutable_static.rs:8:2: 8:2
+-         _4 = (*_5);                      // scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
+-         _1 = Add(move _2, move _4);      // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:22
++         _4 = const 2_u8;                 // scope 0 at $DIR/read_immutable_static.rs:+1:19: +1:22
++         _1 = const 4_u8;                 // scope 0 at $DIR/read_immutable_static.rs:+1:13: +1:22
+          StorageDead(_4);                 // scope 0 at $DIR/read_immutable_static.rs:+1:21: +1:22
+          StorageDead(_2);                 // scope 0 at $DIR/read_immutable_static.rs:+1:21: +1:22
+          StorageDead(_5);                 // scope 0 at $DIR/read_immutable_static.rs:+1:22: +1:23
+          StorageDead(_3);                 // scope 0 at $DIR/read_immutable_static.rs:+1:22: +1:23
+          nop;                             // scope 0 at $DIR/read_immutable_static.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/read_immutable_static.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/read_immutable_static.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
@@ -2,26 +2,26 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref.rs:4:11: 4:11
-      let _1: i32;                         // in scope 0 at $DIR/ref_deref.rs:5:5: 5:10
-      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref.rs:5:6: 5:10
-      let _3: i32;                         // in scope 0 at $DIR/ref_deref.rs:5:8: 5:9
-      let mut _4: &i32;                    // in scope 0 at $DIR/ref_deref.rs:5:6: 5:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
+      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
+      let _3: i32;                         // in scope 0 at $DIR/ref_deref.rs:+1:8: +1:9
+      let mut _4: &i32;                    // in scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
-          _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
+          StorageLive(_1);                 // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
+          _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
                                            // mir::Constant
                                            // + span: $DIR/ref_deref.rs:5:6: 5:10
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
-          _2 = _4;                         // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
--         _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
-+         _1 = const 4_i32;                // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
-          StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
-          StorageDead(_1);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
-          nop;                             // scope 0 at $DIR/ref_deref.rs:4:11: 6:2
-          return;                          // scope 0 at $DIR/ref_deref.rs:6:2: 6:2
+          _2 = _4;                         // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
+-         _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
++         _1 = const 4_i32;                // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
+          StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:+1:10: +1:11
+          StorageDead(_1);                 // scope 0 at $DIR/ref_deref.rs:+1:10: +1:11
+          nop;                             // scope 0 at $DIR/ref_deref.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/ref_deref.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
@@ -2,29 +2,29 @@
 + // MIR for `main` after PromoteTemps
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref.rs:4:11: 4:11
-      let _1: i32;                         // in scope 0 at $DIR/ref_deref.rs:5:5: 5:10
-      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref.rs:5:6: 5:10
-      let _3: i32;                         // in scope 0 at $DIR/ref_deref.rs:5:8: 5:9
-+     let mut _4: &i32;                    // in scope 0 at $DIR/ref_deref.rs:5:6: 5:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
+      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
+      let _3: i32;                         // in scope 0 at $DIR/ref_deref.rs:+1:8: +1:9
++     let mut _4: &i32;                    // in scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
--         StorageLive(_3);                 // scope 0 at $DIR/ref_deref.rs:5:8: 5:9
--         _3 = const 4_i32;                // scope 0 at $DIR/ref_deref.rs:5:8: 5:9
--         _2 = &_3;                        // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
-+         _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
+          StorageLive(_1);                 // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
+-         StorageLive(_3);                 // scope 0 at $DIR/ref_deref.rs:+1:8: +1:9
+-         _3 = const 4_i32;                // scope 0 at $DIR/ref_deref.rs:+1:8: +1:9
+-         _2 = &_3;                        // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
++         _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
 +                                          // mir::Constant
 +                                          // + span: $DIR/ref_deref.rs:5:6: 5:10
 +                                          // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
-+         _2 = &(*_4);                     // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
-          _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
--         StorageDead(_3);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
-          StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
-          StorageDead(_1);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
-          _0 = const ();                   // scope 0 at $DIR/ref_deref.rs:4:11: 6:2
-          return;                          // scope 0 at $DIR/ref_deref.rs:6:2: 6:2
++         _2 = &(*_4);                     // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
+          _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
+-         StorageDead(_3);                 // scope 0 at $DIR/ref_deref.rs:+1:10: +1:11
+          StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:+1:10: +1:11
+          StorageDead(_1);                 // scope 0 at $DIR/ref_deref.rs:+1:10: +1:11
+          _0 = const ();                   // scope 0 at $DIR/ref_deref.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/ref_deref.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
@@ -2,25 +2,25 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref_project.rs:4:11: 4:11
-      let _1: i32;                         // in scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
-      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
-      let _3: (i32, i32);                  // in scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
-      let mut _4: &(i32, i32);             // in scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref_project.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
+      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+      let _3: (i32, i32);                  // in scope 0 at $DIR/ref_deref_project.rs:+1:8: +1:14
+      let mut _4: &(i32, i32);             // in scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
-          StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
-          _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
+          StorageLive(_1);                 // scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
+          StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+          _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
                                            // mir::Constant
                                            // + span: $DIR/ref_deref_project.rs:5:6: 5:17
                                            // + literal: Const { ty: &(i32, i32), val: Unevaluated(main, [], Some(promoted[0])) }
-          _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
-          _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
-          StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
-          StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
-          nop;                             // scope 0 at $DIR/ref_deref_project.rs:4:11: 6:2
-          return;                          // scope 0 at $DIR/ref_deref_project.rs:6:2: 6:2
+          _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+          _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
+          StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18
+          StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18
+          nop;                             // scope 0 at $DIR/ref_deref_project.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/ref_deref_project.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
@@ -2,29 +2,29 @@
 + // MIR for `main` after PromoteTemps
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref_project.rs:4:11: 4:11
-      let _1: i32;                         // in scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
-      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
-      let _3: (i32, i32);                  // in scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
-+     let mut _4: &(i32, i32);             // in scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/ref_deref_project.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
+      let mut _2: &i32;                    // in scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+      let _3: (i32, i32);                  // in scope 0 at $DIR/ref_deref_project.rs:+1:8: +1:14
++     let mut _4: &(i32, i32);             // in scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
-          StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
--         StorageLive(_3);                 // scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
--         _3 = (const 4_i32, const 5_i32); // scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
--         _2 = &(_3.1: i32);               // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
-+         _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
+          StorageLive(_1);                 // scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
+          StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+-         StorageLive(_3);                 // scope 0 at $DIR/ref_deref_project.rs:+1:8: +1:14
+-         _3 = (const 4_i32, const 5_i32); // scope 0 at $DIR/ref_deref_project.rs:+1:8: +1:14
+-         _2 = &(_3.1: i32);               // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
++         _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
 +                                          // mir::Constant
 +                                          // + span: $DIR/ref_deref_project.rs:5:6: 5:17
 +                                          // + literal: Const { ty: &(i32, i32), val: Unevaluated(main, [], Some(promoted[0])) }
-+         _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
-          _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
--         StorageDead(_3);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
-          StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
-          StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
-          _0 = const ();                   // scope 0 at $DIR/ref_deref_project.rs:4:11: 6:2
-          return;                          // scope 0 at $DIR/ref_deref_project.rs:6:2: 6:2
++         _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
+          _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
+-         StorageDead(_3);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18
+          StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18
+          StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18
+          _0 = const ();                   // scope 0 at $DIR/ref_deref_project.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/ref_deref_project.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -2,28 +2,28 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/reify_fn_ptr.rs:3:11: 3:11
-      let mut _1: *const fn();             // in scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:41
-      let mut _2: usize;                   // in scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:26
-      let mut _3: fn();                    // in scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/reify_fn_ptr.rs:+0:11: +0:11
+      let mut _1: *const fn();             // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
+      let mut _2: usize;                   // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
+      let mut _3: fn();                    // in scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
       scope 1 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:41
-          StorageLive(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:26
-          StorageLive(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:17
-          _3 = main as fn() (Pointer(ReifyFnPointer)); // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:17
+          StorageLive(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
+          StorageLive(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
+          StorageLive(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
+          _3 = main as fn() (Pointer(ReifyFnPointer)); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
                                            // mir::Constant
                                            // + span: $DIR/reify_fn_ptr.rs:4:13: 4:17
                                            // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
-          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:26
-          StorageDead(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:25: 4:26
-          _1 = move _2 as *const fn() (PointerFromExposedAddress); // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:41
-          StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:40: 4:41
-          StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:41: 4:42
-          nop;                             // scope 0 at $DIR/reify_fn_ptr.rs:3:11: 5:2
-          return;                          // scope 0 at $DIR/reify_fn_ptr.rs:5:2: 5:2
+          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
+          StorageDead(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:25: +1:26
+          _1 = move _2 as *const fn() (PointerFromExposedAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41
+          StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:40: +1:41
+          StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:41: +1:42
+          nop;                             // scope 0 at $DIR/reify_fn_ptr.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/reify_fn_ptr.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
@@ -2,42 +2,42 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/repeat.rs:5:11: 5:11
-      let _1: u32;                         // in scope 0 at $DIR/repeat.rs:6:9: 6:10
-      let mut _2: u32;                     // in scope 0 at $DIR/repeat.rs:6:18: 6:28
-      let mut _3: [u32; 8];                // in scope 0 at $DIR/repeat.rs:6:18: 6:25
-      let _4: usize;                       // in scope 0 at $DIR/repeat.rs:6:26: 6:27
-      let mut _5: usize;                   // in scope 0 at $DIR/repeat.rs:6:18: 6:28
-      let mut _6: bool;                    // in scope 0 at $DIR/repeat.rs:6:18: 6:28
+      let mut _0: ();                      // return place in scope 0 at $DIR/repeat.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/repeat.rs:+1:9: +1:10
+      let mut _2: u32;                     // in scope 0 at $DIR/repeat.rs:+1:18: +1:28
+      let mut _3: [u32; 8];                // in scope 0 at $DIR/repeat.rs:+1:18: +1:25
+      let _4: usize;                       // in scope 0 at $DIR/repeat.rs:+1:26: +1:27
+      let mut _5: usize;                   // in scope 0 at $DIR/repeat.rs:+1:18: +1:28
+      let mut _6: bool;                    // in scope 0 at $DIR/repeat.rs:+1:18: +1:28
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/repeat.rs:6:9: 6:10
+          debug x => _1;                   // in scope 1 at $DIR/repeat.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:6:9: 6:10
-          StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
-          StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:6:18: 6:25
-          _3 = [const 42_u32; 8];          // scope 0 at $DIR/repeat.rs:6:18: 6:25
-          StorageLive(_4);                 // scope 0 at $DIR/repeat.rs:6:26: 6:27
-          _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:6:26: 6:27
-          _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         _6 = Lt(_4, _5);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:6:18: 6:28
-+         _6 = const true;                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:6:18: 6:28
+          StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+          StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:25
+          _3 = [const 42_u32; 8];          // scope 0 at $DIR/repeat.rs:+1:18: +1:25
+          StorageLive(_4);                 // scope 0 at $DIR/repeat.rs:+1:26: +1:27
+          _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:+1:26: +1:27
+          _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         _6 = Lt(_4, _5);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
++         _6 = const true;                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
       }
   
       bb1: {
--         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:6:18: 6:32
-+         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:28
-+         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:32
-          StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:6:31: 6:32
-          StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
-          StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
-          nop;                             // scope 0 at $DIR/repeat.rs:5:11: 7:2
-          StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:7:1: 7:2
-          return;                          // scope 0 at $DIR/repeat.rs:7:2: 7:2
+-         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:+1:18: +1:32
++         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:28
++         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:32
+          StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:+1:31: +1:32
+          StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
+          StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
+          nop;                             // scope 0 at $DIR/repeat.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/repeat.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
@@ -2,42 +2,42 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/repeat.rs:5:11: 5:11
-      let _1: u32;                         // in scope 0 at $DIR/repeat.rs:6:9: 6:10
-      let mut _2: u32;                     // in scope 0 at $DIR/repeat.rs:6:18: 6:28
-      let mut _3: [u32; 8];                // in scope 0 at $DIR/repeat.rs:6:18: 6:25
-      let _4: usize;                       // in scope 0 at $DIR/repeat.rs:6:26: 6:27
-      let mut _5: usize;                   // in scope 0 at $DIR/repeat.rs:6:18: 6:28
-      let mut _6: bool;                    // in scope 0 at $DIR/repeat.rs:6:18: 6:28
+      let mut _0: ();                      // return place in scope 0 at $DIR/repeat.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/repeat.rs:+1:9: +1:10
+      let mut _2: u32;                     // in scope 0 at $DIR/repeat.rs:+1:18: +1:28
+      let mut _3: [u32; 8];                // in scope 0 at $DIR/repeat.rs:+1:18: +1:25
+      let _4: usize;                       // in scope 0 at $DIR/repeat.rs:+1:26: +1:27
+      let mut _5: usize;                   // in scope 0 at $DIR/repeat.rs:+1:18: +1:28
+      let mut _6: bool;                    // in scope 0 at $DIR/repeat.rs:+1:18: +1:28
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/repeat.rs:6:9: 6:10
+          debug x => _1;                   // in scope 1 at $DIR/repeat.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:6:9: 6:10
-          StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
-          StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:6:18: 6:25
-          _3 = [const 42_u32; 8];          // scope 0 at $DIR/repeat.rs:6:18: 6:25
-          StorageLive(_4);                 // scope 0 at $DIR/repeat.rs:6:26: 6:27
-          _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:6:26: 6:27
-          _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         _6 = Lt(_4, _5);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:6:18: 6:28
-+         _6 = const true;                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:6:18: 6:28
+          StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:+1:9: +1:10
+          StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+          StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:25
+          _3 = [const 42_u32; 8];          // scope 0 at $DIR/repeat.rs:+1:18: +1:25
+          StorageLive(_4);                 // scope 0 at $DIR/repeat.rs:+1:26: +1:27
+          _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:+1:26: +1:27
+          _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         _6 = Lt(_4, _5);                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
++         _6 = const true;                 // scope 0 at $DIR/repeat.rs:+1:18: +1:28
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:+1:18: +1:28
       }
   
       bb1: {
--         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:6:18: 6:32
-+         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:28
-+         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:32
-          StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:6:31: 6:32
-          StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
-          StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
-          nop;                             // scope 0 at $DIR/repeat.rs:5:11: 7:2
-          StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:7:1: 7:2
-          return;                          // scope 0 at $DIR/repeat.rs:7:2: 7:2
+-         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:+1:18: +1:28
+-         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:+1:18: +1:32
++         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:28
++         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:+1:18: +1:32
+          StorageDead(_2);                 // scope 0 at $DIR/repeat.rs:+1:31: +1:32
+          StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
+          StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:+1:32: +1:33
+          nop;                             // scope 0 at $DIR/repeat.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/repeat.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
@@ -2,20 +2,20 @@
 + // MIR for `add` after ConstProp
   
   fn add() -> u32 {
-      let mut _0: u32;                     // return place in scope 0 at $DIR/return_place.rs:5:13: 5:16
-      let mut _1: (u32, bool);             // in scope 0 at $DIR/return_place.rs:6:5: 6:10
+      let mut _0: u32;                     // return place in scope 0 at $DIR/return_place.rs:+0:13: +0:16
+      let mut _1: (u32, bool);             // in scope 0 at $DIR/return_place.rs:+1:5: +1:10
   
       bb0: {
--         _1 = CheckedAdd(const 2_u32, const 2_u32); // scope 0 at $DIR/return_place.rs:6:5: 6:10
--         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
-+         _1 = const (4_u32, false);       // scope 0 at $DIR/return_place.rs:6:5: 6:10
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
+-         _1 = CheckedAdd(const 2_u32, const 2_u32); // scope 0 at $DIR/return_place.rs:+1:5: +1:10
+-         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
++         _1 = const (4_u32, false);       // scope 0 at $DIR/return_place.rs:+1:5: +1:10
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:+1:5: +1:10
       }
   
       bb1: {
--         _0 = move (_1.0: u32);           // scope 0 at $DIR/return_place.rs:6:5: 6:10
-+         _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:6:5: 6:10
-          return;                          // scope 0 at $DIR/return_place.rs:7:2: 7:2
+-         _0 = move (_1.0: u32);           // scope 0 at $DIR/return_place.rs:+1:5: +1:10
++         _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:+1:5: +1:10
+          return;                          // scope 0 at $DIR/return_place.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/return_place.add.PreCodegen.before.mir
+++ b/src/test/mir-opt/const_prop/return_place.add.PreCodegen.before.mir
@@ -1,10 +1,10 @@
 // MIR for `add` before PreCodegen
 
 fn add() -> u32 {
-    let mut _0: u32;                     // return place in scope 0 at $DIR/return_place.rs:5:13: 5:16
+    let mut _0: u32;                     // return place in scope 0 at $DIR/return_place.rs:+0:13: +0:16
 
     bb0: {
-        _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:6:5: 6:10
-        return;                          // scope 0 at $DIR/return_place.rs:7:2: 7:2
+        _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:+1:5: +1:10
+        return;                          // scope 0 at $DIR/return_place.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -2,34 +2,34 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/scalar_literal_propagation.rs:2:11: 2:11
-      let _1: u32;                         // in scope 0 at $DIR/scalar_literal_propagation.rs:3:9: 3:10
-      let _2: ();                          // in scope 0 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
-      let mut _3: u32;                     // in scope 0 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/scalar_literal_propagation.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/scalar_literal_propagation.rs:+1:9: +1:10
+      let _2: ();                          // in scope 0 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
+      let mut _3: u32;                     // in scope 0 at $DIR/scalar_literal_propagation.rs:+2:13: +2:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/scalar_literal_propagation.rs:3:9: 3:10
+          debug x => _1;                   // in scope 1 at $DIR/scalar_literal_propagation.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:3:9: 3:10
-          _1 = const 1_u32;                // scope 0 at $DIR/scalar_literal_propagation.rs:3:13: 3:14
-          StorageLive(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
-          StorageLive(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
--         _3 = _1;                         // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
--         _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
-+         _3 = const 1_u32;                // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
-+         _2 = consume(const 1_u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
+          StorageLive(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:+1:9: +1:10
+          _1 = const 1_u32;                // scope 0 at $DIR/scalar_literal_propagation.rs:+1:13: +1:14
+          StorageLive(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
+          StorageLive(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:13: +2:14
+-         _3 = _1;                         // scope 1 at $DIR/scalar_literal_propagation.rs:+2:13: +2:14
+-         _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
++         _3 = const 1_u32;                // scope 1 at $DIR/scalar_literal_propagation.rs:+2:13: +2:14
++         _2 = consume(const 1_u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
                                            // mir::Constant
                                            // + span: $DIR/scalar_literal_propagation.rs:4:5: 4:12
                                            // + literal: Const { ty: fn(u32) {consume}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:14: 4:15
-          StorageDead(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:15: 4:16
-          nop;                             // scope 0 at $DIR/scalar_literal_propagation.rs:2:11: 5:2
-          StorageDead(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:5:1: 5:2
-          return;                          // scope 0 at $DIR/scalar_literal_propagation.rs:5:2: 5:2
+          StorageDead(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:14: +2:15
+          StorageDead(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:+2:15: +2:16
+          nop;                             // scope 0 at $DIR/scalar_literal_propagation.rs:+0:11: +3:2
+          StorageDead(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/scalar_literal_propagation.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
@@ -2,52 +2,52 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/slice_len.rs:4:11: 4:11
-      let _1: u32;                         // in scope 0 at $DIR/slice_len.rs:5:5: 5:33
-      let mut _2: &[u32];                  // in scope 0 at $DIR/slice_len.rs:5:5: 5:30
-      let mut _3: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
-      let _4: &[u32; 3];                   // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
-      let _5: [u32; 3];                    // in scope 0 at $DIR/slice_len.rs:5:7: 5:19
-      let _6: usize;                       // in scope 0 at $DIR/slice_len.rs:5:31: 5:32
-      let mut _7: usize;                   // in scope 0 at $DIR/slice_len.rs:5:5: 5:33
-      let mut _8: bool;                    // in scope 0 at $DIR/slice_len.rs:5:5: 5:33
-      let mut _9: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
-      let mut _10: &[u32; 3];              // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/slice_len.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+      let mut _2: &[u32];                  // in scope 0 at $DIR/slice_len.rs:+1:5: +1:30
+      let mut _3: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+      let _4: &[u32; 3];                   // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+      let _5: [u32; 3];                    // in scope 0 at $DIR/slice_len.rs:+1:7: +1:19
+      let _6: usize;                       // in scope 0 at $DIR/slice_len.rs:+1:31: +1:32
+      let mut _7: usize;                   // in scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+      let mut _8: bool;                    // in scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+      let mut _9: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+      let mut _10: &[u32; 3];              // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-          StorageLive(_2);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:30
-          StorageLive(_3);                 // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          StorageLive(_4);                 // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _9 = const main::promoted[0];    // scope 0 at $DIR/slice_len.rs:5:6: 5:19
+          StorageLive(_1);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+          StorageLive(_2);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:30
+          StorageLive(_3);                 // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          StorageLive(_4);                 // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _9 = const main::promoted[0];    // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
                                            // mir::Constant
                                            // + span: $DIR/slice_len.rs:5:6: 5:19
                                            // + literal: Const { ty: &[u32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
-          _4 = _9;                         // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _3 = _4;                         // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          StorageLive(_10);                // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _10 = _3;                        // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:5:18: 5:19
-          StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:5:31: 5:32
-          _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:5:31: 5:32
-          _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-          StorageDead(_10);                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
--         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _8 = const true;                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
+          _4 = _9;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          StorageLive(_10);                // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _10 = _3;                        // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:+1:18: +1:19
+          StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
+          _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
+          _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+          StorageDead(_10);                // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+-         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
++         _8 = const true;                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
       }
   
       bb1: {
--         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-          StorageDead(_6);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          StorageDead(_4);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          StorageDead(_2);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          StorageDead(_1);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          nop;                             // scope 0 at $DIR/slice_len.rs:4:11: 6:2
-          return;                          // scope 0 at $DIR/slice_len.rs:6:2: 6:2
+-         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
++         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+          StorageDead(_6);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          StorageDead(_4);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          StorageDead(_2);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          StorageDead(_1);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          nop;                             // scope 0 at $DIR/slice_len.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/slice_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
@@ -2,52 +2,52 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/slice_len.rs:4:11: 4:11
-      let _1: u32;                         // in scope 0 at $DIR/slice_len.rs:5:5: 5:33
-      let mut _2: &[u32];                  // in scope 0 at $DIR/slice_len.rs:5:5: 5:30
-      let mut _3: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
-      let _4: &[u32; 3];                   // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
-      let _5: [u32; 3];                    // in scope 0 at $DIR/slice_len.rs:5:7: 5:19
-      let _6: usize;                       // in scope 0 at $DIR/slice_len.rs:5:31: 5:32
-      let mut _7: usize;                   // in scope 0 at $DIR/slice_len.rs:5:5: 5:33
-      let mut _8: bool;                    // in scope 0 at $DIR/slice_len.rs:5:5: 5:33
-      let mut _9: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
-      let mut _10: &[u32; 3];              // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/slice_len.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+      let mut _2: &[u32];                  // in scope 0 at $DIR/slice_len.rs:+1:5: +1:30
+      let mut _3: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+      let _4: &[u32; 3];                   // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+      let _5: [u32; 3];                    // in scope 0 at $DIR/slice_len.rs:+1:7: +1:19
+      let _6: usize;                       // in scope 0 at $DIR/slice_len.rs:+1:31: +1:32
+      let mut _7: usize;                   // in scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+      let mut _8: bool;                    // in scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+      let mut _9: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+      let mut _10: &[u32; 3];              // in scope 0 at $DIR/slice_len.rs:+1:6: +1:19
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-          StorageLive(_2);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:30
-          StorageLive(_3);                 // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          StorageLive(_4);                 // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _9 = const main::promoted[0];    // scope 0 at $DIR/slice_len.rs:5:6: 5:19
+          StorageLive(_1);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+          StorageLive(_2);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:30
+          StorageLive(_3);                 // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          StorageLive(_4);                 // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _9 = const main::promoted[0];    // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
                                            // mir::Constant
                                            // + span: $DIR/slice_len.rs:5:6: 5:19
                                            // + literal: Const { ty: &[u32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
-          _4 = _9;                         // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _3 = _4;                         // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          StorageLive(_10);                // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _10 = _3;                        // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:5:6: 5:19
-          StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:5:18: 5:19
-          StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:5:31: 5:32
-          _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:5:31: 5:32
-          _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-          StorageDead(_10);                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
--         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _8 = const true;                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
+          _4 = _9;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          StorageLive(_10);                // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _10 = _3;                        // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
+          StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:+1:18: +1:19
+          StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
+          _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:+1:31: +1:32
+          _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+          StorageDead(_10);                // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+-         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
++         _8 = const true;                 // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
       }
   
       bb1: {
--         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-          StorageDead(_6);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          StorageDead(_4);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          StorageDead(_2);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          StorageDead(_1);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
-          nop;                             // scope 0 at $DIR/slice_len.rs:4:11: 6:2
-          return;                          // scope 0 at $DIR/slice_len.rs:6:2: 6:2
+-         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
++         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:+1:5: +1:33
+          StorageDead(_6);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          StorageDead(_4);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          StorageDead(_2);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          StorageDead(_1);                 // scope 0 at $DIR/slice_len.rs:+1:33: +1:34
+          nop;                             // scope 0 at $DIR/slice_len.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/slice_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
@@ -2,33 +2,33 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/switch_int.rs:6:11: 6:11
-      let mut _1: i32;                     // in scope 0 at $DIR/switch_int.rs:7:11: 7:12
+      let mut _0: ();                      // return place in scope 0 at $DIR/switch_int.rs:+0:11: +0:11
+      let mut _1: i32;                     // in scope 0 at $DIR/switch_int.rs:+1:11: +1:12
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
-          _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
--         switchInt(_1) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
-+         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
+          StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:+1:11: +1:12
+          _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:+1:11: +1:12
+-         switchInt(_1) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:+1:5: +1:12
++         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:9:14: 9:21
+          _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:+3:14: +3:21
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
       }
   
       bb2: {
-          _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:8:14: 8:20
+          _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:+2:14: +2:20
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_1);                 // scope 0 at $DIR/switch_int.rs:11:1: 11:2
-          return;                          // scope 0 at $DIR/switch_int.rs:11:2: 11:2
+          StorageDead(_1);                 // scope 0 at $DIR/switch_int.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/switch_int.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.diff
@@ -2,33 +2,33 @@
 + // MIR for `main` after SimplifyConstCondition-after-const-prop
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/switch_int.rs:6:11: 6:11
-      let mut _1: i32;                     // in scope 0 at $DIR/switch_int.rs:7:11: 7:12
+      let mut _0: ();                      // return place in scope 0 at $DIR/switch_int.rs:+0:11: +0:11
+      let mut _1: i32;                     // in scope 0 at $DIR/switch_int.rs:+1:11: +1:12
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
-          _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
--         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
-+         goto -> bb2;                     // scope 0 at $DIR/switch_int.rs:7:5: 7:12
+          StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:+1:11: +1:12
+          _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:+1:11: +1:12
+-         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:+1:5: +1:12
++         goto -> bb2;                     // scope 0 at $DIR/switch_int.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:9:14: 9:21
+          _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:+3:14: +3:21
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
       }
   
       bb2: {
-          _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:8:14: 8:20
+          _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:+2:14: +2:20
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_1);                 // scope 0 at $DIR/switch_int.rs:11:1: 11:2
-          return;                          // scope 0 at $DIR/switch_int.rs:11:2: 11:2
+          StorageDead(_1);                 // scope 0 at $DIR/switch_int.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/switch_int.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -2,35 +2,35 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/tuple_literal_propagation.rs:2:11: 2:11
-      let _1: (u32, u32);                  // in scope 0 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
-      let _2: ();                          // in scope 0 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
-      let mut _3: (u32, u32);              // in scope 0 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/tuple_literal_propagation.rs:+0:11: +0:11
+      let _1: (u32, u32);                  // in scope 0 at $DIR/tuple_literal_propagation.rs:+1:9: +1:10
+      let _2: ();                          // in scope 0 at $DIR/tuple_literal_propagation.rs:+3:5: +3:15
+      let mut _3: (u32, u32);              // in scope 0 at $DIR/tuple_literal_propagation.rs:+3:13: +3:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
+          debug x => _1;                   // in scope 1 at $DIR/tuple_literal_propagation.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
-          Deinit(_1);                      // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
-          (_1.0: u32) = const 1_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
-          (_1.1: u32) = const 2_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
-          StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
-          StorageLive(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
--         _3 = _1;                         // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
-+         _3 = const (1_u32, 2_u32);       // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
-          _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
+          StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:+1:9: +1:10
+          Deinit(_1);                      // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
+          (_1.0: u32) = const 1_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
+          (_1.1: u32) = const 2_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:+1:13: +1:19
+          StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:5: +3:15
+          StorageLive(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:13: +3:14
+-         _3 = _1;                         // scope 1 at $DIR/tuple_literal_propagation.rs:+3:13: +3:14
++         _3 = const (1_u32, 2_u32);       // scope 1 at $DIR/tuple_literal_propagation.rs:+3:13: +3:14
+          _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/tuple_literal_propagation.rs:+3:5: +3:15
                                            // mir::Constant
                                            // + span: $DIR/tuple_literal_propagation.rs:5:5: 5:12
                                            // + literal: Const { ty: fn((u32, u32)) {consume}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:14: 5:15
-          StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:15: 5:16
-          nop;                             // scope 0 at $DIR/tuple_literal_propagation.rs:2:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/tuple_literal_propagation.rs:6:2: 6:2
+          StorageDead(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:14: +3:15
+          StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:+3:15: +3:16
+          nop;                             // scope 0 at $DIR/tuple_literal_propagation.rs:+0:11: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/tuple_literal_propagation.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -2,41 +2,41 @@
 + // MIR for `bar` after ConstProp
   
   fn bar() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/const_prop_miscompile.rs:11:10: 11:10
-      let mut _1: (i32,);                  // in scope 0 at $DIR/const_prop_miscompile.rs:12:9: 12:14
-      let _2: ();                          // in scope 0 at $DIR/const_prop_miscompile.rs:13:5: 15:6
-      let mut _3: *mut i32;                // in scope 0 at $DIR/const_prop_miscompile.rs:14:10: 14:22
-      let mut _5: i32;                     // in scope 0 at $DIR/const_prop_miscompile.rs:16:13: 16:20
+      let mut _0: ();                      // return place in scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +0:10
+      let mut _1: (i32,);                  // in scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
+      let _2: ();                          // in scope 0 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
+      let mut _3: *mut i32;                // in scope 0 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
+      let mut _5: i32;                     // in scope 0 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
       scope 1 {
-          debug v => _1;                   // in scope 1 at $DIR/const_prop_miscompile.rs:12:9: 12:14
-          let _4: bool;                    // in scope 1 at $DIR/const_prop_miscompile.rs:16:9: 16:10
+          debug v => _1;                   // in scope 1 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
+          let _4: bool;                    // in scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
           scope 2 {
           }
           scope 3 {
-              debug y => _4;               // in scope 3 at $DIR/const_prop_miscompile.rs:16:9: 16:10
+              debug y => _4;               // in scope 3 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:12:9: 12:14
-          Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
-          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
-          StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:13:5: 15:6
-          StorageLive(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:14:10: 14:22
-          _3 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:14:10: 14:22
-          (*_3) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:14:9: 14:26
-          StorageDead(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:14:26: 14:27
-          nop;                             // scope 2 at $DIR/const_prop_miscompile.rs:13:5: 15:6
-          StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:15:5: 15:6
-          StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:9: 16:10
-          StorageLive(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:13: 16:20
-          _5 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:16:15: 16:18
-          _4 = Eq(move _5, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:16:13: 16:25
-          StorageDead(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:24: 16:25
-          nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:11:10: 17:2
-          StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:17:1: 17:2
-          StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:17:1: 17:2
-          return;                          // scope 0 at $DIR/const_prop_miscompile.rs:17:2: 17:2
+          StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
+          Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
+          StorageLive(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
+          _3 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
+          (*_3) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:+3:9: +3:26
+          StorageDead(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:26: +3:27
+          nop;                             // scope 2 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
+          StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+4:5: +4:6
+          StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:9: +5:10
+          StorageLive(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:20
+          _5 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+5:15: +5:18
+          _4 = Eq(move _5, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+5:13: +5:25
+          StorageDead(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:+5:24: +5:25
+          nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +6:2
+          StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+6:1: +6:2
+          StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/const_prop_miscompile.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -2,35 +2,35 @@
 + // MIR for `foo` after ConstProp
   
   fn foo() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/const_prop_miscompile.rs:4:10: 4:10
-      let mut _1: (i32,);                  // in scope 0 at $DIR/const_prop_miscompile.rs:5:9: 5:14
-      let mut _2: &mut i32;                // in scope 0 at $DIR/const_prop_miscompile.rs:6:6: 6:14
-      let mut _4: i32;                     // in scope 0 at $DIR/const_prop_miscompile.rs:7:13: 7:20
+      let mut _0: ();                      // return place in scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +0:10
+      let mut _1: (i32,);                  // in scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
+      let mut _2: &mut i32;                // in scope 0 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
+      let mut _4: i32;                     // in scope 0 at $DIR/const_prop_miscompile.rs:+3:13: +3:20
       scope 1 {
-          debug u => _1;                   // in scope 1 at $DIR/const_prop_miscompile.rs:5:9: 5:14
-          let _3: bool;                    // in scope 1 at $DIR/const_prop_miscompile.rs:7:9: 7:10
+          debug u => _1;                   // in scope 1 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
+          let _3: bool;                    // in scope 1 at $DIR/const_prop_miscompile.rs:+3:9: +3:10
           scope 2 {
-              debug y => _3;               // in scope 2 at $DIR/const_prop_miscompile.rs:7:9: 7:10
+              debug y => _3;               // in scope 2 at $DIR/const_prop_miscompile.rs:+3:9: +3:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:5:9: 5:14
-          Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
-          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
-          StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:6:6: 6:14
-          _2 = &mut (_1.0: i32);           // scope 1 at $DIR/const_prop_miscompile.rs:6:6: 6:14
-          (*_2) = const 5_i32;             // scope 1 at $DIR/const_prop_miscompile.rs:6:5: 6:18
-          StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:6:18: 6:19
-          StorageLive(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:7:9: 7:10
-          StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:7:13: 7:20
-          _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:7:15: 7:18
-          _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:7:13: 7:25
-          StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:7:24: 7:25
-          nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:4:10: 8:2
-          StorageDead(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:8:1: 8:2
-          StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/const_prop_miscompile.rs:8:2: 8:2
+          StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
+          Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
+          _2 = &mut (_1.0: i32);           // scope 1 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
+          (*_2) = const 5_i32;             // scope 1 at $DIR/const_prop_miscompile.rs:+2:5: +2:18
+          StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:18: +2:19
+          StorageLive(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:9: +3:10
+          StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:20
+          _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:+3:15: +3:18
+          _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:+3:13: +3:25
+          StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:+3:24: +3:25
+          nop;                             // scope 0 at $DIR/const_prop_miscompile.rs:+0:10: +4:2
+          StorageDead(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:+4:1: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/const_prop_miscompile.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
@@ -2,74 +2,74 @@
 + // MIR for `cycle` after DeadStoreElimination
   
   fn cycle(_1: i32, _2: i32, _3: i32) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/cycle.rs:9:10: 9:15
-      debug y => _2;                       // in scope 0 at $DIR/cycle.rs:9:22: 9:27
-      debug z => _3;                       // in scope 0 at $DIR/cycle.rs:9:34: 9:39
-      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:9:46: 9:46
-      let mut _4: ();                      // in scope 0 at $DIR/cycle.rs:9:1: 18:2
-      let mut _5: bool;                    // in scope 0 at $DIR/cycle.rs:12:11: 12:17
-      let _6: i32;                         // in scope 0 at $DIR/cycle.rs:13:13: 13:17
-      let mut _7: i32;                     // in scope 0 at $DIR/cycle.rs:14:13: 14:14
-      let mut _8: i32;                     // in scope 0 at $DIR/cycle.rs:15:13: 15:14
-      let mut _9: i32;                     // in scope 0 at $DIR/cycle.rs:16:13: 16:17
-      let mut _10: !;                      // in scope 0 at $DIR/cycle.rs:12:5: 17:6
-      let _11: ();                         // in scope 0 at $DIR/cycle.rs:12:5: 17:6
-      let mut _12: !;                      // in scope 0 at $DIR/cycle.rs:12:5: 17:6
+      debug x => _1;                       // in scope 0 at $DIR/cycle.rs:+0:10: +0:15
+      debug y => _2;                       // in scope 0 at $DIR/cycle.rs:+0:22: +0:27
+      debug z => _3;                       // in scope 0 at $DIR/cycle.rs:+0:34: +0:39
+      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:46: +0:46
+      let mut _4: ();                      // in scope 0 at $DIR/cycle.rs:+0:1: +9:2
+      let mut _5: bool;                    // in scope 0 at $DIR/cycle.rs:+3:11: +3:17
+      let _6: i32;                         // in scope 0 at $DIR/cycle.rs:+4:13: +4:17
+      let mut _7: i32;                     // in scope 0 at $DIR/cycle.rs:+5:13: +5:14
+      let mut _8: i32;                     // in scope 0 at $DIR/cycle.rs:+6:13: +6:14
+      let mut _9: i32;                     // in scope 0 at $DIR/cycle.rs:+7:13: +7:17
+      let mut _10: !;                      // in scope 0 at $DIR/cycle.rs:+3:5: +8:6
+      let _11: ();                         // in scope 0 at $DIR/cycle.rs:+3:5: +8:6
+      let mut _12: !;                      // in scope 0 at $DIR/cycle.rs:+3:5: +8:6
       scope 1 {
-          debug temp => _6;                // in scope 1 at $DIR/cycle.rs:13:13: 13:17
+          debug temp => _6;                // in scope 1 at $DIR/cycle.rs:+4:13: +4:17
       }
   
       bb0: {
-          goto -> bb1;                     // scope 0 at $DIR/cycle.rs:12:5: 17:6
+          goto -> bb1;                     // scope 0 at $DIR/cycle.rs:+3:5: +8:6
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/cycle.rs:12:11: 12:17
-          _5 = cond() -> bb2;              // scope 0 at $DIR/cycle.rs:12:11: 12:17
+          StorageLive(_5);                 // scope 0 at $DIR/cycle.rs:+3:11: +3:17
+          _5 = cond() -> bb2;              // scope 0 at $DIR/cycle.rs:+3:11: +3:17
                                            // mir::Constant
                                            // + span: $DIR/cycle.rs:12:11: 12:15
                                            // + literal: Const { ty: fn() -> bool {cond}, val: Value(<ZST>) }
       }
   
       bb2: {
-          switchInt(move _5) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/cycle.rs:12:11: 12:17
+          switchInt(move _5) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/cycle.rs:+3:11: +3:17
       }
   
       bb3: {
-          StorageLive(_6);                 // scope 0 at $DIR/cycle.rs:13:13: 13:17
--         _6 = _3;                         // scope 0 at $DIR/cycle.rs:13:20: 13:21
-+         nop;                             // scope 0 at $DIR/cycle.rs:13:20: 13:21
-          StorageLive(_7);                 // scope 1 at $DIR/cycle.rs:14:13: 14:14
--         _7 = _2;                         // scope 1 at $DIR/cycle.rs:14:13: 14:14
--         _3 = move _7;                    // scope 1 at $DIR/cycle.rs:14:9: 14:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:14:13: 14:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:14:9: 14:14
-          StorageDead(_7);                 // scope 1 at $DIR/cycle.rs:14:13: 14:14
-          StorageLive(_8);                 // scope 1 at $DIR/cycle.rs:15:13: 15:14
--         _8 = _1;                         // scope 1 at $DIR/cycle.rs:15:13: 15:14
--         _2 = move _8;                    // scope 1 at $DIR/cycle.rs:15:9: 15:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:15:13: 15:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:15:9: 15:14
-          StorageDead(_8);                 // scope 1 at $DIR/cycle.rs:15:13: 15:14
-          StorageLive(_9);                 // scope 1 at $DIR/cycle.rs:16:13: 16:17
--         _9 = _6;                         // scope 1 at $DIR/cycle.rs:16:13: 16:17
--         _1 = move _9;                    // scope 1 at $DIR/cycle.rs:16:9: 16:17
-+         nop;                             // scope 1 at $DIR/cycle.rs:16:13: 16:17
-+         nop;                             // scope 1 at $DIR/cycle.rs:16:9: 16:17
-          StorageDead(_9);                 // scope 1 at $DIR/cycle.rs:16:16: 16:17
--         _4 = const ();                   // scope 0 at $DIR/cycle.rs:12:18: 17:6
-+         nop;                             // scope 0 at $DIR/cycle.rs:12:18: 17:6
-          StorageDead(_6);                 // scope 0 at $DIR/cycle.rs:17:5: 17:6
-          StorageDead(_5);                 // scope 0 at $DIR/cycle.rs:17:5: 17:6
-          goto -> bb1;                     // scope 0 at $DIR/cycle.rs:12:5: 17:6
+          StorageLive(_6);                 // scope 0 at $DIR/cycle.rs:+4:13: +4:17
+-         _6 = _3;                         // scope 0 at $DIR/cycle.rs:+4:20: +4:21
++         nop;                             // scope 0 at $DIR/cycle.rs:+4:20: +4:21
+          StorageLive(_7);                 // scope 1 at $DIR/cycle.rs:+5:13: +5:14
+-         _7 = _2;                         // scope 1 at $DIR/cycle.rs:+5:13: +5:14
+-         _3 = move _7;                    // scope 1 at $DIR/cycle.rs:+5:9: +5:14
++         nop;                             // scope 1 at $DIR/cycle.rs:+5:13: +5:14
++         nop;                             // scope 1 at $DIR/cycle.rs:+5:9: +5:14
+          StorageDead(_7);                 // scope 1 at $DIR/cycle.rs:+5:13: +5:14
+          StorageLive(_8);                 // scope 1 at $DIR/cycle.rs:+6:13: +6:14
+-         _8 = _1;                         // scope 1 at $DIR/cycle.rs:+6:13: +6:14
+-         _2 = move _8;                    // scope 1 at $DIR/cycle.rs:+6:9: +6:14
++         nop;                             // scope 1 at $DIR/cycle.rs:+6:13: +6:14
++         nop;                             // scope 1 at $DIR/cycle.rs:+6:9: +6:14
+          StorageDead(_8);                 // scope 1 at $DIR/cycle.rs:+6:13: +6:14
+          StorageLive(_9);                 // scope 1 at $DIR/cycle.rs:+7:13: +7:17
+-         _9 = _6;                         // scope 1 at $DIR/cycle.rs:+7:13: +7:17
+-         _1 = move _9;                    // scope 1 at $DIR/cycle.rs:+7:9: +7:17
++         nop;                             // scope 1 at $DIR/cycle.rs:+7:13: +7:17
++         nop;                             // scope 1 at $DIR/cycle.rs:+7:9: +7:17
+          StorageDead(_9);                 // scope 1 at $DIR/cycle.rs:+7:16: +7:17
+-         _4 = const ();                   // scope 0 at $DIR/cycle.rs:+3:18: +8:6
++         nop;                             // scope 0 at $DIR/cycle.rs:+3:18: +8:6
+          StorageDead(_6);                 // scope 0 at $DIR/cycle.rs:+8:5: +8:6
+          StorageDead(_5);                 // scope 0 at $DIR/cycle.rs:+8:5: +8:6
+          goto -> bb1;                     // scope 0 at $DIR/cycle.rs:+3:5: +8:6
       }
   
       bb4: {
-          StorageLive(_11);                // scope 0 at $DIR/cycle.rs:12:5: 17:6
-          _0 = const ();                   // scope 0 at $DIR/cycle.rs:12:5: 17:6
-          StorageDead(_11);                // scope 0 at $DIR/cycle.rs:17:5: 17:6
-          StorageDead(_5);                 // scope 0 at $DIR/cycle.rs:17:5: 17:6
-          return;                          // scope 0 at $DIR/cycle.rs:18:2: 18:2
+          StorageLive(_11);                // scope 0 at $DIR/cycle.rs:+3:5: +8:6
+          _0 = const ();                   // scope 0 at $DIR/cycle.rs:+3:5: +8:6
+          StorageDead(_11);                // scope 0 at $DIR/cycle.rs:+8:5: +8:6
+          StorageDead(_5);                 // scope 0 at $DIR/cycle.rs:+8:5: +8:6
+          return;                          // scope 0 at $DIR/cycle.rs:+9:2: +9:2
       }
   }
   

--- a/src/test/mir-opt/dead-store-elimination/provenance_soundness.pointer_to_int.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/provenance_soundness.pointer_to_int.DeadStoreElimination.diff
@@ -2,34 +2,34 @@
 + // MIR for `pointer_to_int` after DeadStoreElimination
   
   fn pointer_to_int(_1: *mut i32) -> () {
-      debug p => _1;                       // in scope 0 at $DIR/provenance_soundness.rs:7:19: 7:20
-      let mut _0: ();                      // return place in scope 0 at $DIR/provenance_soundness.rs:7:32: 7:32
-      let _2: usize;                       // in scope 0 at $DIR/provenance_soundness.rs:8:9: 8:11
-      let mut _3: *mut i32;                // in scope 0 at $DIR/provenance_soundness.rs:8:14: 8:15
-      let mut _5: *mut i32;                // in scope 0 at $DIR/provenance_soundness.rs:9:14: 9:15
+      debug p => _1;                       // in scope 0 at $DIR/provenance_soundness.rs:+0:19: +0:20
+      let mut _0: ();                      // return place in scope 0 at $DIR/provenance_soundness.rs:+0:32: +0:32
+      let _2: usize;                       // in scope 0 at $DIR/provenance_soundness.rs:+1:9: +1:11
+      let mut _3: *mut i32;                // in scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:15
+      let mut _5: *mut i32;                // in scope 0 at $DIR/provenance_soundness.rs:+2:14: +2:15
       scope 1 {
-          debug _x => _2;                  // in scope 1 at $DIR/provenance_soundness.rs:8:9: 8:11
-          let _4: isize;                   // in scope 1 at $DIR/provenance_soundness.rs:9:9: 9:11
+          debug _x => _2;                  // in scope 1 at $DIR/provenance_soundness.rs:+1:9: +1:11
+          let _4: isize;                   // in scope 1 at $DIR/provenance_soundness.rs:+2:9: +2:11
           scope 2 {
-              debug _y => _4;              // in scope 2 at $DIR/provenance_soundness.rs:9:9: 9:11
+              debug _y => _4;              // in scope 2 at $DIR/provenance_soundness.rs:+2:9: +2:11
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/provenance_soundness.rs:8:9: 8:11
-          StorageLive(_3);                 // scope 0 at $DIR/provenance_soundness.rs:8:14: 8:15
-          _3 = _1;                         // scope 0 at $DIR/provenance_soundness.rs:8:14: 8:15
-          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/provenance_soundness.rs:8:14: 8:24
-          StorageDead(_3);                 // scope 0 at $DIR/provenance_soundness.rs:8:23: 8:24
-          StorageLive(_4);                 // scope 1 at $DIR/provenance_soundness.rs:9:9: 9:11
-          StorageLive(_5);                 // scope 1 at $DIR/provenance_soundness.rs:9:14: 9:15
-          _5 = _1;                         // scope 1 at $DIR/provenance_soundness.rs:9:14: 9:15
-          _4 = move _5 as isize (PointerExposeAddress); // scope 1 at $DIR/provenance_soundness.rs:9:14: 9:24
-          StorageDead(_5);                 // scope 1 at $DIR/provenance_soundness.rs:9:23: 9:24
-          _0 = const ();                   // scope 0 at $DIR/provenance_soundness.rs:7:32: 10:2
-          StorageDead(_4);                 // scope 1 at $DIR/provenance_soundness.rs:10:1: 10:2
-          StorageDead(_2);                 // scope 0 at $DIR/provenance_soundness.rs:10:1: 10:2
-          return;                          // scope 0 at $DIR/provenance_soundness.rs:10:2: 10:2
+          StorageLive(_2);                 // scope 0 at $DIR/provenance_soundness.rs:+1:9: +1:11
+          StorageLive(_3);                 // scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:15
+          _3 = _1;                         // scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:15
+          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/provenance_soundness.rs:+1:14: +1:24
+          StorageDead(_3);                 // scope 0 at $DIR/provenance_soundness.rs:+1:23: +1:24
+          StorageLive(_4);                 // scope 1 at $DIR/provenance_soundness.rs:+2:9: +2:11
+          StorageLive(_5);                 // scope 1 at $DIR/provenance_soundness.rs:+2:14: +2:15
+          _5 = _1;                         // scope 1 at $DIR/provenance_soundness.rs:+2:14: +2:15
+          _4 = move _5 as isize (PointerExposeAddress); // scope 1 at $DIR/provenance_soundness.rs:+2:14: +2:24
+          StorageDead(_5);                 // scope 1 at $DIR/provenance_soundness.rs:+2:23: +2:24
+          _0 = const ();                   // scope 0 at $DIR/provenance_soundness.rs:+0:32: +3:2
+          StorageDead(_4);                 // scope 1 at $DIR/provenance_soundness.rs:+3:1: +3:2
+          StorageDead(_2);                 // scope 0 at $DIR/provenance_soundness.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/provenance_soundness.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/dead-store-elimination/provenance_soundness.retags.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/provenance_soundness.retags.DeadStoreElimination.diff
@@ -2,13 +2,13 @@
 + // MIR for `retags` after DeadStoreElimination
   
   fn retags(_1: &mut i32) -> () {
-      debug _r => _1;                      // in scope 0 at $DIR/provenance_soundness.rs:13:11: 13:13
-      let mut _0: ();                      // return place in scope 0 at $DIR/provenance_soundness.rs:13:25: 13:25
+      debug _r => _1;                      // in scope 0 at $DIR/provenance_soundness.rs:+0:11: +0:13
+      let mut _0: ();                      // return place in scope 0 at $DIR/provenance_soundness.rs:+0:25: +0:25
   
       bb0: {
-          Retag([fn entry] _1);            // scope 0 at $DIR/provenance_soundness.rs:13:1: 13:27
-          _0 = const ();                   // scope 0 at $DIR/provenance_soundness.rs:13:25: 13:27
-          return;                          // scope 0 at $DIR/provenance_soundness.rs:13:27: 13:27
+          Retag([fn entry] _1);            // scope 0 at $DIR/provenance_soundness.rs:+0:1: +0:27
+          _0 = const ();                   // scope 0 at $DIR/provenance_soundness.rs:+0:25: +0:27
+          return;                          // scope 0 at $DIR/provenance_soundness.rs:+0:27: +0:27
       }
   }
   

--- a/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
@@ -2,20 +2,20 @@
 + // MIR for `bar` after Deaggregator
   
   fn bar(_1: usize) -> Baz {
-      debug a => _1;                       // in scope 0 at $DIR/deaggregator_test.rs:8:8: 8:9
-      let mut _0: Baz;                     // return place in scope 0 at $DIR/deaggregator_test.rs:8:21: 8:24
-      let mut _2: usize;                   // in scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
+      debug a => _1;                       // in scope 0 at $DIR/deaggregator_test.rs:+0:8: +0:9
+      let mut _0: Baz;                     // return place in scope 0 at $DIR/deaggregator_test.rs:+0:21: +0:24
+      let mut _2: usize;                   // in scope 0 at $DIR/deaggregator_test.rs:+1:14: +1:15
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
-          _2 = _1;                         // scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
--         _0 = Baz { x: move _2, y: const 0f32, z: const false }; // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
-+         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
-+         (_0.0: usize) = move _2;         // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
-+         (_0.1: f32) = const 0f32;        // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
-+         (_0.2: bool) = const false;      // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
-          StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test.rs:9:34: 9:35
-          return;                          // scope 0 at $DIR/deaggregator_test.rs:10:2: 10:2
+          StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test.rs:+1:14: +1:15
+          _2 = _1;                         // scope 0 at $DIR/deaggregator_test.rs:+1:14: +1:15
+-         _0 = Baz { x: move _2, y: const 0f32, z: const false }; // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
++         (_0.0: usize) = move _2;         // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
++         (_0.1: f32) = const 0f32;        // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
++         (_0.2: bool) = const false;      // scope 0 at $DIR/deaggregator_test.rs:+1:5: +1:35
+          StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test.rs:+1:34: +1:35
+          return;                          // scope 0 at $DIR/deaggregator_test.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
@@ -2,19 +2,19 @@
 + // MIR for `bar` after Deaggregator
   
   fn bar(_1: usize) -> Baz {
-      debug a => _1;                       // in scope 0 at $DIR/deaggregator_test_enum.rs:7:8: 7:9
-      let mut _0: Baz;                     // return place in scope 0 at $DIR/deaggregator_test_enum.rs:7:21: 7:24
-      let mut _2: usize;                   // in scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
+      debug a => _1;                       // in scope 0 at $DIR/deaggregator_test_enum.rs:+0:8: +0:9
+      let mut _0: Baz;                     // return place in scope 0 at $DIR/deaggregator_test_enum.rs:+0:21: +0:24
+      let mut _2: usize;                   // in scope 0 at $DIR/deaggregator_test_enum.rs:+1:19: +1:20
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
-          _2 = _1;                         // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
--         _0 = Baz::Foo { x: move _2 };    // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
-+         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
-+         ((_0 as Foo).0: usize) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
-+         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
-          StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:21: 8:22
-          return;                          // scope 0 at $DIR/deaggregator_test_enum.rs:9:2: 9:2
+          StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:+1:19: +1:20
+          _2 = _1;                         // scope 0 at $DIR/deaggregator_test_enum.rs:+1:19: +1:20
+-         _0 = Baz::Foo { x: move _2 };    // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
++         ((_0 as Foo).0: usize) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
++         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum.rs:+1:5: +1:22
+          StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:+1:21: +1:22
+          return;                          // scope 0 at $DIR/deaggregator_test_enum.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
@@ -2,44 +2,44 @@
 + // MIR for `test1` after Deaggregator
   
   fn test1(_1: bool, _2: i32) -> Foo {
-      debug x => _1;                       // in scope 0 at $DIR/deaggregator_test_enum_2.rs:9:10: 9:11
-      debug y => _2;                       // in scope 0 at $DIR/deaggregator_test_enum_2.rs:9:19: 9:20
-      let mut _0: Foo;                     // return place in scope 0 at $DIR/deaggregator_test_enum_2.rs:9:30: 9:33
-      let mut _3: bool;                    // in scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
-      let mut _4: i32;                     // in scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
-      let mut _5: i32;                     // in scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
+      debug x => _1;                       // in scope 0 at $DIR/deaggregator_test_enum_2.rs:+0:10: +0:11
+      debug y => _2;                       // in scope 0 at $DIR/deaggregator_test_enum_2.rs:+0:19: +0:20
+      let mut _0: Foo;                     // return place in scope 0 at $DIR/deaggregator_test_enum_2.rs:+0:30: +0:33
+      let mut _3: bool;                    // in scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:8: +1:9
+      let mut _4: i32;                     // in scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:16: +2:17
+      let mut _5: i32;                     // in scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:16: +4:17
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
-          _3 = _1;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
-          switchInt(move _3) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
+          StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:8: +1:9
+          switchInt(move _3) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:8: +1:9
       }
   
       bb1: {
-          StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
-          _4 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
--         _0 = Foo::A(move _4);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
-+         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
-+         ((_0 as A).0: i32) = move _4;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
-+         discriminant(_0) = 0;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
-          StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:17: 11:18
-          goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
+          StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:16: +2:17
+          _4 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:16: +2:17
+-         _0 = Foo::A(move _4);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
++         ((_0 as A).0: i32) = move _4;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
++         discriminant(_0) = 0;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:9: +2:18
+          StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+2:17: +2:18
+          goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:5: +5:6
       }
   
       bb2: {
-          StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
-          _5 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
--         _0 = Foo::B(move _5);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
-+         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
-+         ((_0 as B).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
-+         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
-          StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:17: 13:18
-          goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
+          StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:16: +4:17
+          _5 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:16: +4:17
+-         _0 = Foo::B(move _5);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
++         ((_0 as B).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
++         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:9: +4:18
+          StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+4:17: +4:18
+          goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:+1:5: +5:6
       }
   
       bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:14:5: 14:6
-          return;                          // scope 0 at $DIR/deaggregator_test_enum_2.rs:15:2: 15:2
+          StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:+5:5: +5:6
+          return;                          // scope 0 at $DIR/deaggregator_test_enum_2.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
@@ -2,34 +2,34 @@
 + // MIR for `test` after Deaggregator
   
   fn test(_1: i32) -> [Foo; 2] {
-      debug x => _1;                       // in scope 0 at $DIR/deaggregator_test_multiple.rs:9:9: 9:10
-      let mut _0: [Foo; 2];                // return place in scope 0 at $DIR/deaggregator_test_multiple.rs:9:20: 9:28
-      let mut _2: Foo;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
-      let mut _3: i32;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
-      let mut _4: Foo;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
-      let mut _5: i32;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
+      debug x => _1;                       // in scope 0 at $DIR/deaggregator_test_multiple.rs:+0:9: +0:10
+      let mut _0: [Foo; 2];                // return place in scope 0 at $DIR/deaggregator_test_multiple.rs:+0:20: +0:28
+      let mut _2: Foo;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
+      let mut _3: i32;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:+1:13: +1:14
+      let mut _4: Foo;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
+      let mut _5: i32;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:+1:24: +1:25
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
-          StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
-          _3 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
--         _2 = Foo::A(move _3);            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
-+         Deinit(_2);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
-+         ((_2 as A).0: i32) = move _3;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
-+         discriminant(_2) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
-          StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:14: 10:15
-          StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
-          StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
-          _5 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
--         _4 = Foo::A(move _5);            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
-+         Deinit(_4);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
-+         ((_4 as A).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
-+         discriminant(_4) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
-          StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:25: 10:26
-          _0 = [move _2, move _4];         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:5: 10:27
-          StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:26: 10:27
-          StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:26: 10:27
-          return;                          // scope 0 at $DIR/deaggregator_test_multiple.rs:11:2: 11:2
+          StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
+          StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:13: +1:14
+          _3 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:13: +1:14
+-         _2 = Foo::A(move _3);            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
++         Deinit(_2);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
++         ((_2 as A).0: i32) = move _3;    // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
++         discriminant(_2) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:6: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:14: +1:15
+          StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
+          StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:24: +1:25
+          _5 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:24: +1:25
+-         _4 = Foo::A(move _5);            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
++         Deinit(_4);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
++         ((_4 as A).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
++         discriminant(_4) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:17: +1:26
+          StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:25: +1:26
+          _0 = [move _2, move _4];         // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:5: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:26: +1:27
+          StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:+1:26: +1:27
+          return;                          // scope 0 at $DIR/deaggregator_test_multiple.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
+++ b/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
@@ -2,14 +2,14 @@
 + // MIR for `is_line_doc_comment_2` after DeduplicateBlocks
   
   fn is_line_doc_comment_2(_1: &str) -> bool {
-      debug s => _1;                       // in scope 0 at $DIR/deduplicate_blocks.rs:2:36: 2:37
-      let mut _0: bool;                    // return place in scope 0 at $DIR/deduplicate_blocks.rs:2:48: 2:52
-      let mut _2: &[u8];                   // in scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-      let mut _3: &str;                    // in scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-      let mut _4: usize;                   // in scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
-      let mut _5: bool;                    // in scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
-      let mut _6: usize;                   // in scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
-      let mut _7: bool;                    // in scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
+      debug s => _1;                       // in scope 0 at $DIR/deduplicate_blocks.rs:+0:36: +0:37
+      let mut _0: bool;                    // return place in scope 0 at $DIR/deduplicate_blocks.rs:+0:48: +0:52
+      let mut _2: &[u8];                   // in scope 0 at $DIR/deduplicate_blocks.rs:+1:11: +1:23
+      let mut _3: &str;                    // in scope 0 at $DIR/deduplicate_blocks.rs:+1:11: +1:23
+      let mut _4: usize;                   // in scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
+      let mut _5: bool;                    // in scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
+      let mut _6: usize;                   // in scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
+      let mut _7: bool;                    // in scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
       scope 1 (inlined core::str::<impl str>::as_bytes) { // at $DIR/deduplicate_blocks.rs:3:11: 3:23
           debug self => _3;                // in scope 1 at $SRC_DIR/core/src/str/mod.rs:LL:COL
           let mut _8: &str;                // in scope 1 at $SRC_DIR/core/src/str/mod.rs:LL:COL
@@ -18,9 +18,9 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-          StorageLive(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-          _3 = _1;                         // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
+          StorageLive(_2);                 // scope 0 at $DIR/deduplicate_blocks.rs:+1:11: +1:23
+          StorageLive(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:+1:11: +1:23
+          _3 = _1;                         // scope 0 at $DIR/deduplicate_blocks.rs:+1:11: +1:23
           StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
           _8 = _3;                         // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
 -         _2 = transmute::<&str, &[u8]>(move _8) -> bb14; // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
@@ -31,77 +31,77 @@
       }
   
       bb1: {
-          switchInt((*_2)[0 of 4]) -> [47_u8: bb2, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
+          switchInt((*_2)[0 of 4]) -> [47_u8: bb2, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
       }
   
       bb2: {
-          switchInt((*_2)[1 of 4]) -> [47_u8: bb3, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
+          switchInt((*_2)[1 of 4]) -> [47_u8: bb3, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
       }
   
       bb3: {
-          switchInt((*_2)[2 of 4]) -> [47_u8: bb4, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
+          switchInt((*_2)[2 of 4]) -> [47_u8: bb4, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
       }
   
       bb4: {
--         switchInt((*_2)[3 of 4]) -> [47_u8: bb10, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
-+         switchInt((*_2)[3 of 4]) -> [47_u8: bb9, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
+-         switchInt((*_2)[3 of 4]) -> [47_u8: bb10, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
++         switchInt((*_2)[3 of 4]) -> [47_u8: bb9, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
       }
   
       bb5: {
-          _4 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
-          _5 = Ge(move _4, const 3_usize); // scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
-          switchInt(move _5) -> [false: bb9, otherwise: bb6]; // scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
+          _4 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
+          _5 = Ge(move _4, const 3_usize); // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
+          switchInt(move _5) -> [false: bb9, otherwise: bb6]; // scope 0 at $DIR/deduplicate_blocks.rs:+3:9: +3:31
       }
   
       bb6: {
-          switchInt((*_2)[0 of 3]) -> [47_u8: bb7, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
+          switchInt((*_2)[0 of 3]) -> [47_u8: bb7, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
       }
   
       bb7: {
-          switchInt((*_2)[1 of 3]) -> [47_u8: bb8, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
+          switchInt((*_2)[1 of 3]) -> [47_u8: bb8, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
       }
   
       bb8: {
--         switchInt((*_2)[2 of 3]) -> [47_u8: bb11, 33_u8: bb12, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
-+         switchInt((*_2)[2 of 3]) -> [47_u8: bb10, 33_u8: bb10, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
+-         switchInt((*_2)[2 of 3]) -> [47_u8: bb11, 33_u8: bb12, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
++         switchInt((*_2)[2 of 3]) -> [47_u8: bb10, 33_u8: bb10, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:+1:5: +1:23
       }
   
       bb9: {
--         _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:7:14: 7:19
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:7:14: 7:19
+-         _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:+5:14: +5:19
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:+5:14: +5:19
 -     }
 - 
 -     bb10: {
-          _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
-+         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
+          _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:+2:41: +2:46
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:+2:41: +2:46
++         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:+2:41: +2:46
       }
   
 -     bb11: {
--         _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:5:35: 5:39
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:5:35: 5:39
+-         _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:+3:35: +3:39
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:+3:35: +3:39
 -     }
 - 
 -     bb12: {
 +     bb10: {
-          _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
-+         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
+          _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:+4:35: +4:39
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:+4:35: +4:39
++         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:+4:35: +4:39
       }
   
 -     bb13: {
 +     bb11: {
-          StorageDead(_2);                 // scope 0 at $DIR/deduplicate_blocks.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/deduplicate_blocks.rs:9:2: 9:2
+          StorageDead(_2);                 // scope 0 at $DIR/deduplicate_blocks.rs:+7:1: +7:2
+          return;                          // scope 0 at $DIR/deduplicate_blocks.rs:+7:2: +7:2
       }
   
 -     bb14: {
 +     bb12: {
           StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
-          StorageDead(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:22: 3:23
-          _6 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
-          _7 = Ge(move _6, const 4_usize); // scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
-          switchInt(move _7) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
+          StorageDead(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:+1:22: +1:23
+          _6 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
+          _7 = Ge(move _6, const 4_usize); // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
+          switchInt(move _7) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/deduplicate_blocks.rs:+2:9: +2:37
       }
   }
   

--- a/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
@@ -2,110 +2,110 @@
 + // MIR for `main` after Derefer
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_complex_case.rs:4:11: 4:11
-      let mut _1: std::slice::Iter<i32>;   // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-      let mut _2: &[i32; 2];               // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-      let _3: [i32; 2];                    // in scope 0 at $DIR/derefer_complex_case.rs:5:18: 5:26
-      let mut _4: std::slice::Iter<i32>;   // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-      let mut _5: ();                      // in scope 0 at $DIR/derefer_complex_case.rs:4:1: 6:2
-      let _6: ();                          // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-      let mut _7: std::option::Option<&i32>; // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-      let mut _8: &mut std::slice::Iter<i32>; // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-      let mut _9: &mut std::slice::Iter<i32>; // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-      let mut _10: isize;                  // in scope 0 at $DIR/derefer_complex_case.rs:5:5: 5:40
-      let mut _11: !;                      // in scope 0 at $DIR/derefer_complex_case.rs:5:5: 5:40
-      let mut _13: i32;                    // in scope 0 at $DIR/derefer_complex_case.rs:5:34: 5:37
-      let mut _14: &[i32; 2];              // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-+     let mut _15: &i32;                   // in scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
+      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_complex_case.rs:+0:11: +0:11
+      let mut _1: std::slice::Iter<i32>;   // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _2: &[i32; 2];               // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let _3: [i32; 2];                    // in scope 0 at $DIR/derefer_complex_case.rs:+1:18: +1:26
+      let mut _4: std::slice::Iter<i32>;   // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _5: ();                      // in scope 0 at $DIR/derefer_complex_case.rs:+0:1: +2:2
+      let _6: ();                          // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _7: std::option::Option<&i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _8: &mut std::slice::Iter<i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _9: &mut std::slice::Iter<i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _10: isize;                  // in scope 0 at $DIR/derefer_complex_case.rs:+1:5: +1:40
+      let mut _11: !;                      // in scope 0 at $DIR/derefer_complex_case.rs:+1:5: +1:40
+      let mut _13: i32;                    // in scope 0 at $DIR/derefer_complex_case.rs:+1:34: +1:37
+      let mut _14: &[i32; 2];              // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
++     let mut _15: &i32;                   // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       scope 1 {
-          debug iter => _4;                // in scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          let _12: i32;                    // in scope 1 at $DIR/derefer_complex_case.rs:5:10: 5:13
+          debug iter => _4;                // in scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          let _12: i32;                    // in scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
           scope 2 {
-              debug foo => _12;            // in scope 2 at $DIR/derefer_complex_case.rs:5:10: 5:13
+              debug foo => _12;            // in scope 2 at $DIR/derefer_complex_case.rs:+1:10: +1:13
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          StorageLive(_2);                 // scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          _14 = const main::promoted[0];   // scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
+          StorageLive(_1);                 // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          StorageLive(_2);                 // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _14 = const main::promoted[0];   // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:5:17: 5:26
                                            // + literal: Const { ty: &[i32; 2], val: Unevaluated(main, [], Some(promoted[0])) }
-          _2 = &(*_14);                    // scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> bb1; // scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
+          _2 = &(*_14);                    // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> bb1; // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:5:17: 5:26
                                            // + literal: Const { ty: fn(&[i32; 2]) -> <&[i32; 2] as IntoIterator>::IntoIter {<&[i32; 2] as IntoIterator>::into_iter}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/derefer_complex_case.rs:5:25: 5:26
-          StorageLive(_4);                 // scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          _4 = move _1;                    // scope 0 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          goto -> bb2;                     // scope 1 at $DIR/derefer_complex_case.rs:5:5: 5:40
+          StorageDead(_2);                 // scope 0 at $DIR/derefer_complex_case.rs:+1:25: +1:26
+          StorageLive(_4);                 // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _4 = move _1;                    // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          goto -> bb2;                     // scope 1 at $DIR/derefer_complex_case.rs:+1:5: +1:40
       }
   
       bb2: {
-          StorageLive(_6);                 // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          StorageLive(_7);                 // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          StorageLive(_8);                 // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          StorageLive(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          _9 = &mut _4;                    // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          _8 = &mut (*_9);                 // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          _7 = <std::slice::Iter<i32> as Iterator>::next(move _8) -> bb3; // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
+          StorageLive(_6);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          StorageLive(_7);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          StorageLive(_8);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          StorageLive(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _9 = &mut _4;                    // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _8 = &mut (*_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _7 = <std::slice::Iter<i32> as Iterator>::next(move _8) -> bb3; // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:5:17: 5:26
                                            // + literal: Const { ty: for<'r> fn(&'r mut std::slice::Iter<i32>) -> Option<<std::slice::Iter<i32> as Iterator>::Item> {<std::slice::Iter<i32> as Iterator>::next}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_8);                 // scope 1 at $DIR/derefer_complex_case.rs:5:25: 5:26
-          _10 = discriminant(_7);          // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
-          switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
+          StorageDead(_8);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:25: +1:26
+          _10 = discriminant(_7);          // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       }
   
       bb4: {
-          StorageLive(_12);                // scope 1 at $DIR/derefer_complex_case.rs:5:10: 5:13
--         _12 = (*((_7 as Some).0: &i32)); // scope 1 at $DIR/derefer_complex_case.rs:5:10: 5:13
-+         StorageLive(_15);                // scope 1 at $DIR/derefer_complex_case.rs:5:10: 5:13
-+         _15 = deref_copy ((_7 as Some).0: &i32); // scope 1 at $DIR/derefer_complex_case.rs:5:10: 5:13
-+         _12 = (*_15);                    // scope 1 at $DIR/derefer_complex_case.rs:5:10: 5:13
-+         StorageDead(_15);                // scope 2 at $DIR/derefer_complex_case.rs:5:34: 5:37
-          StorageLive(_13);                // scope 2 at $DIR/derefer_complex_case.rs:5:34: 5:37
-          _13 = _12;                       // scope 2 at $DIR/derefer_complex_case.rs:5:34: 5:37
-          _6 = std::mem::drop::<i32>(move _13) -> bb7; // scope 2 at $DIR/derefer_complex_case.rs:5:29: 5:38
+          StorageLive(_12);                // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
+-         _12 = (*((_7 as Some).0: &i32)); // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
++         StorageLive(_15);                // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
++         _15 = deref_copy ((_7 as Some).0: &i32); // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
++         _12 = (*_15);                    // scope 1 at $DIR/derefer_complex_case.rs:+1:10: +1:13
++         StorageDead(_15);                // scope 2 at $DIR/derefer_complex_case.rs:+1:34: +1:37
+          StorageLive(_13);                // scope 2 at $DIR/derefer_complex_case.rs:+1:34: +1:37
+          _13 = _12;                       // scope 2 at $DIR/derefer_complex_case.rs:+1:34: +1:37
+          _6 = std::mem::drop::<i32>(move _13) -> bb7; // scope 2 at $DIR/derefer_complex_case.rs:+1:29: +1:38
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:5:29: 5:33
                                            // + literal: Const { ty: fn(i32) {std::mem::drop::<i32>}, val: Value(<ZST>) }
       }
   
       bb5: {
-          unreachable;                     // scope 1 at $DIR/derefer_complex_case.rs:5:17: 5:26
+          unreachable;                     // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       }
   
       bb6: {
-          _0 = const ();                   // scope 1 at $DIR/derefer_complex_case.rs:5:5: 5:40
-          StorageDead(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          StorageDead(_7);                 // scope 1 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          StorageDead(_6);                 // scope 1 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          StorageDead(_4);                 // scope 0 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          StorageDead(_1);                 // scope 0 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          return;                          // scope 0 at $DIR/derefer_complex_case.rs:6:2: 6:2
+          _0 = const ();                   // scope 1 at $DIR/derefer_complex_case.rs:+1:5: +1:40
+          StorageDead(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          StorageDead(_7);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          StorageDead(_6);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          StorageDead(_4);                 // scope 0 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          StorageDead(_1);                 // scope 0 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          return;                          // scope 0 at $DIR/derefer_complex_case.rs:+2:2: +2:2
       }
   
       bb7: {
-          StorageDead(_13);                // scope 2 at $DIR/derefer_complex_case.rs:5:37: 5:38
-          StorageDead(_12);                // scope 1 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          StorageDead(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          StorageDead(_7);                 // scope 1 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          StorageDead(_6);                 // scope 1 at $DIR/derefer_complex_case.rs:5:39: 5:40
-          _5 = const ();                   // scope 1 at $DIR/derefer_complex_case.rs:5:5: 5:40
-          goto -> bb2;                     // scope 1 at $DIR/derefer_complex_case.rs:5:5: 5:40
+          StorageDead(_13);                // scope 2 at $DIR/derefer_complex_case.rs:+1:37: +1:38
+          StorageDead(_12);                // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          StorageDead(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          StorageDead(_7);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          StorageDead(_6);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
+          _5 = const ();                   // scope 1 at $DIR/derefer_complex_case.rs:+1:5: +1:40
+          goto -> bb2;                     // scope 1 at $DIR/derefer_complex_case.rs:+1:5: +1:40
 +     }
 + 
 +     bb8 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_complex_case.rs:4:1: 6:2
++         resume;                          // scope 0 at $DIR/derefer_complex_case.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/derefer_inline_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_inline_test.main.Derefer.diff
@@ -2,60 +2,60 @@
 + // MIR for `main` after Derefer
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_inline_test.rs:9:11: 9:11
-      let _1: std::boxed::Box<std::boxed::Box<u32>>; // in scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-      let mut _2: usize;                   // in scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-      let mut _3: usize;                   // in scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-      let mut _4: *mut u8;                 // in scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-      let mut _5: std::boxed::Box<std::boxed::Box<u32>>; // in scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
+      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_inline_test.rs:+0:11: +0:11
+      let _1: std::boxed::Box<std::boxed::Box<u32>>; // in scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+      let mut _2: usize;                   // in scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+      let mut _3: usize;                   // in scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+      let mut _4: *mut u8;                 // in scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+      let mut _5: std::boxed::Box<std::boxed::Box<u32>>; // in scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
       scope 1 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-          _2 = SizeOf(std::boxed::Box<u32>); // scope 1 at $DIR/derefer_inline_test.rs:10:5: 10:12
-          _3 = AlignOf(std::boxed::Box<u32>); // scope 1 at $DIR/derefer_inline_test.rs:10:5: 10:12
-          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 1 at $DIR/derefer_inline_test.rs:10:5: 10:12
+          StorageLive(_1);                 // scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+          _2 = SizeOf(std::boxed::Box<u32>); // scope 1 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+          _3 = AlignOf(std::boxed::Box<u32>); // scope 1 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 1 at $DIR/derefer_inline_test.rs:+1:5: +1:12
                                            // mir::Constant
                                            // + span: $DIR/derefer_inline_test.rs:10:5: 10:12
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-          _5 = ShallowInitBox(move _4, std::boxed::Box<u32>); // scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-          (*_5) = f() -> [return: bb2, unwind: bb6]; // scope 0 at $DIR/derefer_inline_test.rs:10:9: 10:12
+          StorageLive(_5);                 // scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+          _5 = ShallowInitBox(move _4, std::boxed::Box<u32>); // scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+          (*_5) = f() -> [return: bb2, unwind: bb6]; // scope 0 at $DIR/derefer_inline_test.rs:+1:9: +1:12
                                            // mir::Constant
                                            // + span: $DIR/derefer_inline_test.rs:10:9: 10:10
                                            // + literal: Const { ty: fn() -> Box<u32> {f}, val: Value(<ZST>) }
       }
   
       bb2: {
-          _1 = move _5;                    // scope 0 at $DIR/derefer_inline_test.rs:10:5: 10:12
-          drop(_5) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/derefer_inline_test.rs:10:11: 10:12
+          _1 = move _5;                    // scope 0 at $DIR/derefer_inline_test.rs:+1:5: +1:12
+          drop(_5) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/derefer_inline_test.rs:+1:11: +1:12
       }
   
       bb3: {
-          StorageDead(_5);                 // scope 0 at $DIR/derefer_inline_test.rs:10:11: 10:12
-          drop(_1) -> bb4;                 // scope 0 at $DIR/derefer_inline_test.rs:10:12: 10:13
+          StorageDead(_5);                 // scope 0 at $DIR/derefer_inline_test.rs:+1:11: +1:12
+          drop(_1) -> bb4;                 // scope 0 at $DIR/derefer_inline_test.rs:+1:12: +1:13
       }
   
       bb4: {
-          StorageDead(_1);                 // scope 0 at $DIR/derefer_inline_test.rs:10:12: 10:13
-          _0 = const ();                   // scope 0 at $DIR/derefer_inline_test.rs:9:11: 11:2
-          return;                          // scope 0 at $DIR/derefer_inline_test.rs:11:2: 11:2
+          StorageDead(_1);                 // scope 0 at $DIR/derefer_inline_test.rs:+1:12: +1:13
+          _0 = const ();                   // scope 0 at $DIR/derefer_inline_test.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/derefer_inline_test.rs:+2:2: +2:2
       }
   
       bb5 (cleanup): {
-          drop(_1) -> bb7;                 // scope 0 at $DIR/derefer_inline_test.rs:10:12: 10:13
+          drop(_1) -> bb7;                 // scope 0 at $DIR/derefer_inline_test.rs:+1:12: +1:13
       }
   
       bb6 (cleanup): {
-          drop(_5) -> bb7;                 // scope 0 at $DIR/derefer_inline_test.rs:10:11: 10:12
+          drop(_5) -> bb7;                 // scope 0 at $DIR/derefer_inline_test.rs:+1:11: +1:12
       }
   
       bb7 (cleanup): {
-          resume;                          // scope 0 at $DIR/derefer_inline_test.rs:9:1: 11:2
+          resume;                          // scope 0 at $DIR/derefer_inline_test.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/derefer_terminator_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_terminator_test.main.Derefer.diff
@@ -2,102 +2,102 @@
 + // MIR for `main` after Derefer
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_terminator_test.rs:4:11: 4:11
-      let _1: bool;                        // in scope 0 at $DIR/derefer_terminator_test.rs:5:9: 5:10
-      let _3: ();                          // in scope 0 at $DIR/derefer_terminator_test.rs:7:5: 10:6
-      let mut _4: &&&&bool;                // in scope 0 at $DIR/derefer_terminator_test.rs:7:15: 7:22
-      let _5: &&&bool;                     // in scope 0 at $DIR/derefer_terminator_test.rs:7:17: 7:21
-      let _6: &&bool;                      // in scope 0 at $DIR/derefer_terminator_test.rs:7:18: 7:21
-      let _7: &bool;                       // in scope 0 at $DIR/derefer_terminator_test.rs:7:19: 7:21
-+     let mut _10: &&&bool;                // in scope 0 at $DIR/derefer_terminator_test.rs:7:15: 7:22
-+     let mut _11: &&bool;                 // in scope 0 at $DIR/derefer_terminator_test.rs:7:15: 7:22
-+     let mut _12: &bool;                  // in scope 0 at $DIR/derefer_terminator_test.rs:7:15: 7:22
+      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_terminator_test.rs:+0:11: +0:11
+      let _1: bool;                        // in scope 0 at $DIR/derefer_terminator_test.rs:+1:9: +1:10
+      let _3: ();                          // in scope 0 at $DIR/derefer_terminator_test.rs:+3:5: +6:6
+      let mut _4: &&&&bool;                // in scope 0 at $DIR/derefer_terminator_test.rs:+3:15: +3:22
+      let _5: &&&bool;                     // in scope 0 at $DIR/derefer_terminator_test.rs:+3:17: +3:21
+      let _6: &&bool;                      // in scope 0 at $DIR/derefer_terminator_test.rs:+3:18: +3:21
+      let _7: &bool;                       // in scope 0 at $DIR/derefer_terminator_test.rs:+3:19: +3:21
++     let mut _10: &&&bool;                // in scope 0 at $DIR/derefer_terminator_test.rs:+3:15: +3:22
++     let mut _11: &&bool;                 // in scope 0 at $DIR/derefer_terminator_test.rs:+3:15: +3:22
++     let mut _12: &bool;                  // in scope 0 at $DIR/derefer_terminator_test.rs:+3:15: +3:22
       scope 1 {
-          debug b => _1;                   // in scope 1 at $DIR/derefer_terminator_test.rs:5:9: 5:10
-          let _2: bool;                    // in scope 1 at $DIR/derefer_terminator_test.rs:6:9: 6:10
+          debug b => _1;                   // in scope 1 at $DIR/derefer_terminator_test.rs:+1:9: +1:10
+          let _2: bool;                    // in scope 1 at $DIR/derefer_terminator_test.rs:+2:9: +2:10
           scope 2 {
-              debug d => _2;               // in scope 2 at $DIR/derefer_terminator_test.rs:6:9: 6:10
-              let _8: i32;                 // in scope 2 at $DIR/derefer_terminator_test.rs:8:22: 8:23
-              let _9: i32;                 // in scope 2 at $DIR/derefer_terminator_test.rs:11:9: 11:10
+              debug d => _2;               // in scope 2 at $DIR/derefer_terminator_test.rs:+2:9: +2:10
+              let _8: i32;                 // in scope 2 at $DIR/derefer_terminator_test.rs:+4:22: +4:23
+              let _9: i32;                 // in scope 2 at $DIR/derefer_terminator_test.rs:+7:9: +7:10
               scope 3 {
-                  debug x => _8;           // in scope 3 at $DIR/derefer_terminator_test.rs:8:22: 8:23
+                  debug x => _8;           // in scope 3 at $DIR/derefer_terminator_test.rs:+4:22: +4:23
               }
               scope 4 {
-                  debug y => _9;           // in scope 4 at $DIR/derefer_terminator_test.rs:11:9: 11:10
+                  debug y => _9;           // in scope 4 at $DIR/derefer_terminator_test.rs:+7:9: +7:10
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/derefer_terminator_test.rs:5:9: 5:10
-          _1 = foo() -> bb1;               // scope 0 at $DIR/derefer_terminator_test.rs:5:13: 5:18
+          StorageLive(_1);                 // scope 0 at $DIR/derefer_terminator_test.rs:+1:9: +1:10
+          _1 = foo() -> bb1;               // scope 0 at $DIR/derefer_terminator_test.rs:+1:13: +1:18
                                            // mir::Constant
                                            // + span: $DIR/derefer_terminator_test.rs:5:13: 5:16
                                            // + literal: Const { ty: fn() -> bool {foo}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 1 at $DIR/derefer_terminator_test.rs:6:9: 6:10
-          _2 = foo() -> bb2;               // scope 1 at $DIR/derefer_terminator_test.rs:6:13: 6:18
+          StorageLive(_2);                 // scope 1 at $DIR/derefer_terminator_test.rs:+2:9: +2:10
+          _2 = foo() -> bb2;               // scope 1 at $DIR/derefer_terminator_test.rs:+2:13: +2:18
                                            // mir::Constant
                                            // + span: $DIR/derefer_terminator_test.rs:6:13: 6:16
                                            // + literal: Const { ty: fn() -> bool {foo}, val: Value(<ZST>) }
       }
   
       bb2: {
-          StorageLive(_3);                 // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 10:6
-          StorageLive(_4);                 // scope 2 at $DIR/derefer_terminator_test.rs:7:15: 7:22
-          StorageLive(_5);                 // scope 2 at $DIR/derefer_terminator_test.rs:7:17: 7:21
-          StorageLive(_6);                 // scope 2 at $DIR/derefer_terminator_test.rs:7:18: 7:21
-          StorageLive(_7);                 // scope 2 at $DIR/derefer_terminator_test.rs:7:19: 7:21
-          _7 = &_1;                        // scope 2 at $DIR/derefer_terminator_test.rs:7:19: 7:21
-          _6 = &_7;                        // scope 2 at $DIR/derefer_terminator_test.rs:7:18: 7:21
-          _5 = &_6;                        // scope 2 at $DIR/derefer_terminator_test.rs:7:17: 7:21
-          _4 = &_5;                        // scope 2 at $DIR/derefer_terminator_test.rs:7:15: 7:22
--         switchInt((*(*(*(*_4))))) -> [false: bb3, otherwise: bb4]; // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         StorageLive(_10);                // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         _10 = deref_copy (*_4);          // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         StorageLive(_11);                // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         _11 = deref_copy (*_10);         // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         StorageDead(_10);                // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         StorageLive(_12);                // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         _12 = deref_copy (*_11);         // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         StorageDead(_11);                // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-+         switchInt((*_12)) -> [false: bb3, otherwise: bb4]; // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
+          StorageLive(_3);                 // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +6:6
+          StorageLive(_4);                 // scope 2 at $DIR/derefer_terminator_test.rs:+3:15: +3:22
+          StorageLive(_5);                 // scope 2 at $DIR/derefer_terminator_test.rs:+3:17: +3:21
+          StorageLive(_6);                 // scope 2 at $DIR/derefer_terminator_test.rs:+3:18: +3:21
+          StorageLive(_7);                 // scope 2 at $DIR/derefer_terminator_test.rs:+3:19: +3:21
+          _7 = &_1;                        // scope 2 at $DIR/derefer_terminator_test.rs:+3:19: +3:21
+          _6 = &_7;                        // scope 2 at $DIR/derefer_terminator_test.rs:+3:18: +3:21
+          _5 = &_6;                        // scope 2 at $DIR/derefer_terminator_test.rs:+3:17: +3:21
+          _4 = &_5;                        // scope 2 at $DIR/derefer_terminator_test.rs:+3:15: +3:22
+-         switchInt((*(*(*(*_4))))) -> [false: bb3, otherwise: bb4]; // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         StorageLive(_10);                // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         _10 = deref_copy (*_4);          // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         StorageLive(_11);                // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         _11 = deref_copy (*_10);         // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         StorageDead(_10);                // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         StorageLive(_12);                // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         _12 = deref_copy (*_11);         // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         StorageDead(_11);                // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
++         switchInt((*_12)) -> [false: bb3, otherwise: bb4]; // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
       }
   
       bb3: {
-+         StorageDead(_12);                // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-          _3 = const ();                   // scope 2 at $DIR/derefer_terminator_test.rs:9:18: 9:20
-          goto -> bb5;                     // scope 2 at $DIR/derefer_terminator_test.rs:9:18: 9:20
++         StorageDead(_12);                // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
+          _3 = const ();                   // scope 2 at $DIR/derefer_terminator_test.rs:+5:18: +5:20
+          goto -> bb5;                     // scope 2 at $DIR/derefer_terminator_test.rs:+5:18: +5:20
       }
   
       bb4: {
-+         StorageDead(_12);                // scope 2 at $DIR/derefer_terminator_test.rs:7:5: 7:22
-          StorageLive(_8);                 // scope 2 at $DIR/derefer_terminator_test.rs:8:22: 8:23
-          _8 = const 5_i32;                // scope 2 at $DIR/derefer_terminator_test.rs:8:26: 8:27
-          _3 = const ();                   // scope 2 at $DIR/derefer_terminator_test.rs:8:17: 8:29
-          StorageDead(_8);                 // scope 2 at $DIR/derefer_terminator_test.rs:8:28: 8:29
-          goto -> bb5;                     // scope 2 at $DIR/derefer_terminator_test.rs:8:28: 8:29
++         StorageDead(_12);                // scope 2 at $DIR/derefer_terminator_test.rs:+3:5: +3:22
+          StorageLive(_8);                 // scope 2 at $DIR/derefer_terminator_test.rs:+4:22: +4:23
+          _8 = const 5_i32;                // scope 2 at $DIR/derefer_terminator_test.rs:+4:26: +4:27
+          _3 = const ();                   // scope 2 at $DIR/derefer_terminator_test.rs:+4:17: +4:29
+          StorageDead(_8);                 // scope 2 at $DIR/derefer_terminator_test.rs:+4:28: +4:29
+          goto -> bb5;                     // scope 2 at $DIR/derefer_terminator_test.rs:+4:28: +4:29
       }
   
       bb5: {
-          StorageDead(_7);                 // scope 2 at $DIR/derefer_terminator_test.rs:10:5: 10:6
-          StorageDead(_6);                 // scope 2 at $DIR/derefer_terminator_test.rs:10:5: 10:6
-          StorageDead(_5);                 // scope 2 at $DIR/derefer_terminator_test.rs:10:5: 10:6
-          StorageDead(_4);                 // scope 2 at $DIR/derefer_terminator_test.rs:10:5: 10:6
-          StorageDead(_3);                 // scope 2 at $DIR/derefer_terminator_test.rs:10:5: 10:6
-          StorageLive(_9);                 // scope 2 at $DIR/derefer_terminator_test.rs:11:9: 11:10
-          _9 = const 42_i32;               // scope 2 at $DIR/derefer_terminator_test.rs:11:13: 11:15
-          _0 = const ();                   // scope 0 at $DIR/derefer_terminator_test.rs:4:11: 12:2
-          StorageDead(_9);                 // scope 2 at $DIR/derefer_terminator_test.rs:12:1: 12:2
-          StorageDead(_2);                 // scope 1 at $DIR/derefer_terminator_test.rs:12:1: 12:2
-          StorageDead(_1);                 // scope 0 at $DIR/derefer_terminator_test.rs:12:1: 12:2
-          return;                          // scope 0 at $DIR/derefer_terminator_test.rs:12:2: 12:2
+          StorageDead(_7);                 // scope 2 at $DIR/derefer_terminator_test.rs:+6:5: +6:6
+          StorageDead(_6);                 // scope 2 at $DIR/derefer_terminator_test.rs:+6:5: +6:6
+          StorageDead(_5);                 // scope 2 at $DIR/derefer_terminator_test.rs:+6:5: +6:6
+          StorageDead(_4);                 // scope 2 at $DIR/derefer_terminator_test.rs:+6:5: +6:6
+          StorageDead(_3);                 // scope 2 at $DIR/derefer_terminator_test.rs:+6:5: +6:6
+          StorageLive(_9);                 // scope 2 at $DIR/derefer_terminator_test.rs:+7:9: +7:10
+          _9 = const 42_i32;               // scope 2 at $DIR/derefer_terminator_test.rs:+7:13: +7:15
+          _0 = const ();                   // scope 0 at $DIR/derefer_terminator_test.rs:+0:11: +8:2
+          StorageDead(_9);                 // scope 2 at $DIR/derefer_terminator_test.rs:+8:1: +8:2
+          StorageDead(_2);                 // scope 1 at $DIR/derefer_terminator_test.rs:+8:1: +8:2
+          StorageDead(_1);                 // scope 0 at $DIR/derefer_terminator_test.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/derefer_terminator_test.rs:+8:2: +8:2
 +     }
 + 
 +     bb6 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_terminator_test.rs:4:1: 12:2
++         resume;                          // scope 0 at $DIR/derefer_terminator_test.rs:+0:1: +8:2
       }
   }
   

--- a/src/test/mir-opt/derefer_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test.main.Derefer.diff
@@ -2,57 +2,57 @@
 + // MIR for `main` after Derefer
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_test.rs:2:11: 2:11
-      let mut _1: (i32, i32);              // in scope 0 at $DIR/derefer_test.rs:3:9: 3:14
-      let mut _3: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test.rs:4:22: 4:28
-+     let mut _6: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test.rs:4:9: 4:14
-+     let mut _7: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test.rs:4:9: 4:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_test.rs:+0:11: +0:11
+      let mut _1: (i32, i32);              // in scope 0 at $DIR/derefer_test.rs:+1:9: +1:14
+      let mut _3: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test.rs:+2:22: +2:28
++     let mut _6: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test.rs:+2:9: +2:14
++     let mut _7: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test.rs:+2:9: +2:14
       scope 1 {
-          debug a => _1;                   // in scope 1 at $DIR/derefer_test.rs:3:9: 3:14
-          let mut _2: (i32, &mut (i32, i32)); // in scope 1 at $DIR/derefer_test.rs:4:9: 4:14
+          debug a => _1;                   // in scope 1 at $DIR/derefer_test.rs:+1:9: +1:14
+          let mut _2: (i32, &mut (i32, i32)); // in scope 1 at $DIR/derefer_test.rs:+2:9: +2:14
           scope 2 {
-              debug b => _2;               // in scope 2 at $DIR/derefer_test.rs:4:9: 4:14
-              let _4: &mut i32;            // in scope 2 at $DIR/derefer_test.rs:5:9: 5:10
+              debug b => _2;               // in scope 2 at $DIR/derefer_test.rs:+2:9: +2:14
+              let _4: &mut i32;            // in scope 2 at $DIR/derefer_test.rs:+3:9: +3:10
               scope 3 {
-                  debug x => _4;           // in scope 3 at $DIR/derefer_test.rs:5:9: 5:10
-                  let _5: &mut i32;        // in scope 3 at $DIR/derefer_test.rs:6:9: 6:10
+                  debug x => _4;           // in scope 3 at $DIR/derefer_test.rs:+3:9: +3:10
+                  let _5: &mut i32;        // in scope 3 at $DIR/derefer_test.rs:+4:9: +4:10
                   scope 4 {
-                      debug y => _5;       // in scope 4 at $DIR/derefer_test.rs:6:9: 6:10
+                      debug y => _5;       // in scope 4 at $DIR/derefer_test.rs:+4:9: +4:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/derefer_test.rs:3:9: 3:14
-          _1 = (const 42_i32, const 43_i32); // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
-          StorageLive(_2);                 // scope 1 at $DIR/derefer_test.rs:4:9: 4:14
-          StorageLive(_3);                 // scope 1 at $DIR/derefer_test.rs:4:22: 4:28
-          _3 = &mut _1;                    // scope 1 at $DIR/derefer_test.rs:4:22: 4:28
-          _2 = (const 99_i32, move _3);    // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
-          StorageDead(_3);                 // scope 1 at $DIR/derefer_test.rs:4:28: 4:29
-          StorageLive(_4);                 // scope 2 at $DIR/derefer_test.rs:5:9: 5:10
--         _4 = &mut ((*(_2.1: &mut (i32, i32))).0: i32); // scope 2 at $DIR/derefer_test.rs:5:13: 5:26
-+         StorageLive(_6);                 // scope 2 at $DIR/derefer_test.rs:5:13: 5:26
-+         _6 = deref_copy (_2.1: &mut (i32, i32)); // scope 2 at $DIR/derefer_test.rs:5:13: 5:26
-+         _4 = &mut ((*_6).0: i32);        // scope 2 at $DIR/derefer_test.rs:5:13: 5:26
-+         StorageDead(_6);                 // scope 3 at $DIR/derefer_test.rs:6:9: 6:10
-          StorageLive(_5);                 // scope 3 at $DIR/derefer_test.rs:6:9: 6:10
--         _5 = &mut ((*(_2.1: &mut (i32, i32))).1: i32); // scope 3 at $DIR/derefer_test.rs:6:13: 6:26
-+         StorageLive(_7);                 // scope 3 at $DIR/derefer_test.rs:6:13: 6:26
-+         _7 = deref_copy (_2.1: &mut (i32, i32)); // scope 3 at $DIR/derefer_test.rs:6:13: 6:26
-+         _5 = &mut ((*_7).1: i32);        // scope 3 at $DIR/derefer_test.rs:6:13: 6:26
-+         StorageDead(_7);                 // scope 0 at $DIR/derefer_test.rs:2:11: 7:2
-          _0 = const ();                   // scope 0 at $DIR/derefer_test.rs:2:11: 7:2
-          StorageDead(_5);                 // scope 3 at $DIR/derefer_test.rs:7:1: 7:2
-          StorageDead(_4);                 // scope 2 at $DIR/derefer_test.rs:7:1: 7:2
-          StorageDead(_2);                 // scope 1 at $DIR/derefer_test.rs:7:1: 7:2
-          StorageDead(_1);                 // scope 0 at $DIR/derefer_test.rs:7:1: 7:2
-          return;                          // scope 0 at $DIR/derefer_test.rs:7:2: 7:2
+          StorageLive(_1);                 // scope 0 at $DIR/derefer_test.rs:+1:9: +1:14
+          _1 = (const 42_i32, const 43_i32); // scope 0 at $DIR/derefer_test.rs:+1:17: +1:24
+          StorageLive(_2);                 // scope 1 at $DIR/derefer_test.rs:+2:9: +2:14
+          StorageLive(_3);                 // scope 1 at $DIR/derefer_test.rs:+2:22: +2:28
+          _3 = &mut _1;                    // scope 1 at $DIR/derefer_test.rs:+2:22: +2:28
+          _2 = (const 99_i32, move _3);    // scope 1 at $DIR/derefer_test.rs:+2:17: +2:29
+          StorageDead(_3);                 // scope 1 at $DIR/derefer_test.rs:+2:28: +2:29
+          StorageLive(_4);                 // scope 2 at $DIR/derefer_test.rs:+3:9: +3:10
+-         _4 = &mut ((*(_2.1: &mut (i32, i32))).0: i32); // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
++         StorageLive(_6);                 // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
++         _6 = deref_copy (_2.1: &mut (i32, i32)); // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
++         _4 = &mut ((*_6).0: i32);        // scope 2 at $DIR/derefer_test.rs:+3:13: +3:26
++         StorageDead(_6);                 // scope 3 at $DIR/derefer_test.rs:+4:9: +4:10
+          StorageLive(_5);                 // scope 3 at $DIR/derefer_test.rs:+4:9: +4:10
+-         _5 = &mut ((*(_2.1: &mut (i32, i32))).1: i32); // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
++         StorageLive(_7);                 // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
++         _7 = deref_copy (_2.1: &mut (i32, i32)); // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
++         _5 = &mut ((*_7).1: i32);        // scope 3 at $DIR/derefer_test.rs:+4:13: +4:26
++         StorageDead(_7);                 // scope 0 at $DIR/derefer_test.rs:+0:11: +5:2
+          _0 = const ();                   // scope 0 at $DIR/derefer_test.rs:+0:11: +5:2
+          StorageDead(_5);                 // scope 3 at $DIR/derefer_test.rs:+5:1: +5:2
+          StorageDead(_4);                 // scope 2 at $DIR/derefer_test.rs:+5:1: +5:2
+          StorageDead(_2);                 // scope 1 at $DIR/derefer_test.rs:+5:1: +5:2
+          StorageDead(_1);                 // scope 0 at $DIR/derefer_test.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/derefer_test.rs:+5:2: +5:2
 +     }
 + 
 +     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_test.rs:2:1: 7:2
++         resume;                          // scope 0 at $DIR/derefer_test.rs:+0:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
@@ -2,34 +2,34 @@
 + // MIR for `main` after Derefer
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_test_multiple.rs:2:12: 2:12
-      let mut _1: (i32, i32);              // in scope 0 at $DIR/derefer_test_multiple.rs:3:9: 3:14
-      let mut _3: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test_multiple.rs:4:22: 4:28
-      let mut _5: &mut (i32, &mut (i32, i32)); // in scope 0 at $DIR/derefer_test_multiple.rs:5:22: 5:28
-      let mut _7: &mut (i32, &mut (i32, &mut (i32, i32))); // in scope 0 at $DIR/derefer_test_multiple.rs:6:22: 6:28
-+     let mut _10: &mut (i32, &mut (i32, &mut (i32, i32))); // in scope 0 at $DIR/derefer_test_multiple.rs:6:9: 6:14
-+     let mut _11: &mut (i32, &mut (i32, i32)); // in scope 0 at $DIR/derefer_test_multiple.rs:6:9: 6:14
-+     let mut _12: &mut (i32, i32);        // in scope 0 at $DIR/derefer_test_multiple.rs:6:9: 6:14
-+     let mut _13: &mut (i32, &mut (i32, &mut (i32, i32))); // in scope 0 at $DIR/derefer_test_multiple.rs:6:9: 6:14
-+     let mut _14: &mut (i32, &mut (i32, i32)); // in scope 0 at $DIR/derefer_test_multiple.rs:6:9: 6:14
-+     let mut _15: &mut (i32, i32);        // in scope 0 at $DIR/derefer_test_multiple.rs:6:9: 6:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/derefer_test_multiple.rs:+0:12: +0:12
+      let mut _1: (i32, i32);              // in scope 0 at $DIR/derefer_test_multiple.rs:+1:9: +1:14
+      let mut _3: &mut (i32, i32);         // in scope 0 at $DIR/derefer_test_multiple.rs:+2:22: +2:28
+      let mut _5: &mut (i32, &mut (i32, i32)); // in scope 0 at $DIR/derefer_test_multiple.rs:+3:22: +3:28
+      let mut _7: &mut (i32, &mut (i32, &mut (i32, i32))); // in scope 0 at $DIR/derefer_test_multiple.rs:+4:22: +4:28
++     let mut _10: &mut (i32, &mut (i32, &mut (i32, i32))); // in scope 0 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
++     let mut _11: &mut (i32, &mut (i32, i32)); // in scope 0 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
++     let mut _12: &mut (i32, i32);        // in scope 0 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
++     let mut _13: &mut (i32, &mut (i32, &mut (i32, i32))); // in scope 0 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
++     let mut _14: &mut (i32, &mut (i32, i32)); // in scope 0 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
++     let mut _15: &mut (i32, i32);        // in scope 0 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
       scope 1 {
-          debug a => _1;                   // in scope 1 at $DIR/derefer_test_multiple.rs:3:9: 3:14
-          let mut _2: (i32, &mut (i32, i32)); // in scope 1 at $DIR/derefer_test_multiple.rs:4:9: 4:14
+          debug a => _1;                   // in scope 1 at $DIR/derefer_test_multiple.rs:+1:9: +1:14
+          let mut _2: (i32, &mut (i32, i32)); // in scope 1 at $DIR/derefer_test_multiple.rs:+2:9: +2:14
           scope 2 {
-              debug b => _2;               // in scope 2 at $DIR/derefer_test_multiple.rs:4:9: 4:14
-              let mut _4: (i32, &mut (i32, &mut (i32, i32))); // in scope 2 at $DIR/derefer_test_multiple.rs:5:9: 5:14
+              debug b => _2;               // in scope 2 at $DIR/derefer_test_multiple.rs:+2:9: +2:14
+              let mut _4: (i32, &mut (i32, &mut (i32, i32))); // in scope 2 at $DIR/derefer_test_multiple.rs:+3:9: +3:14
               scope 3 {
-                  debug c => _4;           // in scope 3 at $DIR/derefer_test_multiple.rs:5:9: 5:14
-                  let mut _6: (i32, &mut (i32, &mut (i32, &mut (i32, i32)))); // in scope 3 at $DIR/derefer_test_multiple.rs:6:9: 6:14
+                  debug c => _4;           // in scope 3 at $DIR/derefer_test_multiple.rs:+3:9: +3:14
+                  let mut _6: (i32, &mut (i32, &mut (i32, &mut (i32, i32)))); // in scope 3 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
                   scope 4 {
-                      debug d => _6;       // in scope 4 at $DIR/derefer_test_multiple.rs:6:9: 6:14
-                      let _8: &mut i32;    // in scope 4 at $DIR/derefer_test_multiple.rs:7:9: 7:10
+                      debug d => _6;       // in scope 4 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
+                      let _8: &mut i32;    // in scope 4 at $DIR/derefer_test_multiple.rs:+5:9: +5:10
                       scope 5 {
-                          debug x => _8;   // in scope 5 at $DIR/derefer_test_multiple.rs:7:9: 7:10
-                          let _9: &mut i32; // in scope 5 at $DIR/derefer_test_multiple.rs:8:9: 8:10
+                          debug x => _8;   // in scope 5 at $DIR/derefer_test_multiple.rs:+5:9: +5:10
+                          let _9: &mut i32; // in scope 5 at $DIR/derefer_test_multiple.rs:+6:9: +6:10
                           scope 6 {
-                              debug y => _9; // in scope 6 at $DIR/derefer_test_multiple.rs:8:9: 8:10
+                              debug y => _9; // in scope 6 at $DIR/derefer_test_multiple.rs:+6:9: +6:10
                           }
                       }
                   }
@@ -38,59 +38,59 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/derefer_test_multiple.rs:3:9: 3:14
-          _1 = (const 42_i32, const 43_i32); // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
-          StorageLive(_2);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:9: 4:14
-          StorageLive(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:22: 4:28
-          _3 = &mut _1;                    // scope 1 at $DIR/derefer_test_multiple.rs:4:22: 4:28
-          _2 = (const 99_i32, move _3);    // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
-          StorageDead(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:28: 4:29
-          StorageLive(_4);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:9: 5:14
-          StorageLive(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:22: 5:28
-          _5 = &mut _2;                    // scope 2 at $DIR/derefer_test_multiple.rs:5:22: 5:28
-          _4 = (const 11_i32, move _5);    // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
-          StorageDead(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:28: 5:29
-          StorageLive(_6);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:9: 6:14
-          StorageLive(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:22: 6:28
-          _7 = &mut _4;                    // scope 3 at $DIR/derefer_test_multiple.rs:6:22: 6:28
-          _6 = (const 13_i32, move _7);    // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
-          StorageDead(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:28: 6:29
-          StorageLive(_8);                 // scope 4 at $DIR/derefer_test_multiple.rs:7:9: 7:10
--         _8 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))))).1: &mut (i32, &mut (i32, i32)))).1: &mut (i32, i32))).1: i32); // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         StorageLive(_10);                // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         _10 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))); // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         StorageLive(_11);                // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         _11 = deref_copy ((*_10).1: &mut (i32, &mut (i32, i32))); // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         StorageDead(_10);                // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         StorageLive(_12);                // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         _12 = deref_copy ((*_11).1: &mut (i32, i32)); // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         StorageDead(_11);                // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         _8 = &mut ((*_12).1: i32);       // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30
-+         StorageDead(_12);                // scope 5 at $DIR/derefer_test_multiple.rs:8:9: 8:10
-          StorageLive(_9);                 // scope 5 at $DIR/derefer_test_multiple.rs:8:9: 8:10
--         _9 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))))).1: &mut (i32, &mut (i32, i32)))).1: &mut (i32, i32))).1: i32); // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         StorageLive(_13);                // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         _13 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))); // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         StorageLive(_14);                // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         _14 = deref_copy ((*_13).1: &mut (i32, &mut (i32, i32))); // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         StorageDead(_13);                // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         StorageLive(_15);                // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         _15 = deref_copy ((*_14).1: &mut (i32, i32)); // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         StorageDead(_14);                // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         _9 = &mut ((*_15).1: i32);       // scope 5 at $DIR/derefer_test_multiple.rs:8:13: 8:30
-+         StorageDead(_15);                // scope 0 at $DIR/derefer_test_multiple.rs:2:12: 9:2
-          _0 = const ();                   // scope 0 at $DIR/derefer_test_multiple.rs:2:12: 9:2
-          StorageDead(_9);                 // scope 5 at $DIR/derefer_test_multiple.rs:9:1: 9:2
-          StorageDead(_8);                 // scope 4 at $DIR/derefer_test_multiple.rs:9:1: 9:2
-          StorageDead(_6);                 // scope 3 at $DIR/derefer_test_multiple.rs:9:1: 9:2
-          StorageDead(_4);                 // scope 2 at $DIR/derefer_test_multiple.rs:9:1: 9:2
-          StorageDead(_2);                 // scope 1 at $DIR/derefer_test_multiple.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/derefer_test_multiple.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/derefer_test_multiple.rs:9:2: 9:2
+          StorageLive(_1);                 // scope 0 at $DIR/derefer_test_multiple.rs:+1:9: +1:14
+          _1 = (const 42_i32, const 43_i32); // scope 0 at $DIR/derefer_test_multiple.rs:+1:17: +1:25
+          StorageLive(_2);                 // scope 1 at $DIR/derefer_test_multiple.rs:+2:9: +2:14
+          StorageLive(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:+2:22: +2:28
+          _3 = &mut _1;                    // scope 1 at $DIR/derefer_test_multiple.rs:+2:22: +2:28
+          _2 = (const 99_i32, move _3);    // scope 1 at $DIR/derefer_test_multiple.rs:+2:17: +2:29
+          StorageDead(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:+2:28: +2:29
+          StorageLive(_4);                 // scope 2 at $DIR/derefer_test_multiple.rs:+3:9: +3:14
+          StorageLive(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:+3:22: +3:28
+          _5 = &mut _2;                    // scope 2 at $DIR/derefer_test_multiple.rs:+3:22: +3:28
+          _4 = (const 11_i32, move _5);    // scope 2 at $DIR/derefer_test_multiple.rs:+3:17: +3:29
+          StorageDead(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:+3:28: +3:29
+          StorageLive(_6);                 // scope 3 at $DIR/derefer_test_multiple.rs:+4:9: +4:14
+          StorageLive(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:+4:22: +4:28
+          _7 = &mut _4;                    // scope 3 at $DIR/derefer_test_multiple.rs:+4:22: +4:28
+          _6 = (const 13_i32, move _7);    // scope 3 at $DIR/derefer_test_multiple.rs:+4:17: +4:29
+          StorageDead(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:+4:28: +4:29
+          StorageLive(_8);                 // scope 4 at $DIR/derefer_test_multiple.rs:+5:9: +5:10
+-         _8 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))))).1: &mut (i32, &mut (i32, i32)))).1: &mut (i32, i32))).1: i32); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         StorageLive(_10);                // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _10 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         StorageLive(_11);                // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _11 = deref_copy ((*_10).1: &mut (i32, &mut (i32, i32))); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         StorageDead(_10);                // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         StorageLive(_12);                // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _12 = deref_copy ((*_11).1: &mut (i32, i32)); // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         StorageDead(_11);                // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         _8 = &mut ((*_12).1: i32);       // scope 4 at $DIR/derefer_test_multiple.rs:+5:13: +5:30
++         StorageDead(_12);                // scope 5 at $DIR/derefer_test_multiple.rs:+6:9: +6:10
+          StorageLive(_9);                 // scope 5 at $DIR/derefer_test_multiple.rs:+6:9: +6:10
+-         _9 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))))).1: &mut (i32, &mut (i32, i32)))).1: &mut (i32, i32))).1: i32); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         StorageLive(_13);                // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _13 = deref_copy (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         StorageLive(_14);                // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _14 = deref_copy ((*_13).1: &mut (i32, &mut (i32, i32))); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         StorageDead(_13);                // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         StorageLive(_15);                // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _15 = deref_copy ((*_14).1: &mut (i32, i32)); // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         StorageDead(_14);                // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         _9 = &mut ((*_15).1: i32);       // scope 5 at $DIR/derefer_test_multiple.rs:+6:13: +6:30
++         StorageDead(_15);                // scope 0 at $DIR/derefer_test_multiple.rs:+0:12: +7:2
+          _0 = const ();                   // scope 0 at $DIR/derefer_test_multiple.rs:+0:12: +7:2
+          StorageDead(_9);                 // scope 5 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
+          StorageDead(_8);                 // scope 4 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
+          StorageDead(_6);                 // scope 3 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
+          StorageDead(_4);                 // scope 2 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
+          StorageDead(_2);                 // scope 1 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
+          StorageDead(_1);                 // scope 0 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
+          return;                          // scope 0 at $DIR/derefer_test_multiple.rs:+7:2: +7:2
 +     }
 + 
 +     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_test_multiple.rs:2:1: 9:2
++         resume;                          // scope 0 at $DIR/derefer_test_multiple.rs:+0:1: +7:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
@@ -2,64 +2,64 @@
 + // MIR for `main` after DestinationPropagation
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/branch.rs:12:11: 12:11
-      let _1: i32;                         // in scope 0 at $DIR/branch.rs:13:9: 13:10
-      let mut _3: bool;                    // in scope 0 at $DIR/branch.rs:15:16: 15:22
-      let _4: i32;                         // in scope 0 at $DIR/branch.rs:18:9: 18:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/branch.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/branch.rs:+1:9: +1:10
+      let mut _3: bool;                    // in scope 0 at $DIR/branch.rs:+3:16: +3:22
+      let _4: i32;                         // in scope 0 at $DIR/branch.rs:+6:9: +6:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/branch.rs:13:9: 13:10
-          let _2: i32;                     // in scope 1 at $DIR/branch.rs:15:9: 15:10
+          debug x => _1;                   // in scope 1 at $DIR/branch.rs:+1:9: +1:10
+          let _2: i32;                     // in scope 1 at $DIR/branch.rs:+3:9: +3:10
           scope 2 {
-              debug y => _2;               // in scope 2 at $DIR/branch.rs:15:9: 15:10
+              debug y => _2;               // in scope 2 at $DIR/branch.rs:+3:9: +3:10
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/branch.rs:13:9: 13:10
-          _1 = val() -> bb1;               // scope 0 at $DIR/branch.rs:13:13: 13:18
+          StorageLive(_1);                 // scope 0 at $DIR/branch.rs:+1:9: +1:10
+          _1 = val() -> bb1;               // scope 0 at $DIR/branch.rs:+1:13: +1:18
                                            // mir::Constant
                                            // + span: $DIR/branch.rs:13:13: 13:16
                                            // + literal: Const { ty: fn() -> i32 {val}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 1 at $DIR/branch.rs:15:9: 15:10
-          StorageLive(_3);                 // scope 1 at $DIR/branch.rs:15:16: 15:22
-          _3 = cond() -> bb2;              // scope 1 at $DIR/branch.rs:15:16: 15:22
+          StorageLive(_2);                 // scope 1 at $DIR/branch.rs:+3:9: +3:10
+          StorageLive(_3);                 // scope 1 at $DIR/branch.rs:+3:16: +3:22
+          _3 = cond() -> bb2;              // scope 1 at $DIR/branch.rs:+3:16: +3:22
                                            // mir::Constant
                                            // + span: $DIR/branch.rs:15:16: 15:20
                                            // + literal: Const { ty: fn() -> bool {cond}, val: Value(<ZST>) }
       }
   
       bb2: {
-          switchInt(move _3) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/branch.rs:15:16: 15:22
+          switchInt(move _3) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/branch.rs:+3:16: +3:22
       }
   
       bb3: {
-          nop;                             // scope 1 at $DIR/branch.rs:16:9: 16:10
-          goto -> bb6;                     // scope 1 at $DIR/branch.rs:15:13: 20:6
+          nop;                             // scope 1 at $DIR/branch.rs:+4:9: +4:10
+          goto -> bb6;                     // scope 1 at $DIR/branch.rs:+3:13: +8:6
       }
   
       bb4: {
-          StorageLive(_4);                 // scope 1 at $DIR/branch.rs:18:9: 18:14
-          _4 = val() -> bb5;               // scope 1 at $DIR/branch.rs:18:9: 18:14
+          StorageLive(_4);                 // scope 1 at $DIR/branch.rs:+6:9: +6:14
+          _4 = val() -> bb5;               // scope 1 at $DIR/branch.rs:+6:9: +6:14
                                            // mir::Constant
                                            // + span: $DIR/branch.rs:18:9: 18:12
                                            // + literal: Const { ty: fn() -> i32 {val}, val: Value(<ZST>) }
       }
   
       bb5: {
-          StorageDead(_4);                 // scope 1 at $DIR/branch.rs:18:14: 18:15
-          nop;                             // scope 1 at $DIR/branch.rs:19:9: 19:10
-          goto -> bb6;                     // scope 1 at $DIR/branch.rs:15:13: 20:6
+          StorageDead(_4);                 // scope 1 at $DIR/branch.rs:+6:14: +6:15
+          nop;                             // scope 1 at $DIR/branch.rs:+7:9: +7:10
+          goto -> bb6;                     // scope 1 at $DIR/branch.rs:+3:13: +8:6
       }
   
       bb6: {
-          StorageDead(_3);                 // scope 1 at $DIR/branch.rs:20:5: 20:6
-          nop;                             // scope 0 at $DIR/branch.rs:12:11: 21:2
-          StorageDead(_2);                 // scope 1 at $DIR/branch.rs:21:1: 21:2
-          StorageDead(_1);                 // scope 0 at $DIR/branch.rs:21:1: 21:2
-          return;                          // scope 0 at $DIR/branch.rs:21:2: 21:2
+          StorageDead(_3);                 // scope 1 at $DIR/branch.rs:+8:5: +8:6
+          nop;                             // scope 0 at $DIR/branch.rs:+0:11: +9:2
+          StorageDead(_2);                 // scope 1 at $DIR/branch.rs:+9:1: +9:2
+          StorageDead(_1);                 // scope 0 at $DIR/branch.rs:+9:1: +9:2
+          return;                          // scope 0 at $DIR/branch.rs:+9:2: +9:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.arg_src.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.arg_src.DestinationPropagation.diff
@@ -2,25 +2,25 @@
 + // MIR for `arg_src` after DestinationPropagation
   
   fn arg_src(_1: i32) -> i32 {
-      debug x => const 123_i32;            // in scope 0 at $DIR/copy_propagation_arg.rs:27:12: 27:17
-      let mut _0: i32;                     // return place in scope 0 at $DIR/copy_propagation_arg.rs:27:27: 27:30
-      let _2: i32;                         // in scope 0 at $DIR/copy_propagation_arg.rs:28:9: 28:10
+      debug x => const 123_i32;            // in scope 0 at $DIR/copy_propagation_arg.rs:+0:12: +0:17
+      let mut _0: i32;                     // return place in scope 0 at $DIR/copy_propagation_arg.rs:+0:27: +0:30
+      let _2: i32;                         // in scope 0 at $DIR/copy_propagation_arg.rs:+1:9: +1:10
       scope 1 {
--         debug y => _2;                   // in scope 1 at $DIR/copy_propagation_arg.rs:28:9: 28:10
-+         debug y => _0;                   // in scope 1 at $DIR/copy_propagation_arg.rs:28:9: 28:10
+-         debug y => _2;                   // in scope 1 at $DIR/copy_propagation_arg.rs:+1:9: +1:10
++         debug y => _0;                   // in scope 1 at $DIR/copy_propagation_arg.rs:+1:9: +1:10
       }
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:28:9: 28:10
--         _2 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:28:13: 28:14
-+         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:28:9: 28:10
-+         _0 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:28:13: 28:14
-          nop;                             // scope 1 at $DIR/copy_propagation_arg.rs:29:5: 29:12
--         _0 = _2;                         // scope 1 at $DIR/copy_propagation_arg.rs:30:5: 30:6
--         StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:31:1: 31:2
-+         nop;                             // scope 1 at $DIR/copy_propagation_arg.rs:30:5: 30:6
-+         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:31:1: 31:2
-          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:31:2: 31:2
+-         StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+1:9: +1:10
+-         _2 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:+1:13: +1:14
++         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+1:9: +1:10
++         _0 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:+1:13: +1:14
+          nop;                             // scope 1 at $DIR/copy_propagation_arg.rs:+2:5: +2:12
+-         _0 = _2;                         // scope 1 at $DIR/copy_propagation_arg.rs:+3:5: +3:6
+-         StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+4:1: +4:2
++         nop;                             // scope 1 at $DIR/copy_propagation_arg.rs:+3:5: +3:6
++         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.diff
@@ -2,27 +2,27 @@
 + // MIR for `bar` after DestinationPropagation
   
   fn bar(_1: u8) -> () {
-      debug x => const 5_u8;               // in scope 0 at $DIR/copy_propagation_arg.rs:15:8: 15:13
-      let mut _0: ();                      // return place in scope 0 at $DIR/copy_propagation_arg.rs:15:19: 15:19
-      let _2: u8;                          // in scope 0 at $DIR/copy_propagation_arg.rs:16:5: 16:13
-      let mut _3: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
+      debug x => const 5_u8;               // in scope 0 at $DIR/copy_propagation_arg.rs:+0:8: +0:13
+      let mut _0: ();                      // return place in scope 0 at $DIR/copy_propagation_arg.rs:+0:19: +0:19
+      let _2: u8;                          // in scope 0 at $DIR/copy_propagation_arg.rs:+1:5: +1:13
+      let mut _3: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:+1:11: +1:12
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:5: 16:13
-          StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
-          _3 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
-          _2 = dummy(move _3) -> bb1;      // scope 0 at $DIR/copy_propagation_arg.rs:16:5: 16:13
+          StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+1:5: +1:13
+          StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:+1:11: +1:12
+          _3 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:+1:11: +1:12
+          _2 = dummy(move _3) -> bb1;      // scope 0 at $DIR/copy_propagation_arg.rs:+1:5: +1:13
                                            // mir::Constant
                                            // + span: $DIR/copy_propagation_arg.rs:16:5: 16:10
                                            // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:12: 16:13
-          StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:13: 16:14
-          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:17:5: 17:10
-          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:15:19: 18:2
-          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:18:2: 18:2
+          StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:+1:12: +1:13
+          StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+1:13: +1:14
+          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:10
+          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+0:19: +3:2
+          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.baz.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.baz.DestinationPropagation.diff
@@ -2,17 +2,17 @@
 + // MIR for `baz` after DestinationPropagation
   
   fn baz(_1: i32) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/copy_propagation_arg.rs:21:8: 21:13
-      let mut _0: ();                      // return place in scope 0 at $DIR/copy_propagation_arg.rs:21:20: 21:20
-      let mut _2: i32;                     // in scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
+      debug x => _1;                       // in scope 0 at $DIR/copy_propagation_arg.rs:+0:8: +0:13
+      let mut _0: ();                      // return place in scope 0 at $DIR/copy_propagation_arg.rs:+0:20: +0:20
+      let mut _2: i32;                     // in scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
-          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
-          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:23:5: 23:10
-          StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
-          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:21:20: 24:2
-          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:24:2: 24:2
+          StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
+          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
+          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:10
+          StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:10
+          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+0:20: +3:2
+          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
@@ -2,27 +2,27 @@
 + // MIR for `foo` after DestinationPropagation
   
   fn foo(_1: u8) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/copy_propagation_arg.rs:9:8: 9:13
-      let mut _0: ();                      // return place in scope 0 at $DIR/copy_propagation_arg.rs:9:19: 9:19
-      let mut _2: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:11:9: 11:17
-      let mut _3: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:11:15: 11:16
+      debug x => _1;                       // in scope 0 at $DIR/copy_propagation_arg.rs:+0:8: +0:13
+      let mut _0: ();                      // return place in scope 0 at $DIR/copy_propagation_arg.rs:+0:19: +0:19
+      let mut _2: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:17
+      let mut _3: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:+2:15: +2:16
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:9: 11:17
-          StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:15: 11:16
-          _3 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:11:15: 11:16
-          _2 = dummy(move _3) -> bb1;      // scope 0 at $DIR/copy_propagation_arg.rs:11:9: 11:17
+          StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:17
+          StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:15: +2:16
+          _3 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:+2:15: +2:16
+          _2 = dummy(move _3) -> bb1;      // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:17
                                            // mir::Constant
                                            // + span: $DIR/copy_propagation_arg.rs:11:9: 11:14
                                            // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:16: 11:17
-          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:11:5: 11:17
-          StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:16: 11:17
-          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:9:19: 12:2
-          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:12:2: 12:2
+          StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:16: +2:17
+          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+2:5: +2:17
+          StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:+2:16: +2:17
+          nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:+0:19: +3:2
+          return;                          // scope 0 at $DIR/copy_propagation_arg.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
@@ -2,19 +2,19 @@
 + // MIR for `main` after DestinationPropagation
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:8:11: 8:11
-      let mut _1: i32;                     // in scope 0 at $DIR/cycle.rs:9:9: 9:14
-      let mut _4: i32;                     // in scope 0 at $DIR/cycle.rs:12:9: 12:10
-      let _5: ();                          // in scope 0 at $DIR/cycle.rs:14:5: 14:12
-      let mut _6: i32;                     // in scope 0 at $DIR/cycle.rs:14:10: 14:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:11: +0:11
+      let mut _1: i32;                     // in scope 0 at $DIR/cycle.rs:+1:9: +1:14
+      let mut _4: i32;                     // in scope 0 at $DIR/cycle.rs:+4:9: +4:10
+      let _5: ();                          // in scope 0 at $DIR/cycle.rs:+6:5: +6:12
+      let mut _6: i32;                     // in scope 0 at $DIR/cycle.rs:+6:10: +6:11
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/cycle.rs:9:9: 9:14
-          let _2: i32;                     // in scope 1 at $DIR/cycle.rs:10:9: 10:10
+          debug x => _1;                   // in scope 1 at $DIR/cycle.rs:+1:9: +1:14
+          let _2: i32;                     // in scope 1 at $DIR/cycle.rs:+2:9: +2:10
           scope 2 {
-              debug y => _2;               // in scope 2 at $DIR/cycle.rs:10:9: 10:10
-              let _3: i32;                 // in scope 2 at $DIR/cycle.rs:11:9: 11:10
+              debug y => _2;               // in scope 2 at $DIR/cycle.rs:+2:9: +2:10
+              let _3: i32;                 // in scope 2 at $DIR/cycle.rs:+3:9: +3:10
               scope 3 {
-                  debug z => _3;           // in scope 3 at $DIR/cycle.rs:11:9: 11:10
+                  debug z => _3;           // in scope 3 at $DIR/cycle.rs:+3:9: +3:10
                   scope 4 (inlined std::mem::drop::<i32>) { // at $DIR/cycle.rs:14:5: 14:12
                       debug _x => _6;      // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
                   }
@@ -23,31 +23,31 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:9:9: 9:14
-          _1 = val() -> bb1;               // scope 0 at $DIR/cycle.rs:9:17: 9:22
+          StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:+1:9: +1:14
+          _1 = val() -> bb1;               // scope 0 at $DIR/cycle.rs:+1:17: +1:22
                                            // mir::Constant
                                            // + span: $DIR/cycle.rs:9:17: 9:20
                                            // + literal: Const { ty: fn() -> i32 {val}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 1 at $DIR/cycle.rs:10:9: 10:10
-          nop;                             // scope 1 at $DIR/cycle.rs:10:13: 10:14
-          StorageLive(_3);                 // scope 2 at $DIR/cycle.rs:11:9: 11:10
-          nop;                             // scope 2 at $DIR/cycle.rs:11:13: 11:14
-          StorageLive(_4);                 // scope 3 at $DIR/cycle.rs:12:9: 12:10
-          nop;                             // scope 3 at $DIR/cycle.rs:12:9: 12:10
-          nop;                             // scope 3 at $DIR/cycle.rs:12:5: 12:10
-          StorageDead(_4);                 // scope 3 at $DIR/cycle.rs:12:9: 12:10
-          StorageLive(_5);                 // scope 3 at $DIR/cycle.rs:14:5: 14:12
-          StorageLive(_6);                 // scope 3 at $DIR/cycle.rs:14:10: 14:11
-          nop;                             // scope 3 at $DIR/cycle.rs:14:10: 14:11
-          StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:14:11: 14:12
-          StorageDead(_5);                 // scope 3 at $DIR/cycle.rs:14:12: 14:13
-          StorageDead(_3);                 // scope 2 at $DIR/cycle.rs:15:1: 15:2
-          StorageDead(_2);                 // scope 1 at $DIR/cycle.rs:15:1: 15:2
-          StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:15:1: 15:2
-          return;                          // scope 0 at $DIR/cycle.rs:15:2: 15:2
+          StorageLive(_2);                 // scope 1 at $DIR/cycle.rs:+2:9: +2:10
+          nop;                             // scope 1 at $DIR/cycle.rs:+2:13: +2:14
+          StorageLive(_3);                 // scope 2 at $DIR/cycle.rs:+3:9: +3:10
+          nop;                             // scope 2 at $DIR/cycle.rs:+3:13: +3:14
+          StorageLive(_4);                 // scope 3 at $DIR/cycle.rs:+4:9: +4:10
+          nop;                             // scope 3 at $DIR/cycle.rs:+4:9: +4:10
+          nop;                             // scope 3 at $DIR/cycle.rs:+4:5: +4:10
+          StorageDead(_4);                 // scope 3 at $DIR/cycle.rs:+4:9: +4:10
+          StorageLive(_5);                 // scope 3 at $DIR/cycle.rs:+6:5: +6:12
+          StorageLive(_6);                 // scope 3 at $DIR/cycle.rs:+6:10: +6:11
+          nop;                             // scope 3 at $DIR/cycle.rs:+6:10: +6:11
+          StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:+6:11: +6:12
+          StorageDead(_5);                 // scope 3 at $DIR/cycle.rs:+6:12: +6:13
+          StorageDead(_3);                 // scope 2 at $DIR/cycle.rs:+7:1: +7:2
+          StorageDead(_2);                 // scope 1 at $DIR/cycle.rs:+7:1: +7:2
+          StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:+7:1: +7:2
+          return;                          // scope 0 at $DIR/cycle.rs:+7:2: +7:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.diff
@@ -2,38 +2,38 @@
 + // MIR for `nrvo` after DestinationPropagation
   
   fn nrvo(_1: for<'r> fn(&'r mut [u8; 1024])) -> [u8; 1024] {
-      debug init => _1;                    // in scope 0 at $DIR/simple.rs:4:9: 4:13
-      let mut _0: [u8; 1024];              // return place in scope 0 at $DIR/simple.rs:4:39: 4:49
-      let mut _2: [u8; 1024];              // in scope 0 at $DIR/simple.rs:5:9: 5:16
-      let _3: ();                          // in scope 0 at $DIR/simple.rs:6:5: 6:19
-      let mut _4: for<'r> fn(&'r mut [u8; 1024]); // in scope 0 at $DIR/simple.rs:6:5: 6:9
-      let mut _5: &mut [u8; 1024];         // in scope 0 at $DIR/simple.rs:6:10: 6:18
-      let mut _6: &mut [u8; 1024];         // in scope 0 at $DIR/simple.rs:6:10: 6:18
+      debug init => _1;                    // in scope 0 at $DIR/simple.rs:+0:9: +0:13
+      let mut _0: [u8; 1024];              // return place in scope 0 at $DIR/simple.rs:+0:39: +0:49
+      let mut _2: [u8; 1024];              // in scope 0 at $DIR/simple.rs:+1:9: +1:16
+      let _3: ();                          // in scope 0 at $DIR/simple.rs:+2:5: +2:19
+      let mut _4: for<'r> fn(&'r mut [u8; 1024]); // in scope 0 at $DIR/simple.rs:+2:5: +2:9
+      let mut _5: &mut [u8; 1024];         // in scope 0 at $DIR/simple.rs:+2:10: +2:18
+      let mut _6: &mut [u8; 1024];         // in scope 0 at $DIR/simple.rs:+2:10: +2:18
       scope 1 {
-          debug buf => _2;                 // in scope 1 at $DIR/simple.rs:5:9: 5:16
+          debug buf => _2;                 // in scope 1 at $DIR/simple.rs:+1:9: +1:16
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simple.rs:5:9: 5:16
-          _2 = [const 0_u8; 1024];         // scope 0 at $DIR/simple.rs:5:19: 5:28
-          StorageLive(_3);                 // scope 1 at $DIR/simple.rs:6:5: 6:19
-          StorageLive(_4);                 // scope 1 at $DIR/simple.rs:6:5: 6:9
-          _4 = _1;                         // scope 1 at $DIR/simple.rs:6:5: 6:9
-          StorageLive(_5);                 // scope 1 at $DIR/simple.rs:6:10: 6:18
-          StorageLive(_6);                 // scope 1 at $DIR/simple.rs:6:10: 6:18
-          _6 = &mut _2;                    // scope 1 at $DIR/simple.rs:6:10: 6:18
-          _5 = &mut (*_6);                 // scope 1 at $DIR/simple.rs:6:10: 6:18
-          _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/simple.rs:6:5: 6:19
+          StorageLive(_2);                 // scope 0 at $DIR/simple.rs:+1:9: +1:16
+          _2 = [const 0_u8; 1024];         // scope 0 at $DIR/simple.rs:+1:19: +1:28
+          StorageLive(_3);                 // scope 1 at $DIR/simple.rs:+2:5: +2:19
+          StorageLive(_4);                 // scope 1 at $DIR/simple.rs:+2:5: +2:9
+          _4 = _1;                         // scope 1 at $DIR/simple.rs:+2:5: +2:9
+          StorageLive(_5);                 // scope 1 at $DIR/simple.rs:+2:10: +2:18
+          StorageLive(_6);                 // scope 1 at $DIR/simple.rs:+2:10: +2:18
+          _6 = &mut _2;                    // scope 1 at $DIR/simple.rs:+2:10: +2:18
+          _5 = &mut (*_6);                 // scope 1 at $DIR/simple.rs:+2:10: +2:18
+          _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/simple.rs:+2:5: +2:19
       }
   
       bb1: {
-          StorageDead(_5);                 // scope 1 at $DIR/simple.rs:6:18: 6:19
-          StorageDead(_4);                 // scope 1 at $DIR/simple.rs:6:18: 6:19
-          StorageDead(_6);                 // scope 1 at $DIR/simple.rs:6:19: 6:20
-          StorageDead(_3);                 // scope 1 at $DIR/simple.rs:6:19: 6:20
-          _0 = _2;                         // scope 1 at $DIR/simple.rs:7:5: 7:8
-          StorageDead(_2);                 // scope 0 at $DIR/simple.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/simple.rs:8:2: 8:2
+          StorageDead(_5);                 // scope 1 at $DIR/simple.rs:+2:18: +2:19
+          StorageDead(_4);                 // scope 1 at $DIR/simple.rs:+2:18: +2:19
+          StorageDead(_6);                 // scope 1 at $DIR/simple.rs:+2:19: +2:20
+          StorageDead(_3);                 // scope 1 at $DIR/simple.rs:+2:19: +2:20
+          _0 = _2;                         // scope 1 at $DIR/simple.rs:+3:5: +3:8
+          StorageDead(_2);                 // scope 0 at $DIR/simple.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/simple.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -2,13 +2,13 @@
 + // MIR for `main` after DestinationPropagation
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/union.rs:8:11: 8:11
-      let _1: main::Un;                    // in scope 0 at $DIR/union.rs:13:9: 13:11
-      let mut _2: u32;                     // in scope 0 at $DIR/union.rs:13:23: 13:28
-      let _3: ();                          // in scope 0 at $DIR/union.rs:15:5: 15:27
-      let mut _4: u32;                     // in scope 0 at $DIR/union.rs:15:10: 15:26
+      let mut _0: ();                      // return place in scope 0 at $DIR/union.rs:+0:11: +0:11
+      let _1: main::Un;                    // in scope 0 at $DIR/union.rs:+5:9: +5:11
+      let mut _2: u32;                     // in scope 0 at $DIR/union.rs:+5:23: +5:28
+      let _3: ();                          // in scope 0 at $DIR/union.rs:+7:5: +7:27
+      let mut _4: u32;                     // in scope 0 at $DIR/union.rs:+7:10: +7:26
       scope 1 {
-          debug un => _1;                  // in scope 1 at $DIR/union.rs:13:9: 13:11
+          debug un => _1;                  // in scope 1 at $DIR/union.rs:+5:9: +5:11
           scope 2 {
           }
           scope 3 (inlined std::mem::drop::<u32>) { // at $DIR/union.rs:15:5: 15:27
@@ -17,25 +17,25 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
-          StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
-          _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
+          StorageLive(_1);                 // scope 0 at $DIR/union.rs:+5:9: +5:11
+          StorageLive(_2);                 // scope 0 at $DIR/union.rs:+5:23: +5:28
+          _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:+5:23: +5:28
                                            // mir::Constant
                                            // + span: $DIR/union.rs:13:23: 13:26
                                            // + literal: Const { ty: fn() -> u32 {val}, val: Value(<ZST>) }
       }
   
       bb1: {
-          nop;                             // scope 0 at $DIR/union.rs:13:14: 13:30
-          nop;                             // scope 0 at $DIR/union.rs:13:14: 13:30
-          StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
-          StorageLive(_3);                 // scope 1 at $DIR/union.rs:15:5: 15:27
-          StorageLive(_4);                 // scope 1 at $DIR/union.rs:15:10: 15:26
-          nop;                             // scope 2 at $DIR/union.rs:15:19: 15:24
-          StorageDead(_4);                 // scope 1 at $DIR/union.rs:15:26: 15:27
-          StorageDead(_3);                 // scope 1 at $DIR/union.rs:15:27: 15:28
-          StorageDead(_1);                 // scope 0 at $DIR/union.rs:16:1: 16:2
-          return;                          // scope 0 at $DIR/union.rs:16:2: 16:2
+          nop;                             // scope 0 at $DIR/union.rs:+5:14: +5:30
+          nop;                             // scope 0 at $DIR/union.rs:+5:14: +5:30
+          StorageDead(_2);                 // scope 0 at $DIR/union.rs:+5:29: +5:30
+          StorageLive(_3);                 // scope 1 at $DIR/union.rs:+7:5: +7:27
+          StorageLive(_4);                 // scope 1 at $DIR/union.rs:+7:10: +7:26
+          nop;                             // scope 2 at $DIR/union.rs:+7:19: +7:24
+          StorageDead(_4);                 // scope 1 at $DIR/union.rs:+7:26: +7:27
+          StorageDead(_3);                 // scope 1 at $DIR/union.rs:+7:27: +7:28
+          StorageDead(_1);                 // scope 0 at $DIR/union.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/union.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -2,77 +2,77 @@
 + // MIR for `opt1` after EarlyOtherwiseBranch
   
   fn opt1(_1: Option<u32>, _2: Option<u32>) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch.rs:3:9: 3:10
-      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch.rs:3:25: 3:26
-      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch.rs:3:44: 3:47
-      let mut _3: (std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
-      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
-      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:4:15: 4:16
-      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
-      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
-      let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
-      let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
-+     let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+     let mut _11: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
+      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch.rs:+0:9: +0:10
+      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch.rs:+0:25: +0:26
+      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch.rs:+0:44: +0:47
+      let mut _3: (std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:19: +2:26
+      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:10: +2:17
+      let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+      let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
++     let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++     let mut _11: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       scope 1 {
-          debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch.rs:5:15: 5:16
-          debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:5:24: 5:25
+          debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
-          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:15: 4:16
-          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:4:15: 4:16
-          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:16: 4:17
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:16: 4:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
--         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         _10 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
+          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
+          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _10 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   
       bb1: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
-          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
++         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
+          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
+-         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
++         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
--         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
+-         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
 -     bb3: {
-          StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
-          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
-          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
-          _9 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
-          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:5:31: 5:32
-          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
-          StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
+          StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _9 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+-         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
++         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
       }
   
 -     bb4: {
 +     bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch.rs:8:2: 8:2
+          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch.rs:+5:2: +5:2
 +     }
 + 
 +     bb4: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         switchInt(_7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         switchInt(_7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -2,91 +2,91 @@
 + // MIR for `opt2` after EarlyOtherwiseBranch
   
   fn opt2(_1: Option<u32>, _2: Option<u32>) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch.rs:11:9: 11:10
-      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch.rs:11:25: 11:26
-      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch.rs:11:44: 11:47
-      let mut _3: (std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
-      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
-      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:12:15: 12:16
-      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
-      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:13:19: 13:26
-      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
-      let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
-      let _10: u32;                        // in scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
-+     let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+     let mut _12: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
+      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch.rs:+0:9: +0:10
+      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch.rs:+0:25: +0:26
+      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch.rs:+0:44: +0:47
+      let mut _3: (std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+3:16: +3:20
+      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:19: +2:26
+      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:10: +2:17
+      let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+      let _10: u32;                        // in scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
++     let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++     let mut _12: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       scope 1 {
-          debug a => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:13:15: 13:16
-          debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch.rs:13:24: 13:25
+          debug a => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
-          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:15: 12:16
-          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:12:15: 12:16
-          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:16: 12:17
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:16: 12:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
--         switchInt(move _8) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         _11 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         _12 = Ne(_8, move _11);          // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         switchInt(move _12) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
+          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
+          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         switchInt(move _8) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _11 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _12 = Ne(_8, move _11);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         switchInt(move _12) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   
       bb1: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
--         switchInt(move _6) -> [0_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
+-         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         switchInt(move _6) -> [0_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
 -     bb2: {
-+         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
-          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
++         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
+          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
+-         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+4:14: +4:15
       }
   
 -     bb3: {
--         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
--         switchInt(move _7) -> [1_isize: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
+-         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         switchInt(move _7) -> [1_isize: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
 -     bb4: {
 +     bb2: {
-          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
-          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
-          StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
-          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
-          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:13:31: 13:32
-          StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
-          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
+          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+-         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
       }
   
 -     bb5: {
 +     bb3: {
-          _0 = const 0_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
+          _0 = const 0_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+3:25: +3:26
+-         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:25: +3:26
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:25: +3:26
       }
   
 -     bb6: {
 +     bb4: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:17:1: 17:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch.rs:17:2: 17:2
+          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch.rs:+6:2: +6:2
 +     }
 + 
 +     bb5: {
-+         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         switchInt(_8) -> [0_isize: bb3, 1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         switchInt(_8) -> [0_isize: bb3, 1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -2,77 +2,77 @@
 + // MIR for `opt3` after EarlyOtherwiseBranch
   
   fn opt3(_1: Option<u32>, _2: Option<bool>) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch.rs:21:9: 21:10
-      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch.rs:21:25: 21:26
-      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch.rs:21:45: 21:48
-      let mut _3: (std::option::Option<u32>, std::option::Option<bool>); // in scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
-      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:22:12: 22:13
-      let mut _5: std::option::Option<bool>; // in scope 0 at $DIR/early_otherwise_branch.rs:22:15: 22:16
-      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:23:19: 23:26
-      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:23:10: 23:17
-      let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:23:15: 23:16
-      let _9: bool;                        // in scope 0 at $DIR/early_otherwise_branch.rs:23:24: 23:25
-+     let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+     let mut _11: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
+      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch.rs:+0:9: +0:10
+      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch.rs:+0:25: +0:26
+      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch.rs:+0:45: +0:48
+      let mut _3: (std::option::Option<u32>, std::option::Option<bool>); // in scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+      let mut _5: std::option::Option<bool>; // in scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:19: +2:26
+      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+2:10: +2:17
+      let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+      let _9: bool;                        // in scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
++     let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++     let mut _11: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       scope 1 {
-          debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch.rs:23:15: 23:16
-          debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:23:24: 23:25
+          debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:12: 22:13
-          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:22:12: 22:13
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:15: 22:16
-          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:22:15: 22:16
-          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
-          (_3.1: std::option::Option<bool>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:16: 22:17
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:16: 22:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
--         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+         _10 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
+          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:12: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:+1:15: +1:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          (_3.1: std::option::Option<bool>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:+1:16: +1:17
+          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _10 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         _11 = Ne(_7, move _10);          // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   
       bb1: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
-          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
++         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
+          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
+-         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
++         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+3:14: +3:15
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
--         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
+-         _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:+1:11: +1:17
+-         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
 -     }
 - 
 -     bb3: {
-          StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:23:15: 23:16
-          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:23:15: 23:16
-          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:23:24: 23:25
-          _9 = (((_3.1: std::option::Option<bool>) as Some).0: bool); // scope 0 at $DIR/early_otherwise_branch.rs:23:24: 23:25
-          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:23:31: 23:32
-          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:23:31: 23:32
-          StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:23:31: 23:32
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:23:31: 23:32
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:23:31: 23:32
+          StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:+2:15: +2:16
+          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _9 = (((_3.1: std::option::Option<bool>) as Some).0: bool); // scope 0 at $DIR/early_otherwise_branch.rs:+2:24: +2:25
+          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+          StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
+-         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
++         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:+2:31: +2:32
       }
   
 -     bb4: {
 +     bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:26:1: 26:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch.rs:26:2: 26:2
+          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch.rs:+5:2: +5:2
 +     }
 + 
 +     bb4: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
-+         switchInt(_7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
++         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
++         switchInt(_7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:+1:5: +1:17
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -2,99 +2,99 @@
 + // MIR for `opt1` after EarlyOtherwiseBranch
   
   fn opt1(_1: Option<u32>, _2: Option<u32>, _3: Option<u32>) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:4:9: 4:10
-      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:4:25: 4:26
-      debug z => _3;                       // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:4:41: 4:42
-      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:4:60: 4:63
-      let mut _4: (std::option::Option<u32>, std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:12: 5:13
-      let mut _6: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:15: 5:16
-      let mut _7: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:18: 5:19
-      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
-      let mut _9: isize;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
-      let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
-      let _11: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
-      let _12: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
-      let _13: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
-+     let mut _14: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+     let mut _15: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+     let mut _16: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+     let mut _17: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
+      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+0:9: +0:10
+      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+0:25: +0:26
+      debug z => _3;                       // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+0:41: +0:42
+      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+0:60: +0:63
+      let mut _4: (std::option::Option<u32>, std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:12: +1:13
+      let mut _6: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:15: +1:16
+      let mut _7: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:18: +1:19
+      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:28: +2:35
+      let mut _9: isize;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:19: +2:26
+      let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:10: +2:17
+      let _11: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
+      let _12: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
+      let _13: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
++     let mut _14: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++     let mut _15: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++     let mut _16: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++     let mut _17: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       scope 1 {
-          debug a => _11;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
-          debug b => _12;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
-          debug c => _13;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
+          debug a => _11;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
+          debug b => _12;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
+          debug c => _13;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
       }
   
       bb0: {
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:12: 5:13
-          _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:12: 5:13
-          StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:15: 5:16
-          _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:15: 5:16
-          StorageLive(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:18: 5:19
-          _7 = _3;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:18: 5:19
-          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-          (_4.0: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-          (_4.1: std::option::Option<u32>) = move _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-          (_4.2: std::option::Option<u32>) = move _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-          StorageDead(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
-          StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
-          _10 = discriminant((_4.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
--         switchInt(move _10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         _14 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         _15 = Ne(_10, move _14);         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         switchInt(move _15) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:12: +1:13
+          _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:12: +1:13
+          StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:15: +1:16
+          _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:15: +1:16
+          StorageLive(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:18: +1:19
+          _7 = _3;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:18: +1:19
+          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.0: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.1: std::option::Option<u32>) = move _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          (_4.2: std::option::Option<u32>) = move _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+          StorageDead(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
+          StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:19: +1:20
+          _10 = discriminant((_4.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+-         switchInt(move _10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         _14 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         _15 = Ne(_10, move _14);         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         switchInt(move _15) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       }
   
       bb1: {
-+         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
-+         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
-          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
--         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
++         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
++         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
+          _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
+-         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+3:14: +3:15
       }
   
       bb2: {
--         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
--         switchInt(move _9) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
+-         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+-         switchInt(move _9) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
 -     }
 - 
 -     bb3: {
-          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
--         switchInt(move _8) -> [1_isize: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         switchInt(move _8) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
+          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:11: +1:20
+-         switchInt(move _8) -> [1_isize: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         switchInt(move _8) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       }
   
 -     bb4: {
 +     bb3: {
-          StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
-          _11 = (((_4.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
-          StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
-          _12 = (((_4.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
-          StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
-          _13 = (((_4.2: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
-          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
-          StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
-          StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
-          StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
--         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
+          StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
+          _11 = (((_4.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:15: +2:16
+          StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
+          _12 = (((_4.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:24: +2:25
+          StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
+          _13 = (((_4.2: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:33: +2:34
+          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
+          StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
+          StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
+          StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
+-         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+2:40: +2:41
       }
   
 -     bb5: {
 +     bb4: {
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:2: 9:2
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+5:2: +5:2
 +     }
 + 
 +     bb5: {
-+         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         switchInt(_10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
++         switchInt(_10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:+1:5: +1:20
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
@@ -2,343 +2,343 @@
 + // MIR for `try_sum` after SimplifyConstCondition-final
   
   fn try_sum(_1: &ViewportPercentageLength, _2: &ViewportPercentageLength) -> Result<ViewportPercentageLength, ()> {
-      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_68867.rs:17:5: 17:6
-      debug other => _2;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:18:5: 18:10
-      let mut _0: std::result::Result<ViewportPercentageLength, ()>; // return place in scope 0 at $DIR/early_otherwise_branch_68867.rs:19:6: 19:42
-      let mut _3: ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-      let mut _4: (&ViewportPercentageLength, &ViewportPercentageLength); // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _5: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-      let mut _6: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
-      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:21: 23:30
-      let mut _9: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:23: 24:34
-      let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:23: 25:34
-      let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-      let _12: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-      let _13: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-      let mut _14: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
-      let mut _15: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
-      let mut _16: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
-      let _17: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-      let _18: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-      let mut _19: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
-      let mut _20: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
-      let mut _21: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
-      let _22: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-      let _23: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-      let mut _24: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
-      let mut _25: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
-      let mut _26: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
-      let _27: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-      let _28: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-      let mut _29: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
-      let mut _30: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
-      let mut _31: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
-      let mut _32: !;                      // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:14: 26:28
-      let mut _33: ();                     // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-      let mut _34: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _35: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _36: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _37: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _38: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _39: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _40: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _41: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _42: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _43: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _44: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _45: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _46: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+1:5: +1:6
+      debug other => _2;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+2:5: +2:10
+      let mut _0: std::result::Result<ViewportPercentageLength, ()>; // return place in scope 0 at $DIR/early_otherwise_branch_68867.rs:+3:6: +3:42
+      let mut _3: ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +11:6
+      let mut _4: (&ViewportPercentageLength, &ViewportPercentageLength); // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _5: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
+      let mut _6: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
+      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:21: +6:30
+      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:21: +7:30
+      let mut _9: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:23: +8:34
+      let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:23: +9:34
+      let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:11: +6:18
+      let _12: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+      let _13: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+      let mut _14: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+      let mut _15: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
+      let mut _16: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
+      let _17: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+      let _18: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+      let mut _19: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+      let mut _20: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
+      let mut _21: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
+      let _22: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+      let _23: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+      let mut _24: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+      let mut _25: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
+      let mut _26: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
+      let _27: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+      let _28: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+      let mut _29: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+      let mut _30: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
+      let mut _31: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
+      let mut _32: !;                      // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:14: +10:28
+      let mut _33: ();                     // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
+      let mut _34: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _35: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _36: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _37: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _38: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _39: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _40: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _41: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _42: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _43: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _44: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _45: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _46: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
       scope 1 {
--         debug one => _12;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
--         debug other => _13;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-+         debug one => _15;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-+         debug other => _16;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
+-         debug one => _12;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+-         debug other => _13;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
++         debug one => _15;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
++         debug other => _16;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
       }
       scope 2 {
--         debug one => _17;                // in scope 2 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
--         debug other => _18;              // in scope 2 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-+         debug one => _20;                // in scope 2 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-+         debug other => _21;              // in scope 2 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
+-         debug one => _17;                // in scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+-         debug other => _18;              // in scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
++         debug one => _20;                // in scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
++         debug other => _21;              // in scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
       }
       scope 3 {
--         debug one => _22;                // in scope 3 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
--         debug other => _23;              // in scope 3 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-+         debug one => _25;                // in scope 3 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-+         debug other => _26;              // in scope 3 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
+-         debug one => _22;                // in scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+-         debug other => _23;              // in scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
++         debug one => _25;                // in scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
++         debug other => _26;              // in scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
       }
       scope 4 {
--         debug one => _27;                // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
--         debug other => _28;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-+         debug one => _30;                // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-+         debug other => _31;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
+-         debug one => _27;                // in scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+-         debug other => _28;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
++         debug one => _30;                // in scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
++         debug other => _31;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
       }
   
       bb0: {
--         StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
--         StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
--         StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
--         _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-+         (_4.0: &ViewportPercentageLength) = _1; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-          StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-          _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
--         (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
--         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _34 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+-         StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +11:6
+-         StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+-         StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
+-         _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +11:6
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
++         (_4.0: &ViewportPercentageLength) = _1; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
+          StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
+          _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
+          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+-         (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
+-         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
+          StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _34 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb1: {
-          StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _35 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _35 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb2: {
-          StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
-          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
-          discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
-          StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
--         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
+          StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
+          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:27: +10:28
+-         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
+-         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
       }
   
       bb3: {
-          StorageLive(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _36 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _8 = discriminant((*_36));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _36 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _8 = discriminant((*_36));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb4: {
-          StorageLive(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _37 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _9 = discriminant((*_37));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _37 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _9 = discriminant((*_37));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb5: {
-          StorageLive(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _38 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _10 = discriminant((*_38));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _38 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _10 = discriminant((*_38));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb6: {
--         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          StorageLive(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          _39 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
--         _12 = (((*_39) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-+         _15 = (((*_39) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          StorageDead(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
--         StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          StorageLive(_40);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          _40 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
--         _13 = (((*_40) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-+         _16 = (((*_40) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          StorageDead(_40);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
--         StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
--         StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
--         _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
--         StorageLive(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
--         _16 = _13;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
--         _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
--         StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
--         StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
--         Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
--         ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
--         discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
--         StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
--         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
--         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
-+         ((((_0 as Ok).0: ViewportPercentageLength) as Vw).0: f32) = Add(move _15, move _16); // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
-+         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
-+         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 0; // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
-+         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
+-         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          StorageLive(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          _39 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+-         _12 = (((*_39) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
++         _15 = (((*_39) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          StorageDead(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+-         StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          StorageLive(_40);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          _40 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+-         _13 = (((*_40) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
++         _16 = (((*_40) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          StorageDead(_40);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+-         StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+-         StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
+-         _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
+-         StorageLive(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
+-         _16 = _13;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
+-         _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+-         StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
+-         StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
+-         Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+-         ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+-         discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+-         StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
+-         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
+-         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
++         ((((_0 as Ok).0: ViewportPercentageLength) as Vw).0: f32) = Add(move _15, move _16); // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
++         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 0; // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
++         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
       }
   
       bb7: {
--         StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          StorageLive(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          _41 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
--         _17 = (((*_41) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-+         _20 = (((*_41) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          StorageDead(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
--         StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          StorageLive(_42);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          _42 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
--         _18 = (((*_42) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-+         _21 = (((*_42) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          StorageDead(_42);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
--         StorageLive(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
--         StorageLive(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
--         _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
--         StorageLive(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
--         _21 = _18;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
--         _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
--         StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
--         StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
--         Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
--         ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
--         discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
--         StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
--         StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
--         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
-+         ((((_0 as Ok).0: ViewportPercentageLength) as Vh).0: f32) = Add(move _20, move _21); // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
-+         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
-+         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 1; // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
-+         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
+-         StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          StorageLive(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          _41 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+-         _17 = (((*_41) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
++         _20 = (((*_41) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          StorageDead(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+-         StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          StorageLive(_42);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          _42 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+-         _18 = (((*_42) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
++         _21 = (((*_42) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          StorageDead(_42);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+-         StorageLive(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+-         StorageLive(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
+-         _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
+-         StorageLive(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
+-         _21 = _18;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
+-         _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+-         StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
+-         StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
+-         Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+-         ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+-         discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+-         StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
+-         StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
+-         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
++         ((((_0 as Ok).0: ViewportPercentageLength) as Vh).0: f32) = Add(move _20, move _21); // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
++         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 1; // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
++         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
       }
   
       bb8: {
--         StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          StorageLive(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          _43 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
--         _22 = (((*_43) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-+         _25 = (((*_43) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          StorageDead(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
--         StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          StorageLive(_44);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          _44 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
--         _23 = (((*_44) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-+         _26 = (((*_44) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          StorageDead(_44);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
--         StorageLive(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
--         StorageLive(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
--         _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
--         StorageLive(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
--         _26 = _23;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
--         _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
--         StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
--         StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
--         Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
--         ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
--         discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
--         StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
--         StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
--         StorageDead(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
-+         ((((_0 as Ok).0: ViewportPercentageLength) as Vmin).0: f32) = Add(move _25, move _26); // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
-+         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
-+         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 2; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
-+         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
+-         StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          StorageLive(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          _43 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+-         _22 = (((*_43) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
++         _25 = (((*_43) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          StorageDead(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+-         StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          StorageLive(_44);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          _44 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+-         _23 = (((*_44) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
++         _26 = (((*_44) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          StorageDead(_44);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+-         StorageLive(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+-         StorageLive(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
+-         _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
+-         StorageLive(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
+-         _26 = _23;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
+-         _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+-         StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
+-         StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
+-         Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+-         ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+-         discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+-         StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
+-         StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
+-         StorageDead(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
++         ((((_0 as Ok).0: ViewportPercentageLength) as Vmin).0: f32) = Add(move _25, move _26); // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
++         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 2; // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
++         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
       }
   
       bb9: {
--         StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          StorageLive(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          _45 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
--         _27 = (((*_45) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-+         _30 = (((*_45) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          StorageDead(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
--         StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          StorageLive(_46);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          _46 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
--         _28 = (((*_46) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-+         _31 = (((*_46) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          StorageDead(_46);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
--         StorageLive(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
--         StorageLive(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
--         _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
--         StorageLive(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
--         _31 = _28;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
--         _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
--         StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
--         StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
--         Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
--         ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
--         discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
--         StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
--         StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
--         StorageDead(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
-+         ((((_0 as Ok).0: ViewportPercentageLength) as Vmax).0: f32) = Add(move _30, move _31); // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
-+         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
-+         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 3; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
-+         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
+-         StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          StorageLive(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          _45 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+-         _27 = (((*_45) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
++         _30 = (((*_45) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          StorageDead(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+-         StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          StorageLive(_46);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          _46 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+-         _28 = (((*_46) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
++         _31 = (((*_46) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          StorageDead(_46);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+-         StorageLive(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+-         StorageLive(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
+-         _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
+-         StorageLive(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
+-         _31 = _28;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
+-         _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+-         StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
+-         StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
+-         Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+-         ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+-         discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+-         StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
+-         StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
+-         StorageDead(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
++         ((((_0 as Ok).0: ViewportPercentageLength) as Vmax).0: f32) = Add(move _30, move _31); // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
++         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 3; // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
++         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
       }
   
       bb10: {
-          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
--         ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-          discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
--         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+-         ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+          discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+-         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
+-         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -2,252 +2,252 @@
 + // MIR for `try_sum` after EarlyOtherwiseBranch
   
   fn try_sum(_1: &ViewportPercentageLength, _2: &ViewportPercentageLength) -> Result<ViewportPercentageLength, ()> {
-      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_68867.rs:17:5: 17:6
-      debug other => _2;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:18:5: 18:10
-      let mut _0: std::result::Result<ViewportPercentageLength, ()>; // return place in scope 0 at $DIR/early_otherwise_branch_68867.rs:19:6: 19:42
-      let mut _3: ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-      let mut _4: (&ViewportPercentageLength, &ViewportPercentageLength); // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _5: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-      let mut _6: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
-      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:21: 23:30
-      let mut _9: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:23: 24:34
-      let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:23: 25:34
-      let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-      let _12: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-      let _13: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-      let mut _14: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
-      let mut _15: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
-      let mut _16: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
-      let _17: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-      let _18: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-      let mut _19: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
-      let mut _20: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
-      let mut _21: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
-      let _22: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-      let _23: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-      let mut _24: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
-      let mut _25: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
-      let mut _26: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
-      let _27: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-      let _28: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-      let mut _29: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
-      let mut _30: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
-      let mut _31: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
-      let mut _32: !;                      // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:14: 26:28
-      let mut _33: ();                     // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-      let mut _34: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _35: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _36: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _37: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _38: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _39: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _40: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _41: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _42: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _43: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _44: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _45: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-      let mut _46: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+1:5: +1:6
+      debug other => _2;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+2:5: +2:10
+      let mut _0: std::result::Result<ViewportPercentageLength, ()>; // return place in scope 0 at $DIR/early_otherwise_branch_68867.rs:+3:6: +3:42
+      let mut _3: ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +11:6
+      let mut _4: (&ViewportPercentageLength, &ViewportPercentageLength); // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _5: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
+      let mut _6: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
+      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:21: +6:30
+      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:21: +7:30
+      let mut _9: isize;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:23: +8:34
+      let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:23: +9:34
+      let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:11: +6:18
+      let _12: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+      let _13: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+      let mut _14: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+      let mut _15: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
+      let mut _16: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
+      let _17: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+      let _18: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+      let mut _19: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+      let mut _20: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
+      let mut _21: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
+      let _22: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+      let _23: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+      let mut _24: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+      let mut _25: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
+      let mut _26: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
+      let _27: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+      let _28: f32;                        // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+      let mut _29: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+      let mut _30: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
+      let mut _31: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
+      let mut _32: !;                      // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:14: +10:28
+      let mut _33: ();                     // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
+      let mut _34: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _35: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _36: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _37: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _38: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _39: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _40: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _41: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _42: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _43: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _44: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _45: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+      let mut _46: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
       scope 1 {
-          debug one => _12;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          debug other => _13;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
+          debug one => _12;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          debug other => _13;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
       }
       scope 2 {
-          debug one => _17;                // in scope 2 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          debug other => _18;              // in scope 2 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
+          debug one => _17;                // in scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          debug other => _18;              // in scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
       }
       scope 3 {
-          debug one => _22;                // in scope 3 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          debug other => _23;              // in scope 3 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
+          debug one => _22;                // in scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          debug other => _23;              // in scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
       }
       scope 4 {
-          debug one => _27;                // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          debug other => _28;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
+          debug one => _27;                // in scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          debug other => _28;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-          _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-          StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-          _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _34 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +11:6
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
+          _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:15: +5:16
+          StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
+          _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:18: +5:23
+          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:23: +5:24
+          StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _34 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb1: {
-          StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _35 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _35 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb2: {
-          StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
-          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
-          discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
-          StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
+          StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
+          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:25: +10:27
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:21: +10:28
+          StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+10:27: +10:28
+          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
       }
   
       bb3: {
-          StorageLive(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _36 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _8 = discriminant((*_36));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _36 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _8 = discriminant((*_36));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb4: {
-          StorageLive(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _37 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _9 = discriminant((*_37));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _37 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _9 = discriminant((*_37));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb5: {
-          StorageLive(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _38 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          _10 = discriminant((*_38));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-          switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+          StorageLive(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _38 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          _10 = discriminant((*_38));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:14: +5:24
+          StorageDead(_38);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
+          switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:8: +5:24
       }
   
       bb6: {
-          StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          StorageLive(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          _39 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          _12 = (((*_39) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          StorageDead(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          StorageLive(_40);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          _40 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          _13 = (((*_40) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          StorageDead(_40);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
-          StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
-          StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
-          _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
-          StorageLive(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
-          _16 = _13;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
-          _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
-          StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
-          StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
-          Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
-          ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
-          discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
-          StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-          StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-          StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
+          StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          StorageLive(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          _39 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          _12 = (((*_39) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:14: +6:17
+          StorageDead(_39);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          StorageLive(_40);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          _40 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          _13 = (((*_40) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:24: +6:29
+          StorageDead(_40);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+          StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+          StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
+          _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:41
+          StorageLive(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
+          _16 = _13;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:44: +6:49
+          _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:38: +6:49
+          StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
+          StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:48: +6:49
+          Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+          ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+          discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:35: +6:50
+          StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
+          StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
+          StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+6:49: +6:50
       }
   
       bb7: {
-          StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          StorageLive(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          _41 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          _17 = (((*_41) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          StorageDead(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          StorageLive(_42);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          _42 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          _18 = (((*_42) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          StorageDead(_42);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
-          StorageLive(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
-          StorageLive(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
-          _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
-          StorageLive(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
-          _21 = _18;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:44: 23:49
-          _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
-          StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
-          StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
-          Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
-          ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
-          discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
-          StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-          StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-          StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
+          StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          StorageLive(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          _41 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          _17 = (((*_41) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:14: +7:17
+          StorageDead(_41);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          StorageLive(_42);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          _42 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          _18 = (((*_42) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:24: +7:29
+          StorageDead(_42);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+          StorageLive(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+          StorageLive(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
+          _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:41
+          StorageLive(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
+          _21 = _18;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:44: +7:49
+          _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:38: +7:49
+          StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
+          StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:48: +7:49
+          Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+          ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+          discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:35: +7:50
+          StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
+          StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
+          StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+7:49: +7:50
       }
   
       bb8: {
-          StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          StorageLive(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          _43 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          _22 = (((*_43) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          StorageDead(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          StorageLive(_44);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          _44 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          _23 = (((*_44) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          StorageDead(_44);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
-          StorageLive(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
-          StorageLive(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
-          _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
-          StorageLive(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
-          _26 = _23;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:50: 24:55
-          _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
-          StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
-          StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
-          Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
-          ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
-          discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
-          StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-          StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-          StorageDead(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
+          StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          StorageLive(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          _43 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          _22 = (((*_43) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:16: +8:19
+          StorageDead(_43);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          StorageLive(_44);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          _44 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          _23 = (((*_44) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:28: +8:33
+          StorageDead(_44);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+          StorageLive(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+          StorageLive(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
+          _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:47
+          StorageLive(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
+          _26 = _23;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:50: +8:55
+          _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:44: +8:55
+          StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
+          StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:54: +8:55
+          Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+          ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+          discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:39: +8:56
+          StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
+          StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
+          StorageDead(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+8:55: +8:56
       }
   
       bb9: {
-          StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          StorageLive(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          _45 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          _27 = (((*_45) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          StorageDead(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          StorageLive(_46);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          _46 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          _28 = (((*_46) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          StorageDead(_46);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
-          StorageLive(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
-          StorageLive(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
-          _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
-          StorageLive(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
-          _31 = _28;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
-          _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
-          StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
-          StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
-          Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
-          ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
-          discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
-          StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-          StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-          StorageDead(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
+          StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          StorageLive(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          _45 = deref_copy (_4.0: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          _27 = (((*_45) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:16: +9:19
+          StorageDead(_45);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          StorageLive(_46);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          _46 = deref_copy (_4.1: &ViewportPercentageLength); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          _28 = (((*_46) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:28: +9:33
+          StorageDead(_46);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+          StorageLive(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+          StorageLive(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
+          _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:47
+          StorageLive(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
+          _31 = _28;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:50: +9:55
+          _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:44: +9:55
+          StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
+          StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:54: +9:55
+          Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+          ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+          discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:39: +9:56
+          StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
+          StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
+          StorageDead(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
+          goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:+9:55: +9:56
       }
   
       bb10: {
-          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-          ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-          discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+          ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+          discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:+5:5: +11:7
+          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+11:6: +11:7
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:1: +12:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:+12:2: +12:2
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -2,94 +2,94 @@
 + // MIR for `noopt1` after EarlyOtherwiseBranch
   
   fn noopt1(_1: Option<u32>, _2: Option<u32>) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:7:11: 7:12
-      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:7:27: 7:28
-      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch_noopt.rs:7:46: 7:49
-      let mut _3: (std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
-      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:15: 8:16
-      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:16: 11:23
-      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:19: 9:26
-      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:10: 9:17
-      let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
-      let _10: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
-      let _11: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
-      let _12: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
+      debug x => _1;                       // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+0:11: +0:12
+      debug y => _2;                       // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+0:27: +0:28
+      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+0:46: +0:49
+      let mut _3: (std::option::Option<u32>, std::option::Option<u32>); // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+      let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:12: +1:13
+      let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:15: +1:16
+      let mut _6: isize;                   // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:16: +4:23
+      let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:19: +2:26
+      let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:10: +2:17
+      let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:15: +2:16
+      let _10: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:24: +2:25
+      let _11: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:15: +3:16
+      let _12: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:21: +4:22
       scope 1 {
-          debug a => _9;                   // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
-          debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
+          debug a => _9;                   // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:+2:15: +2:16
+          debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:+2:24: +2:25
       }
       scope 2 {
-          debug a => _11;                  // in scope 2 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
+          debug a => _11;                  // in scope 2 at $DIR/early_otherwise_branch_noopt.rs:+3:15: +3:16
       }
       scope 3 {
-          debug b => _12;                  // in scope 3 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
+          debug b => _12;                  // in scope 3 at $DIR/early_otherwise_branch_noopt.rs:+4:21: +4:22
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
-          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:15: 8:16
-          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:15: 8:16
-          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:16: 8:17
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:16: 8:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          switchInt(move _8) -> [0_isize: bb1, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
+          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:12: +1:13
+          _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:12: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:15: +1:16
+          _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:15: +1:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:16: +1:17
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:16: +1:17
+          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          switchInt(move _8) -> [0_isize: bb1, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb1: {
-          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          switchInt(move _6) -> [0_isize: bb2, 1_isize: bb7, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
+          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          switchInt(move _6) -> [0_isize: bb2, 1_isize: bb7, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb2: {
-          _0 = const 3_u32;                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:12:25: 12:26
-          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:12:25: 12:26
+          _0 = const 3_u32;                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+5:25: +5:26
+          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+5:25: +5:26
       }
   
       bb3: {
-          unreachable;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          unreachable;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
       }
   
       bb4: {
-          _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          switchInt(move _7) -> [0_isize: bb6, 1_isize: bb5, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
+          _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:11: +1:17
+          switchInt(move _7) -> [0_isize: bb6, 1_isize: bb5, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+1:5: +1:17
       }
   
       bb5: {
-          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
-          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
-          StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
-          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
-          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
-          StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
-          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
-          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
+          StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:15: +2:16
+          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:15: +2:16
+          StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:24: +2:25
+          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:24: +2:25
+          _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_noopt.rs:+2:31: +2:32
+          StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:31: +2:32
+          StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:31: +2:32
+          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+2:31: +2:32
       }
   
       bb6: {
-          StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
-          _11 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
-          _0 = const 1_u32;                // scope 2 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
-          StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
-          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
+          StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:15: +3:16
+          _11 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:15: +3:16
+          _0 = const 1_u32;                // scope 2 at $DIR/early_otherwise_branch_noopt.rs:+3:28: +3:29
+          StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:28: +3:29
+          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+3:28: +3:29
       }
   
       bb7: {
-          StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
-          _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
-          _0 = const 2_u32;                // scope 3 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
-          StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
-          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
+          StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:21: +4:22
+          _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:21: +4:22
+          _0 = const 2_u32;                // scope 3 at $DIR/early_otherwise_branch_noopt.rs:+4:28: +4:29
+          StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:28: +4:29
+          goto -> bb8;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+4:28: +4:29
       }
   
       bb8: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:1: 14:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:2: 14:2
+          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+7:1: +7:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:+7:2: +7:2
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
@@ -2,46 +2,46 @@
 + // MIR for `no_deref_ptr` after EarlyOtherwiseBranch
   
   fn no_deref_ptr(_1: Option<i32>, _2: *const Option<i32>) -> i32 {
-      debug a => _1;                       // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:18:24: 18:25
-      debug b => _2;                       // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:18:40: 18:41
-      let mut _0: i32;                     // return place in scope 0 at $DIR/early_otherwise_branch_soundness.rs:18:66: 18:69
-      let mut _3: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:21:9: 21:16
-      let mut _4: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:13: 22:20
-      let _5: i32;                         // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:18: 22:19
+      debug a => _1;                       // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:24: +0:25
+      debug b => _2;                       // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:40: +0:41
+      let mut _0: i32;                     // return place in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:66: +0:69
+      let mut _3: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+3:9: +3:16
+      let mut _4: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:13: +4:20
+      let _5: i32;                         // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
       scope 1 {
-          debug v => _5;                   // in scope 1 at $DIR/early_otherwise_branch_soundness.rs:22:18: 22:19
+          debug v => _5;                   // in scope 1 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
       }
   
       bb0: {
-          _3 = discriminant(_1);           // scope 0 at $DIR/early_otherwise_branch_soundness.rs:19:11: 19:12
-          switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:19:5: 19:12
+          _3 = discriminant(_1);           // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:11: +1:12
+          switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:25:14: 25:15
-          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:25:14: 25:15
+          _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+7:14: +7:15
+          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+7:14: +7:15
       }
   
       bb2: {
-          _4 = discriminant((*_2));        // scope 0 at $DIR/early_otherwise_branch_soundness.rs:21:26: 21:28
-          switchInt(move _4) -> [1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:21:20: 21:28
+          _4 = discriminant((*_2));        // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+3:26: +3:28
+          switchInt(move _4) -> [1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+3:20: +3:28
       }
   
       bb3: {
-          _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:23:18: 23:19
-          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:23:18: 23:19
+          _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+5:18: +5:19
+          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+5:18: +5:19
       }
   
       bb4: {
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:18: 22:19
-          _5 = (((*_2) as Some).0: i32);   // scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:18: 22:19
-          _0 = _5;                         // scope 1 at $DIR/early_otherwise_branch_soundness.rs:22:24: 22:25
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:24: 22:25
-          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:24: 22:25
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
+          _5 = (((*_2) as Some).0: i32);   // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:18: +4:19
+          _0 = _5;                         // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
+          goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+4:24: +4:25
       }
   
       bb5: {
-          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:27:2: 27:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+9:2: +9:2
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
@@ -2,39 +2,39 @@
 + // MIR for `no_downcast` after EarlyOtherwiseBranch
   
   fn no_downcast(_1: &E) -> u32 {
-      debug e => _1;                       // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:12:16: 12:17
-      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch_soundness.rs:12:26: 12:29
-      let mut _2: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:20: 13:30
-      let mut _3: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
-      let mut _4: &E;                      // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:12:16: 12:17
+      debug e => _1;                       // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:16: +0:17
+      let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:26: +0:29
+      let mut _2: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:20: +1:30
+      let mut _3: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+      let mut _4: &E;                      // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:16: +0:17
       scope 1 {
       }
   
       bb0: {
-          _3 = discriminant((*_1));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
-          switchInt(move _3) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
+          _3 = discriminant((*_1));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          switchInt(move _3) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
       }
   
       bb1: {
-          StorageLive(_4);                 // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
-          _4 = deref_copy (((*_1) as Some).0: &E); // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
-          _2 = discriminant((*_4));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
-          StorageDead(_4);                 // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
-          switchInt(move _2) -> [1_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
+          StorageLive(_4);                 // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          _4 = deref_copy (((*_1) as Some).0: &E); // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          _2 = discriminant((*_4));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          StorageDead(_4);                 // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          switchInt(move _2) -> [1_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 1 at $DIR/early_otherwise_branch_soundness.rs:13:38: 13:39
-          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:5: 13:52
+          _0 = const 1_u32;                // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:38: +1:39
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:52
       }
   
       bb3: {
-          _0 = const 2_u32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:49: 13:50
-          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:5: 13:52
+          _0 = const 2_u32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:49: +1:50
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:5: +1:52
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:14:2: 14:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/enum_cast.bar.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.bar.mir_map.0.mir
@@ -1,13 +1,13 @@
 // MIR for `bar` 0 mir_map
 
 fn bar(_1: Bar) -> usize {
-    debug bar => _1;                     // in scope 0 at $DIR/enum_cast.rs:22:8: 22:11
-    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:22:21: 22:26
-    let mut _2: isize;                   // in scope 0 at $DIR/enum_cast.rs:23:5: 23:8
+    debug bar => _1;                     // in scope 0 at $DIR/enum_cast.rs:+0:8: +0:11
+    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:+0:21: +0:26
+    let mut _2: isize;                   // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
 
     bb0: {
-        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:23:5: 23:17
-        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:23:5: 23:17
-        return;                          // scope 0 at $DIR/enum_cast.rs:24:2: 24:2
+        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/enum_cast.boo.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.boo.mir_map.0.mir
@@ -1,13 +1,13 @@
 // MIR for `boo` 0 mir_map
 
 fn boo(_1: Boo) -> usize {
-    debug boo => _1;                     // in scope 0 at $DIR/enum_cast.rs:26:8: 26:11
-    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:26:21: 26:26
-    let mut _2: u8;                      // in scope 0 at $DIR/enum_cast.rs:27:5: 27:8
+    debug boo => _1;                     // in scope 0 at $DIR/enum_cast.rs:+0:8: +0:11
+    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:+0:21: +0:26
+    let mut _2: u8;                      // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
 
     bb0: {
-        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:27:5: 27:17
-        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:27:5: 27:17
-        return;                          // scope 0 at $DIR/enum_cast.rs:28:2: 28:2
+        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/enum_cast.droppy.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.droppy.mir_map.0.mir
@@ -1,54 +1,54 @@
 // MIR for `droppy` 0 mir_map
 
 fn droppy() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/enum_cast.rs:39:13: 39:13
-    let _1: ();                          // in scope 0 at $DIR/enum_cast.rs:40:5: 45:6
-    let _2: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:41:13: 41:14
-    let mut _4: isize;                   // in scope 0 at $DIR/enum_cast.rs:44:17: 44:18
-    let _5: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:46:9: 46:10
+    let mut _0: ();                      // return place in scope 0 at $DIR/enum_cast.rs:+0:13: +0:13
+    let _1: ();                          // in scope 0 at $DIR/enum_cast.rs:+1:5: +6:6
+    let _2: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:+2:13: +2:14
+    let mut _4: isize;                   // in scope 0 at $DIR/enum_cast.rs:+5:17: +5:18
+    let _5: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
     scope 1 {
-        debug x => _2;                   // in scope 1 at $DIR/enum_cast.rs:41:13: 41:14
+        debug x => _2;                   // in scope 1 at $DIR/enum_cast.rs:+2:13: +2:14
         scope 2 {
-            debug y => _3;               // in scope 2 at $DIR/enum_cast.rs:44:13: 44:14
+            debug y => _3;               // in scope 2 at $DIR/enum_cast.rs:+5:13: +5:14
         }
         scope 3 {
-            let _3: usize;               // in scope 3 at $DIR/enum_cast.rs:44:13: 44:14
+            let _3: usize;               // in scope 3 at $DIR/enum_cast.rs:+5:13: +5:14
         }
     }
     scope 4 {
-        debug z => _5;                   // in scope 4 at $DIR/enum_cast.rs:46:9: 46:10
+        debug z => _5;                   // in scope 4 at $DIR/enum_cast.rs:+7:9: +7:10
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/enum_cast.rs:40:5: 45:6
-        StorageLive(_2);                 // scope 0 at $DIR/enum_cast.rs:41:13: 41:14
-        _2 = Droppy::C;                  // scope 0 at $DIR/enum_cast.rs:41:17: 41:26
-        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/enum_cast.rs:41:13: 41:14
-        StorageLive(_3);                 // scope 3 at $DIR/enum_cast.rs:44:13: 44:14
-        _4 = discriminant(_2);           // scope 3 at $DIR/enum_cast.rs:44:17: 44:27
-        _3 = move _4 as usize (Misc);    // scope 3 at $DIR/enum_cast.rs:44:17: 44:27
-        FakeRead(ForLet(None), _3);      // scope 3 at $DIR/enum_cast.rs:44:13: 44:14
-        _1 = const ();                   // scope 0 at $DIR/enum_cast.rs:40:5: 45:6
-        StorageDead(_3);                 // scope 1 at $DIR/enum_cast.rs:45:5: 45:6
-        drop(_2) -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/enum_cast.rs:45:5: 45:6
+        StorageLive(_1);                 // scope 0 at $DIR/enum_cast.rs:+1:5: +6:6
+        StorageLive(_2);                 // scope 0 at $DIR/enum_cast.rs:+2:13: +2:14
+        _2 = Droppy::C;                  // scope 0 at $DIR/enum_cast.rs:+2:17: +2:26
+        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/enum_cast.rs:+2:13: +2:14
+        StorageLive(_3);                 // scope 3 at $DIR/enum_cast.rs:+5:13: +5:14
+        _4 = discriminant(_2);           // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
+        _3 = move _4 as usize (Misc);    // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
+        FakeRead(ForLet(None), _3);      // scope 3 at $DIR/enum_cast.rs:+5:13: +5:14
+        _1 = const ();                   // scope 0 at $DIR/enum_cast.rs:+1:5: +6:6
+        StorageDead(_3);                 // scope 1 at $DIR/enum_cast.rs:+6:5: +6:6
+        drop(_2) -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/enum_cast.rs:+6:5: +6:6
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 0 at $DIR/enum_cast.rs:45:5: 45:6
-        StorageDead(_1);                 // scope 0 at $DIR/enum_cast.rs:45:5: 45:6
-        StorageLive(_5);                 // scope 0 at $DIR/enum_cast.rs:46:9: 46:10
-        _5 = Droppy::B;                  // scope 0 at $DIR/enum_cast.rs:46:13: 46:22
-        FakeRead(ForLet(None), _5);      // scope 0 at $DIR/enum_cast.rs:46:9: 46:10
-        _0 = const ();                   // scope 0 at $DIR/enum_cast.rs:39:13: 47:2
-        drop(_5) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/enum_cast.rs:47:1: 47:2
+        StorageDead(_2);                 // scope 0 at $DIR/enum_cast.rs:+6:5: +6:6
+        StorageDead(_1);                 // scope 0 at $DIR/enum_cast.rs:+6:5: +6:6
+        StorageLive(_5);                 // scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
+        _5 = Droppy::B;                  // scope 0 at $DIR/enum_cast.rs:+7:13: +7:22
+        FakeRead(ForLet(None), _5);      // scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
+        _0 = const ();                   // scope 0 at $DIR/enum_cast.rs:+0:13: +8:2
+        drop(_5) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/enum_cast.rs:+8:1: +8:2
     }
 
     bb2: {
-        StorageDead(_5);                 // scope 0 at $DIR/enum_cast.rs:47:1: 47:2
-        return;                          // scope 0 at $DIR/enum_cast.rs:47:2: 47:2
+        StorageDead(_5);                 // scope 0 at $DIR/enum_cast.rs:+8:1: +8:2
+        return;                          // scope 0 at $DIR/enum_cast.rs:+8:2: +8:2
     }
 
     bb3 (cleanup): {
-        resume;                          // scope 0 at $DIR/enum_cast.rs:39:1: 47:2
+        resume;                          // scope 0 at $DIR/enum_cast.rs:+0:1: +8:2
     }
 }

--- a/src/test/mir-opt/enum_cast.foo.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.foo.mir_map.0.mir
@@ -1,13 +1,13 @@
 // MIR for `foo` 0 mir_map
 
 fn foo(_1: Foo) -> usize {
-    debug foo => _1;                     // in scope 0 at $DIR/enum_cast.rs:18:8: 18:11
-    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:18:21: 18:26
-    let mut _2: isize;                   // in scope 0 at $DIR/enum_cast.rs:19:5: 19:8
+    debug foo => _1;                     // in scope 0 at $DIR/enum_cast.rs:+0:8: +0:11
+    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:+0:21: +0:26
+    let mut _2: isize;                   // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
 
     bb0: {
-        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:19:5: 19:17
-        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:19:5: 19:17
-        return;                          // scope 0 at $DIR/enum_cast.rs:20:2: 20:2
+        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/equal_true.opt.InstCombine.diff
+++ b/src/test/mir-opt/equal_true.opt.InstCombine.diff
@@ -2,34 +2,34 @@
 + // MIR for `opt` after InstCombine
   
   fn opt(_1: bool) -> i32 {
-      debug x => _1;                       // in scope 0 at $DIR/equal_true.rs:3:8: 3:9
-      let mut _0: i32;                     // return place in scope 0 at $DIR/equal_true.rs:3:20: 3:23
-      let mut _2: bool;                    // in scope 0 at $DIR/equal_true.rs:4:8: 4:17
-      let mut _3: bool;                    // in scope 0 at $DIR/equal_true.rs:4:8: 4:9
+      debug x => _1;                       // in scope 0 at $DIR/equal_true.rs:+0:8: +0:9
+      let mut _0: i32;                     // return place in scope 0 at $DIR/equal_true.rs:+0:20: +0:23
+      let mut _2: bool;                    // in scope 0 at $DIR/equal_true.rs:+1:8: +1:17
+      let mut _3: bool;                    // in scope 0 at $DIR/equal_true.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/equal_true.rs:4:8: 4:17
-          StorageLive(_3);                 // scope 0 at $DIR/equal_true.rs:4:8: 4:9
-          _3 = _1;                         // scope 0 at $DIR/equal_true.rs:4:8: 4:9
--         _2 = Eq(move _3, const true);    // scope 0 at $DIR/equal_true.rs:4:8: 4:17
-+         _2 = move _3;                    // scope 0 at $DIR/equal_true.rs:4:8: 4:17
-          StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:4:16: 4:17
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:4:8: 4:17
+          StorageLive(_2);                 // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
+          StorageLive(_3);                 // scope 0 at $DIR/equal_true.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/equal_true.rs:+1:8: +1:9
+-         _2 = Eq(move _3, const true);    // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
++         _2 = move _3;                    // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
+          StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:+1:16: +1:17
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
       }
   
       bb1: {
-          _0 = const 0_i32;                // scope 0 at $DIR/equal_true.rs:4:20: 4:21
-          goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:4:5: 4:34
+          _0 = const 0_i32;                // scope 0 at $DIR/equal_true.rs:+1:20: +1:21
+          goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:+1:5: +1:34
       }
   
       bb2: {
-          _0 = const 1_i32;                // scope 0 at $DIR/equal_true.rs:4:31: 4:32
-          goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:4:5: 4:34
+          _0 = const 1_i32;                // scope 0 at $DIR/equal_true.rs:+1:31: +1:32
+          goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:+1:5: +1:34
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/equal_true.rs:4:33: 4:34
-          return;                          // scope 0 at $DIR/equal_true.rs:5:2: 5:2
+          StorageDead(_2);                 // scope 0 at $DIR/equal_true.rs:+1:33: +1:34
+          return;                          // scope 0 at $DIR/equal_true.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
@@ -1,83 +1,83 @@
 // MIR for `match_tuple` after SimplifyCfg-initial
 
 fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
-    debug x => _1;                       // in scope 0 at $DIR/exponential-or.rs:4:16: 4:17
-    let mut _0: u32;                     // return place in scope 0 at $DIR/exponential-or.rs:4:53: 4:56
-    let mut _2: isize;                   // in scope 0 at $DIR/exponential-or.rs:6:37: 6:48
-    let mut _3: bool;                    // in scope 0 at $DIR/exponential-or.rs:6:70: 6:77
-    let mut _4: bool;                    // in scope 0 at $DIR/exponential-or.rs:6:70: 6:77
-    let mut _5: bool;                    // in scope 0 at $DIR/exponential-or.rs:6:62: 6:67
-    let mut _6: bool;                    // in scope 0 at $DIR/exponential-or.rs:6:62: 6:67
-    let _7: u32;                         // in scope 0 at $DIR/exponential-or.rs:6:10: 6:21
-    let _8: u32;                         // in scope 0 at $DIR/exponential-or.rs:6:57: 6:78
-    let mut _9: u32;                     // in scope 0 at $DIR/exponential-or.rs:6:83: 6:84
-    let mut _10: u32;                    // in scope 0 at $DIR/exponential-or.rs:6:87: 6:88
+    debug x => _1;                       // in scope 0 at $DIR/exponential-or.rs:+0:16: +0:17
+    let mut _0: u32;                     // return place in scope 0 at $DIR/exponential-or.rs:+0:53: +0:56
+    let mut _2: isize;                   // in scope 0 at $DIR/exponential-or.rs:+2:37: +2:48
+    let mut _3: bool;                    // in scope 0 at $DIR/exponential-or.rs:+2:70: +2:77
+    let mut _4: bool;                    // in scope 0 at $DIR/exponential-or.rs:+2:70: +2:77
+    let mut _5: bool;                    // in scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
+    let mut _6: bool;                    // in scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
+    let _7: u32;                         // in scope 0 at $DIR/exponential-or.rs:+2:10: +2:21
+    let _8: u32;                         // in scope 0 at $DIR/exponential-or.rs:+2:57: +2:78
+    let mut _9: u32;                     // in scope 0 at $DIR/exponential-or.rs:+2:83: +2:84
+    let mut _10: u32;                    // in scope 0 at $DIR/exponential-or.rs:+2:87: +2:88
     scope 1 {
-        debug y => _7;                   // in scope 1 at $DIR/exponential-or.rs:6:10: 6:21
-        debug z => _8;                   // in scope 1 at $DIR/exponential-or.rs:6:57: 6:78
+        debug y => _7;                   // in scope 1 at $DIR/exponential-or.rs:+2:10: +2:21
+        debug z => _8;                   // in scope 1 at $DIR/exponential-or.rs:+2:57: +2:78
     }
 
     bb0: {
-        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/exponential-or.rs:5:11: 5:12
-        switchInt((_1.0: u32)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:15: 6:20
+        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/exponential-or.rs:+1:11: +1:12
+        switchInt((_1.0: u32)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:+2:15: +2:20
     }
 
     bb1: {
-        _0 = const 0_u32;                // scope 0 at $DIR/exponential-or.rs:7:14: 7:15
-        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:7:14: 7:15
+        _0 = const 0_u32;                // scope 0 at $DIR/exponential-or.rs:+3:14: +3:15
+        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:+3:14: +3:15
     }
 
     bb2: {
-        _2 = discriminant((_1.2: std::option::Option<i32>)); // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
-        switchInt(move _2) -> [0_isize: bb4, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
+        _2 = discriminant((_1.2: std::option::Option<i32>)); // scope 0 at $DIR/exponential-or.rs:+2:37: +2:55
+        switchInt(move _2) -> [0_isize: bb4, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:+2:37: +2:55
     }
 
     bb3: {
-        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
+        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:+2:37: +2:55
     }
 
     bb4: {
-        _5 = Le(const 6_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
-        switchInt(move _5) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
+        _5 = Le(const 6_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
+        switchInt(move _5) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
     }
 
     bb5: {
-        _6 = Le((_1.3: u32), const 9_u32); // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
-        switchInt(move _6) -> [false: bb6, otherwise: bb8]; // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
+        _6 = Le((_1.3: u32), const 9_u32); // scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
+        switchInt(move _6) -> [false: bb6, otherwise: bb8]; // scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
     }
 
     bb6: {
-        _3 = Le(const 13_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
-        switchInt(move _3) -> [false: bb1, otherwise: bb7]; // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
+        _3 = Le(const 13_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:+2:70: +2:77
+        switchInt(move _3) -> [false: bb1, otherwise: bb7]; // scope 0 at $DIR/exponential-or.rs:+2:70: +2:77
     }
 
     bb7: {
-        _4 = Le((_1.3: u32), const 16_u32); // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
-        switchInt(move _4) -> [false: bb1, otherwise: bb8]; // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
+        _4 = Le((_1.3: u32), const 16_u32); // scope 0 at $DIR/exponential-or.rs:+2:70: +2:77
+        switchInt(move _4) -> [false: bb1, otherwise: bb8]; // scope 0 at $DIR/exponential-or.rs:+2:70: +2:77
     }
 
     bb8: {
-        falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/exponential-or.rs:6:9: 6:79
+        falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/exponential-or.rs:+2:9: +2:79
     }
 
     bb9: {
-        StorageLive(_7);                 // scope 0 at $DIR/exponential-or.rs:6:10: 6:21
-        _7 = (_1.0: u32);                // scope 0 at $DIR/exponential-or.rs:6:10: 6:21
-        StorageLive(_8);                 // scope 0 at $DIR/exponential-or.rs:6:57: 6:78
-        _8 = (_1.3: u32);                // scope 0 at $DIR/exponential-or.rs:6:57: 6:78
-        StorageLive(_9);                 // scope 1 at $DIR/exponential-or.rs:6:83: 6:84
-        _9 = _7;                         // scope 1 at $DIR/exponential-or.rs:6:83: 6:84
-        StorageLive(_10);                // scope 1 at $DIR/exponential-or.rs:6:87: 6:88
-        _10 = _8;                        // scope 1 at $DIR/exponential-or.rs:6:87: 6:88
-        _0 = BitXor(move _9, move _10);  // scope 1 at $DIR/exponential-or.rs:6:83: 6:88
-        StorageDead(_10);                // scope 1 at $DIR/exponential-or.rs:6:87: 6:88
-        StorageDead(_9);                 // scope 1 at $DIR/exponential-or.rs:6:87: 6:88
-        StorageDead(_8);                 // scope 0 at $DIR/exponential-or.rs:6:87: 6:88
-        StorageDead(_7);                 // scope 0 at $DIR/exponential-or.rs:6:87: 6:88
-        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:6:87: 6:88
+        StorageLive(_7);                 // scope 0 at $DIR/exponential-or.rs:+2:10: +2:21
+        _7 = (_1.0: u32);                // scope 0 at $DIR/exponential-or.rs:+2:10: +2:21
+        StorageLive(_8);                 // scope 0 at $DIR/exponential-or.rs:+2:57: +2:78
+        _8 = (_1.3: u32);                // scope 0 at $DIR/exponential-or.rs:+2:57: +2:78
+        StorageLive(_9);                 // scope 1 at $DIR/exponential-or.rs:+2:83: +2:84
+        _9 = _7;                         // scope 1 at $DIR/exponential-or.rs:+2:83: +2:84
+        StorageLive(_10);                // scope 1 at $DIR/exponential-or.rs:+2:87: +2:88
+        _10 = _8;                        // scope 1 at $DIR/exponential-or.rs:+2:87: +2:88
+        _0 = BitXor(move _9, move _10);  // scope 1 at $DIR/exponential-or.rs:+2:83: +2:88
+        StorageDead(_10);                // scope 1 at $DIR/exponential-or.rs:+2:87: +2:88
+        StorageDead(_9);                 // scope 1 at $DIR/exponential-or.rs:+2:87: +2:88
+        StorageDead(_8);                 // scope 0 at $DIR/exponential-or.rs:+2:87: +2:88
+        StorageDead(_7);                 // scope 0 at $DIR/exponential-or.rs:+2:87: +2:88
+        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:+2:87: +2:88
     }
 
     bb10: {
-        return;                          // scope 0 at $DIR/exponential-or.rs:9:2: 9:2
+        return;                          // scope 0 at $DIR/exponential-or.rs:+5:2: +5:2
     }
 }

--- a/src/test/mir-opt/fn_ptr_shim.core.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/fn_ptr_shim.core.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
@@ -1,13 +1,13 @@
 // MIR for `std::ops::Fn::call` before AddMovesForPackedDrops
 
 fn std::ops::Fn::call(_1: *const fn(), _2: ()) -> <fn() as FnOnce<()>>::Output {
-    let mut _0: <fn() as std::ops::FnOnce<()>>::Output; // return place in scope 0 at $SRC_DIR/core/src/ops/function.rs:LL:COL
+    let mut _0: <fn() as std::ops::FnOnce<()>>::Output; // return place in scope 0 at $SRC_DIR/core/src/ops/function.rs:+0:5: +0:67
 
     bb0: {
-        _0 = move (*_1)() -> bb1;        // scope 0 at $SRC_DIR/core/src/ops/function.rs:LL:COL
+        _0 = move (*_1)() -> bb1;        // scope 0 at $SRC_DIR/core/src/ops/function.rs:+0:5: +0:67
     }
 
     bb1: {
-        return;                          // scope 0 at $SRC_DIR/core/src/ops/function.rs:LL:COL
+        return;                          // scope 0 at $SRC_DIR/core/src/ops/function.rs:+0:5: +0:67
     }
 }

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -2,145 +2,145 @@
 + // MIR for `float_to_exponential_common` after ConstProp
   
   fn float_to_exponential_common(_1: &mut Formatter, _2: &T, _3: bool) -> Result<(), std::fmt::Error> {
-      debug fmt => _1;                     // in scope 0 at $DIR/funky_arms.rs:11:35: 11:38
-      debug num => _2;                     // in scope 0 at $DIR/funky_arms.rs:11:60: 11:63
-      debug upper => _3;                   // in scope 0 at $DIR/funky_arms.rs:11:69: 11:74
-      let mut _0: std::result::Result<(), std::fmt::Error>; // return place in scope 0 at $DIR/funky_arms.rs:11:85: 11:91
-      let _4: bool;                        // in scope 0 at $DIR/funky_arms.rs:15:9: 15:19
-      let mut _5: &std::fmt::Formatter;    // in scope 0 at $DIR/funky_arms.rs:15:22: 15:37
-      let mut _7: std::option::Option<usize>; // in scope 0 at $DIR/funky_arms.rs:24:30: 24:45
-      let mut _8: &std::fmt::Formatter;    // in scope 0 at $DIR/funky_arms.rs:24:30: 24:45
-      let mut _9: isize;                   // in scope 0 at $DIR/funky_arms.rs:24:12: 24:27
-      let mut _11: &mut std::fmt::Formatter; // in scope 0 at $DIR/funky_arms.rs:26:43: 26:46
-      let mut _12: &T;                     // in scope 0 at $DIR/funky_arms.rs:26:48: 26:51
-      let mut _13: core::num::flt2dec::Sign; // in scope 0 at $DIR/funky_arms.rs:26:53: 26:57
-      let mut _14: u32;                    // in scope 0 at $DIR/funky_arms.rs:26:59: 26:79
-      let mut _15: u32;                    // in scope 0 at $DIR/funky_arms.rs:26:59: 26:75
-      let mut _16: usize;                  // in scope 0 at $DIR/funky_arms.rs:26:59: 26:68
-      let mut _17: bool;                   // in scope 0 at $DIR/funky_arms.rs:26:81: 26:86
-      let mut _18: &mut std::fmt::Formatter; // in scope 0 at $DIR/funky_arms.rs:28:46: 28:49
-      let mut _19: &T;                     // in scope 0 at $DIR/funky_arms.rs:28:51: 28:54
-      let mut _20: core::num::flt2dec::Sign; // in scope 0 at $DIR/funky_arms.rs:28:56: 28:60
-      let mut _21: bool;                   // in scope 0 at $DIR/funky_arms.rs:28:62: 28:67
+      debug fmt => _1;                     // in scope 0 at $DIR/funky_arms.rs:+0:35: +0:38
+      debug num => _2;                     // in scope 0 at $DIR/funky_arms.rs:+0:60: +0:63
+      debug upper => _3;                   // in scope 0 at $DIR/funky_arms.rs:+0:69: +0:74
+      let mut _0: std::result::Result<(), std::fmt::Error>; // return place in scope 0 at $DIR/funky_arms.rs:+0:85: +0:91
+      let _4: bool;                        // in scope 0 at $DIR/funky_arms.rs:+4:9: +4:19
+      let mut _5: &std::fmt::Formatter;    // in scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
+      let mut _7: std::option::Option<usize>; // in scope 0 at $DIR/funky_arms.rs:+13:30: +13:45
+      let mut _8: &std::fmt::Formatter;    // in scope 0 at $DIR/funky_arms.rs:+13:30: +13:45
+      let mut _9: isize;                   // in scope 0 at $DIR/funky_arms.rs:+13:12: +13:27
+      let mut _11: &mut std::fmt::Formatter; // in scope 0 at $DIR/funky_arms.rs:+15:43: +15:46
+      let mut _12: &T;                     // in scope 0 at $DIR/funky_arms.rs:+15:48: +15:51
+      let mut _13: core::num::flt2dec::Sign; // in scope 0 at $DIR/funky_arms.rs:+15:53: +15:57
+      let mut _14: u32;                    // in scope 0 at $DIR/funky_arms.rs:+15:59: +15:79
+      let mut _15: u32;                    // in scope 0 at $DIR/funky_arms.rs:+15:59: +15:75
+      let mut _16: usize;                  // in scope 0 at $DIR/funky_arms.rs:+15:59: +15:68
+      let mut _17: bool;                   // in scope 0 at $DIR/funky_arms.rs:+15:81: +15:86
+      let mut _18: &mut std::fmt::Formatter; // in scope 0 at $DIR/funky_arms.rs:+17:46: +17:49
+      let mut _19: &T;                     // in scope 0 at $DIR/funky_arms.rs:+17:51: +17:54
+      let mut _20: core::num::flt2dec::Sign; // in scope 0 at $DIR/funky_arms.rs:+17:56: +17:60
+      let mut _21: bool;                   // in scope 0 at $DIR/funky_arms.rs:+17:62: +17:67
       scope 1 {
-          debug force_sign => _4;          // in scope 1 at $DIR/funky_arms.rs:15:9: 15:19
-          let _6: core::num::flt2dec::Sign; // in scope 1 at $DIR/funky_arms.rs:19:9: 19:13
+          debug force_sign => _4;          // in scope 1 at $DIR/funky_arms.rs:+4:9: +4:19
+          let _6: core::num::flt2dec::Sign; // in scope 1 at $DIR/funky_arms.rs:+8:9: +8:13
           scope 2 {
-              debug sign => _6;            // in scope 2 at $DIR/funky_arms.rs:19:9: 19:13
+              debug sign => _6;            // in scope 2 at $DIR/funky_arms.rs:+8:9: +8:13
               scope 3 {
-                  debug precision => _10;  // in scope 3 at $DIR/funky_arms.rs:24:17: 24:26
-                  let _10: usize;          // in scope 3 at $DIR/funky_arms.rs:24:17: 24:26
+                  debug precision => _10;  // in scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
+                  let _10: usize;          // in scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
               }
           }
       }
   
       bb0: {
-          StorageLive(_4);                 // scope 0 at $DIR/funky_arms.rs:15:9: 15:19
-          StorageLive(_5);                 // scope 0 at $DIR/funky_arms.rs:15:22: 15:37
-          _5 = &(*_1);                     // scope 0 at $DIR/funky_arms.rs:15:22: 15:37
-          _4 = Formatter::sign_plus(move _5) -> bb1; // scope 0 at $DIR/funky_arms.rs:15:22: 15:37
+          StorageLive(_4);                 // scope 0 at $DIR/funky_arms.rs:+4:9: +4:19
+          StorageLive(_5);                 // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
+          _5 = &(*_1);                     // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
+          _4 = Formatter::sign_plus(move _5) -> bb1; // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:15:26: 15:35
                                            // + literal: Const { ty: for<'r> fn(&'r Formatter) -> bool {Formatter::sign_plus}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_5);                 // scope 0 at $DIR/funky_arms.rs:15:36: 15:37
-          StorageLive(_6);                 // scope 1 at $DIR/funky_arms.rs:19:9: 19:13
-          switchInt(_4) -> [false: bb3, otherwise: bb2]; // scope 1 at $DIR/funky_arms.rs:19:16: 19:32
+          StorageDead(_5);                 // scope 0 at $DIR/funky_arms.rs:+4:36: +4:37
+          StorageLive(_6);                 // scope 1 at $DIR/funky_arms.rs:+8:9: +8:13
+          switchInt(_4) -> [false: bb3, otherwise: bb2]; // scope 1 at $DIR/funky_arms.rs:+8:16: +8:32
       }
   
       bb2: {
-          Deinit(_6);                      // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
-          discriminant(_6) = 1;            // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
-          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
+          Deinit(_6);                      // scope 1 at $DIR/funky_arms.rs:+10:17: +10:41
+          discriminant(_6) = 1;            // scope 1 at $DIR/funky_arms.rs:+10:17: +10:41
+          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:+10:17: +10:41
       }
   
       bb3: {
-          Deinit(_6);                      // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
-          discriminant(_6) = 0;            // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
-          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
+          Deinit(_6);                      // scope 1 at $DIR/funky_arms.rs:+9:18: +9:38
+          discriminant(_6) = 0;            // scope 1 at $DIR/funky_arms.rs:+9:18: +9:38
+          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:+9:18: +9:38
       }
   
       bb4: {
-          StorageLive(_7);                 // scope 3 at $DIR/funky_arms.rs:24:30: 24:45
-          StorageLive(_8);                 // scope 3 at $DIR/funky_arms.rs:24:30: 24:45
-          _8 = &(*_1);                     // scope 3 at $DIR/funky_arms.rs:24:30: 24:45
-          _7 = Formatter::precision(move _8) -> bb5; // scope 3 at $DIR/funky_arms.rs:24:30: 24:45
+          StorageLive(_7);                 // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
+          StorageLive(_8);                 // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
+          _8 = &(*_1);                     // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
+          _7 = Formatter::precision(move _8) -> bb5; // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:24:34: 24:43
                                            // + literal: Const { ty: for<'r> fn(&'r Formatter) -> Option<usize> {Formatter::precision}, val: Value(<ZST>) }
       }
   
       bb5: {
-          StorageDead(_8);                 // scope 3 at $DIR/funky_arms.rs:24:44: 24:45
-          _9 = discriminant(_7);           // scope 3 at $DIR/funky_arms.rs:24:12: 24:27
-          switchInt(move _9) -> [1_isize: bb6, otherwise: bb8]; // scope 3 at $DIR/funky_arms.rs:24:12: 24:27
+          StorageDead(_8);                 // scope 3 at $DIR/funky_arms.rs:+13:44: +13:45
+          _9 = discriminant(_7);           // scope 3 at $DIR/funky_arms.rs:+13:12: +13:27
+          switchInt(move _9) -> [1_isize: bb6, otherwise: bb8]; // scope 3 at $DIR/funky_arms.rs:+13:12: +13:27
       }
   
       bb6: {
-          StorageLive(_10);                // scope 3 at $DIR/funky_arms.rs:24:17: 24:26
-          _10 = ((_7 as Some).0: usize);   // scope 3 at $DIR/funky_arms.rs:24:17: 24:26
-          StorageLive(_11);                // scope 3 at $DIR/funky_arms.rs:26:43: 26:46
-          _11 = &mut (*_1);                // scope 3 at $DIR/funky_arms.rs:26:43: 26:46
-          StorageLive(_12);                // scope 3 at $DIR/funky_arms.rs:26:48: 26:51
-          _12 = _2;                        // scope 3 at $DIR/funky_arms.rs:26:48: 26:51
-          StorageLive(_13);                // scope 3 at $DIR/funky_arms.rs:26:53: 26:57
-          _13 = _6;                        // scope 3 at $DIR/funky_arms.rs:26:53: 26:57
-          StorageLive(_14);                // scope 3 at $DIR/funky_arms.rs:26:59: 26:79
-          StorageLive(_15);                // scope 3 at $DIR/funky_arms.rs:26:59: 26:75
-          StorageLive(_16);                // scope 3 at $DIR/funky_arms.rs:26:59: 26:68
-          _16 = _10;                       // scope 3 at $DIR/funky_arms.rs:26:59: 26:68
-          _15 = move _16 as u32 (Misc);    // scope 3 at $DIR/funky_arms.rs:26:59: 26:75
-          StorageDead(_16);                // scope 3 at $DIR/funky_arms.rs:26:74: 26:75
-          _14 = Add(move _15, const 1_u32); // scope 3 at $DIR/funky_arms.rs:26:59: 26:79
-          StorageDead(_15);                // scope 3 at $DIR/funky_arms.rs:26:78: 26:79
-          StorageLive(_17);                // scope 3 at $DIR/funky_arms.rs:26:81: 26:86
-          _17 = _3;                        // scope 3 at $DIR/funky_arms.rs:26:81: 26:86
-          _0 = float_to_exponential_common_exact::<T>(move _11, move _12, move _13, move _14, move _17) -> bb7; // scope 3 at $DIR/funky_arms.rs:26:9: 26:87
+          StorageLive(_10);                // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
+          _10 = ((_7 as Some).0: usize);   // scope 3 at $DIR/funky_arms.rs:+13:17: +13:26
+          StorageLive(_11);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
+          _11 = &mut (*_1);                // scope 3 at $DIR/funky_arms.rs:+15:43: +15:46
+          StorageLive(_12);                // scope 3 at $DIR/funky_arms.rs:+15:48: +15:51
+          _12 = _2;                        // scope 3 at $DIR/funky_arms.rs:+15:48: +15:51
+          StorageLive(_13);                // scope 3 at $DIR/funky_arms.rs:+15:53: +15:57
+          _13 = _6;                        // scope 3 at $DIR/funky_arms.rs:+15:53: +15:57
+          StorageLive(_14);                // scope 3 at $DIR/funky_arms.rs:+15:59: +15:79
+          StorageLive(_15);                // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
+          StorageLive(_16);                // scope 3 at $DIR/funky_arms.rs:+15:59: +15:68
+          _16 = _10;                       // scope 3 at $DIR/funky_arms.rs:+15:59: +15:68
+          _15 = move _16 as u32 (Misc);    // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
+          StorageDead(_16);                // scope 3 at $DIR/funky_arms.rs:+15:74: +15:75
+          _14 = Add(move _15, const 1_u32); // scope 3 at $DIR/funky_arms.rs:+15:59: +15:79
+          StorageDead(_15);                // scope 3 at $DIR/funky_arms.rs:+15:78: +15:79
+          StorageLive(_17);                // scope 3 at $DIR/funky_arms.rs:+15:81: +15:86
+          _17 = _3;                        // scope 3 at $DIR/funky_arms.rs:+15:81: +15:86
+          _0 = float_to_exponential_common_exact::<T>(move _11, move _12, move _13, move _14, move _17) -> bb7; // scope 3 at $DIR/funky_arms.rs:+15:9: +15:87
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:26:9: 26:42
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut Formatter<'s>, &'t0 T, Sign, u32, bool) -> Result<(), std::fmt::Error> {float_to_exponential_common_exact::<T>}, val: Value(<ZST>) }
       }
   
       bb7: {
-          StorageDead(_17);                // scope 3 at $DIR/funky_arms.rs:26:86: 26:87
-          StorageDead(_14);                // scope 3 at $DIR/funky_arms.rs:26:86: 26:87
-          StorageDead(_13);                // scope 3 at $DIR/funky_arms.rs:26:86: 26:87
-          StorageDead(_12);                // scope 3 at $DIR/funky_arms.rs:26:86: 26:87
-          StorageDead(_11);                // scope 3 at $DIR/funky_arms.rs:26:86: 26:87
-          StorageDead(_10);                // scope 2 at $DIR/funky_arms.rs:27:5: 27:6
-          goto -> bb10;                    // scope 2 at $DIR/funky_arms.rs:24:5: 29:6
+          StorageDead(_17);                // scope 3 at $DIR/funky_arms.rs:+15:86: +15:87
+          StorageDead(_14);                // scope 3 at $DIR/funky_arms.rs:+15:86: +15:87
+          StorageDead(_13);                // scope 3 at $DIR/funky_arms.rs:+15:86: +15:87
+          StorageDead(_12);                // scope 3 at $DIR/funky_arms.rs:+15:86: +15:87
+          StorageDead(_11);                // scope 3 at $DIR/funky_arms.rs:+15:86: +15:87
+          StorageDead(_10);                // scope 2 at $DIR/funky_arms.rs:+16:5: +16:6
+          goto -> bb10;                    // scope 2 at $DIR/funky_arms.rs:+13:5: +18:6
       }
   
       bb8: {
-          StorageLive(_18);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
-          _18 = &mut (*_1);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
-          StorageLive(_19);                // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
-          _19 = _2;                        // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
-          StorageLive(_20);                // scope 2 at $DIR/funky_arms.rs:28:56: 28:60
-          _20 = _6;                        // scope 2 at $DIR/funky_arms.rs:28:56: 28:60
-          StorageLive(_21);                // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
-          _21 = _3;                        // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
-          _0 = float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, move _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:28:9: 28:68
+          StorageLive(_18);                // scope 2 at $DIR/funky_arms.rs:+17:46: +17:49
+          _18 = &mut (*_1);                // scope 2 at $DIR/funky_arms.rs:+17:46: +17:49
+          StorageLive(_19);                // scope 2 at $DIR/funky_arms.rs:+17:51: +17:54
+          _19 = _2;                        // scope 2 at $DIR/funky_arms.rs:+17:51: +17:54
+          StorageLive(_20);                // scope 2 at $DIR/funky_arms.rs:+17:56: +17:60
+          _20 = _6;                        // scope 2 at $DIR/funky_arms.rs:+17:56: +17:60
+          StorageLive(_21);                // scope 2 at $DIR/funky_arms.rs:+17:62: +17:67
+          _21 = _3;                        // scope 2 at $DIR/funky_arms.rs:+17:62: +17:67
+          _0 = float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, move _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:+17:9: +17:68
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:28:9: 28:45
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut Formatter<'s>, &'t0 T, Sign, bool) -> Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}, val: Value(<ZST>) }
       }
   
       bb9: {
-          StorageDead(_21);                // scope 2 at $DIR/funky_arms.rs:28:67: 28:68
-          StorageDead(_20);                // scope 2 at $DIR/funky_arms.rs:28:67: 28:68
-          StorageDead(_19);                // scope 2 at $DIR/funky_arms.rs:28:67: 28:68
-          StorageDead(_18);                // scope 2 at $DIR/funky_arms.rs:28:67: 28:68
-          goto -> bb10;                    // scope 2 at $DIR/funky_arms.rs:24:5: 29:6
+          StorageDead(_21);                // scope 2 at $DIR/funky_arms.rs:+17:67: +17:68
+          StorageDead(_20);                // scope 2 at $DIR/funky_arms.rs:+17:67: +17:68
+          StorageDead(_19);                // scope 2 at $DIR/funky_arms.rs:+17:67: +17:68
+          StorageDead(_18);                // scope 2 at $DIR/funky_arms.rs:+17:67: +17:68
+          goto -> bb10;                    // scope 2 at $DIR/funky_arms.rs:+13:5: +18:6
       }
   
       bb10: {
-          StorageDead(_6);                 // scope 1 at $DIR/funky_arms.rs:30:1: 30:2
-          StorageDead(_4);                 // scope 0 at $DIR/funky_arms.rs:30:1: 30:2
-          StorageDead(_7);                 // scope 0 at $DIR/funky_arms.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/funky_arms.rs:30:2: 30:2
+          StorageDead(_6);                 // scope 1 at $DIR/funky_arms.rs:+19:1: +19:2
+          StorageDead(_4);                 // scope 0 at $DIR/funky_arms.rs:+19:1: +19:2
+          StorageDead(_7);                 // scope 0 at $DIR/funky_arms.rs:+19:1: +19:2
+          return;                          // scope 0 at $DIR/funky_arms.rs:+19:2: +19:2
       }
   }
   

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -15,70 +15,70 @@
 } */
 
 fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 10:17]) -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
-    let mut _2: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
-    let _3: std::string::String;         // in scope 0 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
-    let _4: ();                          // in scope 0 at $DIR/generator-drop-cleanup.rs:12:9: 12:14
-    let mut _5: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:12:9: 12:14
-    let mut _6: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:10:18: 10:18
-    let mut _7: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
-    let mut _8: u32;                     // in scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+    let mut _0: ();                      // return place in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+    let mut _2: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+    let _3: std::string::String;         // in scope 0 at $DIR/generator-drop-cleanup.rs:+1:13: +1:15
+    let _4: ();                          // in scope 0 at $DIR/generator-drop-cleanup.rs:+2:9: +2:14
+    let mut _5: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+2:9: +2:14
+    let mut _6: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:18: +0:18
+    let mut _7: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+    let mut _8: u32;                     // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     scope 1 {
-        debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
+        debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:+1:13: +1:15
     }
 
     bb0: {
-        _8 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
-        switchInt(move _8) -> [0_u32: bb7, 3_u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        _8 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        switchInt(move _8) -> [0_u32: bb7, 3_u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 
     bb1: {
-        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
-        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
-        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:+2:13: +2:14
+        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:+2:14: +2:15
+        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb2: {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb3: {
-        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 
     bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 
     bb5 (cleanup): {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb6: {
-        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 
     bb7: {
-        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 
     bb8: {
-        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb9: {
-        goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 
     bb10: {
-        StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
-        StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
-        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 
     bb11: {
-        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 10:17
+        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     }
 }

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -3,112 +3,112 @@
 fn main::{closure#0}(_1: [generator@$DIR/generator-storage-dead-unwind.rs:22:16: 22:18], _2: ()) -> ()
 yields ()
  {
-    let mut _0: ();                      // return place in scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 22:19
-    let _3: Foo;                         // in scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-    let _5: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-    let mut _6: ();                      // in scope 0 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-    let _7: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
-    let mut _8: Foo;                     // in scope 0 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-    let _9: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
-    let mut _10: Bar;                    // in scope 0 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:19: +0:19
+    let _3: Foo;                         // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
+    let _5: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+    let mut _6: ();                      // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+    let _7: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
+    let mut _8: Foo;                     // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
+    let _9: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
+    let mut _10: Bar;                    // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
     scope 1 {
-        debug a => _3;                   // in scope 1 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-        let _4: Bar;                     // in scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
+        debug a => _3;                   // in scope 1 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
+        let _4: Bar;                     // in scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
         scope 2 {
-            debug b => _4;               // in scope 2 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
+            debug b => _4;               // in scope 2 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
         }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-        Deinit(_3);                      // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
-        (_3.0: i32) = const 5_i32;       // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
-        StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
-        Deinit(_4);                      // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
-        (_4.0: i32) = const 6_i32;       // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
-        StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        Deinit(_6);                      // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
+        Deinit(_3);                      // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:17: +1:23
+        (_3.0: i32) = const 5_i32;       // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:17: +1:23
+        StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
+        Deinit(_4);                      // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:17: +2:23
+        (_4.0: i32) = const 6_i32;       // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:17: +2:23
+        StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+        StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+        Deinit(_6);                      // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+        _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
     }
 
     bb1: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
-        StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
-        StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-        _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:13: +3:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:14: +3:15
+        StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
+        StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
+        _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
+        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:26:9: 26:13
                                          // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
-        StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
-        StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
-        _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
-        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb8]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:15: +4:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:16: +4:17
+        StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
+        StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
+        _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
+        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb8]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:27:9: 27:13
                                          // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
-        _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:15: +5:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:16: +5:17
+        _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:19: +6:6
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb4: {
-        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:18: 22:18
+        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:18: +0:18
     }
 
     bb5: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:13: +3:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:14: +3:15
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb6: {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb7: {
-        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 22:18
+        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:16: +0:18
     }
 
     bb8 (cleanup): {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:15: +5:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:16: +5:17
         goto -> bb10;                    // scope 2 at no-location
     }
 
     bb9 (cleanup): {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:15: +4:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:16: +4:17
         goto -> bb10;                    // scope 2 at no-location
     }
 
     bb10 (cleanup): {
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb11 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 22:18
+        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:16: +0:18
     }
 
     bb12 (cleanup): {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 }

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -15,70 +15,70 @@
 } */
 
 fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]>, _2: u8) -> GeneratorState<(), ()> {
-    debug _x => _10;                     // in scope 0 at $DIR/generator-tiny.rs:19:17: 19:19
-    let mut _0: std::ops::GeneratorState<(), ()>; // return place in scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-    let _3: HasDrop;                     // in scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
-    let mut _4: !;                       // in scope 0 at $DIR/generator-tiny.rs:21:9: 24:10
-    let mut _5: ();                      // in scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-    let _6: u8;                          // in scope 0 at $DIR/generator-tiny.rs:22:13: 22:18
-    let mut _7: ();                      // in scope 0 at $DIR/generator-tiny.rs:22:13: 22:18
-    let _8: ();                          // in scope 0 at $DIR/generator-tiny.rs:23:13: 23:21
-    let mut _9: ();                      // in scope 0 at $DIR/generator-tiny.rs:19:25: 19:25
-    let _10: u8;                         // in scope 0 at $DIR/generator-tiny.rs:19:17: 19:19
-    let mut _11: u32;                    // in scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
+    debug _x => _10;                     // in scope 0 at $DIR/generator-tiny.rs:+0:17: +0:19
+    let mut _0: std::ops::GeneratorState<(), ()>; // return place in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+    let _3: HasDrop;                     // in scope 0 at $DIR/generator-tiny.rs:+1:13: +1:15
+    let mut _4: !;                       // in scope 0 at $DIR/generator-tiny.rs:+2:9: +5:10
+    let mut _5: ();                      // in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+    let _6: u8;                          // in scope 0 at $DIR/generator-tiny.rs:+3:13: +3:18
+    let mut _7: ();                      // in scope 0 at $DIR/generator-tiny.rs:+3:13: +3:18
+    let _8: ();                          // in scope 0 at $DIR/generator-tiny.rs:+4:13: +4:21
+    let mut _9: ();                      // in scope 0 at $DIR/generator-tiny.rs:+0:25: +0:25
+    let _10: u8;                         // in scope 0 at $DIR/generator-tiny.rs:+0:17: +0:19
+    let mut _11: u32;                    // in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
     scope 1 {
-        debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:20:13: 20:15
+        debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:+1:13: +1:15
     }
 
     bb0: {
-        _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))); // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-        switchInt(move _11) -> [0_u32: bb1, 3_u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
+        _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))); // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        switchInt(move _11) -> [0_u32: bb1, 3_u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
     }
 
     bb1: {
-        _10 = move _2;                   // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-        nop;                             // scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
-        Deinit((((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop)); // scope 0 at $DIR/generator-tiny.rs:20:18: 20:25
-        StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
-        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
+        _10 = move _2;                   // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        nop;                             // scope 0 at $DIR/generator-tiny.rs:+1:13: +1:15
+        Deinit((((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop)); // scope 0 at $DIR/generator-tiny.rs:+1:18: +1:25
+        StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
+        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
     }
 
     bb2: {
-        StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        Deinit(_7);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))) = 3; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        return;                          // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        Deinit(_7);                      // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))) = 3; // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        return;                          // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
     }
 
     bb3: {
-        StorageDead(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:17: 22:18
-        StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:18: 22:19
-        StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
-        _8 = callee() -> bb4;            // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
+        StorageDead(_7);                 // scope 1 at $DIR/generator-tiny.rs:+3:17: +3:18
+        StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:+3:18: +3:19
+        StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:+4:13: +4:21
+        _8 = callee() -> bb4;            // scope 1 at $DIR/generator-tiny.rs:+4:13: +4:21
                                          // mir::Constant
                                          // + span: $DIR/generator-tiny.rs:23:13: 23:19
                                          // + literal: Const { ty: fn() {callee}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:21: 23:22
-        _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:21:14: 24:10
-        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
+        StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:+4:21: +4:22
+        _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:+2:14: +5:10
+        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
     }
 
     bb5: {
-        StorageLive(_4);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-        StorageLive(_6);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-        StorageLive(_7);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-        _6 = move _2;                    // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
-        goto -> bb3;                     // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
+        StorageLive(_4);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        StorageLive(_6);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        StorageLive(_7);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        _6 = move _2;                    // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        goto -> bb3;                     // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
     }
 
     bb6: {
-        unreachable;                     // scope 0 at $DIR/generator-tiny.rs:19:16: 19:24
+        unreachable;                     // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
     }
 }

--- a/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
@@ -2,29 +2,29 @@
 + // MIR for `dont_opt_bool` after SimplifyComparisonIntegral
   
   fn dont_opt_bool(_1: bool) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:16:18: 16:19
-      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:16:30: 16:33
-      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
+      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:18: +0:19
+      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:30: +0:33
+      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
-          _2 = _1;                         // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _2 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
       }
   
       bb1: {
-          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:17:12: 17:13
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:17:5: 17:26
+          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:12: +1:13
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:26
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:17:23: 17:24
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:17:5: 17:26
+          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:23: +1:24
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:26
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:17:25: 17:26
-          return;                          // scope 0 at $DIR/if-condition-int.rs:18:2: 18:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:25: +1:26
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
@@ -2,33 +2,33 @@
 + // MIR for `dont_opt_floats` after SimplifyComparisonIntegral
   
   fn dont_opt_floats(_1: f32) -> i32 {
-      debug a => _1;                       // in scope 0 at $DIR/if-condition-int.rs:52:20: 52:21
-      let mut _0: i32;                     // return place in scope 0 at $DIR/if-condition-int.rs:52:31: 52:34
-      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
-      let mut _3: f32;                     // in scope 0 at $DIR/if-condition-int.rs:53:8: 53:9
+      debug a => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:20: +0:21
+      let mut _0: i32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:31: +0:34
+      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:18
+      let mut _3: f32;                     // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
-          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:53:8: 53:9
-          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:53:8: 53:9
-          _2 = Eq(move _3, const -42f32);  // scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
-          StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:53:17: 53:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:18
+          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _2 = Eq(move _3, const -42f32);  // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:18
+          StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:17: +1:18
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:18
       }
   
       bb1: {
-          _0 = const 0_i32;                // scope 0 at $DIR/if-condition-int.rs:53:21: 53:22
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:53:5: 53:35
+          _0 = const 0_i32;                // scope 0 at $DIR/if-condition-int.rs:+1:21: +1:22
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:35
       }
   
       bb2: {
-          _0 = const 1_i32;                // scope 0 at $DIR/if-condition-int.rs:53:32: 53:33
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:53:5: 53:35
+          _0 = const 1_i32;                // scope 0 at $DIR/if-condition-int.rs:+1:32: +1:33
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:35
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:53:34: 53:35
-          return;                          // scope 0 at $DIR/if-condition-int.rs:54:2: 54:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:34: +1:35
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
@@ -2,57 +2,57 @@
 + // MIR for `dont_remove_comparison` after SimplifyComparisonIntegral
   
   fn dont_remove_comparison(_1: i8) -> i32 {
-      debug a => _1;                       // in scope 0 at $DIR/if-condition-int.rs:43:27: 43:28
-      let mut _0: i32;                     // return place in scope 0 at $DIR/if-condition-int.rs:43:37: 43:40
-      let _2: bool;                        // in scope 0 at $DIR/if-condition-int.rs:44:9: 44:10
-      let mut _3: i8;                      // in scope 0 at $DIR/if-condition-int.rs:44:13: 44:14
-      let mut _4: i32;                     // in scope 0 at $DIR/if-condition-int.rs:46:23: 46:31
-      let mut _5: bool;                    // in scope 0 at $DIR/if-condition-int.rs:46:23: 46:24
-      let mut _6: i32;                     // in scope 0 at $DIR/if-condition-int.rs:47:23: 47:31
-      let mut _7: bool;                    // in scope 0 at $DIR/if-condition-int.rs:47:23: 47:24
+      debug a => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:27: +0:28
+      let mut _0: i32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:37: +0:40
+      let _2: bool;                        // in scope 0 at $DIR/if-condition-int.rs:+1:9: +1:10
+      let mut _3: i8;                      // in scope 0 at $DIR/if-condition-int.rs:+1:13: +1:14
+      let mut _4: i32;                     // in scope 0 at $DIR/if-condition-int.rs:+3:23: +3:31
+      let mut _5: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+3:23: +3:24
+      let mut _6: i32;                     // in scope 0 at $DIR/if-condition-int.rs:+4:23: +4:31
+      let mut _7: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+4:23: +4:24
       scope 1 {
-          debug b => _2;                   // in scope 1 at $DIR/if-condition-int.rs:44:9: 44:10
+          debug b => _2;                   // in scope 1 at $DIR/if-condition-int.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:44:9: 44:10
-          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:44:13: 44:14
-          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:44:13: 44:14
--         _2 = Eq(move _3, const 17_i8);   // scope 0 at $DIR/if-condition-int.rs:44:13: 44:20
--         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:44:19: 44:20
--         switchInt(_2) -> [false: bb2, otherwise: bb1]; // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
-+         _2 = Eq(_3, const 17_i8);        // scope 0 at $DIR/if-condition-int.rs:44:13: 44:20
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:44:19: 44:20
-+         switchInt(move _3) -> [17_i8: bb1, otherwise: bb2]; // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:13: +1:14
+          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:13: +1:14
+-         _2 = Eq(move _3, const 17_i8);   // scope 0 at $DIR/if-condition-int.rs:+1:13: +1:20
+-         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:19: +1:20
+-         switchInt(_2) -> [false: bb2, otherwise: bb1]; // scope 1 at $DIR/if-condition-int.rs:+2:5: +2:12
++         _2 = Eq(_3, const 17_i8);        // scope 0 at $DIR/if-condition-int.rs:+1:13: +1:20
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:19: +1:20
++         switchInt(move _3) -> [17_i8: bb1, otherwise: bb2]; // scope 1 at $DIR/if-condition-int.rs:+2:5: +2:12
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
-          StorageLive(_6);                 // scope 1 at $DIR/if-condition-int.rs:47:23: 47:31
-          StorageLive(_7);                 // scope 1 at $DIR/if-condition-int.rs:47:23: 47:24
-          _7 = _2;                         // scope 1 at $DIR/if-condition-int.rs:47:23: 47:24
-          _6 = move _7 as i32 (Misc);      // scope 1 at $DIR/if-condition-int.rs:47:23: 47:31
-          StorageDead(_7);                 // scope 1 at $DIR/if-condition-int.rs:47:30: 47:31
-          _0 = Add(const 100_i32, move _6); // scope 1 at $DIR/if-condition-int.rs:47:17: 47:31
-          StorageDead(_6);                 // scope 1 at $DIR/if-condition-int.rs:47:30: 47:31
-          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:47:30: 47:31
++         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:+2:5: +2:12
+          StorageLive(_6);                 // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:31
+          StorageLive(_7);                 // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:24
+          _7 = _2;                         // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:24
+          _6 = move _7 as i32 (Misc);      // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:31
+          StorageDead(_7);                 // scope 1 at $DIR/if-condition-int.rs:+4:30: +4:31
+          _0 = Add(const 100_i32, move _6); // scope 1 at $DIR/if-condition-int.rs:+4:17: +4:31
+          StorageDead(_6);                 // scope 1 at $DIR/if-condition-int.rs:+4:30: +4:31
+          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:+4:30: +4:31
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
-          StorageLive(_4);                 // scope 1 at $DIR/if-condition-int.rs:46:23: 46:31
-          StorageLive(_5);                 // scope 1 at $DIR/if-condition-int.rs:46:23: 46:24
-          _5 = _2;                         // scope 1 at $DIR/if-condition-int.rs:46:23: 46:24
-          _4 = move _5 as i32 (Misc);      // scope 1 at $DIR/if-condition-int.rs:46:23: 46:31
-          StorageDead(_5);                 // scope 1 at $DIR/if-condition-int.rs:46:30: 46:31
-          _0 = Add(const 10_i32, move _4); // scope 1 at $DIR/if-condition-int.rs:46:18: 46:31
-          StorageDead(_4);                 // scope 1 at $DIR/if-condition-int.rs:46:30: 46:31
-          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:46:30: 46:31
++         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:+2:5: +2:12
+          StorageLive(_4);                 // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:31
+          StorageLive(_5);                 // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:24
+          _5 = _2;                         // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:24
+          _4 = move _5 as i32 (Misc);      // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:31
+          StorageDead(_5);                 // scope 1 at $DIR/if-condition-int.rs:+3:30: +3:31
+          _0 = Add(const 10_i32, move _4); // scope 1 at $DIR/if-condition-int.rs:+3:18: +3:31
+          StorageDead(_4);                 // scope 1 at $DIR/if-condition-int.rs:+3:30: +3:31
+          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:+3:30: +3:31
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:49:1: 49:2
-          return;                          // scope 0 at $DIR/if-condition-int.rs:49:2: 49:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
@@ -2,38 +2,38 @@
 + // MIR for `opt_char` after SimplifyComparisonIntegral
   
   fn opt_char(_1: char) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:20:13: 20:14
-      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:20:25: 20:28
-      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
-      let mut _3: char;                    // in scope 0 at $DIR/if-condition-int.rs:21:8: 21:9
+      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:13: +0:14
+      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:25: +0:28
+      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+      let mut _3: char;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
-          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:9
-          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:21:8: 21:9
--         _2 = Eq(move _3, const 'x');     // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
--         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:15: 21:16
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:21:15: 21:16
-+         switchInt(move _3) -> ['x': bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+-         _2 = Eq(move _3, const 'x');     // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+-         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:15: +1:16
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:15: +1:16
++         switchInt(move _3) -> ['x': bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
-          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:21:19: 21:20
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:19: +1:20
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:33
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
-          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:21:30: 21:31
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:30: +1:31
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:33
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:21:32: 21:33
-          return;                          // scope 0 at $DIR/if-condition-int.rs:22:2: 22:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:32: +1:33
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
@@ -2,38 +2,38 @@
 + // MIR for `opt_i8` after SimplifyComparisonIntegral
   
   fn opt_i8(_1: i8) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:24:11: 24:12
-      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:24:21: 24:24
-      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
-      let mut _3: i8;                      // in scope 0 at $DIR/if-condition-int.rs:25:8: 25:9
+      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:11: +0:12
+      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:21: +0:24
+      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+      let mut _3: i8;                      // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
-          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:9
-          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:25:8: 25:9
--         _2 = Eq(move _3, const 42_i8);   // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
--         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:14: 25:15
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:25:14: 25:15
-+         switchInt(move _3) -> [42_i8: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+-         _2 = Eq(move _3, const 42_i8);   // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+-         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:14: +1:15
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:14: +1:15
++         switchInt(move _3) -> [42_i8: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
-          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:25:18: 25:19
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:18: +1:19
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:32
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
-          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:25:29: 25:30
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:29: +1:30
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:32
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:25:31: 25:32
-          return;                          // scope 0 at $DIR/if-condition-int.rs:26:2: 26:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:31: +1:32
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
@@ -2,64 +2,64 @@
 + // MIR for `opt_multiple_ifs` after SimplifyComparisonIntegral
   
   fn opt_multiple_ifs(_1: u32) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:32:21: 32:22
-      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:32:32: 32:35
-      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
-      let mut _3: u32;                     // in scope 0 at $DIR/if-condition-int.rs:33:8: 33:9
-      let mut _4: bool;                    // in scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
-      let mut _5: u32;                     // in scope 0 at $DIR/if-condition-int.rs:35:15: 35:16
+      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:21: +0:22
+      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:32: +0:35
+      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+      let mut _3: u32;                     // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+      let mut _4: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
+      let mut _5: u32;                     // in scope 0 at $DIR/if-condition-int.rs:+3:15: +3:16
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
-          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:9
-          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:33:8: 33:9
--         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
--         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:14: 33:15
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:33:14: 33:15
-+         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+-         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+-         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:14: +1:15
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:14: +1:15
++         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
-          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:34:9: 34:10
-          goto -> bb6;                     // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:+2:9: +2:10
+          goto -> bb6;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +7:6
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
-          StorageLive(_4);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
-          StorageLive(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:16
-          _5 = _1;                         // scope 0 at $DIR/if-condition-int.rs:35:15: 35:16
--         _4 = Ne(move _5, const 21_u32);  // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
--         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:21: 35:22
--         switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:35:21: 35:22
-+         switchInt(move _5) -> [21_u32: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          StorageLive(_4);                 // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
+          StorageLive(_5);                 // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:16
+          _5 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:16
+-         _4 = Ne(move _5, const 21_u32);  // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
+-         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:+3:21: +3:22
+-         switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+3:21: +3:22
++         switchInt(move _5) -> [21_u32: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
       }
   
       bb3: {
-+         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
-          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:36:9: 36:10
-          goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
++         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
+          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:+4:9: +4:10
+          goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:+3:12: +7:6
       }
   
       bb4: {
-+         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
-          _0 = const 2_u32;                // scope 0 at $DIR/if-condition-int.rs:38:9: 38:10
-          goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
++         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:+3:15: +3:22
+          _0 = const 2_u32;                // scope 0 at $DIR/if-condition-int.rs:+6:9: +6:10
+          goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:+3:12: +7:6
       }
   
       bb5: {
-          StorageDead(_4);                 // scope 0 at $DIR/if-condition-int.rs:39:5: 39:6
-          goto -> bb6;                     // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
+          StorageDead(_4);                 // scope 0 at $DIR/if-condition-int.rs:+7:5: +7:6
+          goto -> bb6;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +7:6
       }
   
       bb6: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:39:5: 39:6
-          return;                          // scope 0 at $DIR/if-condition-int.rs:40:2: 40:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+7:5: +7:6
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
@@ -2,38 +2,38 @@
 + // MIR for `opt_negative` after SimplifyComparisonIntegral
   
   fn opt_negative(_1: i32) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:28:17: 28:18
-      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:28:28: 28:31
-      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
-      let mut _3: i32;                     // in scope 0 at $DIR/if-condition-int.rs:29:8: 29:9
+      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:17: +0:18
+      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:28: +0:31
+      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+      let mut _3: i32;                     // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
-          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:9
-          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:29:8: 29:9
--         _2 = Eq(move _3, const -42_i32); // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
--         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:15: 29:16
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:29:15: 29:16
-+         switchInt(move _3) -> [-42_i32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+-         _2 = Eq(move _3, const -42_i32); // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+-         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:15: +1:16
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:15: +1:16
++         switchInt(move _3) -> [-42_i32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
-          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:29:19: 29:20
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:19: +1:20
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:33
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
-          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:29:30: 29:31
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:16
+          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:30: +1:31
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:33
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:29:32: 29:33
-          return;                          // scope 0 at $DIR/if-condition-int.rs:30:2: 30:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:32: +1:33
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
@@ -2,38 +2,38 @@
 + // MIR for `opt_u32` after SimplifyComparisonIntegral
   
   fn opt_u32(_1: u32) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:11:12: 11:13
-      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:11:23: 11:26
-      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
-      let mut _3: u32;                     // in scope 0 at $DIR/if-condition-int.rs:12:8: 12:9
+      debug x => _1;                       // in scope 0 at $DIR/if-condition-int.rs:+0:12: +0:13
+      let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:+0:23: +0:26
+      let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+      let mut _3: u32;                     // in scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
-          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:9
-          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:12:8: 12:9
--         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
--         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:14: 12:15
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
-+         nop;                             // scope 0 at $DIR/if-condition-int.rs:12:14: 12:15
-+         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
+          StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:9
+-         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+-         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:14: +1:15
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
++         nop;                             // scope 0 at $DIR/if-condition-int.rs:+1:14: +1:15
++         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
-          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:12:18: 12:19
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:18: +1:19
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:32
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
-          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:12:29: 12:30
-          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:+1:8: +1:15
+          _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:+1:29: +1:30
+          goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:+1:5: +1:32
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:12:31: 12:32
-          return;                          // scope 0 at $DIR/if-condition-int.rs:13:2: 13:2
+          StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:+1:31: +1:32
+          return;                          // scope 0 at $DIR/if-condition-int.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/caller_with_trivial_bound.foo.Inline.diff
+++ b/src/test/mir-opt/inline/caller_with_trivial_bound.foo.Inline.diff
@@ -2,32 +2,32 @@
 + // MIR for `foo` after Inline
   
   fn foo() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/caller-with-trivial-bound.rs:17:1: 17:1
-      let mut _1: <IntFactory as Factory<T>>::Item; // in scope 0 at $DIR/caller-with-trivial-bound.rs:20:9: 20:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/caller-with-trivial-bound.rs:+1:1: +1:1
+      let mut _1: <IntFactory as Factory<T>>::Item; // in scope 0 at $DIR/caller-with-trivial-bound.rs:+4:9: +4:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/caller-with-trivial-bound.rs:20:9: 20:14
+          debug x => _1;                   // in scope 1 at $DIR/caller-with-trivial-bound.rs:+4:9: +4:14
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/caller-with-trivial-bound.rs:20:9: 20:14
-          _1 = bar::<T>() -> bb1;          // scope 0 at $DIR/caller-with-trivial-bound.rs:20:51: 20:61
+          StorageLive(_1);                 // scope 0 at $DIR/caller-with-trivial-bound.rs:+4:9: +4:14
+          _1 = bar::<T>() -> bb1;          // scope 0 at $DIR/caller-with-trivial-bound.rs:+4:51: +4:61
                                            // mir::Constant
                                            // + span: $DIR/caller-with-trivial-bound.rs:20:51: 20:59
                                            // + literal: Const { ty: fn() -> <IntFactory as Factory<T>>::Item {bar::<T>}, val: Value(<ZST>) }
       }
   
       bb1: {
-          _0 = const ();                   // scope 0 at $DIR/caller-with-trivial-bound.rs:19:1: 21:2
-          drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/caller-with-trivial-bound.rs:21:1: 21:2
+          _0 = const ();                   // scope 0 at $DIR/caller-with-trivial-bound.rs:+3:1: +5:2
+          drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/caller-with-trivial-bound.rs:+5:1: +5:2
       }
   
       bb2: {
-          StorageDead(_1);                 // scope 0 at $DIR/caller-with-trivial-bound.rs:21:1: 21:2
-          return;                          // scope 0 at $DIR/caller-with-trivial-bound.rs:21:2: 21:2
+          StorageDead(_1);                 // scope 0 at $DIR/caller-with-trivial-bound.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/caller-with-trivial-bound.rs:+5:2: +5:2
       }
   
       bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/caller-with-trivial-bound.rs:16:1: 21:2
+          resume;                          // scope 0 at $DIR/caller-with-trivial-bound.rs:+0:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/inline/cycle.f.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.f.Inline.diff
@@ -2,42 +2,42 @@
 + // MIR for `f` after Inline
   
   fn f(_1: impl Fn()) -> () {
-      debug g => _1;                       // in scope 0 at $DIR/cycle.rs:5:6: 5:7
-      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:5:20: 5:20
-      let _2: ();                          // in scope 0 at $DIR/cycle.rs:6:5: 6:8
-      let mut _3: &impl Fn();              // in scope 0 at $DIR/cycle.rs:6:5: 6:6
-      let mut _4: ();                      // in scope 0 at $DIR/cycle.rs:6:5: 6:8
+      debug g => _1;                       // in scope 0 at $DIR/cycle.rs:+0:6: +0:7
+      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:20: +0:20
+      let _2: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:8
+      let mut _3: &impl Fn();              // in scope 0 at $DIR/cycle.rs:+1:5: +1:6
+      let mut _4: ();                      // in scope 0 at $DIR/cycle.rs:+1:5: +1:8
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:6:5: 6:8
-          StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:6:5: 6:6
-          _3 = &_1;                        // scope 0 at $DIR/cycle.rs:6:5: 6:6
-          StorageLive(_4);                 // scope 0 at $DIR/cycle.rs:6:5: 6:8
-          Deinit(_4);                      // scope 0 at $DIR/cycle.rs:6:5: 6:8
-          _2 = <impl Fn() as Fn<()>>::call(move _3, move _4) -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/cycle.rs:6:5: 6:8
+          StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:8
+          StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:6
+          _3 = &_1;                        // scope 0 at $DIR/cycle.rs:+1:5: +1:6
+          StorageLive(_4);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:8
+          Deinit(_4);                      // scope 0 at $DIR/cycle.rs:+1:5: +1:8
+          _2 = <impl Fn() as Fn<()>>::call(move _3, move _4) -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/cycle.rs:+1:5: +1:8
                                            // mir::Constant
                                            // + span: $DIR/cycle.rs:6:5: 6:6
                                            // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as FnOnce<()>>::Output {<impl Fn() as Fn<()>>::call}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_4);                 // scope 0 at $DIR/cycle.rs:6:7: 6:8
-          StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:6:7: 6:8
-          StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:6:8: 6:9
-          _0 = const ();                   // scope 0 at $DIR/cycle.rs:5:20: 7:2
-          drop(_1) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/cycle.rs:7:1: 7:2
+          StorageDead(_4);                 // scope 0 at $DIR/cycle.rs:+1:7: +1:8
+          StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:+1:7: +1:8
+          StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:+1:8: +1:9
+          _0 = const ();                   // scope 0 at $DIR/cycle.rs:+0:20: +2:2
+          drop(_1) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/cycle.rs:+2:1: +2:2
       }
   
       bb2: {
-          return;                          // scope 0 at $DIR/cycle.rs:7:2: 7:2
+          return;                          // scope 0 at $DIR/cycle.rs:+2:2: +2:2
       }
   
       bb3 (cleanup): {
-          drop(_1) -> bb4;                 // scope 0 at $DIR/cycle.rs:7:1: 7:2
+          drop(_1) -> bb4;                 // scope 0 at $DIR/cycle.rs:+2:1: +2:2
       }
   
       bb4 (cleanup): {
-          resume;                          // scope 0 at $DIR/cycle.rs:5:1: 7:2
+          resume;                          // scope 0 at $DIR/cycle.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/cycle.g.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.g.Inline.diff
@@ -2,56 +2,56 @@
 + // MIR for `g` after Inline
   
   fn g() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:11:8: 11:8
-      let _1: ();                          // in scope 0 at $DIR/cycle.rs:12:5: 12:12
-+     let mut _2: fn() {main};             // in scope 0 at $DIR/cycle.rs:12:5: 12:12
+      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:8: +0:8
+      let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
++     let mut _2: fn() {main};             // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +     scope 1 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
-+         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
-+         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         let mut _4: &fn() {main};        // in scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:6:5: 6:8
++         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:+0:6: +0:7
++         let _3: ();                      // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         let mut _4: &fn() {main};        // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
 +         scope 2 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
 +         }
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:12:5: 12:12
--         _1 = f::<fn() {main}>(main) -> bb1; // scope 0 at $DIR/cycle.rs:12:5: 12:12
-+         StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:12:5: 12:12
-+         _2 = main;                       // scope 0 at $DIR/cycle.rs:12:5: 12:12
+          StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
+-         _1 = f::<fn() {main}>(main) -> bb1; // scope 0 at $DIR/cycle.rs:+1:5: +1:12
++         StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
++         _2 = main;                       // scope 0 at $DIR/cycle.rs:+1:5: +1:12
                                            // mir::Constant
 -                                          // + span: $DIR/cycle.rs:12:5: 12:6
 -                                          // + literal: Const { ty: fn(fn() {main}) {f::<fn() {main}>}, val: Value(<ZST>) }
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:12:7: 12:11
                                            // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
 +         _3 = move (*_4)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:12:5: 12:12
-          StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:12:12: 12:13
-          _0 = const ();                   // scope 0 at $DIR/cycle.rs:11:8: 13:2
-          return;                          // scope 0 at $DIR/cycle.rs:13:2: 13:2
++         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
+          StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:+1:12: +1:13
+          _0 = const ();                   // scope 0 at $DIR/cycle.rs:+0:8: +2:2
+          return;                          // scope 0 at $DIR/cycle.rs:+2:2: +2:2
 +     }
 + 
 +     bb2 (cleanup): {
-+         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
++         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 1 at $DIR/cycle.rs:5:1: 7:2
++         resume;                          // scope 1 at $DIR/cycle.rs:+0:1: +0:2
 +     }
 + 
 +     bb4: {
-+         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
-+         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
-+         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
-+         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
++         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
++         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
++         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:+0:8: +0:9
++         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
       }
   }
   

--- a/src/test/mir-opt/inline/cycle.main.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.main.Inline.diff
@@ -2,21 +2,21 @@
 + // MIR for `main` after Inline
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:16:11: 16:11
-      let _1: ();                          // in scope 0 at $DIR/cycle.rs:17:5: 17:9
-+     let mut _2: fn() {g};                // in scope 0 at $DIR/cycle.rs:17:5: 17:9
+      let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:11: +0:11
+      let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
++     let mut _2: fn() {g};                // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +     scope 1 (inlined f::<fn() {g}>) {    // at $DIR/cycle.rs:17:5: 17:9
-+         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
-+         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         let mut _4: &fn() {g};           // in scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:6:5: 6:8
++         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:+0:6: +0:7
++         let _3: ();                      // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         let mut _4: &fn() {g};           // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
 +         scope 2 (inlined <fn() {g} as Fn<()>>::call - shim(fn() {g})) { // at $DIR/cycle.rs:6:5: 6:8
 +             scope 3 (inlined g) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
-+                 let mut _6: fn() {main}; // in scope 3 at $DIR/cycle.rs:12:5: 12:12
++                 let mut _6: fn() {main}; // in scope 3 at $DIR/cycle.rs:+0:5: +0:12
 +                 scope 4 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
-+                     debug g => _6;       // in scope 4 at $DIR/cycle.rs:5:6: 5:7
-+                     let _7: ();          // in scope 4 at $DIR/cycle.rs:6:5: 6:8
-+                     let mut _8: &fn() {main}; // in scope 4 at $DIR/cycle.rs:6:5: 6:6
++                     debug g => _6;       // in scope 4 at $DIR/cycle.rs:+0:6: +0:7
++                     let _7: ();          // in scope 4 at $DIR/cycle.rs:+0:5: +0:8
++                     let mut _8: &fn() {main}; // in scope 4 at $DIR/cycle.rs:+0:5: +0:6
 +                     scope 5 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
 +                     }
 +                 }
@@ -25,50 +25,50 @@
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:17:5: 17:9
--         _1 = f::<fn() {g}>(g) -> bb1;    // scope 0 at $DIR/cycle.rs:17:5: 17:9
-+         StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:17:5: 17:9
-+         _2 = g;                          // scope 0 at $DIR/cycle.rs:17:5: 17:9
+          StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
+-         _1 = f::<fn() {g}>(g) -> bb1;    // scope 0 at $DIR/cycle.rs:+1:5: +1:9
++         StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
++         _2 = g;                          // scope 0 at $DIR/cycle.rs:+1:5: +1:9
                                            // mir::Constant
 -                                          // + span: $DIR/cycle.rs:17:5: 17:6
 -                                          // + literal: Const { ty: fn(fn() {g}) {f::<fn() {g}>}, val: Value(<ZST>) }
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:17:7: 17:8
                                            // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         StorageLive(_6);                 // scope 3 at $DIR/cycle.rs:12:5: 12:12
-+         StorageLive(_7);                 // scope 4 at $DIR/cycle.rs:6:5: 6:8
-+         StorageLive(_8);                 // scope 4 at $DIR/cycle.rs:6:5: 6:6
-+         _8 = &_6;                        // scope 4 at $DIR/cycle.rs:6:5: 6:6
++         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         StorageLive(_6);                 // scope 3 at $DIR/cycle.rs:+0:5: +0:12
++         StorageLive(_7);                 // scope 4 at $DIR/cycle.rs:+0:5: +0:8
++         StorageLive(_8);                 // scope 4 at $DIR/cycle.rs:+0:5: +0:6
++         _8 = &_6;                        // scope 4 at $DIR/cycle.rs:+0:5: +0:6
 +         _7 = move (*_8)() -> [return: bb4, unwind: bb2]; // scope 5 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:17:5: 17:9
-          StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:17:9: 17:10
-          _0 = const ();                   // scope 0 at $DIR/cycle.rs:16:11: 18:2
-          return;                          // scope 0 at $DIR/cycle.rs:18:2: 18:2
++         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
+          StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:+1:9: +1:10
+          _0 = const ();                   // scope 0 at $DIR/cycle.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/cycle.rs:+2:2: +2:2
 +     }
 + 
 +     bb2 (cleanup): {
-+         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
++         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 1 at $DIR/cycle.rs:5:1: 7:2
++         resume;                          // scope 1 at $DIR/cycle.rs:+0:1: +0:2
 +     }
 + 
 +     bb4: {
-+         StorageDead(_8);                 // scope 4 at $DIR/cycle.rs:6:7: 6:8
-+         StorageDead(_7);                 // scope 4 at $DIR/cycle.rs:6:8: 6:9
-+         StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:12:5: 12:12
-+         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
-+         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
-+         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
-+         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
++         StorageDead(_8);                 // scope 4 at $DIR/cycle.rs:+0:7: +0:8
++         StorageDead(_7);                 // scope 4 at $DIR/cycle.rs:+0:8: +0:9
++         StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:+0:5: +0:12
++         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
++         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
++         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:+0:8: +0:9
++         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
       }
   }
   

--- a/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
@@ -2,29 +2,29 @@
 + // MIR for `get_query` after Inline
   
   fn get_query(_1: &T) -> () {
-      debug t => _1;                       // in scope 0 at $DIR/dyn-trait.rs:32:31: 32:32
-      let mut _0: ();                      // return place in scope 0 at $DIR/dyn-trait.rs:32:38: 32:38
-      let _2: &<Q as Query>::C;            // in scope 0 at $DIR/dyn-trait.rs:33:9: 33:10
-      let mut _3: &T;                      // in scope 0 at $DIR/dyn-trait.rs:33:22: 33:23
-      let mut _4: &<Q as Query>::C;        // in scope 0 at $DIR/dyn-trait.rs:34:23: 34:24
+      debug t => _1;                       // in scope 0 at $DIR/dyn-trait.rs:+0:31: +0:32
+      let mut _0: ();                      // return place in scope 0 at $DIR/dyn-trait.rs:+0:38: +0:38
+      let _2: &<Q as Query>::C;            // in scope 0 at $DIR/dyn-trait.rs:+1:9: +1:10
+      let mut _3: &T;                      // in scope 0 at $DIR/dyn-trait.rs:+1:22: +1:23
+      let mut _4: &<Q as Query>::C;        // in scope 0 at $DIR/dyn-trait.rs:+2:23: +2:24
       scope 1 {
-          debug c => _2;                   // in scope 1 at $DIR/dyn-trait.rs:33:9: 33:10
+          debug c => _2;                   // in scope 1 at $DIR/dyn-trait.rs:+1:9: +1:10
 +         scope 2 (inlined try_execute_query::<<Q as Query>::C>) { // at $DIR/dyn-trait.rs:34:5: 34:25
-+             debug c => _4;               // in scope 2 at $DIR/dyn-trait.rs:26:36: 26:37
-+             let mut _5: &dyn Cache<V = <Q as Query>::V>; // in scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
-+             let mut _6: &<Q as Query>::C; // in scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
++             debug c => _4;               // in scope 2 at $DIR/dyn-trait.rs:+0:36: +0:37
++             let mut _5: &dyn Cache<V = <Q as Query>::V>; // in scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
++             let mut _6: &<Q as Query>::C; // in scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
 +             scope 3 (inlined mk_cycle::<<Q as Query>::V>) { // at $DIR/dyn-trait.rs:27:5: 27:16
-+                 debug c => _5;           // in scope 3 at $DIR/dyn-trait.rs:20:27: 20:28
-+                 let mut _7: &dyn Cache<V = <Q as Query>::V>; // in scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
++                 debug c => _5;           // in scope 3 at $DIR/dyn-trait.rs:+0:27: +0:28
++                 let mut _7: &dyn Cache<V = <Q as Query>::V>; // in scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
 +             }
 +         }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/dyn-trait.rs:33:9: 33:10
-          StorageLive(_3);                 // scope 0 at $DIR/dyn-trait.rs:33:22: 33:23
-          _3 = &(*_1);                     // scope 0 at $DIR/dyn-trait.rs:33:22: 33:23
-          _2 = <Q as Query>::cache::<T>(move _3) -> bb1; // scope 0 at $DIR/dyn-trait.rs:33:13: 33:24
+          StorageLive(_2);                 // scope 0 at $DIR/dyn-trait.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/dyn-trait.rs:+1:22: +1:23
+          _3 = &(*_1);                     // scope 0 at $DIR/dyn-trait.rs:+1:22: +1:23
+          _2 = <Q as Query>::cache::<T>(move _3) -> bb1; // scope 0 at $DIR/dyn-trait.rs:+1:13: +1:24
                                            // mir::Constant
                                            // + span: $DIR/dyn-trait.rs:33:13: 33:21
                                            // + user_ty: UserType(0)
@@ -32,18 +32,18 @@
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/dyn-trait.rs:33:23: 33:24
-          StorageLive(_4);                 // scope 1 at $DIR/dyn-trait.rs:34:23: 34:24
-          _4 = &(*_2);                     // scope 1 at $DIR/dyn-trait.rs:34:23: 34:24
--         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> bb2; // scope 1 at $DIR/dyn-trait.rs:34:5: 34:25
-+         StorageLive(_5);                 // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
-+         StorageLive(_6);                 // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
-+         _6 = _4;                         // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
-+         _5 = move _6 as &dyn Cache<V = <Q as Query>::V> (Pointer(Unsize)); // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
-+         StorageDead(_6);                 // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
-+         StorageLive(_7);                 // scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
-+         _7 = _5;                         // scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
-+         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(move _7) -> bb2; // scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
+          StorageDead(_3);                 // scope 0 at $DIR/dyn-trait.rs:+1:23: +1:24
+          StorageLive(_4);                 // scope 1 at $DIR/dyn-trait.rs:+2:23: +2:24
+          _4 = &(*_2);                     // scope 1 at $DIR/dyn-trait.rs:+2:23: +2:24
+-         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> bb2; // scope 1 at $DIR/dyn-trait.rs:+2:5: +2:25
++         StorageLive(_5);                 // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
++         StorageLive(_6);                 // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
++         _6 = _4;                         // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
++         _5 = move _6 as &dyn Cache<V = <Q as Query>::V> (Pointer(Unsize)); // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
++         StorageDead(_6);                 // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
++         StorageLive(_7);                 // scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
++         _7 = _5;                         // scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
++         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(move _7) -> bb2; // scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
                                            // mir::Constant
 -                                          // + span: $DIR/dyn-trait.rs:34:5: 34:22
 -                                          // + literal: Const { ty: for<'r> fn(&'r <Q as Query>::C) {try_execute_query::<<Q as Query>::C>}, val: Value(<ZST>) }
@@ -52,15 +52,15 @@
       }
   
       bb2: {
-+         StorageDead(_7);                 // scope 3 at $DIR/dyn-trait.rs:21:21: 21:22
-+         StorageDead(_5);                 // scope 2 at $DIR/dyn-trait.rs:27:15: 27:16
-          StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:34:24: 34:25
-          StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:35:1: 35:2
-          return;                          // scope 0 at $DIR/dyn-trait.rs:35:2: 35:2
++         StorageDead(_7);                 // scope 3 at $DIR/dyn-trait.rs:+0:21: +0:22
++         StorageDead(_5);                 // scope 2 at $DIR/dyn-trait.rs:+0:15: +0:16
+          StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:+2:24: +2:25
+          StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/dyn-trait.rs:+3:2: +3:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/dyn-trait.rs:32:1: 35:2
++         resume;                          // scope 0 at $DIR/dyn-trait.rs:+0:1: +3:2
       }
   }
   

--- a/src/test/mir-opt/inline/dyn_trait.mk_cycle.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.mk_cycle.Inline.diff
@@ -2,22 +2,22 @@
 + // MIR for `mk_cycle` after Inline
   
   fn mk_cycle(_1: &dyn Cache<V = V>) -> () {
-      debug c => _1;                       // in scope 0 at $DIR/dyn-trait.rs:20:27: 20:28
-      let mut _0: ();                      // return place in scope 0 at $DIR/dyn-trait.rs:20:49: 20:49
-      let mut _2: &dyn Cache<V = V>;       // in scope 0 at $DIR/dyn-trait.rs:21:5: 21:22
+      debug c => _1;                       // in scope 0 at $DIR/dyn-trait.rs:+0:27: +0:28
+      let mut _0: ();                      // return place in scope 0 at $DIR/dyn-trait.rs:+0:49: +0:49
+      let mut _2: &dyn Cache<V = V>;       // in scope 0 at $DIR/dyn-trait.rs:+1:5: +1:22
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/dyn-trait.rs:21:5: 21:22
-          _2 = &(*_1);                     // scope 0 at $DIR/dyn-trait.rs:21:5: 21:22
-          _0 = <dyn Cache<V = V> as Cache>::store_nocache(move _2) -> bb1; // scope 0 at $DIR/dyn-trait.rs:21:5: 21:22
+          StorageLive(_2);                 // scope 0 at $DIR/dyn-trait.rs:+1:5: +1:22
+          _2 = &(*_1);                     // scope 0 at $DIR/dyn-trait.rs:+1:5: +1:22
+          _0 = <dyn Cache<V = V> as Cache>::store_nocache(move _2) -> bb1; // scope 0 at $DIR/dyn-trait.rs:+1:5: +1:22
                                            // mir::Constant
                                            // + span: $DIR/dyn-trait.rs:21:7: 21:20
                                            // + literal: Const { ty: for<'r> fn(&'r dyn Cache<V = V>) {<dyn Cache<V = V> as Cache>::store_nocache}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:21:21: 21:22
-          return;                          // scope 0 at $DIR/dyn-trait.rs:22:2: 22:2
+          StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:+1:21: +1:22
+          return;                          // scope 0 at $DIR/dyn-trait.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
@@ -2,25 +2,25 @@
 + // MIR for `try_execute_query` after Inline
   
   fn try_execute_query(_1: &C) -> () {
-      debug c => _1;                       // in scope 0 at $DIR/dyn-trait.rs:26:36: 26:37
-      let mut _0: ();                      // return place in scope 0 at $DIR/dyn-trait.rs:26:43: 26:43
-      let mut _2: &dyn Cache<V = <C as Cache>::V>; // in scope 0 at $DIR/dyn-trait.rs:27:14: 27:15
-      let mut _3: &C;                      // in scope 0 at $DIR/dyn-trait.rs:27:14: 27:15
+      debug c => _1;                       // in scope 0 at $DIR/dyn-trait.rs:+0:36: +0:37
+      let mut _0: ();                      // return place in scope 0 at $DIR/dyn-trait.rs:+0:43: +0:43
+      let mut _2: &dyn Cache<V = <C as Cache>::V>; // in scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
+      let mut _3: &C;                      // in scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
 +     scope 1 (inlined mk_cycle::<<C as Cache>::V>) { // at $DIR/dyn-trait.rs:27:5: 27:16
-+         debug c => _2;                   // in scope 1 at $DIR/dyn-trait.rs:20:27: 20:28
-+         let mut _4: &dyn Cache<V = <C as Cache>::V>; // in scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
++         debug c => _2;                   // in scope 1 at $DIR/dyn-trait.rs:+0:27: +0:28
++         let mut _4: &dyn Cache<V = <C as Cache>::V>; // in scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
 +     }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/dyn-trait.rs:27:14: 27:15
-          StorageLive(_3);                 // scope 0 at $DIR/dyn-trait.rs:27:14: 27:15
-          _3 = &(*_1);                     // scope 0 at $DIR/dyn-trait.rs:27:14: 27:15
-          _2 = move _3 as &dyn Cache<V = <C as Cache>::V> (Pointer(Unsize)); // scope 0 at $DIR/dyn-trait.rs:27:14: 27:15
-          StorageDead(_3);                 // scope 0 at $DIR/dyn-trait.rs:27:14: 27:15
--         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> bb1; // scope 0 at $DIR/dyn-trait.rs:27:5: 27:16
-+         StorageLive(_4);                 // scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
-+         _4 = _2;                         // scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
-+         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(move _4) -> bb1; // scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
+          StorageLive(_2);                 // scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
+          StorageLive(_3);                 // scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
+          _3 = &(*_1);                     // scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
+          _2 = move _3 as &dyn Cache<V = <C as Cache>::V> (Pointer(Unsize)); // scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
+-         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> bb1; // scope 0 at $DIR/dyn-trait.rs:+1:5: +1:16
++         StorageLive(_4);                 // scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
++         _4 = _2;                         // scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
++         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(move _4) -> bb1; // scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
                                            // mir::Constant
 -                                          // + span: $DIR/dyn-trait.rs:27:5: 27:13
 -                                          // + literal: Const { ty: for<'r> fn(&'r (dyn Cache<V = <C as Cache>::V> + 'r)) {mk_cycle::<<C as Cache>::V>}, val: Value(<ZST>) }
@@ -29,13 +29,13 @@
       }
   
       bb1: {
-+         StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:21:21: 21:22
-          StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:27:15: 27:16
-          return;                          // scope 0 at $DIR/dyn-trait.rs:28:2: 28:2
++         StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:+0:21: +0:22
+          StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:+1:15: +1:16
+          return;                          // scope 0 at $DIR/dyn-trait.rs:+2:2: +2:2
 +     }
 + 
 +     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/dyn-trait.rs:26:1: 28:2
++         resume;                          // scope 0 at $DIR/dyn-trait.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -1,48 +1,48 @@
 // MIR for `bar` after Inline
 
 fn bar() -> bool {
-    let mut _0: bool;                    // return place in scope 0 at $DIR/inline-any-operand.rs:10:13: 10:17
-    let _1: fn(i32, i32) -> bool {foo};  // in scope 0 at $DIR/inline-any-operand.rs:11:9: 11:10
-    let mut _2: fn(i32, i32) -> bool {foo}; // in scope 0 at $DIR/inline-any-operand.rs:12:5: 12:6
-    let mut _3: i32;                     // in scope 0 at $DIR/inline-any-operand.rs:12:5: 12:13
-    let mut _4: i32;                     // in scope 0 at $DIR/inline-any-operand.rs:12:5: 12:13
+    let mut _0: bool;                    // return place in scope 0 at $DIR/inline-any-operand.rs:+0:13: +0:17
+    let _1: fn(i32, i32) -> bool {foo};  // in scope 0 at $DIR/inline-any-operand.rs:+1:9: +1:10
+    let mut _2: fn(i32, i32) -> bool {foo}; // in scope 0 at $DIR/inline-any-operand.rs:+2:5: +2:6
+    let mut _3: i32;                     // in scope 0 at $DIR/inline-any-operand.rs:+2:5: +2:13
+    let mut _4: i32;                     // in scope 0 at $DIR/inline-any-operand.rs:+2:5: +2:13
     scope 1 {
-        debug f => _1;                   // in scope 1 at $DIR/inline-any-operand.rs:11:9: 11:10
+        debug f => _1;                   // in scope 1 at $DIR/inline-any-operand.rs:+1:9: +1:10
         scope 2 (inlined foo) {          // at $DIR/inline-any-operand.rs:12:5: 12:13
-            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:16:8: 16:9
-            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:16:16: 16:17
-            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
-            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:+6:8: +6:9
+            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:+6:16: +6:17
+            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:6
+            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/inline-any-operand.rs:11:9: 11:10
-        _1 = foo;                        // scope 0 at $DIR/inline-any-operand.rs:11:13: 11:16
+        StorageLive(_1);                 // scope 0 at $DIR/inline-any-operand.rs:+1:9: +1:10
+        _1 = foo;                        // scope 0 at $DIR/inline-any-operand.rs:+1:13: +1:16
                                          // mir::Constant
                                          // + span: $DIR/inline-any-operand.rs:11:13: 11:16
                                          // + literal: Const { ty: fn(i32, i32) -> bool {foo}, val: Value(<ZST>) }
-        StorageLive(_2);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:6
-        _2 = _1;                         // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:6
-        StorageLive(_3);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        _3 = const 1_i32;                // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageLive(_4);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        _4 = const -1_i32;               // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
-        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
-        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
-        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
-        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:11
-        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
-        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
-        StorageDead(_4);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageDead(_3);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageDead(_2);                 // scope 1 at $DIR/inline-any-operand.rs:12:12: 12:13
-        StorageDead(_1);                 // scope 0 at $DIR/inline-any-operand.rs:13:1: 13:2
-        return;                          // scope 0 at $DIR/inline-any-operand.rs:13:2: 13:2
+        StorageLive(_2);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:6
+        _2 = _1;                         // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:6
+        StorageLive(_3);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
+        _3 = const 1_i32;                // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
+        StorageLive(_4);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
+        _4 = const -1_i32;               // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
+        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:6
+        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:6
+        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
+        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
+        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:11
+        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
+        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
+        StorageDead(_4);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
+        StorageDead(_3);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
+        StorageDead(_2);                 // scope 1 at $DIR/inline-any-operand.rs:+2:12: +2:13
+        StorageDead(_1);                 // scope 0 at $DIR/inline-any-operand.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/inline-any-operand.rs:+3:2: +3:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-any-operand.rs:10:1: 13:2
+        resume;                          // scope 0 at $DIR/inline-any-operand.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -1,53 +1,53 @@
 // MIR for `foo` after Inline
 
 fn foo(_1: T, _2: i32) -> i32 {
-    debug _t => _1;                      // in scope 0 at $DIR/inline-closure.rs:10:17: 10:19
-    debug q => _2;                       // in scope 0 at $DIR/inline-closure.rs:10:24: 10:25
-    let mut _0: i32;                     // return place in scope 0 at $DIR/inline-closure.rs:10:35: 10:38
-    let _3: [closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure.rs:11:9: 11:10
-    let mut _4: &[closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure.rs:12:5: 12:6
-    let mut _5: (i32, i32);              // in scope 0 at $DIR/inline-closure.rs:12:5: 12:12
-    let mut _6: i32;                     // in scope 0 at $DIR/inline-closure.rs:12:7: 12:8
-    let mut _7: i32;                     // in scope 0 at $DIR/inline-closure.rs:12:10: 12:11
-    let mut _8: i32;                     // in scope 0 at $DIR/inline-closure.rs:12:5: 12:12
-    let mut _9: i32;                     // in scope 0 at $DIR/inline-closure.rs:12:5: 12:12
+    debug _t => _1;                      // in scope 0 at $DIR/inline-closure.rs:+0:17: +0:19
+    debug q => _2;                       // in scope 0 at $DIR/inline-closure.rs:+0:24: +0:25
+    let mut _0: i32;                     // return place in scope 0 at $DIR/inline-closure.rs:+0:35: +0:38
+    let _3: [closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure.rs:+1:9: +1:10
+    let mut _4: &[closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure.rs:+2:5: +2:6
+    let mut _5: (i32, i32);              // in scope 0 at $DIR/inline-closure.rs:+2:5: +2:12
+    let mut _6: i32;                     // in scope 0 at $DIR/inline-closure.rs:+2:7: +2:8
+    let mut _7: i32;                     // in scope 0 at $DIR/inline-closure.rs:+2:10: +2:11
+    let mut _8: i32;                     // in scope 0 at $DIR/inline-closure.rs:+2:5: +2:12
+    let mut _9: i32;                     // in scope 0 at $DIR/inline-closure.rs:+2:5: +2:12
     scope 1 {
-        debug x => _3;                   // in scope 1 at $DIR/inline-closure.rs:11:9: 11:10
+        debug x => _3;                   // in scope 1 at $DIR/inline-closure.rs:+1:9: +1:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure.rs:12:5: 12:12
-            debug _t => _8;              // in scope 2 at $DIR/inline-closure.rs:11:14: 11:16
-            debug _q => _9;              // in scope 2 at $DIR/inline-closure.rs:11:18: 11:20
+            debug _t => _8;              // in scope 2 at $DIR/inline-closure.rs:+1:14: +1:16
+            debug _q => _9;              // in scope 2 at $DIR/inline-closure.rs:+1:18: +1:20
         }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 0 at $DIR/inline-closure.rs:11:9: 11:10
-        Deinit(_3);                      // scope 0 at $DIR/inline-closure.rs:11:13: 11:24
-        StorageLive(_4);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:6
-        _4 = &_3;                        // scope 1 at $DIR/inline-closure.rs:12:5: 12:6
-        StorageLive(_5);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        StorageLive(_6);                 // scope 1 at $DIR/inline-closure.rs:12:7: 12:8
-        _6 = _2;                         // scope 1 at $DIR/inline-closure.rs:12:7: 12:8
-        StorageLive(_7);                 // scope 1 at $DIR/inline-closure.rs:12:10: 12:11
-        _7 = _2;                         // scope 1 at $DIR/inline-closure.rs:12:10: 12:11
-        Deinit(_5);                      // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        (_5.0: i32) = move _6;           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        (_5.1: i32) = move _7;           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        StorageLive(_8);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        _8 = move (_5.0: i32);           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        StorageLive(_9);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        _9 = move (_5.1: i32);           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        _0 = _8;                         // scope 2 at $DIR/inline-closure.rs:11:22: 11:24
-        StorageDead(_9);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        StorageDead(_8);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        StorageDead(_7);                 // scope 1 at $DIR/inline-closure.rs:12:11: 12:12
-        StorageDead(_6);                 // scope 1 at $DIR/inline-closure.rs:12:11: 12:12
-        StorageDead(_5);                 // scope 1 at $DIR/inline-closure.rs:12:11: 12:12
-        StorageDead(_4);                 // scope 1 at $DIR/inline-closure.rs:12:11: 12:12
-        StorageDead(_3);                 // scope 0 at $DIR/inline-closure.rs:13:1: 13:2
-        return;                          // scope 0 at $DIR/inline-closure.rs:13:2: 13:2
+        StorageLive(_3);                 // scope 0 at $DIR/inline-closure.rs:+1:9: +1:10
+        Deinit(_3);                      // scope 0 at $DIR/inline-closure.rs:+1:13: +1:24
+        StorageLive(_4);                 // scope 1 at $DIR/inline-closure.rs:+2:5: +2:6
+        _4 = &_3;                        // scope 1 at $DIR/inline-closure.rs:+2:5: +2:6
+        StorageLive(_5);                 // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        StorageLive(_6);                 // scope 1 at $DIR/inline-closure.rs:+2:7: +2:8
+        _6 = _2;                         // scope 1 at $DIR/inline-closure.rs:+2:7: +2:8
+        StorageLive(_7);                 // scope 1 at $DIR/inline-closure.rs:+2:10: +2:11
+        _7 = _2;                         // scope 1 at $DIR/inline-closure.rs:+2:10: +2:11
+        Deinit(_5);                      // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        (_5.0: i32) = move _6;           // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        (_5.1: i32) = move _7;           // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        StorageLive(_8);                 // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        _8 = move (_5.0: i32);           // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        StorageLive(_9);                 // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        _9 = move (_5.1: i32);           // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        _0 = _8;                         // scope 2 at $DIR/inline-closure.rs:+1:22: +1:24
+        StorageDead(_9);                 // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        StorageDead(_8);                 // scope 1 at $DIR/inline-closure.rs:+2:5: +2:12
+        StorageDead(_7);                 // scope 1 at $DIR/inline-closure.rs:+2:11: +2:12
+        StorageDead(_6);                 // scope 1 at $DIR/inline-closure.rs:+2:11: +2:12
+        StorageDead(_5);                 // scope 1 at $DIR/inline-closure.rs:+2:11: +2:12
+        StorageDead(_4);                 // scope 1 at $DIR/inline-closure.rs:+2:11: +2:12
+        StorageDead(_3);                 // scope 0 at $DIR/inline-closure.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/inline-closure.rs:+3:2: +3:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-closure.rs:10:1: 13:2
+        resume;                          // scope 0 at $DIR/inline-closure.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -1,60 +1,60 @@
 // MIR for `foo` after Inline
 
 fn foo(_1: T, _2: &i32) -> i32 {
-    debug _t => _1;                      // in scope 0 at $DIR/inline-closure-borrows-arg.rs:11:17: 11:19
-    debug q => _2;                       // in scope 0 at $DIR/inline-closure-borrows-arg.rs:11:24: 11:25
-    let mut _0: i32;                     // return place in scope 0 at $DIR/inline-closure-borrows-arg.rs:11:36: 11:39
-    let _3: [closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
-    let mut _4: &[closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:6
-    let mut _5: (&i32, &i32);            // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-    let mut _6: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:7: 16:8
-    let mut _7: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:10: 16:11
-    let mut _8: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-    let mut _9: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+    debug _t => _1;                      // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+0:17: +0:19
+    debug q => _2;                       // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+0:24: +0:25
+    let mut _0: i32;                     // return place in scope 0 at $DIR/inline-closure-borrows-arg.rs:+0:36: +0:39
+    let _3: [closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+1:9: +1:10
+    let mut _4: &[closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:6
+    let mut _5: (&i32, &i32);            // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+    let mut _6: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+5:7: +5:8
+    let mut _7: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+5:10: +5:11
+    let mut _8: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+    let mut _9: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
     scope 1 {
-        debug x => _3;                   // in scope 1 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
+        debug x => _3;                   // in scope 1 at $DIR/inline-closure-borrows-arg.rs:+1:9: +1:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-            debug r => _8;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:14: 12:15
-            debug _s => _9;              // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:23: 12:25
-            let _10: &i32;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
+            debug r => _8;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:+1:14: +1:15
+            debug _s => _9;              // in scope 2 at $DIR/inline-closure-borrows-arg.rs:+1:23: +1:25
+            let _10: &i32;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:+2:13: +2:21
             scope 3 {
-                debug variable => _10;   // in scope 3 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
+                debug variable => _10;   // in scope 3 at $DIR/inline-closure-borrows-arg.rs:+2:13: +2:21
             }
         }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 0 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
-        Deinit(_3);                      // scope 0 at $DIR/inline-closure-borrows-arg.rs:12:13: 15:6
-        StorageLive(_4);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:6
-        _4 = &_3;                        // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:6
-        StorageLive(_5);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageLive(_6);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:7: 16:8
-        _6 = &(*_2);                     // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:7: 16:8
-        StorageLive(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:10: 16:11
-        _7 = &(*_2);                     // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:10: 16:11
-        Deinit(_5);                      // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        (_5.0: &i32) = move _6;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        (_5.1: &i32) = move _7;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageLive(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        _8 = move (_5.0: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageLive(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        _9 = move (_5.1: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageLive(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
-        _10 = _8;                        // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:24: 13:27
-        _0 = (*_10);                     // scope 3 at $DIR/inline-closure-borrows-arg.rs:14:9: 14:18
-        StorageDead(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:15:5: 15:6
-        StorageDead(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageDead(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageDead(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12
-        StorageDead(_6);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12
-        StorageDead(_5);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12
-        StorageDead(_4);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12
-        StorageDead(_3);                 // scope 0 at $DIR/inline-closure-borrows-arg.rs:17:1: 17:2
-        return;                          // scope 0 at $DIR/inline-closure-borrows-arg.rs:17:2: 17:2
+        StorageLive(_3);                 // scope 0 at $DIR/inline-closure-borrows-arg.rs:+1:9: +1:10
+        Deinit(_3);                      // scope 0 at $DIR/inline-closure-borrows-arg.rs:+1:13: +4:6
+        StorageLive(_4);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:6
+        _4 = &_3;                        // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:6
+        StorageLive(_5);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        StorageLive(_6);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:7: +5:8
+        _6 = &(*_2);                     // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:7: +5:8
+        StorageLive(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:10: +5:11
+        _7 = &(*_2);                     // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:10: +5:11
+        Deinit(_5);                      // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        (_5.0: &i32) = move _6;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        (_5.1: &i32) = move _7;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        StorageLive(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        _8 = move (_5.0: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        StorageLive(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        _9 = move (_5.1: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        StorageLive(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:+2:13: +2:21
+        _10 = _8;                        // scope 2 at $DIR/inline-closure-borrows-arg.rs:+2:24: +2:27
+        _0 = (*_10);                     // scope 3 at $DIR/inline-closure-borrows-arg.rs:+3:9: +3:18
+        StorageDead(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:+4:5: +4:6
+        StorageDead(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        StorageDead(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:5: +5:12
+        StorageDead(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:11: +5:12
+        StorageDead(_6);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:11: +5:12
+        StorageDead(_5);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:11: +5:12
+        StorageDead(_4);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:+5:11: +5:12
+        StorageDead(_3);                 // scope 0 at $DIR/inline-closure-borrows-arg.rs:+6:1: +6:2
+        return;                          // scope 0 at $DIR/inline-closure-borrows-arg.rs:+6:2: +6:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-closure-borrows-arg.rs:11:1: 17:2
+        resume;                          // scope 0 at $DIR/inline-closure-borrows-arg.rs:+0:1: +6:2
     }
 }

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -1,73 +1,73 @@
 // MIR for `foo` after Inline
 
 fn foo(_1: T, _2: i32) -> (i32, T) {
-    debug t => _1;                       // in scope 0 at $DIR/inline-closure-captures.rs:10:17: 10:18
-    debug q => _2;                       // in scope 0 at $DIR/inline-closure-captures.rs:10:23: 10:24
-    let mut _0: (i32, T);                // return place in scope 0 at $DIR/inline-closure-captures.rs:10:34: 10:42
-    let _3: [closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-captures.rs:11:9: 11:10
-    let mut _4: &i32;                    // in scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-    let mut _5: &T;                      // in scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-    let mut _6: &[closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-captures.rs:12:5: 12:6
-    let mut _7: (i32,);                  // in scope 0 at $DIR/inline-closure-captures.rs:12:5: 12:9
-    let mut _8: i32;                     // in scope 0 at $DIR/inline-closure-captures.rs:12:7: 12:8
-    let mut _9: i32;                     // in scope 0 at $DIR/inline-closure-captures.rs:12:5: 12:9
+    debug t => _1;                       // in scope 0 at $DIR/inline-closure-captures.rs:+0:17: +0:18
+    debug q => _2;                       // in scope 0 at $DIR/inline-closure-captures.rs:+0:23: +0:24
+    let mut _0: (i32, T);                // return place in scope 0 at $DIR/inline-closure-captures.rs:+0:34: +0:42
+    let _3: [closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-captures.rs:+1:9: +1:10
+    let mut _4: &i32;                    // in scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+    let mut _5: &T;                      // in scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+    let mut _6: &[closure@foo<T>::{closure#0}]; // in scope 0 at $DIR/inline-closure-captures.rs:+2:5: +2:6
+    let mut _7: (i32,);                  // in scope 0 at $DIR/inline-closure-captures.rs:+2:5: +2:9
+    let mut _8: i32;                     // in scope 0 at $DIR/inline-closure-captures.rs:+2:7: +2:8
+    let mut _9: i32;                     // in scope 0 at $DIR/inline-closure-captures.rs:+2:5: +2:9
     scope 1 {
-        debug x => _3;                   // in scope 1 at $DIR/inline-closure-captures.rs:11:9: 11:10
+        debug x => _3;                   // in scope 1 at $DIR/inline-closure-captures.rs:+1:9: +1:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure-captures.rs:12:5: 12:9
-            debug _q => _9;              // in scope 2 at $DIR/inline-closure-captures.rs:11:14: 11:16
-            debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline-closure-captures.rs:10:23: 10:24
-            debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline-closure-captures.rs:10:17: 10:18
-            let mut _10: i32;            // in scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
-            let mut _11: T;              // in scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-            let mut _12: &i32;           // in scope 2 at $DIR/inline-closure-captures.rs:11:13: 11:17
-            let mut _13: &T;             // in scope 2 at $DIR/inline-closure-captures.rs:11:13: 11:17
+            debug _q => _9;              // in scope 2 at $DIR/inline-closure-captures.rs:+1:14: +1:16
+            debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline-closure-captures.rs:+0:23: +0:24
+            debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline-closure-captures.rs:+0:17: +0:18
+            let mut _10: i32;            // in scope 2 at $DIR/inline-closure-captures.rs:+1:19: +1:20
+            let mut _11: T;              // in scope 2 at $DIR/inline-closure-captures.rs:+1:22: +1:23
+            let mut _12: &i32;           // in scope 2 at $DIR/inline-closure-captures.rs:+1:13: +1:17
+            let mut _13: &T;             // in scope 2 at $DIR/inline-closure-captures.rs:+1:13: +1:17
         }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 0 at $DIR/inline-closure-captures.rs:11:9: 11:10
-        StorageLive(_4);                 // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-        _4 = &_2;                        // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-        StorageLive(_5);                 // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-        _5 = &_1;                        // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-        Deinit(_3);                      // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-        (_3.0: &i32) = move _4;          // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-        (_3.1: &T) = move _5;            // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
-        StorageDead(_5);                 // scope 0 at $DIR/inline-closure-captures.rs:11:16: 11:17
-        StorageDead(_4);                 // scope 0 at $DIR/inline-closure-captures.rs:11:16: 11:17
-        StorageLive(_6);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:6
-        _6 = &_3;                        // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:6
-        StorageLive(_7);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageLive(_8);                 // scope 1 at $DIR/inline-closure-captures.rs:12:7: 12:8
-        _8 = _2;                         // scope 1 at $DIR/inline-closure-captures.rs:12:7: 12:8
-        Deinit(_7);                      // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        (_7.0: i32) = move _8;           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageLive(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        _9 = move (_7.0: i32);           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageLive(_10);                // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
-        StorageLive(_12);                // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
-        _12 = deref_copy ((*_6).0: &i32); // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
-        _10 = (*_12);                    // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
-        StorageDead(_12);                // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-        StorageLive(_11);                // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-        StorageLive(_13);                // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-        _13 = deref_copy ((*_6).1: &T);  // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-        _11 = (*_13);                    // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-        StorageDead(_13);                // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
-        Deinit(_0);                      // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
-        (_0.0: i32) = move _10;          // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
-        (_0.1: T) = move _11;            // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
-        StorageDead(_11);                // scope 2 at $DIR/inline-closure-captures.rs:11:23: 11:24
-        StorageDead(_10);                // scope 2 at $DIR/inline-closure-captures.rs:11:23: 11:24
-        StorageDead(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageDead(_8);                 // scope 1 at $DIR/inline-closure-captures.rs:12:8: 12:9
-        StorageDead(_7);                 // scope 1 at $DIR/inline-closure-captures.rs:12:8: 12:9
-        StorageDead(_6);                 // scope 1 at $DIR/inline-closure-captures.rs:12:8: 12:9
-        StorageDead(_3);                 // scope 0 at $DIR/inline-closure-captures.rs:13:1: 13:2
-        return;                          // scope 0 at $DIR/inline-closure-captures.rs:13:2: 13:2
+        StorageLive(_3);                 // scope 0 at $DIR/inline-closure-captures.rs:+1:9: +1:10
+        StorageLive(_4);                 // scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+        _4 = &_2;                        // scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+        StorageLive(_5);                 // scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+        _5 = &_1;                        // scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+        Deinit(_3);                      // scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+        (_3.0: &i32) = move _4;          // scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+        (_3.1: &T) = move _5;            // scope 0 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+        StorageDead(_5);                 // scope 0 at $DIR/inline-closure-captures.rs:+1:16: +1:17
+        StorageDead(_4);                 // scope 0 at $DIR/inline-closure-captures.rs:+1:16: +1:17
+        StorageLive(_6);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:6
+        _6 = &_3;                        // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:6
+        StorageLive(_7);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:9
+        StorageLive(_8);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:7: +2:8
+        _8 = _2;                         // scope 1 at $DIR/inline-closure-captures.rs:+2:7: +2:8
+        Deinit(_7);                      // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:9
+        (_7.0: i32) = move _8;           // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:9
+        StorageLive(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:9
+        _9 = move (_7.0: i32);           // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:9
+        StorageLive(_10);                // scope 2 at $DIR/inline-closure-captures.rs:+1:19: +1:20
+        StorageLive(_12);                // scope 2 at $DIR/inline-closure-captures.rs:+1:19: +1:20
+        _12 = deref_copy ((*_6).0: &i32); // scope 2 at $DIR/inline-closure-captures.rs:+1:19: +1:20
+        _10 = (*_12);                    // scope 2 at $DIR/inline-closure-captures.rs:+1:19: +1:20
+        StorageDead(_12);                // scope 2 at $DIR/inline-closure-captures.rs:+1:22: +1:23
+        StorageLive(_11);                // scope 2 at $DIR/inline-closure-captures.rs:+1:22: +1:23
+        StorageLive(_13);                // scope 2 at $DIR/inline-closure-captures.rs:+1:22: +1:23
+        _13 = deref_copy ((*_6).1: &T);  // scope 2 at $DIR/inline-closure-captures.rs:+1:22: +1:23
+        _11 = (*_13);                    // scope 2 at $DIR/inline-closure-captures.rs:+1:22: +1:23
+        StorageDead(_13);                // scope 2 at $DIR/inline-closure-captures.rs:+1:18: +1:24
+        Deinit(_0);                      // scope 2 at $DIR/inline-closure-captures.rs:+1:18: +1:24
+        (_0.0: i32) = move _10;          // scope 2 at $DIR/inline-closure-captures.rs:+1:18: +1:24
+        (_0.1: T) = move _11;            // scope 2 at $DIR/inline-closure-captures.rs:+1:18: +1:24
+        StorageDead(_11);                // scope 2 at $DIR/inline-closure-captures.rs:+1:23: +1:24
+        StorageDead(_10);                // scope 2 at $DIR/inline-closure-captures.rs:+1:23: +1:24
+        StorageDead(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:5: +2:9
+        StorageDead(_8);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:8: +2:9
+        StorageDead(_7);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:8: +2:9
+        StorageDead(_6);                 // scope 1 at $DIR/inline-closure-captures.rs:+2:8: +2:9
+        StorageDead(_3);                 // scope 0 at $DIR/inline-closure-captures.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/inline-closure-captures.rs:+3:2: +3:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-closure-captures.rs:10:1: 13:2
+        resume;                          // scope 0 at $DIR/inline-closure-captures.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
@@ -2,27 +2,27 @@
 + // MIR for `inlined_no_sanitize` after Inline
   
   fn inlined_no_sanitize() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:23:37: 23:37
-      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:24:5: 24:18
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:+0:37: +0:37
+      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
 +     scope 1 (inlined no_sanitize) {      // at $DIR/inline-compatibility.rs:24:5: 24:18
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:24:5: 24:18
--         _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:24:5: 24:18
+          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
+-         _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-compatibility.rs:24:5: 24:16
 -                                          // + literal: Const { ty: unsafe fn() {no_sanitize}, val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:24:18: 24:19
-          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:23:37: 25:2
-          return;                          // scope 0 at $DIR/inline-compatibility.rs:25:2: 25:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:18: +1:19
+          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:+0:37: +2:2
+          return;                          // scope 0 at $DIR/inline-compatibility.rs:+2:2: +2:2
 +     }
 + 
 +     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-compatibility.rs:23:1: 25:2
++         resume;                          // scope 0 at $DIR/inline-compatibility.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
@@ -2,27 +2,27 @@
 + // MIR for `inlined_target_feature` after Inline
   
   fn inlined_target_feature() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:12:40: 12:40
-      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:13:5: 13:21
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:+0:40: +0:40
+      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
 +     scope 1 (inlined target_feature) {   // at $DIR/inline-compatibility.rs:13:5: 13:21
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:13:5: 13:21
--         _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:13:5: 13:21
+          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
+-         _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-compatibility.rs:13:5: 13:19
 -                                          // + literal: Const { ty: unsafe fn() {target_feature}, val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:13:21: 13:22
-          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:12:40: 14:2
-          return;                          // scope 0 at $DIR/inline-compatibility.rs:14:2: 14:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:21: +1:22
+          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:+0:40: +2:2
+          return;                          // scope 0 at $DIR/inline-compatibility.rs:+2:2: +2:2
 +     }
 + 
 +     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-compatibility.rs:12:1: 14:2
++         resume;                          // scope 0 at $DIR/inline-compatibility.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.diff
@@ -2,24 +2,24 @@
 + // MIR for `not_inlined_c_variadic` after Inline
   
   fn not_inlined_c_variadic() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:41:40: 41:40
-      let _1: u32;                         // in scope 0 at $DIR/inline-compatibility.rs:42:9: 42:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:+0:40: +0:40
+      let _1: u32;                         // in scope 0 at $DIR/inline-compatibility.rs:+1:9: +1:10
       scope 1 {
-          debug s => _1;                   // in scope 1 at $DIR/inline-compatibility.rs:42:9: 42:10
+          debug s => _1;                   // in scope 1 at $DIR/inline-compatibility.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:42:9: 42:10
-          _1 = sum(const 4_u32, const 4_u32, const 30_u32, const 200_u32, const 1000_u32) -> bb1; // scope 0 at $DIR/inline-compatibility.rs:42:13: 42:52
+          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:9: +1:10
+          _1 = sum(const 4_u32, const 4_u32, const 30_u32, const 200_u32, const 1000_u32) -> bb1; // scope 0 at $DIR/inline-compatibility.rs:+1:13: +1:52
                                            // mir::Constant
                                            // + span: $DIR/inline-compatibility.rs:42:13: 42:16
                                            // + literal: Const { ty: unsafe extern "C" fn(u32, ...) -> u32 {sum}, val: Value(<ZST>) }
       }
   
       bb1: {
-          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:41:40: 43:2
-          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:43:1: 43:2
-          return;                          // scope 0 at $DIR/inline-compatibility.rs:43:2: 43:2
+          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:+0:40: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/inline-compatibility.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.diff
@@ -2,21 +2,21 @@
 + // MIR for `not_inlined_no_sanitize` after Inline
   
   fn not_inlined_no_sanitize() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:28:41: 28:41
-      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:29:5: 29:18
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:+0:41: +0:41
+      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:29:5: 29:18
-          _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:29:5: 29:18
+          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
+          _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
                                            // mir::Constant
                                            // + span: $DIR/inline-compatibility.rs:29:5: 29:16
                                            // + literal: Const { ty: unsafe fn() {no_sanitize}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:29:18: 29:19
-          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:28:41: 30:2
-          return;                          // scope 0 at $DIR/inline-compatibility.rs:30:2: 30:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:18: +1:19
+          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:+0:41: +2:2
+          return;                          // scope 0 at $DIR/inline-compatibility.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.diff
@@ -2,21 +2,21 @@
 + // MIR for `not_inlined_target_feature` after Inline
   
   fn not_inlined_target_feature() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:17:44: 17:44
-      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:18:5: 18:21
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:+0:44: +0:44
+      let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:18:5: 18:21
-          _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:18:5: 18:21
+          StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
+          _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
                                            // mir::Constant
                                            // + span: $DIR/inline-compatibility.rs:18:5: 18:19
                                            // + literal: Const { ty: unsafe fn() {target_feature}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:18:21: 18:22
-          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:17:44: 19:2
-          return;                          // scope 0 at $DIR/inline-compatibility.rs:19:2: 19:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:21: +1:22
+          _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:+0:44: +2:2
+          return;                          // scope 0 at $DIR/inline-compatibility.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
@@ -2,8 +2,8 @@
 + // MIR for `one` after Inline
   
   fn one() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle.rs:13:10: 13:10
-      let _1: ();                          // in scope 0 at $DIR/inline-cycle.rs:14:5: 14:24
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle.rs:+0:10: +0:10
+      let _1: ();                          // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:24
 +     scope 1 (inlined <C as Call>::call) { // at $DIR/inline-cycle.rs:14:5: 14:24
 +         scope 2 (inlined <A<C> as Call>::call) { // at $DIR/inline-cycle.rs:43:9: 43:23
 +             scope 3 (inlined <B<C> as Call>::call) { // at $DIR/inline-cycle.rs:28:9: 28:31
@@ -12,9 +12,9 @@
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:14:5: 14:24
--         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle.rs:14:5: 14:24
-+         _1 = <C as Call>::call() -> bb1; // scope 3 at $DIR/inline-cycle.rs:36:9: 36:28
+          StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:24
+-         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:24
++         _1 = <C as Call>::call() -> bb1; // scope 3 at $DIR/inline-cycle.rs:+23:9: +23:28
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle.rs:14:5: 14:22
 +                                          // + span: $DIR/inline-cycle.rs:36:9: 36:26
@@ -22,13 +22,13 @@
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:14:24: 14:25
-          _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:13:10: 15:2
-          return;                          // scope 0 at $DIR/inline-cycle.rs:15:2: 15:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:24: +1:25
+          _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:+0:10: +2:2
+          return;                          // scope 0 at $DIR/inline-cycle.rs:+2:2: +2:2
 +     }
 + 
 +     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-cycle.rs:13:1: 15:2
++         resume;                          // scope 0 at $DIR/inline-cycle.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -2,36 +2,36 @@
 + // MIR for `two` after Inline
   
   fn two() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle.rs:48:10: 48:10
-      let _1: ();                          // in scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
-+     let mut _2: fn() {f};                // in scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle.rs:+0:10: +0:10
+      let _1: ();                          // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
++     let mut _2: fn() {f};                // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
 +     scope 1 (inlined call::<fn() {f}>) { // at $DIR/inline-cycle.rs:49:5: 49:12
-+         debug f => _2;                   // in scope 1 at $DIR/inline-cycle.rs:53:22: 53:23
-+         let _3: ();                      // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
-+         let mut _4: fn() {f};            // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
-+         let mut _5: ();                  // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         debug f => _2;                   // in scope 1 at $DIR/inline-cycle.rs:+5:22: +5:23
++         let _3: ();                      // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
++         let mut _4: fn() {f};            // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
++         let mut _5: ();                  // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
 +         scope 2 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline-cycle.rs:54:5: 54:8
 +             scope 3 (inlined f) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
-+                 let _6: ();              // in scope 3 at $DIR/inline-cycle.rs:59:5: 59:12
++                 let _6: ();              // in scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
 +             }
 +         }
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
--         _1 = call::<fn() {f}>(f) -> bb1; // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
-+         StorageLive(_2);                 // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
-+         _2 = f;                          // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
+          StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
+-         _1 = call::<fn() {f}>(f) -> bb1; // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
++         StorageLive(_2);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
++         _2 = f;                          // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle.rs:49:5: 49:9
 +                                          // + span: $DIR/inline-cycle.rs:49:10: 49:11
 +                                          // + literal: Const { ty: fn() {f}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
-+         StorageLive(_4);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
-+         _4 = move _2;                    // scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
-+         StorageLive(_5);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
-+         StorageLive(_6);                 // scope 3 at $DIR/inline-cycle.rs:59:5: 59:12
-+         _6 = call::<fn() {f}>(f) -> bb1; // scope 3 at $DIR/inline-cycle.rs:59:5: 59:12
++         StorageLive(_3);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
++         StorageLive(_4);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
++         _4 = move _2;                    // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
++         StorageLive(_5);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
++         StorageLive(_6);                 // scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
++         _6 = call::<fn() {f}>(f) -> bb1; // scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
 +                                          // mir::Constant
 +                                          // + span: $DIR/inline-cycle.rs:59:5: 59:9
                                            // + literal: Const { ty: fn(fn() {f}) {call::<fn() {f}>}, val: Value(<ZST>) }
@@ -42,18 +42,18 @@
       }
   
       bb1: {
-+         StorageDead(_6);                 // scope 3 at $DIR/inline-cycle.rs:59:12: 59:13
-+         StorageDead(_5);                 // scope 1 at $DIR/inline-cycle.rs:54:7: 54:8
-+         StorageDead(_4);                 // scope 1 at $DIR/inline-cycle.rs:54:7: 54:8
-+         StorageDead(_3);                 // scope 1 at $DIR/inline-cycle.rs:54:8: 54:9
-+         StorageDead(_2);                 // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
-          StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:49:12: 49:13
-          _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:48:10: 50:2
-          return;                          // scope 0 at $DIR/inline-cycle.rs:50:2: 50:2
++         StorageDead(_6);                 // scope 3 at $DIR/inline-cycle.rs:+11:12: +11:13
++         StorageDead(_5);                 // scope 1 at $DIR/inline-cycle.rs:+6:7: +6:8
++         StorageDead(_4);                 // scope 1 at $DIR/inline-cycle.rs:+6:7: +6:8
++         StorageDead(_3);                 // scope 1 at $DIR/inline-cycle.rs:+6:8: +6:9
++         StorageDead(_2);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
+          StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:12: +1:13
+          _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:+0:10: +2:2
+          return;                          // scope 0 at $DIR/inline-cycle.rs:+2:2: +2:2
 +     }
 + 
 +     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-cycle.rs:48:1: 50:2
++         resume;                          // scope 0 at $DIR/inline-cycle.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
@@ -2,8 +2,8 @@
 + // MIR for `main` after Inline
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle-generic.rs:8:11: 8:11
-      let _1: ();                          // in scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle-generic.rs:+0:11: +0:11
+      let _1: ();                          // in scope 0 at $DIR/inline-cycle-generic.rs:+1:5: +1:24
 +     scope 1 (inlined <C as Call>::call) { // at $DIR/inline-cycle-generic.rs:9:5: 9:24
 +         scope 2 (inlined <B<A> as Call>::call) { // at $DIR/inline-cycle-generic.rs:38:9: 38:31
 +             scope 3 (inlined <A as Call>::call) { // at $DIR/inline-cycle-generic.rs:31:9: 31:28
@@ -14,9 +14,9 @@
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
--         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
-+         _1 = <C as Call>::call() -> bb1; // scope 4 at $DIR/inline-cycle-generic.rs:31:9: 31:28
+          StorageLive(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:+1:5: +1:24
+-         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle-generic.rs:+1:5: +1:24
++         _1 = <C as Call>::call() -> bb1; // scope 4 at $DIR/inline-cycle-generic.rs:+23:9: +23:28
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle-generic.rs:9:5: 9:22
 +                                          // + span: $DIR/inline-cycle-generic.rs:31:9: 31:26
@@ -24,13 +24,13 @@
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:9:24: 9:25
-          _0 = const ();                   // scope 0 at $DIR/inline-cycle-generic.rs:8:11: 10:2
-          return;                          // scope 0 at $DIR/inline-cycle-generic.rs:10:2: 10:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:+1:24: +1:25
+          _0 = const ();                   // scope 0 at $DIR/inline-cycle-generic.rs:+0:11: +2:2
+          return;                          // scope 0 at $DIR/inline-cycle-generic.rs:+2:2: +2:2
 +     }
 + 
 +     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-cycle-generic.rs:8:1: 10:2
++         resume;                          // scope 0 at $DIR/inline-cycle-generic.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
@@ -2,27 +2,27 @@
 + // MIR for `f` after Inline
   
   fn f() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-diverging.rs:7:12: 7:12
-      let mut _1: !;                       // in scope 0 at $DIR/inline-diverging.rs:7:12: 9:2
-      let _2: !;                           // in scope 0 at $DIR/inline-diverging.rs:8:5: 8:12
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-diverging.rs:+0:12: +0:12
+      let mut _1: !;                       // in scope 0 at $DIR/inline-diverging.rs:+0:12: +2:2
+      let _2: !;                           // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:12
 +     scope 1 (inlined sleep) {            // at $DIR/inline-diverging.rs:8:5: 8:12
 +     }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:8:5: 8:12
--         _2 = sleep();                    // scope 0 at $DIR/inline-diverging.rs:8:5: 8:12
+          StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:12
+-         _2 = sleep();                    // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:12
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-diverging.rs:8:5: 8:10
 -                                          // + literal: Const { ty: fn() -> ! {sleep}, val: Value(<ZST>) }
-+         goto -> bb1;                     // scope 0 at $DIR/inline-diverging.rs:8:5: 8:12
++         goto -> bb1;                     // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:12
 +     }
 + 
 +     bb1: {
-+         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:39:5: 39:12
++         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:+32:5: +32:12
 +     }
 + 
 +     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-diverging.rs:7:1: 9:2
++         resume;                          // scope 0 at $DIR/inline-diverging.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -2,38 +2,38 @@
 + // MIR for `g` after Inline
   
   fn g(_1: i32) -> u32 {
-      debug i => _1;                       // in scope 0 at $DIR/inline-diverging.rs:12:10: 12:11
-      let mut _0: u32;                     // return place in scope 0 at $DIR/inline-diverging.rs:12:21: 12:24
-      let mut _2: bool;                    // in scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
-      let mut _3: i32;                     // in scope 0 at $DIR/inline-diverging.rs:13:8: 13:9
-      let mut _4: i32;                     // in scope 0 at $DIR/inline-diverging.rs:14:9: 14:10
-      let mut _5: !;                       // in scope 0 at $DIR/inline-diverging.rs:15:12: 17:6
-      let _6: !;                           // in scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
+      debug i => _1;                       // in scope 0 at $DIR/inline-diverging.rs:+0:10: +0:11
+      let mut _0: u32;                     // return place in scope 0 at $DIR/inline-diverging.rs:+0:21: +0:24
+      let mut _2: bool;                    // in scope 0 at $DIR/inline-diverging.rs:+1:8: +1:13
+      let mut _3: i32;                     // in scope 0 at $DIR/inline-diverging.rs:+1:8: +1:9
+      let mut _4: i32;                     // in scope 0 at $DIR/inline-diverging.rs:+2:9: +2:10
+      let mut _5: !;                       // in scope 0 at $DIR/inline-diverging.rs:+3:12: +5:6
+      let _6: !;                           // in scope 0 at $DIR/inline-diverging.rs:+4:9: +4:16
 +     scope 1 (inlined panic) {            // at $DIR/inline-diverging.rs:16:9: 16:16
 +         let mut _7: !;                   // in scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
 +     }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
-          StorageLive(_3);                 // scope 0 at $DIR/inline-diverging.rs:13:8: 13:9
-          _3 = _1;                         // scope 0 at $DIR/inline-diverging.rs:13:8: 13:9
-          _2 = Gt(move _3, const 0_i32);   // scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
-          StorageDead(_3);                 // scope 0 at $DIR/inline-diverging.rs:13:12: 13:13
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
+          StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:+1:8: +1:13
+          StorageLive(_3);                 // scope 0 at $DIR/inline-diverging.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/inline-diverging.rs:+1:8: +1:9
+          _2 = Gt(move _3, const 0_i32);   // scope 0 at $DIR/inline-diverging.rs:+1:8: +1:13
+          StorageDead(_3);                 // scope 0 at $DIR/inline-diverging.rs:+1:12: +1:13
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/inline-diverging.rs:+1:8: +1:13
       }
   
       bb1: {
-          StorageLive(_4);                 // scope 0 at $DIR/inline-diverging.rs:14:9: 14:10
-          _4 = _1;                         // scope 0 at $DIR/inline-diverging.rs:14:9: 14:10
-          _0 = move _4 as u32 (Misc);      // scope 0 at $DIR/inline-diverging.rs:14:9: 14:17
-          StorageDead(_4);                 // scope 0 at $DIR/inline-diverging.rs:14:16: 14:17
-          StorageDead(_2);                 // scope 0 at $DIR/inline-diverging.rs:17:5: 17:6
-          return;                          // scope 0 at $DIR/inline-diverging.rs:18:2: 18:2
+          StorageLive(_4);                 // scope 0 at $DIR/inline-diverging.rs:+2:9: +2:10
+          _4 = _1;                         // scope 0 at $DIR/inline-diverging.rs:+2:9: +2:10
+          _0 = move _4 as u32 (Misc);      // scope 0 at $DIR/inline-diverging.rs:+2:9: +2:17
+          StorageDead(_4);                 // scope 0 at $DIR/inline-diverging.rs:+2:16: +2:17
+          StorageDead(_2);                 // scope 0 at $DIR/inline-diverging.rs:+5:5: +5:6
+          return;                          // scope 0 at $DIR/inline-diverging.rs:+6:2: +6:2
       }
   
       bb2: {
-          StorageLive(_6);                 // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
--         _6 = panic();                    // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
+          StorageLive(_6);                 // scope 0 at $DIR/inline-diverging.rs:+4:9: +4:16
+-         _6 = panic();                    // scope 0 at $DIR/inline-diverging.rs:+4:9: +4:16
 +         StorageLive(_7);                 // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
 +         _7 = begin_panic::<&str>(const "explicit panic"); // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
                                            // mir::Constant
@@ -47,7 +47,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-diverging.rs:12:1: 18:2
++         resume;                          // scope 0 at $DIR/inline-diverging.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -2,23 +2,23 @@
 + // MIR for `h` after Inline
   
   fn h() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-diverging.rs:21:12: 21:12
-      let _1: (!, !);                      // in scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
-+     let mut _2: fn() -> ! {sleep};       // in scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-diverging.rs:+0:12: +0:12
+      let _1: (!, !);                      // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
++     let mut _2: fn() -> ! {sleep};       // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
 +     scope 1 (inlined call_twice::<!, fn() -> ! {sleep}>) { // at $DIR/inline-diverging.rs:22:5: 22:22
-+         debug f => _2;                   // in scope 1 at $DIR/inline-diverging.rs:26:36: 26:37
-+         let _3: !;                       // in scope 1 at $DIR/inline-diverging.rs:27:9: 27:10
-+         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
-+         let mut _5: ();                  // in scope 1 at $DIR/inline-diverging.rs:27:13: 27:16
-+         let mut _7: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:28:13: 28:14
-+         let mut _8: ();                  // in scope 1 at $DIR/inline-diverging.rs:28:13: 28:16
-+         let mut _9: !;                   // in scope 1 at $DIR/inline-diverging.rs:29:6: 29:7
-+         let mut _10: !;                  // in scope 1 at $DIR/inline-diverging.rs:29:9: 29:10
++         debug f => _2;                   // in scope 1 at $DIR/inline-diverging.rs:+5:36: +5:37
++         let _3: !;                       // in scope 1 at $DIR/inline-diverging.rs:+6:9: +6:10
++         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
++         let mut _5: ();                  // in scope 1 at $DIR/inline-diverging.rs:+6:13: +6:16
++         let mut _7: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:+7:13: +7:14
++         let mut _8: ();                  // in scope 1 at $DIR/inline-diverging.rs:+7:13: +7:16
++         let mut _9: !;                   // in scope 1 at $DIR/inline-diverging.rs:+8:6: +8:7
++         let mut _10: !;                  // in scope 1 at $DIR/inline-diverging.rs:+8:9: +8:10
 +         scope 2 {
-+             debug a => _3;               // in scope 2 at $DIR/inline-diverging.rs:27:9: 27:10
-+             let _6: !;                   // in scope 2 at $DIR/inline-diverging.rs:28:9: 28:10
++             debug a => _3;               // in scope 2 at $DIR/inline-diverging.rs:+6:9: +6:10
++             let _6: !;                   // in scope 2 at $DIR/inline-diverging.rs:+7:9: +7:10
 +             scope 3 {
-+                 debug b => _6;           // in scope 3 at $DIR/inline-diverging.rs:28:9: 28:10
++                 debug b => _6;           // in scope 3 at $DIR/inline-diverging.rs:+7:9: +7:10
 +             }
 +             scope 6 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:28:13: 28:16
 +                 scope 7 (inlined sleep) { // at $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -32,29 +32,29 @@
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
--         _1 = call_twice::<!, fn() -> ! {sleep}>(sleep); // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
-+         StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
-+         _2 = sleep;                      // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
+          StorageLive(_1);                 // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
+-         _1 = call_twice::<!, fn() -> ! {sleep}>(sleep); // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
++         StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
++         _2 = sleep;                      // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
                                            // mir::Constant
 -                                          // + span: $DIR/inline-diverging.rs:22:5: 22:15
 -                                          // + literal: Const { ty: fn(fn() -> ! {sleep}) -> (!, !) {call_twice::<!, fn() -> ! {sleep}>}, val: Value(<ZST>) }
 -                                          // mir::Constant
                                            // + span: $DIR/inline-diverging.rs:22:16: 22:21
                                            // + literal: Const { ty: fn() -> ! {sleep}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:27:9: 27:10
-+         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
-+         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
-+         StorageLive(_5);                 // scope 1 at $DIR/inline-diverging.rs:27:13: 27:16
-+         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:39:5: 39:12
++         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:+6:9: +6:10
++         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
++         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
++         StorageLive(_5);                 // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:16
++         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:+18:5: +18:12
 +     }
 + 
 +     bb1: {
-+         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:39:5: 39:12
++         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:+18:5: +18:12
 +     }
 + 
 +     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-diverging.rs:21:1: 23:2
++         resume;                          // scope 0 at $DIR/inline-diverging.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -2,14 +2,14 @@
 + // MIR for `main` after Inline
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-generator.rs:8:11: 8:11
-      let _1: std::ops::GeneratorState<i32, bool>; // in scope 0 at $DIR/inline-generator.rs:9:9: 9:11
-      let mut _2: std::pin::Pin<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>; // in scope 0 at $DIR/inline-generator.rs:9:14: 9:32
-      let mut _3: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 0 at $DIR/inline-generator.rs:9:23: 9:31
-      let mut _4: [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 0 at $DIR/inline-generator.rs:9:28: 9:31
-+     let mut _7: bool;                    // in scope 0 at $DIR/inline-generator.rs:9:14: 9:46
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-generator.rs:+0:11: +0:11
+      let _1: std::ops::GeneratorState<i32, bool>; // in scope 0 at $DIR/inline-generator.rs:+1:9: +1:11
+      let mut _2: std::pin::Pin<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>; // in scope 0 at $DIR/inline-generator.rs:+1:14: +1:32
+      let mut _3: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 0 at $DIR/inline-generator.rs:+1:23: +1:31
+      let mut _4: [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 0 at $DIR/inline-generator.rs:+1:28: +1:31
++     let mut _7: bool;                    // in scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
       scope 1 {
-          debug _r => _1;                  // in scope 1 at $DIR/inline-generator.rs:9:9: 9:11
+          debug _r => _1;                  // in scope 1 at $DIR/inline-generator.rs:+1:9: +1:11
       }
 +     scope 2 (inlined g) {                // at $DIR/inline-generator.rs:9:28: 9:31
 +     }
@@ -24,33 +24,33 @@
 +         }
 +     }
 +     scope 6 (inlined g::{closure#0}) {   // at $DIR/inline-generator.rs:9:14: 9:46
-+         debug a => _11;                  // in scope 6 at $DIR/inline-generator.rs:15:6: 15:7
-+         let mut _8: i32;                 // in scope 6 at $DIR/inline-generator.rs:15:17: 15:39
-+         let mut _9: bool;                // in scope 6 at $DIR/inline-generator.rs:15:20: 15:21
-+         let mut _10: bool;               // in scope 6 at $DIR/inline-generator.rs:15:9: 15:9
-+         let _11: bool;                   // in scope 6 at $DIR/inline-generator.rs:15:6: 15:7
-+         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         let mut _13: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         let mut _14: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         let mut _15: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         debug a => _11;                  // in scope 6 at $DIR/inline-generator.rs:+7:6: +7:7
++         let mut _8: i32;                 // in scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
++         let mut _9: bool;                // in scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
++         let mut _10: bool;               // in scope 6 at $DIR/inline-generator.rs:+7:9: +7:9
++         let _11: bool;                   // in scope 6 at $DIR/inline-generator.rs:+7:6: +7:7
++         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         let mut _13: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         let mut _14: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         let mut _15: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-generator.rs:9:9: 9:11
-          StorageLive(_2);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:32
-          StorageLive(_3);                 // scope 0 at $DIR/inline-generator.rs:9:23: 9:31
-          StorageLive(_4);                 // scope 0 at $DIR/inline-generator.rs:9:28: 9:31
--         _4 = g() -> bb1;                 // scope 0 at $DIR/inline-generator.rs:9:28: 9:31
+          StorageLive(_1);                 // scope 0 at $DIR/inline-generator.rs:+1:9: +1:11
+          StorageLive(_2);                 // scope 0 at $DIR/inline-generator.rs:+1:14: +1:32
+          StorageLive(_3);                 // scope 0 at $DIR/inline-generator.rs:+1:23: +1:31
+          StorageLive(_4);                 // scope 0 at $DIR/inline-generator.rs:+1:28: +1:31
+-         _4 = g() -> bb1;                 // scope 0 at $DIR/inline-generator.rs:+1:28: +1:31
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-generator.rs:9:28: 9:29
 -                                          // + literal: Const { ty: fn() -> impl Generator<bool> {g}, val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {
-+         Deinit(_4);                      // scope 2 at $DIR/inline-generator.rs:15:5: 15:41
-+         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:15:5: 15:41
-          _3 = &mut _4;                    // scope 0 at $DIR/inline-generator.rs:9:23: 9:31
--         _2 = Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>::new(move _3) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:9:14: 9:32
++         Deinit(_4);                      // scope 2 at $DIR/inline-generator.rs:+7:5: +7:41
++         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:+7:5: +7:41
+          _3 = &mut _4;                    // scope 0 at $DIR/inline-generator.rs:+1:23: +1:31
+-         _2 = Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>::new(move _3) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:+1:14: +1:32
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-generator.rs:9:14: 9:22
 -                                          // + user_ty: UserType(0)
@@ -66,91 +66,91 @@
 +         (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]) = move _6; // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
-          StorageDead(_3);                 // scope 0 at $DIR/inline-generator.rs:9:31: 9:32
--         _1 = <[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
+          StorageDead(_3);                 // scope 0 at $DIR/inline-generator.rs:+1:31: +1:32
+-         _1 = <[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-generator.rs:9:33: 9:39
 -                                          // + literal: Const { ty: for<'r> fn(Pin<&'r mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>, bool) -> GeneratorState<<[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::Yield, <[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::Return> {<[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::resume}, val: Value(<ZST>) }
-+         StorageLive(_7);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         _7 = const false;                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageLive(_10);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageLive(_11);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageLive(_12);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageLive(_13);                // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         _13 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         _12 = discriminant((*_13));      // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         StorageDead(_13);                // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         StorageLive(_7);                 // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         _7 = const false;                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         StorageLive(_10);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         StorageLive(_11);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         StorageLive(_12);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         StorageLive(_13);                // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         _13 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         _12 = discriminant((*_13));      // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         StorageDead(_13);                // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
       }
   
 -     bb3: {
 +     bb1: {
-+         StorageDead(_12);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageDead(_11);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageDead(_10);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageDead(_7);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-          StorageDead(_2);                 // scope 0 at $DIR/inline-generator.rs:9:45: 9:46
-          StorageDead(_4);                 // scope 0 at $DIR/inline-generator.rs:9:46: 9:47
-          _0 = const ();                   // scope 0 at $DIR/inline-generator.rs:8:11: 10:2
-          StorageDead(_1);                 // scope 0 at $DIR/inline-generator.rs:10:1: 10:2
-          return;                          // scope 0 at $DIR/inline-generator.rs:10:2: 10:2
++         StorageDead(_12);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         StorageDead(_11);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         StorageDead(_10);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
++         StorageDead(_7);                 // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
+          StorageDead(_2);                 // scope 0 at $DIR/inline-generator.rs:+1:45: +1:46
+          StorageDead(_4);                 // scope 0 at $DIR/inline-generator.rs:+1:46: +1:47
+          _0 = const ();                   // scope 0 at $DIR/inline-generator.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-generator.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/inline-generator.rs:+2:2: +2:2
       }
   
 -     bb4 (cleanup): {
 +     bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/inline-generator.rs:8:1: 10:2
+          resume;                          // scope 0 at $DIR/inline-generator.rs:+0:1: +2:2
 +     }
 + 
 +     bb3: {
-+         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
-+         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
-+         _9 = _11;                        // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
-+         switchInt(move _9) -> [false: bb5, otherwise: bb4]; // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
++         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
++         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
++         _9 = _11;                        // scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
++         switchInt(move _9) -> [false: bb5, otherwise: bb4]; // scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
 +     }
 + 
 +     bb4: {
-+         _8 = const 7_i32;                // scope 6 at $DIR/inline-generator.rs:15:24: 15:25
-+         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
++         _8 = const 7_i32;                // scope 6 at $DIR/inline-generator.rs:+7:24: +7:25
++         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
 +     }
 + 
 +     bb5: {
-+         _8 = const 13_i32;               // scope 6 at $DIR/inline-generator.rs:15:35: 15:37
-+         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
++         _8 = const 13_i32;               // scope 6 at $DIR/inline-generator.rs:+7:35: +7:37
++         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
 +     }
 + 
 +     bb6: {
-+         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
-+         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
-+         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
-+         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
-+         StorageLive(_14);                // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
-+         _14 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
-+         discriminant((*_14)) = 3;        // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
-+         StorageDead(_14);                // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
-+         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:11: 15:39
++         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:+7:38: +7:39
++         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
++         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
++         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
++         StorageLive(_14);                // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
++         _14 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
++         discriminant((*_14)) = 3;        // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
++         StorageDead(_14);                // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
++         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:+7:11: +7:39
 +     }
 + 
 +     bb7: {
-+         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
-+         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         StorageLive(_15);                // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         _15 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         discriminant((*_15)) = 1;        // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         StorageDead(_15);                // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:8: 15:8
++         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:+7:38: +7:39
++         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
++         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
++         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
++         StorageLive(_15);                // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
++         _15 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
++         discriminant((*_15)) = 1;        // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
++         StorageDead(_15);                // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
++         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:+7:8: +7:8
 +     }
 + 
 +     bb8: {
-+         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
 +     }
 + 
 +     bb9: {
-+         unreachable;                     // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         unreachable;                     // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
       }
   }
   

--- a/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
@@ -2,47 +2,47 @@
 + // MIR for `default` after Inline
   
   fn default() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-instruction-set.rs:50:18: 50:18
-      let _1: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:51:5: 51:26
-      let _2: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:52:5: 52:26
-      let _3: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:53:5: 53:30
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-instruction-set.rs:+0:18: +0:18
+      let _1: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
+      let _2: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
+      let _3: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:+3:5: +3:30
 +     scope 1 (inlined instruction_set_default) { // at $DIR/inline-instruction-set.rs:53:5: 53:30
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:51:5: 51:26
-          _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:51:5: 51:26
+          StorageLive(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
+          _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:51:5: 51:24
                                            // + literal: Const { ty: fn() {instruction_set_a32}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:51:26: 51:27
-          StorageLive(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:52:5: 52:26
-          _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:52:5: 52:26
+          StorageDead(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:+1:26: +1:27
+          StorageLive(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
+          _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:52:5: 52:24
                                            // + literal: Const { ty: fn() {instruction_set_t32}, val: Value(<ZST>) }
       }
   
       bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:52:26: 52:27
-          StorageLive(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:53:5: 53:30
--         _3 = instruction_set_default() -> bb3; // scope 0 at $DIR/inline-instruction-set.rs:53:5: 53:30
+          StorageDead(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:+2:26: +2:27
+          StorageLive(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:+3:5: +3:30
+-         _3 = instruction_set_default() -> bb3; // scope 0 at $DIR/inline-instruction-set.rs:+3:5: +3:30
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-instruction-set.rs:53:5: 53:28
 -                                          // + literal: Const { ty: fn() {instruction_set_default}, val: Value(<ZST>) }
 -     }
 - 
 -     bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:53:30: 53:31
-          _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:50:18: 54:2
-          return;                          // scope 0 at $DIR/inline-instruction-set.rs:54:2: 54:2
+          StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:+3:30: +3:31
+          _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:+0:18: +4:2
+          return;                          // scope 0 at $DIR/inline-instruction-set.rs:+4:2: +4:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-instruction-set.rs:50:1: 54:2
++         resume;                          // scope 0 at $DIR/inline-instruction-set.rs:+0:1: +4:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
@@ -2,35 +2,35 @@
 + // MIR for `t32` after Inline
   
   fn t32() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-instruction-set.rs:41:14: 41:14
-      let _1: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:42:5: 42:26
-      let _2: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:43:5: 43:26
-      let _3: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:46:5: 46:30
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-instruction-set.rs:+0:14: +0:14
+      let _1: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
+      let _2: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
+      let _3: ();                          // in scope 0 at $DIR/inline-instruction-set.rs:+5:5: +5:30
 +     scope 1 (inlined instruction_set_t32) { // at $DIR/inline-instruction-set.rs:43:5: 43:26
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:42:5: 42:26
-          _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:42:5: 42:26
+          StorageLive(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
+          _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:42:5: 42:24
                                            // + literal: Const { ty: fn() {instruction_set_a32}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:42:26: 42:27
-          StorageLive(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:43:5: 43:26
--         _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:43:5: 43:26
+          StorageDead(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:+1:26: +1:27
+          StorageLive(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
+-         _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-instruction-set.rs:43:5: 43:24
 -                                          // + literal: Const { ty: fn() {instruction_set_t32}, val: Value(<ZST>) }
 -     }
 - 
 -     bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:43:26: 43:27
-          StorageLive(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:46:5: 46:30
--         _3 = instruction_set_default() -> bb3; // scope 0 at $DIR/inline-instruction-set.rs:46:5: 46:30
-+         _3 = instruction_set_default() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:46:5: 46:30
+          StorageDead(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:+2:26: +2:27
+          StorageLive(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:+5:5: +5:30
+-         _3 = instruction_set_default() -> bb3; // scope 0 at $DIR/inline-instruction-set.rs:+5:5: +5:30
++         _3 = instruction_set_default() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:+5:5: +5:30
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:46:5: 46:28
                                            // + literal: Const { ty: fn() {instruction_set_default}, val: Value(<ZST>) }
@@ -38,13 +38,13 @@
   
 -     bb3: {
 +     bb2: {
-          StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:46:30: 46:31
-          _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:41:14: 47:2
-          return;                          // scope 0 at $DIR/inline-instruction-set.rs:47:2: 47:2
+          StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:+5:30: +5:31
+          _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:+0:14: +6:2
+          return;                          // scope 0 at $DIR/inline-instruction-set.rs:+6:2: +6:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-instruction-set.rs:41:1: 47:2
++         resume;                          // scope 0 at $DIR/inline-instruction-set.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -2,18 +2,18 @@
 + // MIR for `main` after Inline
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-into-box-place.rs:7:11: 7:11
-      let _1: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-      let mut _2: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _3: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _4: *mut u8;                 // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _5: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _6: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-      let mut _7: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _8: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-+     let mut _9: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-into-box-place.rs:+0:11: +0:11
+      let _1: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:9: +1:11
+      let mut _2: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _3: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _4: *mut u8;                 // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _5: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _6: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
+      let mut _7: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _8: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
++     let mut _9: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
       scope 1 {
-          debug _x => _1;                  // in scope 1 at $DIR/inline-into-box-place.rs:8:9: 8:11
+          debug _x => _1;                  // in scope 1 at $DIR/inline-into-box-place.rs:+1:9: +1:11
       }
       scope 2 {
       }
@@ -22,23 +22,23 @@
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-          _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:9: +1:11
+          _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
                                            // mir::Constant
                                            // + span: $DIR/inline-into-box-place.rs:8:29: 8:43
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
--         (*_7) = Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         StorageLive(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         _9 = &mut (*_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+          StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+          _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+-         (*_7) = Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
++         StorageLive(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
++         _9 = &mut (*_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
 +         StorageLive(_10);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         _10 = const alloc::raw_vec::RawVec::<u32>::NEW; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
                                            // mir::Constant
@@ -55,24 +55,24 @@
 +         ((*_9).0: alloc::raw_vec::RawVec<u32>) = move _10; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_9).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_10);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         StorageDead(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
--         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         StorageDead(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+          StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+          _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
+          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:+0:11: +2:2
+-         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:+2:1: +2:2
++         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:+2:1: +2:2
       }
   
 -     bb3: {
 +     bb2: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/inline-into-box-place.rs:+2:2: +2:2
       }
   
 -     bb4 (cleanup): {
--         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
--         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb5; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+-         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb5; // scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(Unique<Vec<u32>>, std::alloc::Global) {alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>}, val: Value(<ZST>) }
@@ -80,7 +80,7 @@
 - 
 -     bb5 (cleanup): {
 +     bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -2,18 +2,18 @@
 + // MIR for `main` after Inline
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-into-box-place.rs:7:11: 7:11
-      let _1: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-      let mut _2: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _3: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _4: *mut u8;                 // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _5: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _6: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-      let mut _7: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _8: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-+     let mut _9: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-into-box-place.rs:+0:11: +0:11
+      let _1: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:9: +1:11
+      let mut _2: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _3: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _4: *mut u8;                 // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _5: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _6: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
+      let mut _7: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+      let mut _8: *const std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
++     let mut _9: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
       scope 1 {
-          debug _x => _1;                  // in scope 1 at $DIR/inline-into-box-place.rs:8:9: 8:11
+          debug _x => _1;                  // in scope 1 at $DIR/inline-into-box-place.rs:+1:9: +1:11
       }
       scope 2 {
       }
@@ -22,23 +22,23 @@
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-          _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:9: +1:11
+          _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
                                            // mir::Constant
                                            // + span: $DIR/inline-into-box-place.rs:8:29: 8:43
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
--         (*_7) = Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         StorageLive(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         _9 = &mut (*_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+          StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+          _7 = (((_5.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+-         (*_7) = Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
++         StorageLive(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
++         _9 = &mut (*_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
 +         StorageLive(_10);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         _10 = const alloc::raw_vec::RawVec::<u32>::NEW; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
                                            // mir::Constant
@@ -55,24 +55,24 @@
 +         ((*_9).0: alloc::raw_vec::RawVec<u32>) = move _10; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_9).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_10);                // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-+         StorageDead(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
--         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         StorageDead(_9);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+          StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+          _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:+1:29: +1:43
+          StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
+          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:+0:11: +2:2
+-         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:+2:1: +2:2
++         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:+2:1: +2:2
       }
   
 -     bb3: {
 +     bb2: {
-          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/inline-into-box-place.rs:+2:2: +2:2
       }
   
 -     bb4 (cleanup): {
--         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
--         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb5; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:+1:33: +1:43
+-         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb5; // scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(Unique<Vec<u32>>, std::alloc::Global) {alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>}, val: Value(<ZST>) }
@@ -80,7 +80,7 @@
 - 
 -     bb5 (cleanup): {
 +     bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
@@ -1,59 +1,59 @@
 // MIR for `main` after Inline
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/inline-options.rs:8:11: 8:11
-    let _1: ();                          // in scope 0 at $DIR/inline-options.rs:9:5: 9:18
-    let _2: ();                          // in scope 0 at $DIR/inline-options.rs:10:5: 10:21
+    let mut _0: ();                      // return place in scope 0 at $DIR/inline-options.rs:+0:11: +0:11
+    let _1: ();                          // in scope 0 at $DIR/inline-options.rs:+1:5: +1:18
+    let _2: ();                          // in scope 0 at $DIR/inline-options.rs:+2:5: +2:21
     scope 1 (inlined inlined::<u32>) {   // at $DIR/inline-options.rs:10:5: 10:21
-        let _3: ();                      // in scope 1 at $DIR/inline-options.rs:16:23: 16:26
-        let _4: ();                      // in scope 1 at $DIR/inline-options.rs:16:28: 16:31
-        let _5: ();                      // in scope 1 at $DIR/inline-options.rs:16:33: 16:36
+        let _3: ();                      // in scope 1 at $DIR/inline-options.rs:+8:23: +8:26
+        let _4: ();                      // in scope 1 at $DIR/inline-options.rs:+8:28: +8:31
+        let _5: ();                      // in scope 1 at $DIR/inline-options.rs:+8:33: +8:36
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/inline-options.rs:9:5: 9:18
-        _1 = not_inlined() -> bb1;       // scope 0 at $DIR/inline-options.rs:9:5: 9:18
+        StorageLive(_1);                 // scope 0 at $DIR/inline-options.rs:+1:5: +1:18
+        _1 = not_inlined() -> bb1;       // scope 0 at $DIR/inline-options.rs:+1:5: +1:18
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:9:5: 9:16
                                          // + literal: Const { ty: fn() {not_inlined}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 0 at $DIR/inline-options.rs:9:18: 9:19
-        StorageLive(_2);                 // scope 0 at $DIR/inline-options.rs:10:5: 10:21
-        StorageLive(_3);                 // scope 1 at $DIR/inline-options.rs:16:23: 16:26
-        _3 = g() -> bb2;                 // scope 1 at $DIR/inline-options.rs:16:23: 16:26
+        StorageDead(_1);                 // scope 0 at $DIR/inline-options.rs:+1:18: +1:19
+        StorageLive(_2);                 // scope 0 at $DIR/inline-options.rs:+2:5: +2:21
+        StorageLive(_3);                 // scope 1 at $DIR/inline-options.rs:+8:23: +8:26
+        _3 = g() -> bb2;                 // scope 1 at $DIR/inline-options.rs:+8:23: +8:26
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:23: 16:24
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 1 at $DIR/inline-options.rs:16:26: 16:27
-        StorageLive(_4);                 // scope 1 at $DIR/inline-options.rs:16:28: 16:31
-        _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:16:28: 16:31
+        StorageDead(_3);                 // scope 1 at $DIR/inline-options.rs:+8:26: +8:27
+        StorageLive(_4);                 // scope 1 at $DIR/inline-options.rs:+8:28: +8:31
+        _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:+8:28: +8:31
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:28: 16:29
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline-options.rs:16:31: 16:32
-        StorageLive(_5);                 // scope 1 at $DIR/inline-options.rs:16:33: 16:36
-        _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:16:33: 16:36
+        StorageDead(_4);                 // scope 1 at $DIR/inline-options.rs:+8:31: +8:32
+        StorageLive(_5);                 // scope 1 at $DIR/inline-options.rs:+8:33: +8:36
+        _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:+8:33: +8:36
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:33: 16:34
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_5);                 // scope 1 at $DIR/inline-options.rs:16:36: 16:37
-        StorageDead(_2);                 // scope 0 at $DIR/inline-options.rs:10:21: 10:22
-        _0 = const ();                   // scope 0 at $DIR/inline-options.rs:8:11: 11:2
-        return;                          // scope 0 at $DIR/inline-options.rs:11:2: 11:2
+        StorageDead(_5);                 // scope 1 at $DIR/inline-options.rs:+8:36: +8:37
+        StorageDead(_2);                 // scope 0 at $DIR/inline-options.rs:+2:21: +2:22
+        _0 = const ();                   // scope 0 at $DIR/inline-options.rs:+0:11: +3:2
+        return;                          // scope 0 at $DIR/inline-options.rs:+3:2: +3:2
     }
 
     bb5 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-options.rs:8:1: 11:2
+        resume;                          // scope 0 at $DIR/inline-options.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -1,76 +1,76 @@
 // MIR for `bar` after Inline
 
 fn bar() -> bool {
-    let mut _0: bool;                    // return place in scope 0 at $DIR/inline-retag.rs:10:13: 10:17
-    let _1: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}; // in scope 0 at $DIR/inline-retag.rs:11:9: 11:10
-    let mut _2: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}; // in scope 0 at $DIR/inline-retag.rs:12:5: 12:6
-    let mut _3: &i32;                    // in scope 0 at $DIR/inline-retag.rs:12:7: 12:9
-    let _4: &i32;                        // in scope 0 at $DIR/inline-retag.rs:12:7: 12:9
-    let _5: i32;                         // in scope 0 at $DIR/inline-retag.rs:12:8: 12:9
-    let mut _6: &i32;                    // in scope 0 at $DIR/inline-retag.rs:12:11: 12:14
-    let _7: &i32;                        // in scope 0 at $DIR/inline-retag.rs:12:11: 12:14
-    let _8: i32;                         // in scope 0 at $DIR/inline-retag.rs:12:12: 12:14
+    let mut _0: bool;                    // return place in scope 0 at $DIR/inline-retag.rs:+0:13: +0:17
+    let _1: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}; // in scope 0 at $DIR/inline-retag.rs:+1:9: +1:10
+    let mut _2: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}; // in scope 0 at $DIR/inline-retag.rs:+2:5: +2:6
+    let mut _3: &i32;                    // in scope 0 at $DIR/inline-retag.rs:+2:7: +2:9
+    let _4: &i32;                        // in scope 0 at $DIR/inline-retag.rs:+2:7: +2:9
+    let _5: i32;                         // in scope 0 at $DIR/inline-retag.rs:+2:8: +2:9
+    let mut _6: &i32;                    // in scope 0 at $DIR/inline-retag.rs:+2:11: +2:14
+    let _7: &i32;                        // in scope 0 at $DIR/inline-retag.rs:+2:11: +2:14
+    let _8: i32;                         // in scope 0 at $DIR/inline-retag.rs:+2:12: +2:14
     scope 1 {
-        debug f => _1;                   // in scope 1 at $DIR/inline-retag.rs:11:9: 11:10
-        let mut _9: &i32;                // in scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        let mut _10: &i32;               // in scope 1 at $DIR/inline-retag.rs:12:7: 12:9
+        debug f => _1;                   // in scope 1 at $DIR/inline-retag.rs:+1:9: +1:10
+        let mut _9: &i32;                // in scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        let mut _10: &i32;               // in scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
         scope 2 (inlined foo) {          // at $DIR/inline-retag.rs:12:5: 12:15
-            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:16:8: 16:9
-            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:16:17: 16:18
-            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:17:5: 17:7
-            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:17:11: 17:13
+            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:+6:8: +6:9
+            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:+6:17: +6:18
+            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:+7:5: +7:7
+            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:+7:11: +7:13
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/inline-retag.rs:11:9: 11:10
-        _1 = foo;                        // scope 0 at $DIR/inline-retag.rs:11:13: 11:16
+        StorageLive(_1);                 // scope 0 at $DIR/inline-retag.rs:+1:9: +1:10
+        _1 = foo;                        // scope 0 at $DIR/inline-retag.rs:+1:13: +1:16
                                          // mir::Constant
                                          // + span: $DIR/inline-retag.rs:11:13: 11:16
                                          // + literal: Const { ty: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}, val: Value(<ZST>) }
-        StorageLive(_2);                 // scope 1 at $DIR/inline-retag.rs:12:5: 12:6
-        _2 = _1;                         // scope 1 at $DIR/inline-retag.rs:12:5: 12:6
-        StorageLive(_3);                 // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
-        StorageLive(_4);                 // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
-        _10 = const bar::promoted[1];    // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
+        StorageLive(_2);                 // scope 1 at $DIR/inline-retag.rs:+2:5: +2:6
+        _2 = _1;                         // scope 1 at $DIR/inline-retag.rs:+2:5: +2:6
+        StorageLive(_3);                 // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
+        StorageLive(_4);                 // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
+        _10 = const bar::promoted[1];    // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
                                          // mir::Constant
                                          // + span: $DIR/inline-retag.rs:12:7: 12:9
                                          // + literal: Const { ty: &i32, val: Unevaluated(bar, [], Some(promoted[1])) }
-        Retag(_10);                      // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
-        _4 = &(*_10);                    // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
-        Retag(_4);                       // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
-        _3 = &(*_4);                     // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
-        Retag(_3);                       // scope 1 at $DIR/inline-retag.rs:12:7: 12:9
-        StorageLive(_6);                 // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        StorageLive(_7);                 // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        _9 = const bar::promoted[0];     // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
+        Retag(_10);                      // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
+        _4 = &(*_10);                    // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
+        Retag(_4);                       // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
+        _3 = &(*_4);                     // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
+        Retag(_3);                       // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
+        StorageLive(_6);                 // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        StorageLive(_7);                 // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        _9 = const bar::promoted[0];     // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
                                          // mir::Constant
                                          // + span: $DIR/inline-retag.rs:12:11: 12:14
                                          // + literal: Const { ty: &i32, val: Unevaluated(bar, [], Some(promoted[0])) }
-        Retag(_9);                       // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        _7 = &(*_9);                     // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        Retag(_7);                       // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        _6 = &(*_7);                     // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        Retag(_6);                       // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
-        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
-        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
-        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
-        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
-        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
-        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:17:5: 17:13
-        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
-        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
-        StorageDead(_6);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15
-        StorageDead(_3);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15
-        StorageDead(_2);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15
-        StorageDead(_1);                 // scope 0 at $DIR/inline-retag.rs:13:1: 13:2
-        StorageDead(_7);                 // scope 0 at $DIR/inline-retag.rs:13:1: 13:2
-        StorageDead(_4);                 // scope 0 at $DIR/inline-retag.rs:13:1: 13:2
-        return;                          // scope 0 at $DIR/inline-retag.rs:13:2: 13:2
+        Retag(_9);                       // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        _7 = &(*_9);                     // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        Retag(_7);                       // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        _6 = &(*_7);                     // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        Retag(_6);                       // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
+        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:+6:1: +8:2
+        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:+6:1: +8:2
+        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:+7:5: +7:7
+        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:+7:5: +7:7
+        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:+7:11: +7:13
+        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:+7:11: +7:13
+        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:+7:5: +7:13
+        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:+7:12: +7:13
+        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:+7:12: +7:13
+        StorageDead(_6);                 // scope 1 at $DIR/inline-retag.rs:+2:14: +2:15
+        StorageDead(_3);                 // scope 1 at $DIR/inline-retag.rs:+2:14: +2:15
+        StorageDead(_2);                 // scope 1 at $DIR/inline-retag.rs:+2:14: +2:15
+        StorageDead(_1);                 // scope 0 at $DIR/inline-retag.rs:+3:1: +3:2
+        StorageDead(_7);                 // scope 0 at $DIR/inline-retag.rs:+3:1: +3:2
+        StorageDead(_4);                 // scope 0 at $DIR/inline-retag.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/inline-retag.rs:+3:2: +3:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-retag.rs:10:1: 13:2
+        resume;                          // scope 0 at $DIR/inline-retag.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
@@ -2,16 +2,16 @@
 + // MIR for `clone` after Inline
   
   fn clone(_1: fn(A, B)) -> fn(A, B) {
-      debug f => _1;                       // in scope 0 at $DIR/inline-shims.rs:5:20: 5:21
-      let mut _0: fn(A, B);                // return place in scope 0 at $DIR/inline-shims.rs:5:36: 5:44
-      let mut _2: &fn(A, B);               // in scope 0 at $DIR/inline-shims.rs:6:5: 6:14
+      debug f => _1;                       // in scope 0 at $DIR/inline-shims.rs:+0:20: +0:21
+      let mut _0: fn(A, B);                // return place in scope 0 at $DIR/inline-shims.rs:+0:36: +0:44
+      let mut _2: &fn(A, B);               // in scope 0 at $DIR/inline-shims.rs:+1:5: +1:14
 +     scope 1 (inlined <fn(A, B) as Clone>::clone - shim(fn(A, B))) { // at $DIR/inline-shims.rs:6:5: 6:14
 +     }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/inline-shims.rs:6:5: 6:14
-          _2 = &_1;                        // scope 0 at $DIR/inline-shims.rs:6:5: 6:14
--         _0 = <fn(A, B) as Clone>::clone(move _2) -> bb1; // scope 0 at $DIR/inline-shims.rs:6:5: 6:14
+          StorageLive(_2);                 // scope 0 at $DIR/inline-shims.rs:+1:5: +1:14
+          _2 = &_1;                        // scope 0 at $DIR/inline-shims.rs:+1:5: +1:14
+-         _0 = <fn(A, B) as Clone>::clone(move _2) -> bb1; // scope 0 at $DIR/inline-shims.rs:+1:5: +1:14
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-shims.rs:6:7: 6:12
 -                                          // + literal: Const { ty: for<'r> fn(&'r fn(A, B)) -> fn(A, B) {<fn(A, B) as Clone>::clone}, val: Value(<ZST>) }
@@ -19,12 +19,12 @@
 - 
 -     bb1: {
 +         _0 = (*_2);                      // scope 1 at $SRC_DIR/core/src/clone.rs:LL:COL
-          StorageDead(_2);                 // scope 0 at $DIR/inline-shims.rs:6:13: 6:14
-          return;                          // scope 0 at $DIR/inline-shims.rs:7:2: 7:2
+          StorageDead(_2);                 // scope 0 at $DIR/inline-shims.rs:+1:13: +1:14
+          return;                          // scope 0 at $DIR/inline-shims.rs:+2:2: +2:2
 +     }
 + 
 +     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-shims.rs:5:1: 7:2
++         resume;                          // scope 0 at $DIR/inline-shims.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
@@ -2,12 +2,12 @@
 + // MIR for `drop` after Inline
   
   fn drop(_1: *mut Vec<A>, _2: *mut Option<B>) -> () {
-      debug a => _1;                       // in scope 0 at $DIR/inline-shims.rs:10:19: 10:20
-      debug b => _2;                       // in scope 0 at $DIR/inline-shims.rs:10:35: 10:36
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-shims.rs:10:54: 10:54
-      let _3: ();                          // in scope 0 at $DIR/inline-shims.rs:11:14: 11:40
-      let mut _4: *mut std::vec::Vec<A>;   // in scope 0 at $DIR/inline-shims.rs:11:38: 11:39
-      let mut _5: *mut std::option::Option<B>; // in scope 0 at $DIR/inline-shims.rs:12:38: 12:39
+      debug a => _1;                       // in scope 0 at $DIR/inline-shims.rs:+0:19: +0:20
+      debug b => _2;                       // in scope 0 at $DIR/inline-shims.rs:+0:35: +0:36
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-shims.rs:+0:54: +0:54
+      let _3: ();                          // in scope 0 at $DIR/inline-shims.rs:+1:14: +1:40
+      let mut _4: *mut std::vec::Vec<A>;   // in scope 0 at $DIR/inline-shims.rs:+1:38: +1:39
+      let mut _5: *mut std::option::Option<B>; // in scope 0 at $DIR/inline-shims.rs:+2:38: +2:39
       scope 1 {
       }
       scope 2 {
@@ -18,35 +18,35 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/inline-shims.rs:11:5: 11:42
-          StorageLive(_4);                 // scope 1 at $DIR/inline-shims.rs:11:38: 11:39
-          _4 = _1;                         // scope 1 at $DIR/inline-shims.rs:11:38: 11:39
-          _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> bb1; // scope 1 at $DIR/inline-shims.rs:11:14: 11:40
+          StorageLive(_3);                 // scope 0 at $DIR/inline-shims.rs:+1:5: +1:42
+          StorageLive(_4);                 // scope 1 at $DIR/inline-shims.rs:+1:38: +1:39
+          _4 = _1;                         // scope 1 at $DIR/inline-shims.rs:+1:38: +1:39
+          _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> bb1; // scope 1 at $DIR/inline-shims.rs:+1:14: +1:40
                                            // mir::Constant
                                            // + span: $DIR/inline-shims.rs:11:14: 11:37
                                            // + literal: Const { ty: unsafe fn(*mut Vec<A>) {std::ptr::drop_in_place::<Vec<A>>}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_4);                 // scope 1 at $DIR/inline-shims.rs:11:39: 11:40
-          StorageDead(_3);                 // scope 0 at $DIR/inline-shims.rs:11:41: 11:42
-          StorageLive(_5);                 // scope 2 at $DIR/inline-shims.rs:12:38: 12:39
-          _5 = _2;                         // scope 2 at $DIR/inline-shims.rs:12:38: 12:39
--         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> bb2; // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
+          StorageDead(_4);                 // scope 1 at $DIR/inline-shims.rs:+1:39: +1:40
+          StorageDead(_3);                 // scope 0 at $DIR/inline-shims.rs:+1:41: +1:42
+          StorageLive(_5);                 // scope 2 at $DIR/inline-shims.rs:+2:38: +2:39
+          _5 = _2;                         // scope 2 at $DIR/inline-shims.rs:+2:38: +2:39
+-         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> bb2; // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-shims.rs:12:14: 12:37
 -                                          // + literal: Const { ty: unsafe fn(*mut Option<B>) {std::ptr::drop_in_place::<Option<B>>}, val: Value(<ZST>) }
-+         StorageLive(_6);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
-+         StorageLive(_7);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
++         StorageLive(_6);                 // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
++         StorageLive(_7);                 // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
 +         _6 = discriminant((*_5));        // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 +         switchInt(move _6) -> [0_isize: bb2, otherwise: bb3]; // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
       }
   
       bb2: {
-+         StorageDead(_7);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
-+         StorageDead(_6);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
-          StorageDead(_5);                 // scope 2 at $DIR/inline-shims.rs:12:39: 12:40
-          return;                          // scope 0 at $DIR/inline-shims.rs:13:2: 13:2
++         StorageDead(_7);                 // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
++         StorageDead(_6);                 // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
+          StorageDead(_5);                 // scope 2 at $DIR/inline-shims.rs:+2:39: +2:40
+          return;                          // scope 0 at $DIR/inline-shims.rs:+3:2: +3:2
 +     }
 + 
 +     bb3: {
@@ -54,7 +54,7 @@
 +     }
 + 
 +     bb4 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-shims.rs:10:1: 13:2
++         resume;                          // scope 0 at $DIR/inline-shims.rs:+0:1: +3:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -2,31 +2,31 @@
 + // MIR for `main` after Inline
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inline-specialization.rs:4:11: 4:11
-      let _1: u32;                         // in scope 0 at $DIR/inline-specialization.rs:5:9: 5:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/inline-specialization.rs:+0:11: +0:11
+      let _1: u32;                         // in scope 0 at $DIR/inline-specialization.rs:+1:9: +1:10
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/inline-specialization.rs:5:9: 5:10
+          debug x => _1;                   // in scope 1 at $DIR/inline-specialization.rs:+1:9: +1:10
       }
 +     scope 2 (inlined <Vec<()> as Foo>::bar) { // at $DIR/inline-specialization.rs:5:13: 5:38
 +     }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inline-specialization.rs:5:9: 5:10
--         _1 = <Vec<()> as Foo>::bar() -> bb1; // scope 0 at $DIR/inline-specialization.rs:5:13: 5:38
+          StorageLive(_1);                 // scope 0 at $DIR/inline-specialization.rs:+1:9: +1:10
+-         _1 = <Vec<()> as Foo>::bar() -> bb1; // scope 0 at $DIR/inline-specialization.rs:+1:13: +1:38
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-specialization.rs:5:13: 5:36
 -                                          // + literal: Const { ty: fn() -> u32 {<Vec<()> as Foo>::bar}, val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {
-+         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:14:31: 14:34
-          _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:4:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/inline-specialization.rs:6:2: 6:2
++         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:+10:31: +10:34
+          _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:+0:11: +2:2
+          StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/inline-specialization.rs:+2:2: +2:2
 +     }
 + 
 +     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-specialization.rs:4:1: 6:2
++         resume;                          // scope 0 at $DIR/inline-specialization.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
@@ -1,21 +1,21 @@
 // MIR for `test` after Inline
 
 fn test(_1: &dyn X) -> u32 {
-    debug x => _1;                       // in scope 0 at $DIR/inline-trait-method.rs:8:9: 8:10
-    let mut _0: u32;                     // return place in scope 0 at $DIR/inline-trait-method.rs:8:23: 8:26
-    let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
+    debug x => _1;                       // in scope 0 at $DIR/inline-trait-method.rs:+0:9: +0:10
+    let mut _0: u32;                     // return place in scope 0 at $DIR/inline-trait-method.rs:+0:23: +0:26
+    let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method.rs:+1:5: +1:10
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
-        _2 = &(*_1);                     // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
-        _0 = <dyn X as X>::y(move _2) -> bb1; // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
+        StorageLive(_2);                 // scope 0 at $DIR/inline-trait-method.rs:+1:5: +1:10
+        _2 = &(*_1);                     // scope 0 at $DIR/inline-trait-method.rs:+1:5: +1:10
+        _0 = <dyn X as X>::y(move _2) -> bb1; // scope 0 at $DIR/inline-trait-method.rs:+1:5: +1:10
                                          // mir::Constant
                                          // + span: $DIR/inline-trait-method.rs:9:7: 9:8
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> u32 {<dyn X as X>::y}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method.rs:9:9: 9:10
-        return;                          // scope 0 at $DIR/inline-trait-method.rs:10:2: 10:2
+        StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method.rs:+1:9: +1:10
+        return;                          // scope 0 at $DIR/inline-trait-method.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -1,36 +1,36 @@
 // MIR for `test2` after Inline
 
 fn test2(_1: &dyn X) -> bool {
-    debug x => _1;                       // in scope 0 at $DIR/inline-trait-method_2.rs:4:10: 4:11
-    let mut _0: bool;                    // return place in scope 0 at $DIR/inline-trait-method_2.rs:4:24: 4:28
-    let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-    let mut _3: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
+    debug x => _1;                       // in scope 0 at $DIR/inline-trait-method_2.rs:+0:10: +0:11
+    let mut _0: bool;                    // return place in scope 0 at $DIR/inline-trait-method_2.rs:+0:24: +0:28
+    let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
+    let mut _3: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
     scope 1 (inlined test) {             // at $DIR/inline-trait-method_2.rs:5:5: 5:12
-        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:9:9: 9:10
-        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
+        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:+5:9: +5:10
+        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-        StorageLive(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-        _3 = &(*_1);                     // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-        _2 = move _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-        StorageDead(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
-        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
-        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
+        StorageLive(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
+        StorageLive(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
+        _3 = &(*_1);                     // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
+        _2 = move _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
+        StorageDead(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
+        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
+        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
+        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
                                          // mir::Constant
                                          // + span: $DIR/inline-trait-method_2.rs:10:7: 10:8
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:9: 10:10
-        StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:11: 5:12
-        return;                          // scope 0 at $DIR/inline-trait-method_2.rs:6:2: 6:2
+        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:+6:9: +6:10
+        StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:+1:11: +1:12
+        return;                          // scope 0 at $DIR/inline-trait-method_2.rs:+2:2: +2:2
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-trait-method_2.rs:4:1: 6:2
+        resume;                          // scope 0 at $DIR/inline-trait-method_2.rs:+0:1: +2:2
     }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -1,34 +1,34 @@
 // MIR for `a` after Inline
 
 fn a(_1: &mut [T]) -> &mut [T] {
-    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:2:13: 2:14
-    let mut _0: &mut [T];                // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:2:29: 2:37
-    let mut _2: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-    let mut _3: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-    let mut _4: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:13: +0:14
+    let mut _0: &mut [T];                // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:29: +0:37
+    let mut _2: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+    let mut _3: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+    let mut _4: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
     scope 1 (inlined <[T] as AsMut<[T]>>::as_mut) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         debug self => _4;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         let mut _5: &mut [T];            // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
         StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         _5 = &mut (*_4);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:14: 3:15
-        _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:4:1: 4:2
-        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:4:1: 4:2
-        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:4:2: 4:2
+        _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:14: +1:15
+        _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
+        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:2:1: 4:2
+        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
     }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -1,11 +1,11 @@
 // MIR for `b` after Inline
 
 fn b(_1: &mut Box<T>) -> &mut T {
-    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:7:13: 7:14
-    let mut _0: &mut T;                  // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:7:32: 7:38
-    let mut _2: &mut T;                  // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-    let mut _3: &mut T;                  // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-    let mut _4: &mut std::boxed::Box<T>; // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:13: +0:14
+    let mut _0: &mut T;                  // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:32: +0:38
+    let mut _2: &mut T;                  // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+    let mut _3: &mut T;                  // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+    let mut _4: &mut std::boxed::Box<T>; // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
     scope 1 (inlined <Box<T> as AsMut<T>>::as_mut) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         debug self => _4;                // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         let mut _5: &mut T;              // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
@@ -15,10 +15,10 @@ fn b(_1: &mut Box<T>) -> &mut T {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
         StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageLive(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageLive(_7);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
@@ -32,15 +32,15 @@ fn b(_1: &mut Box<T>) -> &mut T {
         _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageDead(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:14: 8:15
-        _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:9:1: 9:2
-        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:9:1: 9:2
-        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:9:2: 9:2
+        _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:14: +1:15
+        _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
+        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:7:1: 9:2
+        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
     }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
@@ -1,26 +1,26 @@
 // MIR for `c` after Inline
 
 fn c(_1: &[T]) -> &[T] {
-    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:12:13: 12:14
-    let mut _0: &[T];                    // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:12:25: 12:29
-    let _2: &[T];                        // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
-    let mut _3: &[T];                    // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
+    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:13: +0:14
+    let mut _0: &[T];                    // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:25: +0:29
+    let _2: &[T];                        // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+    let mut _3: &[T];                    // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
     scope 1 (inlined <[T] as AsRef<[T]>>::as_ref) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         debug self => _3;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
-        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
-        _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
+        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
         _2 = _3;                         // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
-        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:14: 13:15
-        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:14:1: 14:2
-        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:14:2: 14:2
+        _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:14: +1:15
+        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:12:1: 14:2
+        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
     }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -1,10 +1,10 @@
 // MIR for `d` after Inline
 
 fn d(_1: &Box<T>) -> &T {
-    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:17:13: 17:14
-    let mut _0: &T;                      // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:17:28: 17:30
-    let _2: &T;                          // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
-    let mut _3: &std::boxed::Box<T>;     // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
+    debug x => _1;                       // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:13: +0:14
+    let mut _0: &T;                      // return place in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:28: +0:30
+    let _2: &T;                          // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+    let mut _3: &std::boxed::Box<T>;     // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
     scope 1 (inlined <Box<T> as AsRef<T>>::as_ref) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         debug self => _3;                // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         let mut _4: std::boxed::Box<T>;  // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
@@ -12,9 +12,9 @@ fn d(_1: &Box<T>) -> &T {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
-        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
-        _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
+        StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
         StorageLive(_4);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _4 = deref_copy (*_3);           // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
@@ -22,13 +22,13 @@ fn d(_1: &Box<T>) -> &T {
         _2 = &(*_5);                     // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageDead(_4);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
-        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:14: 18:15
-        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:19:1: 19:2
-        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:19:2: 19:2
+        _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:5: +1:15
+        StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+1:14: +1:15
+        StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:17:1: 19:2
+        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
     }
 }

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -1,46 +1,46 @@
 // MIR for `main` after Inline
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:4:11: 4:11
-    let _1: [closure@$DIR/issue-76997-inline-scopes-parenting.rs:5:13: 5:16]; // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:5:9: 5:10
-    let mut _2: &[closure@$DIR/issue-76997-inline-scopes-parenting.rs:5:13: 5:16]; // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:6
-    let mut _3: ((),);                   // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-    let mut _4: ();                      // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:6:7: 6:9
-    let mut _5: ();                      // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+0:11: +0:11
+    let _1: [closure@$DIR/issue-76997-inline-scopes-parenting.rs:5:13: 5:16]; // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:9: +1:10
+    let mut _2: &[closure@$DIR/issue-76997-inline-scopes-parenting.rs:5:13: 5:16]; // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:6
+    let mut _3: ((),);                   // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
+    let mut _4: ();                      // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:7: +2:9
+    let mut _5: ();                      // in scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
     scope 1 {
-        debug f => _1;                   // in scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:5:9: 5:10
+        debug f => _1;                   // in scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:9: +1:10
         scope 2 (inlined main::{closure#0}) { // at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-            debug x => _5;               // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:14: 5:15
-            let _6: ();                  // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
+            debug x => _5;               // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:14: +1:15
+            let _6: ();                  // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:23: +1:24
             scope 3 {
-                debug y => _6;           // in scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
+                debug y => _6;           // in scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:23: +1:24
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:5:9: 5:10
-        Deinit(_1);                      // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:5:13: 5:33
-        StorageLive(_2);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:6
-        _2 = &_1;                        // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:6
-        StorageLive(_3);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        StorageLive(_4);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:7: 6:9
-        Deinit(_4);                      // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:7: 6:9
-        Deinit(_3);                      // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        (_3.0: ()) = move _4;            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        StorageLive(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        _5 = move (_3.0: ());            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        StorageLive(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
-        StorageDead(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:32: 5:33
-        StorageDead(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        StorageDead(_4);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:9: 6:10
-        StorageDead(_3);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:9: 6:10
-        StorageDead(_2);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:9: 6:10
-        StorageDead(_1);                 // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:7:1: 7:2
-        return;                          // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:7:2: 7:2
+        StorageLive(_1);                 // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:9: +1:10
+        Deinit(_1);                      // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:13: +1:33
+        StorageLive(_2);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:6
+        _2 = &_1;                        // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:6
+        StorageLive(_3);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
+        StorageLive(_4);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:7: +2:9
+        Deinit(_4);                      // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:7: +2:9
+        Deinit(_3);                      // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
+        (_3.0: ()) = move _4;            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
+        StorageLive(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
+        _5 = move (_3.0: ());            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
+        StorageLive(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:23: +1:24
+        StorageDead(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:+1:32: +1:33
+        StorageDead(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:5: +2:10
+        StorageDead(_4);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:9: +2:10
+        StorageDead(_3);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:9: +2:10
+        StorageDead(_2);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:+2:9: +2:10
+        StorageDead(_1);                 // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+3:2: +3:2
     }
 
     bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:4:1: 7:2
+        resume;                          // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
@@ -2,31 +2,31 @@
 + // MIR for `bar` after Inline
   
   fn bar(_1: P) -> () {
-      debug _baz => _1;                    // in scope 0 at $DIR/issue-78442.rs:9:5: 9:9
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-78442.rs:10:3: 10:3
-      let _2: ();                          // in scope 0 at $DIR/issue-78442.rs:11:5: 11:17
-      let mut _3: &fn() {foo};             // in scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-      let _4: fn() {foo};                  // in scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-      let mut _5: ();                      // in scope 0 at $DIR/issue-78442.rs:11:5: 11:17
+      debug _baz => _1;                    // in scope 0 at $DIR/issue-78442.rs:+2:5: +2:9
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-78442.rs:+3:3: +3:3
+      let _2: ();                          // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+      let mut _3: &fn() {foo};             // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+      let _4: fn() {foo};                  // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+      let mut _5: ();                      // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
 +     scope 1 (inlined <fn() {foo} as Fn<()>>::call - shim(fn() {foo})) { // at $DIR/issue-78442.rs:11:5: 11:17
 +     }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
-          StorageLive(_3);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-          StorageLive(_4);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
--         _4 = hide_foo() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-+         _4 = hide_foo() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
+          StorageLive(_2);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+          StorageLive(_3);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+          StorageLive(_4);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+-         _4 = hide_foo() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
++         _4 = hide_foo() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
                                            // mir::Constant
                                            // + span: $DIR/issue-78442.rs:11:5: 11:13
                                            // + literal: Const { ty: fn() -> impl Fn() {hide_foo}, val: Value(<ZST>) }
       }
   
       bb1: {
-          _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-          StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
-          Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
--         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
+          _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+          StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+          Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+-         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
 -                                          // mir::Constant
 -                                          // + span: $DIR/issue-78442.rs:11:5: 11:15
 -                                          // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r fn() {foo}, ()) -> <fn() {foo} as FnOnce<()>>::Output {<fn() {foo} as Fn<()>>::call}, val: Value(<ZST>) }
@@ -34,35 +34,35 @@
       }
   
       bb2: {
--         StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
--         StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
--         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
--         StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
--         _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:10:3: 12:2
--         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
-+         return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
+-         StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:+4:16: +4:17
+-         StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:+4:16: +4:17
+-         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:+4:17: +4:18
+-         StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:+4:17: +4:18
+-         _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:+3:3: +5:2
+-         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:+5:1: +5:2
++         return;                          // scope 0 at $DIR/issue-78442.rs:+5:2: +5:2
       }
   
 -     bb3: {
--         return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
+-         return;                          // scope 0 at $DIR/issue-78442.rs:+5:2: +5:2
 +     bb3 (cleanup): {
-+         drop(_1) -> bb4;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
++         drop(_1) -> bb4;                 // scope 0 at $DIR/issue-78442.rs:+5:1: +5:2
       }
   
       bb4 (cleanup): {
--         drop(_1) -> bb5;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
-+         resume;                          // scope 0 at $DIR/issue-78442.rs:7:1: 12:2
+-         drop(_1) -> bb5;                 // scope 0 at $DIR/issue-78442.rs:+5:1: +5:2
++         resume;                          // scope 0 at $DIR/issue-78442.rs:+0:1: +5:2
       }
   
 -     bb5 (cleanup): {
--         resume;                          // scope 0 at $DIR/issue-78442.rs:7:1: 12:2
+-         resume;                          // scope 0 at $DIR/issue-78442.rs:+0:1: +5:2
 +     bb5: {
-+         StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
-+         StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
-+         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
-+         StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
-+         _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:10:3: 12:2
-+         drop(_1) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
++         StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:+4:16: +4:17
++         StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:+4:16: +4:17
++         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:+4:17: +4:18
++         StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:+4:17: +4:18
++         _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:+3:3: +5:2
++         drop(_1) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+5:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
@@ -2,31 +2,31 @@
 + // MIR for `bar` after RevealAll
   
   fn bar(_1: P) -> () {
-      debug _baz => _1;                    // in scope 0 at $DIR/issue-78442.rs:9:5: 9:9
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-78442.rs:10:3: 10:3
-      let _2: ();                          // in scope 0 at $DIR/issue-78442.rs:11:5: 11:17
--     let mut _3: &impl Fn();              // in scope 0 at $DIR/issue-78442.rs:11:5: 11:15
--     let _4: impl Fn();                   // in scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-+     let mut _3: &fn() {foo};             // in scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-+     let _4: fn() {foo};                  // in scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-      let mut _5: ();                      // in scope 0 at $DIR/issue-78442.rs:11:5: 11:17
+      debug _baz => _1;                    // in scope 0 at $DIR/issue-78442.rs:+2:5: +2:9
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-78442.rs:+3:3: +3:3
+      let _2: ();                          // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+-     let mut _3: &impl Fn();              // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+-     let _4: impl Fn();                   // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
++     let mut _3: &fn() {foo};             // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
++     let _4: fn() {foo};                  // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+      let mut _5: ();                      // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
-          StorageLive(_3);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-          StorageLive(_4);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-          _4 = hide_foo() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
+          StorageLive(_2);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+          StorageLive(_3);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+          StorageLive(_4);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+          _4 = hide_foo() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
                                            // mir::Constant
                                            // + span: $DIR/issue-78442.rs:11:5: 11:13
                                            // + literal: Const { ty: fn() -> impl Fn() {hide_foo}, val: Value(<ZST>) }
       }
   
       bb1: {
-          _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
-          StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
-          Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
--         _2 = <impl Fn() as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
-+         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
+          _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+          StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+          Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+-         _2 = <impl Fn() as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
++         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
                                            // mir::Constant
                                            // + span: $DIR/issue-78442.rs:11:5: 11:15
 -                                          // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as FnOnce<()>>::Output {<impl Fn() as Fn<()>>::call}, val: Value(<ZST>) }
@@ -34,24 +34,24 @@
       }
   
       bb2: {
-          StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
-          StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
-          StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
-          StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
-          _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:10:3: 12:2
-          drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
+          StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:+4:16: +4:17
+          StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:+4:16: +4:17
+          StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:+4:17: +4:18
+          StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:+4:17: +4:18
+          _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:+3:3: +5:2
+          drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:+5:1: +5:2
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
+          return;                          // scope 0 at $DIR/issue-78442.rs:+5:2: +5:2
       }
   
       bb4 (cleanup): {
-          drop(_1) -> bb5;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
+          drop(_1) -> bb5;                 // scope 0 at $DIR/issue-78442.rs:+5:1: +5:2
       }
   
       bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/issue-78442.rs:7:1: 12:2
+          resume;                          // scope 0 at $DIR/issue-78442.rs:+0:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/instrument_coverage.bar.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage.bar.InstrumentCoverage.diff
@@ -2,12 +2,12 @@
 + // MIR for `bar` after InstrumentCoverage
   
   fn bar() -> bool {
-      let mut _0: bool;                    // return place in scope 0 at /the/src/instrument_coverage.rs:19:13: 19:17
+      let mut _0: bool;                    // return place in scope 0 at /the/src/instrument_coverage.rs:+0:13: +0:17
   
       bb0: {
-+         Coverage::Counter(1) for /the/src/instrument_coverage.rs:19:1 - 21:2; // scope 0 at /the/src/instrument_coverage.rs:21:2: 21:2
-          _0 = const true;                 // scope 0 at /the/src/instrument_coverage.rs:20:5: 20:9
-          return;                          // scope 0 at /the/src/instrument_coverage.rs:21:2: 21:2
++         Coverage::Counter(1) for /the/src/instrument_coverage.rs:19:1 - 21:2; // scope 0 at /the/src/instrument_coverage.rs:+2:2: +2:2
+          _0 = const true;                 // scope 0 at /the/src/instrument_coverage.rs:+1:5: +1:9
+          return;                          // scope 0 at /the/src/instrument_coverage.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
@@ -2,50 +2,50 @@
 + // MIR for `main` after InstrumentCoverage
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at /the/src/instrument_coverage.rs:10:11: 10:11
-      let mut _1: ();                      // in scope 0 at /the/src/instrument_coverage.rs:10:1: 16:2
-      let mut _2: bool;                    // in scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
-      let mut _3: !;                       // in scope 0 at /the/src/instrument_coverage.rs:12:18: 14:10
+      let mut _0: ();                      // return place in scope 0 at /the/src/instrument_coverage.rs:+0:11: +0:11
+      let mut _1: ();                      // in scope 0 at /the/src/instrument_coverage.rs:+0:1: +6:2
+      let mut _2: bool;                    // in scope 0 at /the/src/instrument_coverage.rs:+2:12: +2:17
+      let mut _3: !;                       // in scope 0 at /the/src/instrument_coverage.rs:+2:18: +4:10
   
       bb0: {
-+         Coverage::Counter(1) for /the/src/instrument_coverage.rs:10:1 - 10:11; // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
-          goto -> bb1;                     // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
++         Coverage::Counter(1) for /the/src/instrument_coverage.rs:10:1 - 10:11; // scope 0 at /the/src/instrument_coverage.rs:+1:5: +5:6
+          goto -> bb1;                     // scope 0 at /the/src/instrument_coverage.rs:+1:5: +5:6
       }
   
       bb1: {
-+         Coverage::Expression(4294967295) = 1 + 2 for /the/src/instrument_coverage.rs:11:5 - 12:17; // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
-          falseUnwind -> [real: bb2, cleanup: bb6]; // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
++         Coverage::Expression(4294967295) = 1 + 2 for /the/src/instrument_coverage.rs:11:5 - 12:17; // scope 0 at /the/src/instrument_coverage.rs:+1:5: +5:6
+          falseUnwind -> [real: bb2, cleanup: bb6]; // scope 0 at /the/src/instrument_coverage.rs:+1:5: +5:6
       }
   
       bb2: {
-          StorageLive(_2);                 // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
-          _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
+          StorageLive(_2);                 // scope 0 at /the/src/instrument_coverage.rs:+2:12: +2:17
+          _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at /the/src/instrument_coverage.rs:+2:12: +2:17
                                            // mir::Constant
                                            // + span: /the/src/instrument_coverage.rs:12:12: 12:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(<ZST>) }
       }
   
       bb3: {
-          switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
+          switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at /the/src/instrument_coverage.rs:+2:12: +2:17
       }
   
       bb4: {
-+         Coverage::Expression(4294967293) = 4294967294 + 0 for /the/src/instrument_coverage.rs:16:1 - 16:2; // scope 0 at /the/src/instrument_coverage.rs:16:2: 16:2
-+         Coverage::Expression(4294967294) = 4294967295 - 2 for /the/src/instrument_coverage.rs:13:13 - 13:18; // scope 0 at /the/src/instrument_coverage.rs:16:2: 16:2
-          _0 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:13:13: 13:18
-          StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:14:9: 14:10
-          return;                          // scope 0 at /the/src/instrument_coverage.rs:16:2: 16:2
++         Coverage::Expression(4294967293) = 4294967294 + 0 for /the/src/instrument_coverage.rs:16:1 - 16:2; // scope 0 at /the/src/instrument_coverage.rs:+6:2: +6:2
++         Coverage::Expression(4294967294) = 4294967295 - 2 for /the/src/instrument_coverage.rs:13:13 - 13:18; // scope 0 at /the/src/instrument_coverage.rs:+6:2: +6:2
+          _0 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:+3:13: +3:18
+          StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:+4:9: +4:10
+          return;                          // scope 0 at /the/src/instrument_coverage.rs:+6:2: +6:2
       }
   
       bb5: {
-+         Coverage::Counter(2) for /the/src/instrument_coverage.rs:14:10 - 14:11; // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
-          _1 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:14:10: 14:10
-          StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:14:9: 14:10
-          goto -> bb1;                     // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
++         Coverage::Counter(2) for /the/src/instrument_coverage.rs:14:10 - 14:11; // scope 0 at /the/src/instrument_coverage.rs:+1:5: +5:6
+          _1 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:+4:10: +4:10
+          StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:+4:9: +4:10
+          goto -> bb1;                     // scope 0 at /the/src/instrument_coverage.rs:+1:5: +5:6
       }
   
       bb6 (cleanup): {
-          resume;                          // scope 0 at /the/src/instrument_coverage.rs:10:1: 16:2
+          resume;                          // scope 0 at /the/src/instrument_coverage.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
@@ -1,52 +1,52 @@
 // MIR for `main` after SimplifyCfg-initial
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-38669.rs:4:11: 4:11
-    let mut _1: bool;                    // in scope 0 at $DIR/issue-38669.rs:5:9: 5:25
-    let mut _2: ();                      // in scope 0 at $DIR/issue-38669.rs:4:1: 12:2
-    let _3: ();                          // in scope 0 at $DIR/issue-38669.rs:7:9: 9:10
-    let mut _4: bool;                    // in scope 0 at $DIR/issue-38669.rs:7:12: 7:24
-    let mut _5: !;                       // in scope 0 at $DIR/issue-38669.rs:7:25: 9:10
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-38669.rs:+0:11: +0:11
+    let mut _1: bool;                    // in scope 0 at $DIR/issue-38669.rs:+1:9: +1:25
+    let mut _2: ();                      // in scope 0 at $DIR/issue-38669.rs:+0:1: +8:2
+    let _3: ();                          // in scope 0 at $DIR/issue-38669.rs:+3:9: +5:10
+    let mut _4: bool;                    // in scope 0 at $DIR/issue-38669.rs:+3:12: +3:24
+    let mut _5: !;                       // in scope 0 at $DIR/issue-38669.rs:+3:25: +5:10
     scope 1 {
-        debug should_break => _1;        // in scope 1 at $DIR/issue-38669.rs:5:9: 5:25
+        debug should_break => _1;        // in scope 1 at $DIR/issue-38669.rs:+1:9: +1:25
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/issue-38669.rs:5:9: 5:25
-        _1 = const false;                // scope 0 at $DIR/issue-38669.rs:5:28: 5:33
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/issue-38669.rs:5:9: 5:25
-        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
+        StorageLive(_1);                 // scope 0 at $DIR/issue-38669.rs:+1:9: +1:25
+        _1 = const false;                // scope 0 at $DIR/issue-38669.rs:+1:28: +1:33
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/issue-38669.rs:+1:9: +1:25
+        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:+2:5: +7:6
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, cleanup: bb5]; // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
+        falseUnwind -> [real: bb2, cleanup: bb5]; // scope 1 at $DIR/issue-38669.rs:+2:5: +7:6
     }
 
     bb2: {
-        StorageLive(_3);                 // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
-        StorageLive(_4);                 // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
-        _4 = _1;                         // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
-        switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
+        StorageLive(_3);                 // scope 1 at $DIR/issue-38669.rs:+3:9: +5:10
+        StorageLive(_4);                 // scope 1 at $DIR/issue-38669.rs:+3:12: +3:24
+        _4 = _1;                         // scope 1 at $DIR/issue-38669.rs:+3:12: +3:24
+        switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-38669.rs:+3:12: +3:24
     }
 
     bb3: {
-        _0 = const ();                   // scope 1 at $DIR/issue-38669.rs:8:13: 8:18
-        StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
-        StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
-        StorageDead(_1);                 // scope 0 at $DIR/issue-38669.rs:12:1: 12:2
-        return;                          // scope 0 at $DIR/issue-38669.rs:12:2: 12:2
+        _0 = const ();                   // scope 1 at $DIR/issue-38669.rs:+4:13: +4:18
+        StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:+5:9: +5:10
+        StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:+5:9: +5:10
+        StorageDead(_1);                 // scope 0 at $DIR/issue-38669.rs:+8:1: +8:2
+        return;                          // scope 0 at $DIR/issue-38669.rs:+8:2: +8:2
     }
 
     bb4: {
-        _3 = const ();                   // scope 1 at $DIR/issue-38669.rs:9:10: 9:10
-        StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
-        StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
-        _1 = const true;                 // scope 1 at $DIR/issue-38669.rs:10:9: 10:28
-        _2 = const ();                   // scope 1 at $DIR/issue-38669.rs:6:10: 11:6
-        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
+        _3 = const ();                   // scope 1 at $DIR/issue-38669.rs:+5:10: +5:10
+        StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:+5:9: +5:10
+        StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:+5:9: +5:10
+        _1 = const true;                 // scope 1 at $DIR/issue-38669.rs:+6:9: +6:28
+        _2 = const ();                   // scope 1 at $DIR/issue-38669.rs:+2:10: +7:6
+        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:+2:5: +7:6
     }
 
     bb5 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-38669.rs:4:1: 12:2
+        resume;                          // scope 0 at $DIR/issue-38669.rs:+0:1: +8:2
     }
 }

--- a/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
@@ -1,70 +1,70 @@
 // MIR for `main` after ElaborateDrops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-41110.rs:7:11: 7:11
-    let _1: ();                          // in scope 0 at $DIR/issue-41110.rs:8:9: 8:10
-    let mut _2: S;                       // in scope 0 at $DIR/issue-41110.rs:8:13: 8:14
-    let mut _3: S;                       // in scope 0 at $DIR/issue-41110.rs:8:21: 8:27
-    let mut _4: S;                       // in scope 0 at $DIR/issue-41110.rs:8:21: 8:22
-    let mut _5: bool;                    // in scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-41110.rs:+0:11: +0:11
+    let _1: ();                          // in scope 0 at $DIR/issue-41110.rs:+1:9: +1:10
+    let mut _2: S;                       // in scope 0 at $DIR/issue-41110.rs:+1:13: +1:14
+    let mut _3: S;                       // in scope 0 at $DIR/issue-41110.rs:+1:21: +1:27
+    let mut _4: S;                       // in scope 0 at $DIR/issue-41110.rs:+1:21: +1:22
+    let mut _5: bool;                    // in scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/issue-41110.rs:8:9: 8:10
+        debug x => _1;                   // in scope 1 at $DIR/issue-41110.rs:+1:9: +1:10
     }
 
     bb0: {
-        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:9: 8:10
-        StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:8:9: 8:10
-        StorageLive(_2);                 // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
-        _5 = const true;                 // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
-        _2 = S;                          // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
-        StorageLive(_3);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
-        StorageLive(_4);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
-        _4 = S;                          // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
-        _3 = S::id(move _4) -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
+        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:+1:9: +1:10
+        StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 0 at $DIR/issue-41110.rs:+1:13: +1:14
+        _5 = const true;                 // scope 0 at $DIR/issue-41110.rs:+1:13: +1:14
+        _2 = S;                          // scope 0 at $DIR/issue-41110.rs:+1:13: +1:14
+        StorageLive(_3);                 // scope 0 at $DIR/issue-41110.rs:+1:21: +1:27
+        StorageLive(_4);                 // scope 0 at $DIR/issue-41110.rs:+1:21: +1:22
+        _4 = S;                          // scope 0 at $DIR/issue-41110.rs:+1:21: +1:22
+        _3 = S::id(move _4) -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:+1:21: +1:27
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:23: 8:25
                                          // + literal: Const { ty: fn(S) -> S {S::id}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
-        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
-        _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
+        StorageDead(_4);                 // scope 0 at $DIR/issue-41110.rs:+1:26: +1:27
+        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:+1:13: +1:28
+        _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-41110.rs:+1:13: +1:28
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:15: 8:20
                                          // + literal: Const { ty: fn(S, S) {S::other}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-        StorageDead(_2);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-        _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:7:11: 9:2
-        StorageDead(_1);                 // scope 0 at $DIR/issue-41110.rs:9:1: 9:2
-        return;                          // scope 0 at $DIR/issue-41110.rs:9:2: 9:2
+        StorageDead(_3);                 // scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
+        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
+        StorageDead(_2);                 // scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
+        _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:+0:11: +2:2
+        StorageDead(_1);                 // scope 0 at $DIR/issue-41110.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/issue-41110.rs:+2:2: +2:2
     }
 
     bb3 (cleanup): {
-        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
     }
 
     bb4 (cleanup): {
-        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:+1:26: +1:27
     }
 
     bb5 (cleanup): {
-        goto -> bb8;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        goto -> bb8;                     // scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
     }
 
     bb6 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41110.rs:7:1: 9:2
+        resume;                          // scope 0 at $DIR/issue-41110.rs:+0:1: +2:2
     }
 
     bb7 (cleanup): {
-        drop(_2) -> bb6;                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        drop(_2) -> bb6;                 // scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
     }
 
     bb8 (cleanup): {
-        switchInt(_5) -> [false: bb6, otherwise: bb7]; // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        switchInt(_5) -> [false: bb6, otherwise: bb7]; // scope 0 at $DIR/issue-41110.rs:+1:27: +1:28
     }
 }

--- a/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
@@ -1,101 +1,101 @@
 // MIR for `test` after ElaborateDrops
 
 fn test() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-41110.rs:14:15: 14:15
-    let _1: S;                           // in scope 0 at $DIR/issue-41110.rs:15:9: 15:10
-    let _3: ();                          // in scope 0 at $DIR/issue-41110.rs:17:5: 17:12
-    let mut _4: S;                       // in scope 0 at $DIR/issue-41110.rs:17:10: 17:11
-    let mut _5: S;                       // in scope 0 at $DIR/issue-41110.rs:18:9: 18:10
-    let mut _6: bool;                    // in scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-41110.rs:+0:15: +0:15
+    let _1: S;                           // in scope 0 at $DIR/issue-41110.rs:+1:9: +1:10
+    let _3: ();                          // in scope 0 at $DIR/issue-41110.rs:+3:5: +3:12
+    let mut _4: S;                       // in scope 0 at $DIR/issue-41110.rs:+3:10: +3:11
+    let mut _5: S;                       // in scope 0 at $DIR/issue-41110.rs:+4:9: +4:10
+    let mut _6: bool;                    // in scope 0 at $DIR/issue-41110.rs:+5:1: +5:2
     scope 1 {
-        debug u => _1;                   // in scope 1 at $DIR/issue-41110.rs:15:9: 15:10
-        let mut _2: S;                   // in scope 1 at $DIR/issue-41110.rs:16:9: 16:14
+        debug u => _1;                   // in scope 1 at $DIR/issue-41110.rs:+1:9: +1:10
+        let mut _2: S;                   // in scope 1 at $DIR/issue-41110.rs:+2:9: +2:14
         scope 2 {
-            debug v => _2;               // in scope 2 at $DIR/issue-41110.rs:16:9: 16:14
+            debug v => _2;               // in scope 2 at $DIR/issue-41110.rs:+2:9: +2:14
         }
     }
 
     bb0: {
-        _6 = const false;                // scope 0 at $DIR/issue-41110.rs:15:9: 15:10
-        StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:15:9: 15:10
-        _6 = const true;                 // scope 0 at $DIR/issue-41110.rs:15:13: 15:14
-        _1 = S;                          // scope 0 at $DIR/issue-41110.rs:15:13: 15:14
-        StorageLive(_2);                 // scope 1 at $DIR/issue-41110.rs:16:9: 16:14
-        _2 = S;                          // scope 1 at $DIR/issue-41110.rs:16:17: 16:18
-        StorageLive(_3);                 // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
-        StorageLive(_4);                 // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
-        _4 = move _2;                    // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
-        _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7]; // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
+        _6 = const false;                // scope 0 at $DIR/issue-41110.rs:+1:9: +1:10
+        StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:+1:9: +1:10
+        _6 = const true;                 // scope 0 at $DIR/issue-41110.rs:+1:13: +1:14
+        _1 = S;                          // scope 0 at $DIR/issue-41110.rs:+1:13: +1:14
+        StorageLive(_2);                 // scope 1 at $DIR/issue-41110.rs:+2:9: +2:14
+        _2 = S;                          // scope 1 at $DIR/issue-41110.rs:+2:17: +2:18
+        StorageLive(_3);                 // scope 2 at $DIR/issue-41110.rs:+3:5: +3:12
+        StorageLive(_4);                 // scope 2 at $DIR/issue-41110.rs:+3:10: +3:11
+        _4 = move _2;                    // scope 2 at $DIR/issue-41110.rs:+3:10: +3:11
+        _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7]; // scope 2 at $DIR/issue-41110.rs:+3:5: +3:12
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:17:5: 17:9
                                          // + literal: Const { ty: fn(S) {std::mem::drop::<S>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
-        StorageDead(_3);                 // scope 2 at $DIR/issue-41110.rs:17:12: 17:13
-        StorageLive(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-        _6 = const false;                // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-        _5 = move _1;                    // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-        goto -> bb12;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+        StorageDead(_4);                 // scope 2 at $DIR/issue-41110.rs:+3:11: +3:12
+        StorageDead(_3);                 // scope 2 at $DIR/issue-41110.rs:+3:12: +3:13
+        StorageLive(_5);                 // scope 2 at $DIR/issue-41110.rs:+4:9: +4:10
+        _6 = const false;                // scope 2 at $DIR/issue-41110.rs:+4:9: +4:10
+        _5 = move _1;                    // scope 2 at $DIR/issue-41110.rs:+4:9: +4:10
+        goto -> bb12;                    // scope 2 at $DIR/issue-41110.rs:+4:5: +4:6
     }
 
     bb2: {
-        goto -> bb3;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
+        goto -> bb3;                     // scope 2 at $DIR/issue-41110.rs:+4:9: +4:10
     }
 
     bb3: {
-        StorageDead(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-        _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:14:15: 19:2
-        drop(_2) -> [return: bb4, unwind: bb9]; // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
+        StorageDead(_5);                 // scope 2 at $DIR/issue-41110.rs:+4:9: +4:10
+        _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:+0:15: +5:2
+        drop(_2) -> [return: bb4, unwind: bb9]; // scope 1 at $DIR/issue-41110.rs:+5:1: +5:2
     }
 
     bb4: {
-        StorageDead(_2);                 // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
-        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        StorageDead(_2);                 // scope 1 at $DIR/issue-41110.rs:+5:1: +5:2
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:+5:1: +5:2
     }
 
     bb5: {
-        _6 = const false;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
-        StorageDead(_1);                 // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
-        return;                          // scope 0 at $DIR/issue-41110.rs:19:2: 19:2
+        _6 = const false;                // scope 0 at $DIR/issue-41110.rs:+5:1: +5:2
+        StorageDead(_1);                 // scope 0 at $DIR/issue-41110.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/issue-41110.rs:+5:2: +5:2
     }
 
     bb6 (cleanup): {
-        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
+        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:+4:9: +4:10
     }
 
     bb7 (cleanup): {
-        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
+        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:+3:11: +3:12
     }
 
     bb8 (cleanup): {
-        goto -> bb9;                     // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
+        goto -> bb9;                     // scope 1 at $DIR/issue-41110.rs:+5:1: +5:2
     }
 
     bb9 (cleanup): {
-        goto -> bb14;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        goto -> bb14;                    // scope 0 at $DIR/issue-41110.rs:+5:1: +5:2
     }
 
     bb10 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41110.rs:14:1: 19:2
+        resume;                          // scope 0 at $DIR/issue-41110.rs:+0:1: +5:2
     }
 
     bb11 (cleanup): {
-        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
-        goto -> bb6;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:+4:5: +4:6
+        goto -> bb6;                     // scope 2 at $DIR/issue-41110.rs:+4:5: +4:6
     }
 
     bb12: {
-        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
-        goto -> bb2;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:+4:5: +4:6
+        goto -> bb2;                     // scope 2 at $DIR/issue-41110.rs:+4:5: +4:6
     }
 
     bb13 (cleanup): {
-        drop(_1) -> bb10;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        drop(_1) -> bb10;                // scope 0 at $DIR/issue-41110.rs:+5:1: +5:2
     }
 
     bb14 (cleanup): {
-        switchInt(_6) -> [false: bb10, otherwise: bb13]; // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        switchInt(_6) -> [false: bb10, otherwise: bb13]; // scope 0 at $DIR/issue-41110.rs:+5:1: +5:2
     }
 }

--- a/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.32bit.mir
+++ b/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.32bit.mir
@@ -1,20 +1,20 @@
 // MIR for `<impl at $DIR/issue-41697.rs:18:1: 18:23>::{constant#0}` after SimplifyCfg-promote-consts
 
 <impl at $DIR/issue-41697.rs:18:1: 18:23>::{constant#0}: usize = {
-    let mut _0: usize;                   // return place in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-    let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+    let mut _0: usize;                   // return place in scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
+    let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
 
     bb0: {
-        _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
     }
 
     bb1: {
-        _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-        return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
+        return;                          // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        resume;                          // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
     }
 }

--- a/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.64bit.mir
+++ b/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.64bit.mir
@@ -1,20 +1,20 @@
 // MIR for `<impl at $DIR/issue-41697.rs:18:1: 18:23>::{constant#0}` after SimplifyCfg-promote-consts
 
 <impl at $DIR/issue-41697.rs:18:1: 18:23>::{constant#0}: usize = {
-    let mut _0: usize;                   // return place in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-    let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+    let mut _0: usize;                   // return place in scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
+    let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
 
     bb0: {
-        _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
     }
 
     bb1: {
-        _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-        return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
+        return;                          // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        resume;                          // scope 0 at $DIR/issue-41697.rs:+0:19: +0:22
     }
 }

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -1,152 +1,152 @@
 // MIR for `main` after ElaborateDrops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-41888.rs:6:11: 6:11
-    let _1: E;                           // in scope 0 at $DIR/issue-41888.rs:7:9: 7:10
-    let mut _2: bool;                    // in scope 0 at $DIR/issue-41888.rs:8:8: 8:14
-    let mut _3: E;                       // in scope 0 at $DIR/issue-41888.rs:9:13: 9:20
-    let mut _4: K;                       // in scope 0 at $DIR/issue-41888.rs:9:18: 9:19
-    let mut _5: isize;                   // in scope 0 at $DIR/issue-41888.rs:10:16: 10:24
-    let mut _7: bool;                    // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    let mut _8: bool;                    // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    let mut _9: bool;                    // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    let mut _10: isize;                  // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    let mut _11: isize;                  // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-41888.rs:+0:11: +0:11
+    let _1: E;                           // in scope 0 at $DIR/issue-41888.rs:+1:9: +1:10
+    let mut _2: bool;                    // in scope 0 at $DIR/issue-41888.rs:+2:8: +2:14
+    let mut _3: E;                       // in scope 0 at $DIR/issue-41888.rs:+3:13: +3:20
+    let mut _4: K;                       // in scope 0 at $DIR/issue-41888.rs:+3:18: +3:19
+    let mut _5: isize;                   // in scope 0 at $DIR/issue-41888.rs:+4:16: +4:24
+    let mut _7: bool;                    // in scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+    let mut _8: bool;                    // in scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+    let mut _9: bool;                    // in scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+    let mut _10: isize;                  // in scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+    let mut _11: isize;                  // in scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     scope 1 {
-        debug e => _1;                   // in scope 1 at $DIR/issue-41888.rs:7:9: 7:10
+        debug e => _1;                   // in scope 1 at $DIR/issue-41888.rs:+1:9: +1:10
         scope 2 {
-            debug _k => _6;              // in scope 2 at $DIR/issue-41888.rs:10:21: 10:23
-            let _6: K;                   // in scope 2 at $DIR/issue-41888.rs:10:21: 10:23
+            debug _k => _6;              // in scope 2 at $DIR/issue-41888.rs:+4:21: +4:23
+            let _6: K;                   // in scope 2 at $DIR/issue-41888.rs:+4:21: +4:23
         }
     }
 
     bb0: {
-        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
-        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
-        _8 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
-        StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
-        StorageLive(_2);                 // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
-        _2 = cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
+        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:+1:9: +1:10
+        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:+1:9: +1:10
+        _8 = const false;                // scope 0 at $DIR/issue-41888.rs:+1:9: +1:10
+        StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 1 at $DIR/issue-41888.rs:+2:8: +2:14
+        _2 = cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue-41888.rs:+2:8: +2:14
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:8:8: 8:12
                                          // + literal: Const { ty: fn() -> bool {cond}, val: Value(<ZST>) }
     }
 
     bb1: {
-        switchInt(move _2) -> [false: bb7, otherwise: bb2]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
+        switchInt(move _2) -> [false: bb7, otherwise: bb2]; // scope 1 at $DIR/issue-41888.rs:+2:8: +2:14
     }
 
     bb2: {
-        StorageLive(_3);                 // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
-        StorageLive(_4);                 // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
-        _4 = K;                          // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
-        _3 = E::F(move _4);              // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
-        StorageDead(_4);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
-        goto -> bb14;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        StorageLive(_3);                 // scope 1 at $DIR/issue-41888.rs:+3:13: +3:20
+        StorageLive(_4);                 // scope 1 at $DIR/issue-41888.rs:+3:18: +3:19
+        _4 = K;                          // scope 1 at $DIR/issue-41888.rs:+3:18: +3:19
+        _3 = E::F(move _4);              // scope 1 at $DIR/issue-41888.rs:+3:13: +3:20
+        StorageDead(_4);                 // scope 1 at $DIR/issue-41888.rs:+3:19: +3:20
+        goto -> bb14;                    // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
     }
 
     bb3: {
-        goto -> bb4;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+        goto -> bb4;                     // scope 1 at $DIR/issue-41888.rs:+3:19: +3:20
     }
 
     bb4: {
-        StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
-        _5 = discriminant(_1);           // scope 2 at $DIR/issue-41888.rs:10:16: 10:24
-        switchInt(move _5) -> [0_isize: bb5, otherwise: bb6]; // scope 2 at $DIR/issue-41888.rs:10:16: 10:24
+        StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:+3:19: +3:20
+        _5 = discriminant(_1);           // scope 2 at $DIR/issue-41888.rs:+4:16: +4:24
+        switchInt(move _5) -> [0_isize: bb5, otherwise: bb6]; // scope 2 at $DIR/issue-41888.rs:+4:16: +4:24
     }
 
     bb5: {
-        StorageLive(_6);                 // scope 2 at $DIR/issue-41888.rs:10:21: 10:23
-        _9 = const false;                // scope 2 at $DIR/issue-41888.rs:10:21: 10:23
-        _6 = move ((_1 as F).0: K);      // scope 2 at $DIR/issue-41888.rs:10:21: 10:23
-        _0 = const ();                   // scope 2 at $DIR/issue-41888.rs:10:29: 13:10
-        StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:13:9: 13:10
-        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
+        StorageLive(_6);                 // scope 2 at $DIR/issue-41888.rs:+4:21: +4:23
+        _9 = const false;                // scope 2 at $DIR/issue-41888.rs:+4:21: +4:23
+        _6 = move ((_1 as F).0: K);      // scope 2 at $DIR/issue-41888.rs:+4:21: +4:23
+        _0 = const ();                   // scope 2 at $DIR/issue-41888.rs:+4:29: +7:10
+        StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:+7:9: +7:10
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:+4:9: +7:10
     }
 
     bb6: {
-        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:13:10: 13:10
-        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
+        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:+7:10: +7:10
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:+4:9: +7:10
     }
 
     bb7: {
-        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:14:6: 14:6
-        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
+        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:+8:6: +8:6
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:+2:5: +8:6
     }
 
     bb8: {
-        StorageDead(_2);                 // scope 1 at $DIR/issue-41888.rs:14:5: 14:6
-        goto -> bb20;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        StorageDead(_2);                 // scope 1 at $DIR/issue-41888.rs:+8:5: +8:6
+        goto -> bb20;                    // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb9: {
-        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        _8 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        StorageDead(_1);                 // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        return;                          // scope 0 at $DIR/issue-41888.rs:15:2: 15:2
+        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+        _8 = const false;                // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+        StorageDead(_1);                 // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+        return;                          // scope 0 at $DIR/issue-41888.rs:+9:2: +9:2
     }
 
     bb10 (cleanup): {
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:+3:19: +3:20
     }
 
     bb11 (cleanup): {
-        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb12 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41888.rs:6:1: 15:2
+        resume;                          // scope 0 at $DIR/issue-41888.rs:+0:1: +9:2
     }
 
     bb13 (cleanup): {
-        _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb10;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        goto -> bb10;                    // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
     }
 
     bb14: {
-        _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb3;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
+        goto -> bb3;                     // scope 1 at $DIR/issue-41888.rs:+3:9: +3:10
     }
 
     bb15: {
-        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        goto -> bb9;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+        goto -> bb9;                     // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb16 (cleanup): {
-        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb17: {
-        drop(_1) -> [return: bb15, unwind: bb12]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        drop(_1) -> [return: bb15, unwind: bb12]; // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb18 (cleanup): {
-        drop(_1) -> bb12;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        drop(_1) -> bb12;                // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb19: {
-        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _10) -> [0_isize: bb15, otherwise: bb17]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+        switchInt(move _10) -> [0_isize: bb15, otherwise: bb17]; // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb20: {
-        switchInt(_7) -> [false: bb15, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb15, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb21 (cleanup): {
-        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _11) -> [0_isize: bb16, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
+        switchInt(move _11) -> [0_isize: bb16, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 
     bb22 (cleanup): {
-        switchInt(_7) -> [false: bb12, otherwise: bb21]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb12, otherwise: bb21]; // scope 0 at $DIR/issue-41888.rs:+9:1: +9:2
     }
 }

--- a/src/test/mir-opt/issue_49232.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_49232.main.mir_map.0.mir
@@ -1,82 +1,82 @@
 // MIR for `main` 0 mir_map
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-49232.rs:5:11: 5:11
-    let mut _1: ();                      // in scope 0 at $DIR/issue-49232.rs:5:1: 15:2
-    let _2: i32;                         // in scope 0 at $DIR/issue-49232.rs:7:13: 7:19
-    let mut _3: bool;                    // in scope 0 at $DIR/issue-49232.rs:8:19: 8:23
-    let mut _4: !;                       // in scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-    let _5: ();                          // in scope 0 at $DIR/issue-49232.rs:13:9: 13:22
-    let mut _6: &i32;                    // in scope 0 at $DIR/issue-49232.rs:13:14: 13:21
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-49232.rs:+0:11: +0:11
+    let mut _1: ();                      // in scope 0 at $DIR/issue-49232.rs:+0:1: +10:2
+    let _2: i32;                         // in scope 0 at $DIR/issue-49232.rs:+2:13: +2:19
+    let mut _3: bool;                    // in scope 0 at $DIR/issue-49232.rs:+3:19: +3:23
+    let mut _4: !;                       // in scope 0 at $DIR/issue-49232.rs:+5:25: +5:30
+    let _5: ();                          // in scope 0 at $DIR/issue-49232.rs:+8:9: +8:22
+    let mut _6: &i32;                    // in scope 0 at $DIR/issue-49232.rs:+8:14: +8:21
     scope 1 {
-        debug beacon => _2;              // in scope 1 at $DIR/issue-49232.rs:7:13: 7:19
+        debug beacon => _2;              // in scope 1 at $DIR/issue-49232.rs:+2:13: +2:19
     }
 
     bb0: {
-        goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
+        goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:+1:5: +9:6
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
+        falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/issue-49232.rs:+1:5: +9:6
     }
 
     bb2: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
-        StorageLive(_3);                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
-        _3 = const true;                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
-        FakeRead(ForMatchedPlace(None), _3); // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
-        switchInt(_3) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/issue-49232.rs:8:13: 8:23
+        StorageLive(_2);                 // scope 0 at $DIR/issue-49232.rs:+2:13: +2:19
+        StorageLive(_3);                 // scope 0 at $DIR/issue-49232.rs:+3:19: +3:23
+        _3 = const true;                 // scope 0 at $DIR/issue-49232.rs:+3:19: +3:23
+        FakeRead(ForMatchedPlace(None), _3); // scope 0 at $DIR/issue-49232.rs:+3:19: +3:23
+        switchInt(_3) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/issue-49232.rs:+3:13: +3:23
     }
 
     bb3: {
-        falseEdge -> [real: bb5, imaginary: bb4]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
+        falseEdge -> [real: bb5, imaginary: bb4]; // scope 0 at $DIR/issue-49232.rs:+4:17: +4:22
     }
 
     bb4: {
-        _0 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-        goto -> bb10;                    // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
+        _0 = const ();                   // scope 0 at $DIR/issue-49232.rs:+5:25: +5:30
+        goto -> bb10;                    // scope 0 at $DIR/issue-49232.rs:+5:25: +5:30
     }
 
     bb5: {
-        _2 = const 4_i32;                // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
-        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
+        _2 = const 4_i32;                // scope 0 at $DIR/issue-49232.rs:+4:26: +4:27
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:+4:26: +4:27
     }
 
     bb6: {
-        unreachable;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
+        unreachable;                     // scope 0 at $DIR/issue-49232.rs:+5:25: +5:30
     }
 
     bb7: {
-        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:11:13: 11:14
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:+6:13: +6:14
     }
 
     bb8: {
-        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
-        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
-        StorageLive(_5);                 // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
-        StorageLive(_6);                 // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
-        _6 = &_2;                        // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
-        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb9, unwind: bb11]; // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
+        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/issue-49232.rs:+2:13: +2:19
+        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:+7:10: +7:11
+        StorageLive(_5);                 // scope 1 at $DIR/issue-49232.rs:+8:9: +8:22
+        StorageLive(_6);                 // scope 1 at $DIR/issue-49232.rs:+8:14: +8:21
+        _6 = &_2;                        // scope 1 at $DIR/issue-49232.rs:+8:14: +8:21
+        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb9, unwind: bb11]; // scope 1 at $DIR/issue-49232.rs:+8:9: +8:22
                                          // mir::Constant
                                          // + span: $DIR/issue-49232.rs:13:9: 13:13
                                          // + literal: Const { ty: fn(&i32) {std::mem::drop::<&i32>}, val: Value(<ZST>) }
     }
 
     bb9: {
-        StorageDead(_6);                 // scope 1 at $DIR/issue-49232.rs:13:21: 13:22
-        StorageDead(_5);                 // scope 1 at $DIR/issue-49232.rs:13:22: 13:23
-        _1 = const ();                   // scope 0 at $DIR/issue-49232.rs:6:10: 14:6
-        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
-        goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
+        StorageDead(_6);                 // scope 1 at $DIR/issue-49232.rs:+8:21: +8:22
+        StorageDead(_5);                 // scope 1 at $DIR/issue-49232.rs:+8:22: +8:23
+        _1 = const ();                   // scope 0 at $DIR/issue-49232.rs:+1:10: +9:6
+        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:+9:5: +9:6
+        goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:+1:5: +9:6
     }
 
     bb10: {
-        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
-        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
-        return;                          // scope 0 at $DIR/issue-49232.rs:15:2: 15:2
+        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:+7:10: +7:11
+        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:+9:5: +9:6
+        return;                          // scope 0 at $DIR/issue-49232.rs:+10:2: +10:2
     }
 
     bb11 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-49232.rs:5:1: 15:2
+        resume;                          // scope 0 at $DIR/issue-49232.rs:+0:1: +10:2
     }
 }

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -1,122 +1,122 @@
 // MIR for `test` before ElaborateDrops
 
 fn test() -> Option<Box<u32>> {
-    let mut _0: std::option::Option<std::boxed::Box<u32>>; // return place in scope 0 at $DIR/issue-62289.rs:8:14: 8:30
-    let mut _1: std::boxed::Box<u32>;    // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-    let mut _2: usize;                   // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-    let mut _3: usize;                   // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-    let mut _4: *mut u8;                 // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-    let mut _5: std::boxed::Box<u32>;    // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-    let mut _6: std::ops::ControlFlow<std::option::Option<std::convert::Infallible>, u32>; // in scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-    let mut _7: std::option::Option<u32>; // in scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-    let mut _8: isize;                   // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let _9: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let mut _10: !;                      // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let mut _11: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let _12: u32;                        // in scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+    let mut _0: std::option::Option<std::boxed::Box<u32>>; // return place in scope 0 at $DIR/issue-62289.rs:+0:14: +0:30
+    let mut _1: std::boxed::Box<u32>;    // in scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+    let mut _2: usize;                   // in scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+    let mut _3: usize;                   // in scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+    let mut _4: *mut u8;                 // in scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+    let mut _5: std::boxed::Box<u32>;    // in scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+    let mut _6: std::ops::ControlFlow<std::option::Option<std::convert::Infallible>, u32>; // in scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
+    let mut _7: std::option::Option<u32>; // in scope 0 at $DIR/issue-62289.rs:+1:15: +1:19
+    let mut _8: isize;                   // in scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+    let _9: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+    let mut _10: !;                      // in scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+    let mut _11: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+    let _12: u32;                        // in scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
     scope 1 {
     }
     scope 2 {
-        debug residual => _9;            // in scope 2 at $DIR/issue-62289.rs:9:19: 9:20
+        debug residual => _9;            // in scope 2 at $DIR/issue-62289.rs:+1:19: +1:20
         scope 3 {
         }
     }
     scope 4 {
-        debug val => _12;                // in scope 4 at $DIR/issue-62289.rs:9:15: 9:20
+        debug val => _12;                // in scope 4 at $DIR/issue-62289.rs:+1:15: +1:20
         scope 5 {
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        _2 = SizeOf(u32);                // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
-        _3 = AlignOf(u32);               // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
-        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
+        StorageLive(_1);                 // scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+        _2 = SizeOf(u32);                // scope 1 at $DIR/issue-62289.rs:+1:10: +1:21
+        _3 = AlignOf(u32);               // scope 1 at $DIR/issue-62289.rs:+1:10: +1:21
+        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 1 at $DIR/issue-62289.rs:+1:10: +1:21
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:10: 9:21
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageLive(_5);                 // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        _5 = ShallowInitBox(move _4, u32); // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        StorageLive(_7);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-        _7 = Option::<u32>::None;        // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-        _6 = <Option<u32> as Try>::branch(move _7) -> [return: bb2, unwind: bb12]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        StorageLive(_5);                 // scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+        _5 = ShallowInitBox(move _4, u32); // scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+        StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
+        StorageLive(_7);                 // scope 0 at $DIR/issue-62289.rs:+1:15: +1:19
+        _7 = Option::<u32>::None;        // scope 0 at $DIR/issue-62289.rs:+1:15: +1:19
+        _6 = <Option<u32> as Try>::branch(move _7) -> [return: bb2, unwind: bb12]; // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
                                          // + literal: Const { ty: fn(Option<u32>) -> ControlFlow<<Option<u32> as Try>::Residual, <Option<u32> as Try>::Output> {<Option<u32> as Try>::branch}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_7);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _8 = discriminant(_6);           // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        StorageDead(_7);                 // scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+        _8 = discriminant(_6);           // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
+        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
     }
 
     bb3: {
-        StorageLive(_12);                // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        _12 = ((_6 as Continue).0: u32); // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        (*_5) = _12;                     // scope 5 at $DIR/issue-62289.rs:9:15: 9:20
-        StorageDead(_12);                // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _1 = move _5;                    // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        drop(_5) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        StorageLive(_12);                // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
+        _12 = ((_6 as Continue).0: u32); // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
+        (*_5) = _12;                     // scope 5 at $DIR/issue-62289.rs:+1:15: +1:20
+        StorageDead(_12);                // scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+        _1 = move _5;                    // scope 0 at $DIR/issue-62289.rs:+1:10: +1:21
+        drop(_5) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:+1:20: +1:21
     }
 
     bb4: {
-        unreachable;                     // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        unreachable;                     // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
     }
 
     bb5: {
-        StorageLive(_9);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _9 = ((_6 as Break).0: std::option::Option<std::convert::Infallible>); // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        StorageLive(_11);                // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
-        _11 = _9;                        // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
-        _0 = <Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _11) -> [return: bb6, unwind: bb12]; // scope 3 at $DIR/issue-62289.rs:9:15: 9:20
+        StorageLive(_9);                 // scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+        _9 = ((_6 as Break).0: std::option::Option<std::convert::Infallible>); // scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+        StorageLive(_11);                // scope 3 at $DIR/issue-62289.rs:+1:19: +1:20
+        _11 = _9;                        // scope 3 at $DIR/issue-62289.rs:+1:19: +1:20
+        _0 = <Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _11) -> [return: bb6, unwind: bb12]; // scope 3 at $DIR/issue-62289.rs:+1:15: +1:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:19: 9:20
                                          // + literal: Const { ty: fn(Option<Infallible>) -> Option<Box<u32>> {<Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual}, val: Value(<ZST>) }
     }
 
     bb6: {
-        StorageDead(_11);                // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
-        StorageDead(_9);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        drop(_5) -> bb9;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        StorageDead(_11);                // scope 3 at $DIR/issue-62289.rs:+1:19: +1:20
+        StorageDead(_9);                 // scope 0 at $DIR/issue-62289.rs:+1:19: +1:20
+        drop(_5) -> bb9;                 // scope 0 at $DIR/issue-62289.rs:+1:20: +1:21
     }
 
     bb7: {
-        StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
-        drop(_1) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:+1:20: +1:21
+        _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:+1:5: +1:22
+        drop(_1) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:+1:21: +1:22
     }
 
     bb8: {
-        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:+1:21: +1:22
+        StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:+2:1: +2:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:+2:2: +2:2
     }
 
     bb9: {
-        StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+        StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:+1:20: +1:21
+        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:+1:21: +1:22
+        StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:+2:1: +2:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:+2:2: +2:2
     }
 
     bb10: {
-        return;                          // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+        return;                          // scope 0 at $DIR/issue-62289.rs:+2:2: +2:2
     }
 
     bb11 (cleanup): {
-        drop(_1) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        drop(_1) -> bb13;                // scope 0 at $DIR/issue-62289.rs:+1:21: +1:22
     }
 
     bb12 (cleanup): {
-        drop(_5) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        drop(_5) -> bb13;                // scope 0 at $DIR/issue-62289.rs:+1:20: +1:21
     }
 
     bb13 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-62289.rs:8:1: 10:2
+        resume;                          // scope 0 at $DIR/issue-62289.rs:+0:1: +2:2
     }
 }

--- a/src/test/mir-opt/issue_72181.bar.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.bar.mir_map.0.32bit.mir
@@ -1,17 +1,17 @@
 // MIR for `bar` 0 mir_map
 
 fn bar(_1: [(Never, u32); 1]) -> u32 {
-    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:19:40: 19:43
-    let _2: u32;                         // in scope 0 at $DIR/issue-72181.rs:19:13: 19:14
+    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:+0:40: +0:43
+    let _2: u32;                         // in scope 0 at $DIR/issue-72181.rs:+0:13: +0:14
     scope 1 {
-        debug x => _2;                   // in scope 1 at $DIR/issue-72181.rs:19:13: 19:14
+        debug x => _2;                   // in scope 1 at $DIR/issue-72181.rs:+0:13: +0:14
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
-        _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
-        _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:19:46: 19:47
-        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:19:48: 19:49
-        return;                          // scope 0 at $DIR/issue-72181.rs:19:49: 19:49
+        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:13: +0:14
+        _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:+0:13: +0:14
+        _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:+0:46: +0:47
+        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:48: +0:49
+        return;                          // scope 0 at $DIR/issue-72181.rs:+0:49: +0:49
     }
 }

--- a/src/test/mir-opt/issue_72181.bar.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.bar.mir_map.0.64bit.mir
@@ -1,17 +1,17 @@
 // MIR for `bar` 0 mir_map
 
 fn bar(_1: [(Never, u32); 1]) -> u32 {
-    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:19:40: 19:43
-    let _2: u32;                         // in scope 0 at $DIR/issue-72181.rs:19:13: 19:14
+    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:+0:40: +0:43
+    let _2: u32;                         // in scope 0 at $DIR/issue-72181.rs:+0:13: +0:14
     scope 1 {
-        debug x => _2;                   // in scope 1 at $DIR/issue-72181.rs:19:13: 19:14
+        debug x => _2;                   // in scope 1 at $DIR/issue-72181.rs:+0:13: +0:14
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
-        _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
-        _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:19:46: 19:47
-        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:19:48: 19:49
-        return;                          // scope 0 at $DIR/issue-72181.rs:19:49: 19:49
+        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:13: +0:14
+        _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:+0:13: +0:14
+        _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:+0:46: +0:47
+        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:48: +0:49
+        return;                          // scope 0 at $DIR/issue-72181.rs:+0:49: +0:49
     }
 }

--- a/src/test/mir-opt/issue_72181.foo.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.foo.mir_map.0.32bit.mir
@@ -1,27 +1,27 @@
 // MIR for `foo` 0 mir_map
 
 fn foo(_1: [(Never, u32); 1]) -> u32 {
-    debug xs => _1;                      // in scope 0 at $DIR/issue-72181.rs:16:8: 16:10
-    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:16:34: 16:37
-    let _2: usize;                       // in scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-    let mut _3: usize;                   // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-    let mut _4: bool;                    // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
+    debug xs => _1;                      // in scope 0 at $DIR/issue-72181.rs:+0:8: +0:10
+    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:+0:34: +0:37
+    let _2: usize;                       // in scope 0 at $DIR/issue-72181.rs:+0:43: +0:44
+    let mut _3: usize;                   // in scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
+    let mut _4: bool;                    // in scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-        _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-        _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-        _4 = Lt(_2, _3);                 // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
+        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:43: +0:44
+        _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:+0:43: +0:44
+        _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
+        _4 = Lt(_2, _3);                 // scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
+        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
     }
 
     bb1: {
-        _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:16:40: 16:47
-        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:16:48: 16:49
-        return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
+        _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:+0:40: +0:47
+        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:48: +0:49
+        return;                          // scope 0 at $DIR/issue-72181.rs:+0:49: +0:49
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
+        resume;                          // scope 0 at $DIR/issue-72181.rs:+0:1: +0:49
     }
 }

--- a/src/test/mir-opt/issue_72181.foo.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.foo.mir_map.0.64bit.mir
@@ -1,27 +1,27 @@
 // MIR for `foo` 0 mir_map
 
 fn foo(_1: [(Never, u32); 1]) -> u32 {
-    debug xs => _1;                      // in scope 0 at $DIR/issue-72181.rs:16:8: 16:10
-    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:16:34: 16:37
-    let _2: usize;                       // in scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-    let mut _3: usize;                   // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-    let mut _4: bool;                    // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
+    debug xs => _1;                      // in scope 0 at $DIR/issue-72181.rs:+0:8: +0:10
+    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-72181.rs:+0:34: +0:37
+    let _2: usize;                       // in scope 0 at $DIR/issue-72181.rs:+0:43: +0:44
+    let mut _3: usize;                   // in scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
+    let mut _4: bool;                    // in scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-        _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-        _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-        _4 = Lt(_2, _3);                 // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
+        StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:43: +0:44
+        _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:+0:43: +0:44
+        _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
+        _4 = Lt(_2, _3);                 // scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
+        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:+0:40: +0:45
     }
 
     bb1: {
-        _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:16:40: 16:47
-        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:16:48: 16:49
-        return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
+        _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:+0:40: +0:47
+        StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:+0:48: +0:49
+        return;                          // scope 0 at $DIR/issue-72181.rs:+0:49: +0:49
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
+        resume;                          // scope 0 at $DIR/issue-72181.rs:+0:1: +0:49
     }
 }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
@@ -1,18 +1,18 @@
 // MIR for `main` 0 mir_map
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-72181.rs:23:11: 23:11
-    let mut _1: usize;                   // in scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-    let mut _3: Foo;                     // in scope 0 at $DIR/issue-72181.rs:26:14: 26:27
-    let mut _4: Foo;                     // in scope 0 at $DIR/issue-72181.rs:26:29: 26:42
-    let mut _5: u64;                     // in scope 0 at $DIR/issue-72181.rs:27:13: 27:30
-    let _6: usize;                       // in scope 0 at $DIR/issue-72181.rs:27:24: 27:25
-    let mut _7: usize;                   // in scope 0 at $DIR/issue-72181.rs:27:22: 27:26
-    let mut _8: bool;                    // in scope 0 at $DIR/issue-72181.rs:27:22: 27:26
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-72181.rs:+0:11: +0:11
+    let mut _1: usize;                   // in scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
+    let mut _3: Foo;                     // in scope 0 at $DIR/issue-72181.rs:+3:14: +3:27
+    let mut _4: Foo;                     // in scope 0 at $DIR/issue-72181.rs:+3:29: +3:42
+    let mut _5: u64;                     // in scope 0 at $DIR/issue-72181.rs:+4:13: +4:30
+    let _6: usize;                       // in scope 0 at $DIR/issue-72181.rs:+4:24: +4:25
+    let mut _7: usize;                   // in scope 0 at $DIR/issue-72181.rs:+4:22: +4:26
+    let mut _8: bool;                    // in scope 0 at $DIR/issue-72181.rs:+4:22: +4:26
     scope 1 {
-        let _2: [Foo; 2];                // in scope 1 at $DIR/issue-72181.rs:26:9: 26:10
+        let _2: [Foo; 2];                // in scope 1 at $DIR/issue-72181.rs:+3:9: +3:10
         scope 2 {
-            debug f => _2;               // in scope 2 at $DIR/issue-72181.rs:26:9: 26:10
+            debug f => _2;               // in scope 2 at $DIR/issue-72181.rs:+3:9: +3:10
             scope 3 {
             }
             scope 4 {
@@ -21,42 +21,42 @@ fn main() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
+        StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
+        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
-        StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
-        StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
-        _3 = Foo { a: const 42_u64 };    // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
-        StorageLive(_4);                 // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
-        _4 = Foo { a: const 10_u64 };    // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
-        _2 = [move _3, move _4];         // scope 1 at $DIR/issue-72181.rs:26:13: 26:43
-        StorageDead(_4);                 // scope 1 at $DIR/issue-72181.rs:26:42: 26:43
-        StorageDead(_3);                 // scope 1 at $DIR/issue-72181.rs:26:42: 26:43
-        FakeRead(ForLet(None), _2);      // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
-        StorageLive(_5);                 // scope 2 at $DIR/issue-72181.rs:27:13: 27:30
-        StorageLive(_6);                 // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
-        _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
-        _7 = Len(_2);                    // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
-        _8 = Lt(_6, _7);                 // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
-        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
+        StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:+1:34: +1:35
+        StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:+3:9: +3:10
+        StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:+3:14: +3:27
+        _3 = Foo { a: const 42_u64 };    // scope 1 at $DIR/issue-72181.rs:+3:14: +3:27
+        StorageLive(_4);                 // scope 1 at $DIR/issue-72181.rs:+3:29: +3:42
+        _4 = Foo { a: const 10_u64 };    // scope 1 at $DIR/issue-72181.rs:+3:29: +3:42
+        _2 = [move _3, move _4];         // scope 1 at $DIR/issue-72181.rs:+3:13: +3:43
+        StorageDead(_4);                 // scope 1 at $DIR/issue-72181.rs:+3:42: +3:43
+        StorageDead(_3);                 // scope 1 at $DIR/issue-72181.rs:+3:42: +3:43
+        FakeRead(ForLet(None), _2);      // scope 1 at $DIR/issue-72181.rs:+3:9: +3:10
+        StorageLive(_5);                 // scope 2 at $DIR/issue-72181.rs:+4:13: +4:30
+        StorageLive(_6);                 // scope 4 at $DIR/issue-72181.rs:+4:24: +4:25
+        _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:+4:24: +4:25
+        _7 = Len(_2);                    // scope 4 at $DIR/issue-72181.rs:+4:22: +4:26
+        _8 = Lt(_6, _7);                 // scope 4 at $DIR/issue-72181.rs:+4:22: +4:26
+        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:+4:22: +4:26
     }
 
     bb2: {
-        _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:27:22: 27:28
-        StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
-        StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
-        _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:23:11: 28:2
-        StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:28:1: 28:2
-        return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
+        _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:+4:22: +4:28
+        StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:+4:30: +4:31
+        StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:+4:30: +4:31
+        _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:+0:11: +5:2
+        StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/issue-72181.rs:+5:2: +5:2
     }
 
     bb3 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
+        resume;                          // scope 0 at $DIR/issue-72181.rs:+0:1: +5:2
     }
 }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
@@ -1,18 +1,18 @@
 // MIR for `main` 0 mir_map
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-72181.rs:23:11: 23:11
-    let mut _1: usize;                   // in scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-    let mut _3: Foo;                     // in scope 0 at $DIR/issue-72181.rs:26:14: 26:27
-    let mut _4: Foo;                     // in scope 0 at $DIR/issue-72181.rs:26:29: 26:42
-    let mut _5: u64;                     // in scope 0 at $DIR/issue-72181.rs:27:13: 27:30
-    let _6: usize;                       // in scope 0 at $DIR/issue-72181.rs:27:24: 27:25
-    let mut _7: usize;                   // in scope 0 at $DIR/issue-72181.rs:27:22: 27:26
-    let mut _8: bool;                    // in scope 0 at $DIR/issue-72181.rs:27:22: 27:26
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-72181.rs:+0:11: +0:11
+    let mut _1: usize;                   // in scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
+    let mut _3: Foo;                     // in scope 0 at $DIR/issue-72181.rs:+3:14: +3:27
+    let mut _4: Foo;                     // in scope 0 at $DIR/issue-72181.rs:+3:29: +3:42
+    let mut _5: u64;                     // in scope 0 at $DIR/issue-72181.rs:+4:13: +4:30
+    let _6: usize;                       // in scope 0 at $DIR/issue-72181.rs:+4:24: +4:25
+    let mut _7: usize;                   // in scope 0 at $DIR/issue-72181.rs:+4:22: +4:26
+    let mut _8: bool;                    // in scope 0 at $DIR/issue-72181.rs:+4:22: +4:26
     scope 1 {
-        let _2: [Foo; 2];                // in scope 1 at $DIR/issue-72181.rs:26:9: 26:10
+        let _2: [Foo; 2];                // in scope 1 at $DIR/issue-72181.rs:+3:9: +3:10
         scope 2 {
-            debug f => _2;               // in scope 2 at $DIR/issue-72181.rs:26:9: 26:10
+            debug f => _2;               // in scope 2 at $DIR/issue-72181.rs:+3:9: +3:10
             scope 3 {
             }
             scope 4 {
@@ -21,42 +21,42 @@ fn main() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
+        StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
+        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
-        StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
-        StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
-        _3 = Foo { a: const 42_u64 };    // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
-        StorageLive(_4);                 // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
-        _4 = Foo { a: const 10_u64 };    // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
-        _2 = [move _3, move _4];         // scope 1 at $DIR/issue-72181.rs:26:13: 26:43
-        StorageDead(_4);                 // scope 1 at $DIR/issue-72181.rs:26:42: 26:43
-        StorageDead(_3);                 // scope 1 at $DIR/issue-72181.rs:26:42: 26:43
-        FakeRead(ForLet(None), _2);      // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
-        StorageLive(_5);                 // scope 2 at $DIR/issue-72181.rs:27:13: 27:30
-        StorageLive(_6);                 // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
-        _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
-        _7 = Len(_2);                    // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
-        _8 = Lt(_6, _7);                 // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
-        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
+        StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:+1:34: +1:35
+        StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:+3:9: +3:10
+        StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:+3:14: +3:27
+        _3 = Foo { a: const 42_u64 };    // scope 1 at $DIR/issue-72181.rs:+3:14: +3:27
+        StorageLive(_4);                 // scope 1 at $DIR/issue-72181.rs:+3:29: +3:42
+        _4 = Foo { a: const 10_u64 };    // scope 1 at $DIR/issue-72181.rs:+3:29: +3:42
+        _2 = [move _3, move _4];         // scope 1 at $DIR/issue-72181.rs:+3:13: +3:43
+        StorageDead(_4);                 // scope 1 at $DIR/issue-72181.rs:+3:42: +3:43
+        StorageDead(_3);                 // scope 1 at $DIR/issue-72181.rs:+3:42: +3:43
+        FakeRead(ForLet(None), _2);      // scope 1 at $DIR/issue-72181.rs:+3:9: +3:10
+        StorageLive(_5);                 // scope 2 at $DIR/issue-72181.rs:+4:13: +4:30
+        StorageLive(_6);                 // scope 4 at $DIR/issue-72181.rs:+4:24: +4:25
+        _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:+4:24: +4:25
+        _7 = Len(_2);                    // scope 4 at $DIR/issue-72181.rs:+4:22: +4:26
+        _8 = Lt(_6, _7);                 // scope 4 at $DIR/issue-72181.rs:+4:22: +4:26
+        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:+4:22: +4:26
     }
 
     bb2: {
-        _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:27:22: 27:28
-        StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
-        StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
-        _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:23:11: 28:2
-        StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:28:1: 28:2
-        return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
+        _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:+4:22: +4:28
+        StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:+4:30: +4:31
+        StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:+4:30: +4:31
+        _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:+0:11: +5:2
+        StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/issue-72181.rs:+5:2: +5:2
     }
 
     bb3 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
+        resume;                          // scope 0 at $DIR/issue-72181.rs:+0:1: +5:2
     }
 }

--- a/src/test/mir-opt/issue_72181_1.f.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.f.mir_map.0.mir
@@ -1,29 +1,29 @@
 // MIR for `f` 0 mir_map
 
 fn f(_1: Void) -> ! {
-    debug v => _1;                       // in scope 0 at $DIR/issue-72181-1.rs:10:6: 10:7
-    let mut _0: !;                       // return place in scope 0 at $DIR/issue-72181-1.rs:10:18: 10:19
-    let mut _2: !;                       // in scope 0 at $DIR/issue-72181-1.rs:10:20: 12:2
-    let mut _3: !;                       // in scope 0 at $DIR/issue-72181-1.rs:11:5: 11:15
+    debug v => _1;                       // in scope 0 at $DIR/issue-72181-1.rs:+0:6: +0:7
+    let mut _0: !;                       // return place in scope 0 at $DIR/issue-72181-1.rs:+0:18: +0:19
+    let mut _2: !;                       // in scope 0 at $DIR/issue-72181-1.rs:+0:20: +2:2
+    let mut _3: !;                       // in scope 0 at $DIR/issue-72181-1.rs:+1:5: +1:15
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-72181-1.rs:10:20: 12:2
-        StorageLive(_3);                 // scope 0 at $DIR/issue-72181-1.rs:11:5: 11:15
-        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/issue-72181-1.rs:11:11: 11:12
-        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:11:11: 11:12
+        StorageLive(_2);                 // scope 0 at $DIR/issue-72181-1.rs:+0:20: +2:2
+        StorageLive(_3);                 // scope 0 at $DIR/issue-72181-1.rs:+1:5: +1:15
+        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/issue-72181-1.rs:+1:11: +1:12
+        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:+1:11: +1:12
     }
 
     bb1: {
-        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:11:5: 11:15
+        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:+1:5: +1:15
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 0 at $DIR/issue-72181-1.rs:11:14: 11:15
-        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:10:20: 12:2
+        StorageDead(_3);                 // scope 0 at $DIR/issue-72181-1.rs:+1:14: +1:15
+        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:+0:20: +2:2
     }
 
     bb3: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:12:1: 12:2
-        return;                          // scope 0 at $DIR/issue-72181-1.rs:12:2: 12:2
+        StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/issue-72181-1.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
@@ -5,53 +5,53 @@
 | 1: user_ty: Canonical { max_universe: U0, variables: [], value: Ty(Void) }, span: $DIR/issue-72181-1.rs:16:12: 16:16, inferred_ty: Void
 |
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-72181-1.rs:15:11: 15:11
-    let mut _1: !;                       // in scope 0 at $DIR/issue-72181-1.rs:15:11: 21:2
-    let _2: Void as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 0 at $DIR/issue-72181-1.rs:16:9: 16:10
-    let mut _3: ();                      // in scope 0 at $DIR/issue-72181-1.rs:17:41: 17:43
-    let _4: !;                           // in scope 0 at $DIR/issue-72181-1.rs:20:5: 20:9
-    let mut _5: Void;                    // in scope 0 at $DIR/issue-72181-1.rs:20:7: 20:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-72181-1.rs:+0:11: +0:11
+    let mut _1: !;                       // in scope 0 at $DIR/issue-72181-1.rs:+0:11: +6:2
+    let _2: Void as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 0 at $DIR/issue-72181-1.rs:+1:9: +1:10
+    let mut _3: ();                      // in scope 0 at $DIR/issue-72181-1.rs:+2:41: +2:43
+    let _4: !;                           // in scope 0 at $DIR/issue-72181-1.rs:+5:5: +5:9
+    let mut _5: Void;                    // in scope 0 at $DIR/issue-72181-1.rs:+5:7: +5:8
     scope 1 {
-        debug v => _2;                   // in scope 1 at $DIR/issue-72181-1.rs:16:9: 16:10
+        debug v => _2;                   // in scope 1 at $DIR/issue-72181-1.rs:+1:9: +1:10
     }
     scope 2 {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-72181-1.rs:16:9: 16:10
-        StorageLive(_3);                 // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
-        _3 = ();                         // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
-        _2 = transmute::<(), Void>(move _3) -> bb4; // scope 2 at $DIR/issue-72181-1.rs:17:9: 17:44
+        StorageLive(_2);                 // scope 0 at $DIR/issue-72181-1.rs:+1:9: +1:10
+        StorageLive(_3);                 // scope 2 at $DIR/issue-72181-1.rs:+2:41: +2:43
+        _3 = ();                         // scope 2 at $DIR/issue-72181-1.rs:+2:41: +2:43
+        _2 = transmute::<(), Void>(move _3) -> bb4; // scope 2 at $DIR/issue-72181-1.rs:+2:9: +2:44
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:17:9: 17:40
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(()) -> Void {transmute::<(), Void>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 2 at $DIR/issue-72181-1.rs:17:43: 17:44
-        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/issue-72181-1.rs:16:9: 16:10
-        AscribeUserType(_2, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/issue-72181-1.rs:16:12: 16:16
-        StorageLive(_4);                 // scope 1 at $DIR/issue-72181-1.rs:20:5: 20:9
-        StorageLive(_5);                 // scope 1 at $DIR/issue-72181-1.rs:20:7: 20:8
-        _5 = move _2;                    // scope 1 at $DIR/issue-72181-1.rs:20:7: 20:8
-        _4 = f(move _5) -> bb4;          // scope 1 at $DIR/issue-72181-1.rs:20:5: 20:9
+        StorageDead(_3);                 // scope 2 at $DIR/issue-72181-1.rs:+2:43: +2:44
+        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/issue-72181-1.rs:+1:9: +1:10
+        AscribeUserType(_2, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/issue-72181-1.rs:+1:12: +1:16
+        StorageLive(_4);                 // scope 1 at $DIR/issue-72181-1.rs:+5:5: +5:9
+        StorageLive(_5);                 // scope 1 at $DIR/issue-72181-1.rs:+5:7: +5:8
+        _5 = move _2;                    // scope 1 at $DIR/issue-72181-1.rs:+5:7: +5:8
+        _4 = f(move _5) -> bb4;          // scope 1 at $DIR/issue-72181-1.rs:+5:5: +5:9
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:20:5: 20:6
                                          // + literal: Const { ty: fn(Void) -> ! {f}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_5);                 // scope 1 at $DIR/issue-72181-1.rs:20:8: 20:9
-        StorageDead(_4);                 // scope 1 at $DIR/issue-72181-1.rs:20:9: 20:10
-        StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:21:1: 21:2
-        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:15:11: 21:2
+        StorageDead(_5);                 // scope 1 at $DIR/issue-72181-1.rs:+5:8: +5:9
+        StorageDead(_4);                 // scope 1 at $DIR/issue-72181-1.rs:+5:9: +5:10
+        StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:+6:1: +6:2
+        unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:+0:11: +6:2
     }
 
     bb3: {
-        return;                          // scope 0 at $DIR/issue-72181-1.rs:21:2: 21:2
+        return;                          // scope 0 at $DIR/issue-72181-1.rs:+6:2: +6:2
     }
 
     bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181-1.rs:15:1: 21:2
+        resume;                          // scope 0 at $DIR/issue-72181-1.rs:+0:1: +6:2
     }
 }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -2,10 +2,10 @@
 + // MIR for `main` after PreCodegen
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:1:11: 1:11
-      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-      let _3: i32;                         // in scope 0 at $DIR/issue-73223.rs:3:14: 3:15
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+      let _3: i32;                         // in scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
       let mut _5: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _6: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _7: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -19,10 +19,10 @@
       let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _19: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
-          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
-          let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:+1:9: +1:14
+          let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
           scope 3 {
-              debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
+              debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:+6:9: +6:14
               let _8: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _9: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let mut _20: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -37,21 +37,21 @@
           }
       }
       scope 2 {
-          debug v => _3;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
+          debug v => _3;                   // in scope 2 at $DIR/issue-73223.rs:+2:14: +2:15
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _3 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _1 = _3;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_3);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _3 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _1 = _3;                         // scope 2 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_3);                 // scope 0 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:+4:6: +4:7
+          StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
           StorageLive(_5);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _6 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -109,9 +109,9 @@
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_5);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_4);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
+          StorageDead(_4);                 // scope 1 at $DIR/issue-73223.rs:+8:1: +8:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/issue-73223.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -2,10 +2,10 @@
 + // MIR for `main` after PreCodegen
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:1:11: 1:11
-      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-      let _3: i32;                         // in scope 0 at $DIR/issue-73223.rs:3:14: 3:15
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+      let _3: i32;                         // in scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
       let mut _5: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _6: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _7: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -19,10 +19,10 @@
       let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _19: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
-          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
-          let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:+1:9: +1:14
+          let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
           scope 3 {
-              debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
+              debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:+6:9: +6:14
               let _8: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _9: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let mut _20: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -37,21 +37,21 @@
           }
       }
       scope 2 {
-          debug v => _3;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
+          debug v => _3;                   // in scope 2 at $DIR/issue-73223.rs:+2:14: +2:15
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _3 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _1 = _3;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_3);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _3 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _1 = _3;                         // scope 2 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_3);                 // scope 0 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:+4:6: +4:7
+          StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
           StorageLive(_5);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _6 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -109,9 +109,9 @@
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_5);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_4);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
+          StorageDead(_4);                 // scope 1 at $DIR/issue-73223.rs:+8:1: +8:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/issue-73223.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -2,18 +2,18 @@
 + // MIR for `main` after SimplifyArmIdentity
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:1:11: 1:11
-      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-      let mut _3: isize;                   // in scope 0 at $DIR/issue-73223.rs:3:9: 3:16
-      let _4: i32;                         // in scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-      let mut _5: !;                       // in scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-      let mut _7: i32;                     // in scope 0 at $DIR/issue-73223.rs:7:22: 7:27
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+      let mut _3: isize;                   // in scope 0 at $DIR/issue-73223.rs:+2:9: +2:16
+      let _4: i32;                         // in scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+      let mut _5: !;                       // in scope 0 at $DIR/issue-73223.rs:+3:17: +3:23
+      let mut _7: i32;                     // in scope 0 at $DIR/issue-73223.rs:+6:22: +6:27
       let _8: ();                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _9: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _10: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _11: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _12: i32;                        // in scope 0 at $DIR/issue-73223.rs:8:23: 8:24
+      let _12: i32;                        // in scope 0 at $DIR/issue-73223.rs:+7:23: +7:24
       let mut _15: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _16: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _17: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -27,10 +27,10 @@
       let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _27: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
-          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
-          let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:+1:9: +1:14
+          let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
           scope 3 {
-              debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
+              debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:+6:9: +6:14
               let _13: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _14: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let mut _28: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -45,39 +45,39 @@
           }
       }
       scope 2 {
-          debug v => _4;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
+          debug v => _4;                   // in scope 2 at $DIR/issue-73223.rs:+2:14: +2:15
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:2:17: 2:30
+          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:+1:17: +1:30
       }
   
       bb1: {
-          nop;                             // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:+3:17: +3:23
+          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:+4:6: +4:7
+          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/issue-73223.rs:+8:2: +8:2
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
-          StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
-          _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
-          Deinit(_6);                      // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
+          StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:+4:6: +4:7
+          StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
+          StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:+6:22: +6:27
+          _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:+6:22: +6:27
+          Deinit(_6);                      // scope 1 at $DIR/issue-73223.rs:+6:17: +6:28
+          ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:+6:17: +6:28
+          discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:+6:17: +6:28
+          StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:+6:27: +6:28
           StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -148,10 +148,10 @@
           StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          nop;                             // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-          StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:+0:11: +8:2
+          StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:+8:1: +8:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/issue-73223.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -2,18 +2,18 @@
 + // MIR for `main` after SimplifyArmIdentity
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:1:11: 1:11
-      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-      let mut _3: isize;                   // in scope 0 at $DIR/issue-73223.rs:3:9: 3:16
-      let _4: i32;                         // in scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-      let mut _5: !;                       // in scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-      let mut _7: i32;                     // in scope 0 at $DIR/issue-73223.rs:7:22: 7:27
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue-73223.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+      let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+      let mut _3: isize;                   // in scope 0 at $DIR/issue-73223.rs:+2:9: +2:16
+      let _4: i32;                         // in scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+      let mut _5: !;                       // in scope 0 at $DIR/issue-73223.rs:+3:17: +3:23
+      let mut _7: i32;                     // in scope 0 at $DIR/issue-73223.rs:+6:22: +6:27
       let _8: ();                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _9: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _10: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _11: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _12: i32;                        // in scope 0 at $DIR/issue-73223.rs:8:23: 8:24
+      let _12: i32;                        // in scope 0 at $DIR/issue-73223.rs:+7:23: +7:24
       let mut _15: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _16: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _17: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -27,10 +27,10 @@
       let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _27: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
-          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
-          let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:+1:9: +1:14
+          let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
           scope 3 {
-              debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
+              debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:+6:9: +6:14
               let _13: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _14: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let mut _28: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -45,39 +45,39 @@
           }
       }
       scope 2 {
-          debug v => _4;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
+          debug v => _4;                   // in scope 2 at $DIR/issue-73223.rs:+2:14: +2:15
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:2:17: 2:30
+          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:+1:9: +1:14
+          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:+1:23: +1:30
+          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:+1:17: +1:30
       }
   
       bb1: {
-          nop;                             // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:+3:17: +3:23
+          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:+4:6: +4:7
+          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/issue-73223.rs:+8:2: +8:2
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
-          _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
-          StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
-          _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
-          Deinit(_6);                      // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
+          StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:+2:14: +2:15
+          _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:+2:20: +2:21
+          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:+4:6: +4:7
+          StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:+6:9: +6:14
+          StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:+6:22: +6:27
+          _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:+6:22: +6:27
+          Deinit(_6);                      // scope 1 at $DIR/issue-73223.rs:+6:17: +6:28
+          ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:+6:17: +6:28
+          discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:+6:17: +6:28
+          StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:+6:27: +6:28
           StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -148,10 +148,10 @@
           StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          nop;                             // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-          StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:+0:11: +8:2
+          StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:+8:1: +8:2
+          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/issue-73223.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -2,67 +2,67 @@
 + // MIR for `test` after SimplifyComparisonIntegral
   
   fn test(_1: T) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/issue_76432.rs:6:38: 6:39
-      let mut _0: ();                      // return place in scope 0 at $DIR/issue_76432.rs:6:44: 6:44
-      let _2: &[T];                        // in scope 0 at $DIR/issue_76432.rs:7:9: 7:10
-      let mut _3: &[T; 3];                 // in scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-      let _4: &[T; 3];                     // in scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-      let _5: [T; 3];                      // in scope 0 at $DIR/issue_76432.rs:7:20: 7:29
-      let mut _6: T;                       // in scope 0 at $DIR/issue_76432.rs:7:21: 7:22
-      let mut _7: T;                       // in scope 0 at $DIR/issue_76432.rs:7:24: 7:25
-      let mut _8: T;                       // in scope 0 at $DIR/issue_76432.rs:7:27: 7:28
-      let _9: [*const T; 3];               // in scope 0 at $DIR/issue_76432.rs:8:5: 11:6
-      let mut _10: usize;                  // in scope 0 at $DIR/issue_76432.rs:9:9: 9:33
-      let mut _11: usize;                  // in scope 0 at $DIR/issue_76432.rs:9:9: 9:33
-      let mut _12: bool;                   // in scope 0 at $DIR/issue_76432.rs:9:9: 9:33
-      let mut _16: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:38: 9:52
-      let mut _17: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:38: 9:52
-      let mut _18: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:54: 9:68
-      let mut _19: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:54: 9:68
-      let mut _20: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:70: 9:84
-      let mut _21: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:70: 9:84
+      debug x => _1;                       // in scope 0 at $DIR/issue_76432.rs:+0:38: +0:39
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue_76432.rs:+0:44: +0:44
+      let _2: &[T];                        // in scope 0 at $DIR/issue_76432.rs:+1:9: +1:10
+      let mut _3: &[T; 3];                 // in scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+      let _4: &[T; 3];                     // in scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+      let _5: [T; 3];                      // in scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
+      let mut _6: T;                       // in scope 0 at $DIR/issue_76432.rs:+1:21: +1:22
+      let mut _7: T;                       // in scope 0 at $DIR/issue_76432.rs:+1:24: +1:25
+      let mut _8: T;                       // in scope 0 at $DIR/issue_76432.rs:+1:27: +1:28
+      let _9: [*const T; 3];               // in scope 0 at $DIR/issue_76432.rs:+2:5: +5:6
+      let mut _10: usize;                  // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
+      let mut _11: usize;                  // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
+      let mut _12: bool;                   // in scope 0 at $DIR/issue_76432.rs:+3:9: +3:33
+      let mut _16: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:38: +3:52
+      let mut _17: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:38: +3:52
+      let mut _18: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:54: +3:68
+      let mut _19: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:54: +3:68
+      let mut _20: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:70: +3:84
+      let mut _21: *const T;               // in scope 0 at $DIR/issue_76432.rs:+3:70: +3:84
       let mut _22: !;                      // in scope 0 at $SRC_DIR/core/src/panic.rs:LL:COL
-      let mut _23: &[T; 3];                // in scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+      let mut _23: &[T; 3];                // in scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
       scope 1 {
-          debug v => _2;                   // in scope 1 at $DIR/issue_76432.rs:7:9: 7:10
-          let _13: &T;                     // in scope 1 at $DIR/issue_76432.rs:9:10: 9:16
-          let _14: &T;                     // in scope 1 at $DIR/issue_76432.rs:9:18: 9:24
-          let _15: &T;                     // in scope 1 at $DIR/issue_76432.rs:9:26: 9:32
+          debug v => _2;                   // in scope 1 at $DIR/issue_76432.rs:+1:9: +1:10
+          let _13: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
+          let _14: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
+          let _15: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
           scope 2 {
-              debug v1 => _13;             // in scope 2 at $DIR/issue_76432.rs:9:10: 9:16
-              debug v2 => _14;             // in scope 2 at $DIR/issue_76432.rs:9:18: 9:24
-              debug v3 => _15;             // in scope 2 at $DIR/issue_76432.rs:9:26: 9:32
+              debug v1 => _13;             // in scope 2 at $DIR/issue_76432.rs:+3:10: +3:16
+              debug v2 => _14;             // in scope 2 at $DIR/issue_76432.rs:+3:18: +3:24
+              debug v3 => _15;             // in scope 2 at $DIR/issue_76432.rs:+3:26: +3:32
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/issue_76432.rs:7:9: 7:10
-          StorageLive(_3);                 // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-          StorageLive(_4);                 // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-          StorageLive(_5);                 // scope 0 at $DIR/issue_76432.rs:7:20: 7:29
-          StorageLive(_6);                 // scope 0 at $DIR/issue_76432.rs:7:21: 7:22
-          _6 = _1;                         // scope 0 at $DIR/issue_76432.rs:7:21: 7:22
-          StorageLive(_7);                 // scope 0 at $DIR/issue_76432.rs:7:24: 7:25
-          _7 = _1;                         // scope 0 at $DIR/issue_76432.rs:7:24: 7:25
-          StorageLive(_8);                 // scope 0 at $DIR/issue_76432.rs:7:27: 7:28
-          _8 = _1;                         // scope 0 at $DIR/issue_76432.rs:7:27: 7:28
-          _5 = [move _6, move _7, move _8]; // scope 0 at $DIR/issue_76432.rs:7:20: 7:29
-          StorageDead(_8);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
-          StorageDead(_7);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
-          StorageDead(_6);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
-          _4 = &_5;                        // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-          _3 = _4;                         // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-          StorageLive(_23);                // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-          _23 = _3;                        // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-          _2 = move _3 as &[T] (Pointer(Unsize)); // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
-          StorageDead(_3);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
-          StorageDead(_4);                 // scope 0 at $DIR/issue_76432.rs:7:29: 7:30
-          StorageLive(_9);                 // scope 1 at $DIR/issue_76432.rs:8:5: 11:6
-          _10 = const 3_usize;             // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
-          StorageDead(_23);                // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
-          _11 = const 3_usize;             // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
-          _12 = const true;                // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
-          goto -> bb2;                     // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
+          StorageLive(_2);                 // scope 0 at $DIR/issue_76432.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          StorageLive(_4);                 // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          StorageLive(_5);                 // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
+          StorageLive(_6);                 // scope 0 at $DIR/issue_76432.rs:+1:21: +1:22
+          _6 = _1;                         // scope 0 at $DIR/issue_76432.rs:+1:21: +1:22
+          StorageLive(_7);                 // scope 0 at $DIR/issue_76432.rs:+1:24: +1:25
+          _7 = _1;                         // scope 0 at $DIR/issue_76432.rs:+1:24: +1:25
+          StorageLive(_8);                 // scope 0 at $DIR/issue_76432.rs:+1:27: +1:28
+          _8 = _1;                         // scope 0 at $DIR/issue_76432.rs:+1:27: +1:28
+          _5 = [move _6, move _7, move _8]; // scope 0 at $DIR/issue_76432.rs:+1:20: +1:29
+          StorageDead(_8);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
+          StorageDead(_7);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
+          StorageDead(_6);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
+          _4 = &_5;                        // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          _3 = _4;                         // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          StorageLive(_23);                // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          _23 = _3;                        // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          _2 = move _3 as &[T] (Pointer(Unsize)); // scope 0 at $DIR/issue_76432.rs:+1:19: +1:29
+          StorageDead(_3);                 // scope 0 at $DIR/issue_76432.rs:+1:28: +1:29
+          StorageDead(_4);                 // scope 0 at $DIR/issue_76432.rs:+1:29: +1:30
+          StorageLive(_9);                 // scope 1 at $DIR/issue_76432.rs:+2:5: +5:6
+          _10 = const 3_usize;             // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+          StorageDead(_23);                // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+          _11 = const 3_usize;             // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+          _12 = const true;                // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
+          goto -> bb2;                     // scope 1 at $DIR/issue_76432.rs:+3:9: +3:33
       }
   
       bb1: {
@@ -77,39 +77,39 @@
       }
   
       bb2: {
-          StorageLive(_13);                // scope 1 at $DIR/issue_76432.rs:9:10: 9:16
-          _13 = &(*_2)[0 of 3];            // scope 1 at $DIR/issue_76432.rs:9:10: 9:16
-          StorageLive(_14);                // scope 1 at $DIR/issue_76432.rs:9:18: 9:24
-          _14 = &(*_2)[1 of 3];            // scope 1 at $DIR/issue_76432.rs:9:18: 9:24
-          StorageLive(_15);                // scope 1 at $DIR/issue_76432.rs:9:26: 9:32
-          _15 = &(*_2)[2 of 3];            // scope 1 at $DIR/issue_76432.rs:9:26: 9:32
-          StorageLive(_16);                // scope 2 at $DIR/issue_76432.rs:9:38: 9:52
-          StorageLive(_17);                // scope 2 at $DIR/issue_76432.rs:9:38: 9:52
-          _17 = &raw const (*_13);         // scope 2 at $DIR/issue_76432.rs:9:38: 9:40
-          _16 = _17;                       // scope 2 at $DIR/issue_76432.rs:9:38: 9:52
-          StorageLive(_18);                // scope 2 at $DIR/issue_76432.rs:9:54: 9:68
-          StorageLive(_19);                // scope 2 at $DIR/issue_76432.rs:9:54: 9:68
-          _19 = &raw const (*_14);         // scope 2 at $DIR/issue_76432.rs:9:54: 9:56
-          _18 = _19;                       // scope 2 at $DIR/issue_76432.rs:9:54: 9:68
-          StorageLive(_20);                // scope 2 at $DIR/issue_76432.rs:9:70: 9:84
-          StorageLive(_21);                // scope 2 at $DIR/issue_76432.rs:9:70: 9:84
-          _21 = &raw const (*_15);         // scope 2 at $DIR/issue_76432.rs:9:70: 9:72
-          _20 = _21;                       // scope 2 at $DIR/issue_76432.rs:9:70: 9:84
-          _9 = [move _16, move _18, move _20]; // scope 2 at $DIR/issue_76432.rs:9:37: 9:85
-          StorageDead(_21);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_20);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_19);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_18);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_17);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_16);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_15);                // scope 1 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_14);                // scope 1 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_13);                // scope 1 at $DIR/issue_76432.rs:9:84: 9:85
-          StorageDead(_9);                 // scope 1 at $DIR/issue_76432.rs:11:6: 11:7
-          nop;                             // scope 0 at $DIR/issue_76432.rs:6:44: 12:2
-          StorageDead(_5);                 // scope 0 at $DIR/issue_76432.rs:12:1: 12:2
-          StorageDead(_2);                 // scope 0 at $DIR/issue_76432.rs:12:1: 12:2
-          return;                          // scope 0 at $DIR/issue_76432.rs:12:2: 12:2
+          StorageLive(_13);                // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
+          _13 = &(*_2)[0 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
+          StorageLive(_14);                // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
+          _14 = &(*_2)[1 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
+          StorageLive(_15);                // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
+          _15 = &(*_2)[2 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
+          StorageLive(_16);                // scope 2 at $DIR/issue_76432.rs:+3:38: +3:52
+          StorageLive(_17);                // scope 2 at $DIR/issue_76432.rs:+3:38: +3:52
+          _17 = &raw const (*_13);         // scope 2 at $DIR/issue_76432.rs:+3:38: +3:40
+          _16 = _17;                       // scope 2 at $DIR/issue_76432.rs:+3:38: +3:52
+          StorageLive(_18);                // scope 2 at $DIR/issue_76432.rs:+3:54: +3:68
+          StorageLive(_19);                // scope 2 at $DIR/issue_76432.rs:+3:54: +3:68
+          _19 = &raw const (*_14);         // scope 2 at $DIR/issue_76432.rs:+3:54: +3:56
+          _18 = _19;                       // scope 2 at $DIR/issue_76432.rs:+3:54: +3:68
+          StorageLive(_20);                // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
+          StorageLive(_21);                // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
+          _21 = &raw const (*_15);         // scope 2 at $DIR/issue_76432.rs:+3:70: +3:72
+          _20 = _21;                       // scope 2 at $DIR/issue_76432.rs:+3:70: +3:84
+          _9 = [move _16, move _18, move _20]; // scope 2 at $DIR/issue_76432.rs:+3:37: +3:85
+          StorageDead(_21);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_20);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_19);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_18);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_17);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_16);                // scope 2 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_15);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_14);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_13);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
+          StorageDead(_9);                 // scope 1 at $DIR/issue_76432.rs:+5:6: +5:7
+          nop;                             // scope 0 at $DIR/issue_76432.rs:+0:44: +6:2
+          StorageDead(_5);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2
+          StorageDead(_2);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/issue_76432.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/issue_78192.f.InstCombine.diff
+++ b/src/test/mir-opt/issue_78192.f.InstCombine.diff
@@ -2,28 +2,28 @@
 + // MIR for `f` after InstCombine
   
   fn f(_1: &T) -> *const T {
-      debug a => _1;                       // in scope 0 at $DIR/issue-78192.rs:2:13: 2:14
-      let mut _0: *const T;                // return place in scope 0 at $DIR/issue-78192.rs:2:23: 2:31
-      let _2: &*const T;                   // in scope 0 at $DIR/issue-78192.rs:3:9: 3:10
-      let _3: &*const T;                   // in scope 0 at $DIR/issue-78192.rs:3:24: 3:40
-      let _4: *const T;                    // in scope 0 at $DIR/issue-78192.rs:3:25: 3:40
+      debug a => _1;                       // in scope 0 at $DIR/issue-78192.rs:+0:13: +0:14
+      let mut _0: *const T;                // return place in scope 0 at $DIR/issue-78192.rs:+0:23: +0:31
+      let _2: &*const T;                   // in scope 0 at $DIR/issue-78192.rs:+1:9: +1:10
+      let _3: &*const T;                   // in scope 0 at $DIR/issue-78192.rs:+1:24: +1:40
+      let _4: *const T;                    // in scope 0 at $DIR/issue-78192.rs:+1:25: +1:40
       scope 1 {
-          debug b => _2;                   // in scope 1 at $DIR/issue-78192.rs:3:9: 3:10
+          debug b => _2;                   // in scope 1 at $DIR/issue-78192.rs:+1:9: +1:10
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/issue-78192.rs:3:9: 3:10
-          StorageLive(_3);                 // scope 0 at $DIR/issue-78192.rs:3:24: 3:40
-          StorageLive(_4);                 // scope 0 at $DIR/issue-78192.rs:3:25: 3:40
-          _4 = &raw const (*_1);           // scope 0 at $DIR/issue-78192.rs:3:26: 3:27
-          _3 = &_4;                        // scope 0 at $DIR/issue-78192.rs:3:24: 3:40
--         _2 = &(*_3);                     // scope 0 at $DIR/issue-78192.rs:3:24: 3:40
-+         _2 = _3;                         // scope 0 at $DIR/issue-78192.rs:3:24: 3:40
-          StorageDead(_3);                 // scope 0 at $DIR/issue-78192.rs:3:40: 3:41
-          _0 = (*_2);                      // scope 1 at $DIR/issue-78192.rs:4:5: 4:7
-          StorageDead(_4);                 // scope 0 at $DIR/issue-78192.rs:5:1: 5:2
-          StorageDead(_2);                 // scope 0 at $DIR/issue-78192.rs:5:1: 5:2
-          return;                          // scope 0 at $DIR/issue-78192.rs:5:2: 5:2
+          StorageLive(_2);                 // scope 0 at $DIR/issue-78192.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/issue-78192.rs:+1:24: +1:40
+          StorageLive(_4);                 // scope 0 at $DIR/issue-78192.rs:+1:25: +1:40
+          _4 = &raw const (*_1);           // scope 0 at $DIR/issue-78192.rs:+1:26: +1:27
+          _3 = &_4;                        // scope 0 at $DIR/issue-78192.rs:+1:24: +1:40
+-         _2 = &(*_3);                     // scope 0 at $DIR/issue-78192.rs:+1:24: +1:40
++         _2 = _3;                         // scope 0 at $DIR/issue-78192.rs:+1:24: +1:40
+          StorageDead(_3);                 // scope 0 at $DIR/issue-78192.rs:+1:40: +1:41
+          _0 = (*_2);                      // scope 1 at $DIR/issue-78192.rs:+2:5: +2:7
+          StorageDead(_4);                 // scope 0 at $DIR/issue-78192.rs:+3:1: +3:2
+          StorageDead(_2);                 // scope 0 at $DIR/issue-78192.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/issue-78192.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/issue_99325.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_99325.main.mir_map.0.mir
@@ -5,14 +5,14 @@
 | 1: user_ty: Canonical { max_universe: U0, variables: [], value: TypeOf(DefId(0:3 ~ issue_99325[8f58]::function_with_bytes), UserSubsts { substs: [Const { ty: &'static [u8; 4], kind: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:8 ~ issue_99325[8f58]::main::{constant#1}), const_param_did: Some(DefId(0:4 ~ issue_99325[8f58]::function_with_bytes::BYTES)) }, substs: [], promoted: None }) }], user_self_ty: None }) }, span: $DIR/issue-99325.rs:11:16: 11:68, inferred_ty: fn() -> &'static [u8] {function_with_bytes::<&*b"AAAA">}
 |
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/issue-99325.rs:9:15: 9:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-99325.rs:+0:15: +0:15
     let _1: ();                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _2: (&&[u8], &&[u8; 4]);     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _3: &&[u8];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _4: &[u8];                       // in scope 0 at $DIR/issue-99325.rs:10:16: 10:48
+    let _4: &[u8];                       // in scope 0 at $DIR/issue-99325.rs:+1:16: +1:48
     let mut _5: &&[u8; 4];               // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _6: &[u8; 4];                    // in scope 0 at $DIR/issue-99325.rs:10:50: 10:75
-    let _7: [u8; 4];                     // in scope 0 at $DIR/issue-99325.rs:10:51: 10:75
+    let _6: &[u8; 4];                    // in scope 0 at $DIR/issue-99325.rs:+1:50: +1:75
+    let _7: [u8; 4];                     // in scope 0 at $DIR/issue-99325.rs:+1:51: +1:75
     let _8: &&[u8];                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _9: &&[u8; 4];                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _10: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -30,9 +30,9 @@ fn main() -> () {
     let _23: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _24: (&&[u8], &&[u8; 4]);    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _25: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _26: &[u8];                      // in scope 0 at $DIR/issue-99325.rs:11:16: 11:70
+    let _26: &[u8];                      // in scope 0 at $DIR/issue-99325.rs:+2:16: +2:70
     let mut _27: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _28: &[u8; 4];                   // in scope 0 at $DIR/issue-99325.rs:11:72: 11:79
+    let _28: &[u8; 4];                   // in scope 0 at $DIR/issue-99325.rs:+2:72: +2:79
     let _29: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _30: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _31: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -68,8 +68,8 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_4);                 // scope 0 at $DIR/issue-99325.rs:10:16: 10:48
-        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb19]; // scope 0 at $DIR/issue-99325.rs:10:16: 10:48
+        StorageLive(_4);                 // scope 0 at $DIR/issue-99325.rs:+1:16: +1:48
+        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb19]; // scope 0 at $DIR/issue-99325.rs:+1:16: +1:48
                                          // mir::Constant
                                          // + span: $DIR/issue-99325.rs:10:16: 10:46
                                          // + user_ty: UserType(0)
@@ -79,10 +79,10 @@ fn main() -> () {
     bb1: {
         _3 = &_4;                        // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_5);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_6);                 // scope 0 at $DIR/issue-99325.rs:10:50: 10:75
-        StorageLive(_7);                 // scope 0 at $DIR/issue-99325.rs:10:51: 10:75
-        _7 = [const 65_u8, const 65_u8, const 65_u8, const 65_u8]; // scope 0 at $DIR/issue-99325.rs:10:51: 10:75
-        _6 = &_7;                        // scope 0 at $DIR/issue-99325.rs:10:50: 10:75
+        StorageLive(_6);                 // scope 0 at $DIR/issue-99325.rs:+1:50: +1:75
+        StorageLive(_7);                 // scope 0 at $DIR/issue-99325.rs:+1:51: +1:75
+        _7 = [const 65_u8, const 65_u8, const 65_u8, const 65_u8]; // scope 0 at $DIR/issue-99325.rs:+1:51: +1:75
+        _6 = &_7;                        // scope 0 at $DIR/issue-99325.rs:+1:50: +1:75
         _5 = &_6;                        // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _2 = (move _3, move _5);         // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_5);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -176,8 +176,8 @@ fn main() -> () {
         StorageLive(_23);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_24);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_25);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_26);                // scope 0 at $DIR/issue-99325.rs:11:16: 11:70
-        _26 = function_with_bytes::<&*b"AAAA">() -> [return: bb10, unwind: bb19]; // scope 0 at $DIR/issue-99325.rs:11:16: 11:70
+        StorageLive(_26);                // scope 0 at $DIR/issue-99325.rs:+2:16: +2:70
+        _26 = function_with_bytes::<&*b"AAAA">() -> [return: bb10, unwind: bb19]; // scope 0 at $DIR/issue-99325.rs:+2:16: +2:70
                                          // mir::Constant
                                          // + span: $DIR/issue-99325.rs:11:16: 11:68
                                          // + user_ty: UserType(1)
@@ -187,8 +187,8 @@ fn main() -> () {
     bb10: {
         _25 = &_26;                      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_27);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_28);                // scope 0 at $DIR/issue-99325.rs:11:72: 11:79
-        _28 = const b"AAAA";             // scope 0 at $DIR/issue-99325.rs:11:72: 11:79
+        StorageLive(_28);                // scope 0 at $DIR/issue-99325.rs:+2:72: +2:79
+        _28 = const b"AAAA";             // scope 0 at $DIR/issue-99325.rs:+2:72: +2:79
                                          // mir::Constant
                                          // + span: $DIR/issue-99325.rs:11:72: 11:79
                                          // + literal: Const { ty: &[u8; 4], val: Value(Scalar(alloc4)) }
@@ -281,12 +281,12 @@ fn main() -> () {
         StorageDead(_26);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_24);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_23);                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _0 = const ();                   // scope 0 at $DIR/issue-99325.rs:9:15: 12:2
-        return;                          // scope 0 at $DIR/issue-99325.rs:12:2: 12:2
+        _0 = const ();                   // scope 0 at $DIR/issue-99325.rs:+0:15: +3:2
+        return;                          // scope 0 at $DIR/issue-99325.rs:+3:2: +3:2
     }
 
     bb19 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-99325.rs:9:1: 12:2
+        resume;                          // scope 0 at $DIR/issue-99325.rs:+0:1: +3:2
     }
 }
 

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -1,12 +1,12 @@
 // MIR for `num_to_digit` after PreCodegen
 
 fn num_to_digit(_1: char) -> u32 {
-    debug num => _1;                     // in scope 0 at $DIR/issue-59352.rs:12:21: 12:24
-    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-59352.rs:12:35: 12:38
-    let mut _2: char;                    // in scope 0 at $DIR/issue-59352.rs:14:8: 14:11
-    let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/issue-59352.rs:14:26: 14:41
-    let mut _4: char;                    // in scope 0 at $DIR/issue-59352.rs:14:26: 14:29
-    let mut _5: u32;                     // in scope 0 at $DIR/issue-59352.rs:14:8: 14:23
+    debug num => _1;                     // in scope 0 at $DIR/issue-59352.rs:+0:21: +0:24
+    let mut _0: u32;                     // return place in scope 0 at $DIR/issue-59352.rs:+0:35: +0:38
+    let mut _2: char;                    // in scope 0 at $DIR/issue-59352.rs:+2:8: +2:11
+    let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/issue-59352.rs:+2:26: +2:41
+    let mut _4: char;                    // in scope 0 at $DIR/issue-59352.rs:+2:26: +2:29
+    let mut _5: u32;                     // in scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
     let mut _12: isize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 (inlined char::methods::<impl char>::is_digit) { // at $DIR/issue-59352.rs:14:8: 14:23
         debug self => _2;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
@@ -29,9 +29,9 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:11
-        _2 = _1;                         // scope 0 at $DIR/issue-59352.rs:14:8: 14:11
-        StorageLive(_5);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
+        StorageLive(_2);                 // scope 0 at $DIR/issue-59352.rs:+2:8: +2:11
+        _2 = _1;                         // scope 0 at $DIR/issue-59352.rs:+2:8: +2:11
+        StorageLive(_5);                 // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
         StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_8);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
@@ -43,31 +43,31 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb1: {
-        StorageDead(_12);                // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageLive(_3);                 // scope 0 at $DIR/issue-59352.rs:14:26: 14:41
-        StorageLive(_4);                 // scope 0 at $DIR/issue-59352.rs:14:26: 14:29
-        _4 = _1;                         // scope 0 at $DIR/issue-59352.rs:14:26: 14:29
-        _3 = char::methods::<impl char>::to_digit(move _4, const 8_u32) -> bb2; // scope 0 at $DIR/issue-59352.rs:14:26: 14:41
+        StorageDead(_12);                // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        StorageLive(_3);                 // scope 0 at $DIR/issue-59352.rs:+2:26: +2:41
+        StorageLive(_4);                 // scope 0 at $DIR/issue-59352.rs:+2:26: +2:29
+        _4 = _1;                         // scope 0 at $DIR/issue-59352.rs:+2:26: +2:29
+        _3 = char::methods::<impl char>::to_digit(move _4, const 8_u32) -> bb2; // scope 0 at $DIR/issue-59352.rs:+2:26: +2:41
                                          // mir::Constant
                                          // + span: $DIR/issue-59352.rs:14:30: 14:38
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_4);                 // scope 0 at $DIR/issue-59352.rs:14:40: 14:41
-        StorageLive(_10);                // scope 0 at $DIR/issue-59352.rs:14:26: 14:50
+        StorageDead(_4);                 // scope 0 at $DIR/issue-59352.rs:+2:40: +2:41
+        StorageLive(_10);                // scope 0 at $DIR/issue-59352.rs:+2:26: +2:50
         _10 = discriminant(_3);          // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb3: {
-        StorageDead(_12);                // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
-        _0 = const 0_u32;                // scope 0 at $DIR/issue-59352.rs:14:60: 14:61
-        goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
+        StorageDead(_12);                // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        _0 = const 0_u32;                // scope 0 at $DIR/issue-59352.rs:+2:60: +2:61
+        goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:+2:5: +2:63
     }
 
     bb4: {
-        return;                          // scope 0 at $DIR/issue-59352.rs:15:2: 15:2
+        return;                          // scope 0 at $DIR/issue-59352.rs:+3:2: +3:2
     }
 
     bb5: {
@@ -80,9 +80,9 @@ fn num_to_digit(_1: char) -> u32 {
         StorageDead(_9);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_5);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageDead(_2);                 // scope 0 at $DIR/issue-59352.rs:14:22: 14:23
-        switchInt(move _12) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
+        StorageDead(_5);                 // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        StorageDead(_2);                 // scope 0 at $DIR/issue-59352.rs:+2:22: +2:23
+        switchInt(move _12) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
     }
 
     bb6: {
@@ -102,8 +102,8 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb8: {
         _0 = move ((_3 as Some).0: u32); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        StorageDead(_10);                // scope 0 at $DIR/issue-59352.rs:14:26: 14:50
-        StorageDead(_3);                 // scope 0 at $DIR/issue-59352.rs:14:49: 14:50
-        goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
+        StorageDead(_10);                // scope 0 at $DIR/issue-59352.rs:+2:26: +2:50
+        StorageDead(_3);                 // scope 0 at $DIR/issue-59352.rs:+2:49: +2:50
+        goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:+2:5: +2:63
     }
 }

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -2,17 +2,17 @@
 + // MIR for `foo` after MatchBranchSimplification
   
   fn foo(_1: [u8; 16]) -> Option<[u8; 4]> {
-      debug bytes => _1;                   // in scope 0 at $DIR/issue-75439.rs:5:12: 5:17
-      let mut _0: std::option::Option<[u8; 4]>; // return place in scope 0 at $DIR/issue-75439.rs:5:32: 5:47
-      let _2: [u32; 4];                    // in scope 0 at $DIR/issue-75439.rs:7:9: 7:15
-      let mut _3: [u8; 16];                // in scope 0 at $DIR/issue-75439.rs:7:47: 7:52
-      let mut _5: [u8; 4];                 // in scope 0 at $DIR/issue-75439.rs:10:14: 10:38
-      let mut _6: u32;                     // in scope 0 at $DIR/issue-75439.rs:10:33: 10:35
+      debug bytes => _1;                   // in scope 0 at $DIR/issue-75439.rs:+0:12: +0:17
+      let mut _0: std::option::Option<[u8; 4]>; // return place in scope 0 at $DIR/issue-75439.rs:+0:32: +0:47
+      let _2: [u32; 4];                    // in scope 0 at $DIR/issue-75439.rs:+2:9: +2:15
+      let mut _3: [u8; 16];                // in scope 0 at $DIR/issue-75439.rs:+2:47: +2:52
+      let mut _5: [u8; 4];                 // in scope 0 at $DIR/issue-75439.rs:+5:14: +5:38
+      let mut _6: u32;                     // in scope 0 at $DIR/issue-75439.rs:+5:33: +5:35
       scope 1 {
-          debug dwords => _2;              // in scope 1 at $DIR/issue-75439.rs:7:9: 7:15
+          debug dwords => _2;              // in scope 1 at $DIR/issue-75439.rs:+2:9: +2:15
           scope 3 {
-              debug ip => _4;              // in scope 3 at $DIR/issue-75439.rs:9:27: 9:29
-              let _4: u32;                 // in scope 3 at $DIR/issue-75439.rs:9:27: 9:29
+              debug ip => _4;              // in scope 3 at $DIR/issue-75439.rs:+4:27: +4:29
+              let _4: u32;                 // in scope 3 at $DIR/issue-75439.rs:+4:27: +4:29
               scope 4 {
               }
           }
@@ -21,69 +21,69 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/issue-75439.rs:7:9: 7:15
-          StorageLive(_3);                 // scope 2 at $DIR/issue-75439.rs:7:47: 7:52
-          _3 = _1;                         // scope 2 at $DIR/issue-75439.rs:7:47: 7:52
-          _2 = transmute::<[u8; 16], [u32; 4]>(move _3) -> bb1; // scope 2 at $DIR/issue-75439.rs:7:37: 7:53
+          StorageLive(_2);                 // scope 0 at $DIR/issue-75439.rs:+2:9: +2:15
+          StorageLive(_3);                 // scope 2 at $DIR/issue-75439.rs:+2:47: +2:52
+          _3 = _1;                         // scope 2 at $DIR/issue-75439.rs:+2:47: +2:52
+          _2 = transmute::<[u8; 16], [u32; 4]>(move _3) -> bb1; // scope 2 at $DIR/issue-75439.rs:+2:37: +2:53
                                            // mir::Constant
                                            // + span: $DIR/issue-75439.rs:7:37: 7:46
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn([u8; 16]) -> [u32; 4] {transmute::<[u8; 16], [u32; 4]>}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 2 at $DIR/issue-75439.rs:7:52: 7:53
-          switchInt(_2[0 of 4]) -> [0_u32: bb2, otherwise: bb8]; // scope 3 at $DIR/issue-75439.rs:9:12: 9:30
+          StorageDead(_3);                 // scope 2 at $DIR/issue-75439.rs:+2:52: +2:53
+          switchInt(_2[0 of 4]) -> [0_u32: bb2, otherwise: bb8]; // scope 3 at $DIR/issue-75439.rs:+4:12: +4:30
       }
   
       bb2: {
-          switchInt(_2[1 of 4]) -> [0_u32: bb3, otherwise: bb8]; // scope 3 at $DIR/issue-75439.rs:9:12: 9:30
+          switchInt(_2[1 of 4]) -> [0_u32: bb3, otherwise: bb8]; // scope 3 at $DIR/issue-75439.rs:+4:12: +4:30
       }
   
       bb3: {
-          switchInt(_2[2 of 4]) -> [0_u32: bb5, 4294901760_u32: bb6, otherwise: bb8]; // scope 3 at $DIR/issue-75439.rs:9:12: 9:30
+          switchInt(_2[2 of 4]) -> [0_u32: bb5, 4294901760_u32: bb6, otherwise: bb8]; // scope 3 at $DIR/issue-75439.rs:+4:12: +4:30
       }
   
       bb4: {
-          StorageLive(_5);                 // scope 3 at $DIR/issue-75439.rs:10:14: 10:38
-          StorageLive(_6);                 // scope 4 at $DIR/issue-75439.rs:10:33: 10:35
-          _6 = _4;                         // scope 4 at $DIR/issue-75439.rs:10:33: 10:35
-          _5 = transmute::<u32, [u8; 4]>(move _6) -> bb7; // scope 4 at $DIR/issue-75439.rs:10:23: 10:36
+          StorageLive(_5);                 // scope 3 at $DIR/issue-75439.rs:+5:14: +5:38
+          StorageLive(_6);                 // scope 4 at $DIR/issue-75439.rs:+5:33: +5:35
+          _6 = _4;                         // scope 4 at $DIR/issue-75439.rs:+5:33: +5:35
+          _5 = transmute::<u32, [u8; 4]>(move _6) -> bb7; // scope 4 at $DIR/issue-75439.rs:+5:23: +5:36
                                            // mir::Constant
                                            // + span: $DIR/issue-75439.rs:10:23: 10:32
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u32) -> [u8; 4] {transmute::<u32, [u8; 4]>}, val: Value(<ZST>) }
       }
   
       bb5: {
-          StorageLive(_4);                 // scope 3 at $DIR/issue-75439.rs:9:27: 9:29
-          _4 = _2[3 of 4];                 // scope 3 at $DIR/issue-75439.rs:9:27: 9:29
-          goto -> bb4;                     // scope 3 at $DIR/issue-75439.rs:9:12: 9:30
+          StorageLive(_4);                 // scope 3 at $DIR/issue-75439.rs:+4:27: +4:29
+          _4 = _2[3 of 4];                 // scope 3 at $DIR/issue-75439.rs:+4:27: +4:29
+          goto -> bb4;                     // scope 3 at $DIR/issue-75439.rs:+4:12: +4:30
       }
   
       bb6: {
-          StorageLive(_4);                 // scope 3 at $DIR/issue-75439.rs:9:27: 9:29
-          _4 = _2[3 of 4];                 // scope 3 at $DIR/issue-75439.rs:9:27: 9:29
-          goto -> bb4;                     // scope 3 at $DIR/issue-75439.rs:9:12: 9:30
+          StorageLive(_4);                 // scope 3 at $DIR/issue-75439.rs:+4:27: +4:29
+          _4 = _2[3 of 4];                 // scope 3 at $DIR/issue-75439.rs:+4:27: +4:29
+          goto -> bb4;                     // scope 3 at $DIR/issue-75439.rs:+4:12: +4:30
       }
   
       bb7: {
-          StorageDead(_6);                 // scope 4 at $DIR/issue-75439.rs:10:35: 10:36
-          Deinit(_0);                      // scope 3 at $DIR/issue-75439.rs:10:9: 10:39
-          ((_0 as Some).0: [u8; 4]) = move _5; // scope 3 at $DIR/issue-75439.rs:10:9: 10:39
-          discriminant(_0) = 1;            // scope 3 at $DIR/issue-75439.rs:10:9: 10:39
-          StorageDead(_5);                 // scope 3 at $DIR/issue-75439.rs:10:38: 10:39
-          StorageDead(_4);                 // scope 1 at $DIR/issue-75439.rs:11:5: 11:6
-          goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
+          StorageDead(_6);                 // scope 4 at $DIR/issue-75439.rs:+5:35: +5:36
+          Deinit(_0);                      // scope 3 at $DIR/issue-75439.rs:+5:9: +5:39
+          ((_0 as Some).0: [u8; 4]) = move _5; // scope 3 at $DIR/issue-75439.rs:+5:9: +5:39
+          discriminant(_0) = 1;            // scope 3 at $DIR/issue-75439.rs:+5:9: +5:39
+          StorageDead(_5);                 // scope 3 at $DIR/issue-75439.rs:+5:38: +5:39
+          StorageDead(_4);                 // scope 1 at $DIR/issue-75439.rs:+6:5: +6:6
+          goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:+4:5: +8:6
       }
   
       bb8: {
-          Deinit(_0);                      // scope 1 at $DIR/issue-75439.rs:12:9: 12:13
-          discriminant(_0) = 0;            // scope 1 at $DIR/issue-75439.rs:12:9: 12:13
-          goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
+          Deinit(_0);                      // scope 1 at $DIR/issue-75439.rs:+7:9: +7:13
+          discriminant(_0) = 0;            // scope 1 at $DIR/issue-75439.rs:+7:9: +7:13
+          goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:+4:5: +8:6
       }
   
       bb9: {
-          StorageDead(_2);                 // scope 0 at $DIR/issue-75439.rs:14:1: 14:2
-          return;                          // scope 0 at $DIR/issue-75439.rs:14:2: 14:2
+          StorageDead(_2);                 // scope 0 at $DIR/issue-75439.rs:+9:1: +9:2
+          return;                          // scope 0 at $DIR/issue-75439.rs:+9:2: +9:2
       }
   }
   

--- a/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
+++ b/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
@@ -1,52 +1,52 @@
 // MIR for `main` after SimplifyCfg-promote-consts
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/loop_test.rs:6:11: 6:11
-    let _1: ();                          // in scope 0 at $DIR/loop_test.rs:10:5: 12:6
-    let mut _2: bool;                    // in scope 0 at $DIR/loop_test.rs:10:8: 10:12
-    let mut _3: !;                       // in scope 0 at $DIR/loop_test.rs:10:13: 12:6
-    let mut _4: !;                       // in scope 0 at $DIR/loop_test.rs:13:5: 16:6
-    let mut _5: ();                      // in scope 0 at $DIR/loop_test.rs:6:1: 17:2
-    let _6: i32;                         // in scope 0 at $DIR/loop_test.rs:14:13: 14:14
+    let mut _0: ();                      // return place in scope 0 at $DIR/loop_test.rs:+0:11: +0:11
+    let _1: ();                          // in scope 0 at $DIR/loop_test.rs:+4:5: +6:6
+    let mut _2: bool;                    // in scope 0 at $DIR/loop_test.rs:+4:8: +4:12
+    let mut _3: !;                       // in scope 0 at $DIR/loop_test.rs:+4:13: +6:6
+    let mut _4: !;                       // in scope 0 at $DIR/loop_test.rs:+7:5: +10:6
+    let mut _5: ();                      // in scope 0 at $DIR/loop_test.rs:+0:1: +11:2
+    let _6: i32;                         // in scope 0 at $DIR/loop_test.rs:+8:13: +8:14
     scope 1 {
-        debug x => _6;                   // in scope 1 at $DIR/loop_test.rs:14:13: 14:14
+        debug x => _6;                   // in scope 1 at $DIR/loop_test.rs:+8:13: +8:14
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/loop_test.rs:10:5: 12:6
-        StorageLive(_2);                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
-        _2 = const true;                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
-        switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/loop_test.rs:10:8: 10:12
+        StorageLive(_1);                 // scope 0 at $DIR/loop_test.rs:+4:5: +6:6
+        StorageLive(_2);                 // scope 0 at $DIR/loop_test.rs:+4:8: +4:12
+        _2 = const true;                 // scope 0 at $DIR/loop_test.rs:+4:8: +4:12
+        switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/loop_test.rs:+4:8: +4:12
     }
 
     bb1: {
-        _0 = const ();                   // scope 0 at $DIR/loop_test.rs:11:9: 11:15
-        StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
-        StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
-        return;                          // scope 0 at $DIR/loop_test.rs:17:2: 17:2
+        _0 = const ();                   // scope 0 at $DIR/loop_test.rs:+5:9: +5:15
+        StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:+6:5: +6:6
+        StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:+6:5: +6:6
+        return;                          // scope 0 at $DIR/loop_test.rs:+11:2: +11:2
     }
 
     bb2: {
-        _1 = const ();                   // scope 0 at $DIR/loop_test.rs:12:6: 12:6
-        StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
-        StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
-        StorageLive(_4);                 // scope 0 at $DIR/loop_test.rs:13:5: 16:6
-        goto -> bb3;                     // scope 0 at $DIR/loop_test.rs:13:5: 16:6
+        _1 = const ();                   // scope 0 at $DIR/loop_test.rs:+6:6: +6:6
+        StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:+6:5: +6:6
+        StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:+6:5: +6:6
+        StorageLive(_4);                 // scope 0 at $DIR/loop_test.rs:+7:5: +10:6
+        goto -> bb3;                     // scope 0 at $DIR/loop_test.rs:+7:5: +10:6
     }
 
     bb3: {
-        falseUnwind -> [real: bb4, cleanup: bb5]; // scope 0 at $DIR/loop_test.rs:13:5: 16:6
+        falseUnwind -> [real: bb4, cleanup: bb5]; // scope 0 at $DIR/loop_test.rs:+7:5: +10:6
     }
 
     bb4: {
-        StorageLive(_6);                 // scope 0 at $DIR/loop_test.rs:14:13: 14:14
-        _6 = const 1_i32;                // scope 0 at $DIR/loop_test.rs:14:17: 14:18
-        FakeRead(ForLet(None), _6);      // scope 0 at $DIR/loop_test.rs:14:13: 14:14
-        StorageDead(_6);                 // scope 0 at $DIR/loop_test.rs:16:5: 16:6
+        StorageLive(_6);                 // scope 0 at $DIR/loop_test.rs:+8:13: +8:14
+        _6 = const 1_i32;                // scope 0 at $DIR/loop_test.rs:+8:17: +8:18
+        FakeRead(ForLet(None), _6);      // scope 0 at $DIR/loop_test.rs:+8:13: +8:14
+        StorageDead(_6);                 // scope 0 at $DIR/loop_test.rs:+10:5: +10:6
         goto -> bb3;                     // scope 0 at no-location
     }
 
     bb5 (cleanup): {
-        resume;                          // scope 0 at $DIR/loop_test.rs:6:1: 17:2
+        resume;                          // scope 0 at $DIR/loop_test.rs:+0:1: +11:2
     }
 }

--- a/src/test/mir-opt/lower_array_len.array_bound.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.InstCombine.diff
@@ -2,65 +2,65 @@
 + // MIR for `array_bound` after InstCombine
   
   fn array_bound(_1: usize, _2: &[u8; N]) -> u8 {
-      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:6:36: 6:41
-      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:6:50: 6:55
-      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:6:70: 6:72
-      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-      let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:+0:36: +0:41
+      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:+0:50: +0:55
+      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:+0:70: +0:72
+      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+      let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _7 = _2;                         // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _11 = _7;                        // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
--         _5 = Len((*_11));                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         _7 = _2;                         // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _11 = _7;                        // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:20: +1:21
+-         _5 = Len((*_11));                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb1: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
       }
   
       bb2: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
-          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
+          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
+          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +5:6
       }
   
       bb3: {
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:10:9: 10:11
-          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:11
+          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +5:6
       }
   
       bb4: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:11:5: 11:6
-          return;                          // scope 0 at $DIR/lower_array_len.rs:12:2: 12:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+5:5: +5:6
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
@@ -2,67 +2,67 @@
 + // MIR for `array_bound` after NormalizeArrayLen
   
   fn array_bound(_1: usize, _2: &[u8; N]) -> u8 {
-      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:6:36: 6:41
-      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:6:50: 6:55
-      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:6:70: 6:72
-      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+     let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:+0:36: +0:41
+      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:+0:50: +0:55
+      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:+0:70: +0:72
+      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++     let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _11 = _7;                        // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
--         _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _5 = Len((*_11));                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         _11 = _7;                        // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:20: +1:21
+-         _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         _5 = Len((*_11));                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
       }
   
       bb1: {
-          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
+          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb2: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-          _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+          _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
       }
   
       bb3: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
-          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
+          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
+          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +5:6
       }
   
       bb4: {
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:10:9: 10:11
-          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:11
+          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +5:6
       }
   
       bb5: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:11:5: 11:6
-          return;                          // scope 0 at $DIR/lower_array_len.rs:12:2: 12:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+5:5: +5:6
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_bound.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.SimplifyLocals.diff
@@ -2,69 +2,69 @@
 + // MIR for `array_bound` after SimplifyLocals
   
   fn array_bound(_1: usize, _2: &[u8; N]) -> u8 {
-      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:6:36: 6:41
-      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:6:50: 6:55
-      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:6:70: 6:72
-      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--     let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--     let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--     let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--     let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--     let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--     let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+     let _6: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-+     let mut _7: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+     let mut _8: bool;                    // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:+0:36: +0:41
+      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:+0:50: +0:55
+      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:+0:70: +0:72
+      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-     let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-     let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-     let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-     let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-     let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-     let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++     let _6: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
++     let mut _7: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++     let mut _8: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
-          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
-          _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
-          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:20: +1:21
+          _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb1: {
--         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--         _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--         assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-+         _6 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-+         _7 = const N;                    // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         _8 = Lt(_6, _7);                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+-         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-         _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-         assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
++         _6 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
++         _7 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         _8 = Lt(_6, _7);                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
       }
   
       bb2: {
--         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
-+         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
-          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
+-         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
++         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
+          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +5:6
       }
   
       bb3: {
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:10:9: 10:11
-          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:11
+          goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +5:6
       }
   
       bb4: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:11:5: 11:6
-          return;                          // scope 0 at $DIR/lower_array_len.rs:12:2: 12:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+5:5: +5:6
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.InstCombine.diff
@@ -2,78 +2,78 @@
 + // MIR for `array_bound_mut` after InstCombine
   
   fn array_bound_mut(_1: usize, _2: &mut [u8; N]) -> u8 {
-      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:17:40: 17:45
-      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:17:54: 17:59
-      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:17:78: 17:80
-      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-      let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-      let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-      let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:+0:40: +0:45
+      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:+0:54: +0:59
+      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:+0:78: +0:80
+      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+      let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+      let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+      let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+      let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _14 = _7;                        // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
--         _5 = Len((*_14));                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _14 = _7;                        // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:20: +1:21
+-         _5 = Len((*_14));                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb1: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
       }
   
       bb2: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
-          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
+          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
+          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +7:6
       }
   
       bb3: {
-          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-          _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--         _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         _12 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          _13 = Lt(_11, _12);              // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+          _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+-         _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
++         _12 = const N;                   // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+          _13 = Lt(_11, _12);              // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb4; // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
       }
   
       bb4: {
-          (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
-          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
-          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
+          (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:22
+          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:+4:22: +4:23
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:+6:9: +6:11
+          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +7:6
       }
   
       bb5: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:24:5: 24:6
-          return;                          // scope 0 at $DIR/lower_array_len.rs:25:2: 25:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+7:5: +7:6
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
@@ -2,80 +2,80 @@
 + // MIR for `array_bound_mut` after NormalizeArrayLen
   
   fn array_bound_mut(_1: usize, _2: &mut [u8; N]) -> u8 {
-      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:17:40: 17:45
-      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:17:54: 17:59
-      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:17:78: 17:80
-      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-      let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-      let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+     let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:+0:40: +0:45
+      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:+0:54: +0:59
+      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:+0:78: +0:80
+      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+      let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+      let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+      let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
++     let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         _14 = _7;                        // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
--         _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         _5 = Len((*_14));                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         _14 = _7;                        // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:20: +1:21
+-         _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         _5 = Len((*_14));                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++         StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
       }
   
       bb1: {
-          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
+          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb2: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-          _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+          _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
       }
   
       bb3: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
-          goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
+          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
+          goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +7:6
       }
   
       bb4: {
-          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-          _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-          _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          _13 = Lt(_11, _12);              // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb5; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+          _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+          _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+          _13 = Lt(_11, _12);              // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb5; // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
       }
   
       bb5: {
-          (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
-          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
-          goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
+          (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:22
+          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:+4:22: +4:23
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:+6:9: +6:11
+          goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +7:6
       }
   
       bb6: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:24:5: 24:6
-          return;                          // scope 0 at $DIR/lower_array_len.rs:25:2: 25:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+7:5: +7:6
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.SimplifyLocals.diff
@@ -2,92 +2,92 @@
 + // MIR for `array_bound_mut` after SimplifyLocals
   
   fn array_bound_mut(_1: usize, _2: &mut [u8; N]) -> u8 {
-      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:17:40: 17:45
-      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:17:54: 17:59
-      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:17:78: 17:80
-      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--     let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--     let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--     let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--     let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--     let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--     let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--     let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--     let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--     let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+     let _6: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-+     let mut _7: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+     let mut _8: bool;                    // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+     let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-+     let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+     let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+      debug index => _1;                   // in scope 0 at $DIR/lower_array_len.rs:+0:40: +0:45
+      debug slice => _2;                   // in scope 0 at $DIR/lower_array_len.rs:+0:54: +0:59
+      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_array_len.rs:+0:78: +0:80
+      let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+      let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-     let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-     let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-     let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-     let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-     let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-     let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+-     let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+-     let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+-     let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
++     let _6: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
++     let mut _7: usize;                   // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++     let mut _8: bool;                    // in scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++     let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
++     let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
++     let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
-          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
-          _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
-          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:+1:20: +1:21
+          _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:+1:16: +1:27
+-         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb1: {
--         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--         _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--         assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-+         _6 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-+         _7 = const N;                    // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         _8 = Lt(_6, _7);                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+-         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
+-         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-         _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-         assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
++         _6 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
++         _7 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         _8 = Lt(_6, _7);                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
       }
   
       bb2: {
--         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
-+         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
-          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
+-         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
+-         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
++         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
++         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+3:5: +3:6
+          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +7:6
       }
   
       bb3: {
--         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--         _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--         _12 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--         _13 = Lt(const 0_usize, _12);    // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--         assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-+         _9 = const 0_usize;              // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-+         _10 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         _11 = Lt(const 0_usize, _10);    // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+-         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+-         _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
+-         _12 = const N;                   // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+-         _13 = Lt(const 0_usize, _12);    // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
+-         assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
++         StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
++         _9 = const 0_usize;              // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
++         _10 = const N;                   // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
++         _11 = Lt(const 0_usize, _10);    // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
++         assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17
       }
   
       bb4: {
--         (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
--         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
-+         (*_2)[_9] = const 42_u8;         // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
-+         StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
-          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
+-         (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:22
+-         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:+4:22: +4:23
++         (*_2)[_9] = const 42_u8;         // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:22
++         StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:+4:22: +4:23
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:+6:9: +6:11
+          goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +7:6
       }
   
       bb5: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:24:5: 24:6
-          return;                          // scope 0 at $DIR/lower_array_len.rs:25:2: 25:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+7:5: +7:6
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_len.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.InstCombine.diff
@@ -2,26 +2,26 @@
 + // MIR for `array_len` after InstCombine
   
   fn array_len(_1: &[u8; N]) -> usize {
-      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:30:34: 30:37
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:30:52: 30:57
-      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:+0:34: +0:37
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:+0:52: +0:57
+      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _3 = _1;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
--         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
-          return;                          // scope 0 at $DIR/lower_array_len.rs:32:2: 32:2
+          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         _3 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:7: +1:8
+-         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:13: +1:14
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_len.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.NormalizeArrayLen.diff
@@ -2,29 +2,29 @@
 + // MIR for `array_len` after NormalizeArrayLen
   
   fn array_len(_1: &[u8; N]) -> usize {
-      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:30:34: 30:37
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:30:52: 30:57
-      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:+0:34: +0:37
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:+0:52: +0:57
+      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
--         _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:7: +1:8
+-         _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
-          return;                          // scope 0 at $DIR/lower_array_len.rs:32:2: 32:2
+          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:13: +1:14
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_len.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.SimplifyLocals.diff
@@ -2,21 +2,21 @@
 + // MIR for `array_len` after SimplifyLocals
   
   fn array_len(_1: &[u8; N]) -> usize {
-      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:30:34: 30:37
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:30:52: 30:57
--     let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:+0:34: +0:37
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:+0:52: +0:57
+-     let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
-          _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
-          return;                          // scope 0 at $DIR/lower_array_len.rs:32:2: 32:2
+-         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:7: +1:8
+          _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:13: +1:14
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.InstCombine.diff
@@ -2,25 +2,25 @@
 + // MIR for `array_len_by_value` after InstCombine
   
   fn array_len_by_value(_1: [u8; N]) -> usize {
-      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:37:43: 37:46
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:37:60: 37:65
-      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:+0:43: +0:46
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:+0:60: +0:65
+      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
--         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
-          return;                          // scope 0 at $DIR/lower_array_len.rs:39:2: 39:2
+          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:7: +1:8
+-         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:13: +1:14
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.NormalizeArrayLen.diff
@@ -2,29 +2,29 @@
 + // MIR for `array_len_by_value` after NormalizeArrayLen
   
   fn array_len_by_value(_1: [u8; N]) -> usize {
-      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:37:43: 37:46
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:37:60: 37:65
-      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:+0:43: +0:46
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:+0:60: +0:65
+      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
--         _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:7: +1:8
+-         _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
++         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+          goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
-          return;                          // scope 0 at $DIR/lower_array_len.rs:39:2: 39:2
+          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:13: +1:14
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.SimplifyLocals.diff
@@ -2,21 +2,21 @@
 + // MIR for `array_len_by_value` after SimplifyLocals
   
   fn array_len_by_value(_1: [u8; N]) -> usize {
-      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:37:43: 37:46
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:37:60: 37:65
--     let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:+0:43: +0:46
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:+0:60: +0:65
+-     let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
-          _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
-          return;                          // scope 0 at $DIR/lower_array_len.rs:39:2: 39:2
+-         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:+1:7: +1:8
+          _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:5: +1:14
+-         StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:+1:13: +1:14
+          return;                          // scope 0 at $DIR/lower_array_len.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
@@ -2,23 +2,23 @@
 + // MIR for `align_of` after LowerIntrinsics
   
   fn align_of() -> usize {
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:18:25: 18:30
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:25: +0:30
   
       bb0: {
--         _0 = std::intrinsics::min_align_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
+-         _0 = std::intrinsics::min_align_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:42
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:19:5: 19:40
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::min_align_of::<T>}, val: Value(<ZST>) }
-+         _0 = AlignOf(T);                 // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
-+         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
++         _0 = AlignOf(T);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:42
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:42
       }
   
       bb1: {
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:20:2: 20:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:18:1: 20:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
@@ -2,118 +2,118 @@
 + // MIR for `discriminant` after LowerIntrinsics
   
   fn discriminant(_1: T) -> () {
-      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:73:24: 73:25
-      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:73:30: 73:30
-      let _2: <T as std::marker::DiscriminantKind>::Discriminant; // in scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
-      let mut _3: &T;                      // in scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
-      let _4: &T;                          // in scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
-      let _5: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
-      let mut _6: &i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
-      let _7: &i32;                        // in scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
-      let _8: i32;                         // in scope 0 at $DIR/lower_intrinsics.rs:75:43: 75:44
-      let _9: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
-      let mut _10: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
-      let _11: &();                        // in scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
-      let _12: ();                         // in scope 0 at $DIR/lower_intrinsics.rs:76:43: 76:45
-      let _13: isize;                      // in scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
-      let mut _14: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
-      let _15: &E;                         // in scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
-      let _16: E;                          // in scope 0 at $DIR/lower_intrinsics.rs:77:43: 77:47
-      let mut _17: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
-      let mut _18: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
-      let mut _19: &i32;                   // in scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:24: +0:25
+      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:30: +0:30
+      let _2: <T as std::marker::DiscriminantKind>::Discriminant; // in scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
+      let mut _3: &T;                      // in scope 0 at $DIR/lower_intrinsics.rs:+1:42: +1:44
+      let _4: &T;                          // in scope 0 at $DIR/lower_intrinsics.rs:+1:42: +1:44
+      let _5: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
+      let mut _6: &i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
+      let _7: &i32;                        // in scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
+      let _8: i32;                         // in scope 0 at $DIR/lower_intrinsics.rs:+2:43: +2:44
+      let _9: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
+      let mut _10: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
+      let _11: &();                        // in scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
+      let _12: ();                         // in scope 0 at $DIR/lower_intrinsics.rs:+3:43: +3:45
+      let _13: isize;                      // in scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
+      let mut _14: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
+      let _15: &E;                         // in scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
+      let _16: E;                          // in scope 0 at $DIR/lower_intrinsics.rs:+4:43: +4:47
+      let mut _17: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
+      let mut _18: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
+      let mut _19: &i32;                   // in scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
-          StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
-          StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
-          _4 = &_1;                        // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
-          _3 = &(*_4);                     // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
--         _2 = discriminant_value::<T>(move _3) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
+          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
+          StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:42: +1:44
+          StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:42: +1:44
+          _4 = &_1;                        // scope 0 at $DIR/lower_intrinsics.rs:+1:42: +1:44
+          _3 = &(*_4);                     // scope 0 at $DIR/lower_intrinsics.rs:+1:42: +1:44
+-         _2 = discriminant_value::<T>(move _3) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:74:5: 74:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r T) -> <T as DiscriminantKind>::Discriminant {discriminant_value::<T>}, val: Value(<ZST>) }
-+         _2 = discriminant((*_3));        // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
-+         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
++         _2 = discriminant((*_3));        // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:74:44: 74:45
-          StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:74:45: 74:46
-          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:74:45: 74:46
-          StorageLive(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
-          StorageLive(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
-          StorageLive(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
-          _19 = const discriminant::<T>::promoted[2]; // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+          StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:44: +1:45
+          StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:45: +1:46
+          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:45: +1:46
+          StorageLive(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
+          StorageLive(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
+          StorageLive(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
+          _19 = const discriminant::<T>::promoted[2]; // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:75:42: 75:44
                                            // + literal: Const { ty: &i32, val: Unevaluated(discriminant, [T], Some(promoted[2])) }
-          _7 = &(*_19);                    // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
-          _6 = &(*_7);                     // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
--         _5 = discriminant_value::<i32>(move _6) -> bb2; // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
+          _7 = &(*_19);                    // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
+          _6 = &(*_7);                     // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
+-         _5 = discriminant_value::<i32>(move _6) -> bb2; // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:75:5: 75:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r i32) -> <i32 as DiscriminantKind>::Discriminant {discriminant_value::<i32>}, val: Value(<ZST>) }
-+         _5 = discriminant((*_6));        // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
-+         goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
++         _5 = discriminant((*_6));        // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
++         goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
       }
   
       bb2: {
-          StorageDead(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:75:44: 75:45
-          StorageDead(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:75:45: 75:46
-          StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:75:45: 75:46
-          StorageLive(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
-          StorageLive(_10);                // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
-          StorageLive(_11);                // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
-          _18 = const discriminant::<T>::promoted[1]; // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+          StorageDead(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:+2:44: +2:45
+          StorageDead(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:+2:45: +2:46
+          StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:+2:45: +2:46
+          StorageLive(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
+          StorageLive(_10);                // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
+          StorageLive(_11);                // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
+          _18 = const discriminant::<T>::promoted[1]; // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:76:42: 76:45
                                            // + literal: Const { ty: &(), val: Unevaluated(discriminant, [T], Some(promoted[1])) }
-          _11 = &(*_18);                   // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
-          _10 = &(*_11);                   // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
--         _9 = discriminant_value::<()>(move _10) -> bb3; // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
+          _11 = &(*_18);                   // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
+          _10 = &(*_11);                   // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
+-         _9 = discriminant_value::<()>(move _10) -> bb3; // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:76:5: 76:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r ()) -> <() as DiscriminantKind>::Discriminant {discriminant_value::<()>}, val: Value(<ZST>) }
-+         _9 = discriminant((*_10));       // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
-+         goto -> bb3;                     // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
++         _9 = discriminant((*_10));       // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
++         goto -> bb3;                     // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
       }
   
       bb3: {
-          StorageDead(_10);                // scope 0 at $DIR/lower_intrinsics.rs:76:45: 76:46
-          StorageDead(_11);                // scope 0 at $DIR/lower_intrinsics.rs:76:46: 76:47
-          StorageDead(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:76:46: 76:47
-          StorageLive(_13);                // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
-          StorageLive(_14);                // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
-          StorageLive(_15);                // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
-          _17 = const discriminant::<T>::promoted[0]; // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+          StorageDead(_10);                // scope 0 at $DIR/lower_intrinsics.rs:+3:45: +3:46
+          StorageDead(_11);                // scope 0 at $DIR/lower_intrinsics.rs:+3:46: +3:47
+          StorageDead(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:+3:46: +3:47
+          StorageLive(_13);                // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
+          StorageLive(_14);                // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
+          StorageLive(_15);                // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
+          _17 = const discriminant::<T>::promoted[0]; // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:77:42: 77:47
                                            // + literal: Const { ty: &E, val: Unevaluated(discriminant, [T], Some(promoted[0])) }
-          _15 = &(*_17);                   // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
-          _14 = &(*_15);                   // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
--         _13 = discriminant_value::<E>(move _14) -> bb4; // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
+          _15 = &(*_17);                   // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
+          _14 = &(*_15);                   // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
+-         _13 = discriminant_value::<E>(move _14) -> bb4; // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:77:5: 77:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r E) -> <E as DiscriminantKind>::Discriminant {discriminant_value::<E>}, val: Value(<ZST>) }
-+         _13 = discriminant((*_14));      // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
-+         goto -> bb4;                     // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
++         _13 = discriminant((*_14));      // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
++         goto -> bb4;                     // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
       }
   
       bb4: {
-          StorageDead(_14);                // scope 0 at $DIR/lower_intrinsics.rs:77:47: 77:48
-          StorageDead(_15);                // scope 0 at $DIR/lower_intrinsics.rs:77:48: 77:49
-          StorageDead(_13);                // scope 0 at $DIR/lower_intrinsics.rs:77:48: 77:49
-          _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:73:30: 78:2
-          drop(_1) -> bb5;                 // scope 0 at $DIR/lower_intrinsics.rs:78:1: 78:2
+          StorageDead(_14);                // scope 0 at $DIR/lower_intrinsics.rs:+4:47: +4:48
+          StorageDead(_15);                // scope 0 at $DIR/lower_intrinsics.rs:+4:48: +4:49
+          StorageDead(_13);                // scope 0 at $DIR/lower_intrinsics.rs:+4:48: +4:49
+          _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:+0:30: +5:2
+          drop(_1) -> bb5;                 // scope 0 at $DIR/lower_intrinsics.rs:+5:1: +5:2
       }
   
       bb5: {
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:78:2: 78:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+5:2: +5:2
       }
   
       bb6 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:73:1: 78:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
@@ -1,32 +1,32 @@
 // MIR for `f_u64` before PreCodegen
 
 fn f_u64() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:39:16: 39:16
-    let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
+    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:16: +0:16
+    let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
     scope 1 (inlined f_dispatch::<u64>) { // at $DIR/lower_intrinsics.rs:40:5: 40:21
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:44:22: 44:23
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
-        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:+5:22: +5:23
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:+9:9: +9:21
+        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:+9:19: +9:20
         scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics.rs:45:8: 45:32
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        _1 = const 0_u64;                // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
-        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
-        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
-        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
+        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
+        _1 = const 0_u64;                // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:9: +9:21
+        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:19: +9:20
+        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:+9:19: +9:20
+        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:+9:9: +9:21
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics.rs:48:9: 48:18
                                          // + literal: Const { ty: fn(u64) {f_non_zst::<u64>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:48:20: 48:21
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:48:21: 48:22
-        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        return;                          // scope 0 at $DIR/lower_intrinsics.rs:41:2: 41:2
+        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:20: +9:21
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:21: +9:22
+        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
+        return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
@@ -1,30 +1,30 @@
 // MIR for `f_unit` before PreCodegen
 
 fn f_unit() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:33:17: 33:17
-    let mut _1: ();                      // in scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:18
+    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:17: +0:17
+    let mut _1: ();                      // in scope 0 at $DIR/lower_intrinsics.rs:+1:16: +1:18
     scope 1 (inlined f_dispatch::<()>) { // at $DIR/lower_intrinsics.rs:34:5: 34:19
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:44:22: 44:23
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
-        let mut _3: ();                  // in scope 1 at $DIR/lower_intrinsics.rs:46:15: 46:16
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:+11:22: +11:23
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:+13:9: +13:17
+        let mut _3: ();                  // in scope 1 at $DIR/lower_intrinsics.rs:+13:15: +13:16
         scope 2 (inlined std::mem::size_of::<()>) { // at $DIR/lower_intrinsics.rs:45:8: 45:32
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:18
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
-        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:46:15: 46:16
-        _2 = f_zst::<()>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
+        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:16: +1:18
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:9: +13:17
+        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:15: +13:16
+        _2 = f_zst::<()>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:+13:9: +13:17
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics.rs:46:9: 46:14
                                          // + literal: Const { ty: fn(()) {f_zst::<()>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:46:16: 46:17
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:46:17: 46:18
-        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:18: 34:19
-        return;                          // scope 0 at $DIR/lower_intrinsics.rs:35:2: 35:2
+        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:16: +13:17
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:17: +13:18
+        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:18: +1:19
+        return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
@@ -2,32 +2,32 @@
 + // MIR for `forget` after LowerIntrinsics
   
   fn forget(_1: T) -> () {
-      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:23:18: 23:19
-      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:23:24: 23:24
-      let mut _2: T;                       // in scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
+      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:18: +0:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:24: +0:24
+      let mut _2: T;                       // in scope 0 at $DIR/lower_intrinsics.rs:+1:30: +1:31
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
-          _2 = move _1;                    // scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
--         _0 = std::intrinsics::forget::<T>(move _2) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
+          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:30: +1:31
+          _2 = move _1;                    // scope 0 at $DIR/lower_intrinsics.rs:+1:30: +1:31
+-         _0 = std::intrinsics::forget::<T>(move _2) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:32
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:24:5: 24:29
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(T) {std::intrinsics::forget::<T>}, val: Value(<ZST>) }
-+         _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
-+         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
++         _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:32
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:32
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:24:31: 24:32
-          goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:25:1: 25:2
+          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:31: +1:32
+          goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:+2:1: +2:2
       }
   
       bb2: {
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:25:2: 25:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
       }
   
       bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:23:1: 25:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
@@ -2,34 +2,34 @@
 + // MIR for `non_const` after LowerIntrinsics
   
   fn non_const() -> usize {
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:60:26: 60:31
-      let _1: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:62:9: 62:18
-      let mut _2: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:63:5: 63:14
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:26: +0:31
+      let _1: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:+2:9: +2:18
+      let mut _2: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:14
       scope 1 {
-          debug size_of_t => _1;           // in scope 1 at $DIR/lower_intrinsics.rs:62:9: 62:18
+          debug size_of_t => _1;           // in scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:18
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:62:9: 62:18
-          _1 = std::intrinsics::size_of::<T>; // scope 0 at $DIR/lower_intrinsics.rs:62:21: 62:51
+          StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+2:9: +2:18
+          _1 = std::intrinsics::size_of::<T>; // scope 0 at $DIR/lower_intrinsics.rs:+2:21: +2:51
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:62:21: 62:51
                                            // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}, val: Value(<ZST>) }
-          StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:14
-          _2 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:14
--         _0 = move _2() -> bb1;           // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:16
-+         _0 = SizeOf(T);                  // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:16
-+         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:16
+          StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:14
+          _2 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:14
+-         _0 = move _2() -> bb1;           // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:16
++         _0 = SizeOf(T);                  // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:16
++         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:16
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:63:15: 63:16
-          StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:64:1: 64:2
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:64:2: 64:2
+          StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+3:15: +3:16
+          StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+4:2: +4:2
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:60:1: 64:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +4:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
@@ -2,23 +2,23 @@
 + // MIR for `size_of` after LowerIntrinsics
   
   fn size_of() -> usize {
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:13:24: 13:29
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:24: +0:29
   
       bb0: {
--         _0 = std::intrinsics::size_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:14:5: 14:37
+-         _0 = std::intrinsics::size_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:37
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:14:5: 14:35
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}, val: Value(<ZST>) }
-+         _0 = SizeOf(T);                  // scope 0 at $DIR/lower_intrinsics.rs:14:5: 14:37
-+         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:14:5: 14:37
++         _0 = SizeOf(T);                  // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:37
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:37
       }
   
       bb1: {
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:15:2: 15:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:13:1: 15:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
@@ -2,25 +2,25 @@
 + // MIR for `unreachable` after LowerIntrinsics
   
   fn unreachable() -> ! {
-      let mut _0: !;                       // return place in scope 0 at $DIR/lower_intrinsics.rs:28:25: 28:26
-      let mut _1: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:28:27: 30:2
-      let _2: ();                          // in scope 0 at $DIR/lower_intrinsics.rs:29:14: 29:45
-      let mut _3: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:29:14: 29:45
+      let mut _0: !;                       // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:25: +0:26
+      let mut _1: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:27: +2:2
+      let _2: ();                          // in scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:45
+      let mut _3: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:45
       scope 1 {
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:29:5: 29:47
-          StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
--         _3 = std::intrinsics::unreachable(); // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
+          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:47
+          StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:45
+-         _3 = std::intrinsics::unreachable(); // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:45
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:29:14: 29:43
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn() -> ! {std::intrinsics::unreachable}, val: Value(<ZST>) }
-+         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
++         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:45
       }
   
       bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:28:1: 30:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
@@ -2,86 +2,86 @@
 + // MIR for `wrapping` after LowerIntrinsics
   
   fn wrapping(_1: i32, _2: i32) -> () {
-      debug a => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:6:17: 6:18
-      debug b => _2;                       // in scope 0 at $DIR/lower_intrinsics.rs:6:25: 6:26
-      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:6:33: 6:33
-      let _3: i32;                         // in scope 0 at $DIR/lower_intrinsics.rs:7:9: 7:11
-      let mut _4: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:7:45: 7:46
-      let mut _5: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:7:48: 7:49
-      let mut _7: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:8:45: 8:46
-      let mut _8: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:8:48: 8:49
-      let mut _10: i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:9:45: 9:46
-      let mut _11: i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:9:48: 9:49
+      debug a => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:17: +0:18
+      debug b => _2;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:25: +0:26
+      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:33: +0:33
+      let _3: i32;                         // in scope 0 at $DIR/lower_intrinsics.rs:+1:9: +1:11
+      let mut _4: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:+1:45: +1:46
+      let mut _5: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:+1:48: +1:49
+      let mut _7: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:+2:45: +2:46
+      let mut _8: i32;                     // in scope 0 at $DIR/lower_intrinsics.rs:+2:48: +2:49
+      let mut _10: i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:+3:45: +3:46
+      let mut _11: i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:+3:48: +3:49
       scope 1 {
-          debug _x => _3;                  // in scope 1 at $DIR/lower_intrinsics.rs:7:9: 7:11
-          let _6: i32;                     // in scope 1 at $DIR/lower_intrinsics.rs:8:9: 8:11
+          debug _x => _3;                  // in scope 1 at $DIR/lower_intrinsics.rs:+1:9: +1:11
+          let _6: i32;                     // in scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:11
           scope 2 {
-              debug _y => _6;              // in scope 2 at $DIR/lower_intrinsics.rs:8:9: 8:11
-              let _9: i32;                 // in scope 2 at $DIR/lower_intrinsics.rs:9:9: 9:11
+              debug _y => _6;              // in scope 2 at $DIR/lower_intrinsics.rs:+2:9: +2:11
+              let _9: i32;                 // in scope 2 at $DIR/lower_intrinsics.rs:+3:9: +3:11
               scope 3 {
-                  debug _z => _9;          // in scope 3 at $DIR/lower_intrinsics.rs:9:9: 9:11
+                  debug _z => _9;          // in scope 3 at $DIR/lower_intrinsics.rs:+3:9: +3:11
               }
           }
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:7:9: 7:11
-          StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:7:45: 7:46
-          _4 = _1;                         // scope 0 at $DIR/lower_intrinsics.rs:7:45: 7:46
-          StorageLive(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:7:48: 7:49
-          _5 = _2;                         // scope 0 at $DIR/lower_intrinsics.rs:7:48: 7:49
--         _3 = wrapping_add::<i32>(move _4, move _5) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:7:14: 7:50
+          StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:9: +1:11
+          StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:45: +1:46
+          _4 = _1;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:45: +1:46
+          StorageLive(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:48: +1:49
+          _5 = _2;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:48: +1:49
+-         _3 = wrapping_add::<i32>(move _4, move _5) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:50
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:7:14: 7:44
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> i32 {wrapping_add::<i32>}, val: Value(<ZST>) }
-+         _3 = Add(move _4, move _5);      // scope 0 at $DIR/lower_intrinsics.rs:7:14: 7:50
-+         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:7:14: 7:50
++         _3 = Add(move _4, move _5);      // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:50
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:50
       }
   
       bb1: {
-          StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:7:49: 7:50
-          StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:7:49: 7:50
-          StorageLive(_6);                 // scope 1 at $DIR/lower_intrinsics.rs:8:9: 8:11
-          StorageLive(_7);                 // scope 1 at $DIR/lower_intrinsics.rs:8:45: 8:46
-          _7 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:8:45: 8:46
-          StorageLive(_8);                 // scope 1 at $DIR/lower_intrinsics.rs:8:48: 8:49
-          _8 = _2;                         // scope 1 at $DIR/lower_intrinsics.rs:8:48: 8:49
--         _6 = wrapping_sub::<i32>(move _7, move _8) -> bb2; // scope 1 at $DIR/lower_intrinsics.rs:8:14: 8:50
+          StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:49: +1:50
+          StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:49: +1:50
+          StorageLive(_6);                 // scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:11
+          StorageLive(_7);                 // scope 1 at $DIR/lower_intrinsics.rs:+2:45: +2:46
+          _7 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:+2:45: +2:46
+          StorageLive(_8);                 // scope 1 at $DIR/lower_intrinsics.rs:+2:48: +2:49
+          _8 = _2;                         // scope 1 at $DIR/lower_intrinsics.rs:+2:48: +2:49
+-         _6 = wrapping_sub::<i32>(move _7, move _8) -> bb2; // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:50
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:8:14: 8:44
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> i32 {wrapping_sub::<i32>}, val: Value(<ZST>) }
-+         _6 = Sub(move _7, move _8);      // scope 1 at $DIR/lower_intrinsics.rs:8:14: 8:50
-+         goto -> bb2;                     // scope 1 at $DIR/lower_intrinsics.rs:8:14: 8:50
++         _6 = Sub(move _7, move _8);      // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:50
++         goto -> bb2;                     // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:50
       }
   
       bb2: {
-          StorageDead(_8);                 // scope 1 at $DIR/lower_intrinsics.rs:8:49: 8:50
-          StorageDead(_7);                 // scope 1 at $DIR/lower_intrinsics.rs:8:49: 8:50
-          StorageLive(_9);                 // scope 2 at $DIR/lower_intrinsics.rs:9:9: 9:11
-          StorageLive(_10);                // scope 2 at $DIR/lower_intrinsics.rs:9:45: 9:46
-          _10 = _1;                        // scope 2 at $DIR/lower_intrinsics.rs:9:45: 9:46
-          StorageLive(_11);                // scope 2 at $DIR/lower_intrinsics.rs:9:48: 9:49
-          _11 = _2;                        // scope 2 at $DIR/lower_intrinsics.rs:9:48: 9:49
--         _9 = wrapping_mul::<i32>(move _10, move _11) -> bb3; // scope 2 at $DIR/lower_intrinsics.rs:9:14: 9:50
+          StorageDead(_8);                 // scope 1 at $DIR/lower_intrinsics.rs:+2:49: +2:50
+          StorageDead(_7);                 // scope 1 at $DIR/lower_intrinsics.rs:+2:49: +2:50
+          StorageLive(_9);                 // scope 2 at $DIR/lower_intrinsics.rs:+3:9: +3:11
+          StorageLive(_10);                // scope 2 at $DIR/lower_intrinsics.rs:+3:45: +3:46
+          _10 = _1;                        // scope 2 at $DIR/lower_intrinsics.rs:+3:45: +3:46
+          StorageLive(_11);                // scope 2 at $DIR/lower_intrinsics.rs:+3:48: +3:49
+          _11 = _2;                        // scope 2 at $DIR/lower_intrinsics.rs:+3:48: +3:49
+-         _9 = wrapping_mul::<i32>(move _10, move _11) -> bb3; // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:50
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:9:14: 9:44
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> i32 {wrapping_mul::<i32>}, val: Value(<ZST>) }
-+         _9 = Mul(move _10, move _11);    // scope 2 at $DIR/lower_intrinsics.rs:9:14: 9:50
-+         goto -> bb3;                     // scope 2 at $DIR/lower_intrinsics.rs:9:14: 9:50
++         _9 = Mul(move _10, move _11);    // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:50
++         goto -> bb3;                     // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:50
       }
   
       bb3: {
-          StorageDead(_11);                // scope 2 at $DIR/lower_intrinsics.rs:9:49: 9:50
-          StorageDead(_10);                // scope 2 at $DIR/lower_intrinsics.rs:9:49: 9:50
-          _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:6:33: 10:2
-          StorageDead(_9);                 // scope 2 at $DIR/lower_intrinsics.rs:10:1: 10:2
-          StorageDead(_6);                 // scope 1 at $DIR/lower_intrinsics.rs:10:1: 10:2
-          StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:10:1: 10:2
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:10:2: 10:2
+          StorageDead(_11);                // scope 2 at $DIR/lower_intrinsics.rs:+3:49: +3:50
+          StorageDead(_10);                // scope 2 at $DIR/lower_intrinsics.rs:+3:49: +3:50
+          _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:+0:33: +4:2
+          StorageDead(_9);                 // scope 2 at $DIR/lower_intrinsics.rs:+4:1: +4:2
+          StorageDead(_6);                 // scope 1 at $DIR/lower_intrinsics.rs:+4:1: +4:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+4:2: +4:2
       }
   
       bb4 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:6:1: 10:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +4:2
       }
   }
   

--- a/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
+++ b/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
@@ -2,62 +2,62 @@
 + // MIR for `bound` after LowerSliceLenCalls
   
   fn bound(_1: usize, _2: &[u8]) -> u8 {
-      debug index => _1;                   // in scope 0 at $DIR/lower_slice_len.rs:4:14: 4:19
-      debug slice => _2;                   // in scope 0 at $DIR/lower_slice_len.rs:4:28: 4:33
-      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_slice_len.rs:4:45: 4:47
-      let mut _3: bool;                    // in scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
-      let mut _4: usize;                   // in scope 0 at $DIR/lower_slice_len.rs:5:8: 5:13
-      let mut _5: usize;                   // in scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
-      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
-      let _7: usize;                       // in scope 0 at $DIR/lower_slice_len.rs:6:15: 6:20
-      let mut _8: usize;                   // in scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
-      let mut _9: bool;                    // in scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
+      debug index => _1;                   // in scope 0 at $DIR/lower_slice_len.rs:+0:14: +0:19
+      debug slice => _2;                   // in scope 0 at $DIR/lower_slice_len.rs:+0:28: +0:33
+      let mut _0: u8;                      // return place in scope 0 at $DIR/lower_slice_len.rs:+0:45: +0:47
+      let mut _3: bool;                    // in scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:27
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:13
+      let mut _5: usize;                   // in scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
+      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
+      let _7: usize;                       // in scope 0 at $DIR/lower_slice_len.rs:+2:15: +2:20
+      let mut _8: usize;                   // in scope 0 at $DIR/lower_slice_len.rs:+2:9: +2:21
+      let mut _9: bool;                    // in scope 0 at $DIR/lower_slice_len.rs:+2:9: +2:21
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
-          StorageLive(_4);                 // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:13
-          _4 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:13
-          StorageLive(_5);                 // scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
-          StorageLive(_6);                 // scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
-          _6 = &(*_2);                     // scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
--         _5 = core::slice::<impl [u8]>::len(move _6) -> bb1; // scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
+          StorageLive(_3);                 // scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:27
+          StorageLive(_4);                 // scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:13
+          _4 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:13
+          StorageLive(_5);                 // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
+          StorageLive(_6);                 // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
+          _6 = &(*_2);                     // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
+-         _5 = core::slice::<impl [u8]>::len(move _6) -> bb1; // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_slice_len.rs:5:22: 5:25
 -                                          // + literal: Const { ty: for<'r> fn(&'r [u8]) -> usize {core::slice::<impl [u8]>::len}, val: Value(<ZST>) }
-+         _5 = Len((*_6));                 // scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
-+         goto -> bb1;                     // scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
++         _5 = Len((*_6));                 // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
++         goto -> bb1;                     // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
       }
   
       bb1: {
-          StorageDead(_6);                 // scope 0 at $DIR/lower_slice_len.rs:5:26: 5:27
-          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_slice_len.rs:5:26: 5:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_slice_len.rs:5:26: 5:27
-          switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
+          StorageDead(_6);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
+          _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:27
+          StorageDead(_5);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
+          switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:27
       }
   
       bb2: {
-          StorageLive(_7);                 // scope 0 at $DIR/lower_slice_len.rs:6:15: 6:20
-          _7 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:6:15: 6:20
-          _8 = Len((*_2));                 // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
-          _9 = Lt(_7, _8);                 // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
-          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb3; // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
+          StorageLive(_7);                 // scope 0 at $DIR/lower_slice_len.rs:+2:15: +2:20
+          _7 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:+2:15: +2:20
+          _8 = Len((*_2));                 // scope 0 at $DIR/lower_slice_len.rs:+2:9: +2:21
+          _9 = Lt(_7, _8);                 // scope 0 at $DIR/lower_slice_len.rs:+2:9: +2:21
+          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb3; // scope 0 at $DIR/lower_slice_len.rs:+2:9: +2:21
       }
   
       bb3: {
-          _0 = (*_2)[_7];                  // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
-          StorageDead(_7);                 // scope 0 at $DIR/lower_slice_len.rs:7:5: 7:6
-          goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:5:5: 9:6
+          _0 = (*_2)[_7];                  // scope 0 at $DIR/lower_slice_len.rs:+2:9: +2:21
+          StorageDead(_7);                 // scope 0 at $DIR/lower_slice_len.rs:+3:5: +3:6
+          goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:+1:5: +5:6
       }
   
       bb4: {
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_slice_len.rs:8:9: 8:11
-          goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:5:5: 9:6
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_slice_len.rs:+4:9: +4:11
+          goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:+1:5: +5:6
       }
   
       bb5: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_slice_len.rs:9:5: 9:6
-          return;                          // scope 0 at $DIR/lower_slice_len.rs:10:2: 10:2
+          StorageDead(_3);                 // scope 0 at $DIR/lower_slice_len.rs:+5:5: +5:6
+          return;                          // scope 0 at $DIR/lower_slice_len.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -2,271 +2,271 @@
 + // MIR for `complicated_match` after ElaborateDrops
   
   fn complicated_match(_1: bool, _2: (bool, bool, String)) -> i32 {
-      debug cond => _1;                    // in scope 0 at $DIR/match-arm-scopes.rs:13:22: 13:26
-      debug items => _2;                   // in scope 0 at $DIR/match-arm-scopes.rs:13:34: 13:39
-      let mut _0: i32;                     // return place in scope 0 at $DIR/match-arm-scopes.rs:13:66: 13:69
-      let mut _3: &bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
-      let mut _4: &bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
-      let _5: bool;                        // in scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
-      let _6: &bool;                       // in scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
-      let _7: std::string::String;         // in scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
-      let _8: &std::string::String;        // in scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
-      let mut _9: bool;                    // in scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-      let mut _10: bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
-      let mut _11: !;                      // in scope 0 at $DIR/match-arm-scopes.rs:15:52: 15:60
-      let mut _12: bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-      let mut _13: bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
-      let mut _14: !;                      // in scope 0 at $DIR/match-arm-scopes.rs:15:52: 15:60
-      let _15: bool;                       // in scope 0 at $DIR/match-arm-scopes.rs:16:16: 16:17
-      let _16: std::string::String;        // in scope 0 at $DIR/match-arm-scopes.rs:16:19: 16:20
+      debug cond => _1;                    // in scope 0 at $DIR/match-arm-scopes.rs:+0:22: +0:26
+      debug items => _2;                   // in scope 0 at $DIR/match-arm-scopes.rs:+0:34: +0:39
+      let mut _0: i32;                     // return place in scope 0 at $DIR/match-arm-scopes.rs:+0:66: +0:69
+      let mut _3: &bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:+1:11: +1:16
+      let mut _4: &bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:+1:11: +1:16
+      let _5: bool;                        // in scope 0 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+      let _6: &bool;                       // in scope 0 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+      let _7: std::string::String;         // in scope 0 at $DIR/match-arm-scopes.rs:+2:20: +2:21
+      let _8: &std::string::String;        // in scope 0 at $DIR/match-arm-scopes.rs:+2:20: +2:21
+      let mut _9: bool;                    // in scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
+      let mut _10: bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
+      let mut _11: !;                      // in scope 0 at $DIR/match-arm-scopes.rs:+2:52: +2:60
+      let mut _12: bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
+      let mut _13: bool;                   // in scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
+      let mut _14: !;                      // in scope 0 at $DIR/match-arm-scopes.rs:+2:52: +2:60
+      let _15: bool;                       // in scope 0 at $DIR/match-arm-scopes.rs:+3:16: +3:17
+      let _16: std::string::String;        // in scope 0 at $DIR/match-arm-scopes.rs:+3:19: +3:20
       scope 1 {
-          debug a => _5;                   // in scope 1 at $DIR/match-arm-scopes.rs:15:17: 15:18
-          debug a => _6;                   // in scope 1 at $DIR/match-arm-scopes.rs:15:17: 15:18
-          debug s => _7;                   // in scope 1 at $DIR/match-arm-scopes.rs:15:20: 15:21
-          debug s => _8;                   // in scope 1 at $DIR/match-arm-scopes.rs:15:20: 15:21
+          debug a => _5;                   // in scope 1 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+          debug a => _6;                   // in scope 1 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+          debug s => _7;                   // in scope 1 at $DIR/match-arm-scopes.rs:+2:20: +2:21
+          debug s => _8;                   // in scope 1 at $DIR/match-arm-scopes.rs:+2:20: +2:21
       }
       scope 2 {
-          debug b => _15;                  // in scope 2 at $DIR/match-arm-scopes.rs:16:16: 16:17
-          debug t => _16;                  // in scope 2 at $DIR/match-arm-scopes.rs:16:19: 16:20
+          debug b => _15;                  // in scope 2 at $DIR/match-arm-scopes.rs:+3:16: +3:17
+          debug t => _16;                  // in scope 2 at $DIR/match-arm-scopes.rs:+3:19: +3:20
       }
   
       bb0: {
--         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
--         switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
-+         switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
+-         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match-arm-scopes.rs:+1:11: +1:16
+-         switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +1:16
++         switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +1:16
       }
   
       bb1: {
--         falseEdge -> [real: bb8, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:9: 15:22
-+         switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
+-         falseEdge -> [real: bb8, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:+2:9: +2:22
++         switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +1:16
       }
   
       bb2: {
--         switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
-+         switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
+-         switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +1:16
++         switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +1:16
       }
   
       bb3: {
--         falseEdge -> [real: bb13, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:15:25: 15:38
+-         falseEdge -> [real: bb13, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:+2:25: +2:38
 -     }
 - 
 -     bb4: {
--         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
+-         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +1:16
 -     }
 - 
 -     bb5: {
--         falseEdge -> [real: bb20, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:21
+-         falseEdge -> [real: bb20, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:+3:9: +3:21
 -     }
 - 
 -     bb6: {
-          StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:32: 16:33
-          _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:32: 16:33
-          StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:35: 16:36
-          _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:35: 16:36
--         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+          StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:+3:32: +3:33
+          _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:+3:32: +3:33
+          StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:+3:35: +3:36
+          _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:+3:35: +3:36
+-         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
++         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
       }
   
 -     bb7: {
 +     bb4: {
-          _0 = const 1_i32;                // scope 1 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         drop(_7) -> [return: bb18, unwind: bb25]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-+         drop(_7) -> [return: bb15, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          _0 = const 1_i32;                // scope 1 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+-         drop(_7) -> [return: bb18, unwind: bb25]; // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
++         drop(_7) -> [return: bb15, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
       }
   
 -     bb8: {
 +     bb5: {
-          StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
-          _6 = &(_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
-          StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
-          _8 = &(_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
--         _3 = &shallow (_2.0: bool);      // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
--         _4 = &shallow (_2.1: bool);      // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
-          StorageLive(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-          StorageLive(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
-          _10 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
--         switchInt(move _10) -> [false: bb10, otherwise: bb9]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
-+         switchInt(move _10) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
+          StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+          _6 = &(_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+          StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:20: +2:21
+          _8 = &(_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:+2:20: +2:21
+-         _3 = &shallow (_2.0: bool);      // scope 0 at $DIR/match-arm-scopes.rs:+1:11: +1:16
+-         _4 = &shallow (_2.1: bool);      // scope 0 at $DIR/match-arm-scopes.rs:+1:11: +1:16
+          StorageLive(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
+          StorageLive(_10);                // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
+          _10 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
+-         switchInt(move _10) -> [false: bb10, otherwise: bb9]; // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
++         switchInt(move _10) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
       }
   
 -     bb9: {
 +     bb6: {
-          _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
-          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
+          _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:+2:59: +2:60
+          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
 -         goto -> bb23;                    // scope 0 at no-location
 +         goto -> bb20;                    // scope 0 at no-location
       }
   
 -     bb10: {
 +     bb7: {
-          _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
--         switchInt(move _9) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(move _9) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+          _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:+2:70: +2:71
+-         switchInt(move _9) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
++         switchInt(move _9) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
       }
   
 -     bb11: {
 +     bb8: {
-          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForGuardBinding, _8);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
-          _5 = (_2.1: bool);               // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
-          StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
-          _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
--         goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForGuardBinding, _8);   // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+          _5 = (_2.1: bool);               // scope 0 at $DIR/match-arm-scopes.rs:+2:17: +2:18
+          StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:20: +2:21
+          _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:+2:20: +2:21
+-         goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
++         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
       }
   
 -     bb12: {
 +     bb9: {
-          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         falseEdge -> [real: bb2, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+-         falseEdge -> [real: bb2, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
++         goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
       }
   
 -     bb13: {
 +     bb10: {
-          StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
-          _6 = &(_2.0: bool);              // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
-          StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
-          _8 = &(_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
--         _3 = &shallow (_2.0: bool);      // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
--         _4 = &shallow (_2.1: bool);      // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
-          StorageLive(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-          StorageLive(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
-          _13 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
--         switchInt(move _13) -> [false: bb15, otherwise: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
-+         switchInt(move _13) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
+          StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:26: +2:27
+          _6 = &(_2.0: bool);              // scope 0 at $DIR/match-arm-scopes.rs:+2:26: +2:27
+          StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:36: +2:37
+          _8 = &(_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:+2:36: +2:37
+-         _3 = &shallow (_2.0: bool);      // scope 0 at $DIR/match-arm-scopes.rs:+1:11: +1:16
+-         _4 = &shallow (_2.1: bool);      // scope 0 at $DIR/match-arm-scopes.rs:+1:11: +1:16
+          StorageLive(_12);                // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
+          StorageLive(_13);                // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
+          _13 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
+-         switchInt(move _13) -> [false: bb15, otherwise: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
++         switchInt(move _13) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:+2:45: +2:49
       }
   
 -     bb14: {
 +     bb11: {
-          _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
-          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
+          _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:+2:59: +2:60
+          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
 -         goto -> bb23;                    // scope 0 at no-location
 +         goto -> bb20;                    // scope 0 at no-location
       }
   
 -     bb15: {
 +     bb12: {
-          _12 = (*_6);                     // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
--         switchInt(move _12) -> [false: bb17, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+          _12 = (*_6);                     // scope 0 at $DIR/match-arm-scopes.rs:+2:70: +2:71
+-         switchInt(move _12) -> [false: bb17, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
++         switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
       }
   
 -     bb16: {
 +     bb13: {
-          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         FakeRead(ForGuardBinding, _8);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
-          _5 = (_2.0: bool);               // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
-          StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
-          _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
--         goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+-         FakeRead(ForGuardBinding, _8);   // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:26: +2:27
+          _5 = (_2.0: bool);               // scope 0 at $DIR/match-arm-scopes.rs:+2:26: +2:27
+          StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:36: +2:37
+          _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:+2:36: +2:37
+-         goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
++         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
       }
   
 -     bb17: {
 +     bb14: {
-          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         falseEdge -> [real: bb4, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:+2:72: +2:73
+          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+-         falseEdge -> [real: bb4, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
++         goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:+2:42: +2:73
       }
   
 -     bb18: {
 +     bb15: {
-          StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-+         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+          StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+-         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
++         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
       }
   
 -     bb19: {
 +     bb16: {
-          _0 = const 2_i32;                // scope 2 at $DIR/match-arm-scopes.rs:16:41: 16:42
--         drop(_16) -> [return: bb21, unwind: bb25]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
-+         drop(_16) -> [return: bb18, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
+          _0 = const 2_i32;                // scope 2 at $DIR/match-arm-scopes.rs:+3:41: +3:42
+-         drop(_16) -> [return: bb21, unwind: bb25]; // scope 0 at $DIR/match-arm-scopes.rs:+3:41: +3:42
++         drop(_16) -> [return: bb18, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:+3:41: +3:42
       }
   
 -     bb20: {
 +     bb17: {
-          StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:16: 16:17
-          _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:16: 16:17
-          StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:19: 16:20
-          _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:19: 16:20
--         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+          StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:+3:16: +3:17
+          _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:+3:16: +3:17
+          StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:+3:19: +3:20
+          _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:+3:19: +3:20
+-         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
++         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:+1:5: +4:6
       }
   
 -     bb21: {
 +     bb18: {
-          StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
-          StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
--         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
-+         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
+          StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:+3:41: +3:42
+          StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:+3:41: +3:42
+-         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:+3:41: +3:42
++         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:+3:41: +3:42
       }
   
 -     bb22: {
--         drop(_2) -> [return: bb24, unwind: bb26]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
+-         drop(_2) -> [return: bb24, unwind: bb26]; // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
 +     bb19: {
-+         goto -> bb26;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb26;                    // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
       }
   
 -     bb23: {
 +     bb20: {
-          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         drop(_2) -> [return: bb24, unwind: bb26]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+         drop(_2) -> [return: bb21, unwind: bb23]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
+          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:+2:77: +2:78
+-         drop(_2) -> [return: bb24, unwind: bb26]; // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
++         drop(_2) -> [return: bb21, unwind: bb23]; // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
       }
   
 -     bb24: {
 +     bb21: {
-          return;                          // scope 0 at $DIR/match-arm-scopes.rs:18:2: 18:2
+          return;                          // scope 0 at $DIR/match-arm-scopes.rs:+5:2: +5:2
       }
   
 -     bb25 (cleanup): {
--         drop(_2) -> bb26;                // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
+-         drop(_2) -> bb26;                // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
 +     bb22 (cleanup): {
-+         goto -> bb27;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb27;                    // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
       }
   
 -     bb26 (cleanup): {
 +     bb23 (cleanup): {
-          resume;                          // scope 0 at $DIR/match-arm-scopes.rs:13:1: 18:2
+          resume;                          // scope 0 at $DIR/match-arm-scopes.rs:+0:1: +5:2
 +     }
 + 
 +     bb24: {
-+         goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
 +     }
 + 
 +     bb25 (cleanup): {
-+         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
 +     }
 + 
 +     bb26: {
-+         goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
 +     }
 + 
 +     bb27 (cleanup): {
-+         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:+5:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -1,113 +1,113 @@
 // MIR for `full_tested_match` after PromoteTemps
 
 fn full_tested_match() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/match_false_edges.rs:12:28: 12:28
-    let mut _1: (i32, i32);              // in scope 0 at $DIR/match_false_edges.rs:13:13: 17:6
-    let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
-    let mut _3: isize;                   // in scope 0 at $DIR/match_false_edges.rs:14:9: 14:16
-    let mut _4: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
-    let _5: i32;                         // in scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
-    let _6: &i32;                        // in scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
-    let mut _7: bool;                    // in scope 0 at $DIR/match_false_edges.rs:14:20: 14:27
-    let mut _8: i32;                     // in scope 0 at $DIR/match_false_edges.rs:14:35: 14:36
-    let _9: i32;                         // in scope 0 at $DIR/match_false_edges.rs:15:14: 15:15
-    let mut _10: i32;                    // in scope 0 at $DIR/match_false_edges.rs:15:24: 15:25
-    let mut _11: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/match_false_edges.rs:+0:28: +0:28
+    let mut _1: (i32, i32);              // in scope 0 at $DIR/match_false_edges.rs:+1:13: +5:6
+    let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+    let mut _3: isize;                   // in scope 0 at $DIR/match_false_edges.rs:+2:9: +2:16
+    let mut _4: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+    let _5: i32;                         // in scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+    let _6: &i32;                        // in scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+    let mut _7: bool;                    // in scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
+    let mut _8: i32;                     // in scope 0 at $DIR/match_false_edges.rs:+2:35: +2:36
+    let _9: i32;                         // in scope 0 at $DIR/match_false_edges.rs:+3:14: +3:15
+    let mut _10: i32;                    // in scope 0 at $DIR/match_false_edges.rs:+3:24: +3:25
+    let mut _11: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
     scope 1 {
     }
     scope 2 {
-        debug x => _5;                   // in scope 2 at $DIR/match_false_edges.rs:14:14: 14:15
-        debug x => _6;                   // in scope 2 at $DIR/match_false_edges.rs:14:14: 14:15
+        debug x => _5;                   // in scope 2 at $DIR/match_false_edges.rs:+2:14: +2:15
+        debug x => _6;                   // in scope 2 at $DIR/match_false_edges.rs:+2:14: +2:15
     }
     scope 3 {
-        debug y => _9;                   // in scope 3 at $DIR/match_false_edges.rs:15:14: 15:15
+        debug y => _9;                   // in scope 3 at $DIR/match_false_edges.rs:+3:14: +3:15
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:13:13: 17:6
-        StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
-        _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
-        FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
-        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
-        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:13:13: 13:27
+        StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:+1:13: +5:6
+        StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:+1:13: +1:27
     }
 
     bb1: {
-        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:16:17: 16:23
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:16:17: 16:23
+        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:+4:17: +4:23
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:+4:17: +4:23
     }
 
     bb2: {
-        falseEdge -> [real: bb5, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:14:9: 14:16
+        falseEdge -> [real: bb5, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:+2:9: +2:16
     }
 
     bb3: {
-        falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:15:9: 15:16
+        falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:+3:9: +3:16
     }
 
     bb4: {
-        unreachable;                     // scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
+        unreachable;                     // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
     }
 
     bb5: {
-        StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
-        _11 = const full_tested_match::promoted[0]; // scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
+        StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _11 = const full_tested_match::promoted[0]; // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:14:14: 14:15
                                          // + literal: Const { ty: &Option<i32>, val: Unevaluated(full_tested_match, [], Some(promoted[0])) }
-        _6 = &(((*_11) as Some).0: i32); // scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
-        _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:13:19: 13:27
-        StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:14:20: 14:27
-        _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:14:20: 14:27
+        _6 = &(((*_11) as Some).0: i32); // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
+        _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:14:20: 14:25
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(<ZST>) }
     }
 
     bb6: {
-        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:14:20: 14:27
+        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
     }
 
     bb7: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:14:26: 14:27
-        FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:14:26: 14:27
-        FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:14:26: 14:27
-        StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
-        _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:14:14: 14:15
-        StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:14:35: 14:36
-        _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:14:35: 14:36
-        _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:14:31: 14:37
-        StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:14:36: 14:37
-        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:14:36: 14:37
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:14:36: 14:37
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:14:36: 14:37
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
+        _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
+        _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:+2:31: +2:37
+        StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:+2:36: +2:37
+        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
     }
 
     bb8: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:14:26: 14:27
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:14:36: 14:37
-        goto -> bb3;                     // scope 0 at $DIR/match_false_edges.rs:14:20: 14:27
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
+        goto -> bb3;                     // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
     }
 
     bb9: {
-        StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:15:14: 15:15
-        _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:15:14: 15:15
-        StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:15:24: 15:25
-        _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:15:24: 15:25
-        _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:15:20: 15:26
-        StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:15:25: 15:26
-        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:15:25: 15:26
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:25: 15:26
+        StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:+3:14: +3:15
+        _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+3:14: +3:15
+        StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:+3:24: +3:25
+        _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:+3:24: +3:25
+        _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:+3:20: +3:26
+        StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:+3:25: +3:26
+        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:+3:25: +3:26
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:+3:25: +3:26
     }
 
     bb10: {
-        StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:17:6: 17:7
-        StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:17:6: 17:7
-        _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:12:28: 18:2
-        return;                          // scope 0 at $DIR/match_false_edges.rs:18:2: 18:2
+        StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:+5:6: +5:7
+        StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:+5:6: +5:7
+        _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:+0:28: +6:2
+        return;                          // scope 0 at $DIR/match_false_edges.rs:+6:2: +6:2
     }
 
     bb11 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:12:1: 18:2
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:+0:1: +6:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -1,108 +1,108 @@
 // MIR for `full_tested_match2` before PromoteTemps
 
 fn full_tested_match2() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/match_false_edges.rs:23:29: 23:29
-    let mut _1: (i32, i32);              // in scope 0 at $DIR/match_false_edges.rs:24:13: 28:6
-    let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
-    let mut _3: isize;                   // in scope 0 at $DIR/match_false_edges.rs:25:9: 25:16
-    let mut _4: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
-    let _5: i32;                         // in scope 0 at $DIR/match_false_edges.rs:25:14: 25:15
-    let _6: &i32;                        // in scope 0 at $DIR/match_false_edges.rs:25:14: 25:15
-    let mut _7: bool;                    // in scope 0 at $DIR/match_false_edges.rs:25:20: 25:27
-    let mut _8: i32;                     // in scope 0 at $DIR/match_false_edges.rs:25:35: 25:36
-    let _9: i32;                         // in scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
-    let mut _10: i32;                    // in scope 0 at $DIR/match_false_edges.rs:27:24: 27:25
+    let mut _0: ();                      // return place in scope 0 at $DIR/match_false_edges.rs:+0:29: +0:29
+    let mut _1: (i32, i32);              // in scope 0 at $DIR/match_false_edges.rs:+1:13: +5:6
+    let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+    let mut _3: isize;                   // in scope 0 at $DIR/match_false_edges.rs:+2:9: +2:16
+    let mut _4: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+    let _5: i32;                         // in scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+    let _6: &i32;                        // in scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+    let mut _7: bool;                    // in scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
+    let mut _8: i32;                     // in scope 0 at $DIR/match_false_edges.rs:+2:35: +2:36
+    let _9: i32;                         // in scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+    let mut _10: i32;                    // in scope 0 at $DIR/match_false_edges.rs:+4:24: +4:25
     scope 1 {
     }
     scope 2 {
-        debug x => _5;                   // in scope 2 at $DIR/match_false_edges.rs:25:14: 25:15
-        debug x => _6;                   // in scope 2 at $DIR/match_false_edges.rs:25:14: 25:15
+        debug x => _5;                   // in scope 2 at $DIR/match_false_edges.rs:+2:14: +2:15
+        debug x => _6;                   // in scope 2 at $DIR/match_false_edges.rs:+2:14: +2:15
     }
     scope 3 {
-        debug y => _9;                   // in scope 3 at $DIR/match_false_edges.rs:27:14: 27:15
+        debug y => _9;                   // in scope 3 at $DIR/match_false_edges.rs:+4:14: +4:15
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:24:13: 28:6
-        StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
-        _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
-        FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
-        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
-        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:24:13: 24:27
+        StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:+1:13: +5:6
+        StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:+1:13: +1:27
     }
 
     bb1: {
-        falseEdge -> [real: bb9, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:26:9: 26:13
+        falseEdge -> [real: bb9, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:+3:9: +3:13
     }
 
     bb2: {
-        falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:25:9: 25:16
+        falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:+2:9: +2:16
     }
 
     bb3: {
-        StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
-        _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
-        StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:27:24: 27:25
-        _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:27:24: 27:25
-        _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:27:20: 27:26
-        StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:27:25: 27:26
-        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:27:25: 27:26
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:27:25: 27:26
+        StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:+4:24: +4:25
+        _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:+4:24: +4:25
+        _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:+4:20: +4:26
+        StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:+4:25: +4:26
+        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:+4:25: +4:26
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:+4:25: +4:26
     }
 
     bb4: {
-        unreachable;                     // scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
+        unreachable;                     // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
     }
 
     bb5: {
-        StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:25:14: 25:15
-        _6 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:25:14: 25:15
-        _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:24:19: 24:27
-        StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:25:20: 25:27
-        _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:25:20: 25:27
+        StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _6 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:27
+        StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
+        _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:25:20: 25:25
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(<ZST>) }
     }
 
     bb6: {
-        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:25:20: 25:27
+        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
     }
 
     bb7: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:25:26: 25:27
-        FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:25:26: 25:27
-        FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:25:26: 25:27
-        StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:25:14: 25:15
-        _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:25:14: 25:15
-        StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:25:35: 25:36
-        _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:25:35: 25:36
-        _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:25:31: 25:37
-        StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:25:36: 25:37
-        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:25:36: 25:37
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:25:36: 25:37
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:25:36: 25:37
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:15
+        StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
+        _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:+2:35: +2:36
+        _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:+2:31: +2:37
+        StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:+2:36: +2:37
+        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
     }
 
     bb8: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:25:26: 25:27
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:25:36: 25:37
-        falseEdge -> [real: bb3, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:25:20: 25:27
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:26: +2:27
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:36: +2:37
+        falseEdge -> [real: bb3, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
     }
 
     bb9: {
-        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:26:17: 26:23
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:17: 26:23
+        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:+3:17: +3:23
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:+3:17: +3:23
     }
 
     bb10: {
-        StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:28:6: 28:7
-        StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:28:6: 28:7
-        _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:23:29: 29:2
-        return;                          // scope 0 at $DIR/match_false_edges.rs:29:2: 29:2
+        StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:+5:6: +5:7
+        StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:+5:6: +5:7
+        _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:+0:29: +6:2
+        return;                          // scope 0 at $DIR/match_false_edges.rs:+6:2: +6:2
     }
 
     bb11 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:23:1: 29:2
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:+0:1: +6:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -1,153 +1,153 @@
 // MIR for `main` before PromoteTemps
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/match_false_edges.rs:32:11: 32:11
-    let mut _1: i32;                     // in scope 0 at $DIR/match_false_edges.rs:33:13: 38:6
-    let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-    let mut _3: isize;                   // in scope 0 at $DIR/match_false_edges.rs:36:9: 36:16
-    let mut _4: isize;                   // in scope 0 at $DIR/match_false_edges.rs:34:9: 34:17
-    let mut _5: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-    let _6: i32;                         // in scope 0 at $DIR/match_false_edges.rs:34:14: 34:16
-    let _7: &i32;                        // in scope 0 at $DIR/match_false_edges.rs:34:14: 34:16
-    let mut _8: bool;                    // in scope 0 at $DIR/match_false_edges.rs:34:21: 34:28
-    let _9: std::option::Option<i32>;    // in scope 0 at $DIR/match_false_edges.rs:35:9: 35:11
-    let _10: i32;                        // in scope 0 at $DIR/match_false_edges.rs:36:14: 36:15
-    let _11: &i32;                       // in scope 0 at $DIR/match_false_edges.rs:36:14: 36:15
-    let mut _12: bool;                   // in scope 0 at $DIR/match_false_edges.rs:36:20: 36:29
-    let mut _13: i32;                    // in scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
-    let _14: std::option::Option<i32>;   // in scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
+    let mut _0: ();                      // return place in scope 0 at $DIR/match_false_edges.rs:+0:11: +0:11
+    let mut _1: i32;                     // in scope 0 at $DIR/match_false_edges.rs:+1:13: +6:6
+    let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+    let mut _3: isize;                   // in scope 0 at $DIR/match_false_edges.rs:+4:9: +4:16
+    let mut _4: isize;                   // in scope 0 at $DIR/match_false_edges.rs:+2:9: +2:17
+    let mut _5: &std::option::Option<i32>; // in scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+    let _6: i32;                         // in scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+    let _7: &i32;                        // in scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+    let mut _8: bool;                    // in scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
+    let _9: std::option::Option<i32>;    // in scope 0 at $DIR/match_false_edges.rs:+3:9: +3:11
+    let _10: i32;                        // in scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+    let _11: &i32;                       // in scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+    let mut _12: bool;                   // in scope 0 at $DIR/match_false_edges.rs:+4:20: +4:29
+    let mut _13: i32;                    // in scope 0 at $DIR/match_false_edges.rs:+4:27: +4:28
+    let _14: std::option::Option<i32>;   // in scope 0 at $DIR/match_false_edges.rs:+5:9: +5:11
     scope 1 {
     }
     scope 2 {
-        debug _w => _6;                  // in scope 2 at $DIR/match_false_edges.rs:34:14: 34:16
-        debug _w => _7;                  // in scope 2 at $DIR/match_false_edges.rs:34:14: 34:16
+        debug _w => _6;                  // in scope 2 at $DIR/match_false_edges.rs:+2:14: +2:16
+        debug _w => _7;                  // in scope 2 at $DIR/match_false_edges.rs:+2:14: +2:16
     }
     scope 3 {
-        debug _x => _9;                  // in scope 3 at $DIR/match_false_edges.rs:35:9: 35:11
+        debug _x => _9;                  // in scope 3 at $DIR/match_false_edges.rs:+3:9: +3:11
     }
     scope 4 {
-        debug y => _10;                  // in scope 4 at $DIR/match_false_edges.rs:36:14: 36:15
-        debug y => _11;                  // in scope 4 at $DIR/match_false_edges.rs:36:14: 36:15
+        debug y => _10;                  // in scope 4 at $DIR/match_false_edges.rs:+4:14: +4:15
+        debug y => _11;                  // in scope 4 at $DIR/match_false_edges.rs:+4:14: +4:15
     }
     scope 5 {
-        debug _z => _14;                 // in scope 5 at $DIR/match_false_edges.rs:37:9: 37:11
+        debug _z => _14;                 // in scope 5 at $DIR/match_false_edges.rs:+5:9: +5:11
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:33:13: 38:6
-        StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-        _2 = Option::<i32>::Some(const 1_i32); // scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-        FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-        _4 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-        switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/match_false_edges.rs:33:13: 33:26
+        StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:+1:13: +6:6
+        StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+        _2 = Option::<i32>::Some(const 1_i32); // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+        FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+        _4 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+        switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/match_false_edges.rs:+1:13: +1:26
     }
 
     bb1: {
-        falseEdge -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:35:9: 35:11
+        falseEdge -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:+3:9: +3:11
     }
 
     bb2: {
-        falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:34:9: 34:17
+        falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:+2:9: +2:17
     }
 
     bb3: {
-        StorageLive(_14);                // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
-        _14 = _2;                        // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
-        _1 = const 4_i32;                // scope 5 at $DIR/match_false_edges.rs:37:15: 37:16
-        StorageDead(_14);                // scope 0 at $DIR/match_false_edges.rs:37:15: 37:16
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:37:15: 37:16
+        StorageLive(_14);                // scope 0 at $DIR/match_false_edges.rs:+5:9: +5:11
+        _14 = _2;                        // scope 0 at $DIR/match_false_edges.rs:+5:9: +5:11
+        _1 = const 4_i32;                // scope 5 at $DIR/match_false_edges.rs:+5:15: +5:16
+        StorageDead(_14);                // scope 0 at $DIR/match_false_edges.rs:+5:15: +5:16
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:+5:15: +5:16
     }
 
     bb4: {
-        falseEdge -> [real: bb10, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:16
+        falseEdge -> [real: bb10, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:+4:9: +4:16
     }
 
     bb5: {
-        StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:34:14: 34:16
-        _7 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:34:14: 34:16
-        _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-        StorageLive(_8);                 // scope 0 at $DIR/match_false_edges.rs:34:21: 34:28
-        _8 = guard() -> [return: bb6, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:34:21: 34:28
+        StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+        _7 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+        _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+        StorageLive(_8);                 // scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
+        _8 = guard() -> [return: bb6, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:34:21: 34:26
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(<ZST>) }
     }
 
     bb6: {
-        switchInt(move _8) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:34:21: 34:28
+        switchInt(move _8) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
     }
 
     bb7: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:34:27: 34:28
-        FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:34:27: 34:28
-        FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:34:27: 34:28
-        StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:34:14: 34:16
-        _6 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:34:14: 34:16
-        _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:34:32: 34:33
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:34:32: 34:33
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:34:32: 34:33
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:34:32: 34:33
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:+2:27: +2:28
+        FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:+2:27: +2:28
+        FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:+2:27: +2:28
+        StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+        _6 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:+2:14: +2:16
+        _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:+2:32: +2:33
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:+2:32: +2:33
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:32: +2:33
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:+2:32: +2:33
     }
 
     bb8: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:34:27: 34:28
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:34:32: 34:33
-        falseEdge -> [real: bb1, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:34:21: 34:28
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:+2:27: +2:28
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:+2:32: +2:33
+        falseEdge -> [real: bb1, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
     }
 
     bb9: {
-        StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:35:9: 35:11
-        _9 = _2;                         // scope 0 at $DIR/match_false_edges.rs:35:9: 35:11
-        _1 = const 2_i32;                // scope 3 at $DIR/match_false_edges.rs:35:15: 35:16
-        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:35:15: 35:16
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:15: 35:16
+        StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:+3:9: +3:11
+        _9 = _2;                         // scope 0 at $DIR/match_false_edges.rs:+3:9: +3:11
+        _1 = const 2_i32;                // scope 3 at $DIR/match_false_edges.rs:+3:15: +3:16
+        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:+3:15: +3:16
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:+3:15: +3:16
     }
 
     bb10: {
-        StorageLive(_11);                // scope 0 at $DIR/match_false_edges.rs:36:14: 36:15
-        _11 = &((_2 as Some).0: i32);    // scope 0 at $DIR/match_false_edges.rs:36:14: 36:15
-        _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:33:19: 33:26
-        StorageLive(_12);                // scope 0 at $DIR/match_false_edges.rs:36:20: 36:29
-        StorageLive(_13);                // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
-        _13 = (*_11);                    // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
-        _12 = guard2(move _13) -> [return: bb11, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:36:20: 36:29
+        StorageLive(_11);                // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _11 = &((_2 as Some).0: i32);    // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:+1:19: +1:26
+        StorageLive(_12);                // scope 0 at $DIR/match_false_edges.rs:+4:20: +4:29
+        StorageLive(_13);                // scope 0 at $DIR/match_false_edges.rs:+4:27: +4:28
+        _13 = (*_11);                    // scope 0 at $DIR/match_false_edges.rs:+4:27: +4:28
+        _12 = guard2(move _13) -> [return: bb11, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:+4:20: +4:29
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:36:20: 36:26
                                          // + literal: Const { ty: fn(i32) -> bool {guard2}, val: Value(<ZST>) }
     }
 
     bb11: {
-        switchInt(move _12) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match_false_edges.rs:36:20: 36:29
+        switchInt(move _12) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match_false_edges.rs:+4:20: +4:29
     }
 
     bb12: {
-        StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:36:28: 36:29
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:36:28: 36:29
-        FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:36:28: 36:29
-        FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:36:28: 36:29
-        StorageLive(_10);                // scope 0 at $DIR/match_false_edges.rs:36:14: 36:15
-        _10 = ((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:36:14: 36:15
-        _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:36:33: 36:34
-        StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
+        StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
+        FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
+        FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
+        StorageLive(_10);                // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _10 = ((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:+4:14: +4:15
+        _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:+4:33: +4:34
+        StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:+4:33: +4:34
+        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:+4:33: +4:34
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:+4:33: +4:34
     }
 
     bb13: {
-        StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:36:28: 36:29
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:36:28: 36:29
-        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        falseEdge -> [real: bb3, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:36:20: 36:29
+        StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:+4:28: +4:29
+        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:+4:33: +4:34
+        falseEdge -> [real: bb3, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:+4:20: +4:29
     }
 
     bb14: {
-        StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:38:6: 38:7
-        StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:38:6: 38:7
-        _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:32:11: 39:2
-        return;                          // scope 0 at $DIR/match_false_edges.rs:39:2: 39:2
+        StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:+6:6: +6:7
+        StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:+6:6: +6:7
+        _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:+0:11: +7:2
+        return;                          // scope 0 at $DIR/match_false_edges.rs:+7:2: +7:2
     }
 
     bb15 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:32:1: 39:2
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:+0:1: +7:2
     }
 }

--- a/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
@@ -1,106 +1,106 @@
 // MIR for `main` after SimplifyCfg-initial
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/match_test.rs:6:11: 6:11
-    let _1: i32;                         // in scope 0 at $DIR/match_test.rs:7:9: 7:10
-    let _3: i32;                         // in scope 0 at $DIR/match_test.rs:12:5: 17:6
-    let mut _4: bool;                    // in scope 0 at $DIR/match_test.rs:14:9: 14:16
-    let mut _5: bool;                    // in scope 0 at $DIR/match_test.rs:14:9: 14:16
-    let mut _6: bool;                    // in scope 0 at $DIR/match_test.rs:13:9: 13:14
-    let mut _7: bool;                    // in scope 0 at $DIR/match_test.rs:13:9: 13:14
-    let mut _8: &i32;                    // in scope 0 at $DIR/match_test.rs:12:11: 12:12
-    let mut _9: bool;                    // in scope 0 at $DIR/match_test.rs:13:18: 13:19
+    let mut _0: ();                      // return place in scope 0 at $DIR/match_test.rs:+0:11: +0:11
+    let _1: i32;                         // in scope 0 at $DIR/match_test.rs:+1:9: +1:10
+    let _3: i32;                         // in scope 0 at $DIR/match_test.rs:+6:5: +11:6
+    let mut _4: bool;                    // in scope 0 at $DIR/match_test.rs:+8:9: +8:16
+    let mut _5: bool;                    // in scope 0 at $DIR/match_test.rs:+8:9: +8:16
+    let mut _6: bool;                    // in scope 0 at $DIR/match_test.rs:+7:9: +7:14
+    let mut _7: bool;                    // in scope 0 at $DIR/match_test.rs:+7:9: +7:14
+    let mut _8: &i32;                    // in scope 0 at $DIR/match_test.rs:+6:11: +6:12
+    let mut _9: bool;                    // in scope 0 at $DIR/match_test.rs:+7:18: +7:19
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/match_test.rs:7:9: 7:10
-        let _2: bool;                    // in scope 1 at $DIR/match_test.rs:8:9: 8:10
+        debug x => _1;                   // in scope 1 at $DIR/match_test.rs:+1:9: +1:10
+        let _2: bool;                    // in scope 1 at $DIR/match_test.rs:+2:9: +2:10
         scope 2 {
-            debug b => _2;               // in scope 2 at $DIR/match_test.rs:8:9: 8:10
+            debug b => _2;               // in scope 2 at $DIR/match_test.rs:+2:9: +2:10
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/match_test.rs:7:9: 7:10
-        _1 = const 3_i32;                // scope 0 at $DIR/match_test.rs:7:13: 7:14
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/match_test.rs:7:9: 7:10
-        StorageLive(_2);                 // scope 1 at $DIR/match_test.rs:8:9: 8:10
-        _2 = const true;                 // scope 1 at $DIR/match_test.rs:8:13: 8:17
-        FakeRead(ForLet(None), _2);      // scope 1 at $DIR/match_test.rs:8:9: 8:10
-        StorageLive(_3);                 // scope 2 at $DIR/match_test.rs:12:5: 17:6
-        FakeRead(ForMatchedPlace(None), _1); // scope 2 at $DIR/match_test.rs:12:11: 12:12
-        _6 = Le(const 0_i32, _1);        // scope 2 at $DIR/match_test.rs:13:9: 13:14
-        switchInt(move _6) -> [false: bb4, otherwise: bb1]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
+        StorageLive(_1);                 // scope 0 at $DIR/match_test.rs:+1:9: +1:10
+        _1 = const 3_i32;                // scope 0 at $DIR/match_test.rs:+1:13: +1:14
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/match_test.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 1 at $DIR/match_test.rs:+2:9: +2:10
+        _2 = const true;                 // scope 1 at $DIR/match_test.rs:+2:13: +2:17
+        FakeRead(ForLet(None), _2);      // scope 1 at $DIR/match_test.rs:+2:9: +2:10
+        StorageLive(_3);                 // scope 2 at $DIR/match_test.rs:+6:5: +11:6
+        FakeRead(ForMatchedPlace(None), _1); // scope 2 at $DIR/match_test.rs:+6:11: +6:12
+        _6 = Le(const 0_i32, _1);        // scope 2 at $DIR/match_test.rs:+7:9: +7:14
+        switchInt(move _6) -> [false: bb4, otherwise: bb1]; // scope 2 at $DIR/match_test.rs:+7:9: +7:14
     }
 
     bb1: {
-        _7 = Lt(_1, const 10_i32);       // scope 2 at $DIR/match_test.rs:13:9: 13:14
-        switchInt(move _7) -> [false: bb4, otherwise: bb2]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
+        _7 = Lt(_1, const 10_i32);       // scope 2 at $DIR/match_test.rs:+7:9: +7:14
+        switchInt(move _7) -> [false: bb4, otherwise: bb2]; // scope 2 at $DIR/match_test.rs:+7:9: +7:14
     }
 
     bb2: {
-        falseEdge -> [real: bb9, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
+        falseEdge -> [real: bb9, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:+7:9: +7:14
     }
 
     bb3: {
-        _3 = const 3_i32;                // scope 2 at $DIR/match_test.rs:16:14: 16:15
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:16:14: 16:15
+        _3 = const 3_i32;                // scope 2 at $DIR/match_test.rs:+10:14: +10:15
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:+10:14: +10:15
     }
 
     bb4: {
-        _4 = Le(const 10_i32, _1);       // scope 2 at $DIR/match_test.rs:14:9: 14:16
-        switchInt(move _4) -> [false: bb7, otherwise: bb5]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
+        _4 = Le(const 10_i32, _1);       // scope 2 at $DIR/match_test.rs:+8:9: +8:16
+        switchInt(move _4) -> [false: bb7, otherwise: bb5]; // scope 2 at $DIR/match_test.rs:+8:9: +8:16
     }
 
     bb5: {
-        _5 = Le(_1, const 20_i32);       // scope 2 at $DIR/match_test.rs:14:9: 14:16
-        switchInt(move _5) -> [false: bb7, otherwise: bb6]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
+        _5 = Le(_1, const 20_i32);       // scope 2 at $DIR/match_test.rs:+8:9: +8:16
+        switchInt(move _5) -> [false: bb7, otherwise: bb6]; // scope 2 at $DIR/match_test.rs:+8:9: +8:16
     }
 
     bb6: {
-        falseEdge -> [real: bb12, imaginary: bb8]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
+        falseEdge -> [real: bb12, imaginary: bb8]; // scope 2 at $DIR/match_test.rs:+8:9: +8:16
     }
 
     bb7: {
-        switchInt(_1) -> [-1_i32: bb8, otherwise: bb3]; // scope 2 at $DIR/match_test.rs:12:5: 12:12
+        switchInt(_1) -> [-1_i32: bb8, otherwise: bb3]; // scope 2 at $DIR/match_test.rs:+6:5: +6:12
     }
 
     bb8: {
-        falseEdge -> [real: bb13, imaginary: bb3]; // scope 2 at $DIR/match_test.rs:15:9: 15:11
+        falseEdge -> [real: bb13, imaginary: bb3]; // scope 2 at $DIR/match_test.rs:+9:9: +9:11
     }
 
     bb9: {
-        _8 = &shallow _1;                // scope 2 at $DIR/match_test.rs:12:11: 12:12
-        StorageLive(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
-        _9 = _2;                         // scope 2 at $DIR/match_test.rs:13:18: 13:19
-        switchInt(move _9) -> [false: bb11, otherwise: bb10]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
+        _8 = &shallow _1;                // scope 2 at $DIR/match_test.rs:+6:11: +6:12
+        StorageLive(_9);                 // scope 2 at $DIR/match_test.rs:+7:18: +7:19
+        _9 = _2;                         // scope 2 at $DIR/match_test.rs:+7:18: +7:19
+        switchInt(move _9) -> [false: bb11, otherwise: bb10]; // scope 2 at $DIR/match_test.rs:+7:18: +7:19
     }
 
     bb10: {
-        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
-        FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:13:18: 13:19
-        _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:13:23: 13:24
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:13:23: 13:24
+        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:+7:18: +7:19
+        FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:+7:18: +7:19
+        _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:+7:23: +7:24
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:+7:23: +7:24
     }
 
     bb11: {
-        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
-        falseEdge -> [real: bb3, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
+        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:+7:18: +7:19
+        falseEdge -> [real: bb3, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:+7:18: +7:19
     }
 
     bb12: {
-        _3 = const 1_i32;                // scope 2 at $DIR/match_test.rs:14:20: 14:21
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:14:20: 14:21
+        _3 = const 1_i32;                // scope 2 at $DIR/match_test.rs:+8:20: +8:21
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:+8:20: +8:21
     }
 
     bb13: {
-        _3 = const 2_i32;                // scope 2 at $DIR/match_test.rs:15:15: 15:16
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:15:15: 15:16
+        _3 = const 2_i32;                // scope 2 at $DIR/match_test.rs:+9:15: +9:16
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:+9:15: +9:16
     }
 
     bb14: {
-        StorageDead(_3);                 // scope 2 at $DIR/match_test.rs:17:6: 17:7
-        _0 = const ();                   // scope 0 at $DIR/match_test.rs:6:11: 18:2
-        StorageDead(_2);                 // scope 1 at $DIR/match_test.rs:18:1: 18:2
-        StorageDead(_1);                 // scope 0 at $DIR/match_test.rs:18:1: 18:2
-        return;                          // scope 0 at $DIR/match_test.rs:18:2: 18:2
+        StorageDead(_3);                 // scope 2 at $DIR/match_test.rs:+11:6: +11:7
+        _0 = const ();                   // scope 0 at $DIR/match_test.rs:+0:11: +12:2
+        StorageDead(_2);                 // scope 1 at $DIR/match_test.rs:+12:1: +12:2
+        StorageDead(_1);                 // scope 0 at $DIR/match_test.rs:+12:1: +12:2
+        return;                          // scope 0 at $DIR/match_test.rs:+12:2: +12:2
     }
 }

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
@@ -2,87 +2,87 @@
 + // MIR for `bar` after MatchBranchSimplification
   
   fn bar(_1: i32) -> (bool, bool, bool, bool) {
-      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:13:8: 13:9
-      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:13:19: 13:43
-      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 34:6
-      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:6: 36:7
-      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:9: 36:10
-      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:12: 36:13
-      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-+     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 19:12
+      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:+0:8: +0:9
+      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:19: +0:43
+      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:10
+      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:+6:5: +21:6
+      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+23:6: +23:7
+      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+23:9: +23:10
+      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+23:12: +23:13
+      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
++     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:+1:9: +1:10
+          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:+2:9: +2:10
           scope 2 {
-              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:+2:9: +2:10
+              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:+3:9: +3:10
               scope 3 {
-                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
-                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
+                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:+3:9: +3:10
+                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:+4:9: +4:10
                   scope 4 {
-                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:17:9: 17:10
+                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:+4:9: +4:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
-          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
-          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:+2:9: +2:10
+          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:+3:9: +3:10
+          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:+4:9: +4:10
+          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +21:6
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
 -     }
 - 
 -     bb1: {
--         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:21
--         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
--         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
--         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
--         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
+-         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+15:13: +15:21
+-         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+16:13: +16:22
+-         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+17:13: +17:22
+-         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+18:13: +18:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:+19:13: +19:15
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:+19:13: +19:15
 -     }
 - 
 -     bb2: {
--         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
--         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-+         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
-+         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
-+         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
-+         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
--         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
+-         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+8:13: +8:22
+-         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+9:13: +9:21
++         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
++         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
++         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:+8:13: +8:22
++         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:+9:13: +9:21
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+10:13: +10:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+11:13: +11:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:+12:13: +12:15
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:+12:13: +12:15
 -     }
 - 
 -     bb3: {
-+         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
-          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
-          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
-          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
-          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
-          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
-          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
-          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-          Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:37:2: 37:2
++         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
+          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:+21:6: +21:7
+          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:6: +23:7
+          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:+23:6: +23:7
+          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:9: +23:10
+          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:+23:9: +23:10
+          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:12: +23:13
+          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:+23:12: +23:13
+          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
+          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
+          Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+24:2: +24:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
@@ -2,87 +2,87 @@
 + // MIR for `bar` after MatchBranchSimplification
   
   fn bar(_1: i32) -> (bool, bool, bool, bool) {
-      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:13:8: 13:9
-      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:13:19: 13:43
-      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 34:6
-      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:6: 36:7
-      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:9: 36:10
-      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:12: 36:13
-      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-+     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 19:12
+      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:+0:8: +0:9
+      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:19: +0:43
+      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:10
+      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:+6:5: +21:6
+      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+23:6: +23:7
+      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+23:9: +23:10
+      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+23:12: +23:13
+      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
++     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:+1:9: +1:10
+          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:+2:9: +2:10
           scope 2 {
-              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:+2:9: +2:10
+              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:+3:9: +3:10
               scope 3 {
-                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
-                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
+                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:+3:9: +3:10
+                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:+4:9: +4:10
                   scope 4 {
-                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:17:9: 17:10
+                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:+4:9: +4:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
-          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
-          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:+2:9: +2:10
+          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:+3:9: +3:10
+          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:+4:9: +4:10
+          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +21:6
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
 -     }
 - 
 -     bb1: {
--         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:21
--         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
--         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
--         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
--         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
+-         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+15:13: +15:21
+-         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+16:13: +16:22
+-         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+17:13: +17:22
+-         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+18:13: +18:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:+19:13: +19:15
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:+19:13: +19:15
 -     }
 - 
 -     bb2: {
--         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
--         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-+         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
-+         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
-+         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
-+         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
--         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
+-         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+8:13: +8:22
+-         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+9:13: +9:21
++         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
++         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
++         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:+8:13: +8:22
++         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:+9:13: +9:21
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:+10:13: +10:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:+11:13: +11:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:+12:13: +12:15
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:+12:13: +12:15
 -     }
 - 
 -     bb3: {
-+         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
-          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
-          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
-          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
-          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
-          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
-          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
-          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-          Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
-          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
-          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:37:1: 37:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:37:2: 37:2
++         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:+6:5: +6:12
+          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:+21:6: +21:7
+          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:6: +23:7
+          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:+23:6: +23:7
+          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:9: +23:10
+          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:+23:9: +23:10
+          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:12: +23:13
+          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:+23:12: +23:13
+          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
+          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:+23:15: +23:16
+          Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:+23:5: +23:17
+          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:+23:16: +23:17
+          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+24:1: +24:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+24:2: +24:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
@@ -2,13 +2,13 @@
 + // MIR for `foo` after MatchBranchSimplification
   
   fn foo(_1: Option<()>) -> () {
-      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
-      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
-      let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:+0:8: +0:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:25: +0:25
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:+1:22: +1:26
 +     let mut _3: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:17: 8:20
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:+1:17: +1:20
 -         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
@@ -24,7 +24,7 @@
 +         StorageLive(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _3 = move _2;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         StorageDead(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
@@ -2,13 +2,13 @@
 + // MIR for `foo` after MatchBranchSimplification
   
   fn foo(_1: Option<()>) -> () {
-      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
-      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
-      let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:+0:8: +0:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:25: +0:25
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:+1:22: +1:26
 +     let mut _3: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:17: 8:20
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:+1:17: +1:20
 -         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
@@ -24,7 +24,7 @@
 +         StorageLive(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _3 = move _2;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         StorageDead(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.32bit.mir
+++ b/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.32bit.mir
@@ -1,10 +1,10 @@
 // MIR for `foo` before PreCodegen
 
 fn foo(_1: Option<()>) -> () {
-    debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
-    let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
+    debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:+0:8: +0:11
+    let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:25: +0:25
 
     bb0: {
-        return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
+        return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.64bit.mir
+++ b/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.64bit.mir
@@ -1,10 +1,10 @@
 // MIR for `foo` before PreCodegen
 
 fn foo(_1: Option<()>) -> () {
-    debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
-    let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
+    debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:+0:8: +0:11
+    let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:25: +0:25
 
     bb0: {
-        return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
+        return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
@@ -2,41 +2,41 @@
 + // MIR for `match_nested_if` after MatchBranchSimplification
   
   fn match_nested_if() -> bool {
-      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:39:25: 39:29
-      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-      let mut _2: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-+     let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:25: +0:29
+      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:12
+      let mut _2: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++     let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
       scope 1 {
-          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
+          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:+1:9: +1:12
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:12
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+          _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
 -     }
 - 
 -     bb1: {
-+         StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-+         _3 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
--         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
++         StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++         _3 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
+-         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+8:13: +8:17
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:+8:13: +8:17
 -     }
 - 
 -     bb2: {
--         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
--         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
+-         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
+-         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:+10:14: +10:19
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:+10:14: +10:19
 -     }
 - 
 -     bb3: {
-+         _1 = Ne(_3, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
-+         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8
-          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:52:1: 52:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:52:2: 52:2
++         _1 = Ne(_3, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+10:14: +10:19
++         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:+12:5: +12:8
+          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:+13:1: +13:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+13:2: +13:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
@@ -2,41 +2,41 @@
 + // MIR for `match_nested_if` after MatchBranchSimplification
   
   fn match_nested_if() -> bool {
-      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:39:25: 39:29
-      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-      let mut _2: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-+     let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:+0:25: +0:29
+      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:12
+      let mut _2: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++     let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
       scope 1 {
-          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
+          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:+1:9: +1:12
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:+1:9: +1:12
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+          _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
 -     }
 - 
 -     bb1: {
-+         StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-+         _3 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
--         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
++         StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++         _3 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
+-         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+8:13: +8:17
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:+8:13: +8:17
 -     }
 - 
 -     bb2: {
--         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
--         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
+-         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
+-         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:+10:14: +10:19
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:+10:14: +10:19
 -     }
 - 
 -     bb3: {
-+         _1 = Ne(_3, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
-+         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8
-          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:52:1: 52:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:52:2: 52:2
++         _1 = Ne(_3, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+10:14: +10:19
++         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
+          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:+12:5: +12:8
+          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:+13:1: +13:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:+13:2: +13:2
       }
   }
   

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
@@ -2,27 +2,27 @@
 + // MIR for `exhaustive_match` after MatchBranchSimplification
   
   fn exhaustive_match(_1: E) -> u8 {
-      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:11:25: 11:26
-      let mut _0: u8;                      // return place in scope 0 at $DIR/matches_u8.rs:11:34: 11:36
-      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:13:9: 13:13
+      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:+0:25: +0:26
+      let mut _0: u8;                      // return place in scope 0 at $DIR/matches_u8.rs:+0:34: +0:36
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:+2:9: +2:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:12:11: 12:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
+          _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
+          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/matches_u8.rs:16:2: 16:2
+          return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
@@ -2,27 +2,27 @@
 + // MIR for `exhaustive_match` after MatchBranchSimplification
   
   fn exhaustive_match(_1: E) -> u8 {
-      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:11:25: 11:26
-      let mut _0: u8;                      // return place in scope 0 at $DIR/matches_u8.rs:11:34: 11:36
-      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:13:9: 13:13
+      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:+0:25: +0:26
+      let mut _0: u8;                      // return place in scope 0 at $DIR/matches_u8.rs:+0:34: +0:36
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:+2:9: +2:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:12:11: 12:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
+          _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
+          _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/matches_u8.rs:16:2: 16:2
+          return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
@@ -2,27 +2,27 @@
 + // MIR for `exhaustive_match_i8` after MatchBranchSimplification
   
   fn exhaustive_match_i8(_1: E) -> i8 {
-      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:19:28: 19:29
-      let mut _0: i8;                      // return place in scope 0 at $DIR/matches_u8.rs:19:37: 19:39
-      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:21:9: 21:13
+      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:+0:28: +0:29
+      let mut _0: i8;                      // return place in scope 0 at $DIR/matches_u8.rs:+0:37: +0:39
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:+2:9: +2:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:20:11: 20:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
+          _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
+          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/matches_u8.rs:24:2: 24:2
+          return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
@@ -2,27 +2,27 @@
 + // MIR for `exhaustive_match_i8` after MatchBranchSimplification
   
   fn exhaustive_match_i8(_1: E) -> i8 {
-      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:19:28: 19:29
-      let mut _0: i8;                      // return place in scope 0 at $DIR/matches_u8.rs:19:37: 19:39
-      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:21:9: 21:13
+      debug e => _1;                       // in scope 0 at $DIR/matches_u8.rs:+0:28: +0:29
+      let mut _0: i8;                      // return place in scope 0 at $DIR/matches_u8.rs:+0:37: +0:39
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:+2:9: +2:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:20:11: 20:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
+          _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+3:17: +3:18
       }
   
       bb2: {
-          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
+          _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:+2:17: +2:18
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/matches_u8.rs:24:2: 24:2
+          return;                          // scope 0 at $DIR/matches_u8.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/multiple_return_terminators.test.MultipleReturnTerminators.diff
+++ b/src/test/mir-opt/multiple_return_terminators.test.MultipleReturnTerminators.diff
@@ -2,11 +2,11 @@
 + // MIR for `test` after MultipleReturnTerminators
   
   fn test(_1: bool) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/multiple_return_terminators.rs:4:9: 4:10
-      let mut _0: ();                      // return place in scope 0 at $DIR/multiple_return_terminators.rs:4:18: 4:18
+      debug x => _1;                       // in scope 0 at $DIR/multiple_return_terminators.rs:+0:9: +0:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/multiple_return_terminators.rs:+0:18: +0:18
   
       bb0: {
-          return;                          // scope 0 at $DIR/multiple_return_terminators.rs:10:2: 10:2
+          return;                          // scope 0 at $DIR/multiple_return_terminators.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
+++ b/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
@@ -35,14 +35,14 @@
 | '_#9r: '_#3r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:66: 12:67) ($DIR/named-lifetimes-basic.rs:12:66: 12:67 (#0)
 |
 fn use_x(_1: &'_#6r mut i32, _2: &'_#7r u32, _3: &'_#8r u32, _4: &'_#9r u32) -> bool {
-    debug w => _1;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:26: 12:27
-    debug x => _2;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:42: 12:43
-    debug y => _3;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:54: 12:55
-    debug z => _4;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:66: 12:67
-    let mut _0: bool;                    // return place in scope 0 at $DIR/named-lifetimes-basic.rs:12:81: 12:85
+    debug w => _1;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:+0:26: +0:27
+    debug x => _2;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:+0:42: +0:43
+    debug y => _3;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:+0:54: +0:55
+    debug z => _4;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:+0:66: +0:67
+    let mut _0: bool;                    // return place in scope 0 at $DIR/named-lifetimes-basic.rs:+0:81: +0:85
 
     bb0: {
-        _0 = const ConstValue(Scalar(0x01): bool); // bb0[0]: scope 0 at $DIR/named-lifetimes-basic.rs:12:88: 12:92
-        return;                          // bb0[1]: scope 0 at $DIR/named-lifetimes-basic.rs:12:94: 12:94
+        _0 = const ConstValue(Scalar(0x01): bool); // bb0[0]: scope 0 at $DIR/named-lifetimes-basic.rs:+0:88: +0:92
+        return;                          // bb0[1]: scope 0 at $DIR/named-lifetimes-basic.rs:+0:94: +0:94
     }
 }

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -22,91 +22,91 @@
 | '_#4r: '_#5r due to Assignment at Single(bb1[3]) ($DIR/region-subtyping-basic.rs:19:13: 19:14 (#0)
 |
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:16:11: 16:11
-    let mut _1: [usize; Const { ty: usize, kind: Value(Leaf(0x00000003)) }]; // in scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-    let _3: usize;                       // in scope 0 at $DIR/region-subtyping-basic.rs:18:16: 18:17
-    let mut _4: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-    let mut _5: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-    let mut _7: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-    let _8: bool;                        // in scope 0 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-    let mut _9: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-    let _10: bool;                       // in scope 0 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+    let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:+0:11: +0:11
+    let mut _1: [usize; Const { ty: usize, kind: Value(Leaf(0x00000003)) }]; // in scope 0 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+    let _3: usize;                       // in scope 0 at $DIR/region-subtyping-basic.rs:+2:16: +2:17
+    let mut _4: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+    let mut _5: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+    let mut _7: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
+    let _8: bool;                        // in scope 0 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
+    let mut _9: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
+    let _10: bool;                       // in scope 0 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
     scope 1 {
-        debug v => _1;                   // in scope 1 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-        let _2: &'_#4r usize;            // in scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
+        debug v => _1;                   // in scope 1 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+        let _2: &'_#4r usize;            // in scope 1 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
         scope 2 {
-            debug p => _2;               // in scope 2 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-            let _6: &'_#5r usize;        // in scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+            debug p => _2;               // in scope 2 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
+            let _6: &'_#5r usize;        // in scope 2 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
             scope 3 {
-                debug q => _6;           // in scope 3 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+                debug q => _6;           // in scope 3 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-        _1 = [const ConstValue(Scalar(0x00000001): usize), const ConstValue(Scalar(0x00000002): usize), const ConstValue(Scalar(0x00000003): usize)]; // bb0[1]: scope 0 at $DIR/region-subtyping-basic.rs:17:17: 17:26
-        FakeRead(ForLet(None), _1);      // bb0[2]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-        StorageLive(_2);                 // bb0[3]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_3);                 // bb0[4]: scope 1 at $DIR/region-subtyping-basic.rs:18:16: 18:17
-        _3 = const ConstValue(Scalar(0x00000000): usize); // bb0[5]: scope 1 at $DIR/region-subtyping-basic.rs:18:16: 18:17
-        _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb7]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+        _1 = [const ConstValue(Scalar(0x00000001): usize), const ConstValue(Scalar(0x00000002): usize), const ConstValue(Scalar(0x00000003): usize)]; // bb0[1]: scope 0 at $DIR/region-subtyping-basic.rs:+1:17: +1:26
+        FakeRead(ForLet(None), _1);      // bb0[2]: scope 0 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+        StorageLive(_2);                 // bb0[3]: scope 1 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
+        StorageLive(_3);                 // bb0[4]: scope 1 at $DIR/region-subtyping-basic.rs:+2:16: +2:17
+        _3 = const ConstValue(Scalar(0x00000000): usize); // bb0[5]: scope 1 at $DIR/region-subtyping-basic.rs:+2:16: +2:17
+        _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+        _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb7]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
     }
 
     bb1: {
-        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
-        FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
-        FakeRead(ForLet(None), _6);      // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        _7 = const ConstValue(Scalar(0x01): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(move _7) -> [ConstValue(Scalar(0x00): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:+2:13: +2:18
+        FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
+        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
+        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:+3:13: +3:14
+        FakeRead(ForLet(None), _6);      // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
+        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
+        _7 = const ConstValue(Scalar(0x01): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
+        switchInt(move _7) -> [ConstValue(Scalar(0x00): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
     }
 
     bb2: {
-        StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-        StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
+        StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
+        _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
+        _8 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const ConstValue(ZeroSized: ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-        goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:+5:17: +5:18
+        StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:+5:18: +5:19
+        _0 = const ConstValue(ZeroSized: ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:+4:13: +6:6
+        goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:+4:5: +8:6
     }
 
     bb4: {
-        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x00000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
+        _10 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x00000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
     }
 
     bb5: {
-        StorageDead(_10);                // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
-        _0 = const ConstValue(ZeroSized: ()); // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
-        goto -> bb6;                     // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_10);                // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:+7:18: +7:19
+        _0 = const ConstValue(ZeroSized: ()); // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:+6:12: +8:6
+        goto -> bb6;                     // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:+4:5: +8:6
     }
 
     bb6: {
-        StorageDead(_7);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:24:5: 24:6
-        StorageDead(_6);                 // bb6[1]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_3);                 // bb6[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_2);                 // bb6[3]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_1);                 // bb6[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        return;                          // bb6[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+        StorageDead(_7);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:+8:5: +8:6
+        StorageDead(_6);                 // bb6[1]: scope 2 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        StorageDead(_3);                 // bb6[2]: scope 1 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        StorageDead(_2);                 // bb6[3]: scope 1 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        StorageDead(_1);                 // bb6[4]: scope 0 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        return;                          // bb6[5]: scope 0 at $DIR/region-subtyping-basic.rs:+9:2: +9:2
     }
 
     bb7 (cleanup): {
-        resume;                          // bb7[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
+        resume;                          // bb7[0]: scope 0 at $DIR/region-subtyping-basic.rs:+0:1: +9:2
     }
 }

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -22,91 +22,91 @@
 | '_#4r: '_#5r due to Assignment at Single(bb1[3]) ($DIR/region-subtyping-basic.rs:19:13: 19:14 (#0)
 |
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:16:11: 16:11
-    let mut _1: [usize; Const { ty: usize, kind: Value(Leaf(0x0000000000000003)) }]; // in scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-    let _3: usize;                       // in scope 0 at $DIR/region-subtyping-basic.rs:18:16: 18:17
-    let mut _4: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-    let mut _5: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-    let mut _7: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-    let _8: bool;                        // in scope 0 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-    let mut _9: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-    let _10: bool;                       // in scope 0 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+    let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:+0:11: +0:11
+    let mut _1: [usize; Const { ty: usize, kind: Value(Leaf(0x0000000000000003)) }]; // in scope 0 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+    let _3: usize;                       // in scope 0 at $DIR/region-subtyping-basic.rs:+2:16: +2:17
+    let mut _4: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+    let mut _5: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+    let mut _7: bool;                    // in scope 0 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
+    let _8: bool;                        // in scope 0 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
+    let mut _9: usize;                   // in scope 0 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
+    let _10: bool;                       // in scope 0 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
     scope 1 {
-        debug v => _1;                   // in scope 1 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-        let _2: &'_#4r usize;            // in scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
+        debug v => _1;                   // in scope 1 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+        let _2: &'_#4r usize;            // in scope 1 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
         scope 2 {
-            debug p => _2;               // in scope 2 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-            let _6: &'_#5r usize;        // in scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+            debug p => _2;               // in scope 2 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
+            let _6: &'_#5r usize;        // in scope 2 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
             scope 3 {
-                debug q => _6;           // in scope 3 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+                debug q => _6;           // in scope 3 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-        _1 = [const ConstValue(Scalar(0x0000000000000001): usize), const ConstValue(Scalar(0x0000000000000002): usize), const ConstValue(Scalar(0x0000000000000003): usize)]; // bb0[1]: scope 0 at $DIR/region-subtyping-basic.rs:17:17: 17:26
-        FakeRead(ForLet(None), _1);      // bb0[2]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-        StorageLive(_2);                 // bb0[3]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_3);                 // bb0[4]: scope 1 at $DIR/region-subtyping-basic.rs:18:16: 18:17
-        _3 = const ConstValue(Scalar(0x0000000000000000): usize); // bb0[5]: scope 1 at $DIR/region-subtyping-basic.rs:18:16: 18:17
-        _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb7]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+        _1 = [const ConstValue(Scalar(0x0000000000000001): usize), const ConstValue(Scalar(0x0000000000000002): usize), const ConstValue(Scalar(0x0000000000000003): usize)]; // bb0[1]: scope 0 at $DIR/region-subtyping-basic.rs:+1:17: +1:26
+        FakeRead(ForLet(None), _1);      // bb0[2]: scope 0 at $DIR/region-subtyping-basic.rs:+1:9: +1:14
+        StorageLive(_2);                 // bb0[3]: scope 1 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
+        StorageLive(_3);                 // bb0[4]: scope 1 at $DIR/region-subtyping-basic.rs:+2:16: +2:17
+        _3 = const ConstValue(Scalar(0x0000000000000000): usize); // bb0[5]: scope 1 at $DIR/region-subtyping-basic.rs:+2:16: +2:17
+        _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+        _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
+        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb7]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:+2:14: +2:18
     }
 
     bb1: {
-        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
-        FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
-        FakeRead(ForLet(None), _6);      // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        _7 = const ConstValue(Scalar(0x01): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(move _7) -> [ConstValue(Scalar(0x00): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:+2:13: +2:18
+        FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:+2:9: +2:10
+        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
+        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:+3:13: +3:14
+        FakeRead(ForLet(None), _6);      // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:+3:9: +3:10
+        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
+        _7 = const ConstValue(Scalar(0x01): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
+        switchInt(move _7) -> [ConstValue(Scalar(0x00): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:+4:8: +4:12
     }
 
     bb2: {
-        StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-        StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
+        StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
+        _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
+        _8 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const ConstValue(ZeroSized: ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-        goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:+5:17: +5:18
+        StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:+5:18: +5:19
+        _0 = const ConstValue(ZeroSized: ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:+4:13: +6:6
+        goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:+4:5: +8:6
     }
 
     bb4: {
-        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x0000000000000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
+        _10 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x0000000000000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
     }
 
     bb5: {
-        StorageDead(_10);                // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
-        _0 = const ConstValue(ZeroSized: ()); // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
-        goto -> bb6;                     // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_10);                // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:+7:18: +7:19
+        _0 = const ConstValue(ZeroSized: ()); // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:+6:12: +8:6
+        goto -> bb6;                     // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:+4:5: +8:6
     }
 
     bb6: {
-        StorageDead(_7);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:24:5: 24:6
-        StorageDead(_6);                 // bb6[1]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_3);                 // bb6[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_2);                 // bb6[3]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_1);                 // bb6[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        return;                          // bb6[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+        StorageDead(_7);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:+8:5: +8:6
+        StorageDead(_6);                 // bb6[1]: scope 2 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        StorageDead(_3);                 // bb6[2]: scope 1 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        StorageDead(_2);                 // bb6[3]: scope 1 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        StorageDead(_1);                 // bb6[4]: scope 0 at $DIR/region-subtyping-basic.rs:+9:1: +9:2
+        return;                          // bb6[5]: scope 0 at $DIR/region-subtyping-basic.rs:+9:2: +9:2
     }
 
     bb7 (cleanup): {
-        resume;                          // bb7[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
+        resume;                          // bb7[0]: scope 0 at $DIR/region-subtyping-basic.rs:+0:1: +9:2
     }
 }

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -1,21 +1,21 @@
 // MIR for `unwrap` after SimplifyCfg-elaborate-drops
 
 fn unwrap(_1: Option<T>) -> T {
-    debug opt => _1;                     // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:7:14: 7:17
-    let mut _0: T;                       // return place in scope 0 at $DIR/no-drop-for-inactive-variant.rs:7:33: 7:34
-    let mut _2: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
-    let _3: T;                           // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
+    debug opt => _1;                     // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:+0:14: +0:17
+    let mut _0: T;                       // return place in scope 0 at $DIR/no-drop-for-inactive-variant.rs:+0:33: +0:34
+    let mut _2: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:+2:9: +2:16
+    let _3: T;                           // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:+2:14: +2:15
     let mut _4: !;                       // in scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
-    let mut _5: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
-    let mut _6: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
-    let mut _7: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
+    let mut _5: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:+5:1: +5:2
+    let mut _6: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:+5:1: +5:2
+    let mut _7: isize;                   // in scope 0 at $DIR/no-drop-for-inactive-variant.rs:+5:1: +5:2
     scope 1 {
-        debug x => _3;                   // in scope 1 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
+        debug x => _3;                   // in scope 1 at $DIR/no-drop-for-inactive-variant.rs:+2:14: +2:15
     }
 
     bb0: {
-        _2 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:11: 8:14
-        switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:5: 8:14
+        _2 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+1:11: +1:14
+        switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+1:5: +1:14
     }
 
     bb1: {
@@ -30,20 +30,20 @@ fn unwrap(_1: Option<T>) -> T {
     }
 
     bb2: {
-        unreachable;                     // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:11: 8:14
+        unreachable;                     // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+1:11: +1:14
     }
 
     bb3: {
-        StorageLive(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
-        _3 = move ((_1 as Some).0: T);   // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
-        _0 = move _3;                    // scope 1 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
-        StorageDead(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
-        _5 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
-        return;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:2: 12:2
+        StorageLive(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+2:14: +2:15
+        _3 = move ((_1 as Some).0: T);   // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+2:14: +2:15
+        _0 = move _3;                    // scope 1 at $DIR/no-drop-for-inactive-variant.rs:+2:20: +2:21
+        StorageDead(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+2:20: +2:21
+        _5 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+5:2: +5:2
     }
 
     bb4 (cleanup): {
-        _7 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
-        resume;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:7:1: 12:2
+        _7 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+5:1: +5:2
+        resume;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:+0:1: +5:2
     }
 }

--- a/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
@@ -1,49 +1,49 @@
 // MIR for `main` before ElaborateDrops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/no-spurious-drop-after-call.rs:8:11: 8:11
-    let _1: ();                          // in scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
-    let mut _2: std::string::String;     // in scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
-    let mut _3: &str;                    // in scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
-    let _4: &str;                        // in scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
+    let mut _0: ();                      // return place in scope 0 at $DIR/no-spurious-drop-after-call.rs:+0:11: +0:11
+    let _1: ();                          // in scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:5: +1:35
+    let mut _2: std::string::String;     // in scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:34
+    let mut _3: &str;                    // in scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:34
+    let _4: &str;                        // in scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:22
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
-        StorageLive(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
-        StorageLive(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
-        StorageLive(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
-        _4 = const "";                   // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
+        StorageLive(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:5: +1:35
+        StorageLive(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:34
+        StorageLive(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:34
+        StorageLive(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:22
+        _4 = const "";                   // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:22
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        _3 = &(*_4);                     // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
-        _2 = <str as ToString>::to_string(move _3) -> bb1; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
+        _3 = &(*_4);                     // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:34
+        _2 = <str as ToString>::to_string(move _3) -> bb1; // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:34
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:23: 9:32
                                          // + literal: Const { ty: for<'r> fn(&'r str) -> String {<str as ToString>::to_string}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:33: 9:34
-        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
+        StorageDead(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:33: +1:34
+        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:5: +1:35
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:5: 9:19
                                          // + literal: Const { ty: fn(String) {std::mem::drop::<String>}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
-        StorageDead(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
-        StorageDead(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
-        _0 = const ();                   // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:11: 10:2
-        return;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:10:2: 10:2
+        StorageDead(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:34: +1:35
+        StorageDead(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:35: +1:36
+        StorageDead(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:35: +1:36
+        _0 = const ();                   // scope 0 at $DIR/no-spurious-drop-after-call.rs:+0:11: +2:2
+        return;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:+2:2: +2:2
     }
 
     bb3 (cleanup): {
-        drop(_2) -> bb4;                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
+        drop(_2) -> bb4;                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:34: +1:35
     }
 
     bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:1: 10:2
+        resume;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:+0:1: +2:2
     }
 }

--- a/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
+++ b/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
@@ -2,34 +2,34 @@
 + // MIR for `opt` after InstCombine
   
   fn opt(_1: bool) -> u32 {
-      debug x => _1;                       // in scope 0 at $DIR/not_equal_false.rs:3:8: 3:9
-      let mut _0: u32;                     // return place in scope 0 at $DIR/not_equal_false.rs:3:20: 3:23
-      let mut _2: bool;                    // in scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
-      let mut _3: bool;                    // in scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
+      debug x => _1;                       // in scope 0 at $DIR/not_equal_false.rs:+0:8: +0:9
+      let mut _0: u32;                     // return place in scope 0 at $DIR/not_equal_false.rs:+0:20: +0:23
+      let mut _2: bool;                    // in scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
+      let mut _3: bool;                    // in scope 0 at $DIR/not_equal_false.rs:+1:8: +1:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
-          StorageLive(_3);                 // scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
-          _3 = _1;                         // scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
--         _2 = Ne(move _3, const false);   // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
-+         _2 = move _3;                    // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
-          StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:4:17: 4:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
+          StorageLive(_2);                 // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
+          StorageLive(_3);                 // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:9
+          _3 = _1;                         // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:9
+-         _2 = Ne(move _3, const false);   // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
++         _2 = move _3;                    // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
+          StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:+1:17: +1:18
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
       }
   
       bb1: {
-          _0 = const 0_u32;                // scope 0 at $DIR/not_equal_false.rs:4:21: 4:22
-          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
+          _0 = const 0_u32;                // scope 0 at $DIR/not_equal_false.rs:+1:21: +1:22
+          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:+1:5: +1:35
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/not_equal_false.rs:4:32: 4:33
-          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
+          _0 = const 1_u32;                // scope 0 at $DIR/not_equal_false.rs:+1:32: +1:33
+          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:+1:5: +1:35
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:34: 4:35
-          return;                          // scope 0 at $DIR/not_equal_false.rs:5:2: 5:2
+          StorageDead(_2);                 // scope 0 at $DIR/not_equal_false.rs:+1:34: +1:35
+          return;                          // scope 0 at $DIR/not_equal_false.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
+++ b/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
@@ -2,42 +2,42 @@
 + // MIR for `nrvo` after RenameReturnPlace
   
   fn nrvo(_1: for<'r> fn(&'r mut [u8; 1024])) -> [u8; 1024] {
-      debug init => _1;                    // in scope 0 at $DIR/nrvo-simple.rs:4:9: 4:13
--     let mut _0: [u8; 1024];              // return place in scope 0 at $DIR/nrvo-simple.rs:4:39: 4:49
-+     let mut _0: [u8; 1024];              // return place in scope 0 at $DIR/nrvo-simple.rs:5:9: 5:16
-      let mut _2: [u8; 1024];              // in scope 0 at $DIR/nrvo-simple.rs:5:9: 5:16
-      let _3: ();                          // in scope 0 at $DIR/nrvo-simple.rs:6:5: 6:19
-      let mut _4: for<'r> fn(&'r mut [u8; 1024]); // in scope 0 at $DIR/nrvo-simple.rs:6:5: 6:9
-      let mut _5: &mut [u8; 1024];         // in scope 0 at $DIR/nrvo-simple.rs:6:10: 6:18
-      let mut _6: &mut [u8; 1024];         // in scope 0 at $DIR/nrvo-simple.rs:6:10: 6:18
+      debug init => _1;                    // in scope 0 at $DIR/nrvo-simple.rs:+0:9: +0:13
+-     let mut _0: [u8; 1024];              // return place in scope 0 at $DIR/nrvo-simple.rs:+0:39: +0:49
++     let mut _0: [u8; 1024];              // return place in scope 0 at $DIR/nrvo-simple.rs:+1:9: +1:16
+      let mut _2: [u8; 1024];              // in scope 0 at $DIR/nrvo-simple.rs:+1:9: +1:16
+      let _3: ();                          // in scope 0 at $DIR/nrvo-simple.rs:+2:5: +2:19
+      let mut _4: for<'r> fn(&'r mut [u8; 1024]); // in scope 0 at $DIR/nrvo-simple.rs:+2:5: +2:9
+      let mut _5: &mut [u8; 1024];         // in scope 0 at $DIR/nrvo-simple.rs:+2:10: +2:18
+      let mut _6: &mut [u8; 1024];         // in scope 0 at $DIR/nrvo-simple.rs:+2:10: +2:18
       scope 1 {
--         debug buf => _2;                 // in scope 1 at $DIR/nrvo-simple.rs:5:9: 5:16
-+         debug buf => _0;                 // in scope 1 at $DIR/nrvo-simple.rs:5:9: 5:16
+-         debug buf => _2;                 // in scope 1 at $DIR/nrvo-simple.rs:+1:9: +1:16
++         debug buf => _0;                 // in scope 1 at $DIR/nrvo-simple.rs:+1:9: +1:16
       }
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $DIR/nrvo-simple.rs:5:9: 5:16
--         _2 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:5:19: 5:28
-+         _0 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:5:19: 5:28
-          StorageLive(_3);                 // scope 1 at $DIR/nrvo-simple.rs:6:5: 6:19
-          StorageLive(_4);                 // scope 1 at $DIR/nrvo-simple.rs:6:5: 6:9
-          _4 = _1;                         // scope 1 at $DIR/nrvo-simple.rs:6:5: 6:9
-          StorageLive(_5);                 // scope 1 at $DIR/nrvo-simple.rs:6:10: 6:18
-          StorageLive(_6);                 // scope 1 at $DIR/nrvo-simple.rs:6:10: 6:18
--         _6 = &mut _2;                    // scope 1 at $DIR/nrvo-simple.rs:6:10: 6:18
-+         _6 = &mut _0;                    // scope 1 at $DIR/nrvo-simple.rs:6:10: 6:18
-          _5 = &mut (*_6);                 // scope 1 at $DIR/nrvo-simple.rs:6:10: 6:18
-          _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/nrvo-simple.rs:6:5: 6:19
+-         StorageLive(_2);                 // scope 0 at $DIR/nrvo-simple.rs:+1:9: +1:16
+-         _2 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:+1:19: +1:28
++         _0 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:+1:19: +1:28
+          StorageLive(_3);                 // scope 1 at $DIR/nrvo-simple.rs:+2:5: +2:19
+          StorageLive(_4);                 // scope 1 at $DIR/nrvo-simple.rs:+2:5: +2:9
+          _4 = _1;                         // scope 1 at $DIR/nrvo-simple.rs:+2:5: +2:9
+          StorageLive(_5);                 // scope 1 at $DIR/nrvo-simple.rs:+2:10: +2:18
+          StorageLive(_6);                 // scope 1 at $DIR/nrvo-simple.rs:+2:10: +2:18
+-         _6 = &mut _2;                    // scope 1 at $DIR/nrvo-simple.rs:+2:10: +2:18
++         _6 = &mut _0;                    // scope 1 at $DIR/nrvo-simple.rs:+2:10: +2:18
+          _5 = &mut (*_6);                 // scope 1 at $DIR/nrvo-simple.rs:+2:10: +2:18
+          _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/nrvo-simple.rs:+2:5: +2:19
       }
   
       bb1: {
-          StorageDead(_5);                 // scope 1 at $DIR/nrvo-simple.rs:6:18: 6:19
-          StorageDead(_4);                 // scope 1 at $DIR/nrvo-simple.rs:6:18: 6:19
-          StorageDead(_6);                 // scope 1 at $DIR/nrvo-simple.rs:6:19: 6:20
-          StorageDead(_3);                 // scope 1 at $DIR/nrvo-simple.rs:6:19: 6:20
--         _0 = _2;                         // scope 1 at $DIR/nrvo-simple.rs:7:5: 7:8
--         StorageDead(_2);                 // scope 0 at $DIR/nrvo-simple.rs:8:1: 8:2
-          return;                          // scope 0 at $DIR/nrvo-simple.rs:8:2: 8:2
+          StorageDead(_5);                 // scope 1 at $DIR/nrvo-simple.rs:+2:18: +2:19
+          StorageDead(_4);                 // scope 1 at $DIR/nrvo-simple.rs:+2:18: +2:19
+          StorageDead(_6);                 // scope 1 at $DIR/nrvo-simple.rs:+2:19: +2:20
+          StorageDead(_3);                 // scope 1 at $DIR/nrvo-simple.rs:+2:19: +2:20
+-         _0 = _2;                         // scope 1 at $DIR/nrvo-simple.rs:+3:5: +3:8
+-         StorageDead(_2);                 // scope 0 at $DIR/nrvo-simple.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/nrvo-simple.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
@@ -1,55 +1,55 @@
 // MIR for `main` after SimplifyCfg-elaborate-drops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 5:11
-    let mut _1: Packed;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
-    let mut _2: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
-    let mut _3: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-    let mut _4: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
-    let mut _5: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-    let mut _6: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/packed-struct-drop-aligned.rs:+0:11: +0:11
+    let mut _1: Packed;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:9: +1:14
+    let mut _2: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:24: +1:42
+    let mut _3: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:32: +1:41
+    let mut _4: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+2:11: +2:29
+    let mut _5: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+2:19: +2:28
+    let mut _6: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
+        debug x => _1;                   // in scope 1 at $DIR/packed-struct-drop-aligned.rs:+1:9: +1:14
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
-        StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
-        StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _2 = Aligned(move _3);           // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
-        StorageDead(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:41: 6:42
-        _1 = Packed(move _2);            // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
-        StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
-        StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
-        StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _4 = Aligned(move _5);           // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
-        StorageDead(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
-        StorageLive(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
+        StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:9: +1:14
+        StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:24: +1:42
+        StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:32: +1:41
+        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:32: +1:41
+        _2 = Aligned(move _3);           // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:24: +1:42
+        StorageDead(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:41: +1:42
+        _1 = Packed(move _2);            // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:17: +1:43
+        StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:42: +1:43
+        StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:11: +2:29
+        StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:19: +2:28
+        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:19: +2:28
+        _4 = Aligned(move _5);           // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:11: +2:29
+        StorageDead(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:28: +2:29
+        StorageLive(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
-        return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
+        StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:2: +3:2
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
+        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:+0:1: +3:2
     }
 
     bb3 (cleanup): {
-        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:1: +3:2
     }
 
     bb4: {
-        StorageDead(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
-        _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        StorageDead(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:28: +2:29
+        _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:+0:11: +3:2
+        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:1: +3:2
     }
 }

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -1,55 +1,55 @@
 // MIR for `main` after SimplifyCfg-elaborate-drops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 5:11
-    let mut _1: Packed;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
-    let mut _2: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
-    let mut _3: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-    let mut _4: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
-    let mut _5: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-    let mut _6: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
+    let mut _0: ();                      // return place in scope 0 at $DIR/packed-struct-drop-aligned.rs:+0:11: +0:11
+    let mut _1: Packed;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:9: +1:14
+    let mut _2: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:24: +1:42
+    let mut _3: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:32: +1:41
+    let mut _4: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+2:11: +2:29
+    let mut _5: Droppy;                  // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+2:19: +2:28
+    let mut _6: Aligned;                 // in scope 0 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
+        debug x => _1;                   // in scope 1 at $DIR/packed-struct-drop-aligned.rs:+1:9: +1:14
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
-        StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
-        StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _2 = Aligned(move _3);           // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
-        StorageDead(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:41: 6:42
-        _1 = Packed(move _2);            // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
-        StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
-        StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
-        StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _4 = Aligned(move _5);           // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
-        StorageDead(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
-        StorageLive(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
+        StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:9: +1:14
+        StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:24: +1:42
+        StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:32: +1:41
+        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:32: +1:41
+        _2 = Aligned(move _3);           // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:24: +1:42
+        StorageDead(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:41: +1:42
+        _1 = Packed(move _2);            // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:17: +1:43
+        StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+1:42: +1:43
+        StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:11: +2:29
+        StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:19: +2:28
+        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:19: +2:28
+        _4 = Aligned(move _5);           // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:11: +2:29
+        StorageDead(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:28: +2:29
+        StorageLive(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
     }
 
     bb1: {
-        StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
-        return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
+        StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:2: +3:2
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
+        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:+0:1: +3:2
     }
 
     bb3 (cleanup): {
-        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:1: +3:2
     }
 
     bb4: {
-        StorageDead(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
-        _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        StorageDead(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:5: +2:8
+        StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:+2:28: +2:29
+        _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:+0:11: +3:2
+        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:+3:1: +3:2
     }
 }

--- a/src/test/mir-opt/receiver_ptr_mutability.main.mir_map.0.mir
+++ b/src/test/mir-opt/receiver_ptr_mutability.main.mir_map.0.mir
@@ -7,90 +7,90 @@
 | 3: user_ty: Canonical { max_universe: U0, variables: [CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }], value: Ty(&&&&*mut Test) }, span: $DIR/receiver-ptr-mutability.rs:18:18: 18:31, inferred_ty: &&&&*mut Test
 |
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/receiver-ptr-mutability.rs:13:11: 13:11
-    let _1: *mut Test as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 0 at $DIR/receiver-ptr-mutability.rs:14:9: 14:12
-    let _2: ();                          // in scope 0 at $DIR/receiver-ptr-mutability.rs:15:5: 15:12
-    let mut _3: *const Test;             // in scope 0 at $DIR/receiver-ptr-mutability.rs:15:5: 15:12
-    let mut _4: *mut Test;               // in scope 0 at $DIR/receiver-ptr-mutability.rs:15:5: 15:8
-    let _6: &&&&*mut Test;               // in scope 0 at $DIR/receiver-ptr-mutability.rs:18:34: 18:41
-    let _7: &&&*mut Test;                // in scope 0 at $DIR/receiver-ptr-mutability.rs:18:35: 18:41
-    let _8: &&*mut Test;                 // in scope 0 at $DIR/receiver-ptr-mutability.rs:18:36: 18:41
-    let _9: &*mut Test;                  // in scope 0 at $DIR/receiver-ptr-mutability.rs:18:37: 18:41
-    let _10: ();                         // in scope 0 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
-    let mut _11: *const Test;            // in scope 0 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
-    let mut _12: *mut Test;              // in scope 0 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
+    let mut _0: ();                      // return place in scope 0 at $DIR/receiver-ptr-mutability.rs:+0:11: +0:11
+    let _1: *mut Test as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 0 at $DIR/receiver-ptr-mutability.rs:+1:9: +1:12
+    let _2: ();                          // in scope 0 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:12
+    let mut _3: *const Test;             // in scope 0 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:12
+    let mut _4: *mut Test;               // in scope 0 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:8
+    let _6: &&&&*mut Test;               // in scope 0 at $DIR/receiver-ptr-mutability.rs:+5:34: +5:41
+    let _7: &&&*mut Test;                // in scope 0 at $DIR/receiver-ptr-mutability.rs:+5:35: +5:41
+    let _8: &&*mut Test;                 // in scope 0 at $DIR/receiver-ptr-mutability.rs:+5:36: +5:41
+    let _9: &*mut Test;                  // in scope 0 at $DIR/receiver-ptr-mutability.rs:+5:37: +5:41
+    let _10: ();                         // in scope 0 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
+    let mut _11: *const Test;            // in scope 0 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
+    let mut _12: *mut Test;              // in scope 0 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
     scope 1 {
-        debug ptr => _1;                 // in scope 1 at $DIR/receiver-ptr-mutability.rs:14:9: 14:12
-        let _5: &&&&*mut Test as UserTypeProjection { base: UserType(2), projs: [] }; // in scope 1 at $DIR/receiver-ptr-mutability.rs:18:9: 18:16
+        debug ptr => _1;                 // in scope 1 at $DIR/receiver-ptr-mutability.rs:+1:9: +1:12
+        let _5: &&&&*mut Test as UserTypeProjection { base: UserType(2), projs: [] }; // in scope 1 at $DIR/receiver-ptr-mutability.rs:+5:9: +5:16
         scope 2 {
-            debug ptr_ref => _5;         // in scope 2 at $DIR/receiver-ptr-mutability.rs:18:9: 18:16
+            debug ptr_ref => _5;         // in scope 2 at $DIR/receiver-ptr-mutability.rs:+5:9: +5:16
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/receiver-ptr-mutability.rs:14:9: 14:12
-        _1 = null_mut::<Test>() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/receiver-ptr-mutability.rs:14:26: 14:46
+        StorageLive(_1);                 // scope 0 at $DIR/receiver-ptr-mutability.rs:+1:9: +1:12
+        _1 = null_mut::<Test>() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/receiver-ptr-mutability.rs:+1:26: +1:46
                                          // mir::Constant
                                          // + span: $DIR/receiver-ptr-mutability.rs:14:26: 14:44
                                          // + literal: Const { ty: fn() -> *mut Test {null_mut::<Test>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/receiver-ptr-mutability.rs:14:9: 14:12
-        AscribeUserType(_1, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/receiver-ptr-mutability.rs:14:14: 14:23
-        StorageLive(_2);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:5: 15:12
-        StorageLive(_3);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:5: 15:12
-        StorageLive(_4);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:5: 15:8
-        _4 = _1;                         // scope 1 at $DIR/receiver-ptr-mutability.rs:15:5: 15:8
-        _3 = move _4 as *const Test (Pointer(MutToConstPointer)); // scope 1 at $DIR/receiver-ptr-mutability.rs:15:5: 15:12
-        StorageDead(_4);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:7: 15:8
-        _2 = Test::x(move _3) -> [return: bb2, unwind: bb4]; // scope 1 at $DIR/receiver-ptr-mutability.rs:15:5: 15:12
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/receiver-ptr-mutability.rs:+1:9: +1:12
+        AscribeUserType(_1, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/receiver-ptr-mutability.rs:+1:14: +1:23
+        StorageLive(_2);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:12
+        StorageLive(_3);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:12
+        StorageLive(_4);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:8
+        _4 = _1;                         // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:8
+        _3 = move _4 as *const Test (Pointer(MutToConstPointer)); // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:12
+        StorageDead(_4);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:7: +2:8
+        _2 = Test::x(move _3) -> [return: bb2, unwind: bb4]; // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:12
                                          // mir::Constant
                                          // + span: $DIR/receiver-ptr-mutability.rs:15:9: 15:10
                                          // + literal: Const { ty: fn(*const Test) {Test::x}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:11: 15:12
-        StorageDead(_2);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:12: 15:13
-        StorageLive(_5);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:18:9: 18:16
-        StorageLive(_6);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:18:34: 18:41
-        StorageLive(_7);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:18:35: 18:41
-        StorageLive(_8);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:18:36: 18:41
-        StorageLive(_9);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:18:37: 18:41
-        _9 = &_1;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:18:37: 18:41
-        _8 = &_9;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:18:36: 18:41
-        _7 = &_8;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:18:35: 18:41
-        _6 = &_7;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:18:34: 18:41
-        _5 = &(*_6);                     // scope 1 at $DIR/receiver-ptr-mutability.rs:18:34: 18:41
-        FakeRead(ForLet(None), _5);      // scope 1 at $DIR/receiver-ptr-mutability.rs:18:9: 18:16
-        AscribeUserType(_5, o, UserTypeProjection { base: UserType(3), projs: [] }); // scope 1 at $DIR/receiver-ptr-mutability.rs:18:18: 18:31
-        StorageDead(_6);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:18:41: 18:42
-        StorageLive(_10);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
-        StorageLive(_11);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
-        StorageLive(_12);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
-        _12 = (*(*(*(*_5))));            // scope 2 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
-        _11 = move _12 as *const Test (Pointer(MutToConstPointer)); // scope 2 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
-        StorageDead(_12);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:11: 19:12
-        _10 = Test::x(move _11) -> [return: bb3, unwind: bb4]; // scope 2 at $DIR/receiver-ptr-mutability.rs:19:5: 19:16
+        StorageDead(_3);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:11: +2:12
+        StorageDead(_2);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:12: +2:13
+        StorageLive(_5);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:9: +5:16
+        StorageLive(_6);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:34: +5:41
+        StorageLive(_7);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:35: +5:41
+        StorageLive(_8);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:36: +5:41
+        StorageLive(_9);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:37: +5:41
+        _9 = &_1;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:37: +5:41
+        _8 = &_9;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:36: +5:41
+        _7 = &_8;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:35: +5:41
+        _6 = &_7;                        // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:34: +5:41
+        _5 = &(*_6);                     // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:34: +5:41
+        FakeRead(ForLet(None), _5);      // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:9: +5:16
+        AscribeUserType(_5, o, UserTypeProjection { base: UserType(3), projs: [] }); // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:18: +5:31
+        StorageDead(_6);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+5:41: +5:42
+        StorageLive(_10);                // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
+        StorageLive(_11);                // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
+        StorageLive(_12);                // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
+        _12 = (*(*(*(*_5))));            // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
+        _11 = move _12 as *const Test (Pointer(MutToConstPointer)); // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
+        StorageDead(_12);                // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:11: +6:12
+        _10 = Test::x(move _11) -> [return: bb3, unwind: bb4]; // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
                                          // mir::Constant
                                          // + span: $DIR/receiver-ptr-mutability.rs:19:13: 19:14
                                          // + literal: Const { ty: fn(*const Test) {Test::x}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_11);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:15: 19:16
-        StorageDead(_10);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:16: 19:17
-        _0 = const ();                   // scope 0 at $DIR/receiver-ptr-mutability.rs:13:11: 20:2
-        StorageDead(_9);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:20:1: 20:2
-        StorageDead(_8);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:20:1: 20:2
-        StorageDead(_7);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:20:1: 20:2
-        StorageDead(_5);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:20:1: 20:2
-        StorageDead(_1);                 // scope 0 at $DIR/receiver-ptr-mutability.rs:20:1: 20:2
-        return;                          // scope 0 at $DIR/receiver-ptr-mutability.rs:20:2: 20:2
+        StorageDead(_11);                // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:15: +6:16
+        StorageDead(_10);                // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:16: +6:17
+        _0 = const ();                   // scope 0 at $DIR/receiver-ptr-mutability.rs:+0:11: +7:2
+        StorageDead(_9);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+7:1: +7:2
+        StorageDead(_8);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+7:1: +7:2
+        StorageDead(_7);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+7:1: +7:2
+        StorageDead(_5);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:+7:1: +7:2
+        StorageDead(_1);                 // scope 0 at $DIR/receiver-ptr-mutability.rs:+7:1: +7:2
+        return;                          // scope 0 at $DIR/receiver-ptr-mutability.rs:+7:2: +7:2
     }
 
     bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/receiver-ptr-mutability.rs:13:1: 20:2
+        resume;                          // scope 0 at $DIR/receiver-ptr-mutability.rs:+0:1: +7:2
     }
 }

--- a/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
@@ -2,75 +2,75 @@
 + // MIR for `match_guard` after CleanupNonCodegenStatements
   
   fn match_guard(_1: Option<&&i32>, _2: bool) -> i32 {
-      debug x => _1;                       // in scope 0 at $DIR/remove_fake_borrows.rs:6:16: 6:17
-      debug c => _2;                       // in scope 0 at $DIR/remove_fake_borrows.rs:6:34: 6:35
-      let mut _0: i32;                     // return place in scope 0 at $DIR/remove_fake_borrows.rs:6:46: 6:49
-      let mut _3: isize;                   // in scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
-      let mut _4: &std::option::Option<&&i32>; // in scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-      let mut _5: &&i32;                   // in scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-      let mut _6: &&&i32;                  // in scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-      let mut _7: &i32;                    // in scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-      let mut _8: bool;                    // in scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
+      debug x => _1;                       // in scope 0 at $DIR/remove_fake_borrows.rs:+0:16: +0:17
+      debug c => _2;                       // in scope 0 at $DIR/remove_fake_borrows.rs:+0:34: +0:35
+      let mut _0: i32;                     // return place in scope 0 at $DIR/remove_fake_borrows.rs:+0:46: +0:49
+      let mut _3: isize;                   // in scope 0 at $DIR/remove_fake_borrows.rs:+2:9: +2:16
+      let mut _4: &std::option::Option<&&i32>; // in scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+      let mut _5: &&i32;                   // in scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+      let mut _6: &&&i32;                  // in scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+      let mut _7: &i32;                    // in scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+      let mut _8: bool;                    // in scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
   
       bb0: {
--         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-          _3 = discriminant(_1);           // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-          switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 7:12
+-         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+          _3 = discriminant(_1);           // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+          switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 1_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
-          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
+          _0 = const 1_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:+3:14: +3:15
+          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:+3:14: +3:15
       }
   
       bb2: {
-          switchInt((*(*((_1 as Some).0: &&i32)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 7:12
+          switchInt((*(*((_1 as Some).0: &&i32)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:+1:5: +1:12
       }
   
       bb3: {
-          goto -> bb4;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
+          goto -> bb4;                     // scope 0 at $DIR/remove_fake_borrows.rs:+2:9: +2:16
       }
   
       bb4: {
--         _4 = &shallow _1;                // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
--         _5 = &shallow (*((_1 as Some).0: &&i32)); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
--         _6 = &shallow ((_1 as Some).0: &&i32); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
--         _7 = &shallow (*(*((_1 as Some).0: &&i32))); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-          StorageLive(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-          _8 = _2;                         // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-          switchInt(move _8) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
+-         _4 = &shallow _1;                // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+-         _5 = &shallow (*((_1 as Some).0: &&i32)); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+-         _6 = &shallow ((_1 as Some).0: &&i32); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+-         _7 = &shallow (*(*((_1 as Some).0: &&i32))); // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+1:11: +1:12
+          StorageLive(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+          _8 = _2;                         // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+          switchInt(move _8) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
       }
   
       bb5: {
-          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
--         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
--         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
--         FakeRead(ForMatchGuard, _6);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
--         FakeRead(ForMatchGuard, _7);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-+         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-          _0 = const 0_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
-          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
+          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+-         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+-         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+-         FakeRead(ForMatchGuard, _6);     // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+-         FakeRead(ForMatchGuard, _7);     // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
++         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+          _0 = const 0_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:+2:25: +2:26
+          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:+2:25: +2:26
       }
   
       bb6: {
-          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-          goto -> bb1;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
+          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
+          goto -> bb1;                     // scope 0 at $DIR/remove_fake_borrows.rs:+2:20: +2:21
       }
   
       bb7: {
-          return;                          // scope 0 at $DIR/remove_fake_borrows.rs:11:2: 11:2
+          return;                          // scope 0 at $DIR/remove_fake_borrows.rs:+5:2: +5:2
       }
   
       bb8 (cleanup): {
-          resume;                          // scope 0 at $DIR/remove_fake_borrows.rs:6:1: 11:2
+          resume;                          // scope 0 at $DIR/remove_fake_borrows.rs:+0:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/remove_never_const.no_codegen.PreCodegen.after.mir
+++ b/src/test/mir-opt/remove_never_const.no_codegen.PreCodegen.after.mir
@@ -1,11 +1,11 @@
 // MIR for `no_codegen` after PreCodegen
 
 fn no_codegen() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/remove-never-const.rs:18:20: 18:20
+    let mut _0: ();                      // return place in scope 0 at $DIR/remove-never-const.rs:+0:20: +0:20
     scope 1 {
     }
 
     bb0: {
-        unreachable;                     // scope 0 at $DIR/remove-never-const.rs:19:13: 19:33
+        unreachable;                     // scope 0 at $DIR/remove-never-const.rs:+1:13: +1:33
     }
 }

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -2,26 +2,26 @@
 + // MIR for `main` after RemoveStorageMarkers
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/remove_storage_markers.rs:6:11: 6:11
-      let mut _1: i32;                     // in scope 0 at $DIR/remove_storage_markers.rs:7:9: 7:16
-      let mut _2: std::ops::Range<i32>;    // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _3: std::ops::Range<i32>;    // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _5: ();                      // in scope 0 at $DIR/remove_storage_markers.rs:6:1: 11:2
-      let _6: ();                          // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _7: std::option::Option<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _8: &mut std::ops::Range<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _9: &mut std::ops::Range<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _10: isize;                  // in scope 0 at $DIR/remove_storage_markers.rs:8:5: 10:6
-      let mut _11: !;                      // in scope 0 at $DIR/remove_storage_markers.rs:8:5: 10:6
-      let mut _13: i32;                    // in scope 0 at $DIR/remove_storage_markers.rs:9:16: 9:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_storage_markers.rs:+0:11: +0:11
+      let mut _1: i32;                     // in scope 0 at $DIR/remove_storage_markers.rs:+1:9: +1:16
+      let mut _2: std::ops::Range<i32>;    // in scope 0 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+      let mut _3: std::ops::Range<i32>;    // in scope 0 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+      let mut _5: ();                      // in scope 0 at $DIR/remove_storage_markers.rs:+0:1: +5:2
+      let _6: ();                          // in scope 0 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+      let mut _7: std::option::Option<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+      let mut _8: &mut std::ops::Range<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+      let mut _9: &mut std::ops::Range<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+      let mut _10: isize;                  // in scope 0 at $DIR/remove_storage_markers.rs:+2:5: +4:6
+      let mut _11: !;                      // in scope 0 at $DIR/remove_storage_markers.rs:+2:5: +4:6
+      let mut _13: i32;                    // in scope 0 at $DIR/remove_storage_markers.rs:+3:16: +3:17
       scope 1 {
-          debug sum => _1;                 // in scope 1 at $DIR/remove_storage_markers.rs:7:9: 7:16
-          let mut _4: std::ops::Range<i32>; // in scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
+          debug sum => _1;                 // in scope 1 at $DIR/remove_storage_markers.rs:+1:9: +1:16
+          let mut _4: std::ops::Range<i32>; // in scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           scope 2 {
-              debug iter => _4;            // in scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
-              let _12: i32;                // in scope 2 at $DIR/remove_storage_markers.rs:8:9: 8:10
+              debug iter => _4;            // in scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+              let _12: i32;                // in scope 2 at $DIR/remove_storage_markers.rs:+2:9: +2:10
               scope 3 {
-                  debug i => _12;          // in scope 3 at $DIR/remove_storage_markers.rs:8:9: 8:10
+                  debug i => _12;          // in scope 3 at $DIR/remove_storage_markers.rs:+2:9: +2:10
               }
               scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<i32>>::next) { // at $DIR/remove_storage_markers.rs:8:14: 8:19
                   debug self => _8;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
@@ -34,27 +34,27 @@
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/remove_storage_markers.rs:7:9: 7:16
-          _1 = const 0_i32;                // scope 0 at $DIR/remove_storage_markers.rs:7:19: 7:20
--         StorageLive(_2);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
--         StorageLive(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          Deinit(_3);                      // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          (_3.0: i32) = const 0_i32;       // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          (_3.1: i32) = const 10_i32;      // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
+-         StorageLive(_1);                 // scope 0 at $DIR/remove_storage_markers.rs:+1:9: +1:16
+          _1 = const 0_i32;                // scope 0 at $DIR/remove_storage_markers.rs:+1:19: +1:20
+-         StorageLive(_2);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+-         StorageLive(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          Deinit(_3);                      // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          (_3.0: i32) = const 0_i32;       // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          (_3.1: i32) = const 10_i32;      // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           _2 = move _3;                    // scope 4 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
--         StorageDead(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:8:18: 8:19
--         StorageLive(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          _4 = move _2;                    // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          goto -> bb1;                     // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
+-         StorageDead(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:18: +2:19
+-         StorageLive(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          _4 = move _2;                    // scope 1 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          goto -> bb1;                     // scope 2 at $DIR/remove_storage_markers.rs:+2:5: +4:6
       }
   
       bb1: {
--         StorageLive(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
--         StorageLive(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
--         StorageLive(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
--         StorageLive(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          _9 = &mut _4;                    // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          _8 = &mut (*_9);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
+-         StorageLive(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+-         StorageLive(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+-         StorageLive(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+-         StorageLive(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          _9 = &mut _4;                    // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          _8 = &mut (*_9);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
 -         StorageLive(_14);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
           _14 = &mut (*_8);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
           _7 = <std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next(move _14) -> bb4; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
@@ -64,41 +64,41 @@
       }
   
       bb2: {
--         StorageLive(_12);                // scope 2 at $DIR/remove_storage_markers.rs:8:9: 8:10
-          _12 = ((_7 as Some).0: i32);     // scope 2 at $DIR/remove_storage_markers.rs:8:9: 8:10
--         StorageLive(_13);                // scope 3 at $DIR/remove_storage_markers.rs:9:16: 9:17
-          _13 = _12;                       // scope 3 at $DIR/remove_storage_markers.rs:9:16: 9:17
-          _1 = Add(_1, move _13);          // scope 3 at $DIR/remove_storage_markers.rs:9:9: 9:17
--         StorageDead(_13);                // scope 3 at $DIR/remove_storage_markers.rs:9:16: 9:17
-          _6 = const ();                   // scope 3 at $DIR/remove_storage_markers.rs:8:20: 10:6
--         StorageDead(_12);                // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
-          _5 = const ();                   // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
-          goto -> bb1;                     // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
+-         StorageLive(_12);                // scope 2 at $DIR/remove_storage_markers.rs:+2:9: +2:10
+          _12 = ((_7 as Some).0: i32);     // scope 2 at $DIR/remove_storage_markers.rs:+2:9: +2:10
+-         StorageLive(_13);                // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
+          _13 = _12;                       // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
+          _1 = Add(_1, move _13);          // scope 3 at $DIR/remove_storage_markers.rs:+3:9: +3:17
+-         StorageDead(_13);                // scope 3 at $DIR/remove_storage_markers.rs:+3:16: +3:17
+          _6 = const ();                   // scope 3 at $DIR/remove_storage_markers.rs:+2:20: +4:6
+-         StorageDead(_12);                // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+          _5 = const ();                   // scope 2 at $DIR/remove_storage_markers.rs:+2:5: +4:6
+          goto -> bb1;                     // scope 2 at $DIR/remove_storage_markers.rs:+2:5: +4:6
       }
   
       bb3: {
-          _0 = const ();                   // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
--         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_2);                 // scope 1 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_1);                 // scope 0 at $DIR/remove_storage_markers.rs:11:1: 11:2
-          return;                          // scope 0 at $DIR/remove_storage_markers.rs:11:2: 11:2
+          _0 = const ();                   // scope 2 at $DIR/remove_storage_markers.rs:+2:5: +4:6
+-         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_2);                 // scope 1 at $DIR/remove_storage_markers.rs:+4:5: +4:6
+-         StorageDead(_1);                 // scope 0 at $DIR/remove_storage_markers.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/remove_storage_markers.rs:+5:2: +5:2
       }
   
       bb4: {
 -         StorageDead(_14);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
--         StorageDead(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:8:18: 8:19
-          _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          switchInt(move _10) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
+-         StorageDead(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:+2:18: +2:19
+          _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
+          switchInt(move _10) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
       }
   
       bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/remove_storage_markers.rs:6:1: 11:2
+          resume;                          // scope 0 at $DIR/remove_storage_markers.rs:+0:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
@@ -2,30 +2,30 @@
 + // MIR for `cannot_opt_generic` after RemoveUnneededDrops
   
   fn cannot_opt_generic(_1: T) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:20:26: 20:27
-      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:20:32: 20:32
-      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
-      let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:+0:26: +0:27
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:+0:32: +0:32
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+      let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
       scope 1 (inlined std::mem::drop::<T>) { // at $DIR/remove_unneeded_drops.rs:21:5: 21:12
           debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
-          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
-          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
+          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:20:1: 22:2
+          resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+0:1: +2:2
       }
   
       bb2: {
-          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:11: 21:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:12: 21:13
-          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:20:32: 22:2
-          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:22:2: 22:2
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:32: +2:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
@@ -2,30 +2,30 @@
 + // MIR for `dont_opt` after RemoveUnneededDrops
   
   fn dont_opt(_1: Vec<bool>) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:8:13: 8:14
-      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:8:27: 8:27
-      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
-      let mut _3: std::vec::Vec<bool>;     // in scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:+0:13: +0:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:+0:27: +0:27
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+      let mut _3: std::vec::Vec<bool>;     // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
       scope 1 (inlined std::mem::drop::<Vec<bool>>) { // at $DIR/remove_unneeded_drops.rs:9:5: 9:12
           debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
-          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
-          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
+          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:8:1: 10:2
+          resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+0:1: +2:2
       }
   
       bb2: {
-          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:11: 9:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:12: 9:13
-          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:8:27: 10:2
-          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:10:2: 10:2
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+          nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:27: +2:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
       }
   }
   

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -2,30 +2,30 @@
 + // MIR for `opt` after RemoveUnneededDrops
   
   fn opt(_1: bool) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:3:8: 3:9
-      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:3:17: 3:17
-      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
-      let mut _3: bool;                    // in scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:+0:8: +0:9
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:+0:17: +0:17
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+      let mut _3: bool;                    // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
       scope 1 (inlined std::mem::drop::<bool>) { // at $DIR/remove_unneeded_drops.rs:4:5: 4:12
           debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
-          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
-          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
+          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
 -         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
 -     }
 - 
 -     bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:11: 4:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:12: 4:13
--         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:3:17: 5:2
-          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:5:2: 5:2
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+-         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:17: +2:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
 -     }
 - 
 -     bb2 (cleanup): {
--         resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:3:1: 5:2
+-         resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -2,30 +2,30 @@
 + // MIR for `opt_generic_copy` after RemoveUnneededDrops
   
   fn opt_generic_copy(_1: T) -> () {
-      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:13:30: 13:31
-      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:13:36: 13:36
-      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
-      let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:+0:30: +0:31
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:+0:36: +0:36
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+      let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
       scope 1 (inlined std::mem::drop::<T>) { // at $DIR/remove_unneeded_drops.rs:14:5: 14:12
           debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
-          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
-          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:5: +1:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
+          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:+1:10: +1:11
 -         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
 -     }
 - 
 -     bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:11: 14:12
-          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:12: 14:13
--         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:13:36: 15:2
-          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:15:2: 15:2
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:11: +1:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
+-         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:36: +2:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
 -     }
 - 
 -     bb2 (cleanup): {
--         resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:13:1: 15:2
+-         resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
+++ b/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
@@ -1,15 +1,15 @@
 // MIR for `get_union` after RemoveZsts
 
 fn get_union() -> Foo {
-    let mut _0: Foo;                     // return place in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:12:19: 12:22
-    let mut _1: ();                      // in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:14: 13:16
+    let mut _0: Foo;                     // return place in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+0:19: +0:22
+    let mut _1: ();                      // in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:14: 13:16
-        nop;                             // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:14: 13:16
-        Deinit(_0);                      // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:5: 13:18
-        (_0.0: ()) = move _1;            // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:5: 13:18
-        StorageDead(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:17: 13:18
-        return;                          // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:14:2: 14:2
+        StorageLive(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
+        nop;                             // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:14: +1:16
+        Deinit(_0);                      // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:5: +1:18
+        (_0.0: ()) = move _1;            // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:5: +1:18
+        StorageDead(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+1:17: +1:18
+        return;                          // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -1,23 +1,23 @@
 // MIR for `array_casts` after SimplifyCfg-elaborate-drops
 
 fn array_casts() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/retag.rs:57:18: 57:18
-    let mut _1: [usize; 2];              // in scope 0 at $DIR/retag.rs:58:9: 58:14
-    let mut _3: *mut [usize; 2];         // in scope 0 at $DIR/retag.rs:59:13: 59:19
-    let mut _4: &mut [usize; 2];         // in scope 0 at $DIR/retag.rs:59:13: 59:19
-    let _5: ();                          // in scope 0 at $DIR/retag.rs:60:5: 60:30
-    let mut _6: *mut usize;              // in scope 0 at $DIR/retag.rs:60:15: 60:23
-    let mut _7: *mut usize;              // in scope 0 at $DIR/retag.rs:60:15: 60:16
-    let mut _10: *const [usize; 2];      // in scope 0 at $DIR/retag.rs:63:13: 63:15
-    let _11: &[usize; 2];                // in scope 0 at $DIR/retag.rs:63:13: 63:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/retag.rs:+0:18: +0:18
+    let mut _1: [usize; 2];              // in scope 0 at $DIR/retag.rs:+1:9: +1:14
+    let mut _3: *mut [usize; 2];         // in scope 0 at $DIR/retag.rs:+2:13: +2:19
+    let mut _4: &mut [usize; 2];         // in scope 0 at $DIR/retag.rs:+2:13: +2:19
+    let _5: ();                          // in scope 0 at $DIR/retag.rs:+3:5: +3:30
+    let mut _6: *mut usize;              // in scope 0 at $DIR/retag.rs:+3:15: +3:23
+    let mut _7: *mut usize;              // in scope 0 at $DIR/retag.rs:+3:15: +3:16
+    let mut _10: *const [usize; 2];      // in scope 0 at $DIR/retag.rs:+6:13: +6:15
+    let _11: &[usize; 2];                // in scope 0 at $DIR/retag.rs:+6:13: +6:15
     let _12: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _13: (&usize, &usize);       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _14: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _15: usize;                      // in scope 0 at $DIR/retag.rs:64:16: 64:36
-    let mut _16: *const usize;           // in scope 0 at $DIR/retag.rs:64:26: 64:34
-    let mut _17: *const usize;           // in scope 0 at $DIR/retag.rs:64:26: 64:27
+    let _15: usize;                      // in scope 0 at $DIR/retag.rs:+7:16: +7:36
+    let mut _16: *const usize;           // in scope 0 at $DIR/retag.rs:+7:26: +7:34
+    let mut _17: *const usize;           // in scope 0 at $DIR/retag.rs:+7:26: +7:27
     let mut _18: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _19: usize;                      // in scope 0 at $DIR/retag.rs:64:38: 64:39
+    let _19: usize;                      // in scope 0 at $DIR/retag.rs:+7:38: +7:39
     let mut _22: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _23: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _24: usize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -31,18 +31,18 @@ fn array_casts() -> () {
     let _33: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _34: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/retag.rs:58:9: 58:14
-        let _2: *mut usize;              // in scope 1 at $DIR/retag.rs:59:9: 59:10
+        debug x => _1;                   // in scope 1 at $DIR/retag.rs:+1:9: +1:14
+        let _2: *mut usize;              // in scope 1 at $DIR/retag.rs:+2:9: +2:10
         scope 2 {
-            debug p => _2;               // in scope 2 at $DIR/retag.rs:59:9: 59:10
-            let _8: [usize; 2];          // in scope 2 at $DIR/retag.rs:62:9: 62:10
+            debug p => _2;               // in scope 2 at $DIR/retag.rs:+2:9: +2:10
+            let _8: [usize; 2];          // in scope 2 at $DIR/retag.rs:+5:9: +5:10
             scope 3 {
             }
             scope 4 {
-                debug x => _8;           // in scope 4 at $DIR/retag.rs:62:9: 62:10
-                let _9: *const usize;    // in scope 4 at $DIR/retag.rs:63:9: 63:10
+                debug x => _8;           // in scope 4 at $DIR/retag.rs:+5:9: +5:10
+                let _9: *const usize;    // in scope 4 at $DIR/retag.rs:+6:9: +6:10
                 scope 5 {
-                    debug p => _9;       // in scope 5 at $DIR/retag.rs:63:9: 63:10
+                    debug p => _9;       // in scope 5 at $DIR/retag.rs:+6:9: +6:10
                     let _20: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     let _21: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     let mut _35: &usize; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -62,62 +62,62 @@ fn array_casts() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/retag.rs:58:9: 58:14
-        _1 = [const 0_usize, const 0_usize]; // scope 0 at $DIR/retag.rs:58:29: 58:35
-        StorageLive(_2);                 // scope 1 at $DIR/retag.rs:59:9: 59:10
-        StorageLive(_3);                 // scope 1 at $DIR/retag.rs:59:13: 59:19
-        StorageLive(_4);                 // scope 1 at $DIR/retag.rs:59:13: 59:19
-        _4 = &mut _1;                    // scope 1 at $DIR/retag.rs:59:13: 59:19
-        Retag(_4);                       // scope 1 at $DIR/retag.rs:59:13: 59:19
-        _3 = &raw mut (*_4);             // scope 1 at $DIR/retag.rs:59:13: 59:19
-        Retag([raw] _3);                 // scope 1 at $DIR/retag.rs:59:13: 59:19
-        _2 = move _3 as *mut usize (Pointer(ArrayToPointer)); // scope 1 at $DIR/retag.rs:59:13: 59:33
-        StorageDead(_3);                 // scope 1 at $DIR/retag.rs:59:32: 59:33
-        StorageDead(_4);                 // scope 1 at $DIR/retag.rs:59:33: 59:34
-        StorageLive(_5);                 // scope 2 at $DIR/retag.rs:60:5: 60:30
-        StorageLive(_6);                 // scope 3 at $DIR/retag.rs:60:15: 60:23
-        StorageLive(_7);                 // scope 3 at $DIR/retag.rs:60:15: 60:16
-        _7 = _2;                         // scope 3 at $DIR/retag.rs:60:15: 60:16
-        _6 = ptr::mut_ptr::<impl *mut usize>::add(move _7, const 1_usize) -> bb1; // scope 3 at $DIR/retag.rs:60:15: 60:23
+        StorageLive(_1);                 // scope 0 at $DIR/retag.rs:+1:9: +1:14
+        _1 = [const 0_usize, const 0_usize]; // scope 0 at $DIR/retag.rs:+1:29: +1:35
+        StorageLive(_2);                 // scope 1 at $DIR/retag.rs:+2:9: +2:10
+        StorageLive(_3);                 // scope 1 at $DIR/retag.rs:+2:13: +2:19
+        StorageLive(_4);                 // scope 1 at $DIR/retag.rs:+2:13: +2:19
+        _4 = &mut _1;                    // scope 1 at $DIR/retag.rs:+2:13: +2:19
+        Retag(_4);                       // scope 1 at $DIR/retag.rs:+2:13: +2:19
+        _3 = &raw mut (*_4);             // scope 1 at $DIR/retag.rs:+2:13: +2:19
+        Retag([raw] _3);                 // scope 1 at $DIR/retag.rs:+2:13: +2:19
+        _2 = move _3 as *mut usize (Pointer(ArrayToPointer)); // scope 1 at $DIR/retag.rs:+2:13: +2:33
+        StorageDead(_3);                 // scope 1 at $DIR/retag.rs:+2:32: +2:33
+        StorageDead(_4);                 // scope 1 at $DIR/retag.rs:+2:33: +2:34
+        StorageLive(_5);                 // scope 2 at $DIR/retag.rs:+3:5: +3:30
+        StorageLive(_6);                 // scope 3 at $DIR/retag.rs:+3:15: +3:23
+        StorageLive(_7);                 // scope 3 at $DIR/retag.rs:+3:15: +3:16
+        _7 = _2;                         // scope 3 at $DIR/retag.rs:+3:15: +3:16
+        _6 = ptr::mut_ptr::<impl *mut usize>::add(move _7, const 1_usize) -> bb1; // scope 3 at $DIR/retag.rs:+3:15: +3:23
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:60:17: 60:20
                                          // + literal: Const { ty: unsafe fn(*mut usize, usize) -> *mut usize {ptr::mut_ptr::<impl *mut usize>::add}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_7);                 // scope 3 at $DIR/retag.rs:60:22: 60:23
-        (*_6) = const 1_usize;           // scope 3 at $DIR/retag.rs:60:14: 60:27
-        StorageDead(_6);                 // scope 3 at $DIR/retag.rs:60:27: 60:28
-        _5 = const ();                   // scope 3 at $DIR/retag.rs:60:5: 60:30
-        StorageDead(_5);                 // scope 2 at $DIR/retag.rs:60:29: 60:30
-        StorageLive(_8);                 // scope 2 at $DIR/retag.rs:62:9: 62:10
-        _8 = [const 0_usize, const 1_usize]; // scope 2 at $DIR/retag.rs:62:25: 62:31
-        StorageLive(_9);                 // scope 4 at $DIR/retag.rs:63:9: 63:10
-        StorageLive(_10);                // scope 4 at $DIR/retag.rs:63:13: 63:15
-        StorageLive(_11);                // scope 4 at $DIR/retag.rs:63:13: 63:15
-        _11 = &_8;                       // scope 4 at $DIR/retag.rs:63:13: 63:15
-        Retag(_11);                      // scope 4 at $DIR/retag.rs:63:13: 63:15
-        _10 = &raw const (*_11);         // scope 4 at $DIR/retag.rs:63:13: 63:15
-        Retag([raw] _10);                // scope 4 at $DIR/retag.rs:63:13: 63:15
-        _9 = move _10 as *const usize (Pointer(ArrayToPointer)); // scope 4 at $DIR/retag.rs:63:13: 63:31
-        StorageDead(_10);                // scope 4 at $DIR/retag.rs:63:30: 63:31
-        StorageDead(_11);                // scope 4 at $DIR/retag.rs:63:31: 63:32
+        StorageDead(_7);                 // scope 3 at $DIR/retag.rs:+3:22: +3:23
+        (*_6) = const 1_usize;           // scope 3 at $DIR/retag.rs:+3:14: +3:27
+        StorageDead(_6);                 // scope 3 at $DIR/retag.rs:+3:27: +3:28
+        _5 = const ();                   // scope 3 at $DIR/retag.rs:+3:5: +3:30
+        StorageDead(_5);                 // scope 2 at $DIR/retag.rs:+3:29: +3:30
+        StorageLive(_8);                 // scope 2 at $DIR/retag.rs:+5:9: +5:10
+        _8 = [const 0_usize, const 1_usize]; // scope 2 at $DIR/retag.rs:+5:25: +5:31
+        StorageLive(_9);                 // scope 4 at $DIR/retag.rs:+6:9: +6:10
+        StorageLive(_10);                // scope 4 at $DIR/retag.rs:+6:13: +6:15
+        StorageLive(_11);                // scope 4 at $DIR/retag.rs:+6:13: +6:15
+        _11 = &_8;                       // scope 4 at $DIR/retag.rs:+6:13: +6:15
+        Retag(_11);                      // scope 4 at $DIR/retag.rs:+6:13: +6:15
+        _10 = &raw const (*_11);         // scope 4 at $DIR/retag.rs:+6:13: +6:15
+        Retag([raw] _10);                // scope 4 at $DIR/retag.rs:+6:13: +6:15
+        _9 = move _10 as *const usize (Pointer(ArrayToPointer)); // scope 4 at $DIR/retag.rs:+6:13: +6:31
+        StorageDead(_10);                // scope 4 at $DIR/retag.rs:+6:30: +6:31
+        StorageDead(_11);                // scope 4 at $DIR/retag.rs:+6:31: +6:32
         StorageLive(_12);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_14);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_15);                // scope 5 at $DIR/retag.rs:64:16: 64:36
-        StorageLive(_16);                // scope 6 at $DIR/retag.rs:64:26: 64:34
-        StorageLive(_17);                // scope 6 at $DIR/retag.rs:64:26: 64:27
-        _17 = _9;                        // scope 6 at $DIR/retag.rs:64:26: 64:27
-        _16 = ptr::const_ptr::<impl *const usize>::add(move _17, const 1_usize) -> bb2; // scope 6 at $DIR/retag.rs:64:26: 64:34
+        StorageLive(_15);                // scope 5 at $DIR/retag.rs:+7:16: +7:36
+        StorageLive(_16);                // scope 6 at $DIR/retag.rs:+7:26: +7:34
+        StorageLive(_17);                // scope 6 at $DIR/retag.rs:+7:26: +7:27
+        _17 = _9;                        // scope 6 at $DIR/retag.rs:+7:26: +7:27
+        _16 = ptr::const_ptr::<impl *const usize>::add(move _17, const 1_usize) -> bb2; // scope 6 at $DIR/retag.rs:+7:26: +7:34
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:64:28: 64:31
                                          // + literal: Const { ty: unsafe fn(*const usize, usize) -> *const usize {ptr::const_ptr::<impl *const usize>::add}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_17);                // scope 6 at $DIR/retag.rs:64:33: 64:34
-        _15 = (*_16);                    // scope 6 at $DIR/retag.rs:64:25: 64:34
+        StorageDead(_17);                // scope 6 at $DIR/retag.rs:+7:33: +7:34
+        _15 = (*_16);                    // scope 6 at $DIR/retag.rs:+7:25: +7:34
         _14 = &_15;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_14);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -188,11 +188,11 @@ fn array_casts() -> () {
         StorageDead(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_12);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _0 = const ();                   // scope 0 at $DIR/retag.rs:57:18: 65:2
-        StorageDead(_9);                 // scope 4 at $DIR/retag.rs:65:1: 65:2
-        StorageDead(_8);                 // scope 2 at $DIR/retag.rs:65:1: 65:2
-        StorageDead(_2);                 // scope 1 at $DIR/retag.rs:65:1: 65:2
-        StorageDead(_1);                 // scope 0 at $DIR/retag.rs:65:1: 65:2
-        return;                          // scope 0 at $DIR/retag.rs:65:2: 65:2
+        _0 = const ();                   // scope 0 at $DIR/retag.rs:+0:18: +8:2
+        StorageDead(_9);                 // scope 4 at $DIR/retag.rs:+8:1: +8:2
+        StorageDead(_8);                 // scope 2 at $DIR/retag.rs:+8:1: +8:2
+        StorageDead(_2);                 // scope 1 at $DIR/retag.rs:+8:1: +8:2
+        StorageDead(_1);                 // scope 0 at $DIR/retag.rs:+8:1: +8:2
+        return;                          // scope 0 at $DIR/retag.rs:+8:2: +8:2
     }
 }

--- a/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
+++ b/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
@@ -1,20 +1,20 @@
 // MIR for `std::ptr::drop_in_place` after SimplifyCfg-make_shim
 
 fn std::ptr::drop_in_place(_1: *mut Test) -> () {
-    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _2: &mut Test;               // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _2: &mut Test;               // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
 
     bb0: {
-        Retag([raw] _1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _3 = <Test as Drop>::drop(move _2) -> bb1; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        Retag([raw] _1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _3 = <Test as Drop>::drop(move _2) -> bb1; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut Test) {<Test as Drop>::drop}, val: Value(<ZST>) }
     }
 
     bb1: {
-        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 }

--- a/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
@@ -1,22 +1,22 @@
 // MIR for `main::{closure#0}` after SimplifyCfg-elaborate-drops
 
 fn main::{closure#0}(_1: &[closure@main::{closure#0}], _2: &i32) -> &i32 {
-    debug x => _2;                       // in scope 0 at $DIR/retag.rs:40:32: 40:33
-    let mut _0: &i32;                    // return place in scope 0 at $DIR/retag.rs:40:44: 40:48
-    let _3: &i32;                        // in scope 0 at $DIR/retag.rs:41:13: 41:15
+    debug x => _2;                       // in scope 0 at $DIR/retag.rs:+0:32: +0:33
+    let mut _0: &i32;                    // return place in scope 0 at $DIR/retag.rs:+0:44: +0:48
+    let _3: &i32;                        // in scope 0 at $DIR/retag.rs:+1:13: +1:15
     scope 1 {
-        debug _y => _3;                  // in scope 1 at $DIR/retag.rs:41:13: 41:15
+        debug _y => _3;                  // in scope 1 at $DIR/retag.rs:+1:13: +1:15
     }
 
     bb0: {
-        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:40:31: 40:48
-        Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:40:31: 40:48
-        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:41:13: 41:15
-        _3 = _2;                         // scope 0 at $DIR/retag.rs:41:18: 41:19
-        Retag(_3);                       // scope 0 at $DIR/retag.rs:41:18: 41:19
-        _0 = _2;                         // scope 1 at $DIR/retag.rs:42:9: 42:10
-        Retag(_0);                       // scope 1 at $DIR/retag.rs:42:9: 42:10
-        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:43:5: 43:6
-        return;                          // scope 0 at $DIR/retag.rs:40:48: 40:48
+        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:+0:31: +0:48
+        Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:+0:31: +0:48
+        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:+1:13: +1:15
+        _3 = _2;                         // scope 0 at $DIR/retag.rs:+1:18: +1:19
+        Retag(_3);                       // scope 0 at $DIR/retag.rs:+1:18: +1:19
+        _0 = _2;                         // scope 1 at $DIR/retag.rs:+2:9: +2:10
+        Retag(_0);                       // scope 1 at $DIR/retag.rs:+2:9: +2:10
+        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:+3:5: +3:6
+        return;                          // scope 0 at $DIR/retag.rs:+0:48: +0:48
     }
 }

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -1,117 +1,117 @@
 // MIR for `main` after SimplifyCfg-elaborate-drops
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/retag.rs:29:11: 29:11
-    let mut _1: i32;                     // in scope 0 at $DIR/retag.rs:30:9: 30:14
-    let _2: ();                          // in scope 0 at $DIR/retag.rs:31:5: 37:6
-    let mut _4: &Test;                   // in scope 0 at $DIR/retag.rs:32:17: 32:36
-    let _5: Test;                        // in scope 0 at $DIR/retag.rs:32:17: 32:24
-    let mut _6: &mut i32;                // in scope 0 at $DIR/retag.rs:32:29: 32:35
-    let mut _7: &mut i32;                // in scope 0 at $DIR/retag.rs:32:29: 32:35
-    let mut _9: &mut i32;                // in scope 0 at $DIR/retag.rs:33:19: 33:20
-    let mut _12: *mut i32;               // in scope 0 at $DIR/retag.rs:36:18: 36:29
-    let mut _14: [closure@main::{closure#0}]; // in scope 0 at $DIR/retag.rs:40:31: 43:6
-    let mut _16: for<'r> fn(&'r i32) -> &'r i32; // in scope 0 at $DIR/retag.rs:44:14: 44:15
-    let mut _17: &i32;                   // in scope 0 at $DIR/retag.rs:44:16: 44:18
-    let _18: &i32;                       // in scope 0 at $DIR/retag.rs:44:16: 44:18
-    let _19: &i32;                       // in scope 0 at $DIR/retag.rs:47:5: 47:24
-    let mut _20: &Test;                  // in scope 0 at $DIR/retag.rs:47:5: 47:24
-    let _21: Test;                       // in scope 0 at $DIR/retag.rs:47:5: 47:12
-    let mut _22: &i32;                   // in scope 0 at $DIR/retag.rs:47:21: 47:23
-    let _23: &i32;                       // in scope 0 at $DIR/retag.rs:47:21: 47:23
-    let _24: i32;                        // in scope 0 at $DIR/retag.rs:47:22: 47:23
-    let mut _26: *const i32;             // in scope 0 at $DIR/retag.rs:50:14: 50:28
-    let _27: ();                         // in scope 0 at $DIR/retag.rs:52:5: 52:18
+    let mut _0: ();                      // return place in scope 0 at $DIR/retag.rs:+0:11: +0:11
+    let mut _1: i32;                     // in scope 0 at $DIR/retag.rs:+1:9: +1:14
+    let _2: ();                          // in scope 0 at $DIR/retag.rs:+2:5: +8:6
+    let mut _4: &Test;                   // in scope 0 at $DIR/retag.rs:+3:17: +3:36
+    let _5: Test;                        // in scope 0 at $DIR/retag.rs:+3:17: +3:24
+    let mut _6: &mut i32;                // in scope 0 at $DIR/retag.rs:+3:29: +3:35
+    let mut _7: &mut i32;                // in scope 0 at $DIR/retag.rs:+3:29: +3:35
+    let mut _9: &mut i32;                // in scope 0 at $DIR/retag.rs:+4:19: +4:20
+    let mut _12: *mut i32;               // in scope 0 at $DIR/retag.rs:+7:18: +7:29
+    let mut _14: [closure@main::{closure#0}]; // in scope 0 at $DIR/retag.rs:+11:31: +14:6
+    let mut _16: for<'r> fn(&'r i32) -> &'r i32; // in scope 0 at $DIR/retag.rs:+15:14: +15:15
+    let mut _17: &i32;                   // in scope 0 at $DIR/retag.rs:+15:16: +15:18
+    let _18: &i32;                       // in scope 0 at $DIR/retag.rs:+15:16: +15:18
+    let _19: &i32;                       // in scope 0 at $DIR/retag.rs:+18:5: +18:24
+    let mut _20: &Test;                  // in scope 0 at $DIR/retag.rs:+18:5: +18:24
+    let _21: Test;                       // in scope 0 at $DIR/retag.rs:+18:5: +18:12
+    let mut _22: &i32;                   // in scope 0 at $DIR/retag.rs:+18:21: +18:23
+    let _23: &i32;                       // in scope 0 at $DIR/retag.rs:+18:21: +18:23
+    let _24: i32;                        // in scope 0 at $DIR/retag.rs:+18:22: +18:23
+    let mut _26: *const i32;             // in scope 0 at $DIR/retag.rs:+21:14: +21:28
+    let _27: ();                         // in scope 0 at $DIR/retag.rs:+23:5: +23:18
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/retag.rs:30:9: 30:14
-        let _3: &mut i32;                // in scope 1 at $DIR/retag.rs:32:13: 32:14
-        let _13: for<'r> fn(&'r i32) -> &'r i32; // in scope 1 at $DIR/retag.rs:40:9: 40:10
+        debug x => _1;                   // in scope 1 at $DIR/retag.rs:+1:9: +1:14
+        let _3: &mut i32;                // in scope 1 at $DIR/retag.rs:+3:13: +3:14
+        let _13: for<'r> fn(&'r i32) -> &'r i32; // in scope 1 at $DIR/retag.rs:+11:9: +11:10
         scope 2 {
-            debug v => _3;               // in scope 2 at $DIR/retag.rs:32:13: 32:14
-            let _8: &mut i32;            // in scope 2 at $DIR/retag.rs:33:13: 33:14
+            debug v => _3;               // in scope 2 at $DIR/retag.rs:+3:13: +3:14
+            let _8: &mut i32;            // in scope 2 at $DIR/retag.rs:+4:13: +4:14
             scope 3 {
-                debug w => _8;           // in scope 3 at $DIR/retag.rs:33:13: 33:14
-                let _10: &mut i32;       // in scope 3 at $DIR/retag.rs:34:13: 34:14
+                debug w => _8;           // in scope 3 at $DIR/retag.rs:+4:13: +4:14
+                let _10: &mut i32;       // in scope 3 at $DIR/retag.rs:+5:13: +5:14
                 scope 4 {
-                    debug w => _10;      // in scope 4 at $DIR/retag.rs:34:13: 34:14
-                    let _11: *mut i32;   // in scope 4 at $DIR/retag.rs:36:13: 36:15
+                    debug w => _10;      // in scope 4 at $DIR/retag.rs:+5:13: +5:14
+                    let _11: *mut i32;   // in scope 4 at $DIR/retag.rs:+7:13: +7:15
                     scope 5 {
-                        debug _w => _11; // in scope 5 at $DIR/retag.rs:36:13: 36:15
+                        debug _w => _11; // in scope 5 at $DIR/retag.rs:+7:13: +7:15
                     }
                 }
             }
         }
         scope 6 {
-            debug c => _13;              // in scope 6 at $DIR/retag.rs:40:9: 40:10
-            let _15: &i32;               // in scope 6 at $DIR/retag.rs:44:9: 44:11
+            debug c => _13;              // in scope 6 at $DIR/retag.rs:+11:9: +11:10
+            let _15: &i32;               // in scope 6 at $DIR/retag.rs:+15:9: +15:11
             scope 7 {
-                debug _w => _15;         // in scope 7 at $DIR/retag.rs:44:9: 44:11
-                let _25: *const i32;     // in scope 7 at $DIR/retag.rs:50:9: 50:11
-                let mut _28: &i32;       // in scope 7 at $DIR/retag.rs:47:21: 47:23
+                debug _w => _15;         // in scope 7 at $DIR/retag.rs:+15:9: +15:11
+                let _25: *const i32;     // in scope 7 at $DIR/retag.rs:+21:9: +21:11
+                let mut _28: &i32;       // in scope 7 at $DIR/retag.rs:+18:21: +18:23
                 scope 8 {
-                    debug _w => _25;     // in scope 8 at $DIR/retag.rs:50:9: 50:11
+                    debug _w => _25;     // in scope 8 at $DIR/retag.rs:+21:9: +21:11
                 }
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/retag.rs:30:9: 30:14
-        _1 = const 0_i32;                // scope 0 at $DIR/retag.rs:30:17: 30:18
-        StorageLive(_2);                 // scope 1 at $DIR/retag.rs:31:5: 37:6
-        StorageLive(_3);                 // scope 1 at $DIR/retag.rs:32:13: 32:14
-        StorageLive(_4);                 // scope 1 at $DIR/retag.rs:32:17: 32:36
-        StorageLive(_5);                 // scope 1 at $DIR/retag.rs:32:17: 32:24
-        _5 = Test(const 0_i32);          // scope 1 at $DIR/retag.rs:32:17: 32:24
-        _4 = &_5;                        // scope 1 at $DIR/retag.rs:32:17: 32:36
-        Retag(_4);                       // scope 1 at $DIR/retag.rs:32:17: 32:36
-        StorageLive(_6);                 // scope 1 at $DIR/retag.rs:32:29: 32:35
-        StorageLive(_7);                 // scope 1 at $DIR/retag.rs:32:29: 32:35
-        _7 = &mut _1;                    // scope 1 at $DIR/retag.rs:32:29: 32:35
-        Retag(_7);                       // scope 1 at $DIR/retag.rs:32:29: 32:35
-        _6 = &mut (*_7);                 // scope 1 at $DIR/retag.rs:32:29: 32:35
-        Retag([2phase] _6);              // scope 1 at $DIR/retag.rs:32:29: 32:35
-        _3 = Test::foo(move _4, move _6) -> [return: bb1, unwind: bb8]; // scope 1 at $DIR/retag.rs:32:17: 32:36
+        StorageLive(_1);                 // scope 0 at $DIR/retag.rs:+1:9: +1:14
+        _1 = const 0_i32;                // scope 0 at $DIR/retag.rs:+1:17: +1:18
+        StorageLive(_2);                 // scope 1 at $DIR/retag.rs:+2:5: +8:6
+        StorageLive(_3);                 // scope 1 at $DIR/retag.rs:+3:13: +3:14
+        StorageLive(_4);                 // scope 1 at $DIR/retag.rs:+3:17: +3:36
+        StorageLive(_5);                 // scope 1 at $DIR/retag.rs:+3:17: +3:24
+        _5 = Test(const 0_i32);          // scope 1 at $DIR/retag.rs:+3:17: +3:24
+        _4 = &_5;                        // scope 1 at $DIR/retag.rs:+3:17: +3:36
+        Retag(_4);                       // scope 1 at $DIR/retag.rs:+3:17: +3:36
+        StorageLive(_6);                 // scope 1 at $DIR/retag.rs:+3:29: +3:35
+        StorageLive(_7);                 // scope 1 at $DIR/retag.rs:+3:29: +3:35
+        _7 = &mut _1;                    // scope 1 at $DIR/retag.rs:+3:29: +3:35
+        Retag(_7);                       // scope 1 at $DIR/retag.rs:+3:29: +3:35
+        _6 = &mut (*_7);                 // scope 1 at $DIR/retag.rs:+3:29: +3:35
+        Retag([2phase] _6);              // scope 1 at $DIR/retag.rs:+3:29: +3:35
+        _3 = Test::foo(move _4, move _6) -> [return: bb1, unwind: bb8]; // scope 1 at $DIR/retag.rs:+3:17: +3:36
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:32:25: 32:28
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}, val: Value(<ZST>) }
     }
 
     bb1: {
-        Retag(_3);                       // scope 1 at $DIR/retag.rs:32:17: 32:36
-        StorageDead(_6);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
-        StorageDead(_4);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
-        StorageDead(_7);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
-        drop(_5) -> [return: bb2, unwind: bb9]; // scope 1 at $DIR/retag.rs:32:36: 32:37
+        Retag(_3);                       // scope 1 at $DIR/retag.rs:+3:17: +3:36
+        StorageDead(_6);                 // scope 1 at $DIR/retag.rs:+3:35: +3:36
+        StorageDead(_4);                 // scope 1 at $DIR/retag.rs:+3:35: +3:36
+        StorageDead(_7);                 // scope 1 at $DIR/retag.rs:+3:36: +3:37
+        drop(_5) -> [return: bb2, unwind: bb9]; // scope 1 at $DIR/retag.rs:+3:36: +3:37
     }
 
     bb2: {
-        StorageDead(_5);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
-        StorageLive(_8);                 // scope 2 at $DIR/retag.rs:33:13: 33:14
-        StorageLive(_9);                 // scope 2 at $DIR/retag.rs:33:19: 33:20
-        _9 = move _3;                    // scope 2 at $DIR/retag.rs:33:19: 33:20
-        Retag(_9);                       // scope 2 at $DIR/retag.rs:33:19: 33:20
-        _8 = &mut (*_9);                 // scope 2 at $DIR/retag.rs:33:19: 33:20
-        Retag(_8);                       // scope 2 at $DIR/retag.rs:33:19: 33:20
-        StorageDead(_9);                 // scope 2 at $DIR/retag.rs:33:22: 33:23
-        StorageLive(_10);                // scope 3 at $DIR/retag.rs:34:13: 34:14
-        _10 = move _8;                   // scope 3 at $DIR/retag.rs:34:17: 34:18
-        Retag(_10);                      // scope 3 at $DIR/retag.rs:34:17: 34:18
-        StorageLive(_11);                // scope 4 at $DIR/retag.rs:36:13: 36:15
-        StorageLive(_12);                // scope 4 at $DIR/retag.rs:36:18: 36:29
-        _12 = &raw mut (*_10);           // scope 4 at $DIR/retag.rs:36:18: 36:19
-        Retag([raw] _12);                // scope 4 at $DIR/retag.rs:36:18: 36:19
-        _11 = _12;                       // scope 4 at $DIR/retag.rs:36:18: 36:29
-        StorageDead(_12);                // scope 4 at $DIR/retag.rs:36:29: 36:30
-        _2 = const ();                   // scope 1 at $DIR/retag.rs:31:5: 37:6
-        StorageDead(_11);                // scope 4 at $DIR/retag.rs:37:5: 37:6
-        StorageDead(_10);                // scope 3 at $DIR/retag.rs:37:5: 37:6
-        StorageDead(_8);                 // scope 2 at $DIR/retag.rs:37:5: 37:6
-        StorageDead(_3);                 // scope 1 at $DIR/retag.rs:37:5: 37:6
-        StorageDead(_2);                 // scope 1 at $DIR/retag.rs:37:5: 37:6
-        StorageLive(_13);                // scope 1 at $DIR/retag.rs:40:9: 40:10
-        StorageLive(_14);                // scope 1 at $DIR/retag.rs:40:31: 43:6
-        _14 = [closure@main::{closure#0}]; // scope 1 at $DIR/retag.rs:40:31: 43:6
+        StorageDead(_5);                 // scope 1 at $DIR/retag.rs:+3:36: +3:37
+        StorageLive(_8);                 // scope 2 at $DIR/retag.rs:+4:13: +4:14
+        StorageLive(_9);                 // scope 2 at $DIR/retag.rs:+4:19: +4:20
+        _9 = move _3;                    // scope 2 at $DIR/retag.rs:+4:19: +4:20
+        Retag(_9);                       // scope 2 at $DIR/retag.rs:+4:19: +4:20
+        _8 = &mut (*_9);                 // scope 2 at $DIR/retag.rs:+4:19: +4:20
+        Retag(_8);                       // scope 2 at $DIR/retag.rs:+4:19: +4:20
+        StorageDead(_9);                 // scope 2 at $DIR/retag.rs:+4:22: +4:23
+        StorageLive(_10);                // scope 3 at $DIR/retag.rs:+5:13: +5:14
+        _10 = move _8;                   // scope 3 at $DIR/retag.rs:+5:17: +5:18
+        Retag(_10);                      // scope 3 at $DIR/retag.rs:+5:17: +5:18
+        StorageLive(_11);                // scope 4 at $DIR/retag.rs:+7:13: +7:15
+        StorageLive(_12);                // scope 4 at $DIR/retag.rs:+7:18: +7:29
+        _12 = &raw mut (*_10);           // scope 4 at $DIR/retag.rs:+7:18: +7:19
+        Retag([raw] _12);                // scope 4 at $DIR/retag.rs:+7:18: +7:19
+        _11 = _12;                       // scope 4 at $DIR/retag.rs:+7:18: +7:29
+        StorageDead(_12);                // scope 4 at $DIR/retag.rs:+7:29: +7:30
+        _2 = const ();                   // scope 1 at $DIR/retag.rs:+2:5: +8:6
+        StorageDead(_11);                // scope 4 at $DIR/retag.rs:+8:5: +8:6
+        StorageDead(_10);                // scope 3 at $DIR/retag.rs:+8:5: +8:6
+        StorageDead(_8);                 // scope 2 at $DIR/retag.rs:+8:5: +8:6
+        StorageDead(_3);                 // scope 1 at $DIR/retag.rs:+8:5: +8:6
+        StorageDead(_2);                 // scope 1 at $DIR/retag.rs:+8:5: +8:6
+        StorageLive(_13);                // scope 1 at $DIR/retag.rs:+11:9: +11:10
+        StorageLive(_14);                // scope 1 at $DIR/retag.rs:+11:31: +14:6
+        _14 = [closure@main::{closure#0}]; // scope 1 at $DIR/retag.rs:+11:31: +14:6
                                          // closure
                                          // + def_id: DefId(0:14 ~ retag[4622]::main::{closure#0})
                                          // + substs: [
@@ -119,92 +119,92 @@ fn main() -> () {
                                          //     for<'r> extern "rust-call" fn((&'r i32,)) -> &'r i32,
                                          //     (),
                                          // ]
-        Retag(_14);                      // scope 1 at $DIR/retag.rs:40:31: 43:6
-        _13 = move _14 as for<'r> fn(&'r i32) -> &'r i32 (Pointer(ClosureFnPointer(Normal))); // scope 1 at $DIR/retag.rs:40:31: 43:6
-        StorageDead(_14);                // scope 1 at $DIR/retag.rs:40:47: 40:48
-        StorageLive(_15);                // scope 6 at $DIR/retag.rs:44:9: 44:11
-        StorageLive(_16);                // scope 6 at $DIR/retag.rs:44:14: 44:15
-        _16 = _13;                       // scope 6 at $DIR/retag.rs:44:14: 44:15
-        StorageLive(_17);                // scope 6 at $DIR/retag.rs:44:16: 44:18
-        StorageLive(_18);                // scope 6 at $DIR/retag.rs:44:16: 44:18
-        _18 = &_1;                       // scope 6 at $DIR/retag.rs:44:16: 44:18
-        Retag(_18);                      // scope 6 at $DIR/retag.rs:44:16: 44:18
-        _17 = &(*_18);                   // scope 6 at $DIR/retag.rs:44:16: 44:18
-        Retag(_17);                      // scope 6 at $DIR/retag.rs:44:16: 44:18
-        _15 = move _16(move _17) -> bb3; // scope 6 at $DIR/retag.rs:44:14: 44:19
+        Retag(_14);                      // scope 1 at $DIR/retag.rs:+11:31: +14:6
+        _13 = move _14 as for<'r> fn(&'r i32) -> &'r i32 (Pointer(ClosureFnPointer(Normal))); // scope 1 at $DIR/retag.rs:+11:31: +14:6
+        StorageDead(_14);                // scope 1 at $DIR/retag.rs:+11:47: +11:48
+        StorageLive(_15);                // scope 6 at $DIR/retag.rs:+15:9: +15:11
+        StorageLive(_16);                // scope 6 at $DIR/retag.rs:+15:14: +15:15
+        _16 = _13;                       // scope 6 at $DIR/retag.rs:+15:14: +15:15
+        StorageLive(_17);                // scope 6 at $DIR/retag.rs:+15:16: +15:18
+        StorageLive(_18);                // scope 6 at $DIR/retag.rs:+15:16: +15:18
+        _18 = &_1;                       // scope 6 at $DIR/retag.rs:+15:16: +15:18
+        Retag(_18);                      // scope 6 at $DIR/retag.rs:+15:16: +15:18
+        _17 = &(*_18);                   // scope 6 at $DIR/retag.rs:+15:16: +15:18
+        Retag(_17);                      // scope 6 at $DIR/retag.rs:+15:16: +15:18
+        _15 = move _16(move _17) -> bb3; // scope 6 at $DIR/retag.rs:+15:14: +15:19
     }
 
     bb3: {
-        Retag(_15);                      // scope 6 at $DIR/retag.rs:44:14: 44:19
-        StorageDead(_17);                // scope 6 at $DIR/retag.rs:44:18: 44:19
-        StorageDead(_16);                // scope 6 at $DIR/retag.rs:44:18: 44:19
-        StorageDead(_18);                // scope 6 at $DIR/retag.rs:44:19: 44:20
-        StorageLive(_19);                // scope 7 at $DIR/retag.rs:47:5: 47:24
-        StorageLive(_20);                // scope 7 at $DIR/retag.rs:47:5: 47:24
-        StorageLive(_21);                // scope 7 at $DIR/retag.rs:47:5: 47:12
-        _21 = Test(const 0_i32);         // scope 7 at $DIR/retag.rs:47:5: 47:12
-        _20 = &_21;                      // scope 7 at $DIR/retag.rs:47:5: 47:24
-        Retag(_20);                      // scope 7 at $DIR/retag.rs:47:5: 47:24
-        StorageLive(_22);                // scope 7 at $DIR/retag.rs:47:21: 47:23
-        StorageLive(_23);                // scope 7 at $DIR/retag.rs:47:21: 47:23
-        _28 = const main::promoted[0];   // scope 7 at $DIR/retag.rs:47:21: 47:23
+        Retag(_15);                      // scope 6 at $DIR/retag.rs:+15:14: +15:19
+        StorageDead(_17);                // scope 6 at $DIR/retag.rs:+15:18: +15:19
+        StorageDead(_16);                // scope 6 at $DIR/retag.rs:+15:18: +15:19
+        StorageDead(_18);                // scope 6 at $DIR/retag.rs:+15:19: +15:20
+        StorageLive(_19);                // scope 7 at $DIR/retag.rs:+18:5: +18:24
+        StorageLive(_20);                // scope 7 at $DIR/retag.rs:+18:5: +18:24
+        StorageLive(_21);                // scope 7 at $DIR/retag.rs:+18:5: +18:12
+        _21 = Test(const 0_i32);         // scope 7 at $DIR/retag.rs:+18:5: +18:12
+        _20 = &_21;                      // scope 7 at $DIR/retag.rs:+18:5: +18:24
+        Retag(_20);                      // scope 7 at $DIR/retag.rs:+18:5: +18:24
+        StorageLive(_22);                // scope 7 at $DIR/retag.rs:+18:21: +18:23
+        StorageLive(_23);                // scope 7 at $DIR/retag.rs:+18:21: +18:23
+        _28 = const main::promoted[0];   // scope 7 at $DIR/retag.rs:+18:21: +18:23
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:47:21: 47:23
                                          // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
-        Retag(_28);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
-        _23 = &(*_28);                   // scope 7 at $DIR/retag.rs:47:21: 47:23
-        Retag(_23);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
-        _22 = &(*_23);                   // scope 7 at $DIR/retag.rs:47:21: 47:23
-        Retag(_22);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
-        _19 = Test::foo_shr(move _20, move _22) -> [return: bb4, unwind: bb7]; // scope 7 at $DIR/retag.rs:47:5: 47:24
+        Retag(_28);                      // scope 7 at $DIR/retag.rs:+18:21: +18:23
+        _23 = &(*_28);                   // scope 7 at $DIR/retag.rs:+18:21: +18:23
+        Retag(_23);                      // scope 7 at $DIR/retag.rs:+18:21: +18:23
+        _22 = &(*_23);                   // scope 7 at $DIR/retag.rs:+18:21: +18:23
+        Retag(_22);                      // scope 7 at $DIR/retag.rs:+18:21: +18:23
+        _19 = Test::foo_shr(move _20, move _22) -> [return: bb4, unwind: bb7]; // scope 7 at $DIR/retag.rs:+18:5: +18:24
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:47:13: 47:20
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}, val: Value(<ZST>) }
     }
 
     bb4: {
-        Retag(_19);                      // scope 7 at $DIR/retag.rs:47:5: 47:24
-        StorageDead(_22);                // scope 7 at $DIR/retag.rs:47:23: 47:24
-        StorageDead(_20);                // scope 7 at $DIR/retag.rs:47:23: 47:24
-        StorageDead(_23);                // scope 7 at $DIR/retag.rs:47:24: 47:25
-        drop(_21) -> [return: bb5, unwind: bb9]; // scope 7 at $DIR/retag.rs:47:24: 47:25
+        Retag(_19);                      // scope 7 at $DIR/retag.rs:+18:5: +18:24
+        StorageDead(_22);                // scope 7 at $DIR/retag.rs:+18:23: +18:24
+        StorageDead(_20);                // scope 7 at $DIR/retag.rs:+18:23: +18:24
+        StorageDead(_23);                // scope 7 at $DIR/retag.rs:+18:24: +18:25
+        drop(_21) -> [return: bb5, unwind: bb9]; // scope 7 at $DIR/retag.rs:+18:24: +18:25
     }
 
     bb5: {
-        StorageDead(_21);                // scope 7 at $DIR/retag.rs:47:24: 47:25
-        StorageDead(_19);                // scope 7 at $DIR/retag.rs:47:24: 47:25
-        StorageLive(_25);                // scope 7 at $DIR/retag.rs:50:9: 50:11
-        StorageLive(_26);                // scope 7 at $DIR/retag.rs:50:14: 50:28
-        _26 = &raw const (*_15);         // scope 7 at $DIR/retag.rs:50:14: 50:16
-        Retag([raw] _26);                // scope 7 at $DIR/retag.rs:50:14: 50:16
-        _25 = _26;                       // scope 7 at $DIR/retag.rs:50:14: 50:28
-        StorageDead(_26);                // scope 7 at $DIR/retag.rs:50:28: 50:29
-        StorageLive(_27);                // scope 8 at $DIR/retag.rs:52:5: 52:18
-        _27 = array_casts() -> bb6;      // scope 8 at $DIR/retag.rs:52:5: 52:18
+        StorageDead(_21);                // scope 7 at $DIR/retag.rs:+18:24: +18:25
+        StorageDead(_19);                // scope 7 at $DIR/retag.rs:+18:24: +18:25
+        StorageLive(_25);                // scope 7 at $DIR/retag.rs:+21:9: +21:11
+        StorageLive(_26);                // scope 7 at $DIR/retag.rs:+21:14: +21:28
+        _26 = &raw const (*_15);         // scope 7 at $DIR/retag.rs:+21:14: +21:16
+        Retag([raw] _26);                // scope 7 at $DIR/retag.rs:+21:14: +21:16
+        _25 = _26;                       // scope 7 at $DIR/retag.rs:+21:14: +21:28
+        StorageDead(_26);                // scope 7 at $DIR/retag.rs:+21:28: +21:29
+        StorageLive(_27);                // scope 8 at $DIR/retag.rs:+23:5: +23:18
+        _27 = array_casts() -> bb6;      // scope 8 at $DIR/retag.rs:+23:5: +23:18
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:52:5: 52:16
                                          // + literal: Const { ty: fn() {array_casts}, val: Value(<ZST>) }
     }
 
     bb6: {
-        StorageDead(_27);                // scope 8 at $DIR/retag.rs:52:18: 52:19
-        _0 = const ();                   // scope 0 at $DIR/retag.rs:29:11: 53:2
-        StorageDead(_25);                // scope 7 at $DIR/retag.rs:53:1: 53:2
-        StorageDead(_15);                // scope 6 at $DIR/retag.rs:53:1: 53:2
-        StorageDead(_13);                // scope 1 at $DIR/retag.rs:53:1: 53:2
-        StorageDead(_1);                 // scope 0 at $DIR/retag.rs:53:1: 53:2
-        return;                          // scope 0 at $DIR/retag.rs:53:2: 53:2
+        StorageDead(_27);                // scope 8 at $DIR/retag.rs:+23:18: +23:19
+        _0 = const ();                   // scope 0 at $DIR/retag.rs:+0:11: +24:2
+        StorageDead(_25);                // scope 7 at $DIR/retag.rs:+24:1: +24:2
+        StorageDead(_15);                // scope 6 at $DIR/retag.rs:+24:1: +24:2
+        StorageDead(_13);                // scope 1 at $DIR/retag.rs:+24:1: +24:2
+        StorageDead(_1);                 // scope 0 at $DIR/retag.rs:+24:1: +24:2
+        return;                          // scope 0 at $DIR/retag.rs:+24:2: +24:2
     }
 
     bb7 (cleanup): {
-        drop(_21) -> bb9;                // scope 7 at $DIR/retag.rs:47:24: 47:25
+        drop(_21) -> bb9;                // scope 7 at $DIR/retag.rs:+18:24: +18:25
     }
 
     bb8 (cleanup): {
-        drop(_5) -> bb9;                 // scope 1 at $DIR/retag.rs:32:36: 32:37
+        drop(_5) -> bb9;                 // scope 1 at $DIR/retag.rs:+3:36: +3:37
     }
 
     bb9 (cleanup): {
-        resume;                          // scope 0 at $DIR/retag.rs:29:1: 53:2
+        resume;                          // scope 0 at $DIR/retag.rs:+0:1: +24:2
     }
 }

--- a/src/test/mir-opt/retag.{impl#0}-foo.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.{impl#0}-foo.SimplifyCfg-elaborate-drops.after.mir
@@ -1,20 +1,20 @@
 // MIR for `<impl at $DIR/retag.rs:11:1: 11:10>::foo` after SimplifyCfg-elaborate-drops
 
 fn <impl at $DIR/retag.rs:11:1: 11:10>::foo(_1: &Test, _2: &mut i32) -> &mut i32 {
-    debug self => _1;                    // in scope 0 at $DIR/retag.rs:13:16: 13:21
-    debug x => _2;                       // in scope 0 at $DIR/retag.rs:13:23: 13:24
-    let mut _0: &mut i32;                // return place in scope 0 at $DIR/retag.rs:13:42: 13:53
-    let mut _3: &mut i32;                // in scope 0 at $DIR/retag.rs:14:9: 14:10
+    debug self => _1;                    // in scope 0 at $DIR/retag.rs:+0:16: +0:21
+    debug x => _2;                       // in scope 0 at $DIR/retag.rs:+0:23: +0:24
+    let mut _0: &mut i32;                // return place in scope 0 at $DIR/retag.rs:+0:42: +0:53
+    let mut _3: &mut i32;                // in scope 0 at $DIR/retag.rs:+1:9: +1:10
 
     bb0: {
-        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:13:5: 15:6
-        Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:13:5: 15:6
-        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:14:9: 14:10
-        _3 = &mut (*_2);                 // scope 0 at $DIR/retag.rs:14:9: 14:10
-        Retag(_3);                       // scope 0 at $DIR/retag.rs:14:9: 14:10
-        _0 = &mut (*_3);                 // scope 0 at $DIR/retag.rs:14:9: 14:10
-        Retag(_0);                       // scope 0 at $DIR/retag.rs:14:9: 14:10
-        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:15:5: 15:6
-        return;                          // scope 0 at $DIR/retag.rs:15:6: 15:6
+        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:+0:5: +2:6
+        Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:+0:5: +2:6
+        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:+1:9: +1:10
+        _3 = &mut (*_2);                 // scope 0 at $DIR/retag.rs:+1:9: +1:10
+        Retag(_3);                       // scope 0 at $DIR/retag.rs:+1:9: +1:10
+        _0 = &mut (*_3);                 // scope 0 at $DIR/retag.rs:+1:9: +1:10
+        Retag(_0);                       // scope 0 at $DIR/retag.rs:+1:9: +1:10
+        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:+2:5: +2:6
+        return;                          // scope 0 at $DIR/retag.rs:+2:6: +2:6
     }
 }

--- a/src/test/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-elaborate-drops.after.mir
@@ -1,15 +1,15 @@
 // MIR for `<impl at $DIR/retag.rs:11:1: 11:10>::foo_shr` after SimplifyCfg-elaborate-drops
 
 fn <impl at $DIR/retag.rs:11:1: 11:10>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
-    debug self => _1;                    // in scope 0 at $DIR/retag.rs:16:20: 16:25
-    debug x => _2;                       // in scope 0 at $DIR/retag.rs:16:27: 16:28
-    let mut _0: &i32;                    // return place in scope 0 at $DIR/retag.rs:16:42: 16:49
+    debug self => _1;                    // in scope 0 at $DIR/retag.rs:+0:20: +0:25
+    debug x => _2;                       // in scope 0 at $DIR/retag.rs:+0:27: +0:28
+    let mut _0: &i32;                    // return place in scope 0 at $DIR/retag.rs:+0:42: +0:49
 
     bb0: {
-        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:16:5: 18:6
-        Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:16:5: 18:6
-        _0 = _2;                         // scope 0 at $DIR/retag.rs:17:9: 17:10
-        Retag(_0);                       // scope 0 at $DIR/retag.rs:17:9: 17:10
-        return;                          // scope 0 at $DIR/retag.rs:18:6: 18:6
+        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:+0:5: +2:6
+        Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:+0:5: +2:6
+        _0 = _2;                         // scope 0 at $DIR/retag.rs:+1:9: +1:10
+        Retag(_0);                       // scope 0 at $DIR/retag.rs:+1:9: +1:10
+        return;                          // scope 0 at $DIR/retag.rs:+2:6: +2:6
     }
 }

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -2,18 +2,18 @@
 + // MIR for `identity` after ConstProp
   
   fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:28:13: 28:14
-      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:28:37: 28:53
-      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:+0:13: +0:14
+      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:+0:37: +0:53
+      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       scope 1 {
-          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:+1:9: +1:10
           scope 2 {
               scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
                   debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -30,7 +30,7 @@
           }
       }
       scope 3 {
-          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:+1:8: +1:10
           scope 4 {
           }
       }
@@ -51,33 +51,33 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
       bb2: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -90,11 +90,11 @@
           discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
       bb3: {
@@ -112,12 +112,12 @@
           discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
       bb4: {
@@ -134,12 +134,12 @@
           discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
@@ -1,16 +1,16 @@
 // MIR for `identity` after PreCodegen
 
 fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
-    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:28:13: 28:14
-    let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:28:37: 28:53
-    let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-    let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-    let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-    let _5: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let mut _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let _7: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:+0:13: +0:14
+    let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:+0:37: +0:53
+    let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+    let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+    let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+    let _5: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+    let mut _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+    let _7: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
     scope 1 {
-        debug residual => _5;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+        debug residual => _5;            // in scope 1 at $DIR/separate_const_switch.rs:+1:9: +1:10
         scope 2 {
             scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
                 debug residual => _6;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -27,7 +27,7 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         }
     }
     scope 3 {
-        debug val => _7;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+        debug val => _7;                 // in scope 3 at $DIR/separate_const_switch.rs:+1:8: +1:10
         scope 4 {
         }
     }
@@ -48,11 +48,11 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-        _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+        StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+        _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
         _8 = discriminant(_4);           // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
         switchInt(move _8) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
     }
@@ -72,12 +72,12 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _5 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _6 = _5;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        StorageLive(_5);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        _5 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        StorageLive(_6);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        _6 = _5;                         // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
         StorageLive(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
         _14 = move ((_6 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageLive(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -90,11 +90,11 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageDead(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-        return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+        StorageDead(_6);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        StorageDead(_5);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
+        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
     }
 
     bb2: {
@@ -111,17 +111,17 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _7 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _2 = _7;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-        return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+        _7 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+        _2 = _7;                         // scope 4 at $DIR/separate_const_switch.rs:+1:8: +1:10
+        StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+        Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
+        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
+        return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -2,18 +2,18 @@
 + // MIR for `identity` after SeparateConstSwitch
   
   fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:28:13: 28:14
-      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:28:37: 28:53
-      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:+0:13: +0:14
+      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:+0:37: +0:53
+      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       scope 1 {
-          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:+1:9: +1:10
           scope 2 {
               scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
                   debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -30,7 +30,7 @@
           }
       }
       scope 3 {
-          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:+1:8: +1:10
           scope 4 {
           }
       }
@@ -51,42 +51,42 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:9
+          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 +         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
--         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+-         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
 -     }
 - 
 -     bb2: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:+1:5: +1:11
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
 -     bb3: {
 +     bb2: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -99,11 +99,11 @@
           discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+1:10: +1:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:+2:1: +2:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
 -     bb4: {
@@ -123,10 +123,10 @@
           StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
 -     bb5: {
@@ -146,10 +146,10 @@
           StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
@@ -2,94 +2,94 @@
 + // MIR for `too_complex` after ConstProp
   
   fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:9:16: 9:17
-      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:9:42: 9:53
-      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:16:44: 16:45
-      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:17:42: 17:43
-      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
-      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:+0:16: +0:17
+      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:+0:42: +0:53
+      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:+7:13: +7:18
+      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:+7:44: +7:45
+      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:+8:42: +8:43
+      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:+11:9: +11:33
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:+11:42: +11:43
+      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
       scope 1 {
-          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:16:16: 16:17
+          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:+7:16: +7:17
       }
       scope 2 {
-          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:17:17: 17:18
+          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:+8:17: +8:18
       }
       scope 3 {
-          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:20:31: 20:32
+          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:+11:31: +11:32
       }
       scope 4 {
-          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
+          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:+12:28: +12:29
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
+          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
       }
   
       bb1: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
--         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
-+         _8 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-+         switchInt(const 1_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
+          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
+          Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:43: +8:44
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
+-         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+-         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         _8 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
++         switchInt(const 1_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
--         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
-+         _8 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-+         switchInt(const 0_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
+          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
+          Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
+-         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+-         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         _8 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
++         switchInt(const 0_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb3: {
-          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
+          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
+          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
+          Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
+          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
+          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
       }
   
       bb4: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
+          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
+          Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
       }
   
       bb5: {
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
@@ -1,69 +1,69 @@
 // MIR for `too_complex` after PreCodegen
 
 fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
-    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:9:16: 9:17
-    let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:9:42: 9:53
-    let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-    let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-    let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-    let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:16:44: 16:45
-    let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-    let _7: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-    let mut _8: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
-    let _9: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:+0:16: +0:17
+    let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:+0:42: +0:53
+    let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+    let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:+7:13: +7:18
+    let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+    let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:+7:44: +7:45
+    let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+    let _7: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+    let mut _8: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:+11:42: +11:43
+    let _9: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
     scope 1 {
-        debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:16:16: 16:17
+        debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:+7:16: +7:17
     }
     scope 2 {
-        debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:17:17: 17:18
+        debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:+8:17: +8:18
     }
     scope 3 {
-        debug v => _7;                   // in scope 3 at $DIR/separate_const_switch.rs:20:31: 20:32
+        debug v => _7;                   // in scope 3 at $DIR/separate_const_switch.rs:+11:31: +11:32
     }
     scope 4 {
-        debug r => _9;                   // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
+        debug r => _9;                   // in scope 4 at $DIR/separate_const_switch.rs:+12:28: +12:29
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-        _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
-        switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
+        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+        _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
+        switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-        StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
-        StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-        Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-        discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-        StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
+        StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+        StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
+        StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
+        Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
+        discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
+        StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
     }
 
     bb2: {
-        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-        _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-        StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-        _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-        Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-        ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-        discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-        StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
-        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
-        StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-        _7 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-        StorageLive(_8);                 // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-        _8 = _7;                         // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-        Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-        ((_0 as Some).0: i32) = move _8; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-        discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-        StorageDead(_8);                 // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
-        StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+        _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+        StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
+        _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
+        Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+        ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+        discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+        StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
+        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
+        StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+        _7 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+        StorageLive(_8);                 // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
+        _8 = _7;                         // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
+        Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+        ((_0 as Some).0: i32) = move _8; // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+        discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+        StorageDead(_8);                 // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
+        StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
     }
 
     bb3: {
-        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
-        return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
+        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
+        return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
     }
 }

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -2,101 +2,101 @@
 + // MIR for `too_complex` after SeparateConstSwitch
   
   fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:9:16: 9:17
-      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:9:42: 9:53
-      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:16:44: 16:45
-      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:17:42: 17:43
-      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
-      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:+0:16: +0:17
+      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:+0:42: +0:53
+      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:+7:13: +7:18
+      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:+7:44: +7:45
+      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:+8:42: +8:43
+      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:+11:9: +11:33
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:+11:42: +11:43
+      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
       scope 1 {
-          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:16:16: 16:17
+          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:+7:16: +7:17
       }
       scope 2 {
-          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:17:17: 17:18
+          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:+8:17: +8:18
       }
       scope 3 {
-          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:20:31: 20:32
+          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:+11:31: +11:32
       }
       scope 4 {
-          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
+          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:+12:28: +12:29
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:+6:15: +6:16
+          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:+6:9: +6:16
       }
   
       bb1: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
-+         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:+8:17: +8:18
+          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
+          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:+8:42: +8:43
+          Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
+          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:43: +8:44
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
+-         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
++         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
++         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:+7:16: +7:17
+          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
+          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:+7:44: +7:45
+          Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
+          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
+-         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
 -     }
 - 
 -     bb3: {
-          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
--         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+-         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
++         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
 -     bb4: {
 +     bb3: {
-          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
+          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
+          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
+          Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
+          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
+          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+-         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
++         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
       }
   
 -     bb5: {
 +     bb4: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
+          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
+          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
+          Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
+          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+-         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
++         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
       }
   
 -     bb6: {
 +     bb5: {
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
       }
   }
   

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
@@ -1,29 +1,29 @@
 // MIR for `match_bool` 0 mir_map
 
 fn match_bool(_1: bool) -> usize {
-    debug x => _1;                       // in scope 0 at $DIR/simple-match.rs:5:15: 5:16
-    let mut _0: usize;                   // return place in scope 0 at $DIR/simple-match.rs:5:27: 5:32
+    debug x => _1;                       // in scope 0 at $DIR/simple-match.rs:+0:15: +0:16
+    let mut _0: usize;                   // return place in scope 0 at $DIR/simple-match.rs:+0:27: +0:32
 
     bb0: {
-        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:6:5: 6:12
+        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:+1:11: +1:12
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:+1:5: +1:12
     }
 
     bb1: {
-        falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:+2:9: +2:13
     }
 
     bb2: {
-        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:8:14: 8:16
+        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:+3:14: +3:16
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:+3:14: +3:16
     }
 
     bb3: {
-        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:7:17: 7:19
+        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:+2:17: +2:19
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:+2:17: +2:19
     }
 
     bb4: {
-        return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
+        return;                          // scope 0 at $DIR/simple-match.rs:+5:2: +5:2
     }
 }

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
@@ -1,29 +1,29 @@
 // MIR for `match_bool` 0 mir_map
 
 fn match_bool(_1: bool) -> usize {
-    debug x => _1;                       // in scope 0 at $DIR/simple-match.rs:5:15: 5:16
-    let mut _0: usize;                   // return place in scope 0 at $DIR/simple-match.rs:5:27: 5:32
+    debug x => _1;                       // in scope 0 at $DIR/simple-match.rs:+0:15: +0:16
+    let mut _0: usize;                   // return place in scope 0 at $DIR/simple-match.rs:+0:27: +0:32
 
     bb0: {
-        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:6:5: 6:12
+        FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:+1:11: +1:12
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:+1:5: +1:12
     }
 
     bb1: {
-        falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:+2:9: +2:13
     }
 
     bb2: {
-        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:8:14: 8:16
+        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:+3:14: +3:16
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:+3:14: +3:16
     }
 
     bb3: {
-        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:7:17: 7:19
+        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:+2:17: +2:19
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:+2:17: +2:19
     }
 
     bb4: {
-        return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
+        return;                          // scope 0 at $DIR/simple-match.rs:+5:2: +5:2
     }
 }

--- a/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
@@ -2,45 +2,45 @@
 + // MIR for `id` after SimplifyArmIdentity
   
   fn id(_1: Option<u8>) -> Option<u8> {
-      debug o => _1;                       // in scope 0 at $DIR/simplify-arm.rs:9:7: 9:8
-      let mut _0: std::option::Option<u8>; // return place in scope 0 at $DIR/simplify-arm.rs:9:25: 9:35
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:11:25: 11:26
+      debug o => _1;                       // in scope 0 at $DIR/simplify-arm.rs:+0:7: +0:8
+      let mut _0: std::option::Option<u8>; // return place in scope 0 at $DIR/simplify-arm.rs:+0:25: +0:35
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:+2:9: +2:16
+      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:+2:14: +2:15
+      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:+2:25: +2:26
       scope 1 {
-          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
+          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:+2:14: +2:15
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
-          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:5: +1:12
       }
   
       bb1: {
-          Deinit(_0);                      // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
+          Deinit(_0);                      // scope 0 at $DIR/simplify-arm.rs:+3:17: +3:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:+3:17: +3:21
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+3:17: +3:21
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
       }
   
       bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:14: +2:15
+          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:+2:14: +2:15
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:25: +2:26
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:+2:25: +2:26
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:+2:20: +2:27
+          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:+2:20: +2:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:+2:20: +2:27
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:26: +2:27
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:26: +2:27
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+2:26: +2:27
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
+          return;                          // scope 0 at $DIR/simplify-arm.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
@@ -2,45 +2,45 @@
 + // MIR for `id` after SimplifyBranchSame
   
   fn id(_1: Option<u8>) -> Option<u8> {
-      debug o => _1;                       // in scope 0 at $DIR/simplify-arm.rs:9:7: 9:8
-      let mut _0: std::option::Option<u8>; // return place in scope 0 at $DIR/simplify-arm.rs:9:25: 9:35
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:11:25: 11:26
+      debug o => _1;                       // in scope 0 at $DIR/simplify-arm.rs:+0:7: +0:8
+      let mut _0: std::option::Option<u8>; // return place in scope 0 at $DIR/simplify-arm.rs:+0:25: +0:35
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:+2:9: +2:16
+      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:+2:14: +2:15
+      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:+2:25: +2:26
       scope 1 {
-          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
+          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:+2:14: +2:15
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
-          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:5: +1:12
       }
   
       bb1: {
-          Deinit(_0);                      // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
+          Deinit(_0);                      // scope 0 at $DIR/simplify-arm.rs:+3:17: +3:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:+3:17: +3:21
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+3:17: +3:21
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
       }
   
       bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:14: +2:15
+          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:+2:14: +2:15
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:25: +2:26
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:+2:25: +2:26
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:+2:20: +2:27
+          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:+2:20: +2:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:+2:20: +2:27
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:26: +2:27
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:26: +2:27
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+2:26: +2:27
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
+          return;                          // scope 0 at $DIR/simplify-arm.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
@@ -2,57 +2,57 @@
 + // MIR for `id_result` after SimplifyArmIdentity
   
   fn id_result(_1: Result<u8, i32>) -> Result<u8, i32> {
-      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:16:14: 16:15
-      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:16:37: 16:52
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:18:21: 18:22
-      let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-      let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:19:23: 19:24
+      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:+0:14: +0:15
+      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:+0:37: +0:52
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:+2:9: +2:14
+      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:+2:12: +2:13
+      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:+2:21: +2:22
+      let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:+3:13: +3:14
+      let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:+3:23: +3:24
       scope 1 {
-          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
+          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:+2:12: +2:13
       }
       scope 2 {
-          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
+          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:+3:13: +3:14
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
-          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:5: +1:12
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          Deinit(_0);                      // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
-          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
+          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:+3:13: +3:14
+          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:+3:13: +3:14
+          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:+3:23: +3:24
+          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:+3:23: +3:24
+          Deinit(_0);                      // scope 2 at $DIR/simplify-arm.rs:+3:19: +3:25
+          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:+3:19: +3:25
+          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:+3:19: +3:25
+          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:+3:24: +3:25
+          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:+3:24: +3:25
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+3:24: +3:25
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
       }
   
       bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:12: +2:13
+          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:+2:12: +2:13
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:21: +2:22
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:+2:21: +2:22
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:+2:18: +2:23
+          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:+2:18: +2:23
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:+2:18: +2:23
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:22: +2:23
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:22: +2:23
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+2:22: +2:23
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
+          return;                          // scope 0 at $DIR/simplify-arm.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
@@ -2,57 +2,57 @@
 + // MIR for `id_result` after SimplifyBranchSame
   
   fn id_result(_1: Result<u8, i32>) -> Result<u8, i32> {
-      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:16:14: 16:15
-      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:16:37: 16:52
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:18:21: 18:22
-      let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-      let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:19:23: 19:24
+      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:+0:14: +0:15
+      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:+0:37: +0:52
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-arm.rs:+2:9: +2:14
+      let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:+2:12: +2:13
+      let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:+2:21: +2:22
+      let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:+3:13: +3:14
+      let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:+3:23: +3:24
       scope 1 {
-          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
+          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:+2:12: +2:13
       }
       scope 2 {
-          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
+          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:+3:13: +3:14
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
-          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:5: +1:12
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          Deinit(_0);                      // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
-          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
+          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:+3:13: +3:14
+          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:+3:13: +3:14
+          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:+3:23: +3:24
+          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:+3:23: +3:24
+          Deinit(_0);                      // scope 2 at $DIR/simplify-arm.rs:+3:19: +3:25
+          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:+3:19: +3:25
+          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:+3:19: +3:25
+          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:+3:24: +3:25
+          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:+3:24: +3:25
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+3:24: +3:25
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:+1:11: +1:12
       }
   
       bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:12: +2:13
+          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:+2:12: +2:13
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:21: +2:22
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:+2:21: +2:22
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:+2:18: +2:23
+          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:+2:18: +2:23
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:+2:18: +2:23
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:+2:22: +2:23
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+2:22: +2:23
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+2:22: +2:23
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
+          return;                          // scope 0 at $DIR/simplify-arm.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -2,92 +2,92 @@
 + // MIR for `id_try` after SimplifyArmIdentity
   
   fn id_try(_1: Result<u8, i32>) -> Result<u8, i32> {
-      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:35:11: 35:12
-      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:35:34: 35:49
-      let _2: u8;                          // in scope 0 at $DIR/simplify-arm.rs:36:9: 36:10
-      let mut _3: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
-      let mut _4: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-      let mut _5: isize;                   // in scope 0 at $DIR/simplify-arm.rs:37:9: 37:15
-      let _6: i32;                         // in scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
-      let mut _7: !;                       // in scope 0 at $DIR/simplify-arm.rs:37:19: 37:51
-      let mut _8: i32;                     // in scope 0 at $DIR/simplify-arm.rs:37:37: 37:50
-      let mut _9: i32;                     // in scope 0 at $DIR/simplify-arm.rs:37:48: 37:49
-      let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
-      let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:40:8: 40:9
+      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:+0:11: +0:12
+      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:+0:34: +0:49
+      let _2: u8;                          // in scope 0 at $DIR/simplify-arm.rs:+1:9: +1:10
+      let mut _3: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
+      let mut _4: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
+      let mut _5: isize;                   // in scope 0 at $DIR/simplify-arm.rs:+2:9: +2:15
+      let _6: i32;                         // in scope 0 at $DIR/simplify-arm.rs:+2:13: +2:14
+      let mut _7: !;                       // in scope 0 at $DIR/simplify-arm.rs:+2:19: +2:51
+      let mut _8: i32;                     // in scope 0 at $DIR/simplify-arm.rs:+2:37: +2:50
+      let mut _9: i32;                     // in scope 0 at $DIR/simplify-arm.rs:+2:48: +2:49
+      let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:+3:12: +3:13
+      let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:+5:8: +5:9
       scope 1 {
-          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:36:9: 36:10
+          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:+1:9: +1:10
       }
       scope 2 {
-          debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
+          debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:+2:13: +2:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:37:37: 37:50
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
-              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
+              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:+0:21: +0:22
           }
       }
       scope 3 {
-          debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
+          debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
+          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:+0:22: +0:23
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify-arm.rs:36:9: 36:10
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
-          StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-          _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:24:5: 24:6
-          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:32: 36:33
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
-          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
+          StorageLive(_2);                 // scope 0 at $DIR/simplify-arm.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
+          StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
+          _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
+          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:+0:5: +0:6
+          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:32: +1:33
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
+          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:13: +1:33
       }
   
       bb1: {
-          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
-          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
-          _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:38:18: 38:19
-          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:38:18: 38:19
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
-          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
-          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
-          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
-          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
-          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:40:9: 40:10
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:+3:12: +3:13
+          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:+3:12: +3:13
+          _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:+3:18: +3:19
+          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:+3:18: +3:19
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+4:6: +4:7
+          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:+5:8: +5:9
+          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:+5:8: +5:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:+5:5: +5:10
+          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:+5:5: +5:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:+5:5: +5:10
+          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:+5:9: +5:10
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:+6:1: +6:2
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
       }
   
       bb3: {
-          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
-          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
-          StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:37: 37:50
-          StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
-          _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
+          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:+2:13: +2:14
+          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:+2:13: +2:14
+          StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:+2:37: +2:50
+          StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:+2:48: +2:49
+          _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:+2:48: +2:49
           _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:49: 37:50
-          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
-          StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:50: 37:51
-          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:50: 37:51
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:+2:49: +2:50
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:+0:9: +0:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
+          StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:+2:50: +2:51
+          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:+2:50: +2:51
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+4:6: +4:7
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:+6:1: +6:2
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+          return;                          // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
   
       bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify-arm.rs:35:1: 41:2
+          resume;                          // scope 0 at $DIR/simplify-arm.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -2,92 +2,92 @@
 + // MIR for `id_try` after SimplifyBranchSame
   
   fn id_try(_1: Result<u8, i32>) -> Result<u8, i32> {
-      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:35:11: 35:12
-      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:35:34: 35:49
-      let _2: u8;                          // in scope 0 at $DIR/simplify-arm.rs:36:9: 36:10
-      let mut _3: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
-      let mut _4: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-      let mut _5: isize;                   // in scope 0 at $DIR/simplify-arm.rs:37:9: 37:15
-      let _6: i32;                         // in scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
-      let mut _7: !;                       // in scope 0 at $DIR/simplify-arm.rs:37:19: 37:51
-      let mut _8: i32;                     // in scope 0 at $DIR/simplify-arm.rs:37:37: 37:50
-      let mut _9: i32;                     // in scope 0 at $DIR/simplify-arm.rs:37:48: 37:49
-      let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
-      let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:40:8: 40:9
+      debug r => _1;                       // in scope 0 at $DIR/simplify-arm.rs:+0:11: +0:12
+      let mut _0: std::result::Result<u8, i32>; // return place in scope 0 at $DIR/simplify-arm.rs:+0:34: +0:49
+      let _2: u8;                          // in scope 0 at $DIR/simplify-arm.rs:+1:9: +1:10
+      let mut _3: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
+      let mut _4: std::result::Result<u8, i32>; // in scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
+      let mut _5: isize;                   // in scope 0 at $DIR/simplify-arm.rs:+2:9: +2:15
+      let _6: i32;                         // in scope 0 at $DIR/simplify-arm.rs:+2:13: +2:14
+      let mut _7: !;                       // in scope 0 at $DIR/simplify-arm.rs:+2:19: +2:51
+      let mut _8: i32;                     // in scope 0 at $DIR/simplify-arm.rs:+2:37: +2:50
+      let mut _9: i32;                     // in scope 0 at $DIR/simplify-arm.rs:+2:48: +2:49
+      let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:+3:12: +3:13
+      let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:+5:8: +5:9
       scope 1 {
-          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:36:9: 36:10
+          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:+1:9: +1:10
       }
       scope 2 {
-          debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
+          debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:+2:13: +2:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:37:37: 37:50
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
-              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
+              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:+0:21: +0:22
           }
       }
       scope 3 {
-          debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
+          debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
+          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:+0:22: +0:23
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify-arm.rs:36:9: 36:10
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
-          StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-          _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:24:5: 24:6
-          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:32: 36:33
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
-          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
+          StorageLive(_2);                 // scope 0 at $DIR/simplify-arm.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
+          StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
+          _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
+          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:+0:5: +0:6
+          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:32: +1:33
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
+          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:13: +1:33
       }
   
       bb1: {
-          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
-          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
-          _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:38:18: 38:19
-          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:38:18: 38:19
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
-          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
-          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
-          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
-          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
-          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:40:9: 40:10
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:+3:12: +3:13
+          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:+3:12: +3:13
+          _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:+3:18: +3:19
+          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:+3:18: +3:19
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+4:6: +4:7
+          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:+5:8: +5:9
+          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:+5:8: +5:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:+5:5: +5:10
+          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:+5:5: +5:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:+5:5: +5:10
+          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:+5:9: +5:10
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:+6:1: +6:2
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
       }
   
       bb3: {
-          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
-          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
-          StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:37: 37:50
-          StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
-          _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
+          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:+2:13: +2:14
+          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:+2:13: +2:14
+          StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:+2:37: +2:50
+          StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:+2:48: +2:49
+          _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:+2:48: +2:49
           _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:49: 37:50
-          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
-          StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:50: 37:51
-          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:50: 37:51
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:+2:49: +2:50
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:+0:9: +0:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
+          StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:+2:50: +2:51
+          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:+2:50: +2:51
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+4:6: +4:7
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:+6:1: +6:2
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+          return;                          // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
   
       bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify-arm.rs:35:1: 41:2
+          resume;                          // scope 0 at $DIR/simplify-arm.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
@@ -2,60 +2,60 @@
 + // MIR for `main` after SimplifyArmIdentity
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-arm-identity.rs:17:11: 17:11
-      let _1: Src;                         // in scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-      let mut _2: Dst;                     // in scope 0 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-      let mut _3: isize;                   // in scope 0 at $DIR/simplify-arm-identity.rs:20:9: 20:20
-      let mut _5: u8;                      // in scope 0 at $DIR/simplify-arm-identity.rs:20:33: 20:34
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-arm-identity.rs:+0:11: +0:11
+      let _1: Src;                         // in scope 0 at $DIR/simplify-arm-identity.rs:+1:9: +1:10
+      let mut _2: Dst;                     // in scope 0 at $DIR/simplify-arm-identity.rs:+2:18: +5:6
+      let mut _3: isize;                   // in scope 0 at $DIR/simplify-arm-identity.rs:+3:9: +3:20
+      let mut _5: u8;                      // in scope 0 at $DIR/simplify-arm-identity.rs:+3:33: +3:34
       scope 1 {
-          debug e => _1;                   // in scope 1 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-          let _4: u8;                      // in scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
+          debug e => _1;                   // in scope 1 at $DIR/simplify-arm-identity.rs:+1:9: +1:10
+          let _4: u8;                      // in scope 1 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
           scope 2 {
           }
           scope 3 {
-              debug x => _4;               // in scope 3 at $DIR/simplify-arm-identity.rs:20:18: 20:19
+              debug x => _4;               // in scope 3 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-          Deinit(_1);                      // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
-          ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
-          discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
-          StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
-          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 19:25
+          StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:+1:9: +1:10
+          Deinit(_1);                      // scope 0 at $DIR/simplify-arm-identity.rs:+1:18: +1:29
+          ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:+1:18: +1:29
+          discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:+1:18: +1:29
+          StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:+2:18: +5:6
+          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:+2:24: +2:25
+          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:+2:18: +2:25
       }
   
       bb1: {
-          Deinit(_2);                      // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
+          Deinit(_2);                      // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
+          ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
+          discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
       }
   
       bb2: {
-          unreachable;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
+          unreachable;                     // scope 1 at $DIR/simplify-arm-identity.rs:+2:24: +2:25
       }
   
       bb3: {
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
-          _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
-          StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
-          _5 = _4;                         // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
-          Deinit(_2);                      // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
-          ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
-          discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
-          StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
+          _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
+          StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:+3:33: +3:34
+          _5 = _4;                         // scope 3 at $DIR/simplify-arm-identity.rs:+3:33: +3:34
+          Deinit(_2);                      // scope 3 at $DIR/simplify-arm-identity.rs:+3:24: +3:35
+          ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:+3:24: +3:35
+          discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:+3:24: +3:35
+          StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:+3:34: +3:35
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:+3:34: +3:35
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:+3:34: +3:35
       }
   
       bb4: {
-          StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:22:6: 22:7
-          nop;                             // scope 0 at $DIR/simplify-arm-identity.rs:17:11: 23:2
-          StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:23:1: 23:2
-          return;                          // scope 0 at $DIR/simplify-arm-identity.rs:23:2: 23:2
+          StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:+5:6: +5:7
+          nop;                             // scope 0 at $DIR/simplify-arm-identity.rs:+0:11: +6:2
+          StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/simplify-arm-identity.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
@@ -2,60 +2,60 @@
 + // MIR for `main` after SimplifyArmIdentity
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-arm-identity.rs:17:11: 17:11
-      let _1: Src;                         // in scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-      let mut _2: Dst;                     // in scope 0 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-      let mut _3: isize;                   // in scope 0 at $DIR/simplify-arm-identity.rs:20:9: 20:20
-      let mut _5: u8;                      // in scope 0 at $DIR/simplify-arm-identity.rs:20:33: 20:34
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-arm-identity.rs:+0:11: +0:11
+      let _1: Src;                         // in scope 0 at $DIR/simplify-arm-identity.rs:+1:9: +1:10
+      let mut _2: Dst;                     // in scope 0 at $DIR/simplify-arm-identity.rs:+2:18: +5:6
+      let mut _3: isize;                   // in scope 0 at $DIR/simplify-arm-identity.rs:+3:9: +3:20
+      let mut _5: u8;                      // in scope 0 at $DIR/simplify-arm-identity.rs:+3:33: +3:34
       scope 1 {
-          debug e => _1;                   // in scope 1 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-          let _4: u8;                      // in scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
+          debug e => _1;                   // in scope 1 at $DIR/simplify-arm-identity.rs:+1:9: +1:10
+          let _4: u8;                      // in scope 1 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
           scope 2 {
           }
           scope 3 {
-              debug x => _4;               // in scope 3 at $DIR/simplify-arm-identity.rs:20:18: 20:19
+              debug x => _4;               // in scope 3 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-          Deinit(_1);                      // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
-          ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
-          discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
-          StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
-          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 19:25
+          StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:+1:9: +1:10
+          Deinit(_1);                      // scope 0 at $DIR/simplify-arm-identity.rs:+1:18: +1:29
+          ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:+1:18: +1:29
+          discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:+1:18: +1:29
+          StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:+2:18: +5:6
+          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:+2:24: +2:25
+          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:+2:18: +2:25
       }
   
       bb1: {
-          Deinit(_2);                      // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
+          Deinit(_2);                      // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
+          ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
+          discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:+4:21: +4:32
       }
   
       bb2: {
-          unreachable;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
+          unreachable;                     // scope 1 at $DIR/simplify-arm-identity.rs:+2:24: +2:25
       }
   
       bb3: {
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
-          _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
-          StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
-          _5 = _4;                         // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
-          Deinit(_2);                      // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
-          ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
-          discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
-          StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
+          _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:+3:18: +3:19
+          StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:+3:33: +3:34
+          _5 = _4;                         // scope 3 at $DIR/simplify-arm-identity.rs:+3:33: +3:34
+          Deinit(_2);                      // scope 3 at $DIR/simplify-arm-identity.rs:+3:24: +3:35
+          ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:+3:24: +3:35
+          discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:+3:24: +3:35
+          StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:+3:34: +3:35
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:+3:34: +3:35
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:+3:34: +3:35
       }
   
       bb4: {
-          StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:22:6: 22:7
-          nop;                             // scope 0 at $DIR/simplify-arm-identity.rs:17:11: 23:2
-          StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:23:1: 23:2
-          return;                          // scope 0 at $DIR/simplify-arm-identity.rs:23:2: 23:2
+          StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:+5:6: +5:7
+          nop;                             // scope 0 at $DIR/simplify-arm-identity.rs:+0:11: +6:2
+          StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/simplify-arm-identity.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
@@ -2,51 +2,51 @@
 + // MIR for `main` after SimplifyCfg-early-opt
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cfg.rs:7:11: 7:11
-      let mut _1: ();                      // in scope 0 at $DIR/simplify_cfg.rs:7:1: 13:2
-      let mut _2: bool;                    // in scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
-      let mut _3: !;                       // in scope 0 at $DIR/simplify_cfg.rs:9:18: 11:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cfg.rs:+0:11: +0:11
+      let mut _1: ();                      // in scope 0 at $DIR/simplify_cfg.rs:+0:1: +6:2
+      let mut _2: bool;                    // in scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
+      let mut _3: !;                       // in scope 0 at $DIR/simplify_cfg.rs:+2:18: +4:10
   
       bb0: {
-          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
+          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:+1:5: +5:6
       }
   
       bb1: {
--         goto -> bb2;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
+-         goto -> bb2;                     // scope 0 at $DIR/simplify_cfg.rs:+1:5: +5:6
 -     }
 - 
 -     bb2: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
--         _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
-+         _2 = bar() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
+          StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
+-         _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
++         _2 = bar() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:9:12: 9:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(<ZST>) }
       }
   
 -     bb3: {
--         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
+-         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
 +     bb2: {
-+         switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
++         switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
       }
   
 -     bb4: {
 +     bb3: {
-          _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
-          return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
+          _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:+3:13: +3:18
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:+4:9: +4:10
+          return;                          // scope 0 at $DIR/simplify_cfg.rs:+6:2: +6:2
       }
   
 -     bb5: {
 +     bb4: {
-          _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:11:10: 11:10
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
-          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
+          _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:+4:10: +4:10
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:+4:9: +4:10
+          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:+1:5: +5:6
       }
   
 -     bb6 (cleanup): {
 +     bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify_cfg.rs:7:1: 13:2
+          resume;                          // scope 0 at $DIR/simplify_cfg.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -2,70 +2,70 @@
 + // MIR for `main` after SimplifyCfg-initial
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cfg.rs:7:11: 7:11
-      let mut _1: ();                      // in scope 0 at $DIR/simplify_cfg.rs:7:1: 13:2
-      let mut _2: bool;                    // in scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
-      let mut _3: !;                       // in scope 0 at $DIR/simplify_cfg.rs:9:18: 11:10
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_cfg.rs:+0:11: +0:11
+      let mut _1: ();                      // in scope 0 at $DIR/simplify_cfg.rs:+0:1: +6:2
+      let mut _2: bool;                    // in scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
+      let mut _3: !;                       // in scope 0 at $DIR/simplify_cfg.rs:+2:18: +4:10
   
       bb0: {
-          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
+          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:+1:5: +5:6
       }
   
       bb1: {
--         falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
-+         falseUnwind -> [real: bb2, cleanup: bb6]; // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
+-         falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/simplify_cfg.rs:+1:5: +5:6
++         falseUnwind -> [real: bb2, cleanup: bb6]; // scope 0 at $DIR/simplify_cfg.rs:+1:5: +5:6
       }
   
       bb2: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
--         _2 = bar() -> [return: bb3, unwind: bb11]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
-+         _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
+          StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
+-         _2 = bar() -> [return: bb3, unwind: bb11]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
++         _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:9:12: 9:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(<ZST>) }
       }
   
       bb3: {
-          switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
+          switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
       }
   
       bb4: {
-          _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
--         goto -> bb10;                    // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
-+         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
-+         return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
+          _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:+3:13: +3:18
+-         goto -> bb10;                    // scope 0 at $DIR/simplify_cfg.rs:+3:13: +3:18
++         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:+4:9: +4:10
++         return;                          // scope 0 at $DIR/simplify_cfg.rs:+6:2: +6:2
       }
   
       bb5: {
--         goto -> bb8;                     // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
+-         goto -> bb8;                     // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
 -     }
 - 
 -     bb6: {
--         unreachable;                     // scope 0 at $DIR/simplify_cfg.rs:9:18: 11:10
+-         unreachable;                     // scope 0 at $DIR/simplify_cfg.rs:+2:18: +4:10
 -     }
 - 
 -     bb7: {
--         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:+2:9: +4:10
 -     }
 - 
 -     bb8: {
-          _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:11:10: 11:10
--         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
+          _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:+4:10: +4:10
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:+2:9: +4:10
 -     }
 - 
 -     bb9: {
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
-          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:+4:9: +4:10
+          goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:+1:5: +5:6
       }
   
 -     bb10: {
--         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
--         return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:+4:9: +4:10
+-         return;                          // scope 0 at $DIR/simplify_cfg.rs:+6:2: +6:2
 -     }
 - 
 -     bb11 (cleanup): {
 +     bb6 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify_cfg.rs:7:1: 13:2
+          resume;                          // scope 0 at $DIR/simplify_cfg.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
+++ b/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
@@ -2,39 +2,39 @@
 + // MIR for `main` after SimplifyConstCondition-after-const-prop
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_if.rs:5:11: 5:11
-      let mut _1: bool;                    // in scope 0 at $DIR/simplify_if.rs:6:8: 6:13
-      let _2: ();                          // in scope 0 at $DIR/simplify_if.rs:7:9: 7:15
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_if.rs:+0:11: +0:11
+      let mut _1: bool;                    // in scope 0 at $DIR/simplify_if.rs:+1:8: +1:13
+      let _2: ();                          // in scope 0 at $DIR/simplify_if.rs:+2:9: +2:15
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
-          _1 = const false;                // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
--         switchInt(const false) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
-+         goto -> bb3;                     // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
+          StorageLive(_1);                 // scope 0 at $DIR/simplify_if.rs:+1:8: +1:13
+          _1 = const false;                // scope 0 at $DIR/simplify_if.rs:+1:8: +1:13
+-         switchInt(const false) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/simplify_if.rs:+1:8: +1:13
++         goto -> bb3;                     // scope 0 at $DIR/simplify_if.rs:+1:8: +1:13
       }
   
       bb1: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
-          _2 = noop() -> bb2;              // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
+          StorageLive(_2);                 // scope 0 at $DIR/simplify_if.rs:+2:9: +2:15
+          _2 = noop() -> bb2;              // scope 0 at $DIR/simplify_if.rs:+2:9: +2:15
                                            // mir::Constant
                                            // + span: $DIR/simplify_if.rs:7:9: 7:13
                                            // + literal: Const { ty: fn() {noop}, val: Value(<ZST>) }
       }
   
       bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:7:15: 7:16
-          nop;                             // scope 0 at $DIR/simplify_if.rs:6:14: 8:6
-          goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:+2:15: +2:16
+          nop;                             // scope 0 at $DIR/simplify_if.rs:+1:14: +3:6
+          goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:+1:5: +3:6
       }
   
       bb3: {
-          nop;                             // scope 0 at $DIR/simplify_if.rs:8:6: 8:6
-          goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
+          nop;                             // scope 0 at $DIR/simplify_if.rs:+3:6: +3:6
+          goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:+1:5: +3:6
       }
   
       bb4: {
-          StorageDead(_1);                 // scope 0 at $DIR/simplify_if.rs:8:5: 8:6
-          return;                          // scope 0 at $DIR/simplify_if.rs:9:2: 9:2
+          StorageDead(_1);                 // scope 0 at $DIR/simplify_if.rs:+3:5: +3:6
+          return;                          // scope 0 at $DIR/simplify_if.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.c.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.c.SimplifyLocals.diff
@@ -2,32 +2,32 @@
 + // MIR for `c` after SimplifyLocals
   
   fn c() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:13:8: 13:8
-      let _1: [u8; 10];                    // in scope 0 at $DIR/simplify-locals.rs:14:9: 14:14
--     let mut _2: &[u8];                   // in scope 0 at $DIR/simplify-locals.rs:16:20: 16:26
--     let mut _3: &[u8; 10];               // in scope 0 at $DIR/simplify-locals.rs:16:20: 16:26
--     let _4: &[u8; 10];                   // in scope 0 at $DIR/simplify-locals.rs:16:20: 16:26
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:8: +0:8
+      let _1: [u8; 10];                    // in scope 0 at $DIR/simplify-locals.rs:+1:9: +1:14
+-     let mut _2: &[u8];                   // in scope 0 at $DIR/simplify-locals.rs:+3:20: +3:26
+-     let mut _3: &[u8; 10];               // in scope 0 at $DIR/simplify-locals.rs:+3:20: +3:26
+-     let _4: &[u8; 10];                   // in scope 0 at $DIR/simplify-locals.rs:+3:20: +3:26
       scope 1 {
-          debug bytes => _1;               // in scope 1 at $DIR/simplify-locals.rs:14:9: 14:14
+          debug bytes => _1;               // in scope 1 at $DIR/simplify-locals.rs:+1:9: +1:14
           scope 2 {
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:14:9: 14:14
-          _1 = [const 0_u8; 10];           // scope 0 at $DIR/simplify-locals.rs:14:17: 14:26
--         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:16:20: 16:26
--         StorageLive(_3);                 // scope 1 at $DIR/simplify-locals.rs:16:20: 16:26
--         StorageLive(_4);                 // scope 1 at $DIR/simplify-locals.rs:16:20: 16:26
--         _4 = &_1;                        // scope 1 at $DIR/simplify-locals.rs:16:20: 16:26
--         _3 = &(*_4);                     // scope 1 at $DIR/simplify-locals.rs:16:20: 16:26
--         _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 1 at $DIR/simplify-locals.rs:16:20: 16:26
--         StorageDead(_3);                 // scope 1 at $DIR/simplify-locals.rs:16:25: 16:26
--         StorageDead(_4);                 // scope 1 at $DIR/simplify-locals.rs:16:26: 16:27
--         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals.rs:16:26: 16:27
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:13:8: 17:2
-          StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:17:1: 17:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:17:2: 17:2
+          StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:+1:9: +1:14
+          _1 = [const 0_u8; 10];           // scope 0 at $DIR/simplify-locals.rs:+1:17: +1:26
+-         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:+3:20: +3:26
+-         StorageLive(_3);                 // scope 1 at $DIR/simplify-locals.rs:+3:20: +3:26
+-         StorageLive(_4);                 // scope 1 at $DIR/simplify-locals.rs:+3:20: +3:26
+-         _4 = &_1;                        // scope 1 at $DIR/simplify-locals.rs:+3:20: +3:26
+-         _3 = &(*_4);                     // scope 1 at $DIR/simplify-locals.rs:+3:20: +3:26
+-         _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 1 at $DIR/simplify-locals.rs:+3:20: +3:26
+-         StorageDead(_3);                 // scope 1 at $DIR/simplify-locals.rs:+3:25: +3:26
+-         StorageDead(_4);                 // scope 1 at $DIR/simplify-locals.rs:+3:26: +3:27
+-         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals.rs:+3:26: +3:27
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:8: +4:2
+          StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:+4:1: +4:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+4:2: +4:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.d1.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d1.SimplifyLocals.diff
@@ -2,18 +2,18 @@
 + // MIR for `d1` after SimplifyLocals
   
   fn d1() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:20:9: 20:9
--     let mut _1: E;                       // in scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:9: +0:9
+-     let mut _1: E;                       // in scope 0 at $DIR/simplify-locals.rs:+2:13: +2:17
       scope 1 {
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
--         Deinit(_1);                      // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
--         discriminant(_1) = 0;            // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:22:17: 22:18
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:20:9: 23:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:23:2: 23:2
+-         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:13: +2:17
+-         Deinit(_1);                      // scope 0 at $DIR/simplify-locals.rs:+2:13: +2:17
+-         discriminant(_1) = 0;            // scope 0 at $DIR/simplify-locals.rs:+2:13: +2:17
+-         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:17: +2:18
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:9: +3:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
@@ -2,28 +2,28 @@
 + // MIR for `d2` after SimplifyLocals
   
   fn d2() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:26:9: 26:9
--     let mut _1: E;                       // in scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
--     let mut _2: (i32, E);                // in scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
--     let mut _3: E;                       // in scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:9: +0:9
+-     let mut _1: E;                       // in scope 0 at $DIR/simplify-locals.rs:+2:22: +2:26
+-     let mut _2: (i32, E);                // in scope 0 at $DIR/simplify-locals.rs:+2:5: +2:17
+-     let mut _3: E;                       // in scope 0 at $DIR/simplify-locals.rs:+2:11: +2:15
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
--         Deinit(_1);                      // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
--         discriminant(_1) = 1;            // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
--         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
--         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
--         Deinit(_3);                      // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
--         discriminant(_3) = 0;            // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
--         Deinit(_2);                      // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
--         (_2.0: i32) = const 10_i32;      // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
--         (_2.1: E) = move _3;             // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
--         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:28:15: 28:16
--         (_2.1: E) = move _1;             // scope 0 at $DIR/simplify-locals.rs:28:5: 28:26
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:28:25: 28:26
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:28:26: 28:27
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:26:9: 29:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:29:2: 29:2
+-         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:22: +2:26
+-         Deinit(_1);                      // scope 0 at $DIR/simplify-locals.rs:+2:22: +2:26
+-         discriminant(_1) = 1;            // scope 0 at $DIR/simplify-locals.rs:+2:22: +2:26
+-         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:17
+-         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:+2:11: +2:15
+-         Deinit(_3);                      // scope 0 at $DIR/simplify-locals.rs:+2:11: +2:15
+-         discriminant(_3) = 0;            // scope 0 at $DIR/simplify-locals.rs:+2:11: +2:15
+-         Deinit(_2);                      // scope 0 at $DIR/simplify-locals.rs:+2:6: +2:16
+-         (_2.0: i32) = const 10_i32;      // scope 0 at $DIR/simplify-locals.rs:+2:6: +2:16
+-         (_2.1: E) = move _3;             // scope 0 at $DIR/simplify-locals.rs:+2:6: +2:16
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:+2:15: +2:16
+-         (_2.1: E) = move _1;             // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:26
+-         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:25: +2:26
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:+2:26: +2:27
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:9: +3:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
@@ -2,20 +2,20 @@
 + // MIR for `expose_addr` after SimplifyLocals
   
   fn expose_addr(_1: *const usize) -> () {
-      debug p => _1;                       // in scope 0 at $DIR/simplify-locals.rs:66:16: 66:17
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:66:33: 66:33
-      let _2: usize;                       // in scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
-      let mut _3: *const usize;            // in scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
+      debug p => _1;                       // in scope 0 at $DIR/simplify-locals.rs:+0:16: +0:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:33: +0:33
+      let _2: usize;                       // in scope 0 at $DIR/simplify-locals.rs:+2:5: +2:15
+      let mut _3: *const usize;            // in scope 0 at $DIR/simplify-locals.rs:+2:5: +2:6
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
-          _3 = _1;                         // scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
-          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:68:14: 68:15
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:68:15: 68:16
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:66:33: 69:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:69:2: 69:2
+          StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:15
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:6
+          _3 = _1;                         // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:6
+          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:15
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:+2:14: +2:15
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:+2:15: +2:16
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:33: +3:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.r.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.r.SimplifyLocals.diff
@@ -2,12 +2,12 @@
 + // MIR for `r` after SimplifyLocals
   
   fn r() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:32:8: 32:8
-      let mut _1: i32;                     // in scope 0 at $DIR/simplify-locals.rs:33:9: 33:14
--     let mut _2: &i32;                    // in scope 0 at $DIR/simplify-locals.rs:35:13: 35:15
--     let mut _3: &mut i32;                // in scope 0 at $DIR/simplify-locals.rs:36:13: 36:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:8: +0:8
+      let mut _1: i32;                     // in scope 0 at $DIR/simplify-locals.rs:+1:9: +1:14
+-     let mut _2: &i32;                    // in scope 0 at $DIR/simplify-locals.rs:+3:13: +3:15
+-     let mut _3: &mut i32;                // in scope 0 at $DIR/simplify-locals.rs:+4:13: +4:19
       scope 1 {
-          debug a => _1;                   // in scope 1 at $DIR/simplify-locals.rs:33:9: 33:14
+          debug a => _1;                   // in scope 1 at $DIR/simplify-locals.rs:+1:9: +1:14
           scope 2 {
               scope 3 {
               }
@@ -15,17 +15,17 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:33:9: 33:14
-          _1 = const 1_i32;                // scope 0 at $DIR/simplify-locals.rs:33:17: 33:18
--         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:35:13: 35:15
--         _2 = &_1;                        // scope 1 at $DIR/simplify-locals.rs:35:13: 35:15
--         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals.rs:35:15: 35:16
--         StorageLive(_3);                 // scope 2 at $DIR/simplify-locals.rs:36:13: 36:19
--         _3 = &mut _1;                    // scope 2 at $DIR/simplify-locals.rs:36:13: 36:19
--         StorageDead(_3);                 // scope 2 at $DIR/simplify-locals.rs:36:19: 36:20
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:32:8: 37:2
-          StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:37:1: 37:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:37:2: 37:2
+          StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:+1:9: +1:14
+          _1 = const 1_i32;                // scope 0 at $DIR/simplify-locals.rs:+1:17: +1:18
+-         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:+3:13: +3:15
+-         _2 = &_1;                        // scope 1 at $DIR/simplify-locals.rs:+3:13: +3:15
+-         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals.rs:+3:15: +3:16
+-         StorageLive(_3);                 // scope 2 at $DIR/simplify-locals.rs:+4:13: +4:19
+-         _3 = &mut _1;                    // scope 2 at $DIR/simplify-locals.rs:+4:13: +4:19
+-         StorageDead(_3);                 // scope 2 at $DIR/simplify-locals.rs:+4:19: +4:20
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:8: +5:2
+          StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.t1.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t1.SimplifyLocals.diff
@@ -2,21 +2,21 @@
 + // MIR for `t1` after SimplifyLocals
   
   fn t1() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:42:9: 42:9
--     let _1: u32;                         // in scope 0 at $DIR/simplify-locals.rs:44:14: 44:15
--     let mut _2: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:44:14: 44:15
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:9: +0:9
+-     let _1: u32;                         // in scope 0 at $DIR/simplify-locals.rs:+2:14: +2:15
+-     let mut _2: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:+2:14: +2:15
       scope 1 {
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:44:5: 44:17
--         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:44:14: 44:15
--         _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:44:14: 44:15
--         _1 = (*_2);                      // scope 1 at $DIR/simplify-locals.rs:44:14: 44:15
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:44:17: 44:18
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:44:17: 44:18
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:42:9: 45:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:45:2: 45:2
+-         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:17
+-         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:15
+-         _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:15
+-         _1 = (*_2);                      // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:15
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:+2:17: +2:18
+-         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:17: +2:18
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:9: +3:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.t2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t2.SimplifyLocals.diff
@@ -2,21 +2,21 @@
 + // MIR for `t2` after SimplifyLocals
   
   fn t2() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:48:9: 48:9
--     let _1: &mut u32;                    // in scope 0 at $DIR/simplify-locals.rs:50:14: 50:20
--     let mut _2: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:50:19: 50:20
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:9: +0:9
+-     let _1: &mut u32;                    // in scope 0 at $DIR/simplify-locals.rs:+2:14: +2:20
+-     let mut _2: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:+2:19: +2:20
       scope 1 {
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:50:5: 50:22
--         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:50:19: 50:20
--         _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:50:19: 50:20
--         _1 = &mut (*_2);                 // scope 1 at $DIR/simplify-locals.rs:50:14: 50:20
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:50:22: 50:23
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:50:22: 50:23
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:48:9: 51:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:51:2: 51:2
+-         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:22
+-         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:+2:19: +2:20
+-         _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:+2:19: +2:20
+-         _1 = &mut (*_2);                 // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:20
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:+2:22: +2:23
+-         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:22: +2:23
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:9: +3:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.t3.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t3.SimplifyLocals.diff
@@ -2,25 +2,25 @@
 + // MIR for `t3` after SimplifyLocals
   
   fn t3() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:54:9: 54:9
--     let _1: u32;                         // in scope 0 at $DIR/simplify-locals.rs:56:14: 56:21
--     let mut _2: &mut u32;                // in scope 0 at $DIR/simplify-locals.rs:56:15: 56:21
--     let mut _3: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:56:20: 56:21
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:+0:9: +0:9
+-     let _1: u32;                         // in scope 0 at $DIR/simplify-locals.rs:+2:14: +2:21
+-     let mut _2: &mut u32;                // in scope 0 at $DIR/simplify-locals.rs:+2:15: +2:21
+-     let mut _3: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:+2:20: +2:21
       scope 1 {
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:56:5: 56:23
--         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:56:15: 56:21
--         StorageLive(_3);                 // scope 1 at $DIR/simplify-locals.rs:56:20: 56:21
--         _3 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:56:20: 56:21
--         _2 = &mut (*_3);                 // scope 1 at $DIR/simplify-locals.rs:56:15: 56:21
--         _1 = (*_2);                      // scope 1 at $DIR/simplify-locals.rs:56:14: 56:21
--         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:56:23: 56:24
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:56:23: 56:24
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:56:23: 56:24
-          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:54:9: 57:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:57:2: 57:2
+-         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:5: +2:23
+-         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:+2:15: +2:21
+-         StorageLive(_3);                 // scope 1 at $DIR/simplify-locals.rs:+2:20: +2:21
+-         _3 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:+2:20: +2:21
+-         _2 = &mut (*_3);                 // scope 1 at $DIR/simplify-locals.rs:+2:15: +2:21
+-         _1 = (*_2);                      // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:21
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:+2:23: +2:24
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:+2:23: +2:24
+-         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:+2:23: +2:24
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:+0:9: +3:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals.t4.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t4.SimplifyLocals.diff
@@ -2,21 +2,21 @@
 + // MIR for `t4` after SimplifyLocals
   
   fn t4() -> u32 {
-      let mut _0: u32;                     // return place in scope 0 at $DIR/simplify-locals.rs:60:12: 60:15
-      let mut _1: u32;                     // in scope 0 at $DIR/simplify-locals.rs:62:14: 62:15
-      let mut _2: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:62:14: 62:15
+      let mut _0: u32;                     // return place in scope 0 at $DIR/simplify-locals.rs:+0:12: +0:15
+      let mut _1: u32;                     // in scope 0 at $DIR/simplify-locals.rs:+2:14: +2:15
+      let mut _2: *mut u32;                // in scope 0 at $DIR/simplify-locals.rs:+2:14: +2:15
       scope 1 {
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 1 at $DIR/simplify-locals.rs:62:14: 62:15
-          StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:62:14: 62:15
-          _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:62:14: 62:15
-          _1 = (*_2);                      // scope 1 at $DIR/simplify-locals.rs:62:14: 62:15
-          _0 = Add(move _1, const 1_u32);  // scope 1 at $DIR/simplify-locals.rs:62:14: 62:19
-          StorageDead(_1);                 // scope 1 at $DIR/simplify-locals.rs:62:18: 62:19
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:63:1: 63:2
-          return;                          // scope 0 at $DIR/simplify-locals.rs:63:2: 63:2
+          StorageLive(_1);                 // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:15
+          StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:15
+          _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:15
+          _1 = (*_2);                      // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:15
+          _0 = Add(move _1, const 1_u32);  // scope 1 at $DIR/simplify-locals.rs:+2:14: +2:19
+          StorageDead(_1);                 // scope 1 at $DIR/simplify-locals.rs:+2:18: +2:19
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:+3:1: +3:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:+3:2: +3:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -2,61 +2,61 @@
 + // MIR for `foo` after SimplifyLocals
   
   fn foo() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals-fixedpoint.rs:3:13: 3:13
-      let mut _1: (std::option::Option<u8>, std::option::Option<T>); // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
-      let mut _2: std::option::Option<u8>; // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
-      let mut _3: std::option::Option<T>;  // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:51: 4:68
-      let mut _4: isize;                   // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:22: 4:26
-      let mut _5: isize;                   // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:13: 4:20
--     let mut _7: bool;                    // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
--     let mut _8: u8;                      // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:13
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+0:13: +0:13
+      let mut _1: (std::option::Option<u8>, std::option::Option<T>); // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+1:30: +1:69
+      let mut _2: std::option::Option<u8>; // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+1:31: +1:49
+      let mut _3: std::option::Option<T>;  // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+1:51: +1:68
+      let mut _4: isize;                   // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+1:22: +1:26
+      let mut _5: isize;                   // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+1:13: +1:20
+-     let mut _7: bool;                    // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+2:12: +2:20
+-     let mut _8: u8;                      // in scope 0 at $DIR/simplify-locals-fixedpoint.rs:+2:12: +2:13
       scope 1 {
-          debug a => _6;                   // in scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:18: 4:19
-          let _6: u8;                      // in scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:18: 4:19
+          debug a => _6;                   // in scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:18: +1:19
+          let _6: u8;                      // in scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:18: +1:19
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
-          StorageLive(_2);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
-          Deinit(_2);                      // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
-          discriminant(_2) = 0;            // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
-          StorageLive(_3);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:51: 4:68
-          Deinit(_3);                      // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:51: 4:68
-          discriminant(_3) = 0;            // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:51: 4:68
-          Deinit(_1);                      // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
-          (_1.0: std::option::Option<u8>) = move _2; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
-          (_1.1: std::option::Option<T>) = move _3; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
-          StorageDead(_3);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:68: 4:69
-          StorageDead(_2);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:68: 4:69
-          _5 = discriminant((_1.0: std::option::Option<u8>)); // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
-          switchInt(move _5) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
+          StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:30: +1:69
+          StorageLive(_2);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:31: +1:49
+          Deinit(_2);                      // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:31: +1:49
+          discriminant(_2) = 0;            // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:31: +1:49
+          StorageLive(_3);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:51: +1:68
+          Deinit(_3);                      // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:51: +1:68
+          discriminant(_3) = 0;            // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:51: +1:68
+          Deinit(_1);                      // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:30: +1:69
+          (_1.0: std::option::Option<u8>) = move _2; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:30: +1:69
+          (_1.1: std::option::Option<T>) = move _3; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:30: +1:69
+          StorageDead(_3);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:68: +1:69
+          StorageDead(_2);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:68: +1:69
+          _5 = discriminant((_1.0: std::option::Option<u8>)); // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:12: +1:27
+          switchInt(move _5) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:12: +1:27
       }
   
       bb1: {
-          _4 = discriminant((_1.1: std::option::Option<T>)); // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
-          switchInt(move _4) -> [0_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
+          _4 = discriminant((_1.1: std::option::Option<T>)); // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:12: +1:27
+          switchInt(move _4) -> [0_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:12: +1:27
       }
   
       bb2: {
-          StorageLive(_6);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:18: 4:19
-          _6 = (((_1.0: std::option::Option<u8>) as Some).0: u8); // scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:18: 4:19
--         StorageLive(_7);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
--         StorageLive(_8);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:13
--         _8 = _6;                         // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:13
--         _7 = Gt(move _8, const 42_u8);   // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
--         StorageDead(_8);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:19: 5:20
--         StorageDead(_7);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:7:9: 7:10
-          StorageDead(_6);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:8:5: 8:6
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:5: 8:6
+          StorageLive(_6);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:18: +1:19
+          _6 = (((_1.0: std::option::Option<u8>) as Some).0: u8); // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+1:18: +1:19
+-         StorageLive(_7);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+2:12: +2:20
+-         StorageLive(_8);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+2:12: +2:13
+-         _8 = _6;                         // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+2:12: +2:13
+-         _7 = Gt(move _8, const 42_u8);   // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+2:12: +2:20
+-         StorageDead(_8);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+2:19: +2:20
+-         StorageDead(_7);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:+4:9: +4:10
+          StorageDead(_6);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:+5:5: +5:6
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-fixedpoint.rs:+1:5: +5:6
       }
   
       bb3: {
-          drop(_1) -> bb4;                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:9:1: 9:2
+          drop(_1) -> bb4;                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:+6:1: +6:2
       }
   
       bb4: {
-          StorageDead(_1);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/simplify-locals-fixedpoint.rs:9:2: 9:2
+          StorageDead(_1);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/simplify-locals-fixedpoint.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -2,70 +2,70 @@
 + // MIR for `main` after SimplifyLocals
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:12:11: 12:11
--     let mut _1: ((), ());                // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
--     let mut _2: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
--     let mut _3: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:25: 13:27
--     let _4: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
--     let mut _5: ((), ());                // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
--     let mut _6: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:14:14: 14:16
--     let mut _7: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:14:18: 14:20
--     let _8: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
--     let mut _9: u8;                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
--     let mut _10: u8;                     // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
--     let mut _11: Temp;                   // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
-+     let _1: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-+     let mut _2: ((), ());                // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
-+     let _3: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+0:11: +0:11
+-     let mut _1: ((), ());                // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:20: +1:28
+-     let mut _2: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:21: +1:23
+-     let mut _3: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:25: +1:27
+-     let _4: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+2:5: +2:22
+-     let mut _5: ((), ());                // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+2:13: +2:21
+-     let mut _6: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+2:14: +2:16
+-     let mut _7: ();                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+2:18: +2:20
+-     let _8: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+4:5: +4:35
+-     let mut _9: u8;                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+4:12: +4:34
+-     let mut _10: u8;                     // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+4:12: +4:30
+-     let mut _11: Temp;                   // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+4:12: +4:28
++     let _1: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+2:5: +2:22
++     let mut _2: ((), ());                // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+2:13: +2:21
++     let _3: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+4:5: +4:35
       scope 1 {
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
--         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
--         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:25: 13:27
--         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:27: 13:28
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:27: 13:28
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:28: 13:29
--         StorageLive(_4);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
--         StorageLive(_5);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
--         StorageLive(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:14: 14:16
--         StorageLive(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:18: 14:20
--         StorageDead(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
--         StorageDead(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
--         _4 = use_zst(move _5) -> bb1;    // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-+         StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-+         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
-+         _1 = use_zst(move _2) -> bb1;    // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
+-         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:20: +1:28
+-         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:21: +1:23
+-         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:25: +1:27
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:27: +1:28
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:27: +1:28
+-         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+1:28: +1:29
+-         StorageLive(_4);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:5: +2:22
+-         StorageLive(_5);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:13: +2:21
+-         StorageLive(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:14: +2:16
+-         StorageLive(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:18: +2:20
+-         StorageDead(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:20: +2:21
+-         StorageDead(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:20: +2:21
+-         _4 = use_zst(move _5) -> bb1;    // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:5: +2:22
++         StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:5: +2:22
++         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:13: +2:21
++         _1 = use_zst(move _2) -> bb1;    // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:5: +2:22
                                            // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:12
                                            // + literal: Const { ty: fn(((), ())) {use_zst}, val: Value(<ZST>) }
       }
   
       bb1: {
--         StorageDead(_5);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:21: 14:22
--         StorageDead(_4);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
--         StorageLive(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
--         StorageLive(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
--         StorageLive(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
--         StorageLive(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
--         StorageDead(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:33: 16:34
--         _8 = use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
-+         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:21: 14:22
-+         StorageDead(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
-+         StorageLive(_3);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
-+         _3 = use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
+-         StorageDead(_5);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:21: +2:22
+-         StorageDead(_4);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:22: +2:23
+-         StorageLive(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:5: +4:35
+-         StorageLive(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:12: +4:34
+-         StorageLive(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:12: +4:30
+-         StorageLive(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:12: +4:28
+-         StorageDead(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:33: +4:34
+-         _8 = use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:5: +4:35
++         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:21: +2:22
++         StorageDead(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:22: +2:23
++         StorageLive(_3);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:5: +4:35
++         _3 = use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:5: +4:35
                                            // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:11
                                            // + literal: Const { ty: fn(u8) {use_u8}, val: Value(<ZST>) }
       }
   
       bb2: {
--         StorageDead(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:34: 16:35
--         StorageDead(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
--         StorageDead(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
-+         StorageDead(_3);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
-          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:17:2: 17:2
+-         StorageDead(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:34: +4:35
+-         StorageDead(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:35: +4:36
+-         StorageDead(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:35: +4:36
++         StorageDead(_3);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:35: +4:36
+          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
@@ -2,38 +2,38 @@
 + // MIR for `map` after SimplifyLocals
   
   fn map(_1: Option<Box<()>>) -> Option<Box<()>> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:8: 3:9
-      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:31: 3:46
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
--     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
--     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:25: 6:26
--     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
--     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
--     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+0:8: +0:9
+      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+0:31: +0:46
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:9: +2:13
+-     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
+-     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:25: +3:26
+-     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:1: +5:2
+-     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:1: +5:2
+-     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:1: +5:2
       scope 1 {
-          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
+          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:5: 4:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:5: +1:12
       }
   
       bb1: {
-          ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
-          Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
-          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:26: 6:27
+          ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
+          Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:26: +3:27
       }
   
       bb2: {
-          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2
+          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
@@ -2,38 +2,38 @@
 + // MIR for `map` after SimplifyLocals
   
   fn map(_1: Option<Box<()>>) -> Option<Box<()>> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:8: 3:9
-      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:31: 3:46
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
--     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
--     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:25: 6:26
--     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
--     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
--     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+0:8: +0:9
+      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+0:31: +0:46
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:9: +2:13
+-     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
+-     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:25: +3:26
+-     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:1: +5:2
+-     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:1: +5:2
+-     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:1: +5:2
       scope 1 {
-          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
+          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:5: 4:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:11: +1:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+1:5: +1:12
       }
   
       bb1: {
-          ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
-          Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
-          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:26: 6:27
+          ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:14: +3:15
+          Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:20: +3:27
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+3:26: +3:27
       }
   
       bb2: {
-          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+2:17: +2:21
       }
   
       bb3: {
-          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2
+          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_match.main.ConstProp.diff
+++ b/src/test/mir-opt/simplify_match.main.ConstProp.diff
@@ -2,39 +2,39 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_match.rs:5:11: 5:11
-      let mut _1: bool;                    // in scope 0 at $DIR/simplify_match.rs:6:11: 6:31
-      let _2: bool;                        // in scope 0 at $DIR/simplify_match.rs:6:17: 6:18
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify_match.rs:+0:11: +0:11
+      let mut _1: bool;                    // in scope 0 at $DIR/simplify_match.rs:+1:11: +1:31
+      let _2: bool;                        // in scope 0 at $DIR/simplify_match.rs:+1:17: +1:18
       scope 1 {
-          debug x => _2;                   // in scope 1 at $DIR/simplify_match.rs:6:17: 6:18
+          debug x => _2;                   // in scope 1 at $DIR/simplify_match.rs:+1:17: +1:18
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/simplify_match.rs:6:11: 6:31
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_match.rs:6:17: 6:18
-          _2 = const false;                // scope 0 at $DIR/simplify_match.rs:6:21: 6:26
--         _1 = _2;                         // scope 1 at $DIR/simplify_match.rs:6:28: 6:29
-+         _1 = const false;                // scope 1 at $DIR/simplify_match.rs:6:28: 6:29
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_match.rs:6:30: 6:31
--         switchInt(_1) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:6:5: 6:31
-+         switchInt(const false) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:6:5: 6:31
+          StorageLive(_1);                 // scope 0 at $DIR/simplify_match.rs:+1:11: +1:31
+          StorageLive(_2);                 // scope 0 at $DIR/simplify_match.rs:+1:17: +1:18
+          _2 = const false;                // scope 0 at $DIR/simplify_match.rs:+1:21: +1:26
+-         _1 = _2;                         // scope 1 at $DIR/simplify_match.rs:+1:28: +1:29
++         _1 = const false;                // scope 1 at $DIR/simplify_match.rs:+1:28: +1:29
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_match.rs:+1:30: +1:31
+-         switchInt(_1) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:+1:5: +1:31
++         switchInt(const false) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:+1:5: +1:31
       }
   
       bb1: {
-          nop;                             // scope 0 at $DIR/simplify_match.rs:8:18: 8:20
-          goto -> bb3;                     // scope 0 at $DIR/simplify_match.rs:8:18: 8:20
+          nop;                             // scope 0 at $DIR/simplify_match.rs:+3:18: +3:20
+          goto -> bb3;                     // scope 0 at $DIR/simplify_match.rs:+3:18: +3:20
       }
   
       bb2: {
-          _0 = noop() -> bb3;              // scope 0 at $DIR/simplify_match.rs:7:17: 7:23
+          _0 = noop() -> bb3;              // scope 0 at $DIR/simplify_match.rs:+2:17: +2:23
                                            // mir::Constant
                                            // + span: $DIR/simplify_match.rs:7:17: 7:21
                                            // + literal: Const { ty: fn() {noop}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_1);                 // scope 0 at $DIR/simplify_match.rs:10:1: 10:2
-          return;                          // scope 0 at $DIR/simplify_match.rs:10:2: 10:2
+          StorageDead(_1);                 // scope 0 at $DIR/simplify_match.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/simplify_match.rs:+5:2: +5:2
       }
   }
   

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -2,101 +2,101 @@
 + // MIR for `try_identity` after DestinationPropagation
   
   fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:20:17: 20:18
-      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:20:41: 20:57
-      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:21:9: 21:10
-      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:22:9: 22:15
-      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:22:19: 22:51
-      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:37: 22:50
-      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:48: 22:49
-      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:25:8: 25:9
+      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:+0:17: +0:18
+      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:+0:41: +0:57
+      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
+      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:+2:9: +2:15
+      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:+2:19: +2:51
+      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:37: +2:50
+      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:48: +2:49
+      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:+5:8: +5:9
       scope 1 {
--         debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
-+         debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
+-         debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:+1:9: +1:10
++         debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:+1:9: +1:10
       }
       scope 2 {
-          debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
+          debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:+2:13: +2:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
+              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
           }
       }
       scope 3 {
--         debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
-+         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
+-         debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
++         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
--         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
-+         debug r => _3;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
+-         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
++         debug r => _3;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
       }
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
--         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
--         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
--         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
--         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
--         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-+         _3 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-+         nop;                             // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
+-         StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
+-         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+-         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+-         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+-         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
+-         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
++         _3 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
++         nop;                             // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
       }
   
       bb1: {
--         StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
--         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
--         _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
--         StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
--         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
--         StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
--         _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-+         ((_0 as Ok).0: u32) = ((_3 as Ok).0: u32); // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-+         nop;                             // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-+         nop;                             // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
-+         nop;                             // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
-          Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
--         ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-+         nop;                             // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
--         StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
--         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-+         nop;                             // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+-         StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+-         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+-         _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:+3:18: +3:19
+-         StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:+3:18: +3:19
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
+-         StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
+-         _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
++         ((_0 as Ok).0: u32) = ((_3 as Ok).0: u32); // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
++         nop;                             // scope 3 at $DIR/simplify_try.rs:+3:18: +3:19
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+3:18: +3:19
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
++         nop;                             // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
++         nop;                             // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+-         ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
++         nop;                             // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+-         StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:+5:9: +5:10
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
++         nop;                             // scope 1 at $DIR/simplify_try.rs:+5:9: +5:10
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
       }
   
       bb2: {
-          StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-          nop;                             // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-          StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
-          StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
-          nop;                             // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+          StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+          nop;                             // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+          StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50
+          StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
+          nop;                             // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
           nop;                             // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
-          nop;                             // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-          StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
-          StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
--         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
--         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
+          nop;                             // scope 6 at $DIR/simplify_try.rs:+0:9: +0:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+          StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
+          StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
++         nop;                             // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -2,80 +2,80 @@
 + // MIR for `try_identity` after SimplifyArmIdentity
   
   fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:20:17: 20:18
-      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:20:41: 20:57
-      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:21:9: 21:10
-      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:22:9: 22:15
-      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:22:19: 22:51
-      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:37: 22:50
-      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:48: 22:49
-      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:25:8: 25:9
+      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:+0:17: +0:18
+      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:+0:41: +0:57
+      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
+      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:+2:9: +2:15
+      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:+2:19: +2:51
+      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:37: +2:50
+      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:48: +2:49
+      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:+5:8: +5:9
       scope 1 {
-          debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
+          debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:+1:9: +1:10
       }
       scope 2 {
-          debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
+          debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:+2:13: +2:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
+              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
           }
       }
       scope 3 {
-          debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
+          debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
+          debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
-          StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-          StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-          _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
-          StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
+          StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
+          StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+          StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+          _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+          _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
+          StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
       }
   
       bb1: {
-          StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-          _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-          _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
-          StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
-          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-          StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
-          _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
-          Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-          ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-          StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+          StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+          _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+          _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:+3:18: +3:19
+          StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:+3:18: +3:19
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
+          StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
+          _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+          ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+          StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:+5:9: +5:10
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
       }
   
       bb2: {
-          StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-          StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
-          StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
-          _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+          StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+          StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50
+          StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
+          _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
           _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
-          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-          StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
-          StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
-          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+          StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:+0:9: +0:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+          StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
+          StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -1,79 +1,79 @@
 // MIR for `try_identity` after SimplifyBranchSame
 
 fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
-    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:20:17: 20:18
-    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:20:41: 20:57
-    let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:21:9: 21:10
-    let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-    let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-    let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:22:9: 22:15
-    let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-    let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:22:19: 22:51
-    let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:37: 22:50
-    let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:48: 22:49
-    let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-    let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:25:8: 25:9
+    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:+0:17: +0:18
+    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:+0:41: +0:57
+    let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
+    let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+    let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+    let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:+2:9: +2:15
+    let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+    let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:+2:19: +2:51
+    let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:37: +2:50
+    let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:48: +2:49
+    let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+    let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:+5:8: +5:9
     scope 1 {
-        debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
+        debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:+1:9: +1:10
     }
     scope 2 {
-        debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
+        debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:+2:13: +2:14
         scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
             debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         }
         scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-            debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
+            debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
         }
     }
     scope 3 {
-        debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
+        debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-        debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
+        debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
-        StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-        StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-        _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-        _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
-        StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-        _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-        switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
+        StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
+        StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+        StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+        _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+        _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
+        StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
+        _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+        switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
     }
 
     bb1: {
-        StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-        _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-        _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
-        StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
-        StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-        StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
-        _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
-        Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-        ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-        discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-        StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
-        StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-        return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+        StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+        _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+        _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:+3:18: +3:19
+        StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:+3:18: +3:19
+        StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
+        StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
+        _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:+5:8: +5:9
+        Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+        ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+        discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+        StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:+5:9: +5:10
+        StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
+        return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
     }
 
     bb2: {
-        StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-        _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-        StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
-        StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
-        _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+        StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+        _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+        StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50
+        StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
+        _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
         _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
-        ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
-        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-        StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
-        StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
-        StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-        StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
-        return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+        StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
+        ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:+0:9: +0:10
+        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+        StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
+        StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
+        StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7
+        StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:+6:1: +6:2
+        return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
     }
 }

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -1,54 +1,54 @@
 // MIR for `try_identity` after SimplifyLocals
 
 fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
-    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:20:17: 20:18
-    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:20:41: 20:57
-    let mut _2: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-    let mut _3: isize;                   // in scope 0 at $DIR/simplify_try.rs:22:9: 22:15
-    let _4: i32;                         // in scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-    let mut _5: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:37: 22:50
-    let mut _6: i32;                     // in scope 0 at $DIR/simplify_try.rs:22:48: 22:49
+    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:+0:17: +0:18
+    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:+0:41: +0:57
+    let mut _2: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+    let mut _3: isize;                   // in scope 0 at $DIR/simplify_try.rs:+2:9: +2:15
+    let _4: i32;                         // in scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+    let mut _5: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:37: +2:50
+    let mut _6: i32;                     // in scope 0 at $DIR/simplify_try.rs:+2:48: +2:49
     scope 1 {
-        debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
+        debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:+1:9: +1:10
     }
     scope 2 {
-        debug e => _4;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
+        debug e => _4;                   // in scope 2 at $DIR/simplify_try.rs:+2:13: +2:14
         scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
             debug t => _6;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         }
         scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-            debug e => _5;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
+            debug e => _5;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
         }
     }
     scope 3 {
-        debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
+        debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-        debug r => _2;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
+        debug r => _2;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
     }
 
     bb0: {
-        _2 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-        _3 = discriminant(_2);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-        switchInt(move _3) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
+        _2 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
+        _3 = discriminant(_2);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
+        switchInt(move _3) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
     }
 
     bb1: {
-        ((_0 as Ok).0: u32) = ((_2 as Ok).0: u32); // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
-        Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-        discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
-        return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+        ((_0 as Ok).0: u32) = ((_2 as Ok).0: u32); // scope 0 at $DIR/simplify_try.rs:+3:12: +3:13
+        Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+        discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:+5:5: +5:10
+        return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
     }
 
     bb2: {
-        StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
-        StorageLive(_5);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
-        StorageLive(_6);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
-        StorageDead(_6);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
-        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
-        StorageDead(_5);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
-        StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
-        return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+        StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+2:13: +2:14
+        StorageLive(_5);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50
+        StorageLive(_6);                 // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
+        StorageDead(_6);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
+        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+        StorageDead(_5);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
+        StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
+        return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2
     }
 }

--- a/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.32bit.mir
+++ b/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.32bit.mir
@@ -1,101 +1,101 @@
 // MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
 
 fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
-    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _2: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _3: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _4: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _5: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _6: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _7: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _8: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _9: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _10: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _11: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _13: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _14: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _15: *mut [std::string::String]; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _2: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _3: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _4: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _5: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _6: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _7: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _8: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _9: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _10: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _11: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _13: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _14: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _15: *mut [std::string::String]; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
 
     bb0: {
-        goto -> bb15;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb15;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb1: {
-        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb3 (cleanup): {
-        _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_5)) -> bb4;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_5)) -> bb4;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb4 (cleanup): {
-        _6 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _6) -> [false: bb3, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _6 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _6) -> [false: bb3, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb5: {
-        _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_7)) -> [return: bb6, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_7)) -> [return: bb6, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb6: {
-        _8 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _8) -> [false: bb5, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _8 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _8) -> [false: bb5, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb7: {
-        _4 = const 0_usize;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _4 = const 0_usize;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb8: {
-        goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb9 (cleanup): {
-        _11 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_11)) -> bb10;            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _11 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_11)) -> bb10;            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb10 (cleanup): {
-        _12 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _12) -> [false: bb9, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _12 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _12) -> [false: bb9, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb11: {
-        _13 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_13)) -> [return: bb12, unwind: bb10]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _13 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_13)) -> [return: bb12, unwind: bb10]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb12: {
-        _14 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _14) -> [false: bb11, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _14 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _14) -> [false: bb11, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb13: {
-        _15 = &raw mut (*_1);            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _9 = move _15 as *mut std::string::String (Misc); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _10 = Offset(_9, move _3);       // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        goto -> bb12;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _15 = &raw mut (*_1);            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _9 = move _15 as *mut std::string::String (Misc); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _10 = Offset(_9, move _3);       // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        goto -> bb12;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb14: {
-        goto -> bb13;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb13;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb15: {
-        _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _3 = Len((*_1));                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _3 = Len((*_1));                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 }

--- a/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.64bit.mir
+++ b/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.64bit.mir
@@ -1,101 +1,101 @@
 // MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
 
 fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
-    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _2: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _3: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _4: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _5: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _6: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _7: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _8: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _9: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _10: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _11: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _13: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _14: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _15: *mut [std::string::String]; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _2: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _3: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _4: usize;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _5: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _6: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _7: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _8: bool;                    // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _9: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _10: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _11: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _13: *mut std::string::String; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _14: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _15: *mut [std::string::String]; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
 
     bb0: {
-        goto -> bb15;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb15;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb1: {
-        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb3 (cleanup): {
-        _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_5)) -> bb4;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_5)) -> bb4;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb4 (cleanup): {
-        _6 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _6) -> [false: bb3, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _6 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _6) -> [false: bb3, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb5: {
-        _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_7)) -> [return: bb6, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_7)) -> [return: bb6, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb6: {
-        _8 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _8) -> [false: bb5, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _8 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _8) -> [false: bb5, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb7: {
-        _4 = const 0_usize;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _4 = const 0_usize;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb8: {
-        goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb9 (cleanup): {
-        _11 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_11)) -> bb10;            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _11 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_11)) -> bb10;            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb10 (cleanup): {
-        _12 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _12) -> [false: bb9, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _12 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _12) -> [false: bb9, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb11: {
-        _13 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        drop((*_13)) -> [return: bb12, unwind: bb10]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _13 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        drop((*_13)) -> [return: bb12, unwind: bb10]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb12: {
-        _14 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _14) -> [false: bb11, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _14 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _14) -> [false: bb11, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb13: {
-        _15 = &raw mut (*_1);            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _9 = move _15 as *mut std::string::String (Misc); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _10 = Offset(_9, move _3);       // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        goto -> bb12;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _15 = &raw mut (*_1);            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _9 = move _15 as *mut std::string::String (Misc); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _10 = Offset(_9, move _3);       // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        goto -> bb12;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb14: {
-        goto -> bb13;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb13;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb15: {
-        _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _3 = Len((*_1));                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _3 = Len((*_1));                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 }

--- a/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
@@ -1,203 +1,203 @@
 // MIR for `XXX` 0 mir_map
 
 static XXX: &Foo = {
-    let mut _0: &Foo;                    // return place in scope 0 at $DIR/storage_live_dead_in_statics.rs:5:13: 5:25
-    let _1: &Foo;                        // in scope 0 at $DIR/storage_live_dead_in_statics.rs:5:28: 23:2
-    let _2: Foo;                         // in scope 0 at $DIR/storage_live_dead_in_statics.rs:5:29: 23:2
-    let mut _3: &[(u32, u32)];           // in scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-    let mut _4: &[(u32, u32); 42];       // in scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-    let _5: &[(u32, u32); 42];           // in scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-    let _6: [(u32, u32); 42];            // in scope 0 at $DIR/storage_live_dead_in_statics.rs:7:12: 22:6
-    let mut _7: (u32, u32);              // in scope 0 at $DIR/storage_live_dead_in_statics.rs:8:9: 8:15
-    let mut _8: (u32, u32);              // in scope 0 at $DIR/storage_live_dead_in_statics.rs:8:17: 8:23
-    let mut _9: (u32, u32);              // in scope 0 at $DIR/storage_live_dead_in_statics.rs:8:25: 8:31
-    let mut _10: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:9:9: 9:15
-    let mut _11: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:9:17: 9:23
-    let mut _12: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:9:25: 9:31
-    let mut _13: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:10:9: 10:15
-    let mut _14: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:10:17: 10:23
-    let mut _15: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:10:25: 10:31
-    let mut _16: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:11:9: 11:15
-    let mut _17: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:11:17: 11:23
-    let mut _18: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:11:25: 11:31
-    let mut _19: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:12:9: 12:15
-    let mut _20: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:12:17: 12:23
-    let mut _21: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:12:25: 12:31
-    let mut _22: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:13:9: 13:15
-    let mut _23: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:13:17: 13:23
-    let mut _24: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:13:25: 13:31
-    let mut _25: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:14:9: 14:15
-    let mut _26: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:14:17: 14:23
-    let mut _27: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:14:25: 14:31
-    let mut _28: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:15:9: 15:15
-    let mut _29: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:15:17: 15:23
-    let mut _30: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:15:25: 15:31
-    let mut _31: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:16:9: 16:15
-    let mut _32: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:16:17: 16:23
-    let mut _33: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:16:25: 16:31
-    let mut _34: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:17:9: 17:15
-    let mut _35: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:17:17: 17:23
-    let mut _36: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:17:25: 17:31
-    let mut _37: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:18:9: 18:15
-    let mut _38: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:18:17: 18:23
-    let mut _39: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:18:25: 18:31
-    let mut _40: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:19:9: 19:15
-    let mut _41: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:19:17: 19:23
-    let mut _42: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:19:25: 19:31
-    let mut _43: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:20:9: 20:15
-    let mut _44: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:20:17: 20:23
-    let mut _45: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:20:25: 20:31
-    let mut _46: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:21:9: 21:15
-    let mut _47: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:21:17: 21:23
-    let mut _48: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:21:25: 21:31
+    let mut _0: &Foo;                    // return place in scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:13: +0:25
+    let _1: &Foo;                        // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:28: +18:2
+    let _2: Foo;                         // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:29: +18:2
+    let mut _3: &[(u32, u32)];           // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+    let mut _4: &[(u32, u32); 42];       // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+    let _5: &[(u32, u32); 42];           // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+    let _6: [(u32, u32); 42];            // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:12: +17:6
+    let mut _7: (u32, u32);              // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:9: +3:15
+    let mut _8: (u32, u32);              // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:17: +3:23
+    let mut _9: (u32, u32);              // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:25: +3:31
+    let mut _10: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:9: +4:15
+    let mut _11: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:17: +4:23
+    let mut _12: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:25: +4:31
+    let mut _13: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:9: +5:15
+    let mut _14: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:17: +5:23
+    let mut _15: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:25: +5:31
+    let mut _16: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:9: +6:15
+    let mut _17: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:17: +6:23
+    let mut _18: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:25: +6:31
+    let mut _19: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:9: +7:15
+    let mut _20: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:17: +7:23
+    let mut _21: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:25: +7:31
+    let mut _22: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:9: +8:15
+    let mut _23: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:17: +8:23
+    let mut _24: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:25: +8:31
+    let mut _25: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:9: +9:15
+    let mut _26: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:17: +9:23
+    let mut _27: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:25: +9:31
+    let mut _28: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:9: +10:15
+    let mut _29: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:17: +10:23
+    let mut _30: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:25: +10:31
+    let mut _31: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:9: +11:15
+    let mut _32: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:17: +11:23
+    let mut _33: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:25: +11:31
+    let mut _34: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:9: +12:15
+    let mut _35: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:17: +12:23
+    let mut _36: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:25: +12:31
+    let mut _37: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:9: +13:15
+    let mut _38: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:17: +13:23
+    let mut _39: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:25: +13:31
+    let mut _40: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:9: +14:15
+    let mut _41: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:17: +14:23
+    let mut _42: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:25: +14:31
+    let mut _43: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:9: +15:15
+    let mut _44: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:17: +15:23
+    let mut _45: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:25: +15:31
+    let mut _46: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:9: +16:15
+    let mut _47: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:17: +16:23
+    let mut _48: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:25: +16:31
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:28: 23:2
-        StorageLive(_2);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:29: 23:2
-        StorageLive(_3);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-        StorageLive(_4);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-        StorageLive(_5);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-        StorageLive(_6);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:12: 22:6
-        StorageLive(_7);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:9: 8:15
-        _7 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:9: 8:15
-        StorageLive(_8);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:17: 8:23
-        _8 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:17: 8:23
-        StorageLive(_9);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:25: 8:31
-        _9 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:25: 8:31
-        StorageLive(_10);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:9: 9:15
-        _10 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:9: 9:15
-        StorageLive(_11);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:17: 9:23
-        _11 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:17: 9:23
-        StorageLive(_12);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:25: 9:31
-        _12 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:25: 9:31
-        StorageLive(_13);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:9: 10:15
-        _13 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:9: 10:15
-        StorageLive(_14);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:17: 10:23
-        _14 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:17: 10:23
-        StorageLive(_15);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:25: 10:31
-        _15 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:25: 10:31
-        StorageLive(_16);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:9: 11:15
-        _16 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:9: 11:15
-        StorageLive(_17);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:17: 11:23
-        _17 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:17: 11:23
-        StorageLive(_18);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:25: 11:31
-        _18 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:25: 11:31
-        StorageLive(_19);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:9: 12:15
-        _19 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:9: 12:15
-        StorageLive(_20);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:17: 12:23
-        _20 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:17: 12:23
-        StorageLive(_21);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:25: 12:31
-        _21 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:25: 12:31
-        StorageLive(_22);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:9: 13:15
-        _22 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:9: 13:15
-        StorageLive(_23);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:17: 13:23
-        _23 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:17: 13:23
-        StorageLive(_24);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:25: 13:31
-        _24 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:25: 13:31
-        StorageLive(_25);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:9: 14:15
-        _25 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:9: 14:15
-        StorageLive(_26);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:17: 14:23
-        _26 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:17: 14:23
-        StorageLive(_27);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:25: 14:31
-        _27 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:25: 14:31
-        StorageLive(_28);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:9: 15:15
-        _28 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:9: 15:15
-        StorageLive(_29);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:17: 15:23
-        _29 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:17: 15:23
-        StorageLive(_30);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:25: 15:31
-        _30 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:25: 15:31
-        StorageLive(_31);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:9: 16:15
-        _31 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:9: 16:15
-        StorageLive(_32);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:17: 16:23
-        _32 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:17: 16:23
-        StorageLive(_33);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:25: 16:31
-        _33 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:25: 16:31
-        StorageLive(_34);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:9: 17:15
-        _34 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:9: 17:15
-        StorageLive(_35);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:17: 17:23
-        _35 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:17: 17:23
-        StorageLive(_36);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:25: 17:31
-        _36 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:25: 17:31
-        StorageLive(_37);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:9: 18:15
-        _37 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:9: 18:15
-        StorageLive(_38);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:17: 18:23
-        _38 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:17: 18:23
-        StorageLive(_39);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:25: 18:31
-        _39 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:25: 18:31
-        StorageLive(_40);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:9: 19:15
-        _40 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:9: 19:15
-        StorageLive(_41);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:17: 19:23
-        _41 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:17: 19:23
-        StorageLive(_42);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:25: 19:31
-        _42 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:25: 19:31
-        StorageLive(_43);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:9: 20:15
-        _43 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:9: 20:15
-        StorageLive(_44);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:17: 20:23
-        _44 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:17: 20:23
-        StorageLive(_45);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:25: 20:31
-        _45 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:25: 20:31
-        StorageLive(_46);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:9: 21:15
-        _46 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:9: 21:15
-        StorageLive(_47);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:17: 21:23
-        _47 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:17: 21:23
-        StorageLive(_48);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:25: 21:31
-        _48 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:25: 21:31
-        _6 = [move _7, move _8, move _9, move _10, move _11, move _12, move _13, move _14, move _15, move _16, move _17, move _18, move _19, move _20, move _21, move _22, move _23, move _24, move _25, move _26, move _27, move _28, move _29, move _30, move _31, move _32, move _33, move _34, move _35, move _36, move _37, move _38, move _39, move _40, move _41, move _42, move _43, move _44, move _45, move _46, move _47, move _48]; // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:12: 22:6
-        StorageDead(_48);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_47);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_46);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_45);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_44);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_43);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_42);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_41);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_40);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_39);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_38);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_37);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_36);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_35);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_34);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_33);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_32);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_31);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_30);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_29);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_28);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_27);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_26);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_25);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_24);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_23);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_22);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_21);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_20);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_19);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_18);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_17);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_16);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_15);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_14);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_13);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_12);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_11);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_10);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_9);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_8);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        StorageDead(_7);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        _5 = &_6;                        // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-        _4 = &(*_5);                     // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-        _3 = move _4 as &[(u32, u32)] (Pointer(Unsize)); // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
-        StorageDead(_4);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:22:5: 22:6
-        _2 = Foo { tup: const "hi", data: move _3 }; // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:29: 23:2
+        StorageLive(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:28: +18:2
+        StorageLive(_2);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:29: +18:2
+        StorageLive(_3);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+        StorageLive(_4);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+        StorageLive(_5);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+        StorageLive(_6);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:12: +17:6
+        StorageLive(_7);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:9: +3:15
+        _7 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:9: +3:15
+        StorageLive(_8);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:17: +3:23
+        _8 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:17: +3:23
+        StorageLive(_9);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:25: +3:31
+        _9 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+3:25: +3:31
+        StorageLive(_10);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:9: +4:15
+        _10 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:9: +4:15
+        StorageLive(_11);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:17: +4:23
+        _11 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:17: +4:23
+        StorageLive(_12);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:25: +4:31
+        _12 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+4:25: +4:31
+        StorageLive(_13);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:9: +5:15
+        _13 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:9: +5:15
+        StorageLive(_14);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:17: +5:23
+        _14 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:17: +5:23
+        StorageLive(_15);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:25: +5:31
+        _15 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+5:25: +5:31
+        StorageLive(_16);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:9: +6:15
+        _16 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:9: +6:15
+        StorageLive(_17);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:17: +6:23
+        _17 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:17: +6:23
+        StorageLive(_18);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:25: +6:31
+        _18 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+6:25: +6:31
+        StorageLive(_19);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:9: +7:15
+        _19 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:9: +7:15
+        StorageLive(_20);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:17: +7:23
+        _20 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:17: +7:23
+        StorageLive(_21);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:25: +7:31
+        _21 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+7:25: +7:31
+        StorageLive(_22);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:9: +8:15
+        _22 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:9: +8:15
+        StorageLive(_23);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:17: +8:23
+        _23 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:17: +8:23
+        StorageLive(_24);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:25: +8:31
+        _24 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+8:25: +8:31
+        StorageLive(_25);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:9: +9:15
+        _25 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:9: +9:15
+        StorageLive(_26);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:17: +9:23
+        _26 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:17: +9:23
+        StorageLive(_27);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:25: +9:31
+        _27 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+9:25: +9:31
+        StorageLive(_28);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:9: +10:15
+        _28 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:9: +10:15
+        StorageLive(_29);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:17: +10:23
+        _29 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:17: +10:23
+        StorageLive(_30);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:25: +10:31
+        _30 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+10:25: +10:31
+        StorageLive(_31);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:9: +11:15
+        _31 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:9: +11:15
+        StorageLive(_32);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:17: +11:23
+        _32 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:17: +11:23
+        StorageLive(_33);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:25: +11:31
+        _33 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+11:25: +11:31
+        StorageLive(_34);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:9: +12:15
+        _34 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:9: +12:15
+        StorageLive(_35);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:17: +12:23
+        _35 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:17: +12:23
+        StorageLive(_36);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:25: +12:31
+        _36 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+12:25: +12:31
+        StorageLive(_37);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:9: +13:15
+        _37 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:9: +13:15
+        StorageLive(_38);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:17: +13:23
+        _38 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:17: +13:23
+        StorageLive(_39);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:25: +13:31
+        _39 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+13:25: +13:31
+        StorageLive(_40);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:9: +14:15
+        _40 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:9: +14:15
+        StorageLive(_41);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:17: +14:23
+        _41 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:17: +14:23
+        StorageLive(_42);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:25: +14:31
+        _42 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+14:25: +14:31
+        StorageLive(_43);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:9: +15:15
+        _43 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:9: +15:15
+        StorageLive(_44);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:17: +15:23
+        _44 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:17: +15:23
+        StorageLive(_45);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:25: +15:31
+        _45 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+15:25: +15:31
+        StorageLive(_46);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:9: +16:15
+        _46 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:9: +16:15
+        StorageLive(_47);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:17: +16:23
+        _47 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:17: +16:23
+        StorageLive(_48);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:25: +16:31
+        _48 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+16:25: +16:31
+        _6 = [move _7, move _8, move _9, move _10, move _11, move _12, move _13, move _14, move _15, move _16, move _17, move _18, move _19, move _20, move _21, move _22, move _23, move _24, move _25, move _26, move _27, move _28, move _29, move _30, move _31, move _32, move _33, move _34, move _35, move _36, move _37, move _38, move _39, move _40, move _41, move _42, move _43, move _44, move _45, move _46, move _47, move _48]; // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:12: +17:6
+        StorageDead(_48);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_47);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_46);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_45);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_44);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_43);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_42);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_41);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_40);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_39);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_38);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_37);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_36);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_35);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_34);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_33);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_32);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_31);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_30);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_29);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_28);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_27);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_26);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_25);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_24);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_23);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_22);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_21);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_20);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_19);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_18);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_17);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_16);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_15);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_14);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_13);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_12);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_11);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_10);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_9);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_8);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        StorageDead(_7);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        _5 = &_6;                        // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+        _4 = &(*_5);                     // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+        _3 = move _4 as &[(u32, u32)] (Pointer(Unsize)); // scope 0 at $DIR/storage_live_dead_in_statics.rs:+2:11: +17:6
+        StorageDead(_4);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+17:5: +17:6
+        _2 = Foo { tup: const "hi", data: move _3 }; // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:29: +18:2
                                          // mir::Constant
                                          // + span: $DIR/storage_live_dead_in_statics.rs:6:10: 6:14
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        StorageDead(_3);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:23:1: 23:2
-        _1 = &_2;                        // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:28: 23:2
-        _0 = &(*_1);                     // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:28: 23:2
-        StorageDead(_5);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:23:1: 23:2
-        StorageDead(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:23:1: 23:2
-        return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:1: 5:25
+        StorageDead(_3);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+18:1: +18:2
+        _1 = &_2;                        // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:28: +18:2
+        _0 = &(*_1);                     // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:28: +18:2
+        StorageDead(_5);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+18:1: +18:2
+        StorageDead(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+18:1: +18:2
+        return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:1: +0:25
     }
 }

--- a/src/test/mir-opt/storage_ranges.main.nll.0.mir
+++ b/src/test/mir-opt/storage_ranges.main.nll.0.mir
@@ -19,46 +19,46 @@
 | '_#3r: '_#4r due to Assignment at Single(bb0[10]) ($DIR/storage_ranges.rs:6:17: 6:25 (#0)
 |
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/storage_ranges.rs:3:11: 3:11
-    let _1: i32;                         // in scope 0 at $DIR/storage_ranges.rs:4:9: 4:10
-    let _2: ();                          // in scope 0 at $DIR/storage_ranges.rs:5:5: 7:6
-    let _4: std::option::Option<i32>;    // in scope 0 at $DIR/storage_ranges.rs:6:18: 6:25
-    let mut _5: i32;                     // in scope 0 at $DIR/storage_ranges.rs:6:23: 6:24
+    let mut _0: ();                      // return place in scope 0 at $DIR/storage_ranges.rs:+0:11: +0:11
+    let _1: i32;                         // in scope 0 at $DIR/storage_ranges.rs:+1:9: +1:10
+    let _2: ();                          // in scope 0 at $DIR/storage_ranges.rs:+2:5: +4:6
+    let _4: std::option::Option<i32>;    // in scope 0 at $DIR/storage_ranges.rs:+3:18: +3:25
+    let mut _5: i32;                     // in scope 0 at $DIR/storage_ranges.rs:+3:23: +3:24
     scope 1 {
-        debug a => _1;                   // in scope 1 at $DIR/storage_ranges.rs:4:9: 4:10
-        let _3: &std::option::Option<i32>; // in scope 1 at $DIR/storage_ranges.rs:6:13: 6:14
-        let _6: i32;                     // in scope 1 at $DIR/storage_ranges.rs:8:9: 8:10
+        debug a => _1;                   // in scope 1 at $DIR/storage_ranges.rs:+1:9: +1:10
+        let _3: &std::option::Option<i32>; // in scope 1 at $DIR/storage_ranges.rs:+3:13: +3:14
+        let _6: i32;                     // in scope 1 at $DIR/storage_ranges.rs:+5:9: +5:10
         scope 2 {
-            debug b => _3;               // in scope 2 at $DIR/storage_ranges.rs:6:13: 6:14
+            debug b => _3;               // in scope 2 at $DIR/storage_ranges.rs:+3:13: +3:14
         }
         scope 3 {
-            debug c => _6;               // in scope 3 at $DIR/storage_ranges.rs:8:9: 8:10
+            debug c => _6;               // in scope 3 at $DIR/storage_ranges.rs:+5:9: +5:10
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/storage_ranges.rs:4:9: 4:10
-        _1 = const 0_i32;                // scope 0 at $DIR/storage_ranges.rs:4:13: 4:14
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/storage_ranges.rs:4:9: 4:10
-        StorageLive(_2);                 // scope 1 at $DIR/storage_ranges.rs:5:5: 7:6
-        StorageLive(_3);                 // scope 1 at $DIR/storage_ranges.rs:6:13: 6:14
-        StorageLive(_4);                 // scope 1 at $DIR/storage_ranges.rs:6:18: 6:25
-        StorageLive(_5);                 // scope 1 at $DIR/storage_ranges.rs:6:23: 6:24
-        _5 = _1;                         // scope 1 at $DIR/storage_ranges.rs:6:23: 6:24
-        _4 = Option::<i32>::Some(move _5); // scope 1 at $DIR/storage_ranges.rs:6:18: 6:25
-        StorageDead(_5);                 // scope 1 at $DIR/storage_ranges.rs:6:24: 6:25
-        _3 = &_4;                        // scope 1 at $DIR/storage_ranges.rs:6:17: 6:25
-        FakeRead(ForLet(None), _3);      // scope 1 at $DIR/storage_ranges.rs:6:13: 6:14
-        _2 = const ();                   // scope 1 at $DIR/storage_ranges.rs:5:5: 7:6
-        StorageDead(_4);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
-        StorageDead(_3);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
-        StorageDead(_2);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
-        StorageLive(_6);                 // scope 1 at $DIR/storage_ranges.rs:8:9: 8:10
-        _6 = const 1_i32;                // scope 1 at $DIR/storage_ranges.rs:8:13: 8:14
-        FakeRead(ForLet(None), _6);      // scope 1 at $DIR/storage_ranges.rs:8:9: 8:10
-        _0 = const ();                   // scope 0 at $DIR/storage_ranges.rs:3:11: 9:2
-        StorageDead(_6);                 // scope 1 at $DIR/storage_ranges.rs:9:1: 9:2
-        StorageDead(_1);                 // scope 0 at $DIR/storage_ranges.rs:9:1: 9:2
-        return;                          // scope 0 at $DIR/storage_ranges.rs:9:2: 9:2
+        StorageLive(_1);                 // scope 0 at $DIR/storage_ranges.rs:+1:9: +1:10
+        _1 = const 0_i32;                // scope 0 at $DIR/storage_ranges.rs:+1:13: +1:14
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/storage_ranges.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 1 at $DIR/storage_ranges.rs:+2:5: +4:6
+        StorageLive(_3);                 // scope 1 at $DIR/storage_ranges.rs:+3:13: +3:14
+        StorageLive(_4);                 // scope 1 at $DIR/storage_ranges.rs:+3:18: +3:25
+        StorageLive(_5);                 // scope 1 at $DIR/storage_ranges.rs:+3:23: +3:24
+        _5 = _1;                         // scope 1 at $DIR/storage_ranges.rs:+3:23: +3:24
+        _4 = Option::<i32>::Some(move _5); // scope 1 at $DIR/storage_ranges.rs:+3:18: +3:25
+        StorageDead(_5);                 // scope 1 at $DIR/storage_ranges.rs:+3:24: +3:25
+        _3 = &_4;                        // scope 1 at $DIR/storage_ranges.rs:+3:17: +3:25
+        FakeRead(ForLet(None), _3);      // scope 1 at $DIR/storage_ranges.rs:+3:13: +3:14
+        _2 = const ();                   // scope 1 at $DIR/storage_ranges.rs:+2:5: +4:6
+        StorageDead(_4);                 // scope 1 at $DIR/storage_ranges.rs:+4:5: +4:6
+        StorageDead(_3);                 // scope 1 at $DIR/storage_ranges.rs:+4:5: +4:6
+        StorageDead(_2);                 // scope 1 at $DIR/storage_ranges.rs:+4:5: +4:6
+        StorageLive(_6);                 // scope 1 at $DIR/storage_ranges.rs:+5:9: +5:10
+        _6 = const 1_i32;                // scope 1 at $DIR/storage_ranges.rs:+5:13: +5:14
+        FakeRead(ForLet(None), _6);      // scope 1 at $DIR/storage_ranges.rs:+5:9: +5:10
+        _0 = const ();                   // scope 0 at $DIR/storage_ranges.rs:+0:11: +6:2
+        StorageDead(_6);                 // scope 1 at $DIR/storage_ranges.rs:+6:1: +6:2
+        StorageDead(_1);                 // scope 0 at $DIR/storage_ranges.rs:+6:1: +6:2
+        return;                          // scope 0 at $DIR/storage_ranges.rs:+6:2: +6:2
     }
 }

--- a/src/test/mir-opt/tls_access.main.PreCodegen.after.mir
+++ b/src/test/mir-opt/tls_access.main.PreCodegen.after.mir
@@ -1,28 +1,28 @@
 // MIR for `main` after PreCodegen
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/tls-access.rs:9:11: 9:11
-    let _2: *mut u8;                     // in scope 0 at $DIR/tls-access.rs:11:18: 11:21
-    let mut _3: *mut u8;                 // in scope 0 at $DIR/tls-access.rs:12:9: 12:12
+    let mut _0: ();                      // return place in scope 0 at $DIR/tls-access.rs:+0:11: +0:11
+    let _2: *mut u8;                     // in scope 0 at $DIR/tls-access.rs:+2:18: +2:21
+    let mut _3: *mut u8;                 // in scope 0 at $DIR/tls-access.rs:+3:9: +3:12
     scope 1 {
-        let _1: &u8;                     // in scope 1 at $DIR/tls-access.rs:11:13: 11:14
+        let _1: &u8;                     // in scope 1 at $DIR/tls-access.rs:+2:13: +2:14
         scope 2 {
-            debug a => _1;               // in scope 2 at $DIR/tls-access.rs:11:13: 11:14
+            debug a => _1;               // in scope 2 at $DIR/tls-access.rs:+2:13: +2:14
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 1 at $DIR/tls-access.rs:11:13: 11:14
-        StorageLive(_2);                 // scope 1 at $DIR/tls-access.rs:11:18: 11:21
-        _2 = &/*tls*/ mut FOO;           // scope 1 at $DIR/tls-access.rs:11:18: 11:21
-        _1 = &(*_2);                     // scope 1 at $DIR/tls-access.rs:11:17: 11:21
-        StorageLive(_3);                 // scope 2 at $DIR/tls-access.rs:12:9: 12:12
-        _3 = &/*tls*/ mut FOO;           // scope 2 at $DIR/tls-access.rs:12:9: 12:12
-        (*_3) = const 42_u8;             // scope 2 at $DIR/tls-access.rs:12:9: 12:17
-        StorageDead(_3);                 // scope 2 at $DIR/tls-access.rs:12:17: 12:18
-        _0 = const ();                   // scope 1 at $DIR/tls-access.rs:10:5: 13:6
-        StorageDead(_2);                 // scope 1 at $DIR/tls-access.rs:13:5: 13:6
-        StorageDead(_1);                 // scope 1 at $DIR/tls-access.rs:13:5: 13:6
-        return;                          // scope 0 at $DIR/tls-access.rs:14:2: 14:2
+        StorageLive(_1);                 // scope 1 at $DIR/tls-access.rs:+2:13: +2:14
+        StorageLive(_2);                 // scope 1 at $DIR/tls-access.rs:+2:18: +2:21
+        _2 = &/*tls*/ mut FOO;           // scope 1 at $DIR/tls-access.rs:+2:18: +2:21
+        _1 = &(*_2);                     // scope 1 at $DIR/tls-access.rs:+2:17: +2:21
+        StorageLive(_3);                 // scope 2 at $DIR/tls-access.rs:+3:9: +3:12
+        _3 = &/*tls*/ mut FOO;           // scope 2 at $DIR/tls-access.rs:+3:9: +3:12
+        (*_3) = const 42_u8;             // scope 2 at $DIR/tls-access.rs:+3:9: +3:17
+        StorageDead(_3);                 // scope 2 at $DIR/tls-access.rs:+3:17: +3:18
+        _0 = const ();                   // scope 1 at $DIR/tls-access.rs:+1:5: +4:6
+        StorageDead(_2);                 // scope 1 at $DIR/tls-access.rs:+4:5: +4:6
+        StorageDead(_1);                 // scope 1 at $DIR/tls-access.rs:+4:5: +4:6
+        return;                          // scope 0 at $DIR/tls-access.rs:+5:2: +5:2
     }
 }

--- a/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
@@ -1,23 +1,23 @@
 // MIR for `move_out_by_subslice` 0 mir_map
 
 fn move_out_by_subslice() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/uniform_array_move_out.rs:10:27: 10:27
-    let _1: [std::boxed::Box<i32>; 2];   // in scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
-    let mut _2: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-    let mut _3: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-    let mut _4: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-    let mut _5: *mut u8;                 // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-    let mut _6: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-    let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-    let mut _8: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-    let mut _9: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-    let mut _10: *mut u8;                // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-    let mut _11: std::boxed::Box<i32>;   // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+    let mut _0: ();                      // return place in scope 0 at $DIR/uniform_array_move_out.rs:+0:27: +0:27
+    let _1: [std::boxed::Box<i32>; 2];   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+    let mut _2: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _3: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _4: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _5: *mut u8;                 // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _6: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _8: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _9: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _10: *mut u8;                // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _11: std::boxed::Box<i32>;   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
     scope 1 {
-        debug a => _1;                   // in scope 1 at $DIR/uniform_array_move_out.rs:11:9: 11:10
-        let _12: [std::boxed::Box<i32>; 2]; // in scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
+        debug a => _1;                   // in scope 1 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+        let _12: [std::boxed::Box<i32>; 2]; // in scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
         scope 4 {
-            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:12:10: 12:17
+            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
         }
     }
     scope 2 {
@@ -26,86 +26,86 @@ fn move_out_by_subslice() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
-        StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        _4 = AlignOf(i32);               // scope 2 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+        StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _4 = AlignOf(i32);               // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:11:14: 11:19
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
-        _2 = move _6;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
+        StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:+1:18: +1:19
+        _2 = move _6;                    // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:18: +1:19
     }
 
     bb2: {
-        StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
-        StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        _9 = AlignOf(i32);               // scope 3 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+        StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:18: +1:19
+        StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _9 = AlignOf(i32);               // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:11:21: 11:26
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
-        _7 = move _11;                   // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
+        StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:+1:25: +1:26
+        _7 = move _11;                   // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:25: +1:26
     }
 
     bb4: {
-        StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
-        _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:11:13: 11:27
-        drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:+1:25: +1:26
+        _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:+1:13: +1:27
+        drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb5: {
-        StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-        drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
+        drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb6: {
-        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
-        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
-        _12 = move _1[0..2];             // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
-        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:10:27: 13:2
-        drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
+        _12 = move _1[0..2];             // scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
+        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:+0:27: +3:2
+        drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
     }
 
     bb7: {
-        StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-        drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
+        drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
     }
 
     bb8: {
-        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
+        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:+3:2: +3:2
     }
 
     bb9 (cleanup): {
-        drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
     }
 
     bb10 (cleanup): {
-        drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb11 (cleanup): {
-        drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb12 (cleanup): {
-        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:10:1: 13:2
+        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
@@ -1,23 +1,23 @@
 // MIR for `move_out_from_end` 0 mir_map
 
 fn move_out_from_end() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/uniform_array_move_out.rs:4:24: 4:24
-    let _1: [std::boxed::Box<i32>; 2];   // in scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
-    let mut _2: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-    let mut _3: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-    let mut _4: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-    let mut _5: *mut u8;                 // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-    let mut _6: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-    let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-    let mut _8: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-    let mut _9: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-    let mut _10: *mut u8;                // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-    let mut _11: std::boxed::Box<i32>;   // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+    let mut _0: ();                      // return place in scope 0 at $DIR/uniform_array_move_out.rs:+0:24: +0:24
+    let _1: [std::boxed::Box<i32>; 2];   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+    let mut _2: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _3: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _4: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _5: *mut u8;                 // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _6: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+    let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _8: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _9: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _10: *mut u8;                // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+    let mut _11: std::boxed::Box<i32>;   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
     scope 1 {
-        debug a => _1;                   // in scope 1 at $DIR/uniform_array_move_out.rs:5:9: 5:10
-        let _12: std::boxed::Box<i32>;   // in scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
+        debug a => _1;                   // in scope 1 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+        let _12: std::boxed::Box<i32>;   // in scope 1 at $DIR/uniform_array_move_out.rs:+2:14: +2:16
         scope 4 {
-            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:6:14: 6:16
+            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:+2:14: +2:16
         }
     }
     scope 2 {
@@ -26,86 +26,86 @@ fn move_out_from_end() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
-        StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        _4 = AlignOf(i32);               // scope 2 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+        StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+        StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _4 = AlignOf(i32);               // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:5:14: 5:19
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
-        _2 = move _6;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
+        StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:+1:18: +1:19
+        _2 = move _6;                    // scope 0 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
+        drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:18: +1:19
     }
 
     bb2: {
-        StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
-        StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        _9 = AlignOf(i32);               // scope 3 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+        StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:18: +1:19
+        StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _9 = AlignOf(i32);               // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:5:21: 5:26
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
-        _7 = move _11;                   // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
+        StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:+1:25: +1:26
+        _7 = move _11;                   // scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
+        drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:25: +1:26
     }
 
     bb4: {
-        StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
-        _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:5:13: 5:27
-        drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:+1:25: +1:26
+        _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:+1:13: +1:27
+        drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb5: {
-        StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-        drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
+        drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb6: {
-        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
-        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
-        _12 = move _1[1 of 2];           // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
-        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:4:24: 7:2
-        drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
+        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:+2:14: +2:16
+        _12 = move _1[1 of 2];           // scope 1 at $DIR/uniform_array_move_out.rs:+2:14: +2:16
+        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:+0:24: +3:2
+        drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
     }
 
     bb7: {
-        StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-        drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
+        drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
     }
 
     bb8: {
-        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
+        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
+        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:+3:2: +3:2
     }
 
     bb9 (cleanup): {
-        drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
     }
 
     bb10 (cleanup): {
-        drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb11 (cleanup): {
-        drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
     }
 
     bb12 (cleanup): {
-        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:4:1: 7:2
+        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:+0:1: +3:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals.after.mir
@@ -1,18 +1,18 @@
 // MIR for `process_never` after SimplifyLocals
 
 fn process_never(_1: *const !) -> () {
-    debug input => _1;                   // in scope 0 at $DIR/uninhabited-enum.rs:7:22: 7:27
-    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited-enum.rs:7:39: 7:39
-    let _2: &!;                          // in scope 0 at $DIR/uninhabited-enum.rs:8:8: 8:14
+    debug input => _1;                   // in scope 0 at $DIR/uninhabited-enum.rs:+0:22: +0:27
+    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited-enum.rs:+0:39: +0:39
+    let _2: &!;                          // in scope 0 at $DIR/uninhabited-enum.rs:+1:8: +1:14
     scope 1 {
-        debug _input => _2;              // in scope 1 at $DIR/uninhabited-enum.rs:8:8: 8:14
+        debug _input => _2;              // in scope 1 at $DIR/uninhabited-enum.rs:+1:8: +1:14
     }
     scope 2 {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:8:8: 8:14
-        StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:9:1: 9:2
-        unreachable;                     // scope 0 at $DIR/uninhabited-enum.rs:7:39: 9:2
+        StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+1:8: +1:14
+        StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+2:1: +2:2
+        unreachable;                     // scope 0 at $DIR/uninhabited-enum.rs:+0:39: +2:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
@@ -1,18 +1,18 @@
 // MIR for `process_void` after SimplifyLocals
 
 fn process_void(_1: *const Void) -> () {
-    debug input => _1;                   // in scope 0 at $DIR/uninhabited-enum.rs:13:21: 13:26
-    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited-enum.rs:13:41: 13:41
-    let _2: &Void;                       // in scope 0 at $DIR/uninhabited-enum.rs:14:8: 14:14
+    debug input => _1;                   // in scope 0 at $DIR/uninhabited-enum.rs:+0:21: +0:26
+    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited-enum.rs:+0:41: +0:41
+    let _2: &Void;                       // in scope 0 at $DIR/uninhabited-enum.rs:+1:8: +1:14
     scope 1 {
-        debug _input => _2;              // in scope 1 at $DIR/uninhabited-enum.rs:14:8: 14:14
+        debug _input => _2;              // in scope 1 at $DIR/uninhabited-enum.rs:+1:8: +1:14
     }
     scope 2 {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:14:8: 14:14
-        StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:17:1: 17:2
-        return;                          // scope 0 at $DIR/uninhabited-enum.rs:17:2: 17:2
+        StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+1:8: +1:14
+        StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+4:1: +4:2
+        return;                          // scope 0 at $DIR/uninhabited-enum.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -1,63 +1,63 @@
 // MIR for `main` after SimplifyCfg-after-uninhabited-enum-branching
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 19:11
-    let _1: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
-    let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-    let mut _3: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
-    let _4: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
-    let _5: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-    let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
-    let mut _7: Test2;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-    let mut _8: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
-    let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
+    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +0:11
+    let _1: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +5:6
+    let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+    let mut _3: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+2:9: +2:20
+    let _4: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
+    let _5: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
+    let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +10:6
+    let mut _7: Test2;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+    let mut _8: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+8:9: +8:17
+    let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
-        StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-        Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-        discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-        _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-        StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-        _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
+        StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +5:6
+        StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+        Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+        discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+        _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+        StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
+        _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:23:21: 23:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-        StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
-        StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
-        StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
-        StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
-        StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-        Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-        discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-        _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-        switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19
+        _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
+        StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:23: +4:24
+        StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+5:6: +5:7
+        StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+5:6: +5:7
+        StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +10:6
+        StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+        Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+        discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+        _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+        switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
     }
 
     bb1: {
-        StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
-        _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
+        StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
+        _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:28:21: 28:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
-        StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
-        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
+        _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
+        StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
+        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
     }
 
     bb2: {
-        _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
+        _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
+        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
     }
 
     bb3: {
-        StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
-        StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
-        _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 30:2
-        return;                          // scope 0 at $DIR/uninhabited_enum_branching.rs:30:2: 30:2
+        StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
+        StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
+        _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +11:2
+        return;                          // scope 0 at $DIR/uninhabited_enum_branching.rs:+11:2: +11:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -2,92 +2,92 @@
 + // MIR for `main` after UninhabitedEnumBranching
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 19:11
-      let _1: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
-      let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-      let mut _3: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
-      let _4: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
-      let _5: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-      let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
-      let mut _7: Test2;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-      let mut _8: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
-      let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
+      let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +0:11
+      let _1: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +5:6
+      let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+      let mut _3: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+2:9: +2:20
+      let _4: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
+      let _5: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
+      let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +10:6
+      let mut _7: Test2;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+      let mut _8: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:+8:9: +8:17
+      let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
-          StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-          Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-          discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-          _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
--         switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 20:19
-+         switchInt(move _3) -> bb1;       // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 20:19
+          StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +5:6
+          StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+          Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+          discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+          _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:11: +1:19
+-         switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
++         switchInt(move _3) -> bb1;       // scope 0 at $DIR/uninhabited_enum_branching.rs:+1:5: +1:19
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-          _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
+          StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
+          _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:23:21: 23:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-          StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
+          _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:21: +4:24
+          StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:23: +4:24
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+4:23: +4:24
       }
   
       bb2: {
-          _1 = const "A(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:21:24: 21:34
+          _1 = const "A(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:+2:24: +2:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:21:24: 21:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:21:24: 21:34
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+2:24: +2:34
       }
   
       bb3: {
-          StorageLive(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
-          _4 = const "B(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
+          StorageLive(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
+          _4 = const "B(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:22:24: 22:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _1 = &(*_4);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
-          StorageDead(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:22:33: 22:34
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:22:33: 22:34
+          _1 = &(*_4);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:24: +3:34
+          StorageDead(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:33: +3:34
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+3:33: +3:34
       }
   
       bb4: {
-          StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
-          StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
-          StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
-          StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-          Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-          discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-          _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-          switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19
+          StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+5:6: +5:7
+          StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+5:6: +5:7
+          StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +10:6
+          StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+          Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+          discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+          _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:11: +7:19
+          switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:+7:5: +7:19
       }
   
       bb5: {
-          StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
-          _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
+          StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
+          _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:28:21: 28:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
-          StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
-          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
+          _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:21: +9:24
+          StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
+          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+9:23: +9:24
       }
   
       bb6: {
-          _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
+          _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
+          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:+8:21: +8:24
       }
   
       bb7: {
-          StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
-          StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
-          _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 30:2
-          return;                          // scope 0 at $DIR/uninhabited_enum_branching.rs:30:2: 30:2
+          StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
+          StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:+10:6: +10:7
+          _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:+0:11: +11:2
+          return;                          // scope 0 at $DIR/uninhabited_enum_branching.rs:+11:2: +11:2
       }
   }
   

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -1,96 +1,96 @@
 // MIR for `main` after SimplifyCfg-after-uninhabited-enum-branching
 
 fn main() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching2.rs:18:11: 18:11
-    let _1: Plop;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
-    let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-    let _3: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
-    let mut _4: &Test1;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-    let mut _5: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:22:9: 22:20
-    let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
-    let _7: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-    let _8: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-    let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
-    let mut _10: isize;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:29:9: 29:20
-    let _11: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
-    let _12: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-    let _13: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
+    let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +0:11
+    let _1: Plop;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:9: +1:13
+    let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+    let _3: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+3:5: +8:6
+    let mut _4: &Test1;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+    let mut _5: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+4:9: +4:20
+    let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
+    let _7: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
+    let _8: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
+    let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
+    let mut _10: isize;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+11:9: +11:20
+    let _11: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
+    let _12: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
+    let _13: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
     scope 1 {
-        debug plop => _1;                // in scope 1 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
+        debug plop => _1;                // in scope 1 at $DIR/uninhabited_enum_branching2.rs:+1:9: +1:13
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
-        StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-        Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-        discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-        Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
-        (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
-        (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
-        StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:47: 19:48
-        StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
-        StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-        _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-        _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-        switchInt(move _5) -> [2_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
+        StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:9: +1:13
+        StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+        Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+        discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+        Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+        (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+        (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+        StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:47: +1:48
+        StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +8:6
+        StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+        _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+        _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+        switchInt(move _5) -> [2_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
     }
 
     bb1: {
-        StorageLive(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-        _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
+        StorageLive(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
+        _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-        StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
-        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
+        _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
+        StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
+        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
     }
 
     bb2: {
-        StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-        _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
+        StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
+        _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-        StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
-        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
+        _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
+        StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
+        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
     }
 
     bb3: {
-        StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
-        StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
-        StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
-        _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:11: 28:21
-        switchInt(move _10) -> [2_isize: bb5, otherwise: bb4]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
+        StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
+        StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
+        StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
+        _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
+        switchInt(move _10) -> [2_isize: bb5, otherwise: bb4]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
     }
 
     bb4: {
-        StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
-        _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
+        StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
+        _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
-        StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
-        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
+        _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
+        StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
+        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
     }
 
     bb5: {
-        StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-        _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
+        StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
+        _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-        _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-        StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
-        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
+        _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
+        StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
+        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
     }
 
     bb6: {
-        StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:33:6: 33:7
-        _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:18:11: 34:2
-        StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:34:1: 34:2
-        return;                          // scope 0 at $DIR/uninhabited_enum_branching2.rs:34:2: 34:2
+        StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+15:6: +15:7
+        _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +16:2
+        StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:1: +16:2
+        return;                          // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:2: +16:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -2,137 +2,137 @@
 + // MIR for `main` after UninhabitedEnumBranching
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching2.rs:18:11: 18:11
-      let _1: Plop;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
-      let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-      let _3: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
-      let mut _4: &Test1;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-      let mut _5: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:22:9: 22:20
-      let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
-      let _7: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-      let _8: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-      let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
-      let mut _10: isize;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:29:9: 29:20
-      let _11: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
-      let _12: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-      let _13: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
+      let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +0:11
+      let _1: Plop;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:9: +1:13
+      let mut _2: Test1;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+      let _3: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+3:5: +8:6
+      let mut _4: &Test1;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+      let mut _5: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+4:9: +4:20
+      let _6: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
+      let _7: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
+      let _8: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
+      let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
+      let mut _10: isize;                  // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+11:9: +11:20
+      let _11: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
+      let _12: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
+      let _13: &str;                       // in scope 0 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
       scope 1 {
-          debug plop => _1;                // in scope 1 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
+          debug plop => _1;                // in scope 1 at $DIR/uninhabited_enum_branching2.rs:+1:9: +1:13
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
-          StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-          Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-          discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
-          Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
-          (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
-          (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
-          StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:47: 19:48
-          StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
-          StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-          _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-          _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
--         switchInt(move _5) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
-+         switchInt(move _5) -> [2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
+          StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:9: +1:13
+          StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+          Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+          discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:38: +1:46
+          Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+          (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+          (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:16: +1:48
+          StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+1:47: +1:48
+          StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +8:6
+          StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+          _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+          _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:11: +3:22
+-         switchInt(move _5) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
++         switchInt(move _5) -> [2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+3:5: +3:22
       }
   
       bb1: {
-          StorageLive(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-          _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
+          StorageLive(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
+          _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-          StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
+          _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:21: +7:24
+          StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+7:23: +7:24
       }
   
       bb2: {
-          _3 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
+          _3 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:+4:24: +4:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+4:24: +4:34
       }
   
       bb3: {
-          StorageLive(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
-          _6 = const "B(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
+          StorageLive(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
+          _6 = const "B(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _3 = &(*_6);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
-          StorageDead(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:33: 23:34
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:33: 23:34
+          _3 = &(*_6);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:24: +5:34
+          StorageDead(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:33: +5:34
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+5:33: +5:34
       }
   
       bb4: {
-          StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-          _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
+          StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
+          _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-          StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
+          _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:21: +6:24
+          StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:+6:23: +6:24
       }
   
       bb5: {
-          StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
-          StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
-          StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
-          _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:11: 28:21
--         switchInt(move _10) -> [0_isize: bb7, 1_isize: bb8, 2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
-+         switchInt(move _10) -> [2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
+          StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
+          StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+8:6: +8:7
+          StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +15:6
+          _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:11: +10:21
+-         switchInt(move _10) -> [0_isize: bb7, 1_isize: bb8, 2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
++         switchInt(move _10) -> [2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:+10:5: +10:21
       }
   
       bb6: {
-          StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
-          _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
+          StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
+          _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
-          StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
+          _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:21: +14:24
+          StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+14:23: +14:24
       }
   
       bb7: {
-          _9 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
+          _9 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+11:24: +11:34
       }
   
       bb8: {
-          StorageLive(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
-          _11 = const "B(Empty)";          // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
+          StorageLive(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
+          _11 = const "B(Empty)";          // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _9 = &(*_11);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
-          StorageDead(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:33: 30:34
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:33: 30:34
+          _9 = &(*_11);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:24: +12:34
+          StorageDead(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+12:33: +12:34
       }
   
       bb9: {
-          StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-          _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
+          StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
+          _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }
-          _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-          StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
+          _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:21: +13:24
+          StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:+13:23: +13:24
       }
   
       bb10: {
-          StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:33:6: 33:7
-          _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:18:11: 34:2
-          StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:34:1: 34:2
-          return;                          // scope 0 at $DIR/uninhabited_enum_branching2.rs:34:2: 34:2
+          StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:+15:6: +15:7
+          _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:+0:11: +16:2
+          StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:1: +16:2
+          return;                          // scope 0 at $DIR/uninhabited_enum_branching2.rs:+16:2: +16:2
       }
   }
   

--- a/src/test/mir-opt/uninhabited_fallthrough_elimination.eliminate_fallthrough.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_fallthrough_elimination.eliminate_fallthrough.UninhabitedEnumBranching.diff
@@ -2,37 +2,37 @@
 + // MIR for `eliminate_fallthrough` after UninhabitedEnumBranching
   
   fn eliminate_fallthrough(_1: S) -> u32 {
-      debug s => _1;                       // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:21:26: 21:27
-      let mut _0: u32;                     // return place in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:21:35: 21:38
-      let mut _2: isize;                   // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:23:9: 23:10
+      debug s => _1;                       // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+0:26: +0:27
+      let mut _0: u32;                     // return place in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+0:35: +0:38
+      let mut _2: isize;                   // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+2:9: +2:10
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:22:11: 22:12
--         switchInt(move _2) -> [1_isize: bb3, 2_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:22:5: 22:12
-+         switchInt(move _2) -> [1_isize: bb3, 2_isize: bb2, otherwise: bb5]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:22:5: 22:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+1:11: +1:12
+-         switchInt(move _2) -> [1_isize: bb3, 2_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+1:5: +1:12
++         switchInt(move _2) -> [1_isize: bb3, 2_isize: bb2, otherwise: bb5]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 3_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:25:14: 25:15
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:25:14: 25:15
+          _0 = const 3_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+4:14: +4:15
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+4:14: +4:15
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:23:14: 23:15
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:23:14: 23:15
+          _0 = const 1_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+2:14: +2:15
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+2:14: +2:15
       }
   
       bb3: {
-          _0 = const 2_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:24:14: 24:15
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:24:14: 24:15
+          _0 = const 2_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+3:14: +3:15
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+3:14: +3:15
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:27:2: 27:2
+          return;                          // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+6:2: +6:2
 +     }
 + 
 +     bb5: {
-+         unreachable;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:25:14: 25:15
++         unreachable;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+4:14: +4:15
       }
   }
   

--- a/src/test/mir-opt/uninhabited_fallthrough_elimination.keep_fallthrough.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_fallthrough_elimination.keep_fallthrough.UninhabitedEnumBranching.diff
@@ -2,33 +2,33 @@
 + // MIR for `keep_fallthrough` after UninhabitedEnumBranching
   
   fn keep_fallthrough(_1: S) -> u32 {
-      debug s => _1;                       // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:12:21: 12:22
-      let mut _0: u32;                     // return place in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:12:30: 12:33
-      let mut _2: isize;                   // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:14:9: 14:13
+      debug s => _1;                       // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+0:21: +0:22
+      let mut _0: u32;                     // return place in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+0:30: +0:33
+      let mut _2: isize;                   // in scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+2:9: +2:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:13:11: 13:12
--         switchInt(move _2) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:13:5: 13:12
-+         switchInt(move _2) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:13:5: 13:12
+          _2 = discriminant(_1);           // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+1:11: +1:12
+-         switchInt(move _2) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+1:5: +1:12
++         switchInt(move _2) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+1:5: +1:12
       }
   
       bb1: {
-          _0 = const 3_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:16:14: 16:15
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:16:14: 16:15
+          _0 = const 3_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+4:14: +4:15
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+4:14: +4:15
       }
   
       bb2: {
-          _0 = const 1_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:14:17: 14:18
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:14:17: 14:18
+          _0 = const 1_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+2:17: +2:18
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+2:17: +2:18
       }
   
       bb3: {
-          _0 = const 2_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:15:14: 15:15
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:15:14: 15:15
+          _0 = const 2_u32;                // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+3:14: +3:15
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+3:14: +3:15
       }
   
       bb4: {
-          return;                          // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:18:2: 18:2
+          return;                          // scope 0 at $DIR/uninhabited_fallthrough_elimination.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -2,68 +2,68 @@
 + // MIR for `main` after UnreachablePropagation
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/unreachable.rs:8:11: 8:11
-      let mut _1: std::option::Option<Empty>; // in scope 0 at $DIR/unreachable.rs:9:23: 9:30
-      let mut _2: isize;                   // in scope 0 at $DIR/unreachable.rs:9:12: 9:20
-      let _5: ();                          // in scope 0 at $DIR/unreachable.rs:12:9: 16:10
-      let mut _6: bool;                    // in scope 0 at $DIR/unreachable.rs:12:12: 12:16
-      let mut _7: !;                       // in scope 0 at $DIR/unreachable.rs:18:9: 18:21
+      let mut _0: ();                      // return place in scope 0 at $DIR/unreachable.rs:+0:11: +0:11
+      let mut _1: std::option::Option<Empty>; // in scope 0 at $DIR/unreachable.rs:+1:23: +1:30
+      let mut _2: isize;                   // in scope 0 at $DIR/unreachable.rs:+1:12: +1:20
+      let _5: ();                          // in scope 0 at $DIR/unreachable.rs:+4:9: +8:10
+      let mut _6: bool;                    // in scope 0 at $DIR/unreachable.rs:+4:12: +4:16
+      let mut _7: !;                       // in scope 0 at $DIR/unreachable.rs:+10:9: +10:21
       scope 1 {
-          debug _x => _3;                  // in scope 1 at $DIR/unreachable.rs:9:17: 9:19
-          let _3: Empty;                   // in scope 1 at $DIR/unreachable.rs:9:17: 9:19
-          let mut _4: i32;                 // in scope 1 at $DIR/unreachable.rs:10:13: 10:19
+          debug _x => _3;                  // in scope 1 at $DIR/unreachable.rs:+1:17: +1:19
+          let _3: Empty;                   // in scope 1 at $DIR/unreachable.rs:+1:17: +1:19
+          let mut _4: i32;                 // in scope 1 at $DIR/unreachable.rs:+2:13: +2:19
           scope 2 {
-              debug _y => _4;              // in scope 2 at $DIR/unreachable.rs:10:13: 10:19
+              debug _y => _4;              // in scope 2 at $DIR/unreachable.rs:+2:13: +2:19
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 1 at $DIR/unreachable.rs:9:23: 9:30
-          _1 = empty() -> bb1;             // scope 1 at $DIR/unreachable.rs:9:23: 9:30
+          StorageLive(_1);                 // scope 1 at $DIR/unreachable.rs:+1:23: +1:30
+          _1 = empty() -> bb1;             // scope 1 at $DIR/unreachable.rs:+1:23: +1:30
                                            // mir::Constant
                                            // + span: $DIR/unreachable.rs:9:23: 9:28
                                            // + literal: Const { ty: fn() -> Option<Empty> {empty}, val: Value(<ZST>) }
       }
   
       bb1: {
-          _2 = discriminant(_1);           // scope 1 at $DIR/unreachable.rs:9:12: 9:20
--         switchInt(move _2) -> [1_isize: bb2, otherwise: bb6]; // scope 1 at $DIR/unreachable.rs:9:12: 9:20
-+         goto -> bb2;                     // scope 1 at $DIR/unreachable.rs:9:12: 9:20
+          _2 = discriminant(_1);           // scope 1 at $DIR/unreachable.rs:+1:12: +1:20
+-         switchInt(move _2) -> [1_isize: bb2, otherwise: bb6]; // scope 1 at $DIR/unreachable.rs:+1:12: +1:20
++         goto -> bb2;                     // scope 1 at $DIR/unreachable.rs:+1:12: +1:20
       }
   
       bb2: {
--         StorageLive(_3);                 // scope 1 at $DIR/unreachable.rs:9:17: 9:19
--         _3 = move ((_1 as Some).0: Empty); // scope 1 at $DIR/unreachable.rs:9:17: 9:19
--         StorageLive(_4);                 // scope 1 at $DIR/unreachable.rs:10:13: 10:19
--         StorageLive(_5);                 // scope 2 at $DIR/unreachable.rs:12:9: 16:10
--         StorageLive(_6);                 // scope 2 at $DIR/unreachable.rs:12:12: 12:16
--         _6 = const true;                 // scope 2 at $DIR/unreachable.rs:12:12: 12:16
--         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable.rs:12:12: 12:16
+-         StorageLive(_3);                 // scope 1 at $DIR/unreachable.rs:+1:17: +1:19
+-         _3 = move ((_1 as Some).0: Empty); // scope 1 at $DIR/unreachable.rs:+1:17: +1:19
+-         StorageLive(_4);                 // scope 1 at $DIR/unreachable.rs:+2:13: +2:19
+-         StorageLive(_5);                 // scope 2 at $DIR/unreachable.rs:+4:9: +8:10
+-         StorageLive(_6);                 // scope 2 at $DIR/unreachable.rs:+4:12: +4:16
+-         _6 = const true;                 // scope 2 at $DIR/unreachable.rs:+4:12: +4:16
+-         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable.rs:+4:12: +4:16
 -     }
 - 
 -     bb3: {
--         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:13:13: 13:20
--         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:12:17: 14:10
--         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
+-         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:+5:13: +5:20
+-         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:+4:17: +6:10
+-         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:+4:9: +8:10
 -     }
 - 
 -     bb4: {
--         _4 = const 42_i32;               // scope 2 at $DIR/unreachable.rs:15:13: 15:20
--         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:14:16: 16:10
--         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
+-         _4 = const 42_i32;               // scope 2 at $DIR/unreachable.rs:+7:13: +7:20
+-         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:+6:16: +8:10
+-         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:+4:9: +8:10
 -     }
 - 
 -     bb5: {
--         StorageDead(_6);                 // scope 2 at $DIR/unreachable.rs:16:9: 16:10
--         StorageDead(_5);                 // scope 2 at $DIR/unreachable.rs:16:9: 16:10
--         StorageLive(_7);                 // scope 2 at $DIR/unreachable.rs:18:9: 18:21
--         unreachable;                     // scope 2 at $DIR/unreachable.rs:18:15: 18:17
+-         StorageDead(_6);                 // scope 2 at $DIR/unreachable.rs:+8:9: +8:10
+-         StorageDead(_5);                 // scope 2 at $DIR/unreachable.rs:+8:9: +8:10
+-         StorageLive(_7);                 // scope 2 at $DIR/unreachable.rs:+10:9: +10:21
+-         unreachable;                     // scope 2 at $DIR/unreachable.rs:+10:15: +10:17
 -     }
 - 
 -     bb6: {
-          _0 = const ();                   // scope 0 at $DIR/unreachable.rs:19:6: 19:6
-          StorageDead(_1);                 // scope 0 at $DIR/unreachable.rs:20:1: 20:2
-          return;                          // scope 0 at $DIR/unreachable.rs:20:2: 20:2
+          _0 = const ();                   // scope 0 at $DIR/unreachable.rs:+11:6: +11:6
+          StorageDead(_1);                 // scope 0 at $DIR/unreachable.rs:+12:1: +12:2
+          return;                          // scope 0 at $DIR/unreachable.rs:+12:2: +12:2
       }
   }
   

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -2,73 +2,73 @@
 + // MIR for `main` after UnreachablePropagation
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/unreachable_diverging.rs:12:11: 12:11
-      let _1: bool;                        // in scope 0 at $DIR/unreachable_diverging.rs:13:9: 13:10
-      let mut _2: std::option::Option<Empty>; // in scope 0 at $DIR/unreachable_diverging.rs:14:25: 14:32
-      let mut _3: isize;                   // in scope 0 at $DIR/unreachable_diverging.rs:14:12: 14:22
-      let _5: ();                          // in scope 0 at $DIR/unreachable_diverging.rs:15:9: 17:10
-      let mut _6: bool;                    // in scope 0 at $DIR/unreachable_diverging.rs:15:12: 15:13
-      let mut _7: !;                       // in scope 0 at $DIR/unreachable_diverging.rs:18:9: 18:22
+      let mut _0: ();                      // return place in scope 0 at $DIR/unreachable_diverging.rs:+0:11: +0:11
+      let _1: bool;                        // in scope 0 at $DIR/unreachable_diverging.rs:+1:9: +1:10
+      let mut _2: std::option::Option<Empty>; // in scope 0 at $DIR/unreachable_diverging.rs:+2:25: +2:32
+      let mut _3: isize;                   // in scope 0 at $DIR/unreachable_diverging.rs:+2:12: +2:22
+      let _5: ();                          // in scope 0 at $DIR/unreachable_diverging.rs:+3:9: +5:10
+      let mut _6: bool;                    // in scope 0 at $DIR/unreachable_diverging.rs:+3:12: +3:13
+      let mut _7: !;                       // in scope 0 at $DIR/unreachable_diverging.rs:+6:9: +6:22
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/unreachable_diverging.rs:13:9: 13:10
+          debug x => _1;                   // in scope 1 at $DIR/unreachable_diverging.rs:+1:9: +1:10
           scope 2 {
-              debug bomb => _4;            // in scope 2 at $DIR/unreachable_diverging.rs:14:17: 14:21
-              let _4: Empty;               // in scope 2 at $DIR/unreachable_diverging.rs:14:17: 14:21
+              debug bomb => _4;            // in scope 2 at $DIR/unreachable_diverging.rs:+2:17: +2:21
+              let _4: Empty;               // in scope 2 at $DIR/unreachable_diverging.rs:+2:17: +2:21
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:13:9: 13:10
-          _1 = const true;                 // scope 0 at $DIR/unreachable_diverging.rs:13:13: 13:17
-          StorageLive(_2);                 // scope 2 at $DIR/unreachable_diverging.rs:14:25: 14:32
-          _2 = empty() -> bb1;             // scope 2 at $DIR/unreachable_diverging.rs:14:25: 14:32
+          StorageLive(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:+1:9: +1:10
+          _1 = const true;                 // scope 0 at $DIR/unreachable_diverging.rs:+1:13: +1:17
+          StorageLive(_2);                 // scope 2 at $DIR/unreachable_diverging.rs:+2:25: +2:32
+          _2 = empty() -> bb1;             // scope 2 at $DIR/unreachable_diverging.rs:+2:25: +2:32
                                            // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:14:25: 14:30
                                            // + literal: Const { ty: fn() -> Option<Empty> {empty}, val: Value(<ZST>) }
       }
   
       bb1: {
-          _3 = discriminant(_2);           // scope 2 at $DIR/unreachable_diverging.rs:14:12: 14:22
--         switchInt(move _3) -> [1_isize: bb2, otherwise: bb6]; // scope 2 at $DIR/unreachable_diverging.rs:14:12: 14:22
-+         switchInt(move _3) -> [1_isize: bb2, otherwise: bb5]; // scope 2 at $DIR/unreachable_diverging.rs:14:12: 14:22
+          _3 = discriminant(_2);           // scope 2 at $DIR/unreachable_diverging.rs:+2:12: +2:22
+-         switchInt(move _3) -> [1_isize: bb2, otherwise: bb6]; // scope 2 at $DIR/unreachable_diverging.rs:+2:12: +2:22
++         switchInt(move _3) -> [1_isize: bb2, otherwise: bb5]; // scope 2 at $DIR/unreachable_diverging.rs:+2:12: +2:22
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 2 at $DIR/unreachable_diverging.rs:14:17: 14:21
-          _4 = move ((_2 as Some).0: Empty); // scope 2 at $DIR/unreachable_diverging.rs:14:17: 14:21
-          StorageLive(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:15:9: 17:10
-          StorageLive(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:15:12: 15:13
-          _6 = _1;                         // scope 2 at $DIR/unreachable_diverging.rs:15:12: 15:13
--         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable_diverging.rs:15:12: 15:13
-+         goto -> bb3;                     // scope 2 at $DIR/unreachable_diverging.rs:15:12: 15:13
+          StorageLive(_4);                 // scope 2 at $DIR/unreachable_diverging.rs:+2:17: +2:21
+          _4 = move ((_2 as Some).0: Empty); // scope 2 at $DIR/unreachable_diverging.rs:+2:17: +2:21
+          StorageLive(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:+3:9: +5:10
+          StorageLive(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
+          _6 = _1;                         // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
+-         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
++         goto -> bb3;                     // scope 2 at $DIR/unreachable_diverging.rs:+3:12: +3:13
       }
   
       bb3: {
--         _5 = loop_forever() -> bb5;      // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
-+         _5 = loop_forever() -> bb4;      // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
+-         _5 = loop_forever() -> bb5;      // scope 2 at $DIR/unreachable_diverging.rs:+4:13: +4:27
++         _5 = loop_forever() -> bb4;      // scope 2 at $DIR/unreachable_diverging.rs:+4:13: +4:27
                                            // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:16:13: 16:25
                                            // + literal: Const { ty: fn() {loop_forever}, val: Value(<ZST>) }
       }
   
       bb4: {
--         _5 = const ();                   // scope 2 at $DIR/unreachable_diverging.rs:17:10: 17:10
--         goto -> bb5;                     // scope 2 at $DIR/unreachable_diverging.rs:15:9: 17:10
+-         _5 = const ();                   // scope 2 at $DIR/unreachable_diverging.rs:+5:10: +5:10
+-         goto -> bb5;                     // scope 2 at $DIR/unreachable_diverging.rs:+3:9: +5:10
 -     }
 - 
 -     bb5: {
-          StorageDead(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:17:9: 17:10
-          StorageDead(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:17:9: 17:10
-          StorageLive(_7);                 // scope 2 at $DIR/unreachable_diverging.rs:18:9: 18:22
-          unreachable;                     // scope 2 at $DIR/unreachable_diverging.rs:18:15: 18:19
+          StorageDead(_6);                 // scope 2 at $DIR/unreachable_diverging.rs:+5:9: +5:10
+          StorageDead(_5);                 // scope 2 at $DIR/unreachable_diverging.rs:+5:9: +5:10
+          StorageLive(_7);                 // scope 2 at $DIR/unreachable_diverging.rs:+6:9: +6:22
+          unreachable;                     // scope 2 at $DIR/unreachable_diverging.rs:+6:15: +6:19
       }
   
 -     bb6: {
 +     bb5: {
-          _0 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:19:6: 19:6
-          StorageDead(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
-          StorageDead(_2);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
-          return;                          // scope 0 at $DIR/unreachable_diverging.rs:20:2: 20:2
+          _0 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:+7:6: +7:6
+          StorageDead(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:+8:1: +8:2
+          StorageDead(_2);                 // scope 0 at $DIR/unreachable_diverging.rs:+8:1: +8:2
+          return;                          // scope 0 at $DIR/unreachable_diverging.rs:+8:2: +8:2
       }
   }
   

--- a/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.32bit.mir
@@ -1,10 +1,10 @@
 // MIR for `E::V::{constant#0}` 0 mir_map
 
 E::V::{constant#0}: isize = {
-    let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
+    let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:+0:9: +0:10
 
     bb0: {
-        _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
+        _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:+0:9: +0:10
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:9: +0:10
     }
 }

--- a/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.64bit.mir
@@ -1,10 +1,10 @@
 // MIR for `E::V::{constant#0}` 0 mir_map
 
 E::V::{constant#0}: isize = {
-    let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
+    let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:+0:9: +0:10
 
     bb0: {
-        _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
+        _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:+0:9: +0:10
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:9: +0:10
     }
 }

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
@@ -1,12 +1,12 @@
 // MIR for `Test::X` 0 mir_map
 
 fn Test::X(_1: usize) -> Test {
-    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
+    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
 
     bb0: {
-        Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
-        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
-        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
+        Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
+        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
+        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
     }
 }

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
@@ -1,12 +1,12 @@
 // MIR for `Test::X` 0 mir_map
 
 fn Test::X(_1: usize) -> Test {
-    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
+    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
 
     bb0: {
-        Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
-        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
-        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:6
+        Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
+        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
+        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:6
     }
 }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
@@ -1,37 +1,37 @@
 // MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
 
 fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
-    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _2: &mut std::vec::Vec<i32>; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _2: &mut std::vec::Vec<i32>; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
 
     bb0: {
-        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb1: {
-        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb3: {
-        goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb4 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb5: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb6: {
-        _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut Vec<i32>) {<Vec<i32> as Drop>::drop}, val: Value(<ZST>) }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
@@ -1,37 +1,37 @@
 // MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
 
 fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
-    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _2: &mut std::vec::Vec<i32>; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+    let mut _0: ();                      // return place in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _2: &mut std::vec::Vec<i32>; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+    let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
 
     bb0: {
-        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb1: {
-        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb2 (cleanup): {
-        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb3: {
-        goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb4 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb5: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }
 
     bb6: {
-        _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut Vec<i32>) {<Vec<i32> as Drop>::drop}, val: Value(<ZST>) }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
@@ -1,10 +1,10 @@
 // MIR for `<impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT` 0 mir_map
 
 const <impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT: i32 = {
-    let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:10:32: 10:35
+    let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:+0:32: +0:35
 
     bb0: {
-        _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:35
+        _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:+0:38: +0:39
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:35
     }
 }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
@@ -1,10 +1,10 @@
 // MIR for `<impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT` 0 mir_map
 
 const <impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT: i32 = {
-    let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:10:32: 10:35
+    let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:+0:32: +0:35
 
     bb0: {
-        _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:35
+        _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:+0:38: +0:39
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:35
     }
 }

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
@@ -2,54 +2,54 @@
 + // MIR for `change_loop_body` after ConstProp
   
   fn change_loop_body() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:5:27: 5:27
-      let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
-      let mut _2: ();                      // in scope 0 at $DIR/while_let_loops.rs:5:1: 11:2
-      let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/while_let_loops.rs:7:28: 7:32
-      let mut _4: isize;                   // in scope 0 at $DIR/while_let_loops.rs:7:15: 7:25
-      let mut _5: !;                       // in scope 0 at $DIR/while_let_loops.rs:7:33: 10:6
-      let mut _6: !;                       // in scope 0 at $DIR/while_let_loops.rs:7:5: 10:6
-      let _7: ();                          // in scope 0 at $DIR/while_let_loops.rs:7:5: 10:6
-      let mut _8: !;                       // in scope 0 at $DIR/while_let_loops.rs:7:5: 10:6
+      let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:+0:27: +0:27
+      let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
+      let mut _2: ();                      // in scope 0 at $DIR/while_let_loops.rs:+0:1: +6:2
+      let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/while_let_loops.rs:+2:28: +2:32
+      let mut _4: isize;                   // in scope 0 at $DIR/while_let_loops.rs:+2:15: +2:25
+      let mut _5: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:33: +5:6
+      let mut _6: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
+      let _7: ();                          // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
+      let mut _8: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
       scope 1 {
-          debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
+          debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:+1:9: +1:15
           scope 2 {
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
-          _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
-          StorageLive(_3);                 // scope 2 at $DIR/while_let_loops.rs:7:28: 7:32
-          Deinit(_3);                      // scope 2 at $DIR/while_let_loops.rs:7:28: 7:32
-          discriminant(_3) = 0;            // scope 2 at $DIR/while_let_loops.rs:7:28: 7:32
--         _4 = discriminant(_3);           // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
--         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
-+         _4 = const 0_isize;              // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
-+         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
+          StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
+          _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:+1:18: +1:19
+          StorageLive(_3);                 // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+          Deinit(_3);                      // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+          discriminant(_3) = 0;            // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+-         _4 = discriminant(_3);           // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
++         _4 = const 0_isize;              // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
++         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }
   
       bb1: {
-          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
+          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }
   
       bb2: {
-          _1 = const 1_i32;                // scope 2 at $DIR/while_let_loops.rs:8:9: 8:15
-          nop;                             // scope 2 at $DIR/while_let_loops.rs:9:9: 9:14
-          goto -> bb4;                     // scope 2 at $DIR/while_let_loops.rs:9:9: 9:14
+          _1 = const 1_i32;                // scope 2 at $DIR/while_let_loops.rs:+3:9: +3:15
+          nop;                             // scope 2 at $DIR/while_let_loops.rs:+4:9: +4:14
+          goto -> bb4;                     // scope 2 at $DIR/while_let_loops.rs:+4:9: +4:14
       }
   
       bb3: {
-          StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-          nop;                             // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-          StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
+          StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:+2:5: +5:6
+          nop;                             // scope 1 at $DIR/while_let_loops.rs:+2:5: +5:6
+          StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:+5:5: +5:6
           goto -> bb4;                     // scope 1 at no-location
       }
   
       bb4: {
-          StorageDead(_3);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
-          StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
-          return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2
+          StorageDead(_3);                 // scope 1 at $DIR/while_let_loops.rs:+5:5: +5:6
+          StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/while_let_loops.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
@@ -2,54 +2,54 @@
 + // MIR for `change_loop_body` after ConstProp
   
   fn change_loop_body() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:5:27: 5:27
-      let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
-      let mut _2: ();                      // in scope 0 at $DIR/while_let_loops.rs:5:1: 11:2
-      let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/while_let_loops.rs:7:28: 7:32
-      let mut _4: isize;                   // in scope 0 at $DIR/while_let_loops.rs:7:15: 7:25
-      let mut _5: !;                       // in scope 0 at $DIR/while_let_loops.rs:7:33: 10:6
-      let mut _6: !;                       // in scope 0 at $DIR/while_let_loops.rs:7:5: 10:6
-      let _7: ();                          // in scope 0 at $DIR/while_let_loops.rs:7:5: 10:6
-      let mut _8: !;                       // in scope 0 at $DIR/while_let_loops.rs:7:5: 10:6
+      let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:+0:27: +0:27
+      let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
+      let mut _2: ();                      // in scope 0 at $DIR/while_let_loops.rs:+0:1: +6:2
+      let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/while_let_loops.rs:+2:28: +2:32
+      let mut _4: isize;                   // in scope 0 at $DIR/while_let_loops.rs:+2:15: +2:25
+      let mut _5: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:33: +5:6
+      let mut _6: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
+      let _7: ();                          // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
+      let mut _8: !;                       // in scope 0 at $DIR/while_let_loops.rs:+2:5: +5:6
       scope 1 {
-          debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
+          debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:+1:9: +1:15
           scope 2 {
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
-          _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
-          StorageLive(_3);                 // scope 2 at $DIR/while_let_loops.rs:7:28: 7:32
-          Deinit(_3);                      // scope 2 at $DIR/while_let_loops.rs:7:28: 7:32
-          discriminant(_3) = 0;            // scope 2 at $DIR/while_let_loops.rs:7:28: 7:32
--         _4 = discriminant(_3);           // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
--         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
-+         _4 = const 0_isize;              // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
-+         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
+          StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
+          _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:+1:18: +1:19
+          StorageLive(_3);                 // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+          Deinit(_3);                      // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+          discriminant(_3) = 0;            // scope 2 at $DIR/while_let_loops.rs:+2:28: +2:32
+-         _4 = discriminant(_3);           // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
++         _4 = const 0_isize;              // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
++         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }
   
       bb1: {
-          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:7:15: 7:25
+          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 2 at $DIR/while_let_loops.rs:+2:15: +2:25
       }
   
       bb2: {
-          _1 = const 1_i32;                // scope 2 at $DIR/while_let_loops.rs:8:9: 8:15
-          nop;                             // scope 2 at $DIR/while_let_loops.rs:9:9: 9:14
-          goto -> bb4;                     // scope 2 at $DIR/while_let_loops.rs:9:9: 9:14
+          _1 = const 1_i32;                // scope 2 at $DIR/while_let_loops.rs:+3:9: +3:15
+          nop;                             // scope 2 at $DIR/while_let_loops.rs:+4:9: +4:14
+          goto -> bb4;                     // scope 2 at $DIR/while_let_loops.rs:+4:9: +4:14
       }
   
       bb3: {
-          StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-          nop;                             // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-          StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
+          StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:+2:5: +5:6
+          nop;                             // scope 1 at $DIR/while_let_loops.rs:+2:5: +5:6
+          StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:+5:5: +5:6
           goto -> bb4;                     // scope 1 at no-location
       }
   
       bb4: {
-          StorageDead(_3);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
-          StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
-          return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2
+          StorageDead(_3);                 // scope 1 at $DIR/while_let_loops.rs:+5:5: +5:6
+          StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:+6:1: +6:2
+          return;                          // scope 0 at $DIR/while_let_loops.rs:+6:2: +6:2
       }
   }
   

--- a/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.32bit.mir
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.32bit.mir
@@ -1,17 +1,17 @@
 // MIR for `change_loop_body` after PreCodegen
 
 fn change_loop_body() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:5:27: 5:27
-    let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:+0:27: +0:27
+    let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
     scope 1 {
-        debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
+        debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:+1:9: +1:15
         scope 2 {
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
-        StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
-        return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2
+        StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
+        StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:+6:1: +6:2
+        return;                          // scope 0 at $DIR/while_let_loops.rs:+6:2: +6:2
     }
 }

--- a/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.64bit.mir
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.64bit.mir
@@ -1,17 +1,17 @@
 // MIR for `change_loop_body` after PreCodegen
 
 fn change_loop_body() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:5:27: 5:27
-    let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/while_let_loops.rs:+0:27: +0:27
+    let mut _1: i32;                     // in scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
     scope 1 {
-        debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
+        debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:+1:9: +1:15
         scope 2 {
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
-        StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
-        return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2
+        StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:+1:9: +1:15
+        StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:+6:1: +6:2
+        return;                          // scope 0 at $DIR/while_let_loops.rs:+6:2: +6:2
     }
 }

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -1,56 +1,56 @@
 // MIR for `while_loop` after PreCodegen
 
 fn while_loop(_1: bool) -> () {
-    debug c => _1;                       // in scope 0 at $DIR/while-storage.rs:9:15: 9:16
-    let mut _0: ();                      // return place in scope 0 at $DIR/while-storage.rs:9:24: 9:24
-    let mut _2: bool;                    // in scope 0 at $DIR/while-storage.rs:10:11: 10:22
-    let mut _3: bool;                    // in scope 0 at $DIR/while-storage.rs:10:20: 10:21
-    let mut _4: bool;                    // in scope 0 at $DIR/while-storage.rs:11:12: 11:23
-    let mut _5: bool;                    // in scope 0 at $DIR/while-storage.rs:11:21: 11:22
+    debug c => _1;                       // in scope 0 at $DIR/while-storage.rs:+0:15: +0:16
+    let mut _0: ();                      // return place in scope 0 at $DIR/while-storage.rs:+0:24: +0:24
+    let mut _2: bool;                    // in scope 0 at $DIR/while-storage.rs:+1:11: +1:22
+    let mut _3: bool;                    // in scope 0 at $DIR/while-storage.rs:+1:20: +1:21
+    let mut _4: bool;                    // in scope 0 at $DIR/while-storage.rs:+2:12: +2:23
+    let mut _5: bool;                    // in scope 0 at $DIR/while-storage.rs:+2:21: +2:22
 
     bb0: {
-        goto -> bb1;                     // scope 0 at $DIR/while-storage.rs:10:5: 14:6
+        goto -> bb1;                     // scope 0 at $DIR/while-storage.rs:+1:5: +5:6
     }
 
     bb1: {
-        StorageLive(_2);                 // scope 0 at $DIR/while-storage.rs:10:11: 10:22
-        StorageLive(_3);                 // scope 0 at $DIR/while-storage.rs:10:20: 10:21
-        _3 = _1;                         // scope 0 at $DIR/while-storage.rs:10:20: 10:21
-        _2 = get_bool(move _3) -> bb2;   // scope 0 at $DIR/while-storage.rs:10:11: 10:22
+        StorageLive(_2);                 // scope 0 at $DIR/while-storage.rs:+1:11: +1:22
+        StorageLive(_3);                 // scope 0 at $DIR/while-storage.rs:+1:20: +1:21
+        _3 = _1;                         // scope 0 at $DIR/while-storage.rs:+1:20: +1:21
+        _2 = get_bool(move _3) -> bb2;   // scope 0 at $DIR/while-storage.rs:+1:11: +1:22
                                          // mir::Constant
                                          // + span: $DIR/while-storage.rs:10:11: 10:19
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 0 at $DIR/while-storage.rs:10:21: 10:22
-        switchInt(move _2) -> [false: bb7, otherwise: bb3]; // scope 0 at $DIR/while-storage.rs:10:11: 10:22
+        StorageDead(_3);                 // scope 0 at $DIR/while-storage.rs:+1:21: +1:22
+        switchInt(move _2) -> [false: bb7, otherwise: bb3]; // scope 0 at $DIR/while-storage.rs:+1:11: +1:22
     }
 
     bb3: {
-        StorageLive(_4);                 // scope 0 at $DIR/while-storage.rs:11:12: 11:23
-        StorageLive(_5);                 // scope 0 at $DIR/while-storage.rs:11:21: 11:22
-        _5 = _1;                         // scope 0 at $DIR/while-storage.rs:11:21: 11:22
-        _4 = get_bool(move _5) -> bb4;   // scope 0 at $DIR/while-storage.rs:11:12: 11:23
+        StorageLive(_4);                 // scope 0 at $DIR/while-storage.rs:+2:12: +2:23
+        StorageLive(_5);                 // scope 0 at $DIR/while-storage.rs:+2:21: +2:22
+        _5 = _1;                         // scope 0 at $DIR/while-storage.rs:+2:21: +2:22
+        _4 = get_bool(move _5) -> bb4;   // scope 0 at $DIR/while-storage.rs:+2:12: +2:23
                                          // mir::Constant
                                          // + span: $DIR/while-storage.rs:11:12: 11:20
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_5);                 // scope 0 at $DIR/while-storage.rs:11:22: 11:23
-        switchInt(move _4) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/while-storage.rs:11:12: 11:23
+        StorageDead(_5);                 // scope 0 at $DIR/while-storage.rs:+2:22: +2:23
+        switchInt(move _4) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/while-storage.rs:+2:12: +2:23
     }
 
     bb5: {
-        StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:13:9: 13:10
+        StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:+4:9: +4:10
         goto -> bb8;                     // scope 0 at no-location
     }
 
     bb6: {
-        StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:13:9: 13:10
-        StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
-        goto -> bb1;                     // scope 0 at $DIR/while-storage.rs:10:5: 14:6
+        StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:+4:9: +4:10
+        StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:+5:5: +5:6
+        goto -> bb1;                     // scope 0 at $DIR/while-storage.rs:+1:5: +5:6
     }
 
     bb7: {
@@ -58,7 +58,7 @@ fn while_loop(_1: bool) -> () {
     }
 
     bb8: {
-        StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
-        return;                          // scope 0 at $DIR/while-storage.rs:15:2: 15:2
+        StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:+5:5: +5:6
+        return;                          // scope 0 at $DIR/while-storage.rs:+6:2: +6:2
     }
 }

--- a/src/test/rustdoc-ui/z-help.stdout
+++ b/src/test/rustdoc-ui/z-help.stdout
@@ -76,6 +76,7 @@
     -Z                              meta-stats=val -- gather metadata statistics (default: no)
     -Z                          mir-emit-retag=val -- emit Retagging MIR statements, interpreted e.g., by miri; implies -Zmir-opt-level=0 (default: no)
     -Z                       mir-enable-passes=val -- use like `-Zmir-enable-passes=+DestProp,-InstCombine`. Forces the specified passes to be enabled, overriding all other checks. Passes that are not specified are enabled or disabled by other flags as usual.
+    -Z        mir-pretty-relative-line-numbers=val -- use line numbers relative to the function in mir pretty printing
     -Z                           mir-opt-level=val -- MIR optimization level (0-4; default: 1 in non optimized builds and 2 in optimized builds)
     -Z                         move-size-limit=val -- the size at which the `large_assignments` lint starts to be emitted
     -Z                         mutable-noalias=val -- emit noalias metadata for mutable references (default: yes)

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1960,6 +1960,7 @@ impl<'test> TestCx<'test> {
                     "-Zdump-mir=all",
                     "-Zvalidate-mir",
                     "-Zdump-mir-exclude-pass-number",
+                    "-Zmir-pretty-relative-line-numbers=yes",
                 ]);
                 if let Some(pass) = &self.props.mir_unit_test {
                     rustc.args(&["-Zmir-opt-level=0", &format!("-Zmir-enable-passes=+{}", pass)]);


### PR DESCRIPTION
As shown in #99770, the line numbers can be a big source of needless and confusing diffs. This PR adds a new flag `-Zmir-pretty-relative-line-numbers` to make them relative to the function declaration, which avoids most needless diffs from attribute changes.

@JakobDegen told me that there has been a zulip conversation about disabling line numbers with mixed opinions, so I'd like to get some feedback here, for this hopefully better solution.

r? rust-lang/wg-mir-opt