### PR TITLE
fix: remove fake no_dead_strip for osx

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -566,9 +566,7 @@ impl<'a> Linker for GccLinker<'a> {
     }
 
     fn no_gc_sections(&mut self) {
-        if self.sess.target.is_like_osx {
-            self.linker_arg("-no_dead_strip");
-        } else if self.sess.target.linker_is_gnu || self.sess.target.is_like_wasm {
+        if self.sess.target.linker_is_gnu || self.sess.target.is_like_wasm {
             self.linker_arg("--no-gc-sections");
         }
     }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/99788

Link arg `-no_dead_strip` doesn't exist on OSX at all.
The `no_gc_sections` function was never called before export-executable-symols implementation, and `export-executable-symbols` still works, so we just remove it.
r? @bjorn3 