### PR TITLE
Invoke `backtrace-rs`' buildscript in `std`'s buildscript for Android targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ version = "0.0.0"
 dependencies = [
  "addr2line 0.16.0",
  "alloc",
+ "cc",
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -35,6 +35,10 @@ features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']
 [dev-dependencies]
 rand = "0.7"
 
+[build-dependencies]
+# Dependency of the `backtrace` crate
+cc = "1.0.67"
+
 [target.'cfg(any(all(target_family = "wasm", not(target_os = "emscripten")), all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
 dlmalloc = { version = "0.2.3", features = ['rustc-dep-of-std'] }
 

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -1,5 +1,19 @@
 use std::env;
 
+// backtrace-rs requires a feature check on Android targets, so
+// we need to run its build.rs as well. Note that we use an
+// include! rather than #[path = ""] because backtrace-rs's main
+// function is private.
+#[allow(unused_extern_crates)]
+mod backtrace_rs_build_rs {
+    include!("../backtrace/build.rs");
+
+    #[inline]
+    pub fn call_main() {
+        main();
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
@@ -49,4 +63,6 @@ fn main() {
     }
     println!("cargo:rustc-env=STD_ENV_ARCH={}", env::var("CARGO_CFG_TARGET_ARCH").unwrap());
     println!("cargo:rustc-cfg=backtrace_in_libstd");
+
+    backtrace_rs_build_rs::call_main();
 }

--- a/library/std/src/android-api.c
+++ b/library/std/src/android-api.c
@@ -1,0 +1,4 @@
+// Used from backtrace-rs' build script to detect the value of the `__ANDROID_API__`
+// builtin #define
+
+APIVERSION __ANDROID_API__


### PR DESCRIPTION
On Android targets, `backtrace-rs` uses the buildscript to detect if the Android API level, which is needed to enable backtrace symbolication on targets with Android API >= 21. This PR ensures that `backtrace-rs`'s buildscript is invoked as part of the standard library directly including backtrace.

Alongside the patch from rust-lang/cc-rs#705, this _should_ fix backtraces not being symbolicated on Android, though I have only tested this when building from Windows.

Note that this PR will be essentially a no-op as of right now, since the Rust CI builds with a minimum Android API level of 14 (see rust-lang/release-team#9). A custom toolchain build with a higher minimum API level is required to actually get backtraces with symbols as of right now.

<details>
<summary>A config.toml for building with the latest Android NDK</summary>
<pre lang="toml">
profile = "library"
changelog-seen = 2
<br>
[build]
target = ["x86_64-pc-windows-msvc", "armv7-linux-androideabi"]
<br>
[target.armv7-linux-androideabi]
android-ndk = "C:/Users/arcdev/AppData/Local/Android/Sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/windows-x86_64"
cc = "C:/Users/arcdev/AppData/Local/Android/Sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/windows-x86_64/bin/armv7a-linux-androideabi21-clang.cmd"
cxx = "C:/Users/arcdev/AppData/Local/Android/Sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/windows-x86_64/bin/armv7a-linux-androideabi21-clang++.cmd"
linker = "C:/Users/arcdev/AppData/Local/Android/Sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/windows-x86_64/bin/armv7a-linux-androideabi21-clang++.cmd"
llvm-libunwind = "system"
ar = "C:/msys64/mingw64/bin/ar.exe"
</pre>
</details>

According to the latest [Android Platform API Version Distribution](https://user-images.githubusercontent.com/45273859/181664626-bcee6335-91e3-4683-8f92-63f87dd15c44.png), only about 0.4% of Android devices are on Android API version 19 or below, though the latest NDK still supports a lowest API version of 19 (but only for `armv7a-linux-androideabi` and `i686-linux-android` and not the other architectures ???).