### PR TITLE
Improve type mismatch w/ function signatures

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -20,6 +20,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{AsyncGeneratorKind, GeneratorKind, Node};
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::hir::map;
 use rustc_middle::ty::{
     self, suggest_arbitrary_trait_bound, suggest_constraining_type_param, AdtKind, DefIdTree,
@@ -253,8 +254,8 @@ pub trait InferCtxtExt<'tcx> {
         &self,
         span: Span,
         found_span: Option<Span>,
-        expected_ref: ty::PolyTraitRef<'tcx>,
         found: ty::PolyTraitRef<'tcx>,
+        expected: ty::PolyTraitRef<'tcx>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed>;
 
     fn suggest_fully_qualified_path(
@@ -1529,13 +1530,13 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         &self,
         span: Span,
         found_span: Option<Span>,
-        expected_ref: ty::PolyTraitRef<'tcx>,
         found: ty::PolyTraitRef<'tcx>,
+        expected: ty::PolyTraitRef<'tcx>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        pub(crate) fn build_fn_sig_string<'tcx>(
+        pub(crate) fn build_fn_sig_ty<'tcx>(
             tcx: TyCtxt<'tcx>,
             trait_ref: ty::PolyTraitRef<'tcx>,
-        ) -> String {
+        ) -> Ty<'tcx> {
             let inputs = trait_ref.skip_binder().substs.type_at(1);
             let sig = match inputs.kind() {
                 ty::Tuple(inputs)
@@ -1557,10 +1558,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     abi::Abi::Rust,
                 ),
             };
-            trait_ref.rebind(sig).to_string()
+
+            tcx.mk_fn_ptr(trait_ref.rebind(sig))
         }
 
