### PR TITLE
Clone the `src/llvm-project` submodule if profiling is enabled

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -111,6 +111,11 @@ impl Step for Std {
 
         builder.update_submodule(&Path::new("library").join("stdarch"));
 
+        // Profiler information requires LLVM's compiler-rt
+        if builder.config.profiler {
+            builder.update_submodule(&Path::new("src/llvm-project"));
+        }
+
         let mut target_deps = builder.ensure(StartupObjects { compiler, target });
 
         let compiler_to_use = builder.compiler_for(compiler.stage, compiler.host, target);


### PR DESCRIPTION
To compile rustc with profiling information, `compiler-rt` from LLVM is required. Building it requires the `src/llvm-project` submodule to be initialized and updated.

Fixes #99869