### PR TITLE
fix ICE when computing codegen_fn_attrs on closure with non-fn parent

### DIFF
--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -3165,9 +3165,11 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
     // #73631: closures inherit `#[target_feature]` annotations
     if tcx.features().target_feature_11 && tcx.is_closure(did.to_def_id()) {
         let owner_id = tcx.parent(did.to_def_id());
-        codegen_fn_attrs
-            .target_features
-            .extend(tcx.codegen_fn_attrs(owner_id).target_features.iter().copied())
+        if tcx.def_kind(owner_id).has_codegen_attrs() {
+            codegen_fn_attrs
+                .target_features
+                .extend(tcx.codegen_fn_attrs(owner_id).target_features.iter().copied());
+        }
     }
 
     // If a function uses #[target_feature] it can't be inlined into general

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/issue-99876.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/issue-99876.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(target_feature_11)]
+
+struct S<T>(T)
+where
+    [T; (|| {}, 1).1]: Copy;
+
+fn main() {}


### PR DESCRIPTION
Other call sites check `has_codegen_attrs` first, so let's do that too.

Fixes #99876