### PR TITLE
Adjust an expr span to account for macros

### DIFF
--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -39,8 +39,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let scrut_diverges = self.diverges.replace(Diverges::Maybe);
 
         // #55810: Type check patterns first so we get types for all bindings.
+        let scrut_span = scrut.span.find_ancestor_inside(expr.span).unwrap_or(scrut.span);
         for arm in arms {
-            self.check_pat_top(&arm.pat, scrutinee_ty, Some(scrut.span), true);
+            self.check_pat_top(&arm.pat, scrutinee_ty, Some(scrut_span), true);
         }
 
         // Now typecheck the blocks.

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1234,7 +1234,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Does the expected pattern type originate from an expression and what is the span?
         let (origin_expr, ty_span) = match (decl.ty, decl.init) {
             (Some(ty), _) => (false, Some(ty.span)), // Bias towards the explicit user type.
-            (_, Some(init)) => (true, Some(init.span)), // No explicit type; so use the scrutinee.
+            (_, Some(init)) => {
+                (true, Some(init.span.find_ancestor_inside(decl.span).unwrap_or(init.span)))
+            } // No explicit type; so use the scrutinee.
             _ => (false, None), // We have `let $pat;`, so the expected type is unconstrained.
         };
 

--- a/src/test/ui/suggestions/pattern-slice-vec.fixed
+++ b/src/test/ui/suggestions/pattern-slice-vec.fixed
@@ -24,4 +24,8 @@ fn main() {
         //~^ ERROR: expected an array or slice
         _ => {}
     }
+
+    let [..] = vec![1, 2, 3][..];
+    //~^ ERROR: expected an array or slice
+    //~| HELP: consider slicing here
 }

--- a/src/test/ui/suggestions/pattern-slice-vec.rs
+++ b/src/test/ui/suggestions/pattern-slice-vec.rs
@@ -24,4 +24,8 @@ fn main() {
         //~^ ERROR: expected an array or slice
         _ => {}
     }
+
+    let [..] = vec![1, 2, 3];
+    //~^ ERROR: expected an array or slice
+    //~| HELP: consider slicing here
 }

--- a/src/test/ui/suggestions/pattern-slice-vec.stderr
+++ b/src/test/ui/suggestions/pattern-slice-vec.stderr
@@ -31,6 +31,14 @@ LL |
 LL |         [5] => {}
    |         ^^^ pattern cannot match with input type `Vec<_>`
 
-error: aborting due to 4 previous errors
+error[E0529]: expected an array or slice, found `Vec<{integer}>`
+  --> $DIR/pattern-slice-vec.rs:28:9
+   |
+LL |     let [..] = vec![1, 2, 3];
+   |         ^^^^   ------------- help: consider slicing here: `vec![1, 2, 3][..]`
+   |         |
+   |         pattern cannot match with input type `Vec<{integer}>`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0529`.


### PR DESCRIPTION
Fix this erroneous suggestion:

```
error[E0529]: expected an array or slice, found `Vec<{integer}>`
 --> /home/gh-compiler-errors/test.rs:2:9
  |
2 |     let [..] = vec![1, 2, 3];
  |         ^^^^ pattern cannot match with input type `Vec<{integer}>`
  |
help: consider slicing here
 --> /home/gh-compiler-errors/rust2/library/alloc/src/macros.rs:50:36
  |
50~         $crate::__rust_force_expr!(<[_]>::into_vec(
51+             #[rustc_box]
52+             $crate::boxed::Box::new([$($x),+])
53~         )[..])
```