### PR TITLE
Stabilize raw-dylib for non-x86

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -478,7 +478,7 @@ declare_features! (
     /// Allows macro attributes on expressions, statements and non-inline modules.
     (active, proc_macro_hygiene, "1.30.0", Some(54727), None),
     /// Allows the use of raw-dylibs (RFC 2627).
-    (incomplete, raw_dylib, "1.40.0", Some(58713), None),
+    (active, raw_dylib, "CURRENT_RUSTC_VERSION", Some(58713), None),
     /// Allows `&raw const $place_expr` and `&raw mut $place_expr` expressions.
     (active, raw_ref_op, "1.41.0", Some(64490), None),
     /// Allows using the `#[register_tool]` attribute.

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -345,6 +345,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(link_section, Normal, template!(NameValueStr: "name"), FutureWarnPreceding),
     ungated!(no_mangle, Normal, template!(Word), WarnFollowing, @only_local: true),
     ungated!(used, Normal, template!(Word, List: "compiler|linker"), WarnFollowing, @only_local: true),
+    ungated!(link_ordinal, Normal, template!(List: "ordinal"), ErrorPreceding),
 
     // Limits:
     ungated!(recursion_limit, CrateLevel, template!(NameValueStr: "N"), FutureWarnFollowing),
@@ -406,10 +407,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(naked, Normal, template!(Word), WarnFollowing, @only_local: true, naked_functions, experimental!(naked)),
-    gated!(
-        link_ordinal, Normal, template!(List: "ordinal"), ErrorPreceding, raw_dylib,
-        experimental!(link_ordinal)
-    ),
 
     // Plugins:
     BuiltinAttribute {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -113,12 +113,12 @@ impl<'tcx> Collector<'tcx> {
                             "raw-dylib" => {
                                 if !sess.target.is_like_windows {
                                     sess.emit_err(FrameworkOnlyWindows { span });
-                                } else if !features.raw_dylib {
+                                } else if !features.raw_dylib && sess.target.arch == "x86" {
                                     feature_err(
                                         &sess.parse_sess,
                                         sym::raw_dylib,
                                         span,
-                                        "link kind `raw-dylib` is unstable",
+                                        "link kind `raw-dylib` is unstable on x86",
                                     )
                                     .emit();
                                 }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -3276,6 +3276,15 @@ fn should_inherit_track_caller(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
 fn check_link_ordinal(tcx: TyCtxt<'_>, attr: &ast::Attribute) -> Option<u16> {
     use rustc_ast::{Lit, LitIntType, LitKind};
+    if !tcx.features().raw_dylib && tcx.sess.target.arch == "x86" {
+        feature_err(
+            &tcx.sess.parse_sess,
+            sym::raw_dylib,
+            attr.span,
+            "`#[link_ordinal]` is unstable on x86",
+        )
+        .emit();
+    }
     let meta_item_list = attr.meta_item_list();
     let meta_item_list: Option<&[ast::NestedMetaItem]> = meta_item_list.as_ref().map(Vec::as_ref);
     let sole_meta_list = match meta_item_list {

--- a/src/doc/unstable-book/src/language-features/raw-dylib.md
+++ b/src/doc/unstable-book/src/language-features/raw-dylib.md
@@ -26,9 +26,9 @@ fn main() {
 
 ## Limitations
 
-Currently, this feature is only supported on `-windows-msvc` targets.  Non-Windows platforms don't have import
-libraries, and an incompatibility between LLVM and the BFD linker means that it is not currently supported on
-`-windows-gnu` targets.
+This feature is unstable for the `x86` architecture, and stable for all other architectures.
 
-On the `i686-pc-windows-msvc` target, this feature supports only the `cdecl`, `stdcall`, `system`, and `fastcall`
-calling conventions.
+This feature is only supported on Windows.
+
+On the `x86` architecture, this feature supports only the `cdecl`, `stdcall`, `system`, `fastcall`, and
+`vectorcall` calling conventions.

--- a/src/test/run-make/raw-dylib-alt-calling-convention/lib.rs
+++ b/src/test/run-make/raw-dylib-alt-calling-convention/lib.rs
@@ -1,5 +1,5 @@
-#![feature(raw_dylib)]
 #![feature(abi_vectorcall)]
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[repr(C)]
 #[derive(Clone)]

--- a/src/test/run-make/raw-dylib-link-ordinal/lib.rs
+++ b/src/test/run-make/raw-dylib-link-ordinal/lib.rs
@@ -1,4 +1,4 @@
-#![feature(raw_dylib)]
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "exporter", kind = "raw-dylib")]
 extern {

--- a/src/test/run-make/raw-dylib-stdcall-ordinal/lib.rs
+++ b/src/test/run-make/raw-dylib-stdcall-ordinal/lib.rs
@@ -1,4 +1,4 @@
-#![feature(raw_dylib)]
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "exporter", kind = "raw-dylib")]
 extern "stdcall" {

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib-2.rs
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib-2.rs
@@ -1,10 +1,11 @@
+// only-x86
 #[link(name = "foo")]
 extern "C" {
     #[link_ordinal(42)]
-    //~^ ERROR: the `#[link_ordinal]` attribute is an experimental feature
+    //~^ ERROR: `#[link_ordinal]` is unstable on x86
     fn foo();
     #[link_ordinal(5)]
-    //~^ ERROR: the `#[link_ordinal]` attribute is an experimental feature
+    //~^ ERROR: `#[link_ordinal]` is unstable on x86
     static mut imported_variable: i32;
 }
 

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib-2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib-2.stderr
@@ -1,5 +1,5 @@
-error[E0658]: the `#[link_ordinal]` attribute is an experimental feature
-  --> $DIR/feature-gate-raw-dylib-2.rs:3:5
+error[E0658]: `#[link_ordinal]` is unstable on x86
+  --> $DIR/feature-gate-raw-dylib-2.rs:4:5
    |
 LL |     #[link_ordinal(42)]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -7,8 +7,8 @@ LL |     #[link_ordinal(42)]
    = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
    = help: add `#![feature(raw_dylib)]` to the crate attributes to enable
 
-error[E0658]: the `#[link_ordinal]` attribute is an experimental feature
-  --> $DIR/feature-gate-raw-dylib-2.rs:6:5
+error[E0658]: `#[link_ordinal]` is unstable on x86
+  --> $DIR/feature-gate-raw-dylib-2.rs:7:5
    |
 LL |     #[link_ordinal(5)]
    |     ^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib-import-name-type.rs
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib-import-name-type.rs
@@ -1,7 +1,7 @@
 // only-windows
 // only-x86
 #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated")]
-//~^ ERROR link kind `raw-dylib` is unstable
+//~^ ERROR link kind `raw-dylib` is unstable on x86
 //~| ERROR import name type is unstable
 extern "C" {}
 

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib-import-name-type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib-import-name-type.stderr
@@ -1,4 +1,4 @@
-error[E0658]: link kind `raw-dylib` is unstable
+error[E0658]: link kind `raw-dylib` is unstable on x86
   --> $DIR/feature-gate-raw-dylib-import-name-type.rs:3:29
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated")]

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib.rs
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib.rs
@@ -1,6 +1,7 @@
 // only-windows
+// only-x86
 #[link(name = "foo", kind = "raw-dylib")]
-//~^ ERROR: link kind `raw-dylib` is unstable
+//~^ ERROR: link kind `raw-dylib` is unstable on x86
 extern "C" {}
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib.stderr
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib.stderr
@@ -1,5 +1,5 @@
-error[E0658]: link kind `raw-dylib` is unstable
-  --> $DIR/feature-gate-raw-dylib.rs:2:29
+error[E0658]: link kind `raw-dylib` is unstable on x86
+  --> $DIR/feature-gate-raw-dylib.rs:3:29
    |
 LL | #[link(name = "foo", kind = "raw-dylib")]
    |                             ^^^^^^^^^^^

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-invalid-format.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-invalid-format.rs
@@ -1,7 +1,6 @@
 // only-windows
 // only-x86
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
 //~^ ERROR import name type must be of the form `import_name_type = "string"`

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-invalid-format.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-invalid-format.stderr
@@ -1,17 +1,8 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/import-name-type-invalid-format.rs:3:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: import name type must be of the form `import_name_type = "string"`
-  --> $DIR/import-name-type-invalid-format.rs:6:42
+  --> $DIR/import-name-type-invalid-format.rs:5:42
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
    |                                          ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-multiple.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-multiple.rs
@@ -2,7 +2,6 @@
 // only-windows
 // only-x86
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", import_name_type = "decorated")]
 //~^ ERROR multiple `import_name_type` arguments in a single `#[link]` attribute

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-multiple.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-multiple.stderr
@@ -1,17 +1,8 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/import-name-type-multiple.rs:4:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: multiple `import_name_type` arguments in a single `#[link]` attribute
-  --> $DIR/import-name-type-multiple.rs:7:74
+  --> $DIR/import-name-type-multiple.rs:6:74
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", import_name_type = "decorated")]
    |                                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-unknown-value.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-unknown-value.rs
@@ -1,7 +1,6 @@
 // only-windows
 // only-x86
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
 //~^ ERROR unknown import name type `unknown`, expected one of: decorated, noprefix, undecorated

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-unknown-value.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-unknown-value.stderr
@@ -1,17 +1,8 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/import-name-type-unknown-value.rs:3:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: unknown import name type `unknown`, expected one of: decorated, noprefix, undecorated
-  --> $DIR/import-name-type-unknown-value.rs:6:42
+  --> $DIR/import-name-type-unknown-value.rs:5:42
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-unsupported-link-kind.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-unsupported-link-kind.rs
@@ -1,7 +1,6 @@
 // only-windows
 // only-x86
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name = "foo", import_name_type = "decorated")]
 //~^ ERROR import name type can only be used with link kind `raw-dylib`

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-unsupported-link-kind.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-unsupported-link-kind.stderr
@@ -1,23 +1,14 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/import-name-type-unsupported-link-kind.rs:3:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: import name type can only be used with link kind `raw-dylib`
-  --> $DIR/import-name-type-unsupported-link-kind.rs:6:22
+  --> $DIR/import-name-type-unsupported-link-kind.rs:5:22
    |
 LL | #[link(name = "foo", import_name_type = "decorated")]
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: import name type can only be used with link kind `raw-dylib`
-  --> $DIR/import-name-type-unsupported-link-kind.rs:10:39
+  --> $DIR/import-name-type-unsupported-link-kind.rs:9:39
    |
 LL | #[link(name = "bar", kind = "static", import_name_type = "decorated")]
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-x86-only.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-x86-only.rs
@@ -1,7 +1,5 @@
 // only-windows
 // ignore-x86
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
 #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated")]
 //~^ ERROR import name type is only supported on x86
 extern "C" { }

--- a/src/test/ui/rfc-2627-raw-dylib/import-name-type-x86-only.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/import-name-type-x86-only.stderr
@@ -1,17 +1,8 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/import-name-type-x86-only.rs:3:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: import name type is only supported on x86
-  --> $DIR/import-name-type-x86-only.rs:5:42
+  --> $DIR/import-name-type-x86-only.rs:3:42
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated")]
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
@@ -1,5 +1,4 @@
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name="foo")]
 extern "C" {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
@@ -1,23 +1,14 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-and-name.rs:1:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: cannot use `#[link_name]` with `#[link_ordinal]`
-  --> $DIR/link-ordinal-and-name.rs:7:5
+  --> $DIR/link-ordinal-and-name.rs:6:5
    |
 LL |     #[link_ordinal(42)]
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: cannot use `#[link_name]` with `#[link_ordinal]`
-  --> $DIR/link-ordinal-and-name.rs:11:5
+  --> $DIR/link-ordinal-and-name.rs:10:5
    |
 LL |     #[link_ordinal(5)]
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
@@ -1,5 +1,4 @@
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "foo")]
 extern "C" {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
@@ -1,14 +1,5 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-invalid-format.rs:1:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: illegal ordinal format in `link_ordinal`
-  --> $DIR/link-ordinal-invalid-format.rs:6:5
+  --> $DIR/link-ordinal-invalid-format.rs:5:5
    |
 LL |     #[link_ordinal("JustMonika")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,12 +7,12 @@ LL |     #[link_ordinal("JustMonika")]
    = note: an unsuffixed integer value, e.g., `1`, is expected
 
 error: illegal ordinal format in `link_ordinal`
-  --> $DIR/link-ordinal-invalid-format.rs:9:5
+  --> $DIR/link-ordinal-invalid-format.rs:8:5
    |
 LL |     #[link_ordinal("JustMonika")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: an unsuffixed integer value, e.g., `1`, is expected
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.rs
@@ -1,5 +1,4 @@
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "foo")]
 extern "C" {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.stderr
@@ -1,14 +1,5 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-missing-argument.rs:1:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: incorrect number of arguments to `#[link_ordinal]`
-  --> $DIR/link-ordinal-missing-argument.rs:6:5
+  --> $DIR/link-ordinal-missing-argument.rs:5:5
    |
 LL |     #[link_ordinal()]
    |     ^^^^^^^^^^^^^^^^^
@@ -16,12 +7,12 @@ LL |     #[link_ordinal()]
    = note: the attribute requires exactly one argument
 
 error: incorrect number of arguments to `#[link_ordinal]`
-  --> $DIR/link-ordinal-missing-argument.rs:9:5
+  --> $DIR/link-ordinal-missing-argument.rs:8:5
    |
 LL |     #[link_ordinal()]
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: the attribute requires exactly one argument
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.rs
@@ -1,6 +1,5 @@
 // only-windows
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.stderr
@@ -1,35 +1,26 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-multiple.rs:2:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: multiple `link_ordinal` attributes
+  --> $DIR/link-ordinal-multiple.rs:6:5
+   |
+LL |     #[link_ordinal(1)]
+   |     ^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
   --> $DIR/link-ordinal-multiple.rs:7:5
    |
-LL |     #[link_ordinal(1)]
-   |     ^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/link-ordinal-multiple.rs:8:5
-   |
 LL |     #[link_ordinal(2)]
    |     ^^^^^^^^^^^^^^^^^^
 
 error: multiple `link_ordinal` attributes
-  --> $DIR/link-ordinal-multiple.rs:10:5
+  --> $DIR/link-ordinal-multiple.rs:9:5
    |
 LL |     #[link_ordinal(1)]
    |     ^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/link-ordinal-multiple.rs:11:5
+  --> $DIR/link-ordinal-multiple.rs:10:5
    |
 LL |     #[link_ordinal(2)]
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
@@ -1,5 +1,4 @@
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link_ordinal(123)]
 //~^ ERROR attribute should be applied to a foreign function or static

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.stderr
@@ -1,29 +1,20 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-not-foreign-fn.rs:1:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: attribute should be applied to a foreign function or static
-  --> $DIR/link-ordinal-not-foreign-fn.rs:4:1
+  --> $DIR/link-ordinal-not-foreign-fn.rs:3:1
    |
 LL | #[link_ordinal(123)]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: attribute should be applied to a foreign function or static
