### PR TITLE
Allow search field focus with slash (/) in rustdoc web

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -400,6 +400,7 @@ function loadCss(cssFileName) {
 
             case "s":
             case "S":
+            case "/":
                 ev.preventDefault();
                 searchState.focus();
                 break;


### PR DESCRIPTION
This patch adds support for recognizing `/` as a "jump to search field"
shortcut, akin to `s` and `S`. This new shortcut isn't (yet?) advertised
anywhere, it's merely supported as an "alias" for the current shortcut keys.

Rationale: search in many TUIs has traditionally been mapped to `/` for
compatibility with VIM. A number of websites/apps also respect this convention
(most notably, google.com and right here on github.com). 
(It's also way nerdier than `s` and that should be reason enough to support it!)