### PR TITLE
Show absolute line numbers if span is outside relative span

### DIFF
--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -250,7 +250,18 @@ fn mir_build(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> Body<'_
             // of `mir_build`, so now we can steal it
             let thir = thir.steal();
 
-            build::construct_const(&thir, &infcx, expr, def, id, return_ty, return_ty_span)
+            let span_with_body = span_with_body.to(tcx.hir().span(body_id.hir_id));
+
+            build::construct_const(
+                &thir,
+                &infcx,
+                expr,
+                def,
+                id,
+                return_ty,
+                return_ty_span,
+                span_with_body,
+            )
         };
 
         lints::check(tcx, &body);
@@ -705,9 +716,8 @@ fn construct_const<'a, 'tcx>(
     hir_id: hir::HirId,
     const_ty: Ty<'tcx>,
     const_ty_span: Span,
+    span: Span,
 ) -> Body<'tcx> {
-    let tcx = infcx.tcx;
-    let span = tcx.hir().span(hir_id);
     let mut builder = Builder::new(
         thir,
         infcx,

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -472,7 +472,7 @@ impl SourceMap {
         let hi = self.lookup_char_pos(sp.hi());
         let offset = self.lookup_char_pos(relative_to.lo());
 
-        if lo.file.name != offset.file.name {
+        if lo.file.name != offset.file.name || !relative_to.contains(sp) {
             return self.span_to_embeddable_string(sp);
         }
 

--- a/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
+++ b/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
@@ -4,63 +4,63 @@
   fn <impl at $DIR/combine_clone_of_primitives.rs:6:10: 6:15>::clone(_1: &MyThing<T>) -> MyThing<T> {
       debug self => _1;                    // in scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
       let mut _0: MyThing<T>;              // return place in scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
-      let mut _2: T;                       // in scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-      let mut _3: &T;                      // in scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-      let _4: &T;                          // in scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-      let mut _5: u64;                     // in scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-      let mut _6: &u64;                    // in scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-      let _7: &u64;                        // in scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-      let mut _8: [f32; 3];                // in scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
-      let mut _9: &[f32; 3];               // in scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
-      let _10: &[f32; 3];                  // in scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+      let mut _2: T;                       // in scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+      let mut _3: &T;                      // in scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+      let _4: &T;                          // in scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+      let mut _5: u64;                     // in scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+      let mut _6: &u64;                    // in scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+      let _7: &u64;                        // in scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+      let mut _8: [f32; 3];                // in scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+      let mut _9: &[f32; 3];               // in scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+      let _10: &[f32; 3];                  // in scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-          StorageLive(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-          StorageLive(_4);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-          _4 = &((*_1).0: T);              // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
--         _3 = &(*_4);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-+         _3 = _4;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
-          _2 = <T as Clone>::clone(move _3) -> bb1; // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
+          StorageLive(_2);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+          StorageLive(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+          StorageLive(_4);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+          _4 = &((*_1).0: T);              // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+-         _3 = &(*_4);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
++         _3 = _4;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
+          _2 = <T as Clone>::clone(move _3) -> bb1; // scope 0 at $DIR/combine_clone_of_primitives.rs:8:5: 8:9
                                            // mir::Constant
                                            // + span: $DIR/combine_clone_of_primitives.rs:8:5: 8:9
                                            // + literal: Const { ty: for<'r> fn(&'r T) -> T {<T as Clone>::clone}, val: Value(<ZST>) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:8: +2:9
-          StorageLive(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-          StorageLive(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-          StorageLive(_7);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-          _7 = &((*_1).1: u64);            // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
--         _6 = &(*_7);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
--         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
+          StorageDead(_3);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:8:8: 8:9
+          StorageLive(_5);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+          StorageLive(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+          StorageLive(_7);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+          _7 = &((*_1).1: u64);            // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+-         _6 = &(*_7);                     // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
+-         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
 -                                          // mir::Constant
 -                                          // + span: $DIR/combine_clone_of_primitives.rs:9:5: 9:11
 -                                          // + literal: Const { ty: for<'r> fn(&'r u64) -> u64 {<u64 as Clone>::clone}, val: Value(<ZST>) }
-+         _6 = _7;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-+         _5 = (*_6);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
-+         goto -> bb2;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
++         _6 = _7;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
++         _5 = (*_6);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
++         goto -> bb2;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:9:5: 9:11
       }
   
       bb2: {
-          StorageDead(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:10: +3:11
-          StorageLive(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
-          StorageLive(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
-          StorageLive(_10);                // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
-          _10 = &((*_1).2: [f32; 3]);      // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
--         _9 = &(*_10);                    // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
--         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
+          StorageDead(_6);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:9:10: 9:11
+          StorageLive(_8);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+          StorageLive(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+          StorageLive(_10);                // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+          _10 = &((*_1).2: [f32; 3]);      // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+-         _9 = &(*_10);                    // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
+-         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
 -                                          // mir::Constant
 -                                          // + span: $DIR/combine_clone_of_primitives.rs:10:5: 10:16
 -                                          // + literal: Const { ty: for<'r> fn(&'r [f32; 3]) -> [f32; 3] {<[f32; 3] as Clone>::clone}, val: Value(<ZST>) }
-+         _9 = _10;                        // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
-+         _8 = (*_9);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
-+         goto -> bb3;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
++         _9 = _10;                        // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
++         _8 = (*_9);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
++         goto -> bb3;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:10:5: 10:16
       }
   
       bb3: {
-          StorageDead(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:15: +4:16
+          StorageDead(_9);                 // scope 0 at $DIR/combine_clone_of_primitives.rs:10:15: 10:16
           Deinit(_0);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
           (_0.0: T) = move _2;             // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15
           (_0.1: u64) = move _5;           // scope 0 at $DIR/combine_clone_of_primitives.rs:+0:10: +0:15

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -40,11 +40,11 @@
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
-          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
+          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:44
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:44
       }
 - }
 - 

--- a/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
@@ -12,6 +12,6 @@ static BOP: &i32 = {
         _1 = &_2;                        // scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
         _0 = &(*_1);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
         StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:22: +0:23
-        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:17
+        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:23
     }
 }

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -42,11 +42,11 @@
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
-          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
+          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:55
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:28
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:55
       }
   }
 - 

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -17,14 +17,14 @@
 fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 10:17]) -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     let mut _2: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
-    let _3: std::string::String;         // in scope 0 at $DIR/generator-drop-cleanup.rs:+1:13: +1:15
-    let _4: ();                          // in scope 0 at $DIR/generator-drop-cleanup.rs:+2:9: +2:14
-    let mut _5: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+2:9: +2:14
-    let mut _6: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:18: +0:18
+    let _3: std::string::String;         // in scope 0 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
+    let _4: ();                          // in scope 0 at $DIR/generator-drop-cleanup.rs:12:9: 12:14
+    let mut _5: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:12:9: 12:14
+    let mut _6: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:10:18: 10:18
     let mut _7: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     let mut _8: u32;                     // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
     scope 1 {
-        debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:+1:13: +1:15
+        debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
     }
 
     bb0: {
@@ -33,14 +33,14 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
     }
 
     bb1: {
-        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:+2:13: +2:14
-        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:+2:14: +2:15
-        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
+        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
+        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb2: {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
-        goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb3: {
@@ -52,8 +52,8 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
     }
 
     bb5 (cleanup): {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
-        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb6: {
@@ -65,7 +65,7 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
     }
 
     bb8: {
-        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb9: {

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -3,66 +3,66 @@
 fn main::{closure#0}(_1: [generator@$DIR/generator-storage-dead-unwind.rs:22:16: 22:18], _2: ()) -> ()
 yields ()
  {
-    let mut _0: ();                      // return place in scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:19: +0:19
-    let _3: Foo;                         // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
-    let _5: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
-    let mut _6: ();                      // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
-    let _7: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
-    let mut _8: Foo;                     // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
-    let _9: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
-    let mut _10: Bar;                    // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 22:19
+    let _3: Foo;                         // in scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
+    let _5: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+    let mut _6: ();                      // in scope 0 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+    let _7: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
+    let mut _8: Foo;                     // in scope 0 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
+    let _9: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
+    let mut _10: Bar;                    // in scope 0 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
     scope 1 {
-        debug a => _3;                   // in scope 1 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
-        let _4: Bar;                     // in scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
+        debug a => _3;                   // in scope 1 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
+        let _4: Bar;                     // in scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
         scope 2 {
-            debug b => _4;               // in scope 2 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
+            debug b => _4;               // in scope 2 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
         }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
-        Deinit(_3);                      // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:17: +1:23
-        (_3.0: i32) = const 5_i32;       // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:17: +1:23
-        StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
-        Deinit(_4);                      // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:17: +2:23
-        (_4.0: i32) = const 6_i32;       // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:17: +2:23
-        StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
-        StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
-        Deinit(_6);                      // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
-        _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+        StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
+        Deinit(_3);                      // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
+        (_3.0: i32) = const 5_i32;       // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
+        StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
+        Deinit(_4);                      // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
+        (_4.0: i32) = const 6_i32;       // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
+        StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        Deinit(_6);                      // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
     }
 
     bb1: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:13: +3:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:14: +3:15
-        StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
-        StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
-        _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
-        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
+        StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
+        StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
+        _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
+        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:26:9: 26:13
                                          // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:15: +4:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:16: +4:17
-        StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
-        StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
-        _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
-        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb8]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
+        StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
+        StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
+        _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
+        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb8]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:27:9: 27:13
                                          // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:15: +5:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:16: +5:17
-        _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:19: +6:6
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
-        drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
+        _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb4: {
@@ -70,15 +70,15 @@ yields ()
     }
 
     bb5: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:13: +3:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:14: +3:15
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
-        drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb6: {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
-        drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb7: {
@@ -86,21 +86,21 @@ yields ()
     }
 
     bb8 (cleanup): {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:15: +5:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:16: +5:17
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
         goto -> bb10;                    // scope 2 at no-location
     }
 
     bb9 (cleanup): {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:15: +4:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:16: +4:17
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
         goto -> bb10;                    // scope 2 at no-location
     }
 
     bb10 (cleanup): {
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
-        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb11 (cleanup): {
@@ -108,7 +108,7 @@ yields ()
     }
 
     bb12 (cleanup): {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
-        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 }

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -17,17 +17,17 @@
 fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]>, _2: u8) -> GeneratorState<(), ()> {
     debug _x => _10;                     // in scope 0 at $DIR/generator-tiny.rs:+0:17: +0:19
     let mut _0: std::ops::GeneratorState<(), ()>; // return place in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-    let _3: HasDrop;                     // in scope 0 at $DIR/generator-tiny.rs:+1:13: +1:15
-    let mut _4: !;                       // in scope 0 at $DIR/generator-tiny.rs:+2:9: +5:10
+    let _3: HasDrop;                     // in scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
+    let mut _4: !;                       // in scope 0 at $DIR/generator-tiny.rs:21:9: 24:10
     let mut _5: ();                      // in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-    let _6: u8;                          // in scope 0 at $DIR/generator-tiny.rs:+3:13: +3:18
-    let mut _7: ();                      // in scope 0 at $DIR/generator-tiny.rs:+3:13: +3:18
-    let _8: ();                          // in scope 0 at $DIR/generator-tiny.rs:+4:13: +4:21
-    let mut _9: ();                      // in scope 0 at $DIR/generator-tiny.rs:+0:25: +0:25
+    let _6: u8;                          // in scope 0 at $DIR/generator-tiny.rs:22:13: 22:18
+    let mut _7: ();                      // in scope 0 at $DIR/generator-tiny.rs:22:13: 22:18
+    let _8: ();                          // in scope 0 at $DIR/generator-tiny.rs:23:13: 23:21
+    let mut _9: ();                      // in scope 0 at $DIR/generator-tiny.rs:19:25: 19:25
     let _10: u8;                         // in scope 0 at $DIR/generator-tiny.rs:+0:17: +0:19
     let mut _11: u32;                    // in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
     scope 1 {
-        debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:+1:13: +1:15
+        debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:20:13: 20:15
     }
 
     bb0: {
@@ -37,37 +37,37 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 19:24
 
     bb1: {
         _10 = move _2;                   // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-        nop;                             // scope 0 at $DIR/generator-tiny.rs:+1:13: +1:15
-        Deinit((((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop)); // scope 0 at $DIR/generator-tiny.rs:+1:18: +1:25
-        StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
-        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
+        nop;                             // scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
+        Deinit((((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop)); // scope 0 at $DIR/generator-tiny.rs:20:18: 20:25
+        StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
+        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
     }
 
     bb2: {
-        StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
-        StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
-        Deinit(_7);                      // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
-        Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
-        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
-        discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
-        discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))) = 3; // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
-        return;                          // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        Deinit(_7);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))) = 3; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        return;                          // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
     }
 
     bb3: {
-        StorageDead(_7);                 // scope 1 at $DIR/generator-tiny.rs:+3:17: +3:18
-        StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:+3:18: +3:19
-        StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:+4:13: +4:21
-        _8 = callee() -> bb4;            // scope 1 at $DIR/generator-tiny.rs:+4:13: +4:21
+        StorageDead(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:17: 22:18
+        StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:18: 22:19
+        StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
+        _8 = callee() -> bb4;            // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
                                          // mir::Constant
                                          // + span: $DIR/generator-tiny.rs:23:13: 23:19
                                          // + literal: Const { ty: fn() {callee}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:+4:21: +4:22
-        _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:+2:14: +5:10
-        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
+        StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:21: 23:22
+        _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:21:14: 24:10
+        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
     }
 
     bb5: {

--- a/src/test/mir-opt/inline/cycle.g.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.g.Inline.diff
@@ -6,10 +6,10 @@
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +     let mut _2: fn() {main};             // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +     scope 1 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
-+         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:+0:6: +0:7
-+         let _3: ();                      // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         let mut _4: &fn() {main};        // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
-+         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
++         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
++         let mut _4: &fn() {main};        // in scope 1 at $DIR/cycle.rs:6:5: 6:6
++         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         scope 2 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
 +         }
 +     }
@@ -25,10 +25,10 @@
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:12:7: 12:11
                                            // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:6
-+         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:+0:5: +0:6
-+         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         _3 = move (*_4)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
@@ -40,18 +40,18 @@
 +     }
 + 
 +     bb2 (cleanup): {
-+         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
++         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 1 at $DIR/cycle.rs:+0:1: +0:2
++         resume;                          // scope 1 at $DIR/cycle.rs:5:1: 7:2
 +     }
 + 
 +     bb4: {
-+         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
-+         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
-+         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:+0:8: +0:9
-+         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
++         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
++         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
       }
   }
   

--- a/src/test/mir-opt/inline/cycle.main.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.main.Inline.diff
@@ -6,17 +6,17 @@
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +     let mut _2: fn() {g};                // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +     scope 1 (inlined f::<fn() {g}>) {    // at $DIR/cycle.rs:17:5: 17:9
-+         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:+0:6: +0:7
-+         let _3: ();                      // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         let mut _4: &fn() {g};           // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
-+         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
++         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
++         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
++         let mut _4: &fn() {g};           // in scope 1 at $DIR/cycle.rs:6:5: 6:6
++         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         scope 2 (inlined <fn() {g} as Fn<()>>::call - shim(fn() {g})) { // at $DIR/cycle.rs:6:5: 6:8
 +             scope 3 (inlined g) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
-+                 let mut _6: fn() {main}; // in scope 3 at $DIR/cycle.rs:+0:5: +0:12
++                 let mut _6: fn() {main}; // in scope 3 at $DIR/cycle.rs:12:5: 12:12
 +                 scope 4 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
-+                     debug g => _6;       // in scope 4 at $DIR/cycle.rs:+0:6: +0:7
-+                     let _7: ();          // in scope 4 at $DIR/cycle.rs:+0:5: +0:8
-+                     let mut _8: &fn() {main}; // in scope 4 at $DIR/cycle.rs:+0:5: +0:6
++                     debug g => _6;       // in scope 4 at $DIR/cycle.rs:5:6: 5:7
++                     let _7: ();          // in scope 4 at $DIR/cycle.rs:6:5: 6:8
++                     let mut _8: &fn() {main}; // in scope 4 at $DIR/cycle.rs:6:5: 6:6
 +                     scope 5 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
 +                     }
 +                 }
@@ -35,14 +35,14 @@
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:17:7: 17:8
                                            // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:6
-+         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:+0:5: +0:6
-+         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         StorageLive(_6);                 // scope 3 at $DIR/cycle.rs:+0:5: +0:12
-+         StorageLive(_7);                 // scope 4 at $DIR/cycle.rs:+0:5: +0:8
-+         StorageLive(_8);                 // scope 4 at $DIR/cycle.rs:+0:5: +0:6
-+         _8 = &_6;                        // scope 4 at $DIR/cycle.rs:+0:5: +0:6
++         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
++         StorageLive(_6);                 // scope 3 at $DIR/cycle.rs:12:5: 12:12
++         StorageLive(_7);                 // scope 4 at $DIR/cycle.rs:6:5: 6:8
++         StorageLive(_8);                 // scope 4 at $DIR/cycle.rs:6:5: 6:6
++         _8 = &_6;                        // scope 4 at $DIR/cycle.rs:6:5: 6:6
 +         _7 = move (*_8)() -> [return: bb4, unwind: bb2]; // scope 5 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
@@ -54,21 +54,21 @@
 +     }
 + 
 +     bb2 (cleanup): {
-+         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
++         drop(_2) -> bb3;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         resume;                          // scope 1 at $DIR/cycle.rs:+0:1: +0:2
++         resume;                          // scope 1 at $DIR/cycle.rs:5:1: 7:2
 +     }
 + 
 +     bb4: {
-+         StorageDead(_8);                 // scope 4 at $DIR/cycle.rs:+0:7: +0:8
-+         StorageDead(_7);                 // scope 4 at $DIR/cycle.rs:+0:8: +0:9
-+         StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:+0:5: +0:12
-+         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
-+         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:+0:7: +0:8
-+         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:+0:8: +0:9
-+         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:+0:1: +0:2
++         StorageDead(_8);                 // scope 4 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_7);                 // scope 4 at $DIR/cycle.rs:6:8: 6:9
++         StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:12:5: 12:12
++         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:8: 6:9
++         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
       }
   }
   

--- a/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
@@ -10,12 +10,12 @@
       scope 1 {
           debug c => _2;                   // in scope 1 at $DIR/dyn-trait.rs:+1:9: +1:10
 +         scope 2 (inlined try_execute_query::<<Q as Query>::C>) { // at $DIR/dyn-trait.rs:34:5: 34:25
-+             debug c => _4;               // in scope 2 at $DIR/dyn-trait.rs:+0:36: +0:37
-+             let mut _5: &dyn Cache<V = <Q as Query>::V>; // in scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
-+             let mut _6: &<Q as Query>::C; // in scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
++             debug c => _4;               // in scope 2 at $DIR/dyn-trait.rs:26:36: 26:37
++             let mut _5: &dyn Cache<V = <Q as Query>::V>; // in scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
++             let mut _6: &<Q as Query>::C; // in scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
 +             scope 3 (inlined mk_cycle::<<Q as Query>::V>) { // at $DIR/dyn-trait.rs:27:5: 27:16
-+                 debug c => _5;           // in scope 3 at $DIR/dyn-trait.rs:+0:27: +0:28
-+                 let mut _7: &dyn Cache<V = <Q as Query>::V>; // in scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
++                 debug c => _5;           // in scope 3 at $DIR/dyn-trait.rs:20:27: 20:28
++                 let mut _7: &dyn Cache<V = <Q as Query>::V>; // in scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
 +             }
 +         }
       }
@@ -36,14 +36,14 @@
           StorageLive(_4);                 // scope 1 at $DIR/dyn-trait.rs:+2:23: +2:24
           _4 = &(*_2);                     // scope 1 at $DIR/dyn-trait.rs:+2:23: +2:24
 -         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> bb2; // scope 1 at $DIR/dyn-trait.rs:+2:5: +2:25
-+         StorageLive(_5);                 // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
-+         StorageLive(_6);                 // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
-+         _6 = _4;                         // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
-+         _5 = move _6 as &dyn Cache<V = <Q as Query>::V> (Pointer(Unsize)); // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
-+         StorageDead(_6);                 // scope 2 at $DIR/dyn-trait.rs:+0:14: +0:15
-+         StorageLive(_7);                 // scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
-+         _7 = _5;                         // scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
-+         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(move _7) -> bb2; // scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
++         StorageLive(_5);                 // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
++         StorageLive(_6);                 // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
++         _6 = _4;                         // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
++         _5 = move _6 as &dyn Cache<V = <Q as Query>::V> (Pointer(Unsize)); // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
++         StorageDead(_6);                 // scope 2 at $DIR/dyn-trait.rs:27:14: 27:15
++         StorageLive(_7);                 // scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
++         _7 = _5;                         // scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
++         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(move _7) -> bb2; // scope 3 at $DIR/dyn-trait.rs:21:5: 21:22
                                            // mir::Constant
 -                                          // + span: $DIR/dyn-trait.rs:34:5: 34:22
 -                                          // + literal: Const { ty: for<'r> fn(&'r <Q as Query>::C) {try_execute_query::<<Q as Query>::C>}, val: Value(<ZST>) }
@@ -52,8 +52,8 @@
       }
   
       bb2: {
-+         StorageDead(_7);                 // scope 3 at $DIR/dyn-trait.rs:+0:21: +0:22
-+         StorageDead(_5);                 // scope 2 at $DIR/dyn-trait.rs:+0:15: +0:16
++         StorageDead(_7);                 // scope 3 at $DIR/dyn-trait.rs:21:21: 21:22
++         StorageDead(_5);                 // scope 2 at $DIR/dyn-trait.rs:27:15: 27:16
           StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:+2:24: +2:25
           StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:+3:1: +3:2
           return;                          // scope 0 at $DIR/dyn-trait.rs:+3:2: +3:2

--- a/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
@@ -7,8 +7,8 @@
       let mut _2: &dyn Cache<V = <C as Cache>::V>; // in scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
       let mut _3: &C;                      // in scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
 +     scope 1 (inlined mk_cycle::<<C as Cache>::V>) { // at $DIR/dyn-trait.rs:27:5: 27:16
-+         debug c => _2;                   // in scope 1 at $DIR/dyn-trait.rs:+0:27: +0:28
-+         let mut _4: &dyn Cache<V = <C as Cache>::V>; // in scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
++         debug c => _2;                   // in scope 1 at $DIR/dyn-trait.rs:20:27: 20:28
++         let mut _4: &dyn Cache<V = <C as Cache>::V>; // in scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
 +     }
   
       bb0: {
@@ -18,9 +18,9 @@
           _2 = move _3 as &dyn Cache<V = <C as Cache>::V> (Pointer(Unsize)); // scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
           StorageDead(_3);                 // scope 0 at $DIR/dyn-trait.rs:+1:14: +1:15
 -         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> bb1; // scope 0 at $DIR/dyn-trait.rs:+1:5: +1:16
-+         StorageLive(_4);                 // scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
-+         _4 = _2;                         // scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
-+         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(move _4) -> bb1; // scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
++         StorageLive(_4);                 // scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
++         _4 = _2;                         // scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
++         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(move _4) -> bb1; // scope 1 at $DIR/dyn-trait.rs:21:5: 21:22
                                            // mir::Constant
 -                                          // + span: $DIR/dyn-trait.rs:27:5: 27:13
 -                                          // + literal: Const { ty: for<'r> fn(&'r (dyn Cache<V = <C as Cache>::V> + 'r)) {mk_cycle::<<C as Cache>::V>}, val: Value(<ZST>) }
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:+0:21: +0:22
++         StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:21:21: 21:22
           StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:+1:15: +1:16
           return;                          // scope 0 at $DIR/dyn-trait.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -9,10 +9,10 @@ fn bar() -> bool {
     scope 1 {
         debug f => _1;                   // in scope 1 at $DIR/inline-any-operand.rs:+1:9: +1:10
         scope 2 (inlined foo) {          // at $DIR/inline-any-operand.rs:12:5: 12:13
-            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:+6:8: +6:9
-            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:+6:16: +6:17
-            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:6
-            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
+            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:16:8: 16:9
+            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:16:16: 16:17
+            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
+            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
         }
     }
 
@@ -28,13 +28,13 @@ fn bar() -> bool {
         _3 = const 1_i32;                // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
         StorageLive(_4);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
         _4 = const -1_i32;               // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
-        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:6
-        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:6
-        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
-        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
-        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:+7:5: +7:11
-        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
-        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:+7:10: +7:11
+        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
+        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
+        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:11
+        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
         StorageDead(_4);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
         StorageDead(_3);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13
         StorageDead(_2);                 // scope 1 at $DIR/inline-any-operand.rs:+2:12: +2:13

--- a/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
@@ -14,7 +14,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:24
 -         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:24
-+         _1 = <C as Call>::call() -> bb1; // scope 3 at $DIR/inline-cycle.rs:+23:9: +23:28
++         _1 = <C as Call>::call() -> bb1; // scope 3 at $DIR/inline-cycle.rs:36:9: 36:28
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle.rs:14:5: 14:22
 +                                          // + span: $DIR/inline-cycle.rs:36:9: 36:26

--- a/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -6,13 +6,13 @@
       let _1: ();                          // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
 +     let mut _2: fn() {f};                // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
 +     scope 1 (inlined call::<fn() {f}>) { // at $DIR/inline-cycle.rs:49:5: 49:12
-+         debug f => _2;                   // in scope 1 at $DIR/inline-cycle.rs:+5:22: +5:23
-+         let _3: ();                      // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
-+         let mut _4: fn() {f};            // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
-+         let mut _5: ();                  // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
++         debug f => _2;                   // in scope 1 at $DIR/inline-cycle.rs:53:22: 53:23
++         let _3: ();                      // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         let mut _4: fn() {f};            // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
++         let mut _5: ();                  // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
 +         scope 2 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline-cycle.rs:54:5: 54:8
 +             scope 3 (inlined f) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
-+                 let _6: ();              // in scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
++                 let _6: ();              // in scope 3 at $DIR/inline-cycle.rs:59:5: 59:12
 +             }
 +         }
 +     }
@@ -26,12 +26,12 @@
 -                                          // + span: $DIR/inline-cycle.rs:49:5: 49:9
 +                                          // + span: $DIR/inline-cycle.rs:49:10: 49:11
 +                                          // + literal: Const { ty: fn() {f}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
-+         StorageLive(_4);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
-+         _4 = move _2;                    // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
-+         StorageLive(_5);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
-+         StorageLive(_6);                 // scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
-+         _6 = call::<fn() {f}>(f) -> bb1; // scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
++         StorageLive(_3);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         StorageLive(_4);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
++         _4 = move _2;                    // scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
++         StorageLive(_5);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         StorageLive(_6);                 // scope 3 at $DIR/inline-cycle.rs:59:5: 59:12
++         _6 = call::<fn() {f}>(f) -> bb1; // scope 3 at $DIR/inline-cycle.rs:59:5: 59:12
 +                                          // mir::Constant
 +                                          // + span: $DIR/inline-cycle.rs:59:5: 59:9
                                            // + literal: Const { ty: fn(fn() {f}) {call::<fn() {f}>}, val: Value(<ZST>) }
@@ -42,10 +42,10 @@
       }
   
       bb1: {
-+         StorageDead(_6);                 // scope 3 at $DIR/inline-cycle.rs:+11:12: +11:13
-+         StorageDead(_5);                 // scope 1 at $DIR/inline-cycle.rs:+6:7: +6:8
-+         StorageDead(_4);                 // scope 1 at $DIR/inline-cycle.rs:+6:7: +6:8
-+         StorageDead(_3);                 // scope 1 at $DIR/inline-cycle.rs:+6:8: +6:9
++         StorageDead(_6);                 // scope 3 at $DIR/inline-cycle.rs:59:12: 59:13
++         StorageDead(_5);                 // scope 1 at $DIR/inline-cycle.rs:54:7: 54:8
++         StorageDead(_4);                 // scope 1 at $DIR/inline-cycle.rs:54:7: 54:8
++         StorageDead(_3);                 // scope 1 at $DIR/inline-cycle.rs:54:8: 54:9
 +         StorageDead(_2);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
           StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:12: +1:13
           _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:+0:10: +2:2

--- a/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
@@ -16,7 +16,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:+1:5: +1:24
 -         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle-generic.rs:+1:5: +1:24
-+         _1 = <C as Call>::call() -> bb1; // scope 4 at $DIR/inline-cycle-generic.rs:+23:9: +23:28
++         _1 = <C as Call>::call() -> bb1; // scope 4 at $DIR/inline-cycle-generic.rs:31:9: 31:28
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle-generic.rs:9:5: 9:22
 +                                          // + span: $DIR/inline-cycle-generic.rs:31:9: 31:26

--- a/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
@@ -18,7 +18,7 @@
 +     }
 + 
 +     bb1: {
-+         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:+32:5: +32:12
++         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:39:5: 39:12
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -6,19 +6,19 @@
       let _1: (!, !);                      // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
 +     let mut _2: fn() -> ! {sleep};       // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
 +     scope 1 (inlined call_twice::<!, fn() -> ! {sleep}>) { // at $DIR/inline-diverging.rs:22:5: 22:22
-+         debug f => _2;                   // in scope 1 at $DIR/inline-diverging.rs:+5:36: +5:37
-+         let _3: !;                       // in scope 1 at $DIR/inline-diverging.rs:+6:9: +6:10
-+         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
-+         let mut _5: ();                  // in scope 1 at $DIR/inline-diverging.rs:+6:13: +6:16
-+         let mut _7: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:+7:13: +7:14
-+         let mut _8: ();                  // in scope 1 at $DIR/inline-diverging.rs:+7:13: +7:16
-+         let mut _9: !;                   // in scope 1 at $DIR/inline-diverging.rs:+8:6: +8:7
-+         let mut _10: !;                  // in scope 1 at $DIR/inline-diverging.rs:+8:9: +8:10
++         debug f => _2;                   // in scope 1 at $DIR/inline-diverging.rs:26:36: 26:37
++         let _3: !;                       // in scope 1 at $DIR/inline-diverging.rs:27:9: 27:10
++         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
++         let mut _5: ();                  // in scope 1 at $DIR/inline-diverging.rs:27:13: 27:16
++         let mut _7: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:28:13: 28:14
++         let mut _8: ();                  // in scope 1 at $DIR/inline-diverging.rs:28:13: 28:16
++         let mut _9: !;                   // in scope 1 at $DIR/inline-diverging.rs:29:6: 29:7
++         let mut _10: !;                  // in scope 1 at $DIR/inline-diverging.rs:29:9: 29:10
 +         scope 2 {
-+             debug a => _3;               // in scope 2 at $DIR/inline-diverging.rs:+6:9: +6:10
-+             let _6: !;                   // in scope 2 at $DIR/inline-diverging.rs:+7:9: +7:10
++             debug a => _3;               // in scope 2 at $DIR/inline-diverging.rs:27:9: 27:10
++             let _6: !;                   // in scope 2 at $DIR/inline-diverging.rs:28:9: 28:10
 +             scope 3 {
-+                 debug b => _6;           // in scope 3 at $DIR/inline-diverging.rs:+7:9: +7:10
++                 debug b => _6;           // in scope 3 at $DIR/inline-diverging.rs:28:9: 28:10
 +             }
 +             scope 6 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:28:13: 28:16
 +                 scope 7 (inlined sleep) { // at $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -42,15 +42,15 @@
 -                                          // mir::Constant
                                            // + span: $DIR/inline-diverging.rs:22:16: 22:21
                                            // + literal: Const { ty: fn() -> ! {sleep}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:+6:9: +6:10
-+         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
-+         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
-+         StorageLive(_5);                 // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:16
-+         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:+18:5: +18:12
++         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:27:9: 27:10
++         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
++         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
++         StorageLive(_5);                 // scope 1 at $DIR/inline-diverging.rs:27:13: 27:16
++         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:39:5: 39:12
 +     }
 + 
 +     bb1: {
-+         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:+18:5: +18:12
++         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:39:5: 39:12
       }
   }
   

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -24,15 +24,15 @@
 +         }
 +     }
 +     scope 6 (inlined g::{closure#0}) {   // at $DIR/inline-generator.rs:9:14: 9:46
-+         debug a => _11;                  // in scope 6 at $DIR/inline-generator.rs:+7:6: +7:7
-+         let mut _8: i32;                 // in scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
-+         let mut _9: bool;                // in scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
-+         let mut _10: bool;               // in scope 6 at $DIR/inline-generator.rs:+7:9: +7:9
-+         let _11: bool;                   // in scope 6 at $DIR/inline-generator.rs:+7:6: +7:7
-+         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         let mut _13: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         let mut _14: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         let mut _15: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         debug a => _11;                  // in scope 6 at $DIR/inline-generator.rs:15:6: 15:7
++         let mut _8: i32;                 // in scope 6 at $DIR/inline-generator.rs:15:17: 15:39
++         let mut _9: bool;                // in scope 6 at $DIR/inline-generator.rs:15:20: 15:21
++         let mut _10: bool;               // in scope 6 at $DIR/inline-generator.rs:15:9: 15:9
++         let _11: bool;                   // in scope 6 at $DIR/inline-generator.rs:15:6: 15:7
++         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         let mut _13: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         let mut _14: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         let mut _15: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
 +     }
   
       bb0: {
@@ -47,8 +47,8 @@
 -     }
 - 
 -     bb1: {
-+         Deinit(_4);                      // scope 2 at $DIR/inline-generator.rs:+7:5: +7:41
-+         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:+7:5: +7:41
++         Deinit(_4);                      // scope 2 at $DIR/inline-generator.rs:15:5: 15:41
++         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:15:5: 15:41
           _3 = &mut _4;                    // scope 0 at $DIR/inline-generator.rs:+1:23: +1:31
 -         _2 = Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>::new(move _3) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:+1:14: +1:32
 -                                          // mir::Constant
@@ -76,11 +76,11 @@
 +         StorageLive(_10);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 +         StorageLive(_11);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 +         StorageLive(_12);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
-+         StorageLive(_13);                // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         _13 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         _12 = discriminant((*_13));      // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         StorageDead(_13);                // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         StorageLive(_13);                // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         _13 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         _12 = discriminant((*_13));      // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         StorageDead(_13);                // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
       }
   
 -     bb3: {
@@ -102,55 +102,55 @@
 +     }
 + 
 +     bb3: {
-+         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
-+         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
-+         _9 = _11;                        // scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
-+         switchInt(move _9) -> [false: bb5, otherwise: bb4]; // scope 6 at $DIR/inline-generator.rs:+7:20: +7:21
++         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
++         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
++         _9 = _11;                        // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
++         switchInt(move _9) -> [false: bb5, otherwise: bb4]; // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
 +     }
 + 
 +     bb4: {
-+         _8 = const 7_i32;                // scope 6 at $DIR/inline-generator.rs:+7:24: +7:25
-+         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
++         _8 = const 7_i32;                // scope 6 at $DIR/inline-generator.rs:15:24: 15:25
++         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
 +     }
 + 
 +     bb5: {
-+         _8 = const 13_i32;               // scope 6 at $DIR/inline-generator.rs:+7:35: +7:37
-+         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:+7:17: +7:39
++         _8 = const 13_i32;               // scope 6 at $DIR/inline-generator.rs:15:35: 15:37
++         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
 +     }
 + 
 +     bb6: {
-+         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:+7:38: +7:39
-+         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
-+         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
-+         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
-+         StorageLive(_14);                // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
-+         _14 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
-+         discriminant((*_14)) = 3;        // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
-+         StorageDead(_14);                // scope 6 at $DIR/inline-generator.rs:+7:11: +7:39
-+         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:+7:11: +7:39
++         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
++         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         StorageLive(_14);                // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         _14 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         discriminant((*_14)) = 3;        // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         StorageDead(_14);                // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:11: 15:39
 +     }
 + 
 +     bb7: {
-+         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
-+         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:+7:38: +7:39
-+         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
-+         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
-+         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
-+         StorageLive(_15);                // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
-+         _15 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
-+         discriminant((*_15)) = 1;        // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
-+         StorageDead(_15);                // scope 6 at $DIR/inline-generator.rs:+7:8: +7:8
-+         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:+7:8: +7:8
++         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
++         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
++         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
++         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
++         StorageLive(_15);                // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
++         _15 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
++         discriminant((*_15)) = 1;        // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
++         StorageDead(_15);                // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
++         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:8: 15:8
 +     }
 + 
 +     bb8: {
-+         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
 +     }
 + 
 +     bb9: {
-+         unreachable;                     // scope 6 at $DIR/inline-generator.rs:+7:5: +7:8
++         unreachable;                     // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
       }
   }
   

--- a/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
@@ -5,9 +5,9 @@ fn main() -> () {
     let _1: ();                          // in scope 0 at $DIR/inline-options.rs:+1:5: +1:18
     let _2: ();                          // in scope 0 at $DIR/inline-options.rs:+2:5: +2:21
     scope 1 (inlined inlined::<u32>) {   // at $DIR/inline-options.rs:10:5: 10:21
-        let _3: ();                      // in scope 1 at $DIR/inline-options.rs:+8:23: +8:26
-        let _4: ();                      // in scope 1 at $DIR/inline-options.rs:+8:28: +8:31
-        let _5: ();                      // in scope 1 at $DIR/inline-options.rs:+8:33: +8:36
+        let _3: ();                      // in scope 1 at $DIR/inline-options.rs:16:23: 16:26
+        let _4: ();                      // in scope 1 at $DIR/inline-options.rs:16:28: 16:31
+        let _5: ();                      // in scope 1 at $DIR/inline-options.rs:16:33: 16:36
     }
 
     bb0: {
@@ -21,33 +21,33 @@ fn main() -> () {
     bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/inline-options.rs:+1:18: +1:19
         StorageLive(_2);                 // scope 0 at $DIR/inline-options.rs:+2:5: +2:21
-        StorageLive(_3);                 // scope 1 at $DIR/inline-options.rs:+8:23: +8:26
-        _3 = g() -> bb2;                 // scope 1 at $DIR/inline-options.rs:+8:23: +8:26
+        StorageLive(_3);                 // scope 1 at $DIR/inline-options.rs:16:23: 16:26
+        _3 = g() -> bb2;                 // scope 1 at $DIR/inline-options.rs:16:23: 16:26
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:23: 16:24
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 1 at $DIR/inline-options.rs:+8:26: +8:27
-        StorageLive(_4);                 // scope 1 at $DIR/inline-options.rs:+8:28: +8:31
-        _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:+8:28: +8:31
+        StorageDead(_3);                 // scope 1 at $DIR/inline-options.rs:16:26: 16:27
+        StorageLive(_4);                 // scope 1 at $DIR/inline-options.rs:16:28: 16:31
+        _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:16:28: 16:31
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:28: 16:29
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline-options.rs:+8:31: +8:32
-        StorageLive(_5);                 // scope 1 at $DIR/inline-options.rs:+8:33: +8:36
-        _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:+8:33: +8:36
+        StorageDead(_4);                 // scope 1 at $DIR/inline-options.rs:16:31: 16:32
+        StorageLive(_5);                 // scope 1 at $DIR/inline-options.rs:16:33: 16:36
+        _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:16:33: 16:36
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:33: 16:34
                                          // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_5);                 // scope 1 at $DIR/inline-options.rs:+8:36: +8:37
+        StorageDead(_5);                 // scope 1 at $DIR/inline-options.rs:16:36: 16:37
         StorageDead(_2);                 // scope 0 at $DIR/inline-options.rs:+2:21: +2:22
         _0 = const ();                   // scope 0 at $DIR/inline-options.rs:+0:11: +3:2
         return;                          // scope 0 at $DIR/inline-options.rs:+3:2: +3:2

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -15,10 +15,10 @@ fn bar() -> bool {
         let mut _9: &i32;                // in scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
         let mut _10: &i32;               // in scope 1 at $DIR/inline-retag.rs:+2:7: +2:9
         scope 2 (inlined foo) {          // at $DIR/inline-retag.rs:12:5: 12:15
-            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:+6:8: +6:9
-            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:+6:17: +6:18
-            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:+7:5: +7:7
-            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:+7:11: +7:13
+            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:16:8: 16:9
+            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:16:17: 16:18
+            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:17:5: 17:7
+            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:17:11: 17:13
         }
     }
 
@@ -52,15 +52,15 @@ fn bar() -> bool {
         Retag(_7);                       // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
         _6 = &(*_7);                     // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
         Retag(_6);                       // scope 1 at $DIR/inline-retag.rs:+2:11: +2:14
-        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:+6:1: +8:2
-        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:+6:1: +8:2
-        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:+7:5: +7:7
-        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:+7:5: +7:7
-        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:+7:11: +7:13
-        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:+7:11: +7:13
-        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:+7:5: +7:13
-        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:+7:12: +7:13
-        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:+7:12: +7:13
+        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
+        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
+        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
+        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
+        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
+        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
+        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:17:5: 17:13
+        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
+        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
         StorageDead(_6);                 // scope 1 at $DIR/inline-retag.rs:+2:14: +2:15
         StorageDead(_3);                 // scope 1 at $DIR/inline-retag.rs:+2:14: +2:15
         StorageDead(_2);                 // scope 1 at $DIR/inline-retag.rs:+2:14: +2:15

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -19,7 +19,7 @@
 -     }
 - 
 -     bb1: {
-+         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:+10:31: +10:34
++         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:14:31: 14:34
           _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:+0:11: +2:2
           StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:+2:1: +2:2
           return;                          // scope 0 at $DIR/inline-specialization.rs:+2:2: +2:2

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -6,8 +6,8 @@ fn test2(_1: &dyn X) -> bool {
     let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
     let mut _3: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
     scope 1 (inlined test) {             // at $DIR/inline-trait-method_2.rs:5:5: 5:12
-        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:+5:9: +5:10
-        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
+        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:9:9: 9:10
+        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
     }
 
     bb0: {
@@ -16,16 +16,16 @@ fn test2(_1: &dyn X) -> bool {
         _3 = &(*_1);                     // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
         _2 = move _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
         StorageDead(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:+1:10: +1:11
-        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
-        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
-        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
+        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
+        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
+        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
                                          // mir::Constant
                                          // + span: $DIR/inline-trait-method_2.rs:10:7: 10:8
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:+6:9: +6:10
+        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:9: 10:10
         StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:+1:11: +1:12
         return;                          // scope 0 at $DIR/inline-trait-method_2.rs:+2:2: +2:2
     }

--- a/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
@@ -4,9 +4,9 @@ fn f_u64() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:16: +0:16
     let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
     scope 1 (inlined f_dispatch::<u64>) { // at $DIR/lower_intrinsics.rs:40:5: 40:21
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:+5:22: +5:23
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:+9:9: +9:21
-        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:+9:19: +9:20
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:44:22: 44:23
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
+        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
         scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics.rs:45:8: 45:32
         }
     }
@@ -14,18 +14,18 @@ fn f_u64() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
         _1 = const 0_u64;                // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:9: +9:21
-        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:19: +9:20
-        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:+9:19: +9:20
-        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:+9:9: +9:21
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
+        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
+        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
+        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics.rs:48:9: 48:18
                                          // + literal: Const { ty: fn(u64) {f_non_zst::<u64>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:20: +9:21
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+9:21: +9:22
+        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:48:20: 48:21
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:48:21: 48:22
         StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:21
         return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
     }

--- a/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
@@ -4,26 +4,26 @@ fn f_unit() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:17: +0:17
     let mut _1: ();                      // in scope 0 at $DIR/lower_intrinsics.rs:+1:16: +1:18
     scope 1 (inlined f_dispatch::<()>) { // at $DIR/lower_intrinsics.rs:34:5: 34:19
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:+11:22: +11:23
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:+13:9: +13:17
-        let mut _3: ();                  // in scope 1 at $DIR/lower_intrinsics.rs:+13:15: +13:16
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:44:22: 44:23
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
+        let mut _3: ();                  // in scope 1 at $DIR/lower_intrinsics.rs:46:15: 46:16
         scope 2 (inlined std::mem::size_of::<()>) { // at $DIR/lower_intrinsics.rs:45:8: 45:32
         }
     }
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:16: +1:18
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:9: +13:17
-        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:15: +13:16
-        _2 = f_zst::<()>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:+13:9: +13:17
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
+        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:46:15: 46:16
+        _2 = f_zst::<()>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics.rs:46:9: 46:14
                                          // + literal: Const { ty: fn(()) {f_zst::<()>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:16: +13:17
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+13:17: +13:18
+        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:46:16: 46:17
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:46:17: 46:18
         StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:18: +1:19
         return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
     }

--- a/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
@@ -3,20 +3,20 @@
 fn main::{closure#0}(_1: &[closure@main::{closure#0}], _2: &i32) -> &i32 {
     debug x => _2;                       // in scope 0 at $DIR/retag.rs:+0:32: +0:33
     let mut _0: &i32;                    // return place in scope 0 at $DIR/retag.rs:+0:44: +0:48
-    let _3: &i32;                        // in scope 0 at $DIR/retag.rs:+1:13: +1:15
+    let _3: &i32;                        // in scope 0 at $DIR/retag.rs:42:13: 42:15
     scope 1 {
-        debug _y => _3;                  // in scope 1 at $DIR/retag.rs:+1:13: +1:15
+        debug _y => _3;                  // in scope 1 at $DIR/retag.rs:42:13: 42:15
     }
 
     bb0: {
         Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:+0:31: +0:48
         Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:+0:31: +0:48
-        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:+1:13: +1:15
-        _3 = _2;                         // scope 0 at $DIR/retag.rs:+1:18: +1:19
-        Retag(_3);                       // scope 0 at $DIR/retag.rs:+1:18: +1:19
-        _0 = _2;                         // scope 1 at $DIR/retag.rs:+2:9: +2:10
-        Retag(_0);                       // scope 1 at $DIR/retag.rs:+2:9: +2:10
-        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:+3:5: +3:6
+        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:42:13: 42:15
+        _3 = _2;                         // scope 0 at $DIR/retag.rs:42:18: 42:19
+        Retag(_3);                       // scope 0 at $DIR/retag.rs:42:18: 42:19
+        _0 = _2;                         // scope 1 at $DIR/retag.rs:43:9: 43:10
+        Retag(_0);                       // scope 1 at $DIR/retag.rs:43:9: 43:10
+        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:44:5: 44:6
         return;                          // scope 0 at $DIR/retag.rs:+0:48: +0:48
     }
 }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -23,14 +23,14 @@
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
-              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:+0:21: +0:22
+              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
           }
       }
       scope 3 {
           debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:+0:22: +0:23
+          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
       }
   
       bb0: {
@@ -38,7 +38,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:+0:5: +0:6
+          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:24:5: 24:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:32: +1:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
           switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:13: +1:33
@@ -72,9 +72,9 @@
           _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:+2:48: +2:49
           _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:+2:49: +2:50
-          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:+0:9: +0:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
           StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:+2:50: +2:51
           StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:+2:50: +2:51
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+4:6: +4:7

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -23,14 +23,14 @@
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
-              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:+0:21: +0:22
+              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
           }
       }
       scope 3 {
           debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:+0:22: +0:23
+          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
       }
   
       bb0: {
@@ -38,7 +38,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:+1:31: +1:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:+0:5: +0:6
+          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:24:5: 24:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:+1:32: +1:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:+1:19: +1:33
           switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:+1:13: +1:33
@@ -72,9 +72,9 @@
           _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:+2:48: +2:49
           _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:+2:49: +2:50
-          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:+0:9: +0:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:+0:5: +0:11
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
           StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:+2:50: +2:51
           StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:+2:50: +2:51
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:+4:6: +4:7

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -24,7 +24,7 @@
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
+              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
           }
       }
       scope 3 {
@@ -32,8 +32,8 @@
 +         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
--         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
-+         debug r => _3;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
+-         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
++         debug r => _3;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
       }
   
       bb0: {
@@ -41,13 +41,13 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
 -         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
 -         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
--         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
+-         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
 -         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:9: +1:10
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
 +         _3 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
-+         nop;                             // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
++         nop;                             // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
           switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
@@ -87,9 +87,9 @@
           nop;                             // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
           nop;                             // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
-          nop;                             // scope 6 at $DIR/simplify_try.rs:+0:9: +0:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+          nop;                             // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
           StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
           StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -23,14 +23,14 @@
               debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
+              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
           }
       }
       scope 3 {
           debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
+          debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
       }
   
       bb0: {
@@ -38,7 +38,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
           _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
+          _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
           switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
@@ -68,9 +68,9 @@
           _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
           _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
-          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:+0:9: +0:10
-          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
-          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
           StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
           StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
           StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -22,14 +22,14 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
             debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         }
         scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-            debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
+            debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
         }
     }
     scope 3 {
         debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-        debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
+        debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
     }
 
     bb0: {
@@ -37,7 +37,7 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:+1:31: +1:32
-        _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:+0:5: +0:6
+        _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+1:32: +1:33
         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:+1:19: +1:33
         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:+1:13: +1:33
@@ -67,9 +67,9 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
         _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
-        ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:+0:9: +0:10
-        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
-        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+        ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
+        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
         StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
         StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:+4:6: +4:7

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -17,14 +17,14 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
             debug t => _6;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         }
         scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-            debug e => _5;               // in scope 6 at $DIR/simplify_try.rs:+0:21: +0:22
+            debug e => _5;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
         }
     }
     scope 3 {
         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:+3:12: +3:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-        debug r => _2;                   // in scope 4 at $DIR/simplify_try.rs:+0:22: +0:23
+        debug r => _2;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
     }
 
     bb0: {
@@ -45,8 +45,8 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         StorageLive(_5);                 // scope 2 at $DIR/simplify_try.rs:+2:37: +2:50
         StorageLive(_6);                 // scope 2 at $DIR/simplify_try.rs:+2:48: +2:49
         StorageDead(_6);                 // scope 2 at $DIR/simplify_try.rs:+2:49: +2:50
-        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
-        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:+0:5: +0:11
+        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
         StorageDead(_5);                 // scope 2 at $DIR/simplify_try.rs:+2:50: +2:51
         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:+2:50: +2:51
         return;                          // scope 0 at $DIR/simplify_try.rs:+6:2: +6:2

--- a/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
@@ -198,6 +198,6 @@ static XXX: &Foo = {
         _0 = &(*_1);                     // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:28: +18:2
         StorageDead(_5);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+18:1: +18:2
         StorageDead(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+18:1: +18:2
-        return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:1: +0:25
+        return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:1: +18:2
     }
 }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
@@ -5,6 +5,6 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT: i32 = 
 
     bb0: {
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:+0:38: +0:39
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:35
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:39
     }
 }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
@@ -5,6 +5,6 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT: i32 = 
 
     bb0: {
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:+0:38: +0:39
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:35
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:39
     }
 }

--- a/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -2,13 +2,13 @@ error[E0391]: cycle detected when const-evaluating + checking `Tr::A`
   --> $DIR/defaults-cyclic-fail.rs:5:5
    |
 LL |     const A: u8 = Self::B;
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^
    |
 note: ...which requires const-evaluating + checking `Tr::B`...
   --> $DIR/defaults-cyclic-fail.rs:8:5
    |
 LL |     const B: u8 = Self::A;
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `Tr::A`, completing the cycle
 note: cycle used when const-evaluating + checking `main::promoted[1]`
   --> $DIR/defaults-cyclic-fail.rs:16:16

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -13,7 +13,7 @@ note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
    |
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -13,7 +13,7 @@ note: ...which requires const-evaluating + checking `DEFAULT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
    |
 LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `FooDefault::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -13,7 +13,7 @@ note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
    |

--- a/src/test/ui/consts/issue-36163.stderr
+++ b/src/test/ui/consts/issue-36163.stderr
@@ -8,7 +8,7 @@ note: ...which requires const-evaluating + checking `A`...
   --> $DIR/issue-36163.rs:1:1
    |
 LL | const A: isize = Foo::B as isize;
-   | ^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `Foo::B::{constant#0}`, completing the cycle
 note: cycle used when simplifying constant for the type system `Foo::B::{constant#0}`
   --> $DIR/issue-36163.rs:4:9

--- a/src/test/ui/issues/issue-17252.stderr
+++ b/src/test/ui/issues/issue-17252.stderr
@@ -2,7 +2,7 @@ error[E0391]: cycle detected when const-evaluating + checking `FOO`
   --> $DIR/issue-17252.rs:1:1
    |
 LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires const-evaluating + checking `FOO` again
 note: cycle used when const-evaluating + checking `main::{constant#0}`

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -2,13 +2,13 @@ error[E0391]: cycle detected when const-evaluating + checking `A`
   --> $DIR/issue-23302-3.rs:1:1
    |
 LL | const A: i32 = B;
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^
    |
 note: ...which requires const-evaluating + checking `B`...
   --> $DIR/issue-23302-3.rs:3:1
    |
 LL | const B: i32 = A;
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `A`, completing the cycle
 note: cycle used when simplifying constant for the type system `A`
   --> $DIR/issue-23302-3.rs:1:1


### PR DESCRIPTION
In the MIR pretty printing, it can sometimes happen that the span of the statement is outside the span of the body (for example through inlining). In this case, don't display a relative span but an absolute span. This will make the mir-opt-tests a little more prone to diffs again, but the impact should be small.

Fixes #99854

r? @oli-obk