### PR TITLE
Fix futex module imports on wasm+atomics

### DIFF
--- a/library/std/src/sys/wasm/mod.rs
+++ b/library/std/src/sys/wasm/mod.rs
@@ -52,9 +52,11 @@ cfg_if::cfg_if! {
         #[path = "../unix/locks"]
         pub mod locks {
             #![allow(unsafe_op_in_unsafe_fn)]
-            mod futex;
+            mod futex_condvar;
+            mod futex_mutex;
             mod futex_rwlock;
-            pub(crate) use futex::{Mutex, MovableMutex, Condvar, MovableCondvar};
+            pub(crate) use futex_condvar::{Condvar, MovableCondvar};
+            pub(crate) use futex_mutex::{Mutex, MovableMutex};
             pub(crate) use futex_rwlock::{RwLock, MovableRwLock};
         }
         #[path = "atomics/futex.rs"]


### PR DESCRIPTION
The futex modules were rearranged a bit in #98707, which meant that wasm+atomics would no longer compile on nightly. I don’t believe any other targets were impacted by this.