### PR TITLE
Check for opaque types behind projections

### DIFF
--- a/src/test/ui/type-alias-impl-trait/impl_trait_for_tait.rs
+++ b/src/test/ui/type-alias-impl-trait/impl_trait_for_tait.rs
@@ -1,0 +1,21 @@
+// compile-flags: --crate-type=lib
+
+#![feature(type_alias_impl_trait)]
+type Alias = impl Sized;
+
+fn constrain() -> Alias {
+    1i32
+}
+
+trait HideIt {
+    type Assoc;
+}
+
+impl HideIt for () {
+    type Assoc = Alias;
+}
+
+pub trait Yay {}
+
+impl Yay for <() as HideIt>::Assoc {}
+//~^ ERROR: cannot implement trait on type alias impl trait

--- a/src/test/ui/type-alias-impl-trait/impl_trait_for_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/impl_trait_for_tait.stderr
@@ -1,0 +1,14 @@
+error: cannot implement trait on type alias impl trait
+  --> $DIR/impl_trait_for_tait.rs:20:1
+   |
+LL | impl Yay for <() as HideIt>::Assoc {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/impl_trait_for_tait.rs:4:14
+   |
+LL | type Alias = impl Sized;
+   |              ^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #99840

I still dislike how fragile this is, but integrating into the regular orphan check doesn't really make sense either, it's not about orphan checking at all.

r? @lcnr