### PR TITLE
triagebot.yml: CC Enselic when rustdoc-json-types changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -323,6 +323,7 @@ otherwise, make sure you bump the `FORMAT_VERSION` constant.
 cc = [
     "@CraftSpider",
     "@aDotInTheVoid",
+    "@Enselic",
 ]
 
 [mentions."src/tools/cargo"]


### PR DESCRIPTION
Being the maintainer of [cargo-public-api](https://github.com/Enselic/cargo-public-api) which relies on [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) means I have high stakes in the rustdoc JSON format itself. Would be great if I could be pinged when the format is about to change.

I hope this is OK. Big thanks in advance.
