### PR TITLE
Fuchsia CI zircon lib improvement

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -32,10 +32,16 @@ RUN add-apt-repository -y 'deb https://apt.dilos.org/dilos dilos2 main'
 ENV \
     AR_x86_64_fuchsia=x86_64-fuchsia-ar \
     CC_x86_64_fuchsia=x86_64-fuchsia-clang \
+    CFLAGS_x86_64_fuchsia="--target=x86_64-fuchsia --sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot -I/usr/local/core-linux-amd64-fuchsia-sdk/pkg/fdio/include" \
     CXX_x86_64_fuchsia=x86_64-fuchsia-clang++ \
+    CXXFLAGS_x86_64_fuchsia="--target=x86_64-fuchsia --sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot -I/usr/local/core-linux-amd64-fuchsia-sdk/pkg/fdio/include" \
+    LDFLAGS_x86_64_fuchsia="--target=x86_64-fuchsia --sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot -L/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/lib" \
     AR_aarch64_fuchsia=aarch64-fuchsia-ar \
     CC_aarch64_fuchsia=aarch64-fuchsia-clang \
+    CFLAGS_aarch64_fuchsia="--target=aarch64-fuchsia --sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/sysroot -I/usr/local/core-linux-amd64-fuchsia-sdk/pkg/fdio/include" \
     CXX_aarch64_fuchsia=aarch64-fuchsia-clang++ \
+    CXXFLAGS_aarch64_fuchsia="--target=aarch64-fuchsia --sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/sysroot -I/usr/local/core-linux-amd64-fuchsia-sdk/pkg/fdio/include" \
+    LDFLAGS_aarch64_fuchsia="--target=aarch64-fuchsia --sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/sysroot -L/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/lib" \
     AR_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-ar \
     CC_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-gcc \
     CXX_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-g++ \
@@ -89,14 +95,14 @@ RUN sh /scripts/sccache.sh
 
 ENV CARGO_TARGET_X86_64_FUCHSIA_AR /usr/local/bin/llvm-ar
 ENV CARGO_TARGET_X86_64_FUCHSIA_RUSTFLAGS \
--C link-arg=--sysroot=/usr/local/x86_64-fuchsia \
--C link-arg=-L/usr/local/x86_64-fuchsia/lib \
--C link-arg=-L/usr/local/lib/x86_64-fuchsia/lib
+-C link-arg=--sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot \
+-Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot/lib \
+-Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/lib
 ENV CARGO_TARGET_AARCH64_FUCHSIA_AR /usr/local/bin/llvm-ar
 ENV CARGO_TARGET_AARCH64_FUCHSIA_RUSTFLAGS \
--C link-arg=--sysroot=/usr/local/aarch64-fuchsia \
--C link-arg=-L/usr/local/aarch64-fuchsia/lib \
--C link-arg=-L/usr/local/lib/aarch64-fuchsia/lib
+-C link-arg=--sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/sysroot \
+-Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/sysroot/lib \
+-Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/lib
 
 ENV TARGETS=x86_64-fuchsia
 ENV TARGETS=$TARGETS,aarch64-fuchsia

--- a/src/ci/docker/host-x86_64/dist-various-2/build-fuchsia-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-fuchsia-toolchain.sh
@@ -3,52 +3,58 @@
 set -ex
 source shared.sh
 
-ZIRCON=e9a26dbc70d631029f8ee9763103910b7e3a2fe1
+FUCHSIA_SDK_URL=https://chrome-infra-packages.appspot.com/dl/fuchsia/sdk/core/linux-amd64
+FUCHSIA_SDK_ID=4xjxrGUrDbQ6_zJwj6cDN1IbWsWV5aCQXC_zO_Hu0XkC
+FUCHSIA_SDK_SHA256=e318f1ac652b0db43aff32708fa70337521b5ac595e5a0905c2ff33bf1eed179
+FUCHSIA_SDK_USR_DIR=/usr/local/core-linux-amd64-fuchsia-sdk
+CLANG_DOWNLOAD_URL=\
+https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/linux-amd64
+CLANG_DOWNLOAD_ID=vU0vNjSihOV4Q6taQYCpy03JXGiCyVwxen3rFMNMIgsC
+CLANG_DOWNLOAD_SHA256=bd4d2f3634a284e57843ab5a4180a9cb4dc95c6882c95c317a7deb14c34c220b
 
