### PR TITLE
Cleanup html whitespace

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -311,7 +311,7 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                 w,
                 "<h2 id=\"{id}\" class=\"small-section-header\">\
                     <a href=\"#{id}\">{name}</a>\
-                 </h2>\n{}",
+                 </h2>{}",
                 ITEM_TABLE_OPEN,
                 id = cx.derive_id(my_section.id().to_owned()),
                 name = my_section.name(),
@@ -415,10 +415,10 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                 write!(
                     w,
                     "<div class=\"item-left {stab}{add}module-item\">\
-                            <a class=\"{class}\" href=\"{href}\" title=\"{title}\">{name}</a>\
-                            {visibility_emoji}\
-                            {unsafety_flag}\
-                            {stab_tags}\
+                        <a class=\"{class}\" href=\"{href}\" title=\"{title}\">{name}</a>\
+                        {visibility_emoji}\
+                        {unsafety_flag}\
+                        {stab_tags}\
                      </div>\
                      <div class=\"item-right docblock-short\">{docs}</div>",
                     name = myitem.name.unwrap(),
@@ -1126,7 +1126,8 @@ fn item_union(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean:
         write!(
             w,
             "<h2 id=\"fields\" class=\"fields small-section-header\">\
-                   Fields<a href=\"#fields\" class=\"anchor\"></a></h2>"
+                Fields<a href=\"#fields\" class=\"anchor\"></a>\
+            </h2>"
         );
         for (field, ty) in fields {
             let name = field.name.expect("union field name");
@@ -1238,7 +1239,8 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
         write!(
             w,
             "<h2 id=\"variants\" class=\"variants small-section-header\">\
-                   Variants{}<a href=\"#variants\" class=\"anchor\"></a></h2>",
+                Variants{}<a href=\"#variants\" class=\"anchor\"></a>\
+            </h2>",
             document_non_exhaustive_header(it)
         );
         document_non_exhaustive(w, it);
@@ -1294,9 +1296,9 @@ fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::
                                 w,
                                 "<div class=\"sub-variant-field\">\
                                  <span id=\"{id}\" class=\"variant small-section-header\">\
-                                    <a href=\"#{id}\" class=\"anchor field\"></a>\
-                                    <code>{f}:&nbsp;{t}</code>\
-                                </span>",
+                                     <a href=\"#{id}\" class=\"anchor field\"></a>\
+                                     <code>{f}:&nbsp;{t}</code>\
+                                 </span>",
                                 id = id,
                                 f = field.name.unwrap(),
                                 t = ty.print(cx)

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -82,10 +82,10 @@
             {%- else -%}
                 <img class="rust-logo" src="{{static_root_path|safe}}rust-logo{{page.resource_suffix}}.svg" alt="logo"> {#- -#}
             {%- endif -%}
-            </div>
+            </div> {#- -#}
         </a> {#- -#}
-        <h2 class="location"></h2>
-    </nav>
+        <h2 class="location"></h2> {#- -#}
+    </nav> {#- -#}
     <nav class="sidebar"> {#- -#}
         <a class="sidebar-logo" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {#- -#}
             <div class="logo-container"> {#- -#}
@@ -94,7 +94,7 @@
                 {%- else -%}
                     <img class="rust-logo" src="{{static_root_path|safe}}rust-logo{{page.resource_suffix}}.svg" alt="logo"> {#- -#}
                 {%- endif -%}
-            </div>
+            </div> {#- -#}
         </a> {#- -#}
         {{- sidebar|safe -}}
     </nav> {#- -#}
@@ -122,12 +122,12 @@
                             <div id="help-button" title="help" tabindex="-1"> {#- -#}
                                 <button type="button">?</button> {#- -#}
                             </div> {#- -#}
-                            <div id="settings-menu" tabindex="-1">
+                            <div id="settings-menu" tabindex="-1"> {#- -#}
                                 <a href="{{page.root_path|safe}}settings.html" title="settings"> {#- -#}
                                     <img width="22" height="22" alt="Change settings" {# -#}
                                      src="{{static_root_path|safe}}wheel{{page.resource_suffix}}.svg"> {#- -#}
                                 </a> {#- -#}
-                            </div>
+                            </div> {#- -#}
                         </div> {#- -#}
                     </form> {#- -#}
                 </nav> {#- -#}
@@ -143,6 +143,6 @@
          data-resource-suffix="{{page.resource_suffix}}" {# -#}
          data-rustdoc-version="{{rustdoc_version}}" {# -#}
     > {#- -#}
-    </div>
+    </div> {#- -#}
 </body> {#- -#}
 </html> {#- -#}

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -1,4 +1,4 @@
-<div class="main-heading">
+<div class="main-heading"> {#- -#}
     <h1 class="fqn"> {#- -#}
         <span class="in-band"> {#- -#}
             {{-typ-}}
@@ -27,4 +27,4 @@
             [<span class="inner">&#x2212;</span>] {#- -#}
         </a> {#- -#}
     </span> {#- -#}
-</div>
+</div> {#- -#}


### PR DESCRIPTION
I realized while looking at the raw HTML that we generated some unwanted white space characters. This PR cleans up the one coming directly from rustdoc. I'll check from `pulldown-cmark` for the remaining ones.

Some numbers now: the difference is small, it goes from `63009` to `62859`. But multiplied by the number of files, it becomes quite interesting overall.

r? @notriddle 