### PR TITLE
Fix PermissionDenied UI tests on WSL

### DIFF
--- a/src/test/ui/linkage-attr/issue-10755.rs
+++ b/src/test/ui/linkage-attr/issue-10755.rs
@@ -1,7 +1,10 @@
 // build-fail
 // dont-check-compiler-stderr
 // compile-flags: -C linker=llllll -C linker-flavor=ld
-// error-pattern: linker `llllll` not found
+// error-pattern: `llllll`
+
+// Before, the error-pattern checked for "not found". On WSL with appendWindowsPath=true, running
+// in invalid command returns a PermissionDenied instead.
 
 fn main() {
 }

--- a/src/test/ui/process/process-spawn-nonexistent.rs
+++ b/src/test/ui/process/process-spawn-nonexistent.rs
@@ -6,9 +6,11 @@ use std::io::ErrorKind;
 use std::process::Command;
 
 fn main() {
-    assert_eq!(Command::new("nonexistent")
-                   .spawn()
-                   .unwrap_err()
-                   .kind(),
-               ErrorKind::NotFound);
+    let result = Command::new("nonexistent").spawn().unwrap_err().kind();
+
+    assert!(matches!(
+        result,
+        // Under WSL with appendWindowsPath=true, this fails with PermissionDenied
+        ErrorKind::NotFound | ErrorKind::PermissionDenied
+    ));
 }


### PR DESCRIPTION
On my WSL with `appendWindowsPath=true`, running an invalid command returns `PermissionDenied` instead of `NotFound`, causing two UI tests to fail.