-mkdir -p zircon
-pushd zircon > /dev/null
+install_clang() {
+  mkdir -p clang_download
+  pushd clang_download > /dev/null
 
-# Download sources
-git init
-git remote add origin https://github.com/rust-lang-nursery/mirror-google-fuchsia-zircon
-git fetch --depth=1 origin $ZIRCON
-git reset --hard FETCH_HEAD
+  # Download clang+llvm
+  curl -LO "${CLANG_DOWNLOAD_URL}/+/${CLANG_DOWNLOAD_ID}"
+  echo "$(echo ${CLANG_DOWNLOAD_SHA256}) ${CLANG_DOWNLOAD_ID}" | sha256sum --check --status
+  unzip -qq ${CLANG_DOWNLOAD_ID} -d clang-linux-amd64
 
-# Download toolchain
-./scripts/download-toolchain
-chmod -R a+rx prebuilt/downloads/clang+llvm-x86_64-linux
-cp -a prebuilt/downloads/clang+llvm-x86_64-linux/. /usr/local
+  # Other dists currently depend on our Clang... moving into /usr/local for other
+  #  dist usage instead of a Fuchsia /usr/local directory
+  chmod -R 777 clang-linux-amd64/.
+  cp -a clang-linux-amd64/. /usr/local
 
-build() {
-  local arch="$1"
+  # CFLAGS and CXXFLAGS env variables in main Dockerfile handle sysroot linking
+  for arch in x86_64 aarch64; do
+    for tool in clang clang++; do
+      ln -s /usr/local/bin/${tool} /usr/local/bin/${arch}-fuchsia-${tool}
+    done
+    ln -s /usr/local/bin/llvm-ar /usr/local/bin/${arch}-fuchsia-ar
+  done
 
-  case "${arch}" in
-    x86_64) tgt="zircon-pc-x86-64" ;;
-    aarch64) tgt="zircon-qemu-arm64" ;;
-  esac
-
-  hide_output make -j$(getconf _NPROCESSORS_ONLN) $tgt
-  dst=/usr/local/${arch}-fuchsia
-  mkdir -p $dst
-  cp -a build-${tgt}/sysroot/include $dst/
-  cp -a build-${tgt}/sysroot/lib $dst/
+  popd > /dev/null
+  rm -rf clang_download
 }
 
-# Build sysroot
-for arch in x86_64 aarch64; do
-  build ${arch}
-done
+install_zircon_libs() {
+  mkdir -p zircon
+  pushd zircon > /dev/null
 
-popd > /dev/null
-rm -rf zircon
+  # Download Fuchsia SDK (with Zircon libs)
+  curl -LO "${FUCHSIA_SDK_URL}/+/${FUCHSIA_SDK_ID}"
+  echo "$(echo ${FUCHSIA_SDK_SHA256}) ${FUCHSIA_SDK_ID}" | sha256sum --check --status
+  unzip -qq ${FUCHSIA_SDK_ID} -d core-linux-amd64
 
-for arch in x86_64 aarch64; do
-  for tool in clang clang++; do
-    cat >/usr/local/bin/${arch}-fuchsia-${tool} <<EOF
-#!/bin/sh
-${tool} --target=${arch}-fuchsia --sysroot=/usr/local/${arch}-fuchsia "\$@"
-EOF
-    chmod +x /usr/local/bin/${arch}-fuchsia-${tool}
-  done
-  ln -s /usr/local/bin/llvm-ar /usr/local/bin/${arch}-fuchsia-ar
-done
+  # Moving SDK into Docker's user-space
+  mkdir -p ${FUCHSIA_SDK_USR_DIR}
+  chmod -R 777 core-linux-amd64/.
+  cp -r core-linux-amd64/* ${FUCHSIA_SDK_USR_DIR}
+
+  popd > /dev/null
+  rm -rf zircon
+}
+
+hide_output install_clang
+hide_output install_zircon_libs


### PR DESCRIPTION
Removing Zircon build process, instead pulling `sysroot` and related libs directly from Fuchsia SDK

cc. @tmandry @djkoloski 