### PR TITLE
Remove `parent_pat` from `TopInfo`

### DIFF
--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -72,22 +72,6 @@ struct TopInfo<'tcx> {
     ///              found type `std::result::Result<_, _>`
     /// ```
     span: Option<Span>,
-    /// This refers to the parent pattern. Used to provide extra diagnostic information on errors.
-    /// ```text
-    /// error[E0308]: mismatched types
-    ///   --> $DIR/const-in-struct-pat.rs:8:17
-    ///   |
-    /// L | struct f;
-    ///   | --------- unit struct defined here
-    /// ...
-    /// L |     let Thing { f } = t;
-    ///   |                 ^
-    ///   |                 |
-    ///   |                 expected struct `std::string::String`, found struct `f`
-    ///   |                 `f` is interpreted as a unit struct, not a new binding
-    ///   |                 help: bind the struct field to a different name instead: `f: other_f`
-    /// ```
-    parent_pat: Option<&'tcx Pat<'tcx>>,
 }
 
 impl<'tcx> FnCtxt<'_, 'tcx> {
@@ -147,7 +131,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Option<Span>,
         origin_expr: bool,
     ) {
-        let info = TopInfo { expected, origin_expr, span, parent_pat: None };
+        let info = TopInfo { expected, origin_expr, span };
         self.check_pat(pat, expected, INITIAL_BM, info);
     }
 
@@ -190,9 +174,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.check_pat_struct(pat, qpath, fields, has_rest_pat, expected, def_bm, ti)
             }
             PatKind::Or(pats) => {
-                let parent_pat = Some(pat);
                 for pat in pats {
-                    self.check_pat(pat, expected, def_bm, TopInfo { parent_pat, ..ti });
+                    self.check_pat(pat, expected, def_bm, ti);
                 }
                 expected
             }
@@ -621,7 +604,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         if let Some(p) = sub {
-            self.check_pat(p, expected, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+            self.check_pat(p, expected, def_bm, ti);
         }
 
         local_ty
@@ -782,7 +765,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let Some((variant, pat_ty)) = self.check_struct_path(qpath, pat.hir_id) else {
             let err = self.tcx.ty_error();
             for field in fields {
-                let ti = TopInfo { parent_pat: Some(pat), ..ti };
+                let ti = ti;
                 self.check_pat(field.pat, err, def_bm, ti);
             }
             return err;
@@ -799,11 +782,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn check_pat_path<'b>(
+    fn check_pat_path(
         &self,
-        pat: &Pat<'_>,
+        pat: &Pat<'tcx>,
         qpath: &hir::QPath<'_>,
-        path_resolution: (Res, Option<Ty<'tcx>>, &'b [hir::PathSegment<'b>]),
+        path_resolution: (Res, Option<Ty<'tcx>>, &'tcx [hir::PathSegment<'tcx>]),
         expected: Ty<'tcx>,
         ti: TopInfo<'tcx>,
     ) -> Ty<'tcx> {
@@ -837,7 +820,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Some(err) =
             self.demand_suptype_with_origin(&self.pattern_cause(ti, pat.span), expected, pat_ty)
         {
-            self.emit_bad_pat_path(err, pat.span, res, pat_res, pat_ty, segments, ti.parent_pat);
+            self.emit_bad_pat_path(err, pat, res, pat_res, pat_ty, segments);
         }
         pat_ty
     }
@@ -876,16 +859,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         false
     }
 
-    fn emit_bad_pat_path<'b>(
+    fn emit_bad_pat_path(
         &self,
         mut e: DiagnosticBuilder<'_, ErrorGuaranteed>,
-        pat_span: Span,
+        pat: &hir::Pat<'tcx>,
         res: Res,
         pat_res: Res,
         pat_ty: Ty<'tcx>,
-        segments: &'b [hir::PathSegment<'b>],
-        parent_pat: Option<&Pat<'_>>,
+        segments: &'tcx [hir::PathSegment<'tcx>],
     ) {
+        let pat_span = pat.span;
         if let Some(span) = self.tcx.hir().res_span(pat_res) {
             e.span_label(span, &format!("{} defined here", res.descr()));
             if let [hir::PathSegment { ident, .. }] = &*segments {
@@ -898,8 +881,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         res.descr(),
                     ),
                 );
-                match parent_pat {
-                    Some(Pat { kind: hir::PatKind::Struct(..), .. }) => {
+                match self.tcx.hir().get(self.tcx.hir().get_parent_node(pat.hir_id)) {
+                    hir::Node::Pat(Pat { kind: hir::PatKind::Struct(..), .. }) => {
                         e.span_suggestion_verbose(
                             ident.span.shrink_to_hi(),
                             "bind the struct field to a different name instead",
@@ -960,9 +943,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let on_error = || {
-            let parent_pat = Some(pat);
             for pat in subpats {
-                self.check_pat(pat, tcx.ty_error(), def_bm, TopInfo { parent_pat, ..ti });
+                self.check_pat(pat, tcx.ty_error(), def_bm, ti);
             }
         };
         let report_unexpected_res = |res: Res| {
@@ -1046,7 +1028,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
             for (i, subpat) in subpats.iter().enumerate_and_adjust(variant.fields.len(), ddpos) {
                 let field_ty = self.field_ty(subpat.span, &variant.fields[i], substs);
-                self.check_pat(subpat, field_ty, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+                self.check_pat(subpat, field_ty, def_bm, ti);
 
                 self.tcx.check_stability(
                     variant.fields[i].did,
@@ -1324,7 +1306,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             };
 
-            self.check_pat(field.pat, field_ty, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+            self.check_pat(field.pat, field_ty, def_bm, ti);
         }
 
         let mut unmentioned_fields = variant
@@ -1936,7 +1918,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let err = tcx.ty_error();
             (err, err)
         };
-        self.check_pat(inner, inner_ty, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+        self.check_pat(inner, inner_ty, def_bm, ti);
         rptr_ty
     }
 


### PR DESCRIPTION
We can get the parent pat from the hir map.