### PR TITLE
Recover wrong-cased keywords that start items

### DIFF
--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -29,6 +29,7 @@ extern crate rustc_macros;
 extern crate tracing;
 
 pub mod util {
+    pub mod case;
     pub mod classify;
     pub mod comments;
     pub mod literal;

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -618,6 +618,15 @@ impl Token {
         self.is_non_raw_ident_where(|id| id.name == kw)
     }
 
+    /// Returns `true` if the token is a given keyword, `kw` or if `case_insensitive` is true and this token is an identifier equal to `kw` ignoring the case.
+    pub fn is_keyword_case(&self, kw: Symbol, case_insensitive: bool) -> bool {
+        self.is_keyword(kw)
+            || (case_insensitive
+                && self.is_non_raw_ident_where(|id| {
+                    id.name.as_str().to_lowercase() == kw.as_str().to_lowercase()
+                }))
+    }
+
     pub fn is_path_segment_keyword(&self) -> bool {
         self.is_non_raw_ident_where(Ident::is_path_segment_keyword)
     }

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -5,6 +5,7 @@ pub use TokenKind::*;
 
 use crate::ast;
 use crate::ptr::P;
+use crate::util::case::Case;
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
@@ -618,10 +619,10 @@ impl Token {
         self.is_non_raw_ident_where(|id| id.name == kw)
     }
 
-    /// Returns `true` if the token is a given keyword, `kw` or if `case_insensitive` is true and this token is an identifier equal to `kw` ignoring the case.
-    pub fn is_keyword_case(&self, kw: Symbol, case_insensitive: bool) -> bool {
+    /// Returns `true` if the token is a given keyword, `kw` or if `case` is `Insensitive` and this token is an identifier equal to `kw` ignoring the case.
+    pub fn is_keyword_case(&self, kw: Symbol, case: Case) -> bool {
         self.is_keyword(kw)
-            || (case_insensitive
+            || (case == Case::Insensitive
                 && self.is_non_raw_ident_where(|id| {
                     id.name.as_str().to_lowercase() == kw.as_str().to_lowercase()
                 }))

--- a/compiler/rustc_ast/src/util/case.rs
+++ b/compiler/rustc_ast/src/util/case.rs
@@ -1,0 +1,6 @@
+/// Whatever to ignore case (`fn` vs `Fn` vs `FN`) or not. Used for recovering.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Case {
+    Sensitive,
+    Insensitive,
+}

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2024,7 +2024,7 @@ impl<'a> Parser<'a> {
             if self.eat_keyword(kw::Static) { Movability::Static } else { Movability::Movable };
 
         let asyncness = if self.token.uninterpolated_span().rust_2018() {
-            self.parse_asyncness()
+            self.parse_asyncness(false)
         } else {
             Async::No
         };

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -33,6 +33,7 @@ use core::mem;
 use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Delimiter, Token, TokenKind};
 use rustc_ast::tokenstream::Spacing;
+use rustc_ast::util::case::Case;
 use rustc_ast::util::classify;
 use rustc_ast::util::literal::LitError;
 use rustc_ast::util::parser::{prec_let_scrutinee_needs_par, AssocOp, Fixity};
@@ -2024,7 +2025,7 @@ impl<'a> Parser<'a> {
             if self.eat_keyword(kw::Static) { Movability::Static } else { Movability::Movable };
 
         let asyncness = if self.token.uninterpolated_span().rust_2018() {
-            self.parse_asyncness(false)
+            self.parse_asyncness(Case::Sensitive)
         } else {
             Async::No
         };

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -604,6 +604,20 @@ impl<'a> Parser<'a> {
         self.token.is_keyword(kw)
     }
 
+    fn check_keyword_case(&mut self, kw: Symbol, case_insensitive: bool) -> bool {
+        if self.check_keyword(kw) {
+            return true;
+        }
+
+        if case_insensitive
+        && let Some((ident, /* is_raw */ false)) = self.token.ident()
+        && ident.as_str().to_lowercase() == kw.as_str().to_lowercase() {
+            true
+        } else {
+            false
+        }
+    }
+
     /// If the next token is the given keyword, eats it and returns `true`.
     /// Otherwise, returns `false`. An expectation is also added for diagnostics purposes.
     // Public for rustfmt usage.
@@ -1122,8 +1136,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses asyncness: `async` or nothing.
-    fn parse_asyncness(&mut self) -> Async {
-        if self.eat_keyword(kw::Async) {
+    fn parse_asyncness(&mut self, case_insensitive: bool) -> Async {
+        if self.eat_keyword_case(kw::Async, case_insensitive) {
             let span = self.prev_token.uninterpolated_span();
             Async::Yes { span, closure_id: DUMMY_NODE_ID, return_impl_trait_id: DUMMY_NODE_ID }
         } else {
@@ -1132,8 +1146,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses unsafety: `unsafe` or nothing.
-    fn parse_unsafety(&mut self) -> Unsafe {
-        if self.eat_keyword(kw::Unsafe) {
+    fn parse_unsafety(&mut self, case_insensitive: bool) -> Unsafe {
+        if self.eat_keyword_case(kw::Unsafe, case_insensitive) {
             Unsafe::Yes(self.prev_token.uninterpolated_span())
         } else {
             Unsafe::No
@@ -1141,10 +1155,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses constness: `const` or nothing.
-    fn parse_constness(&mut self) -> Const {
+    fn parse_constness(&mut self, case_insensitive: bool) -> Const {
         // Avoid const blocks to be parsed as const items
         if self.look_ahead(1, |t| t != &token::OpenDelim(Delimiter::Brace))
-            && self.eat_keyword(kw::Const)
+            && self.eat_keyword_case(kw::Const, case_insensitive)
         {
             Const::Yes(self.prev_token.uninterpolated_span())
         } else {
@@ -1399,8 +1413,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses `extern string_literal?`.
-    fn parse_extern(&mut self) -> Extern {
-        if self.eat_keyword(kw::Extern) {
+    fn parse_extern(&mut self, case_insensitive: bool) -> Extern {
+        if self.eat_keyword_case(kw::Extern, case_insensitive) {
             let mut extern_span = self.prev_token.span;
             let abi = self.parse_abi();
             if let Some(abi) = abi {

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -4,6 +4,7 @@ use crate::{maybe_recover_from_interpolated_ty_qpath, maybe_whole};
 
 use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Delimiter, Token, TokenKind};
+use rustc_ast::util::case::Case;
 use rustc_ast::{
     self as ast, BareFnTy, FnRetTy, GenericBound, GenericBounds, GenericParam, Generics, Lifetime,
     MacCall, MutTy, Mutability, PolyTraitRef, TraitBoundModifier, TraitObjectSyntax, Ty, TyKind,
@@ -267,7 +268,7 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::Underscore) {
             // A type to be inferred `_`
             TyKind::Infer
-        } else if self.check_fn_front_matter(false, false) {
+        } else if self.check_fn_front_matter(false, Case::Sensitive) {
             // Function pointer type
             self.parse_ty_bare_fn(lo, Vec::new(), recover_return_sign)?
         } else if self.check_keyword(kw::For) {
@@ -275,7 +276,7 @@ impl<'a> Parser<'a> {
             //   `for<'lt> [unsafe] [extern "ABI"] fn (&'lt S) -> T`
             //   `for<'lt> Trait1<'lt> + Trait2 + 'a`
             let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
-            if self.check_fn_front_matter(false, false) {
+            if self.check_fn_front_matter(false, Case::Sensitive) {
                 self.parse_ty_bare_fn(lo, lifetime_defs, recover_return_sign)?
             } else {
                 let path = self.parse_path(PathStyle::Type)?;

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -267,7 +267,7 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::Underscore) {
             // A type to be inferred `_`
             TyKind::Infer
-        } else if self.check_fn_front_matter(false) {
+        } else if self.check_fn_front_matter(false, false) {
             // Function pointer type
             self.parse_ty_bare_fn(lo, Vec::new(), recover_return_sign)?
         } else if self.check_keyword(kw::For) {
@@ -275,7 +275,7 @@ impl<'a> Parser<'a> {
             //   `for<'lt> [unsafe] [extern "ABI"] fn (&'lt S) -> T`
             //   `for<'lt> Trait1<'lt> + Trait2 + 'a`
             let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
-            if self.check_fn_front_matter(false) {
+            if self.check_fn_front_matter(false, false) {
                 self.parse_ty_bare_fn(lo, lifetime_defs, recover_return_sign)?
             } else {
                 let path = self.parse_path(PathStyle::Type)?;

--- a/src/test/ui/parser/item-kw-case-mismatch.fixed
+++ b/src/test/ui/parser/item-kw-case-mismatch.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+#![allow(unused_imports)]
+
+fn main() {}
+
+use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
+use std::ptr::write; //~ ERROR keyword `use` is written in a wrong case

--- a/src/test/ui/parser/item-kw-case-mismatch.fixed
+++ b/src/test/ui/parser/item-kw-case-mismatch.fixed
@@ -1,7 +1,34 @@
 // run-rustfix
+// edition:2018
 #![allow(unused_imports)]
 
 fn main() {}
 
 use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
 use std::ptr::write; //~ ERROR keyword `use` is written in a wrong case
+
+async fn _a() {}
+//~^ ERROR keyword `fn` is written in a wrong case
+
+fn _b() {}
+//~^ ERROR keyword `fn` is written in a wrong case
+
+async fn _c() {}
+//~^ ERROR keyword `async` is written in a wrong case
+//~| ERROR keyword `fn` is written in a wrong case
+
+async fn _d() {}
+//~^ ERROR keyword `async` is written in a wrong case
+
+const unsafe fn _e() {}
+//~^ ERROR keyword `const` is written in a wrong case
+//~| ERROR keyword `unsafe` is written in a wrong case
+//~| ERROR keyword `fn` is written in a wrong case
+
+unsafe extern fn _f() {}
+//~^ ERROR keyword `unsafe` is written in a wrong case
+//~| ERROR keyword `extern` is written in a wrong case
+
+extern "C" fn _g() {}
+//~^ ERROR keyword `extern` is written in a wrong case
+//~| ERROR keyword `fn` is written in a wrong case

--- a/src/test/ui/parser/item-kw-case-mismatch.rs
+++ b/src/test/ui/parser/item-kw-case-mismatch.rs
@@ -1,7 +1,34 @@
 // run-rustfix
+// edition:2018
 #![allow(unused_imports)]
 
 fn main() {}
 
 Use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
 USE std::ptr::write; //~ ERROR keyword `use` is written in a wrong case
+
+async Fn _a() {}
+//~^ ERROR keyword `fn` is written in a wrong case
+
+Fn _b() {}
+//~^ ERROR keyword `fn` is written in a wrong case
+
+aSYNC fN _c() {}
+//~^ ERROR keyword `async` is written in a wrong case
+//~| ERROR keyword `fn` is written in a wrong case
+
+Async fn _d() {}
+//~^ ERROR keyword `async` is written in a wrong case
+
+CONST UNSAFE FN _e() {}
+//~^ ERROR keyword `const` is written in a wrong case
+//~| ERROR keyword `unsafe` is written in a wrong case
+//~| ERROR keyword `fn` is written in a wrong case
+
+unSAFE EXTern fn _f() {}
+//~^ ERROR keyword `unsafe` is written in a wrong case
+//~| ERROR keyword `extern` is written in a wrong case
+
+EXTERN "C" FN _g() {}
+//~^ ERROR keyword `extern` is written in a wrong case
+//~| ERROR keyword `fn` is written in a wrong case

--- a/src/test/ui/parser/item-kw-case-mismatch.rs
+++ b/src/test/ui/parser/item-kw-case-mismatch.rs
@@ -1,0 +1,7 @@
+// run-rustfix
+#![allow(unused_imports)]
+
+fn main() {}
+
+Use std::ptr::read;  //~ ERROR keyword `use` is written in a wrong case
+USE std::ptr::write; //~ ERROR keyword `use` is written in a wrong case

--- a/src/test/ui/parser/item-kw-case-mismatch.stderr
+++ b/src/test/ui/parser/item-kw-case-mismatch.stderr
@@ -1,14 +1,86 @@
 error: keyword `use` is written in a wrong case
-  --> $DIR/item-kw-case-mismatch.rs:6:1
+  --> $DIR/item-kw-case-mismatch.rs:7:1
    |
 LL | Use std::ptr::read;
    | ^^^ help: write it in the correct case (notice the capitalization): `use`
 
 error: keyword `use` is written in a wrong case
-  --> $DIR/item-kw-case-mismatch.rs:7:1
+  --> $DIR/item-kw-case-mismatch.rs:8:1
    |
 LL | USE std::ptr::write;
    | ^^^ help: write it in the correct case: `use`
 
-error: aborting due to 2 previous errors
+error: keyword `fn` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:10:7
+   |
+LL | async Fn _a() {}
+   |       ^^ help: write it in the correct case (notice the capitalization): `fn`
+
+error: keyword `fn` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:13:1
+   |
+LL | Fn _b() {}
+   | ^^ help: write it in the correct case (notice the capitalization): `fn`
+
+error: keyword `async` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:16:1
+   |
+LL | aSYNC fN _c() {}
+   | ^^^^^ help: write it in the correct case: `async`
+
+error: keyword `fn` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:16:7
+   |
+LL | aSYNC fN _c() {}
+   |       ^^ help: write it in the correct case: `fn`
+
+error: keyword `async` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:20:1
+   |
+LL | Async fn _d() {}
+   | ^^^^^ help: write it in the correct case: `async`
+
+error: keyword `const` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:23:1
+   |
+LL | CONST UNSAFE FN _e() {}
+   | ^^^^^ help: write it in the correct case: `const`
+
+error: keyword `unsafe` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:23:7
+   |
+LL | CONST UNSAFE FN _e() {}
+   |       ^^^^^^ help: write it in the correct case: `unsafe`
+
+error: keyword `fn` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:23:14
+   |
+LL | CONST UNSAFE FN _e() {}
+   |              ^^ help: write it in the correct case: `fn`
+
+error: keyword `unsafe` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:28:1
+   |
+LL | unSAFE EXTern fn _f() {}
+   | ^^^^^^ help: write it in the correct case: `unsafe`
+
+error: keyword `extern` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:28:8
+   |
+LL | unSAFE EXTern fn _f() {}
+   |        ^^^^^^ help: write it in the correct case: `extern`
+
+error: keyword `extern` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:32:1
+   |
+LL | EXTERN "C" FN _g() {}
+   | ^^^^^^ help: write it in the correct case: `extern`
+
+error: keyword `fn` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:32:12
+   |
+LL | EXTERN "C" FN _g() {}
+   |            ^^ help: write it in the correct case: `fn`
+
+error: aborting due to 14 previous errors
 

--- a/src/test/ui/parser/item-kw-case-mismatch.stderr
+++ b/src/test/ui/parser/item-kw-case-mismatch.stderr
@@ -1,0 +1,14 @@
+error: keyword `use` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:6:1
+   |
+LL | Use std::ptr::read;
+   | ^^^ help: write it in the correct case (notice the capitalization): `use`
+
+error: keyword `use` is written in a wrong case
+  --> $DIR/item-kw-case-mismatch.rs:7:1
+   |
+LL | USE std::ptr::write;
+   | ^^^ help: write it in the correct case: `use`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
(_this pr was inspired by [this tweet](https://twitter.com/Azumanga/status/1552982326409367561)_)

r? @estebank 

We've talked a bit about this recovery, but I just wanted to make sure that this is the right approach :)

For now I've only added the case insensitive recovery to `use`s, since most other items like `impl` blocks, modules, functions can start with multiple keywords which complicates the matter. 