-        let argument_kind = match expected_ref.skip_binder().self_ty().kind() {
+        let argument_kind = match expected.skip_binder().self_ty().kind() {
             ty::Closure(..) => "closure",
             ty::Generator(..) => "generator",
             _ => "function",
@@ -1569,17 +1571,22 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             self.tcx.sess,
             span,
             E0631,
-            "type mismatch in {} arguments",
-            argument_kind
+            "type mismatch in {argument_kind} arguments",
         );
 
-        let found_str = format!("expected signature of `{}`", build_fn_sig_string(self.tcx, found));
-        err.span_label(span, found_str);
+        err.span_label(span, "expected due to this");
 
         let found_span = found_span.unwrap_or(span);
-        let expected_str =
-            format!("found signature of `{}`", build_fn_sig_string(self.tcx, expected_ref));
-        err.span_label(found_span, expected_str);
+        err.span_label(found_span, "found signature defined here");
+
+        let expected = build_fn_sig_ty(self.tcx, expected);
+        let found = build_fn_sig_ty(self.tcx, found);
+
+        let (expected_str, found_str) =
+            self.tcx.infer_ctxt().enter(|infcx| infcx.cmp(expected, found));
+
+        let signature_kind = format!("{argument_kind} signature");
+        err.note_expected_found(&signature_kind, expected_str, &signature_kind, found_str);
 
         err
     }

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:2:5
    |
 LL |     f1(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r, 's> fn(&'r (), &'s ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r, 's> fn(&'r (), &'s ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:25
    |
@@ -16,10 +18,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:3:5
    |
 LL |     f2(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'a, 'r> fn(&'a (), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'a, 'r> fn(&'a (), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:17:25
    |
@@ -30,10 +34,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
    |
 LL |     f3(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&(), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&(), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f3`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:29
    |
@@ -44,10 +50,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:5:5
    |
 LL |     f4(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'s, 'r> fn(&'s (), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r, 's> fn(&'s (), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f4`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:19:25
    |
@@ -58,10 +66,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
    |
 LL |     f5(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&'r (), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r (), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f5`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:25
    |
@@ -72,10 +82,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:7:5
    |
 LL |     g1(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&'r (), Box<(dyn for<'s> Fn(&'s ()) + 'static)>) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:23:25
    |
@@ -86,10 +98,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
    |
 LL |     g2(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&'r (), for<'s> fn(&'s ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r (), for<'r> fn(&'r ())) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:24:25
    |
@@ -100,10 +114,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:9:5
    |
 LL |     g3(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'s> fn(&'s (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'s> fn(&'s (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g3`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:25:25
    |
@@ -114,10 +130,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
    |
 LL |     g4(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g4`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:26:25
    |
@@ -128,10 +146,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:11:5
    |
 LL |     h1(|_: (), _: (), _: (), _: ()| {});
-   |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
+   |     ^^ ---------------------------- found signature defined here
    |     |
-   |     expected signature of `for<'r, 's> fn(&'r (), Box<(dyn for<'t0> Fn(&'t0 ()) + 'static)>, &'s (), for<'t0, 't1> fn(&'t0 (), &'t1 ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r, 's> fn(&'r (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>, &'s (), for<'r, 's> fn(&'r (), &'s ())) -> _`
+              found closure signature `fn((), (), (), ()) -> _`
 note: required by a bound in `h1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:29:25
    |
@@ -142,10 +162,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
    |
 LL |     h2(|_: (), _: (), _: (), _: ()| {});
-   |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
+   |     ^^ ---------------------------- found signature defined here
    |     |
-   |     expected signature of `for<'r, 't0> fn(&'r (), Box<(dyn for<'s> Fn(&'s ()) + 'static)>, &'t0 (), for<'s, 't1> fn(&'s (), &'t1 ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'t0, 'r> fn(&'r (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>, &'t0 (), for<'r, 's> fn(&'r (), &'s ())) -> _`
+              found closure signature `fn((), (), (), ()) -> _`
 note: required by a bound in `h2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:30:25
    |

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-infer-var-appearing-twice.rs:14:5
    |
 LL |     with_closure(|x: u32, y: i32| {
-   |     ^^^^^^^^^^^^ ---------------- found signature of `fn(u32, i32) -> _`
+   |     ^^^^^^^^^^^^ ---------------- found signature defined here
    |     |
-   |     expected signature of `fn(_, _) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `fn(_, _) -> _`
+              found closure signature `fn(u32, i32) -> _`
 note: required by a bound in `with_closure`
   --> $DIR/expect-infer-var-appearing-twice.rs:2:14
    |

--- a/src/test/ui/generator/issue-88653.rs
+++ b/src/test/ui/generator/issue-88653.rs
@@ -7,10 +7,12 @@ use std::ops::Generator;
 
 fn foo(bar: bool) -> impl Generator<(bool,)> {
     //~^ ERROR: type mismatch in generator arguments [E0631]
-    //~| NOTE: expected signature of `fn((bool,)) -> _`
+    //~| NOTE: expected due to this
+    //~| NOTE: expected generator signature `fn((bool,)) -> _`
+    //~| NOTE: in this expansion of desugaring of `impl Trait`
     //~| NOTE: in this expansion of desugaring of `impl Trait`
     |bar| {
-        //~^ NOTE: found signature of `fn(bool) -> _`
+        //~^ NOTE: found signature defined here
         if bar {
             yield bar;
         }

--- a/src/test/ui/generator/issue-88653.stderr
+++ b/src/test/ui/generator/issue-88653.stderr
@@ -2,10 +2,13 @@ error[E0631]: type mismatch in generator arguments
   --> $DIR/issue-88653.rs:8:22
    |
 LL | fn foo(bar: bool) -> impl Generator<(bool,)> {
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^ expected signature of `fn((bool,)) -> _`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
 ...
 LL |     |bar| {
-   |     ----- found signature of `fn(bool) -> _`
+   |     ----- found signature defined here
+   |
+   = note: expected generator signature `fn((bool,)) -> _`
+              found generator signature `fn(bool) -> _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/bugs/issue-88382.stderr
+++ b/src/test/ui/generic-associated-types/bugs/issue-88382.stderr
@@ -2,13 +2,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/issue-88382.rs:28:40
    |
 LL |     do_something(SomeImplementation(), test);
-   |     ------------                       ^^^^ expected signature of `for<'r> fn(&'r mut std::iter::Empty<usize>) -> _`
+   |     ------------                       ^^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
 ...
 LL | fn test<'a, I: Iterable>(_: &mut I::Iterator<'a>) {}
-   | ------------------------------------------------- found signature of `for<'r, 'a> fn(&'r mut <_ as Iterable>::Iterator<'a>) -> _`
+   | ------------------------------------------------- found signature defined here
    |
+   = note: expected function signature `for<'r> fn(&'r mut std::iter::Empty<usize>) -> _`
+              found function signature `for<'a, 'r> fn(&'r mut <_ as Iterable>::Iterator<'a>) -> _`
 note: required by a bound in `do_something`
   --> $DIR/issue-88382.rs:22:48
    |

--- a/src/test/ui/intrinsics/const-eval-select-bad.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-bad.stderr
@@ -67,13 +67,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/const-eval-select-bad.rs:34:32
    |
 LL | const fn foo(n: i32) -> i32 {
-   | --------------------------- found signature of `fn(i32) -> _`
+   | --------------------------- found signature defined here
 ...
 LL |     const_eval_select((true,), foo, baz);
-   |     -----------------          ^^^ expected signature of `fn(bool) -> _`
+   |     -----------------          ^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(bool) -> _`
+              found function signature `fn(i32) -> _`
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:7:5
    |
 LL |     foo(|_: isize| {});
-   |     ^^^ ---------- found signature of `fn(isize) -> _`
+   |     ^^^ ---------- found signature defined here
    |     |
-   |     expected signature of `fn(usize) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `fn(usize) -> _`
+              found closure signature `fn(isize) -> _`
 note: required by a bound in `foo`
   --> $DIR/E0631.rs:3:11
    |
@@ -16,10 +18,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
 LL |     bar(|_: isize| {});
-   |     ^^^ ---------- found signature of `fn(isize) -> _`
+   |     ^^^ ---------- found signature defined here
    |     |
-   |     expected signature of `fn(usize) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `fn(usize) -> _`
+              found closure signature `fn(isize) -> _`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |
@@ -30,13 +34,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:9:9
    |
 LL |     fn f(_: u64) {}
-   |     ------------ found signature of `fn(u64) -> _`
+   |     ------------ found signature defined here
 ...
 LL |     foo(f);
-   |     --- ^ expected signature of `fn(usize) -> _`
+   |     --- ^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(usize) -> _`
+              found function signature `fn(u64) -> _`
 note: required by a bound in `foo`
   --> $DIR/E0631.rs:3:11
    |
@@ -47,13 +53,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:10:9
    |
 LL |     fn f(_: u64) {}
-   |     ------------ found signature of `fn(u64) -> _`
+   |     ------------ found signature defined here
 ...
 LL |     bar(f);
-   |     --- ^ expected signature of `fn(usize) -> _`
+   |     --- ^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(usize) -> _`
+              found function signature `fn(u64) -> _`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:3:14
    |
 LL |     a.iter().map(|_: (u32, u32)| 45);
-   |              ^^^ --------------- found signature of `fn((u32, u32)) -> _`
+   |              ^^^ --------------- found signature defined here
    |              |
-   |              expected signature of `fn(&(u32, u32)) -> _`
+   |              expected due to this
    |
+   = note: expected closure signature `fn(&(u32, u32)) -> _`
+              found closure signature `fn((u32, u32)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
@@ -16,10 +18,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:4:14
    |
 LL |     a.iter().map(|_: &(u16, u16)| 45);
-   |              ^^^ ---------------- found signature of `for<'r> fn(&'r (u16, u16)) -> _`
+   |              ^^^ ---------------- found signature defined here
    |              |
-   |              expected signature of `fn(&(u32, u32)) -> _`
+   |              expected due to this
    |
+   = note: expected closure signature `fn(&(u32, u32)) -> _`
+              found closure signature `for<'r> fn(&'r (u16, u16)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
@@ -30,10 +34,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:5:14
    |
 LL |     a.iter().map(|_: (u16, u16)| 45);
-   |              ^^^ --------------- found signature of `fn((u16, u16)) -> _`
+   |              ^^^ --------------- found signature defined here
    |              |
-   |              expected signature of `fn(&(u32, u32)) -> _`
+   |              expected due to this
    |
+   = note: expected closure signature `fn(&(u32, u32)) -> _`
+              found closure signature `fn((u16, u16)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -2,13 +2,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:11:15
    |
 LL | fn takes_mut(x: &mut isize) { }
-   | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
+   | --------------------------- found signature defined here
 ...
 LL |     apply(&3, takes_mut);
-   |     -----     ^^^^^^^^^ expected signature of `fn(&{integer}) -> _`
+   |     -----     ^^^^^^^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(&{integer}) -> _`
+              found function signature `for<'r> fn(&'r mut isize) -> _`
 note: required by a bound in `apply`
   --> $DIR/fn-variance-1.rs:5:37
    |
@@ -19,13 +21,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:15:19
    |
 LL | fn takes_imm(x: &isize) { }
-   | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
+   | ----------------------- found signature defined here
 ...
 LL |     apply(&mut 3, takes_imm);
-   |     -----         ^^^^^^^^^ expected signature of `fn(&mut {integer}) -> _`
+   |     -----         ^^^^^^^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(&mut {integer}) -> _`
+              found function signature `for<'r> fn(&'r isize) -> _`
 note: required by a bound in `apply`
   --> $DIR/fn-variance-1.rs:5:37
    |

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/issue-36053-2.rs:7:32
    |
 LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
-   |                                ^^^^^^ --------- found signature of `for<'r> fn(&'r str) -> _`
+   |                                ^^^^^^ --------- found signature defined here
    |                                |
-   |                                expected signature of `for<'r> fn(&'r &str) -> _`
+   |                                expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r &str) -> _`
+              found closure signature `for<'r> fn(&'r str) -> _`
 note: required by a bound in `filter`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
@@ -2,20 +2,21 @@
 
 use std::ops::FnMut;
 
-fn to_fn_mut<A,F:FnMut<A>>(f: F) -> F { f }
+fn to_fn_mut<A, F: FnMut<A>>(f: F) -> F { f }
 
-fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-//~^ NOTE required by this bound in `call_it`
-//~| NOTE required by a bound in `call_it`
+fn call_it<F: FnMut(isize, isize) -> isize>(y: isize, mut f: F) -> isize {
+    //~^ NOTE required by this bound in `call_it`
+    //~| NOTE required by a bound in `call_it`
     f(2, y)
 }
 
 pub fn main() {
     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
-    //~^ NOTE found signature of `fn(usize, isize) -> _`
+    //~^ NOTE found signature defined here
     let z = call_it(3, f);
     //~^ ERROR type mismatch
-    //~| NOTE expected signature of `fn(isize, isize) -> _`
+    //~| NOTE expected due to this
+    //~| NOTE expected closure signature `fn(isize, _) -> _`
     //~| NOTE required by a bound introduced by this call
     println!("{}", z);
 }

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -2,18 +2,20 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/unboxed-closures-vtable-mismatch.rs:16:24
    |
 LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
-   |                       ----------------------------- found signature of `fn(usize, isize) -> _`
+   |                       ----------------------------- found signature defined here
 LL |
 LL |     let z = call_it(3, f);
-   |             -------    ^ expected signature of `fn(isize, isize) -> _`
+   |             -------    ^ expected due to this
    |             |
    |             required by a bound introduced by this call
    |
+   = note: expected closure signature `fn(isize, _) -> _`
+              found closure signature `fn(usize, _) -> _`
 note: required by a bound in `call_it`
-  --> $DIR/unboxed-closures-vtable-mismatch.rs:7:14
+  --> $DIR/unboxed-closures-vtable-mismatch.rs:7:15
    |
-LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
+LL | fn call_it<F: FnMut(isize, isize) -> isize>(y: isize, mut f: F) -> isize {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR makes use of `note: expected/found` (instead of labeling types in labels) in type mismatch with function signatures. Pros: it's easier to compare the signatures, cons: the error is a little more verbose now.

This is especially nice when
- The signatures differ in a small subset of parameters (same parameters are elided)
- The difference is in details, for example `isize` vs `usize` (there is a better chance that the types align)

Also this PR fixes the inconsistency in variable names in the edited code (`expected` and `found`).

A zulip thread from which this pr started: [[link]](https://rust-lang.zulipchat.com/#narrow/stream/147480-t-compiler.2Fwg-diagnostics/topic/Type.20error.20regression.3F.2E.2E.2E/near/289756602).

An example diagnostic:

<table>
<tr>
<th>this pr</th>
<th>nightly</th>
</tr>
<tr>
<td>

```text
error[E0631]: type mismatch in function arguments
  --> ./t.rs:4:12
   |
4  |     expect(&f);
   |     ------ ^^ expected due to this
   |     |
   |     required by a bound introduced by this call
...
10 | fn f(_: isize, _: u8, _: Vec<u32>) {}
   | ---------------------------------- found signature defined here
   |
   = note: expected function signature `fn(usize, _, Vec<u64>) -> _`
              found function signature `fn(isize, _, Vec<u32>) -> _`
note: required because of the requirements on the impl of `Trait` for `fn(isize, u8, Vec<u32>) {f}`
  --> ./t.rs:8:9
   |
8  | impl<F> Trait for F where F: Fn(usize, u8, Vec<u64>) -> u8 {}
   |         ^^^^^     ^
   = note: required for the cast from `fn(isize, u8, Vec<u32>) {f}` to the object type `dyn Trait`
```

</td>
<td>

```text
error[E0631]: type mismatch in function arguments
  --> ./t.rs:4:12
   |
4  |     expect(&f);
   |     ------ ^^ expected signature of `fn(usize, u8, Vec<u64>) -> _`
   |     |
   |     required by a bound introduced by this call
...
10 | fn f(_: isize, _: u8, _: Vec<u32>) {}
   | ---------------------------------- found signature of `fn(isize, u8, Vec<u32>) -> _`
   |
note: required because of the requirements on the impl of `Trait` for `fn(isize, u8, Vec<u32>) {f}`
  --> ./t.rs:8:9
   |
8  | impl<F> Trait for F where F: Fn(usize, u8, Vec<u64>) -> u8 {}
   |         ^^^^^     ^
   = note: required for the cast to the object type `dyn Trait`
```

</td>
</tr>
</table>

<details><summary>code</summary>
<p>

```rust
fn main() {
    fn expect(_: &dyn Trait) {}

    expect(&f);
}

trait Trait {}
impl<F> Trait for F where F: Fn(usize, u8, Vec<u64>) -> u8 {}

fn f(_: isize, _: u8, _: Vec<u32>) {}
```

</p>
</details>

r? @compiler-errors 