### PR TITLE
Custom allocator support in `rustc_serialize`

### DIFF
--- a/compiler/rustc_serialize/src/lib.rs
+++ b/compiler/rustc_serialize/src/lib.rs
@@ -16,6 +16,7 @@ Core encoding and decoding interfaces.
 #![feature(maybe_uninit_slice)]
 #![feature(let_else)]
 #![feature(new_uninit)]
+#![feature(allocator_api)]
 #![cfg_attr(test, feature(test))]
 #![allow(rustc::internal)]
 #![deny(rustc::untranslatable_diagnostic)]


### PR DESCRIPTION
Adding support for `rustc_serialize` encode/decode for `Box` and `Vec` that use a custom allocator.