### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -129,7 +129,7 @@ fn get_features(
                         .span_suggestion(
                             mi.span(),
                             "expected just one word",
-                            format!("{}", ident.name),
+                            ident.name,
                             Applicability::MaybeIncorrect,
                         )
                         .emit();

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -184,7 +184,7 @@ pub trait InferCtxtExt<'tcx> {
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> bool;
 
-    fn get_closure_name(&self, def_id: DefId, err: &mut Diagnostic, msg: &str) -> Option<String>;
+    fn get_closure_name(&self, def_id: DefId, err: &mut Diagnostic, msg: &str) -> Option<Symbol>;
 
     fn suggest_fn_call(
         &self,
@@ -737,13 +737,13 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
     /// Given a closure's `DefId`, return the given name of the closure.
     ///
     /// This doesn't account for reassignments, but it's only used for suggestions.
-    fn get_closure_name(&self, def_id: DefId, err: &mut Diagnostic, msg: &str) -> Option<String> {
-        let get_name = |err: &mut Diagnostic, kind: &hir::PatKind<'_>| -> Option<String> {
+    fn get_closure_name(&self, def_id: DefId, err: &mut Diagnostic, msg: &str) -> Option<Symbol> {
+        let get_name = |err: &mut Diagnostic, kind: &hir::PatKind<'_>| -> Option<Symbol> {
             // Get the local name of this closure. This can be inaccurate because
             // of the possibility of reassignment, but this should be good enough.
             match &kind {
-                hir::PatKind::Binding(hir::BindingAnnotation::Unannotated, _, name, None) => {
-                    Some(format!("{}", name))
+                hir::PatKind::Binding(hir::BindingAnnotation::Unannotated, _, ident, None) => {
+                    Some(ident.name)
                 }
                 _ => {
                     err.note(msg);

--- a/compiler/rustc_traits/src/evaluate_obligation.rs
+++ b/compiler/rustc_traits/src/evaluate_obligation.rs
@@ -16,6 +16,8 @@ fn evaluate_obligation<'tcx>(
     canonical_goal: CanonicalPredicateGoal<'tcx>,
 ) -> Result<EvaluationResult, OverflowError> {
     debug!("evaluate_obligation(canonical_goal={:#?})", canonical_goal);
+    // HACK This bubble is required for this tests to pass:
+    // impl-trait/issue99642.rs
     tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).enter_with_canonical(
         DUMMY_SP,
         &canonical_goal,

--- a/compiler/rustc_traits/src/evaluate_obligation.rs
+++ b/compiler/rustc_traits/src/evaluate_obligation.rs
@@ -1,4 +1,4 @@
-use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{ParamEnvAnd, TyCtxt};
 use rustc_span::source_map::DUMMY_SP;
@@ -16,7 +16,7 @@ fn evaluate_obligation<'tcx>(
     canonical_goal: CanonicalPredicateGoal<'tcx>,
 ) -> Result<EvaluationResult, OverflowError> {
     debug!("evaluate_obligation(canonical_goal={:#?})", canonical_goal);
-    tcx.infer_ctxt().enter_with_canonical(
+    tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).enter_with_canonical(
         DUMMY_SP,
         &canonical_goal,
         |ref infcx, goal, _canonical_inference_vars| {

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -2,7 +2,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::at::ToTrace;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
-use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
+use rustc_infer::infer::{DefiningAnchor, InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::TraitEngineExt as _;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::{GenericArg, Subst, UserSelfTy, UserSubsts};
@@ -258,10 +258,13 @@ fn type_op_prove_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
     canonicalized: Canonical<'tcx, ParamEnvAnd<'tcx, ProvePredicate<'tcx>>>,
 ) -> Result<&'tcx Canonical<'tcx, QueryResponse<'tcx, ()>>, NoSolution> {
-    tcx.infer_ctxt().enter_canonical_trait_query(&canonicalized, |infcx, fulfill_cx, key| {
-        type_op_prove_predicate_with_cause(infcx, fulfill_cx, key, ObligationCause::dummy());
-        Ok(())
-    })
+    tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).enter_canonical_trait_query(
+        &canonicalized,
+        |infcx, fulfill_cx, key| {
+            type_op_prove_predicate_with_cause(infcx, fulfill_cx, key, ObligationCause::dummy());
+            Ok(())
+        },
+    )
 }
 
 /// The core of the `type_op_prove_predicate` query: for diagnostics purposes in NLL HRTB errors,

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -258,6 +258,8 @@ fn type_op_prove_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
     canonicalized: Canonical<'tcx, ParamEnvAnd<'tcx, ProvePredicate<'tcx>>>,
 ) -> Result<&'tcx Canonical<'tcx, QueryResponse<'tcx, ()>>, NoSolution> {
+    // HACK This bubble is required for this test to pass:
+    // impl-trait/issue-99642.rs
     tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bubble).enter_canonical_trait_query(
         &canonicalized,
         |infcx, fulfill_cx, key| {

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -935,7 +935,7 @@ impl f32 {
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_gamma", issue = "none")]
+    #[unstable(feature = "float_gamma", issue = "99842")]
     #[inline]
     pub fn gamma(self) -> f32 {
         unsafe { cmath::tgammaf(self) }

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -920,4 +920,24 @@ impl f32 {
     pub fn atanh(self) -> f32 {
         0.5 * ((2.0 * self) / (1.0 - self)).ln_1p()
     }
+
+    /// Gamma function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(float_gamma)]
+    /// let x = 5.0f32;
+    ///
+    /// let abs_difference = (x.gamma() - 24.0).abs();
+    ///
+    /// assert!(abs_difference <= f32::EPSILON);
+    /// ```
+    #[rustc_allow_incoherent_impl]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "float_gamma", issue = "none")]
+    #[inline]
+    pub fn gamma(self) -> f32 {
+        unsafe { cmath::tgammaf(self) }
+    }
 }

--- a/library/std/src/f32/tests.rs
+++ b/library/std/src/f32/tests.rs
@@ -551,6 +551,21 @@ fn test_atanh() {
 }
 
 #[test]
+fn test_gamma() {
+    assert_eq!(0.0f32.gamma(), f32::INFINITY);
+    assert_eq!(1.0f32.gamma(), 1.0f32);
+    assert_eq!(2.0f32.gamma(), 1.0f32);
+    assert_eq!(3.0f32.gamma(), 2.0f32);
+    assert_eq!(4.0f32.gamma(), 6.0f32);
+    assert_eq!(5.0f32.gamma(), 24.0f32);
+
+    assert_approx_eq!(0.5f32.gamma(), consts::PI.sqrt());
+    assert_approx_eq!((-0.5f32).gamma(), -2.0 * consts::PI.sqrt());
+
+    assert!((-1.0f32).gamma().is_nan());
+}
+
+#[test]
 fn test_real_consts() {
     use super::consts;
 

--- a/library/std/src/f32/tests.rs
+++ b/library/std/src/f32/tests.rs
@@ -553,11 +553,11 @@ fn test_atanh() {
 #[test]
 fn test_gamma() {
     assert_eq!(0.0f32.gamma(), f32::INFINITY);
-    assert_eq!(1.0f32.gamma(), 1.0f32);
-    assert_eq!(2.0f32.gamma(), 1.0f32);
-    assert_eq!(3.0f32.gamma(), 2.0f32);
-    assert_eq!(4.0f32.gamma(), 6.0f32);
-    assert_eq!(5.0f32.gamma(), 24.0f32);
+    assert_approx_eq!(1.0f32.gamma(), 1.0f32);
+    assert_approx_eq!(2.0f32.gamma(), 1.0f32);
+    assert_approx_eq!(3.0f32.gamma(), 2.0f32);
+    assert_approx_eq!(4.0f32.gamma(), 6.0f32);
+    assert_approx_eq!(5.0f32.gamma(), 24.0f32);
 
     assert_approx_eq!(0.5f32.gamma(), consts::PI.sqrt());
     assert_approx_eq!((-0.5f32).gamma(), -2.0 * consts::PI.sqrt());

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -946,4 +946,24 @@ impl f64 {
             Self::NAN // log(-Inf) = NaN
         }
     }
+
+    /// Gamma function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(float_gamma)]
+    /// let x = 5.0f64;
+    ///
+    /// let abs_difference = (x.gamma() - 24.0).abs();
+    ///
+    /// assert!(abs_difference <= f64::EPSILON);
+    /// ```
+    #[rustc_allow_incoherent_impl]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "float_gamma", issue = "none")]
+    #[inline]
+    pub fn gamma(self) -> f64 {
+        unsafe { cmath::tgamma(self) }
+    }
 }

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -961,7 +961,7 @@ impl f64 {
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_gamma", issue = "none")]
+    #[unstable(feature = "float_gamma", issue = "99842")]
     #[inline]
     pub fn gamma(self) -> f64 {
         unsafe { cmath::tgamma(self) }

--- a/library/std/src/f64/tests.rs
+++ b/library/std/src/f64/tests.rs
@@ -538,11 +538,11 @@ fn test_atanh() {
 #[test]
 fn test_gamma() {
     assert_eq!(0.0f64.gamma(), f64::INFINITY);
-    assert_eq!(1.0f64.gamma(), 1.0f64);
-    assert_eq!(2.0f64.gamma(), 1.0f64);
-    assert_eq!(3.0f64.gamma(), 2.0f64);
-    assert_eq!(4.0f64.gamma(), 6.0f64);
-    assert_eq!(5.0f64.gamma(), 24.0f64);
+    assert_approx_eq!(1.0f64.gamma(), 1.0f64);
+    assert_approx_eq!(2.0f64.gamma(), 1.0f64);
+    assert_approx_eq!(3.0f64.gamma(), 2.0f64);
+    assert_approx_eq!(4.0f64.gamma(), 6.0f64);
+    assert_approx_eq!(5.0f64.gamma(), 24.0f64);
 
     assert_approx_eq!(0.5f64.gamma(), consts::PI.sqrt());
     assert_approx_eq!((-0.5f64).gamma(), -2.0 * consts::PI.sqrt());

--- a/library/std/src/f64/tests.rs
+++ b/library/std/src/f64/tests.rs
@@ -536,6 +536,21 @@ fn test_atanh() {
 }
 
 #[test]
+fn test_gamma() {
+    assert_eq!(0.0f64.gamma(), f64::INFINITY);
+    assert_eq!(1.0f64.gamma(), 1.0f64);
+    assert_eq!(2.0f64.gamma(), 1.0f64);
+    assert_eq!(3.0f64.gamma(), 2.0f64);
+    assert_eq!(4.0f64.gamma(), 6.0f64);
+    assert_eq!(5.0f64.gamma(), 24.0f64);
+
+    assert_approx_eq!(0.5f64.gamma(), consts::PI.sqrt());
+    assert_approx_eq!((-0.5f64).gamma(), -2.0 * consts::PI.sqrt());
+
+    assert!((-1.0f64).gamma().is_nan());
+}
+
+#[test]
 fn test_real_consts() {
     use super::consts;
     let pi: f64 = consts::PI;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -272,6 +272,7 @@
 #![feature(exact_size_is_empty)]
 #![feature(exclusive_wrapper)]
 #![feature(extend_one)]
+#![feature(float_gamma)]
 #![feature(float_minimum_maximum)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -14,6 +14,7 @@ use crate::os::wasi::io::OwnedFd;
 use crate::sys_common::{AsInner, IntoInner};
 
 /// Raw file descriptors.
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub type RawFd = raw::c_int;
 
@@ -22,6 +23,7 @@ pub type RawFd = raw::c_int;
 /// This is only available on unix and WASI platforms and must be imported in
 /// order to call the method. Windows platforms have a corresponding
 /// `AsRawHandle` and `AsRawSocket` set of traits.
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait AsRawFd {
     /// Extracts the raw file descriptor.
@@ -57,6 +59,7 @@ pub trait AsRawFd {
 
 /// A trait to express the ability to construct an object from a raw file
 /// descriptor.
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 pub trait FromRawFd {
     /// Constructs a new instance of `Self` from the given raw file
@@ -100,6 +103,7 @@ pub trait FromRawFd {
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw file descriptor.
+#[cfg_attr(not(bootstrap), rustc_allowed_through_unstable_modules)]
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 pub trait IntoRawFd {
     /// Consumes this object, returning the raw underlying file descriptor.

--- a/library/std/src/os/wasi/io/raw.rs
+++ b/library/std/src/os/wasi/io/raw.rs
@@ -2,4 +2,19 @@
 
 #![unstable(feature = "wasi_ext", issue = "71213")]
 
+// NOTE: despite the fact that this module is unstable,
+// stable Rust had the capability to access the stable
+// re-exported items from os::fd::raw through this
+// unstable module.
+// In PR #95956 the stability checker was changed to check
+// all path segments of an item rather than just the last,
+// which caused the aforementioned stable usage to regress
+// (see issue #99502).
+// As a result, the items in os::fd::raw were given the
+// rustc_allowed_through_unstable_modules attribute.
+// No regression tests were added to ensure this property,
+// as CI is not configured to test wasm32-wasi.
+// If this module is stabilized,
+// you may want to remove those attributes
+// (assuming no other unstable modules need them).
 pub use crate::os::fd::raw::*;

--- a/library/std/src/sys/unix/cmath.rs
+++ b/library/std/src/sys/unix/cmath.rs
@@ -30,4 +30,6 @@ extern "C" {
     pub fn tanf(n: f32) -> f32;
     pub fn tanh(n: f64) -> f64;
     pub fn tanhf(n: f32) -> f32;
+    pub fn tgamma(n: f64) -> f64;
+    pub fn tgammaf(n: f32) -> f32;
 }

--- a/library/std/src/sys/windows/cmath.rs
+++ b/library/std/src/sys/windows/cmath.rs
@@ -23,6 +23,8 @@ extern "C" {
     pub fn sinh(n: c_double) -> c_double;
     pub fn tan(n: c_double) -> c_double;
     pub fn tanh(n: c_double) -> c_double;
+    pub fn tgamma(n: c_double) -> c_double;
+    pub fn tgammaf(n: c_float) -> c_float;
 }
 
 pub use self::shims::*;

--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -41,9 +41,7 @@
 
 .toggle {
 	position: relative;
-	display: inline-block;
 	width: 100%;
-	height: 27px;
 	margin-right: 20px;
 	display: flex;
 	align-items: center;
@@ -58,6 +56,7 @@
 .slider {
 	position: relative;
 	width: 45px;
+	min-width: 45px;
 	display: block;
 	height: 28px;
 	margin-right: 20px;

--- a/src/test/rustdoc-gui/settings.goml
+++ b/src/test/rustdoc-gui/settings.goml
@@ -147,3 +147,12 @@ assert-false: "noscript section"
 javascript: false
 reload:
 assert-css: ("noscript section", {"display": "block"})
+javascript: true
+
+// Check for the display on small screen
+show-text: true
+reload:
+size: (300, 1000)
+click: "#settings-menu"
+wait-for: "#settings"
+assert-css: ("#settings .slider", {"width": "45px"}, ALL)

--- a/src/test/ui/impl-trait/issue-99642-2.rs
+++ b/src/test/ui/impl-trait/issue-99642-2.rs
@@ -1,0 +1,8 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+type Opq = impl Sized;
+fn test() -> impl Iterator<Item = Opq> {
+    Box::new(0..) as Box<dyn Iterator<Item = _>>
+}
+fn main(){}

--- a/src/test/ui/impl-trait/issue-99642.rs
+++ b/src/test/ui/impl-trait/issue-99642.rs
@@ -1,0 +1,7 @@
+// check-pass
+
+fn test() -> impl Iterator<Item = impl Sized> {
+    Box::new(0..) as Box<dyn Iterator<Item = _>>
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
@@ -1,8 +1,10 @@
-error[E0275]: overflow evaluating the requirement `<fn() -> Foo {foo} as FnOnce<()>>::Output == fn() -> Foo {foo}`
+error[E0275]: overflow evaluating the requirement `fn() -> Foo {foo}: Sized`
   --> $DIR/issue-53398-cyclic-types.rs:5:13
    |
 LL | fn foo() -> Foo {
    |             ^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_53398_cyclic_types`)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #99714 (Fix regression introduced with #99383)
 - #99723 (Allow using stable os::fd::raw items through unstable os::wasi module)
 - #99747 (Add gamma function to f32 and f64)
 - #99810 (Fix settings slider on small width screens)
 - #99837 (Avoid `Symbol` to `String` conversions)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99714,99723,99747,99810,99837)
<!-- homu-ignore:end -->