-  --> $DIR/link-ordinal-not-foreign-fn.rs:8:1
+  --> $DIR/link-ordinal-not-foreign-fn.rs:7:1
    |
 LL | #[link_ordinal(123)]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: attribute should be applied to a foreign function or static
-  --> $DIR/link-ordinal-not-foreign-fn.rs:12:1
+  --> $DIR/link-ordinal-not-foreign-fn.rs:11:1
    |
 LL | #[link_ordinal(42)]
    | ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
@@ -1,5 +1,4 @@
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "foo")]
 extern "C" {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
@@ -1,14 +1,5 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-too-large.rs:1:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: ordinal value in `link_ordinal` is too large: `72436`
-  --> $DIR/link-ordinal-too-large.rs:6:5
+  --> $DIR/link-ordinal-too-large.rs:5:5
    |
 LL |     #[link_ordinal(72436)]
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -16,12 +7,12 @@ LL |     #[link_ordinal(72436)]
    = note: the value may not exceed `u16::MAX`
 
 error: ordinal value in `link_ordinal` is too large: `72436`
-  --> $DIR/link-ordinal-too-large.rs:9:5
+  --> $DIR/link-ordinal-too-large.rs:8:5
    |
 LL |     #[link_ordinal(72436)]
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the value may not exceed `u16::MAX`
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.rs
@@ -1,5 +1,4 @@
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "foo")]
 extern "C" {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.stderr
@@ -1,14 +1,5 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-too-many-arguments.rs:1:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: incorrect number of arguments to `#[link_ordinal]`
-  --> $DIR/link-ordinal-too-many-arguments.rs:6:5
+  --> $DIR/link-ordinal-too-many-arguments.rs:5:5
    |
 LL |     #[link_ordinal(3, 4)]
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -16,12 +7,12 @@ LL |     #[link_ordinal(3, 4)]
    = note: the attribute requires exactly one argument
 
 error: incorrect number of arguments to `#[link_ordinal]`
-  --> $DIR/link-ordinal-too-many-arguments.rs:9:5
+  --> $DIR/link-ordinal-too-many-arguments.rs:8:5
    |
 LL |     #[link_ordinal(3, 4)]
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the attribute requires exactly one argument
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.rs
@@ -1,5 +1,4 @@
-#![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 
 #[link(name = "foo")]
 extern "C" {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.stderr
@@ -1,23 +1,14 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/link-ordinal-unsupported-link-kind.rs:1:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: `#[link_ordinal]` is only supported if link kind is `raw-dylib`
-  --> $DIR/link-ordinal-unsupported-link-kind.rs:6:5
+  --> $DIR/link-ordinal-unsupported-link-kind.rs:5:5
    |
 LL |     #[link_ordinal(3)]
    |     ^^^^^^^^^^^^^^^^^^
 
 error: `#[link_ordinal]` is only supported if link kind is `raw-dylib`
-  --> $DIR/link-ordinal-unsupported-link-kind.rs:13:5
+  --> $DIR/link-ordinal-unsupported-link-kind.rs:12:5
    |
 LL |     #[link_ordinal(3)]
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2627-raw-dylib/multiple-declarations.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/multiple-declarations.rs
@@ -3,7 +3,6 @@
 // compile-flags: --crate-type lib --emit link
 #![allow(clashing_extern_declarations)]
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {
     fn f(x: i32);

--- a/src/test/ui/rfc-2627-raw-dylib/multiple-declarations.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/multiple-declarations.stderr
@@ -1,17 +1,8 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/multiple-declarations.rs:5:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error: multiple declarations of external function `f` from library `foo.dll` have different calling conventions
-  --> $DIR/multiple-declarations.rs:15:9
+  --> $DIR/multiple-declarations.rs:14:9
    |
 LL |         fn f(x: i32);
    |         ^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/rfc-2627-raw-dylib/raw-dylib-windows-only.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/raw-dylib-windows-only.rs
@@ -1,7 +1,6 @@
 // ignore-windows
 // compile-flags: --crate-type lib
-#![feature(raw_dylib)]
-//~^ WARNING: the feature `raw_dylib` is incomplete
+#![cfg_attr(target_arch = "x86", feature(raw_dylib))]
 #[link(name = "foo", kind = "raw-dylib")]
 //~^ ERROR: link kind `raw-dylib` is only supported on Windows targets
 extern "C" {}

--- a/src/test/ui/rfc-2627-raw-dylib/raw-dylib-windows-only.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/raw-dylib-windows-only.stderr
@@ -1,18 +1,9 @@
-warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/raw-dylib-windows-only.rs:3:12
-   |
-LL | #![feature(raw_dylib)]
-   |            ^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
-
 error[E0455]: link kind `raw-dylib` is only supported on Windows targets
-  --> $DIR/raw-dylib-windows-only.rs:5:29
+  --> $DIR/raw-dylib-windows-only.rs:4:29
    |
 LL | #[link(name = "foo", kind = "raw-dylib")]
    |                             ^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0455`.

--- a/src/test/ui/rfc-2627-raw-dylib/unsupported-abi.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/unsupported-abi.rs
@@ -1,8 +1,6 @@
 // only-x86_64
 // only-windows
 // compile-flags: --crate-type lib --emit link
-#![allow(incomplete_features)]
-#![feature(raw_dylib)]
 #[link(name = "foo", kind = "raw-dylib")]
 extern "stdcall" {
     fn f(x: i32);

--- a/src/test/ui/rfc-2627-raw-dylib/unsupported-abi.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/unsupported-abi.stderr
@@ -1,5 +1,5 @@
 error: ABI not supported by `#[link(kind = "raw-dylib")]` on this architecture
-  --> $DIR/unsupported-abi.rs:8:5
+  --> $DIR/unsupported-abi.rs:6:5
    |
 LL |     fn f(x: i32);
    |     ^^^^^^^^^^^^^


### PR DESCRIPTION
This stabilizes the `raw-dylib` and `link_ordinal` features (#58713) for non-x86 architectures (i.e., `x86_64`, `aarch64` and `thumbv7a`):
* Marked the `raw_dylib` feature as `active`.
* Marked the `link_ordinal` attribute as `ungated`.
* Added new errors if either feature is used on x86 targets without the `raw_dylib` feature being enabled.
* Updated tests to only set the `raw_dylib` feature when building for x86.