### PR TITLE
Improve BufRead docs and examples regarding UTF-8 issues 

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2287,7 +2287,10 @@ pub trait BufRead: Read {
     ///
     /// # Errors
     ///
-    /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].
+    /// Each line of the iterator has the same error semantics as [`BufRead::read_line`];
+    /// in particular, an error may represent either an underlying IO error reading from
+    /// source or a UTF-8 conversion error parsing the line, the latter of which can be
+    /// recovered from (by continuing to the next line).
     #[stable(feature = "rust1", since = "1.0.0")]
     fn lines(self) -> Lines<Self>
     where

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2147,8 +2147,8 @@ pub trait BufRead: Read {
     ///
     /// # Errors
     ///
-    /// This function has the same error semantics as [`read_until`] and will
-    /// also return an error if the read bytes are not valid UTF-8. If an I/O
+    /// This function has the same error semantics as [`read_until`] in addition
+    /// to also returning an error if the read bytes are not valid UTF-8. If an I/O
     /// error is encountered then `buf` may contain some bytes already read in
     /// the event that all data read so far was valid UTF-8.
     ///

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2234,8 +2234,12 @@ pub trait BufRead: Read {
     /// Returns an iterator over the lines of this reader.
     ///
     /// The iterator returned from this function will yield instances of
-    /// <code>[io::Result]<[String]></code>. Each string returned will *not* have a newline
-    /// byte (the `0xA` byte) or `CRLF` (`0xD`, `0xA` bytes) at the end.
+    /// <code>[io::Result]<[String]></code>, bubbling up any IO errors
+    /// encountered reading from the source or any errors parsing the read
+    /// bytes as UTF-8.
+    ///
+    /// Each string returned will *not* have a newline byte (`0xA`) or the
+    /// `CRLF` bytes (`0xD`, `0xA`) at the end.
     ///
     /// [io::Result]: self::Result "io::Result"
     ///

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2167,21 +2167,21 @@ pub trait BufRead: Read {
     ///
     /// // cursor is at 'f'
     /// let num_bytes = cursor.read_line(&mut buf)
-    ///     .expect("reading from cursor won't fail");
+    ///     .expect("reading ascii strings from cursor won't fail");
     /// assert_eq!(num_bytes, 4);
     /// assert_eq!(buf, "foo\n");
     /// buf.clear();
     ///
     /// // cursor is at 'b'
     /// let num_bytes = cursor.read_line(&mut buf)
-    ///     .expect("reading from cursor won't fail");
+    ///     .expect("reading ascii strings from cursor won't fail");
     /// assert_eq!(num_bytes, 3);
     /// assert_eq!(buf, "bar");
     /// buf.clear();
     ///
     /// // cursor is at EOF
     /// let num_bytes = cursor.read_line(&mut buf)
-    ///     .expect("reading from cursor won't fail");
+    ///     .expect("reading ascii strings from cursor won't fail");
     /// assert_eq!(num_bytes, 0);
     /// assert_eq!(buf, "");
     /// ```


### PR DESCRIPTION
The `BufRead` docs were rather unusually quiet about how to detect UTF-8 errors in the methods that convert `&[u8]` to `&str` (primarily `read_line()` and `lines()`) and didn't offer any clarity on what state a UTF-8 parse error leaves the underlying `BufRead` impl with.

I've also reworked some of the pointer chasing in the docs (lines says to look at read_line which says to look at read_until) without eliminating it altogether.

The patch is organized as a series of commits that each target specific shortcomings in case there's a desire to part-and-parcel this patch series.

**The only question I would have for a reviewer is if I'm committing an egregious sin by directly mentioning `InvalidData` as the error returned on UTF-8 parse failure. Is there a way to document it and talk about it without that implying there's a stability guarantee (in case it's not already guaranteed that *this* is the error that is returned)? My concern is that `InvalidData` doesn't let you actually recover the current line (no access to its bytes and no indication of UTF-8 valid until position), unlike `std::str::Utf8Error` - but I feel like we should be able to document *something* on how to deal with UTF-8 errors via the `BufRead` interface even if what we have might some day change.**

@rustbot label +A-docs +T-libs-api