### PR TITLE
More distinctive pretty-printing of function item types

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1123,8 +1123,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             assert!(N == 1 || N == 2);
             let descriptions = dids.map(|did| match tcx.def_kind(did) {
                 hir::def::DefKind::Ctor(_, hir::def::CtorKind::Fn) => "constructor of",
-                hir::def::DefKind::Fn => "fn item",
-                _ => unreachable!(),
+                hir::def::DefKind::Fn | hir::def::DefKind::AssocFn => "fn item",
+                kind => unreachable!("unexpected DefKind for FnDef: {kind:?}"),
             });
             let highlight = N == 1 || descriptions[0] != descriptions[1];
             descriptions.map(|description| {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -591,7 +591,12 @@ pub trait PrettyPrinter<'tcx>:
             }
             ty::FnDef(def_id, substs) => {
                 let sig = self.tcx().bound_fn_sig(def_id).subst(self.tcx(), substs);
-                p!("[fn item {{", print_value_path(def_id, substs), "}}: ", print(sig), "]");
+                let description = match self.tcx().def_kind(def_id) {
+                    DefKind::Ctor(_, CtorKind::Fn) => "constructor of",
+                    DefKind::Fn => "fn item",
+                    _ => unreachable!(),
+                };
+                p!("[{description} {{", print_value_path(def_id, substs), "}}: ", print(sig), "]");
             }
             ty::FnPtr(ref bare_fn) => p!(print(bare_fn)),
             ty::Infer(infer_ty) => {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -593,8 +593,8 @@ pub trait PrettyPrinter<'tcx>:
                 let sig = self.tcx().bound_fn_sig(def_id).subst(self.tcx(), substs);
                 let description = match self.tcx().def_kind(def_id) {
                     DefKind::Ctor(_, CtorKind::Fn) => "constructor of",
-                    DefKind::Fn => "fn item",
-                    _ => unreachable!(),
+                    DefKind::Fn | DefKind::AssocFn => "fn item",
+                    kind => unreachable!("unexpected DefKind for FnDef: {kind:?}"),
                 };
                 p!("[{description} {{", print_value_path(def_id, substs), "}}: ", print(sig), "]");
             }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -591,7 +591,7 @@ pub trait PrettyPrinter<'tcx>:
             }
             ty::FnDef(def_id, substs) => {
                 let sig = self.tcx().bound_fn_sig(def_id).subst(self.tcx(), substs);
-                p!(print(sig), " {{", print_value_path(def_id, substs), "}}");
+                p!("[fn item {{", print_value_path(def_id, substs), "}}: ", print(sig), "]");
             }
             ty::FnPtr(ref bare_fn) => p!(print(bare_fn)),
             ty::Infer(infer_ty) => {

--- a/src/test/codegen-units/item-collection/function-as-argument.rs
+++ b/src/test/codegen-units/item-collection/function-as-argument.rs
@@ -18,14 +18,14 @@ fn take_fn_pointer<T1, T2>(f: fn(T1, T2), x: T1, y: T2) {
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {
 
-    //~ MONO_ITEM fn take_fn_once::<u32, &str, fn(u32, &str) {function::<u32, &str>}>
+    //~ MONO_ITEM fn take_fn_once::<u32, &str, [fn item {function::<u32, &str>}: fn(u32, &str)]>
     //~ MONO_ITEM fn function::<u32, &str>
-    //~ MONO_ITEM fn <fn(u32, &str) {function::<u32, &str>} as std::ops::FnOnce<(u32, &str)>>::call_once - shim(fn(u32, &str) {function::<u32, &str>})
+    //~ MONO_ITEM fn <[fn item {function::<u32, &str>}: fn(u32, &str)] as std::ops::FnOnce<(u32, &str)>>::call_once - shim([fn item {function::<u32, &str>}: fn(u32, &str)])
     take_fn_once(function, 0u32, "abc");
 
-    //~ MONO_ITEM fn take_fn_once::<char, f64, fn(char, f64) {function::<char, f64>}>
+    //~ MONO_ITEM fn take_fn_once::<char, f64, [fn item {function::<char, f64>}: fn(char, f64)]>
     //~ MONO_ITEM fn function::<char, f64>
-    //~ MONO_ITEM fn <fn(char, f64) {function::<char, f64>} as std::ops::FnOnce<(char, f64)>>::call_once - shim(fn(char, f64) {function::<char, f64>})
+    //~ MONO_ITEM fn <[fn item {function::<char, f64>}: fn(char, f64)] as std::ops::FnOnce<(char, f64)>>::call_once - shim([fn item {function::<char, f64>}: fn(char, f64)])
     take_fn_once(function, 'c', 0f64);
 
     //~ MONO_ITEM fn take_fn_pointer::<i32, ()>

--- a/src/test/codegen-units/item-collection/trait-method-as-argument.rs
+++ b/src/test/codegen-units/item-collection/trait-method-as-argument.rs
@@ -30,30 +30,30 @@ fn take_foo_mut<T, F: FnMut(T) -> T>(mut f: F, arg: T) -> T {
 //~ MONO_ITEM fn start
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {
-    //~ MONO_ITEM fn take_foo_once::<u32, fn(u32) -> u32 {<u32 as Trait>::foo}>
+    //~ MONO_ITEM fn take_foo_once::<u32, [fn item {<u32 as Trait>::foo}: fn(u32) -> u32]>
     //~ MONO_ITEM fn <u32 as Trait>::foo
-    //~ MONO_ITEM fn <fn(u32) -> u32 {<u32 as Trait>::foo} as std::ops::FnOnce<(u32,)>>::call_once - shim(fn(u32) -> u32 {<u32 as Trait>::foo})
+    //~ MONO_ITEM fn <[fn item {<u32 as Trait>::foo}: fn(u32) -> u32] as std::ops::FnOnce<(u32,)>>::call_once - shim([fn item {<u32 as Trait>::foo}: fn(u32) -> u32])
     take_foo_once(Trait::foo, 0u32);
 
-    //~ MONO_ITEM fn take_foo_once::<char, fn(char) -> char {<char as Trait>::foo}>
+    //~ MONO_ITEM fn take_foo_once::<char, [fn item {<char as Trait>::foo}: fn(char) -> char]>
     //~ MONO_ITEM fn <char as Trait>::foo
-    //~ MONO_ITEM fn <fn(char) -> char {<char as Trait>::foo} as std::ops::FnOnce<(char,)>>::call_once - shim(fn(char) -> char {<char as Trait>::foo})
+    //~ MONO_ITEM fn <[fn item {<char as Trait>::foo}: fn(char) -> char] as std::ops::FnOnce<(char,)>>::call_once - shim([fn item {<char as Trait>::foo}: fn(char) -> char])
     take_foo_once(Trait::foo, 'c');
 
-    //~ MONO_ITEM fn take_foo::<u32, fn(u32) -> u32 {<u32 as Trait>::foo}>
-    //~ MONO_ITEM fn <fn(u32) -> u32 {<u32 as Trait>::foo} as std::ops::Fn<(u32,)>>::call - shim(fn(u32) -> u32 {<u32 as Trait>::foo})
+    //~ MONO_ITEM fn take_foo::<u32, [fn item {<u32 as Trait>::foo}: fn(u32) -> u32]>
+    //~ MONO_ITEM fn <[fn item {<u32 as Trait>::foo}: fn(u32) -> u32] as std::ops::Fn<(u32,)>>::call - shim([fn item {<u32 as Trait>::foo}: fn(u32) -> u32])
     take_foo(Trait::foo, 0u32);
 
-    //~ MONO_ITEM fn take_foo::<char, fn(char) -> char {<char as Trait>::foo}>
-    //~ MONO_ITEM fn <fn(char) -> char {<char as Trait>::foo} as std::ops::Fn<(char,)>>::call - shim(fn(char) -> char {<char as Trait>::foo})
+    //~ MONO_ITEM fn take_foo::<char, [fn item {<char as Trait>::foo}: fn(char) -> char]>
+    //~ MONO_ITEM fn <[fn item {<char as Trait>::foo}: fn(char) -> char] as std::ops::Fn<(char,)>>::call - shim([fn item {<char as Trait>::foo}: fn(char) -> char])
     take_foo(Trait::foo, 'c');
 
-    //~ MONO_ITEM fn take_foo_mut::<u32, fn(u32) -> u32 {<u32 as Trait>::foo}>
-    //~ MONO_ITEM fn <fn(u32) -> u32 {<u32 as Trait>::foo} as std::ops::FnMut<(u32,)>>::call_mut - shim(fn(u32) -> u32 {<u32 as Trait>::foo})
+    //~ MONO_ITEM fn take_foo_mut::<u32, [fn item {<u32 as Trait>::foo}: fn(u32) -> u32]>
+    //~ MONO_ITEM fn <[fn item {<u32 as Trait>::foo}: fn(u32) -> u32] as std::ops::FnMut<(u32,)>>::call_mut - shim([fn item {<u32 as Trait>::foo}: fn(u32) -> u32])
     take_foo_mut(Trait::foo, 0u32);
 
-    //~ MONO_ITEM fn take_foo_mut::<char, fn(char) -> char {<char as Trait>::foo}>
-    //~ MONO_ITEM fn <fn(char) -> char {<char as Trait>::foo} as std::ops::FnMut<(char,)>>::call_mut - shim(fn(char) -> char {<char as Trait>::foo})
+    //~ MONO_ITEM fn take_foo_mut::<char, [fn item {<char as Trait>::foo}: fn(char) -> char]>
+    //~ MONO_ITEM fn <[fn item {<char as Trait>::foo}: fn(char) -> char] as std::ops::FnMut<(char,)>>::call_mut - shim([fn item {<char as Trait>::foo}: fn(char) -> char])
     take_foo_mut(Trait::foo, 'c');
 
     0

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.32bit.mir
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.32bit.mir
@@ -39,7 +39,7 @@ fn main() -> () {
         _5 = foo(move _6) -> bb1;        // scope 4 at $DIR/array-index-is-temporary.rs:+4:21: +4:27
                                          // mir::Constant
                                          // + span: $DIR/array-index-is-temporary.rs:16:21: 16:24
-                                         // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {foo}: unsafe fn(*mut usize) -> u32], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -39,7 +39,7 @@ fn main() -> () {
         _5 = foo(move _6) -> bb1;        // scope 4 at $DIR/array-index-is-temporary.rs:+4:21: +4:27
                                          // mir::Constant
                                          // + span: $DIR/array-index-is-temporary.rs:16:21: 16:24
-                                         // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {foo}: unsafe fn(*mut usize) -> u32], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
@@ -22,7 +22,7 @@ fn main() -> () {
         _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/box_expr.rs:+1:13: +1:25
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:7:13: 7:25
-                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -31,7 +31,7 @@ fn main() -> () {
         (*_5) = S::new() -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/box_expr.rs:+1:17: +1:25
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:7:17: 7:23
-                                         // + literal: Const { ty: fn() -> S {S::new}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {S::new}: fn() -> S], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -47,7 +47,7 @@ fn main() -> () {
         _6 = std::mem::drop::<Box<S>>(move _7) -> [return: bb4, unwind: bb6]; // scope 1 at $DIR/box_expr.rs:+2:5: +2:12
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:8:5: 8:9
-                                         // + literal: Const { ty: fn(Box<S>) {std::mem::drop::<Box<S>>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {std::mem::drop::<Box<S>>}: fn(Box<S>)], val: Value(<ZST>) }
     }
 
     bb4: {

--- a/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
+++ b/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
@@ -24,7 +24,7 @@
           _2 = <T as Clone>::clone(move _3) -> bb1; // scope 0 at $DIR/combine_clone_of_primitives.rs:+2:5: +2:9
                                            // mir::Constant
                                            // + span: $DIR/combine_clone_of_primitives.rs:8:5: 8:9
-                                           // + literal: Const { ty: for<'r> fn(&'r T) -> T {<T as Clone>::clone}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<T as Clone>::clone}: for<'r> fn(&'r T) -> T], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -37,7 +37,7 @@
 -         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
 -                                          // mir::Constant
 -                                          // + span: $DIR/combine_clone_of_primitives.rs:9:5: 9:11
--                                          // + literal: Const { ty: for<'r> fn(&'r u64) -> u64 {<u64 as Clone>::clone}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {<u64 as Clone>::clone}: for<'r> fn(&'r u64) -> u64], val: Value(<ZST>) }
 +         _6 = _7;                         // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
 +         _5 = (*_6);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
 +         goto -> bb2;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+3:5: +3:11
@@ -53,7 +53,7 @@
 -         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
 -                                          // mir::Constant
 -                                          // + span: $DIR/combine_clone_of_primitives.rs:10:5: 10:16
--                                          // + literal: Const { ty: for<'r> fn(&'r [f32; 3]) -> [f32; 3] {<[f32; 3] as Clone>::clone}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {<[f32; 3] as Clone>::clone}: for<'r> fn(&'r [f32; 3]) -> [f32; 3]], val: Value(<ZST>) }
 +         _9 = _10;                        // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
 +         _8 = (*_9);                      // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16
 +         goto -> bb3;                     // scope 0 at $DIR/combine_clone_of_primitives.rs:+4:5: +4:16

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -33,7 +33,7 @@
           _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:44
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:9:36: 9:42
-                                           // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {core::slice::<impl [&i32]>::as_ptr}: for<'r> fn(&'r [&i32]) -> *const &i32], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -35,7 +35,7 @@
           _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:+0:31: +0:55
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:13:47: 13:53
-                                           // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {core::slice::<impl [&i32]>::as_ptr}: for<'r> fn(&'r [&i32]) -> *const &i32], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -32,7 +32,7 @@
 +         _6 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> bb1; // scope 2 at $DIR/boxes.rs:+1:14: +1:22
                                            // mir::Constant
                                            // + span: $DIR/boxes.rs:12:14: 12:22
-                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
@@ -30,7 +30,7 @@
           _4 = read(move _5) -> bb1;       // scope 1 at $DIR/const_prop_fails_gracefully.rs:+3:5: +3:12
                                            // mir::Constant
                                            // + span: $DIR/const_prop_fails_gracefully.rs:8:5: 8:9
-                                           // + literal: Const { ty: fn(usize) {read}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {read}: fn(usize)], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -19,7 +19,7 @@
           _2 = begin_panic::<&str>(const "explicit panic"); // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/panic.rs:LL:COL
-                                           // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {begin_panic::<&str>}: fn(&str) -> !], val: Value(<ZST>) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/panic.rs:LL:COL
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -20,7 +20,7 @@
           _1 = encode(move _2) -> bb1;     // scope 0 at $DIR/issue-66971.rs:+1:5: +1:23
                                            // mir::Constant
                                            // + span: $DIR/issue-66971.rs:16:5: 16:11
-                                           // + literal: Const { ty: fn(((), u8, u8)) {encode}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {encode}: fn(((), u8, u8))], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -21,7 +21,7 @@
           _1 = test(move _2) -> bb1;       // scope 0 at $DIR/issue-67019.rs:+1:5: +1:20
                                            // mir::Constant
                                            // + span: $DIR/issue-67019.rs:11:5: 11:9
-                                           // + literal: Const { ty: fn(((u8, u8),)) {test}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {test}: fn(((u8, u8),))], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
@@ -17,7 +17,7 @@
           _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:+1:29: +1:34
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_aggregate_partial_read.rs:5:29: 5:32
-                                           // + literal: Const { ty: fn() -> (i32, i32) {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn() -> (i32, i32)], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -26,7 +26,7 @@
           _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_unprop_assign.rs:+1:13: +1:18
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_unprop_assign.rs:5:13: 5:16
-                                           // + literal: Const { ty: fn() -> i32 {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn() -> i32], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -16,7 +16,7 @@
           _3 = main as fn() (Pointer(ReifyFnPointer)); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:17
                                            // mir::Constant
                                            // + span: $DIR/reify_fn_ptr.rs:4:13: 4:17
-                                           // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {main}: fn()], val: Value(<ZST>) }
           _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:26
           StorageDead(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:+1:25: +1:26
           _1 = move _2 as *const fn() (PointerFromExposedAddress); // scope 0 at $DIR/reify_fn_ptr.rs:+1:13: +1:41

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -21,7 +21,7 @@
 +         _2 = consume(const 1_u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:+2:5: +2:15
                                            // mir::Constant
                                            // + span: $DIR/scalar_literal_propagation.rs:4:5: 4:12
-                                           // + literal: Const { ty: fn(u32) {consume}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {consume}: fn(u32)], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
@@ -16,14 +16,14 @@
           _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:+3:14: +3:21
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
-                                           // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn(i32)], val: Value(<ZST>) }
       }
   
       bb2: {
           _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:+2:14: +2:20
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
-                                           // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn(i32)], val: Value(<ZST>) }
       }
   
       bb3: {

--- a/src/test/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.diff
@@ -16,14 +16,14 @@
           _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:+3:14: +3:21
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
-                                           // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn(i32)], val: Value(<ZST>) }
       }
   
       bb2: {
           _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:+2:14: +2:20
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
-                                           // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn(i32)], val: Value(<ZST>) }
       }
   
       bb3: {

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -22,7 +22,7 @@
           _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/tuple_literal_propagation.rs:+3:5: +3:15
                                            // mir::Constant
                                            // + span: $DIR/tuple_literal_propagation.rs:5:5: 5:12
-                                           // + literal: Const { ty: fn((u32, u32)) {consume}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {consume}: fn((u32, u32))], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
@@ -28,7 +28,7 @@
           _5 = cond() -> bb2;              // scope 0 at $DIR/cycle.rs:+3:11: +3:17
                                            // mir::Constant
                                            // + span: $DIR/cycle.rs:12:11: 12:15
-                                           // + literal: Const { ty: fn() -> bool {cond}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {cond}: fn() -> bool], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
+++ b/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
@@ -27,7 +27,7 @@
 +         _2 = transmute::<&str, &[u8]>(move _8) -> bb12; // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/str/mod.rs:LL:COL
-                                           // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&str) -> &[u8] {transmute::<&str, &[u8]>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {transmute::<&str, &[u8]>}: unsafe extern "rust-intrinsic" fn(&str) -> &[u8]], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
@@ -36,7 +36,7 @@
           _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> bb1; // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:5:17: 5:26
-                                           // + literal: Const { ty: fn(&[i32; 2]) -> <&[i32; 2] as IntoIterator>::IntoIter {<&[i32; 2] as IntoIterator>::into_iter}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<&[i32; 2] as IntoIterator>::into_iter}: fn(&[i32; 2]) -> <&[i32; 2] as IntoIterator>::IntoIter], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -56,7 +56,7 @@
           _7 = <std::slice::Iter<i32> as Iterator>::next(move _8) -> bb3; // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:5:17: 5:26
-                                           // + literal: Const { ty: for<'r> fn(&'r mut std::slice::Iter<i32>) -> Option<<std::slice::Iter<i32> as Iterator>::Item> {<std::slice::Iter<i32> as Iterator>::next}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<std::slice::Iter<i32> as Iterator>::next}: for<'r> fn(&'r mut std::slice::Iter<i32>) -> Option<<std::slice::Iter<i32> as Iterator>::Item>], val: Value(<ZST>) }
       }
   
       bb3: {
@@ -77,7 +77,7 @@
           _6 = std::mem::drop::<i32>(move _13) -> bb7; // scope 2 at $DIR/derefer_complex_case.rs:+1:29: +1:38
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:5:29: 5:33
-                                           // + literal: Const { ty: fn(i32) {std::mem::drop::<i32>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {std::mem::drop::<i32>}: fn(i32)], val: Value(<ZST>) }
       }
   
       bb5: {

--- a/src/test/mir-opt/derefer_inline_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_inline_test.main.Derefer.diff
@@ -18,7 +18,7 @@
           _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 1 at $DIR/derefer_inline_test.rs:+1:5: +1:12
                                            // mir::Constant
                                            // + span: $DIR/derefer_inline_test.rs:10:5: 10:12
-                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -27,7 +27,7 @@
           (*_5) = f() -> [return: bb2, unwind: bb6]; // scope 0 at $DIR/derefer_inline_test.rs:+1:9: +1:12
                                            // mir::Constant
                                            // + span: $DIR/derefer_inline_test.rs:10:9: 10:10
-                                           // + literal: Const { ty: fn() -> Box<u32> {f}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {f}: fn() -> Box<u32>], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/derefer_terminator_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_terminator_test.main.Derefer.diff
@@ -33,7 +33,7 @@
           _1 = foo() -> bb1;               // scope 0 at $DIR/derefer_terminator_test.rs:+1:13: +1:18
                                            // mir::Constant
                                            // + span: $DIR/derefer_terminator_test.rs:5:13: 5:16
-                                           // + literal: Const { ty: fn() -> bool {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn() -> bool], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -41,7 +41,7 @@
           _2 = foo() -> bb2;               // scope 1 at $DIR/derefer_terminator_test.rs:+2:13: +2:18
                                            // mir::Constant
                                            // + span: $DIR/derefer_terminator_test.rs:6:13: 6:16
-                                           // + literal: Const { ty: fn() -> bool {foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {foo}: fn() -> bool], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
@@ -19,7 +19,7 @@
           _1 = val() -> bb1;               // scope 0 at $DIR/branch.rs:+1:13: +1:18
                                            // mir::Constant
                                            // + span: $DIR/branch.rs:13:13: 13:16
-                                           // + literal: Const { ty: fn() -> i32 {val}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {val}: fn() -> i32], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -28,7 +28,7 @@
           _3 = cond() -> bb2;              // scope 1 at $DIR/branch.rs:+3:16: +3:22
                                            // mir::Constant
                                            // + span: $DIR/branch.rs:15:16: 15:20
-                                           // + literal: Const { ty: fn() -> bool {cond}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {cond}: fn() -> bool], val: Value(<ZST>) }
       }
   
       bb2: {
@@ -45,7 +45,7 @@
           _4 = val() -> bb5;               // scope 1 at $DIR/branch.rs:+6:9: +6:14
                                            // mir::Constant
                                            // + span: $DIR/branch.rs:18:9: 18:12
-                                           // + literal: Const { ty: fn() -> i32 {val}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {val}: fn() -> i32], val: Value(<ZST>) }
       }
   
       bb5: {

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.diff
@@ -14,7 +14,7 @@
           _2 = dummy(move _3) -> bb1;      // scope 0 at $DIR/copy_propagation_arg.rs:+1:5: +1:13
                                            // mir::Constant
                                            // + span: $DIR/copy_propagation_arg.rs:16:5: 16:10
-                                           // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {dummy}: fn(u8) -> u8], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
@@ -14,7 +14,7 @@
           _2 = dummy(move _3) -> bb1;      // scope 0 at $DIR/copy_propagation_arg.rs:+2:9: +2:17
                                            // mir::Constant
                                            // + span: $DIR/copy_propagation_arg.rs:11:9: 11:14
-                                           // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {dummy}: fn(u8) -> u8], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
@@ -27,7 +27,7 @@
           _1 = val() -> bb1;               // scope 0 at $DIR/cycle.rs:+1:17: +1:22
                                            // mir::Constant
                                            // + span: $DIR/cycle.rs:9:17: 9:20
-                                           // + literal: Const { ty: fn() -> i32 {val}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {val}: fn() -> i32], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -22,7 +22,7 @@
           _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:+5:23: +5:28
                                            // mir::Constant
                                            // + span: $DIR/union.rs:13:23: 13:26
-                                           // + literal: Const { ty: fn() -> u32 {val}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {val}: fn() -> u32], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -41,7 +41,7 @@
           _4 = Formatter::sign_plus(move _5) -> bb1; // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:15:26: 15:35
-                                           // + literal: Const { ty: for<'r> fn(&'r Formatter) -> bool {Formatter::sign_plus}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {Formatter::sign_plus}: for<'r> fn(&'r Formatter) -> bool], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -69,7 +69,7 @@
           _7 = Formatter::precision(move _8) -> bb5; // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:24:34: 24:43
-                                           // + literal: Const { ty: for<'r> fn(&'r Formatter) -> Option<usize> {Formatter::precision}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {Formatter::precision}: for<'r> fn(&'r Formatter) -> Option<usize>], val: Value(<ZST>) }
       }
   
       bb5: {
@@ -100,7 +100,7 @@
           _0 = float_to_exponential_common_exact::<T>(move _11, move _12, move _13, move _14, move _17) -> bb7; // scope 3 at $DIR/funky_arms.rs:+15:9: +15:87
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:26:9: 26:42
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut Formatter<'s>, &'t0 T, Sign, u32, bool) -> Result<(), std::fmt::Error> {float_to_exponential_common_exact::<T>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {float_to_exponential_common_exact::<T>}: for<'r, 's, 't0> fn(&'r mut Formatter<'s>, &'t0 T, Sign, u32, bool) -> Result<(), std::fmt::Error>], val: Value(<ZST>) }
       }
   
       bb7: {
@@ -125,7 +125,7 @@
           _0 = float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, move _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:+17:9: +17:68
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:28:9: 28:45
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut Formatter<'s>, &'t0 T, Sign, bool) -> Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {float_to_exponential_common_shortest::<T>}: for<'r, 's, 't0> fn(&'r mut Formatter<'s>, &'t0 T, Sign, bool) -> Result<(), std::fmt::Error>], val: Value(<ZST>) }
       }
   
       bb9: {

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -41,7 +41,7 @@ yields ()
         _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:26:9: 26:13
-                                         // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {take::<Foo>}: fn(Foo)], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -53,7 +53,7 @@ yields ()
         _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb8]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:27:9: 27:13
-                                         // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {take::<Bar>}: fn(Bar)], val: Value(<ZST>) }
     }
 
     bb3: {

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -61,7 +61,7 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 19:24
         _8 = callee() -> bb4;            // scope 1 at $DIR/generator-tiny.rs:+4:13: +4:21
                                          // mir::Constant
                                          // + span: $DIR/generator-tiny.rs:23:13: 23:19
-                                         // + literal: Const { ty: fn() {callee}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {callee}: fn()], val: Value(<ZST>) }
     }
 
     bb4: {

--- a/src/test/mir-opt/inline/caller_with_trivial_bound.foo.Inline.diff
+++ b/src/test/mir-opt/inline/caller_with_trivial_bound.foo.Inline.diff
@@ -13,7 +13,7 @@
           _1 = bar::<T>() -> bb1;          // scope 0 at $DIR/caller-with-trivial-bound.rs:+4:51: +4:61
                                            // mir::Constant
                                            // + span: $DIR/caller-with-trivial-bound.rs:20:51: 20:59
-                                           // + literal: Const { ty: fn() -> <IntFactory as Factory<T>>::Item {bar::<T>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {bar::<T>}: fn() -> <IntFactory as Factory<T>>::Item], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/cycle.f.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.f.Inline.diff
@@ -17,7 +17,7 @@
           _2 = <impl Fn() as Fn<()>>::call(move _3, move _4) -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/cycle.rs:+1:5: +1:8
                                            // mir::Constant
                                            // + span: $DIR/cycle.rs:6:5: 6:6
-                                           // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as FnOnce<()>>::Output {<impl Fn() as Fn<()>>::call}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<impl Fn() as Fn<()>>::call}: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as FnOnce<()>>::Output], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/cycle.g.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.g.Inline.diff
@@ -4,27 +4,27 @@
   fn g() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:8: +0:8
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
-+     let mut _2: fn() {main};             // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
-+     scope 1 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
++     let mut _2: [fn item {main}: fn()];  // in scope 0 at $DIR/cycle.rs:+1:5: +1:12
++     scope 1 (inlined f::<[fn item {main}: fn()]>) { // at $DIR/cycle.rs:12:5: 12:12
 +         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:+0:6: +0:7
 +         let _3: ();                      // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         let mut _4: &fn() {main};        // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         let mut _4: &[fn item {main}: fn()]; // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
 +         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         scope 2 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
++         scope 2 (inlined <[fn item {main}: fn()] as Fn<()>>::call - shim([fn item {main}: fn()])) { // at $DIR/cycle.rs:6:5: 6:8
 +         }
 +     }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
--         _1 = f::<fn() {main}>(main) -> bb1; // scope 0 at $DIR/cycle.rs:+1:5: +1:12
+-         _1 = f::<[fn item {main}: fn()]>(main) -> bb1; // scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +         StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +         _2 = main;                       // scope 0 at $DIR/cycle.rs:+1:5: +1:12
                                            // mir::Constant
 -                                          // + span: $DIR/cycle.rs:12:5: 12:6
--                                          // + literal: Const { ty: fn(fn() {main}) {f::<fn() {main}>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {f::<[fn item {main}: fn()]>}: fn([fn item {main}: fn()])], val: Value(<ZST>) }
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:12:7: 12:11
-                                           // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {main}: fn()], val: Value(<ZST>) }
 +         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
 +         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:6
 +         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:+0:5: +0:6

--- a/src/test/mir-opt/inline/cycle.main.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.main.Inline.diff
@@ -4,20 +4,20 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:+0:11: +0:11
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
-+     let mut _2: fn() {g};                // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
-+     scope 1 (inlined f::<fn() {g}>) {    // at $DIR/cycle.rs:17:5: 17:9
++     let mut _2: [fn item {g}: fn()];     // in scope 0 at $DIR/cycle.rs:+1:5: +1:9
++     scope 1 (inlined f::<[fn item {g}: fn()]>) { // at $DIR/cycle.rs:17:5: 17:9
 +         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:+0:6: +0:7
 +         let _3: ();                      // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         let mut _4: &fn() {g};           // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
++         let mut _4: &[fn item {g}: fn()]; // in scope 1 at $DIR/cycle.rs:+0:5: +0:6
 +         let mut _5: ();                  // in scope 1 at $DIR/cycle.rs:+0:5: +0:8
-+         scope 2 (inlined <fn() {g} as Fn<()>>::call - shim(fn() {g})) { // at $DIR/cycle.rs:6:5: 6:8
++         scope 2 (inlined <[fn item {g}: fn()] as Fn<()>>::call - shim([fn item {g}: fn()])) { // at $DIR/cycle.rs:6:5: 6:8
 +             scope 3 (inlined g) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
-+                 let mut _6: fn() {main}; // in scope 3 at $DIR/cycle.rs:+0:5: +0:12
-+                 scope 4 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
++                 let mut _6: [fn item {main}: fn()]; // in scope 3 at $DIR/cycle.rs:+0:5: +0:12
++                 scope 4 (inlined f::<[fn item {main}: fn()]>) { // at $DIR/cycle.rs:12:5: 12:12
 +                     debug g => _6;       // in scope 4 at $DIR/cycle.rs:+0:6: +0:7
 +                     let _7: ();          // in scope 4 at $DIR/cycle.rs:+0:5: +0:8
-+                     let mut _8: &fn() {main}; // in scope 4 at $DIR/cycle.rs:+0:5: +0:6
-+                     scope 5 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
++                     let mut _8: &[fn item {main}: fn()]; // in scope 4 at $DIR/cycle.rs:+0:5: +0:6
++                     scope 5 (inlined <[fn item {main}: fn()] as Fn<()>>::call - shim([fn item {main}: fn()])) { // at $DIR/cycle.rs:6:5: 6:8
 +                     }
 +                 }
 +             }
@@ -26,15 +26,15 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
--         _1 = f::<fn() {g}>(g) -> bb1;    // scope 0 at $DIR/cycle.rs:+1:5: +1:9
+-         _1 = f::<[fn item {g}: fn()]>(g) -> bb1; // scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +         StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +         _2 = g;                          // scope 0 at $DIR/cycle.rs:+1:5: +1:9
                                            // mir::Constant
 -                                          // + span: $DIR/cycle.rs:17:5: 17:6
--                                          // + literal: Const { ty: fn(fn() {g}) {f::<fn() {g}>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {f::<[fn item {g}: fn()]>}: fn([fn item {g}: fn()])], val: Value(<ZST>) }
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:17:7: 17:8
-                                           // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {g}: fn()], val: Value(<ZST>) }
 +         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:8
 +         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:+0:5: +0:6
 +         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:+0:5: +0:6

--- a/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
@@ -28,7 +28,7 @@
                                            // mir::Constant
                                            // + span: $DIR/dyn-trait.rs:33:13: 33:21
                                            // + user_ty: UserType(0)
-                                           // + literal: Const { ty: for<'r> fn(&'r T) -> &'r <Q as Query>::C {<Q as Query>::cache::<T>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<Q as Query>::cache::<T>}: for<'r> fn(&'r T) -> &'r <Q as Query>::C], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -46,9 +46,9 @@
 +         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(move _7) -> bb2; // scope 3 at $DIR/dyn-trait.rs:+0:5: +0:22
                                            // mir::Constant
 -                                          // + span: $DIR/dyn-trait.rs:34:5: 34:22
--                                          // + literal: Const { ty: for<'r> fn(&'r <Q as Query>::C) {try_execute_query::<<Q as Query>::C>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {try_execute_query::<<Q as Query>::C>}: for<'r> fn(&'r <Q as Query>::C)], val: Value(<ZST>) }
 +                                          // + span: $DIR/dyn-trait.rs:21:7: 21:20
-+                                          // + literal: Const { ty: for<'r> fn(&'r dyn Cache<V = <Q as Query>::V>) {<dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: [fn item {<dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache}: for<'r> fn(&'r dyn Cache<V = <Q as Query>::V>)], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/inline/dyn_trait.mk_cycle.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.mk_cycle.Inline.diff
@@ -12,7 +12,7 @@
           _0 = <dyn Cache<V = V> as Cache>::store_nocache(move _2) -> bb1; // scope 0 at $DIR/dyn-trait.rs:+1:5: +1:22
                                            // mir::Constant
                                            // + span: $DIR/dyn-trait.rs:21:7: 21:20
-                                           // + literal: Const { ty: for<'r> fn(&'r dyn Cache<V = V>) {<dyn Cache<V = V> as Cache>::store_nocache}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<dyn Cache<V = V> as Cache>::store_nocache}: for<'r> fn(&'r dyn Cache<V = V>)], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
@@ -23,9 +23,9 @@
 +         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(move _4) -> bb1; // scope 1 at $DIR/dyn-trait.rs:+0:5: +0:22
                                            // mir::Constant
 -                                          // + span: $DIR/dyn-trait.rs:27:5: 27:13
--                                          // + literal: Const { ty: for<'r> fn(&'r (dyn Cache<V = <C as Cache>::V> + 'r)) {mk_cycle::<<C as Cache>::V>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {mk_cycle::<<C as Cache>::V>}: for<'r> fn(&'r (dyn Cache<V = <C as Cache>::V> + 'r))], val: Value(<ZST>) }
 +                                          // + span: $DIR/dyn-trait.rs:21:7: 21:20
-+                                          // + literal: Const { ty: for<'r> fn(&'r dyn Cache<V = <C as Cache>::V>) {<dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: [fn item {<dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache}: for<'r> fn(&'r dyn Cache<V = <C as Cache>::V>)], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -2,8 +2,8 @@
 
 fn bar() -> bool {
     let mut _0: bool;                    // return place in scope 0 at $DIR/inline-any-operand.rs:+0:13: +0:17
-    let _1: fn(i32, i32) -> bool {foo};  // in scope 0 at $DIR/inline-any-operand.rs:+1:9: +1:10
-    let mut _2: fn(i32, i32) -> bool {foo}; // in scope 0 at $DIR/inline-any-operand.rs:+2:5: +2:6
+    let _1: [fn item {foo}: fn(i32, i32) -> bool]; // in scope 0 at $DIR/inline-any-operand.rs:+1:9: +1:10
+    let mut _2: [fn item {foo}: fn(i32, i32) -> bool]; // in scope 0 at $DIR/inline-any-operand.rs:+2:5: +2:6
     let mut _3: i32;                     // in scope 0 at $DIR/inline-any-operand.rs:+2:5: +2:13
     let mut _4: i32;                     // in scope 0 at $DIR/inline-any-operand.rs:+2:5: +2:13
     scope 1 {
@@ -21,7 +21,7 @@ fn bar() -> bool {
         _1 = foo;                        // scope 0 at $DIR/inline-any-operand.rs:+1:13: +1:16
                                          // mir::Constant
                                          // + span: $DIR/inline-any-operand.rs:11:13: 11:16
-                                         // + literal: Const { ty: fn(i32, i32) -> bool {foo}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {foo}: fn(i32, i32) -> bool], val: Value(<ZST>) }
         StorageLive(_2);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:6
         _2 = _1;                         // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:6
         StorageLive(_3);                 // scope 1 at $DIR/inline-any-operand.rs:+2:5: +2:13

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
@@ -12,7 +12,7 @@
 -         _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-compatibility.rs:24:5: 24:16
--                                          // + literal: Const { ty: unsafe fn() {no_sanitize}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {no_sanitize}: unsafe fn()], val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
@@ -12,7 +12,7 @@
 -         _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-compatibility.rs:13:5: 13:19
--                                          // + literal: Const { ty: unsafe fn() {target_feature}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {target_feature}: unsafe fn()], val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.diff
@@ -13,7 +13,7 @@
           _1 = sum(const 4_u32, const 4_u32, const 30_u32, const 200_u32, const 1000_u32) -> bb1; // scope 0 at $DIR/inline-compatibility.rs:+1:13: +1:52
                                            // mir::Constant
                                            // + span: $DIR/inline-compatibility.rs:42:13: 42:16
-                                           // + literal: Const { ty: unsafe extern "C" fn(u32, ...) -> u32 {sum}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {sum}: unsafe extern "C" fn(u32, ...) -> u32], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.diff
@@ -10,7 +10,7 @@
           _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:18
                                            // mir::Constant
                                            // + span: $DIR/inline-compatibility.rs:29:5: 29:16
-                                           // + literal: Const { ty: unsafe fn() {no_sanitize}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {no_sanitize}: unsafe fn()], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.diff
@@ -10,7 +10,7 @@
           _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:+1:5: +1:21
                                            // mir::Constant
                                            // + span: $DIR/inline-compatibility.rs:18:5: 18:19
-                                           // + literal: Const { ty: unsafe fn() {target_feature}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {target_feature}: unsafe fn()], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
@@ -18,7 +18,7 @@
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle.rs:14:5: 14:22
 +                                          // + span: $DIR/inline-cycle.rs:36:9: 36:26
-                                           // + literal: Const { ty: fn() {<C as Call>::call}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<C as Call>::call}: fn()], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -4,13 +4,13 @@
   fn two() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle.rs:+0:10: +0:10
       let _1: ();                          // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
-+     let mut _2: fn() {f};                // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
-+     scope 1 (inlined call::<fn() {f}>) { // at $DIR/inline-cycle.rs:49:5: 49:12
++     let mut _2: [fn item {f}: fn()];     // in scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
++     scope 1 (inlined call::<[fn item {f}: fn()]>) { // at $DIR/inline-cycle.rs:49:5: 49:12
 +         debug f => _2;                   // in scope 1 at $DIR/inline-cycle.rs:+5:22: +5:23
 +         let _3: ();                      // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
-+         let mut _4: fn() {f};            // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
++         let mut _4: [fn item {f}: fn()]; // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
 +         let mut _5: ();                  // in scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
-+         scope 2 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline-cycle.rs:54:5: 54:8
++         scope 2 (inlined <[fn item {f}: fn()] as FnOnce<()>>::call_once - shim([fn item {f}: fn()])) { // at $DIR/inline-cycle.rs:54:5: 54:8
 +             scope 3 (inlined f) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +                 let _6: ();              // in scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
 +             }
@@ -19,26 +19,26 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
--         _1 = call::<fn() {f}>(f) -> bb1; // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
+-         _1 = call::<[fn item {f}: fn()]>(f) -> bb1; // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
 +         StorageLive(_2);                 // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
 +         _2 = f;                          // scope 0 at $DIR/inline-cycle.rs:+1:5: +1:12
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle.rs:49:5: 49:9
 +                                          // + span: $DIR/inline-cycle.rs:49:10: 49:11
-+                                          // + literal: Const { ty: fn() {f}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: [fn item {f}: fn()], val: Value(<ZST>) }
 +         StorageLive(_3);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
 +         StorageLive(_4);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
 +         _4 = move _2;                    // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/inline-cycle.rs:+6:5: +6:8
 +         StorageLive(_6);                 // scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
-+         _6 = call::<fn() {f}>(f) -> bb1; // scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
++         _6 = call::<[fn item {f}: fn()]>(f) -> bb1; // scope 3 at $DIR/inline-cycle.rs:+11:5: +11:12
 +                                          // mir::Constant
 +                                          // + span: $DIR/inline-cycle.rs:59:5: 59:9
-                                           // + literal: Const { ty: fn(fn() {f}) {call::<fn() {f}>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {call::<[fn item {f}: fn()]>}: fn([fn item {f}: fn()])], val: Value(<ZST>) }
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle.rs:49:10: 49:11
 +                                          // + span: $DIR/inline-cycle.rs:59:10: 59:11
-                                           // + literal: Const { ty: fn() {f}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {f}: fn()], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
@@ -20,7 +20,7 @@
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle-generic.rs:9:5: 9:22
 +                                          // + span: $DIR/inline-cycle-generic.rs:31:9: 31:26
-                                           // + literal: Const { ty: fn() {<C as Call>::call}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<C as Call>::call}: fn()], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
@@ -13,7 +13,7 @@
 -         _2 = sleep();                    // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:12
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-diverging.rs:8:5: 8:10
--                                          // + literal: Const { ty: fn() -> ! {sleep}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {sleep}: fn() -> !], val: Value(<ZST>) }
 +         goto -> bb1;                     // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:12
 +     }
 + 

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -38,9 +38,9 @@
 +         _7 = begin_panic::<&str>(const "explicit panic"); // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline-diverging.rs:16:9: 16:14
--                                          // + literal: Const { ty: fn() -> ! {panic}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {panic}: fn() -> !], val: Value(<ZST>) }
 +                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
-+                                          // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(<ZST>) }
++                                          // + literal: Const { ty: [fn item {begin_panic::<&str>}: fn(&str) -> !], val: Value(<ZST>) }
 +                                          // mir::Constant
 +                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
 +                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -4,13 +4,13 @@
   fn h() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-diverging.rs:+0:12: +0:12
       let _1: (!, !);                      // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
-+     let mut _2: fn() -> ! {sleep};       // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
-+     scope 1 (inlined call_twice::<!, fn() -> ! {sleep}>) { // at $DIR/inline-diverging.rs:22:5: 22:22
++     let mut _2: [fn item {sleep}: fn() -> !]; // in scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
++     scope 1 (inlined call_twice::<!, [fn item {sleep}: fn() -> !]>) { // at $DIR/inline-diverging.rs:22:5: 22:22
 +         debug f => _2;                   // in scope 1 at $DIR/inline-diverging.rs:+5:36: +5:37
 +         let _3: !;                       // in scope 1 at $DIR/inline-diverging.rs:+6:9: +6:10
-+         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
++         let mut _4: &[fn item {sleep}: fn() -> !]; // in scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
 +         let mut _5: ();                  // in scope 1 at $DIR/inline-diverging.rs:+6:13: +6:16
-+         let mut _7: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:+7:13: +7:14
++         let mut _7: &[fn item {sleep}: fn() -> !]; // in scope 1 at $DIR/inline-diverging.rs:+7:13: +7:14
 +         let mut _8: ();                  // in scope 1 at $DIR/inline-diverging.rs:+7:13: +7:16
 +         let mut _9: !;                   // in scope 1 at $DIR/inline-diverging.rs:+8:6: +8:7
 +         let mut _10: !;                  // in scope 1 at $DIR/inline-diverging.rs:+8:9: +8:10
@@ -20,12 +20,12 @@
 +             scope 3 {
 +                 debug b => _6;           // in scope 3 at $DIR/inline-diverging.rs:+7:9: +7:10
 +             }
-+             scope 6 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:28:13: 28:16
++             scope 6 (inlined <[fn item {sleep}: fn() -> !] as Fn<()>>::call - shim([fn item {sleep}: fn() -> !])) { // at $DIR/inline-diverging.rs:28:13: 28:16
 +                 scope 7 (inlined sleep) { // at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +                 }
 +             }
 +         }
-+         scope 4 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:27:13: 27:16
++         scope 4 (inlined <[fn item {sleep}: fn() -> !] as Fn<()>>::call - shim([fn item {sleep}: fn() -> !])) { // at $DIR/inline-diverging.rs:27:13: 27:16
 +             scope 5 (inlined sleep) {    // at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +             }
 +         }
@@ -33,15 +33,15 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
--         _1 = call_twice::<!, fn() -> ! {sleep}>(sleep); // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
+-         _1 = call_twice::<!, [fn item {sleep}: fn() -> !]>(sleep); // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
 +         StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
 +         _2 = sleep;                      // scope 0 at $DIR/inline-diverging.rs:+1:5: +1:22
                                            // mir::Constant
 -                                          // + span: $DIR/inline-diverging.rs:22:5: 22:15
--                                          // + literal: Const { ty: fn(fn() -> ! {sleep}) -> (!, !) {call_twice::<!, fn() -> ! {sleep}>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {call_twice::<!, [fn item {sleep}: fn() -> !]>}: fn([fn item {sleep}: fn() -> !]) -> (!, !)], val: Value(<ZST>) }
 -                                          // mir::Constant
                                            // + span: $DIR/inline-diverging.rs:22:16: 22:21
-                                           // + literal: Const { ty: fn() -> ! {sleep}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {sleep}: fn() -> !], val: Value(<ZST>) }
 +         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:+6:9: +6:10
 +         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14
 +         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:+6:13: +6:14

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -43,7 +43,7 @@
 -         _4 = g() -> bb1;                 // scope 0 at $DIR/inline-generator.rs:+1:28: +1:31
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-generator.rs:9:28: 9:29
--                                          // + literal: Const { ty: fn() -> impl Generator<bool> {g}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {g}: fn() -> impl Generator<bool>], val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {
@@ -54,7 +54,7 @@
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-generator.rs:9:14: 9:22
 -                                          // + user_ty: UserType(0)
--                                          // + literal: Const { ty: fn(&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]) -> Pin<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]> {Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>::new}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>::new}: fn(&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]) -> Pin<&mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>], val: Value(<ZST>) }
 -     }
 - 
 -     bb2: {
@@ -70,7 +70,7 @@
 -         _1 = <[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-generator.rs:9:33: 9:39
--                                          // + literal: Const { ty: for<'r> fn(Pin<&'r mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>, bool) -> GeneratorState<<[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::Yield, <[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::Return> {<[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::resume}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {<[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::resume}: for<'r> fn(Pin<&'r mut [generator@$DIR/inline-generator.rs:15:5: 15:8]>, bool) -> GeneratorState<<[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::Yield, <[generator@$DIR/inline-generator.rs:15:5: 15:8] as Generator<bool>>::Return>], val: Value(<ZST>) }
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 +         _7 = const false;                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 +         StorageLive(_10);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46

--- a/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
@@ -14,7 +14,7 @@
           _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:51:5: 51:24
-                                           // + literal: Const { ty: fn() {instruction_set_a32}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {instruction_set_a32}: fn()], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -23,7 +23,7 @@
           _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:52:5: 52:24
-                                           // + literal: Const { ty: fn() {instruction_set_t32}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {instruction_set_t32}: fn()], val: Value(<ZST>) }
       }
   
       bb2: {
@@ -32,7 +32,7 @@
 -         _3 = instruction_set_default() -> bb3; // scope 0 at $DIR/inline-instruction-set.rs:+3:5: +3:30
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-instruction-set.rs:53:5: 53:28
--                                          // + literal: Const { ty: fn() {instruction_set_default}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {instruction_set_default}: fn()], val: Value(<ZST>) }
 -     }
 - 
 -     bb3: {

--- a/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
@@ -14,7 +14,7 @@
           _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:+1:5: +1:26
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:42:5: 42:24
-                                           // + literal: Const { ty: fn() {instruction_set_a32}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {instruction_set_a32}: fn()], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -23,7 +23,7 @@
 -         _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:+2:5: +2:26
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-instruction-set.rs:43:5: 43:24
--                                          // + literal: Const { ty: fn() {instruction_set_t32}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {instruction_set_t32}: fn()], val: Value(<ZST>) }
 -     }
 - 
 -     bb2: {
@@ -33,7 +33,7 @@
 +         _3 = instruction_set_default() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:+5:5: +5:30
                                            // mir::Constant
                                            // + span: $DIR/inline-instruction-set.rs:46:5: 46:28
-                                           // + literal: Const { ty: fn() {instruction_set_default}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {instruction_set_default}: fn()], val: Value(<ZST>) }
       }
   
 -     bb3: {

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -28,7 +28,7 @@
           _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
                                            // mir::Constant
                                            // + span: $DIR/inline-into-box-place.rs:8:29: 8:43
-                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -44,7 +44,7 @@
                                            // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
--                                          // + literal: Const { ty: fn() -> Vec<u32> {Vec::<u32>::new}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {Vec::<u32>::new}: fn() -> Vec<u32>], val: Value(<ZST>) }
 -     }
 - 
 -     bb2: {
@@ -75,7 +75,7 @@
 -         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb5; // scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
--                                          // + literal: Const { ty: unsafe fn(Unique<Vec<u32>>, std::alloc::Global) {alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>}: unsafe fn(Unique<Vec<u32>>, std::alloc::Global)], val: Value(<ZST>) }
 -     }
 - 
 -     bb5 (cleanup): {

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -28,7 +28,7 @@
           _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:+1:29: +1:43
                                            // mir::Constant
                                            // + span: $DIR/inline-into-box-place.rs:8:29: 8:43
-                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -44,7 +44,7 @@
                                            // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
--                                          // + literal: Const { ty: fn() -> Vec<u32> {Vec::<u32>::new}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {Vec::<u32>::new}: fn() -> Vec<u32>], val: Value(<ZST>) }
 -     }
 - 
 -     bb2: {
@@ -75,7 +75,7 @@
 -         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb5; // scope 0 at $DIR/inline-into-box-place.rs:+1:42: +1:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
--                                          // + literal: Const { ty: unsafe fn(Unique<Vec<u32>>, std::alloc::Global) {alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>}: unsafe fn(Unique<Vec<u32>>, std::alloc::Global)], val: Value(<ZST>) }
 -     }
 - 
 -     bb5 (cleanup): {

--- a/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
@@ -15,7 +15,7 @@ fn main() -> () {
         _1 = not_inlined() -> bb1;       // scope 0 at $DIR/inline-options.rs:+1:5: +1:18
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:9:5: 9:16
-                                         // + literal: Const { ty: fn() {not_inlined}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {not_inlined}: fn()], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -25,7 +25,7 @@ fn main() -> () {
         _3 = g() -> bb2;                 // scope 1 at $DIR/inline-options.rs:+8:23: +8:26
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:23: 16:24
-                                         // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {g}: fn()], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -34,7 +34,7 @@ fn main() -> () {
         _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:+8:28: +8:31
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:28: 16:29
-                                         // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {g}: fn()], val: Value(<ZST>) }
     }
 
     bb3: {
@@ -43,7 +43,7 @@ fn main() -> () {
         _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:+8:33: +8:36
                                          // mir::Constant
                                          // + span: $DIR/inline-options.rs:16:33: 16:34
-                                         // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {g}: fn()], val: Value(<ZST>) }
     }
 
     bb4: {

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -2,8 +2,8 @@
 
 fn bar() -> bool {
     let mut _0: bool;                    // return place in scope 0 at $DIR/inline-retag.rs:+0:13: +0:17
-    let _1: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}; // in scope 0 at $DIR/inline-retag.rs:+1:9: +1:10
-    let mut _2: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}; // in scope 0 at $DIR/inline-retag.rs:+2:5: +2:6
+    let _1: [fn item {foo}: for<'r, 's> fn(&'r i32, &'s i32) -> bool]; // in scope 0 at $DIR/inline-retag.rs:+1:9: +1:10
+    let mut _2: [fn item {foo}: for<'r, 's> fn(&'r i32, &'s i32) -> bool]; // in scope 0 at $DIR/inline-retag.rs:+2:5: +2:6
     let mut _3: &i32;                    // in scope 0 at $DIR/inline-retag.rs:+2:7: +2:9
     let _4: &i32;                        // in scope 0 at $DIR/inline-retag.rs:+2:7: +2:9
     let _5: i32;                         // in scope 0 at $DIR/inline-retag.rs:+2:8: +2:9
@@ -27,7 +27,7 @@ fn bar() -> bool {
         _1 = foo;                        // scope 0 at $DIR/inline-retag.rs:+1:13: +1:16
                                          // mir::Constant
                                          // + span: $DIR/inline-retag.rs:11:13: 11:16
-                                         // + literal: Const { ty: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {foo}: for<'r, 's> fn(&'r i32, &'s i32) -> bool], val: Value(<ZST>) }
         StorageLive(_2);                 // scope 1 at $DIR/inline-retag.rs:+2:5: +2:6
         _2 = _1;                         // scope 1 at $DIR/inline-retag.rs:+2:5: +2:6
         StorageLive(_3);                 // scope 1 at $DIR/inline-retag.rs:+2:7: +2:9

--- a/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
@@ -14,7 +14,7 @@
 -         _0 = <fn(A, B) as Clone>::clone(move _2) -> bb1; // scope 0 at $DIR/inline-shims.rs:+1:5: +1:14
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-shims.rs:6:7: 6:12
--                                          // + literal: Const { ty: for<'r> fn(&'r fn(A, B)) -> fn(A, B) {<fn(A, B) as Clone>::clone}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {<fn(A, B) as Clone>::clone}: for<'r> fn(&'r fn(A, B)) -> fn(A, B)], val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
@@ -24,7 +24,7 @@
           _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> bb1; // scope 1 at $DIR/inline-shims.rs:+1:14: +1:40
                                            // mir::Constant
                                            // + span: $DIR/inline-shims.rs:11:14: 11:37
-                                           // + literal: Const { ty: unsafe fn(*mut Vec<A>) {std::ptr::drop_in_place::<Vec<A>>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {std::ptr::drop_in_place::<Vec<A>>}: unsafe fn(*mut Vec<A>)], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -35,7 +35,7 @@
 -         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> bb2; // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-shims.rs:12:14: 12:37
--                                          // + literal: Const { ty: unsafe fn(*mut Option<B>) {std::ptr::drop_in_place::<Option<B>>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {std::ptr::drop_in_place::<Option<B>>}: unsafe fn(*mut Option<B>)], val: Value(<ZST>) }
 +         StorageLive(_6);                 // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
 +         StorageLive(_7);                 // scope 2 at $DIR/inline-shims.rs:+2:14: +2:40
 +         _6 = discriminant((*_5));        // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -15,7 +15,7 @@
 -         _1 = <Vec<()> as Foo>::bar() -> bb1; // scope 0 at $DIR/inline-specialization.rs:+1:13: +1:38
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-specialization.rs:5:13: 5:36
--                                          // + literal: Const { ty: fn() -> u32 {<Vec<()> as Foo>::bar}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {<Vec<()> as Foo>::bar}: fn() -> u32], val: Value(<ZST>) }
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
@@ -11,7 +11,7 @@ fn test(_1: &dyn X) -> u32 {
         _0 = <dyn X as X>::y(move _2) -> bb1; // scope 0 at $DIR/inline-trait-method.rs:+1:5: +1:10
                                          // mir::Constant
                                          // + span: $DIR/inline-trait-method.rs:9:7: 9:8
-                                         // + literal: Const { ty: for<'r> fn(&'r dyn X) -> u32 {<dyn X as X>::y}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<dyn X as X>::y}: for<'r> fn(&'r dyn X) -> u32], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -21,7 +21,7 @@ fn test2(_1: &dyn X) -> bool {
         _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:+6:5: +6:10
                                          // mir::Constant
                                          // + span: $DIR/inline-trait-method_2.rs:10:7: 10:8
-                                         // + literal: Const { ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<dyn X as X>::y}: for<'r> fn(&'r dyn X) -> bool], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
@@ -5,10 +5,10 @@
       debug _baz => _1;                    // in scope 0 at $DIR/issue-78442.rs:+2:5: +2:9
       let mut _0: ();                      // return place in scope 0 at $DIR/issue-78442.rs:+3:3: +3:3
       let _2: ();                          // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
-      let mut _3: &fn() {foo};             // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
-      let _4: fn() {foo};                  // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+      let mut _3: &[fn item {foo}: fn()];  // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
+      let _4: [fn item {foo}: fn()];       // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
       let mut _5: ();                      // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
-+     scope 1 (inlined <fn() {foo} as Fn<()>>::call - shim(fn() {foo})) { // at $DIR/issue-78442.rs:11:5: 11:17
++     scope 1 (inlined <[fn item {foo}: fn()] as Fn<()>>::call - shim([fn item {foo}: fn()])) { // at $DIR/issue-78442.rs:11:5: 11:17
 +     }
   
       bb0: {
@@ -19,17 +19,17 @@
 +         _4 = hide_foo() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
                                            // mir::Constant
                                            // + span: $DIR/issue-78442.rs:11:5: 11:13
-                                           // + literal: Const { ty: fn() -> impl Fn() {hide_foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {hide_foo}: fn() -> impl Fn()], val: Value(<ZST>) }
       }
   
       bb1: {
           _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
           StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
           Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
--         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
+-         _2 = <[fn item {foo}: fn()] as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
 -                                          // mir::Constant
 -                                          // + span: $DIR/issue-78442.rs:11:5: 11:15
--                                          // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r fn() {foo}, ()) -> <fn() {foo} as FnOnce<()>>::Output {<fn() {foo} as Fn<()>>::call}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {<[fn item {foo}: fn()] as Fn<()>>::call}: for<'r> extern "rust-call" fn(&'r [fn item {foo}: fn()], ()) -> <[fn item {foo}: fn()] as FnOnce<()>>::Output], val: Value(<ZST>) }
 +         _2 = move (*_3)() -> [return: bb5, unwind: bb3]; // scope 1 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   

--- a/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
@@ -7,8 +7,8 @@
       let _2: ();                          // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
 -     let mut _3: &impl Fn();              // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
 -     let _4: impl Fn();                   // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
-+     let mut _3: &fn() {foo};             // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
-+     let _4: fn() {foo};                  // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
++     let mut _3: &[fn item {foo}: fn()];  // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
++     let _4: [fn item {foo}: fn()];       // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
       let mut _5: ();                      // in scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
   
       bb0: {
@@ -18,7 +18,7 @@
           _4 = hide_foo() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:15
                                            // mir::Constant
                                            // + span: $DIR/issue-78442.rs:11:5: 11:13
-                                           // + literal: Const { ty: fn() -> impl Fn() {hide_foo}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {hide_foo}: fn() -> impl Fn()], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -26,11 +26,11 @@
           StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
           Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
 -         _2 = <impl Fn() as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
-+         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
++         _2 = <[fn item {foo}: fn()] as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:+4:5: +4:17
                                            // mir::Constant
                                            // + span: $DIR/issue-78442.rs:11:5: 11:15
--                                          // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as FnOnce<()>>::Output {<impl Fn() as Fn<()>>::call}, val: Value(<ZST>) }
-+                                          // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r fn() {foo}, ()) -> <fn() {foo} as FnOnce<()>>::Output {<fn() {foo} as Fn<()>>::call}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {<impl Fn() as Fn<()>>::call}: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as FnOnce<()>>::Output], val: Value(<ZST>) }
++                                          // + literal: Const { ty: [fn item {<[fn item {foo}: fn()] as Fn<()>>::call}: for<'r> extern "rust-call" fn(&'r [fn item {foo}: fn()], ()) -> <[fn item {foo}: fn()] as FnOnce<()>>::Output], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
@@ -23,7 +23,7 @@ fn main() -> () {
         _3 = S::id(move _4) -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:+1:21: +1:27
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:23: 8:25
-                                         // + literal: Const { ty: fn(S) -> S {S::id}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {S::id}: fn(S) -> S], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -32,7 +32,7 @@ fn main() -> () {
         _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-41110.rs:+1:13: +1:28
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:15: 8:20
-                                         // + literal: Const { ty: fn(S, S) {S::other}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {S::other}: fn(S, S)], val: Value(<ZST>) }
     }
 
     bb2: {

--- a/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
@@ -28,7 +28,7 @@ fn test() -> () {
         _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7]; // scope 2 at $DIR/issue-41110.rs:+3:5: +3:12
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:17:5: 17:9
-                                         // + literal: Const { ty: fn(S) {std::mem::drop::<S>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {std::mem::drop::<S>}: fn(S)], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -29,7 +29,7 @@ fn main() -> () {
         _2 = cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue-41888.rs:+2:8: +2:14
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:8:8: 8:12
-                                         // + literal: Const { ty: fn() -> bool {cond}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {cond}: fn() -> bool], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/issue_49232.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_49232.main.mir_map.0.mir
@@ -59,7 +59,7 @@ fn main() -> () {
         _5 = std::mem::drop::<&i32>(move _6) -> [return: bb9, unwind: bb11]; // scope 1 at $DIR/issue-49232.rs:+8:9: +8:22
                                          // mir::Constant
                                          // + span: $DIR/issue-49232.rs:13:9: 13:13
-                                         // + literal: Const { ty: fn(&i32) {std::mem::drop::<&i32>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {std::mem::drop::<&i32>}: fn(&i32)], val: Value(<ZST>) }
     }
 
     bb9: {

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -34,7 +34,7 @@ fn test() -> Option<Box<u32>> {
         _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 1 at $DIR/issue-62289.rs:+1:10: +1:21
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:10: 9:21
-                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -46,7 +46,7 @@ fn test() -> Option<Box<u32>> {
         _6 = <Option<u32> as Try>::branch(move _7) -> [return: bb2, unwind: bb12]; // scope 0 at $DIR/issue-62289.rs:+1:15: +1:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
-                                         // + literal: Const { ty: fn(Option<u32>) -> ControlFlow<<Option<u32> as Try>::Residual, <Option<u32> as Try>::Output> {<Option<u32> as Try>::branch}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<Option<u32> as Try>::branch}: fn(Option<u32>) -> ControlFlow<<Option<u32> as Try>::Residual, <Option<u32> as Try>::Output>], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -76,7 +76,7 @@ fn test() -> Option<Box<u32>> {
         _0 = <Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _11) -> [return: bb6, unwind: bb12]; // scope 3 at $DIR/issue-62289.rs:+1:15: +1:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:19: 9:20
-                                         // + literal: Const { ty: fn(Option<Infallible>) -> Option<Box<u32>> {<Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual}: fn(Option<Infallible>) -> Option<Box<u32>>], val: Value(<ZST>) }
     }
 
     bb6: {

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
@@ -25,7 +25,7 @@ fn main() -> () {
         _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
-                                         // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {std::mem::size_of::<Foo>}: fn() -> usize], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
@@ -25,7 +25,7 @@ fn main() -> () {
         _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:+1:13: +1:34
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
-                                         // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {std::mem::size_of::<Foo>}: fn() -> usize], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
@@ -24,7 +24,7 @@ fn main() -> () {
         _2 = transmute::<(), Void>(move _3) -> bb4; // scope 2 at $DIR/issue-72181-1.rs:+2:9: +2:44
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:17:9: 17:40
-                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(()) -> Void {transmute::<(), Void>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {transmute::<(), Void>}: unsafe extern "rust-intrinsic" fn(()) -> Void], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -37,7 +37,7 @@ fn main() -> () {
         _4 = f(move _5) -> bb4;          // scope 1 at $DIR/issue-72181-1.rs:+5:5: +5:9
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:20:5: 20:6
-                                         // + literal: Const { ty: fn(Void) -> ! {f}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {f}: fn(Void) -> !], val: Value(<ZST>) }
     }
 
     bb2: {

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -98,7 +98,7 @@
           _14 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {core::panicking::assert_failed::<i32, i32>}: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> !], val: Value(<ZST>) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -98,7 +98,7 @@
           _14 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {core::panicking::assert_failed::<i32, i32>}: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> !], val: Value(<ZST>) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -135,7 +135,7 @@
           _21 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _23, move _25, move _27); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {core::panicking::assert_failed::<i32, i32>}: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> !], val: Value(<ZST>) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -135,7 +135,7 @@
           _21 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _23, move _25, move _27); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {core::panicking::assert_failed::<i32, i32>}: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> !], val: Value(<ZST>) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -70,7 +70,7 @@
           _22 = core::panicking::panic(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/panic.rs:LL:COL
-                                           // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {core::panicking::panic}: fn(&'static str) -> !], val: Value(<ZST>) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/panic.rs:LL:COL
                                            // + literal: Const { ty: &str, val: Value(Slice(..)) }

--- a/src/test/mir-opt/issue_99325.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_99325.main.mir_map.0.mir
@@ -1,8 +1,8 @@
 // MIR for `main` 0 mir_map
 
 | User Type Annotations
-| 0: user_ty: Canonical { max_universe: U0, variables: [], value: TypeOf(DefId(0:3 ~ issue_99325[8f58]::function_with_bytes), UserSubsts { substs: [Const { ty: &'static [u8; 4], kind: Value(Branch([Leaf(0x41), Leaf(0x41), Leaf(0x41), Leaf(0x41)])) }], user_self_ty: None }) }, span: $DIR/issue-99325.rs:10:16: 10:46, inferred_ty: fn() -> &'static [u8] {function_with_bytes::<&*b"AAAA">}
-| 1: user_ty: Canonical { max_universe: U0, variables: [], value: TypeOf(DefId(0:3 ~ issue_99325[8f58]::function_with_bytes), UserSubsts { substs: [Const { ty: &'static [u8; 4], kind: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:8 ~ issue_99325[8f58]::main::{constant#1}), const_param_did: Some(DefId(0:4 ~ issue_99325[8f58]::function_with_bytes::BYTES)) }, substs: [], promoted: None }) }], user_self_ty: None }) }, span: $DIR/issue-99325.rs:11:16: 11:68, inferred_ty: fn() -> &'static [u8] {function_with_bytes::<&*b"AAAA">}
+| 0: user_ty: Canonical { max_universe: U0, variables: [], value: TypeOf(DefId(0:3 ~ issue_99325[8f58]::function_with_bytes), UserSubsts { substs: [Const { ty: &'static [u8; 4], kind: Value(Branch([Leaf(0x41), Leaf(0x41), Leaf(0x41), Leaf(0x41)])) }], user_self_ty: None }) }, span: $DIR/issue-99325.rs:10:16: 10:46, inferred_ty: [fn item {function_with_bytes::<&*b"AAAA">}: fn() -> &'static [u8]]
+| 1: user_ty: Canonical { max_universe: U0, variables: [], value: TypeOf(DefId(0:3 ~ issue_99325[8f58]::function_with_bytes), UserSubsts { substs: [Const { ty: &'static [u8; 4], kind: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:8 ~ issue_99325[8f58]::main::{constant#1}), const_param_did: Some(DefId(0:4 ~ issue_99325[8f58]::function_with_bytes::BYTES)) }, substs: [], promoted: None }) }], user_self_ty: None }) }, span: $DIR/issue-99325.rs:11:16: 11:68, inferred_ty: [fn item {function_with_bytes::<&*b"AAAA">}: fn() -> &'static [u8]]
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/issue-99325.rs:+0:15: +0:15
@@ -73,7 +73,7 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-99325.rs:10:16: 10:46
                                          // + user_ty: UserType(0)
-                                         // + literal: Const { ty: fn() -> &'static [u8] {function_with_bytes::<&*b"AAAA">}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {function_with_bytes::<&*b"AAAA">}: fn() -> &'static [u8]], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -101,7 +101,7 @@ fn main() -> () {
         _11 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _12, move _13) -> [return: bb2, unwind: bb19]; // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r, 's> fn(&'r &[u8], &'s &[u8; 4]) -> bool {<&[u8] as PartialEq<&[u8; 4]>>::eq}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<&[u8] as PartialEq<&[u8; 4]>>::eq}: for<'r, 's> fn(&'r &[u8], &'s &[u8; 4]) -> bool], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -132,7 +132,7 @@ fn main() -> () {
         _16 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _17, move _18, move _20, move _22) -> bb19; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r &[u8], &'s &[u8; 4], Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {core::panicking::assert_failed::<&[u8], &[u8; 4]>}: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r &[u8], &'s &[u8; 4], Option<Arguments<'t0>>) -> !], val: Value(<ZST>) }
     }
 
     bb4: {
@@ -181,7 +181,7 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-99325.rs:11:16: 11:68
                                          // + user_ty: UserType(1)
-                                         // + literal: Const { ty: fn() -> &'static [u8] {function_with_bytes::<&*b"AAAA">}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {function_with_bytes::<&*b"AAAA">}: fn() -> &'static [u8]], val: Value(<ZST>) }
     }
 
     bb10: {
@@ -210,7 +210,7 @@ fn main() -> () {
         _32 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _33, move _34) -> [return: bb11, unwind: bb19]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r, 's> fn(&'r &[u8], &'s &[u8; 4]) -> bool {<&[u8] as PartialEq<&[u8; 4]>>::eq}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<&[u8] as PartialEq<&[u8; 4]>>::eq}: for<'r, 's> fn(&'r &[u8], &'s &[u8; 4]) -> bool], val: Value(<ZST>) }
     }
 
     bb11: {
@@ -241,7 +241,7 @@ fn main() -> () {
         _37 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _38, move _39, move _41, move _43) -> bb19; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r &[u8], &'s &[u8; 4], Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<&[u8], &[u8; 4]>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {core::panicking::assert_failed::<&[u8], &[u8; 4]>}: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r &[u8], &'s &[u8; 4], Option<Arguments<'t0>>) -> !], val: Value(<ZST>) }
     }
 
     bb13: {

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -39,7 +39,7 @@ fn num_to_digit(_1: char) -> u32 {
         _7 = char::methods::<impl char>::to_digit(move _8, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
-                                         // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {char::methods::<impl char>::to_digit}: fn(char, u32) -> Option<u32>], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -50,7 +50,7 @@ fn num_to_digit(_1: char) -> u32 {
         _3 = char::methods::<impl char>::to_digit(move _4, const 8_u32) -> bb2; // scope 0 at $DIR/issue-59352.rs:+2:26: +2:41
                                          // mir::Constant
                                          // + span: $DIR/issue-59352.rs:14:30: 14:38
-                                         // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {char::methods::<impl char>::to_digit}: fn(char, u32) -> Option<u32>], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -90,7 +90,7 @@ fn num_to_digit(_1: char) -> u32 {
         _11 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL
-                                         // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {core::panicking::panic}: fn(&'static str) -> !], val: Value(<ZST>) }
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -27,7 +27,7 @@
           _2 = transmute::<[u8; 16], [u32; 4]>(move _3) -> bb1; // scope 2 at $DIR/issue-75439.rs:+2:37: +2:53
                                            // mir::Constant
                                            // + span: $DIR/issue-75439.rs:7:37: 7:46
-                                           // + literal: Const { ty: unsafe extern "rust-intrinsic" fn([u8; 16]) -> [u32; 4] {transmute::<[u8; 16], [u32; 4]>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {transmute::<[u8; 16], [u32; 4]>}: unsafe extern "rust-intrinsic" fn([u8; 16]) -> [u32; 4]], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -50,7 +50,7 @@
           _5 = transmute::<u32, [u8; 4]>(move _6) -> bb7; // scope 4 at $DIR/issue-75439.rs:+5:23: +5:36
                                            // mir::Constant
                                            // + span: $DIR/issue-75439.rs:10:23: 10:32
-                                           // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u32) -> [u8; 4] {transmute::<u32, [u8; 4]>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {transmute::<u32, [u8; 4]>}: unsafe extern "rust-intrinsic" fn(u32) -> [u8; 4]], val: Value(<ZST>) }
       }
   
       bb5: {

--- a/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
@@ -8,7 +8,7 @@
 -         _0 = std::intrinsics::min_align_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:42
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:19:5: 19:40
--                                          // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::min_align_of::<T>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {std::intrinsics::min_align_of::<T>}: extern "rust-intrinsic" fn() -> usize], val: Value(<ZST>) }
 +         _0 = AlignOf(T);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:42
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:42
       }

--- a/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
@@ -32,7 +32,7 @@
 -         _2 = discriminant_value::<T>(move _3) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:74:5: 74:41
--                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r T) -> <T as DiscriminantKind>::Discriminant {discriminant_value::<T>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {discriminant_value::<T>}: for<'r> extern "rust-intrinsic" fn(&'r T) -> <T as DiscriminantKind>::Discriminant], val: Value(<ZST>) }
 +         _2 = discriminant((*_3));        // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:45
       }
@@ -53,7 +53,7 @@
 -         _5 = discriminant_value::<i32>(move _6) -> bb2; // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:75:5: 75:41
--                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r i32) -> <i32 as DiscriminantKind>::Discriminant {discriminant_value::<i32>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {discriminant_value::<i32>}: for<'r> extern "rust-intrinsic" fn(&'r i32) -> <i32 as DiscriminantKind>::Discriminant], val: Value(<ZST>) }
 +         _5 = discriminant((*_6));        // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
 +         goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
       }
@@ -74,7 +74,7 @@
 -         _9 = discriminant_value::<()>(move _10) -> bb3; // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:76:5: 76:41
--                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r ()) -> <() as DiscriminantKind>::Discriminant {discriminant_value::<()>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {discriminant_value::<()>}: for<'r> extern "rust-intrinsic" fn(&'r ()) -> <() as DiscriminantKind>::Discriminant], val: Value(<ZST>) }
 +         _9 = discriminant((*_10));       // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
 +         goto -> bb3;                     // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
       }
@@ -95,7 +95,7 @@
 -         _13 = discriminant_value::<E>(move _14) -> bb4; // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:77:5: 77:41
--                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r E) -> <E as DiscriminantKind>::Discriminant {discriminant_value::<E>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {discriminant_value::<E>}: for<'r> extern "rust-intrinsic" fn(&'r E) -> <E as DiscriminantKind>::Discriminant], val: Value(<ZST>) }
 +         _13 = discriminant((*_14));      // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
 +         goto -> bb4;                     // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48
       }

--- a/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
@@ -20,7 +20,7 @@ fn f_u64() -> () {
         _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:+9:9: +9:21
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics.rs:48:9: 48:18
-                                         // + literal: Const { ty: fn(u64) {f_non_zst::<u64>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {f_non_zst::<u64>}: fn(u64)], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
@@ -18,7 +18,7 @@ fn f_unit() -> () {
         _2 = f_zst::<()>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:+13:9: +13:17
                                          // mir::Constant
                                          // + span: $DIR/lower_intrinsics.rs:46:9: 46:14
-                                         // + literal: Const { ty: fn(()) {f_zst::<()>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {f_zst::<()>}: fn(())], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
@@ -12,7 +12,7 @@
 -         _0 = std::intrinsics::forget::<T>(move _2) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:32
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:24:5: 24:29
--                                          // + literal: Const { ty: extern "rust-intrinsic" fn(T) {std::intrinsics::forget::<T>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {std::intrinsics::forget::<T>}: extern "rust-intrinsic" fn(T)], val: Value(<ZST>) }
 +         _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:32
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:32
       }

--- a/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
@@ -3,8 +3,8 @@
   
   fn non_const() -> usize {
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:26: +0:31
-      let _1: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:+2:9: +2:18
-      let mut _2: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:14
+      let _1: [fn item {std::intrinsics::size_of::<T>}: extern "rust-intrinsic" fn() -> usize]; // in scope 0 at $DIR/lower_intrinsics.rs:+2:9: +2:18
+      let mut _2: [fn item {std::intrinsics::size_of::<T>}: extern "rust-intrinsic" fn() -> usize]; // in scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:14
       scope 1 {
           debug size_of_t => _1;           // in scope 1 at $DIR/lower_intrinsics.rs:+2:9: +2:18
       }
@@ -14,7 +14,7 @@
           _1 = std::intrinsics::size_of::<T>; // scope 0 at $DIR/lower_intrinsics.rs:+2:21: +2:51
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:62:21: 62:51
-                                           // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {std::intrinsics::size_of::<T>}: extern "rust-intrinsic" fn() -> usize], val: Value(<ZST>) }
           StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:14
           _2 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:14
 -         _0 = move _2() -> bb1;           // scope 1 at $DIR/lower_intrinsics.rs:+3:5: +3:16

--- a/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
@@ -8,7 +8,7 @@
 -         _0 = std::intrinsics::size_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:37
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:14:5: 14:35
--                                          // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {std::intrinsics::size_of::<T>}: extern "rust-intrinsic" fn() -> usize], val: Value(<ZST>) }
 +         _0 = SizeOf(T);                  // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:37
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:37
       }

--- a/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
@@ -15,7 +15,7 @@
 -         _3 = std::intrinsics::unreachable(); // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:45
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:29:14: 29:43
--                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn() -> ! {std::intrinsics::unreachable}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {std::intrinsics::unreachable}: unsafe extern "rust-intrinsic" fn() -> !], val: Value(<ZST>) }
 +         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:45
       }
   

--- a/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
@@ -33,7 +33,7 @@
 -         _3 = wrapping_add::<i32>(move _4, move _5) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:50
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:7:14: 7:44
--                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> i32 {wrapping_add::<i32>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {wrapping_add::<i32>}: extern "rust-intrinsic" fn(i32, i32) -> i32], val: Value(<ZST>) }
 +         _3 = Add(move _4, move _5);      // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:50
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:14: +1:50
       }
@@ -49,7 +49,7 @@
 -         _6 = wrapping_sub::<i32>(move _7, move _8) -> bb2; // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:50
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:8:14: 8:44
--                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> i32 {wrapping_sub::<i32>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {wrapping_sub::<i32>}: extern "rust-intrinsic" fn(i32, i32) -> i32], val: Value(<ZST>) }
 +         _6 = Sub(move _7, move _8);      // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:50
 +         goto -> bb2;                     // scope 1 at $DIR/lower_intrinsics.rs:+2:14: +2:50
       }
@@ -65,7 +65,7 @@
 -         _9 = wrapping_mul::<i32>(move _10, move _11) -> bb3; // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:50
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:9:14: 9:44
--                                          // + literal: Const { ty: extern "rust-intrinsic" fn(i32, i32) -> i32 {wrapping_mul::<i32>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {wrapping_mul::<i32>}: extern "rust-intrinsic" fn(i32, i32) -> i32], val: Value(<ZST>) }
 +         _9 = Mul(move _10, move _11);    // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:50
 +         goto -> bb3;                     // scope 2 at $DIR/lower_intrinsics.rs:+3:14: +3:50
       }

--- a/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
+++ b/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
@@ -23,7 +23,7 @@
 -         _5 = core::slice::<impl [u8]>::len(move _6) -> bb1; // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_slice_len.rs:5:22: 5:25
--                                          // + literal: Const { ty: for<'r> fn(&'r [u8]) -> usize {core::slice::<impl [u8]>::len}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: [fn item {core::slice::<impl [u8]>::len}: for<'r> fn(&'r [u8]) -> usize], val: Value(<ZST>) }
 +         _5 = Len((*_6));                 // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
 +         goto -> bb1;                     // scope 0 at $DIR/lower_slice_len.rs:+1:16: +1:27
       }

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -61,7 +61,7 @@ fn full_tested_match() -> () {
         _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:14:20: 14:25
-                                         // + literal: Const { ty: fn() -> bool {guard}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {guard}: fn() -> bool], val: Value(<ZST>) }
     }
 
     bb6: {

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -62,7 +62,7 @@ fn full_tested_match2() -> () {
         _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:+2:20: +2:27
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:25:20: 25:25
-                                         // + literal: Const { ty: fn() -> bool {guard}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {guard}: fn() -> bool], val: Value(<ZST>) }
     }
 
     bb6: {

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -70,7 +70,7 @@ fn main() -> () {
         _8 = guard() -> [return: bb6, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:+2:21: +2:28
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:34:21: 34:26
-                                         // + literal: Const { ty: fn() -> bool {guard}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {guard}: fn() -> bool], val: Value(<ZST>) }
     }
 
     bb6: {
@@ -113,7 +113,7 @@ fn main() -> () {
         _12 = guard2(move _13) -> [return: bb11, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:+4:20: +4:29
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:36:20: 36:26
-                                         // + literal: Const { ty: fn(i32) -> bool {guard2}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {guard2}: fn(i32) -> bool], val: Value(<ZST>) }
     }
 
     bb11: {

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -70,10 +70,10 @@ fn main() -> () {
         StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
         StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
         _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
-        _8 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
+        _8 = ConstValue(ZeroSized: [fn item {use_x}: fn(usize) -> bool])(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
-                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {use_x}: fn(usize) -> bool], val: Value(<ZST>) }
     }
 
     bb3: {
@@ -85,10 +85,10 @@ fn main() -> () {
 
     bb4: {
         StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
-        _10 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x00000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
+        _10 = ConstValue(ZeroSized: [fn item {use_x}: fn(usize) -> bool])(const ConstValue(Scalar(0x00000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
-                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {use_x}: fn(usize) -> bool], val: Value(<ZST>) }
     }
 
     bb5: {

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -70,10 +70,10 @@ fn main() -> () {
         StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
         StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
         _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:+5:15: +5:17
-        _8 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
+        _8 = ConstValue(ZeroSized: [fn item {use_x}: fn(usize) -> bool])(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:+5:9: +5:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
-                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {use_x}: fn(usize) -> bool], val: Value(<ZST>) }
     }
 
     bb3: {
@@ -85,10 +85,10 @@ fn main() -> () {
 
     bb4: {
         StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
-        _10 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x0000000000000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
+        _10 = ConstValue(ZeroSized: [fn item {use_x}: fn(usize) -> bool])(const ConstValue(Scalar(0x0000000000000016): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:+7:9: +7:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
-                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {use_x}: fn(usize) -> bool], val: Value(<ZST>) }
     }
 
     bb5: {

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -23,7 +23,7 @@ fn unwrap(_1: Option<T>) -> T {
         _4 = begin_panic::<&str>(const "explicit panic") -> bb4; // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
-                                         // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {begin_panic::<&str>}: fn(&str) -> !], val: Value(<ZST>) }
                                          // mir::Constant
                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }

--- a/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
@@ -20,7 +20,7 @@ fn main() -> () {
         _2 = <str as ToString>::to_string(move _3) -> bb1; // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:20: +1:34
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:23: 9:32
-                                         // + literal: Const { ty: for<'r> fn(&'r str) -> String {<str as ToString>::to_string}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<str as ToString>::to_string}: for<'r> fn(&'r str) -> String], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -28,7 +28,7 @@ fn main() -> () {
         _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:+1:5: +1:35
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:5: 9:19
-                                         // + literal: Const { ty: fn(String) {std::mem::drop::<String>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {std::mem::drop::<String>}: fn(String)], val: Value(<ZST>) }
     }
 
     bb2: {

--- a/src/test/mir-opt/receiver_ptr_mutability.main.mir_map.0.mir
+++ b/src/test/mir-opt/receiver_ptr_mutability.main.mir_map.0.mir
@@ -32,7 +32,7 @@ fn main() -> () {
         _1 = null_mut::<Test>() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/receiver-ptr-mutability.rs:+1:26: +1:46
                                          // mir::Constant
                                          // + span: $DIR/receiver-ptr-mutability.rs:14:26: 14:44
-                                         // + literal: Const { ty: fn() -> *mut Test {null_mut::<Test>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {null_mut::<Test>}: fn() -> *mut Test], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -47,7 +47,7 @@ fn main() -> () {
         _2 = Test::x(move _3) -> [return: bb2, unwind: bb4]; // scope 1 at $DIR/receiver-ptr-mutability.rs:+2:5: +2:12
                                          // mir::Constant
                                          // + span: $DIR/receiver-ptr-mutability.rs:15:9: 15:10
-                                         // + literal: Const { ty: fn(*const Test) {Test::x}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {Test::x}: fn(*const Test)], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -75,7 +75,7 @@ fn main() -> () {
         _10 = Test::x(move _11) -> [return: bb3, unwind: bb4]; // scope 2 at $DIR/receiver-ptr-mutability.rs:+6:5: +6:16
                                          // mir::Constant
                                          // + span: $DIR/receiver-ptr-mutability.rs:19:13: 19:14
-                                         // + literal: Const { ty: fn(*const Test) {Test::x}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {Test::x}: fn(*const Test)], val: Value(<ZST>) }
     }
 
     bb3: {

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -60,7 +60,7 @@
           _7 = <std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next(move _14) -> bb4; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                           // + literal: Const { ty: for<'r> fn(&'r mut std::ops::Range<i32>) -> Option<<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::Item> {<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next}: for<'r> fn(&'r mut std::ops::Range<i32>) -> Option<<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::Item>], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -81,7 +81,7 @@ fn array_casts() -> () {
         _6 = ptr::mut_ptr::<impl *mut usize>::add(move _7, const 1_usize) -> bb1; // scope 3 at $DIR/retag.rs:+3:15: +3:23
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:60:17: 60:20
-                                         // + literal: Const { ty: unsafe fn(*mut usize, usize) -> *mut usize {ptr::mut_ptr::<impl *mut usize>::add}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {ptr::mut_ptr::<impl *mut usize>::add}: unsafe fn(*mut usize, usize) -> *mut usize], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -112,7 +112,7 @@ fn array_casts() -> () {
         _16 = ptr::const_ptr::<impl *const usize>::add(move _17, const 1_usize) -> bb2; // scope 6 at $DIR/retag.rs:+7:26: +7:34
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:64:28: 64:31
-                                         // + literal: Const { ty: unsafe fn(*const usize, usize) -> *const usize {ptr::const_ptr::<impl *const usize>::add}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {ptr::const_ptr::<impl *const usize>::add}: unsafe fn(*const usize, usize) -> *const usize], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -176,7 +176,7 @@ fn array_casts() -> () {
         _28 = core::panicking::assert_failed::<usize, usize>(move _29, move _30, move _32, move _34); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r usize, &'s usize, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {core::panicking::assert_failed::<usize, usize>}: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r usize, &'s usize, Option<Arguments<'t0>>) -> !], val: Value(<ZST>) }
     }
 
     bb4: {

--- a/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
+++ b/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
@@ -11,7 +11,7 @@ fn std::ptr::drop_in_place(_1: *mut Test) -> () {
         _3 = <Test as Drop>::drop(move _2) -> bb1; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r> fn(&'r mut Test) {<Test as Drop>::drop}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<Test as Drop>::drop}: for<'r> fn(&'r mut Test)], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -74,7 +74,7 @@ fn main() -> () {
         _3 = Test::foo(move _4, move _6) -> [return: bb1, unwind: bb8]; // scope 1 at $DIR/retag.rs:+3:17: +3:36
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:32:25: 32:28
-                                         // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {Test::foo}: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -159,7 +159,7 @@ fn main() -> () {
         _19 = Test::foo_shr(move _20, move _22) -> [return: bb4, unwind: bb7]; // scope 7 at $DIR/retag.rs:+18:5: +18:24
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:47:13: 47:20
-                                         // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {Test::foo_shr}: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32], val: Value(<ZST>) }
     }
 
     bb4: {
@@ -183,7 +183,7 @@ fn main() -> () {
         _27 = array_casts() -> bb6;      // scope 8 at $DIR/retag.rs:+23:5: +23:18
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:52:5: 52:16
-                                         // + literal: Const { ty: fn() {array_casts}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {array_casts}: fn()], val: Value(<ZST>) }
     }
 
     bb6: {

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
@@ -21,7 +21,7 @@
 +         _2 = bar() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:9:12: 9:15
-                                           // + literal: Const { ty: fn() -> bool {bar}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {bar}: fn() -> bool], val: Value(<ZST>) }
       }
   
 -     bb3: {

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -22,7 +22,7 @@
 +         _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:+2:12: +2:17
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:9:12: 9:15
-                                           // + literal: Const { ty: fn() -> bool {bar}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {bar}: fn() -> bool], val: Value(<ZST>) }
       }
   
       bb3: {

--- a/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
+++ b/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
@@ -18,7 +18,7 @@
           _2 = noop() -> bb2;              // scope 0 at $DIR/simplify_if.rs:+2:9: +2:15
                                            // mir::Constant
                                            // + span: $DIR/simplify_if.rs:7:9: 7:13
-                                           // + literal: Const { ty: fn() {noop}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {noop}: fn()], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -39,7 +39,7 @@
 +         _1 = use_zst(move _2) -> bb1;    // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+2:5: +2:22
                                            // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:12
-                                           // + literal: Const { ty: fn(((), ())) {use_zst}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {use_zst}: fn(((), ()))], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -57,7 +57,7 @@
 +         _3 = use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:+4:5: +4:35
                                            // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:11
-                                           // + literal: Const { ty: fn(u8) {use_u8}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {use_u8}: fn(u8)], val: Value(<ZST>) }
       }
   
       bb2: {

--- a/src/test/mir-opt/simplify_match.main.ConstProp.diff
+++ b/src/test/mir-opt/simplify_match.main.ConstProp.diff
@@ -29,7 +29,7 @@
           _0 = noop() -> bb3;              // scope 0 at $DIR/simplify_match.rs:+2:17: +2:23
                                            // mir::Constant
                                            // + span: $DIR/simplify_match.rs:7:17: 7:21
-                                           // + literal: Const { ty: fn() {noop}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {noop}: fn()], val: Value(<ZST>) }
       }
   
       bb3: {

--- a/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
@@ -33,7 +33,7 @@ fn move_out_by_subslice() -> () {
         _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:11:14: 11:19
-                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -52,7 +52,7 @@ fn move_out_by_subslice() -> () {
         _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:11:21: 11:26
-                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
     }
 
     bb3: {

--- a/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
@@ -33,7 +33,7 @@ fn move_out_from_end() -> () {
         _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:+1:14: +1:19
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:5:14: 5:19
-                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
     }
 
     bb1: {
@@ -52,7 +52,7 @@ fn move_out_from_end() -> () {
         _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:5:21: 5:26
-                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {alloc::alloc::exchange_malloc}: unsafe fn(usize, usize) -> *mut u8], val: Value(<ZST>) }
     }
 
     bb3: {

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -22,7 +22,7 @@
           _1 = empty() -> bb1;             // scope 1 at $DIR/unreachable.rs:+1:23: +1:30
                                            // mir::Constant
                                            // + span: $DIR/unreachable.rs:9:23: 9:28
-                                           // + literal: Const { ty: fn() -> Option<Empty> {empty}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {empty}: fn() -> Option<Empty>], val: Value(<ZST>) }
       }
   
       bb1: {

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -24,7 +24,7 @@
           _2 = empty() -> bb1;             // scope 2 at $DIR/unreachable_diverging.rs:+2:25: +2:32
                                            // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:14:25: 14:30
-                                           // + literal: Const { ty: fn() -> Option<Empty> {empty}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {empty}: fn() -> Option<Empty>], val: Value(<ZST>) }
       }
   
       bb1: {
@@ -48,7 +48,7 @@
 +         _5 = loop_forever() -> bb4;      // scope 2 at $DIR/unreachable_diverging.rs:+4:13: +4:27
                                            // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:16:13: 16:25
-                                           // + literal: Const { ty: fn() {loop_forever}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: [fn item {loop_forever}: fn()], val: Value(<ZST>) }
       }
   
       bb4: {

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
@@ -34,6 +34,6 @@ fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
         _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r> fn(&'r mut Vec<i32>) {<Vec<i32> as Drop>::drop}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<Vec<i32> as Drop>::drop}: for<'r> fn(&'r mut Vec<i32>)], val: Value(<ZST>) }
     }
 }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
@@ -34,6 +34,6 @@ fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
         _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r> fn(&'r mut Vec<i32>) {<Vec<i32> as Drop>::drop}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {<Vec<i32> as Drop>::drop}: for<'r> fn(&'r mut Vec<i32>)], val: Value(<ZST>) }
     }
 }

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -19,7 +19,7 @@ fn while_loop(_1: bool) -> () {
         _2 = get_bool(move _3) -> bb2;   // scope 0 at $DIR/while-storage.rs:+1:11: +1:22
                                          // mir::Constant
                                          // + span: $DIR/while-storage.rs:10:11: 10:19
-                                         // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {get_bool}: fn(bool) -> bool], val: Value(<ZST>) }
     }
 
     bb2: {
@@ -34,7 +34,7 @@ fn while_loop(_1: bool) -> () {
         _4 = get_bool(move _5) -> bb4;   // scope 0 at $DIR/while-storage.rs:+2:12: +2:23
                                          // mir::Constant
                                          // + span: $DIR/while-storage.rs:11:12: 11:20
-                                         // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {get_bool}: fn(bool) -> bool], val: Value(<ZST>) }
     }
 
     bb4: {

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -32,9 +32,9 @@ fn bar() ({
         ({
                 let res =
                     ((::alloc::fmt::format as
-                            for<'r> fn(Arguments<'r>) -> String {format})(((::core::fmt::Arguments::new_v1
+                            [fn item {format}: for<'r> fn(Arguments<'r>) -> String])(((::core::fmt::Arguments::new_v1
                                 as
-                                fn(&[&'static str], &[ArgumentV1]) -> Arguments {Arguments::new_v1})((&([("test"
+                                [fn item {Arguments::new_v1}: fn(&[&'static str], &[ArgumentV1]) -> Arguments])((&([("test"
                                             as &str)] as [&str; 1]) as &[&str; 1]),
                             (&([] as [ArgumentV1; 0]) as &[ArgumentV1; 0])) as
                             Arguments)) as String);
@@ -51,7 +51,7 @@ fn id<T>(x: T) -> T ({ (x as T) } as T)
 fn use_id() ({
         let _ =
             ((id::<[i32; (3 as usize)]> as
-                    fn([i32; 3]) -> [i32; 3] {id::<[i32; 3]>})(([(1 as i32),
-                        (2 as i32), (3 as i32)] as [i32; 3])) as [i32; 3]);
+                    [fn item {id::<[i32; 3]>}: fn([i32; 3]) -> [i32; 3]])(([(1
+                            as i32), (2 as i32), (3 as i32)] as [i32; 3])) as [i32; 3]);
     } as ())
 fn main() ({ } as ())

--- a/src/test/run-make/const_fn_mir/dump.mir
+++ b/src/test/run-make/const_fn_mir/dump.mir
@@ -33,7 +33,7 @@ fn main() -> () {
         _1 = foo() -> bb1;               // scope 0 at main.rs:9:5: 9:10
                                          // mir::Constant
                                          // + span: main.rs:9:5: 9:8
-                                         // + literal: Const { ty: fn() -> i32 {foo}, val: Value(<ZST>) }
+                                         // + literal: Const { ty: [fn item {foo}: fn() -> i32], val: Value(<ZST>) }
     }
 
     bb1: {

--- a/src/test/ui/asm/x86_64/type-check-2.rs
+++ b/src/test/ui/asm/x86_64/type-check-2.rs
@@ -64,7 +64,7 @@ fn main() {
         let mut r = &mut 0;
         asm!("{}", in(reg) f);
         asm!("{}", inout(reg) f);
-        //~^ ERROR cannot use value of type `fn() {main}` for inline assembly
+        //~^ ERROR cannot use value of type `[fn item {main}: fn()]` for inline assembly
         asm!("{}", in(reg) r);
         asm!("{}", inout(reg) r);
         //~^ ERROR cannot use value of type `&mut i32` for inline assembly

--- a/src/test/ui/asm/x86_64/type-check-2.stderr
+++ b/src/test/ui/asm/x86_64/type-check-2.stderr
@@ -63,7 +63,7 @@ LL |         asm!("{}", in(reg) [1, 2, 3]);
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
-error: cannot use value of type `fn() {main}` for inline assembly
+error: cannot use value of type `[fn item {main}: fn()]` for inline assembly
   --> $DIR/type-check-2.rs:66:31
    |
 LL |         asm!("{}", inout(reg) f);

--- a/src/test/ui/associated-types/substs-ppaux.normal.stderr
+++ b/src/test/ui/associated-types/substs-ppaux.normal.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>} defined here
+   |     --------------------------- [fn item {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}: fn()] defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -10,7 +10,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
+                found fn item `[fn item {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>();
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>} defined here
+   |     --------------------------- [fn item {<i8 as Foo<'static, 'static>>::bar::<'static, char>}: fn()] defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -28,7 +28,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
+                found fn item `[fn item {<i8 as Foo<'static, 'static>>::bar::<'static, char>}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>();
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
 LL |     fn baz() {}
-   |     -------- fn() {<i8 as Foo<'static, 'static, u8>>::baz} defined here
+   |     -------- [fn item {<i8 as Foo<'static, 'static, u8>>::baz}: fn()] defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -46,7 +46,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
+                found fn item `[fn item {<i8 as Foo<'static, 'static, u8>>::baz}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz();
@@ -56,7 +56,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
 LL | fn foo<'z>() where &'z (): Sized {
-   | -------------------------------- fn() {foo::<'static>} defined here
+   | -------------------------------- [fn item {foo::<'static>}: fn()] defined here
 ...
 LL |     let x: () = foo::<'static>;
    |            --   ^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -64,7 +64,7 @@ LL |     let x: () = foo::<'static>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {foo::<'static>}`
+                found fn item `[fn item {foo::<'static>}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = foo::<'static>();

--- a/src/test/ui/associated-types/substs-ppaux.rs
+++ b/src/test/ui/associated-types/substs-ppaux.rs
@@ -16,35 +16,35 @@ fn foo<'z>() where &'z (): Sized {
     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
+    //[verbose]~| found fn item `[fn item {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}: fn()]`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
+    //[normal]~| found fn item `[fn item {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}: fn()]`
 
 
     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
+    //[verbose]~| found fn item `[fn item {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}: fn()]`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
+    //[normal]~| found fn item `[fn item {<i8 as Foo<'static, 'static>>::bar::<'static, char>}: fn()]`
 
     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
+    //[verbose]~| found fn item `[fn item {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}: fn()]`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
+    //[normal]~| found fn item `[fn item {<i8 as Foo<'static, 'static, u8>>::baz}: fn()]`
 
     let x: () = foo::<'static>;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {foo::<ReStatic>}`
+    //[verbose]~| found fn item `[fn item {foo::<ReStatic>}: fn()]`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {foo::<'static>}`
+    //[normal]~| found fn item `[fn item {foo::<'static>}: fn()]`
 
     <str as Foo<u8>>::bar;
     //[verbose]~^ ERROR the size for values of type

--- a/src/test/ui/associated-types/substs-ppaux.verbose.stderr
+++ b/src/test/ui/associated-types/substs-ppaux.verbose.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>} defined here
+   |     --------------------------- [fn item {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}: fn()] defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -10,7 +10,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
+                found fn item `[fn item {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>();
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>} defined here
+   |     --------------------------- [fn item {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}: fn()] defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -28,7 +28,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
+                found fn item `[fn item {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>();
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
 LL |     fn baz() {}
-   |     -------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz} defined here
+   |     -------- [fn item {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}: fn()] defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -46,7 +46,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
+                found fn item `[fn item {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz();
@@ -56,7 +56,7 @@ error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
 LL | fn foo<'z>() where &'z (): Sized {
-   | -------------------------------- fn() {foo::<ReStatic>} defined here
+   | -------------------------------- [fn item {foo::<ReStatic>}: fn()] defined here
 ...
 LL |     let x: () = foo::<'static>;
    |            --   ^^^^^^^^^^^^^^ expected `()`, found fn item
@@ -64,7 +64,7 @@ LL |     let x: () = foo::<'static>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {foo::<ReStatic>}`
+                found fn item `[fn item {foo::<ReStatic>}: fn()]`
 help: use parentheses to call this function
    |
 LL |     let x: () = foo::<'static>();

--- a/src/test/ui/binop/issue-77910-1.rs
+++ b/src/test/ui/binop/issue-77910-1.rs
@@ -7,5 +7,5 @@ fn main() {
     // we shouldn't ice with the bound var here.
     assert_eq!(foo, y);
     //~^ ERROR binary operation `==` cannot be applied to type
-    //~| ERROR `for<'r> fn(&'r i32) -> &'r i32 {foo}` doesn't implement `Debug`
+    //~| ERROR `[fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]` doesn't implement `Debug`
 }

--- a/src/test/ui/binop/issue-77910-1.stderr
+++ b/src/test/ui/binop/issue-77910-1.stderr
@@ -1,24 +1,24 @@
-error[E0369]: binary operation `==` cannot be applied to type `for<'r> fn(&'r i32) -> &'r i32 {foo}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]`
   --> $DIR/issue-77910-1.rs:8:5
    |
 LL |     assert_eq!(foo, y);
    |     ^^^^^^^^^^^^^^^^^^
    |     |
-   |     for<'r> fn(&'r i32) -> &'r i32 {foo}
+   |     [fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]
    |     _
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `for<'r> fn(&'r i32) -> &'r i32 {foo}` doesn't implement `Debug`
+error[E0277]: `[fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]` doesn't implement `Debug`
   --> $DIR/issue-77910-1.rs:8:5
    |
 LL | fn foo(s: &i32) -> &i32 {
    |    --- consider calling this function
 ...
 LL |     assert_eq!(foo, y);
-   |     ^^^^^^^^^^^^^^^^^^ `for<'r> fn(&'r i32) -> &'r i32 {foo}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^ `[fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for `for<'r> fn(&'r i32) -> &'r i32 {foo}`
+   = help: the trait `Debug` is not implemented for `[fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]`
    = help: use parentheses to call the function: `foo(s)`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/binop/issue-77910-2.stderr
+++ b/src/test/ui/binop/issue-77910-2.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `for<'r> fn(&'r i32) -> &'r i32 {foo}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]`
   --> $DIR/issue-77910-2.rs:7:12
    |
 LL |     if foo == y {}
    |        --- ^^ - _
    |        |
-   |        for<'r> fn(&'r i32) -> &'r i32 {foo}
+   |        [fn item {foo}: for<'r> fn(&'r i32) -> &'r i32]
 
 error: aborting due to previous error
 

--- a/src/test/ui/c-variadic/issue-32201.rs
+++ b/src/test/ui/c-variadic/issue-32201.rs
@@ -7,7 +7,7 @@ fn bar(_: *const u8) {}
 fn main() {
     unsafe {
         foo(0, bar);
-        //~^ ERROR can't pass `fn(*const u8) {bar}` to variadic function
+        //~^ ERROR can't pass `[fn item {bar}: fn(*const u8)]` to variadic function
         //~| HELP cast the value to `fn(*const u8)`
     }
 }

--- a/src/test/ui/c-variadic/issue-32201.stderr
+++ b/src/test/ui/c-variadic/issue-32201.stderr
@@ -1,4 +1,4 @@
-error[E0617]: can't pass `fn(*const u8) {bar}` to variadic function
+error[E0617]: can't pass `[fn item {bar}: fn(*const u8)]` to variadic function
   --> $DIR/issue-32201.rs:9:16
    |
 LL |         foo(0, bar);

--- a/src/test/ui/c-variadic/variadic-ffi-1.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-1.stderr
@@ -45,7 +45,7 @@ LL |         let x: unsafe extern "C" fn(f: isize, x: u8) = foo;
    |                expected due to this
    |
    = note: expected fn pointer `unsafe extern "C" fn(_, _)`
-                 found fn item `unsafe extern "C" fn(_, _, ...) {foo}`
+                 found fn item `[fn item {foo}: unsafe extern "C" fn(_, _, ...)]`
 
 error[E0308]: mismatched types
   --> $DIR/variadic-ffi-1.rs:24:54
@@ -56,7 +56,7 @@ LL |         let y: extern "C" fn(f: isize, x: u8, ...) = bar;
    |                expected due to this
    |
    = note: expected fn pointer `extern "C" fn(_, _, ...)`
-                 found fn item `extern "C" fn(_, _) {bar}`
+                 found fn item `[fn item {bar}: extern "C" fn(_, _)]`
 
 error[E0617]: can't pass `f32` to variadic function
   --> $DIR/variadic-ffi-1.rs:26:19

--- a/src/test/ui/cast/cast-to-bare-fn.stderr
+++ b/src/test/ui/cast/cast-to-bare-fn.stderr
@@ -1,4 +1,4 @@
-error[E0605]: non-primitive cast: `fn(isize) {foo}` as `extern "C" fn() -> isize`
+error[E0605]: non-primitive cast: `[fn item {foo}: fn(isize)]` as `extern "C" fn() -> isize`
   --> $DIR/cast-to-bare-fn.rs:5:13
    |
 LL |     let x = foo as extern "C" fn() -> isize;

--- a/src/test/ui/closures/closure_cap_coerce_many_fail.stderr
+++ b/src/test/ui/closures/closure_cap_coerce_many_fail.stderr
@@ -4,14 +4,14 @@ error[E0308]: `match` arms have incompatible types
 LL |       let _ = match "+" {
    |  _____________-
 LL | |         "+" => add,
-   | |                --- this is found to be of type `fn(i32, i32) -> i32 {add}`
+   | |                --- this is found to be of type `[fn item {add}: fn(i32, i32) -> i32]`
 LL | |         "-" => |a, b| (a - b + cap) as i32,
    | |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn item, found closure
 LL | |         _ => unimplemented!(),
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected fn item `fn(i32, i32) -> i32 {add}`
+   = note: expected fn item `[fn item {add}: fn(i32, i32) -> i32]`
               found closure `[closure@$DIR/closure_cap_coerce_many_fail.rs:9:16: 9:22]`
 
 error[E0308]: `match` arms have incompatible types

--- a/src/test/ui/closures/coerce-unsafe-to-closure.stderr
+++ b/src/test/ui/closures/coerce-unsafe-to-closure.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[fn item {transmute::<_, _>}: unsafe extern "rust-intrinsic" fn(_) -> _]`
   --> $DIR/coerce-unsafe-to-closure.rs:2:44
    |
 LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);
@@ -6,7 +6,7 @@ LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);
    |                                        |
    |                                        required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<(&str,)>` is not implemented for `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+   = help: the trait `FnOnce<(&str,)>` is not implemented for `[fn item {transmute::<_, _>}: unsafe extern "rust-intrinsic" fn(_) -> _]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `Option::<T>::map`
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/src/test/ui/const-generics/generic_const_exprs/eval-privacy.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/eval-privacy.stderr
@@ -1,11 +1,11 @@
-error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+error[E0446]: private type `[fn item {my_const_fn}: fn(u8) -> u8]` in public interface
   --> $DIR/eval-privacy.rs:16:5
    |
 LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   | ----------------------------------- `[fn item {my_const_fn}: fn(u8) -> u8]` declared as private
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-float-bits-reject-conv.stderr
+++ b/src/test/ui/consts/const-float-bits-reject-conv.stderr
@@ -13,12 +13,12 @@ LL |         unsafe { intrinsics::const_eval_select((self,), ct_f32_to_u32, rt_f
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL |     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
-   |     ------------------------------------------------------------------ inside `<fn(f32) -> u32 {core::f32::<impl f32>::to_bits::ct_f32_to_u32} as FnOnce<(f32,)>>::call_once - shim(fn(f32) -> u32 {core::f32::<impl f32>::to_bits::ct_f32_to_u32})` at $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |     ------------------------------------------------------------------ inside `<[fn item {core::f32::<impl f32>::to_bits::ct_f32_to_u32}: fn(f32) -> u32] as FnOnce<(f32,)>>::call_once - shim([fn item {core::f32::<impl f32>::to_bits::ct_f32_to_u32}: fn(f32) -> u32])` at $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
   ::: $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
 LL |     called_in_const.call_once(arg)
-   |     ------------------------------ inside `const_eval_select::<(f32,), fn(f32) -> u32 {core::f32::<impl f32>::to_bits::ct_f32_to_u32}, [closure@core::f32::<impl f32>::to_bits::{closure#0}], u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |     ------------------------------ inside `const_eval_select::<(f32,), [fn item {core::f32::<impl f32>::to_bits::ct_f32_to_u32}: fn(f32) -> u32], [closure@core::f32::<impl f32>::to_bits::{closure#0}], u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
   ::: $DIR/const-float-bits-reject-conv.rs:27:30
    |
@@ -42,12 +42,12 @@ LL |         unsafe { intrinsics::const_eval_select((self,), ct_f32_to_u32, rt_f
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL |     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
-   |     ------------------------------------------------------------------ inside `<fn(f32) -> u32 {core::f32::<impl f32>::to_bits::ct_f32_to_u32} as FnOnce<(f32,)>>::call_once - shim(fn(f32) -> u32 {core::f32::<impl f32>::to_bits::ct_f32_to_u32})` at $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |     ------------------------------------------------------------------ inside `<[fn item {core::f32::<impl f32>::to_bits::ct_f32_to_u32}: fn(f32) -> u32] as FnOnce<(f32,)>>::call_once - shim([fn item {core::f32::<impl f32>::to_bits::ct_f32_to_u32}: fn(f32) -> u32])` at $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
   ::: $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
 LL |     called_in_const.call_once(arg)
-   |     ------------------------------ inside `const_eval_select::<(f32,), fn(f32) -> u32 {core::f32::<impl f32>::to_bits::ct_f32_to_u32}, [closure@core::f32::<impl f32>::to_bits::{closure#0}], u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |     ------------------------------ inside `const_eval_select::<(f32,), [fn item {core::f32::<impl f32>::to_bits::ct_f32_to_u32}: fn(f32) -> u32], [closure@core::f32::<impl f32>::to_bits::{closure#0}], u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
   ::: $DIR/const-float-bits-reject-conv.rs:28:30
    |
@@ -120,12 +120,12 @@ LL |         unsafe { intrinsics::const_eval_select((self,), ct_f64_to_u64, rt_f
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL |     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
-   |     ------------------------------------------------------------------ inside `<fn(f64) -> u64 {core::f64::<impl f64>::to_bits::ct_f64_to_u64} as FnOnce<(f64,)>>::call_once - shim(fn(f64) -> u64 {core::f64::<impl f64>::to_bits::ct_f64_to_u64})` at $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |     ------------------------------------------------------------------ inside `<[fn item {core::f64::<impl f64>::to_bits::ct_f64_to_u64}: fn(f64) -> u64] as FnOnce<(f64,)>>::call_once - shim([fn item {core::f64::<impl f64>::to_bits::ct_f64_to_u64}: fn(f64) -> u64])` at $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
   ::: $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
 LL |     called_in_const.call_once(arg)
-   |     ------------------------------ inside `const_eval_select::<(f64,), fn(f64) -> u64 {core::f64::<impl f64>::to_bits::ct_f64_to_u64}, [closure@core::f64::<impl f64>::to_bits::{closure#0}], u64>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |     ------------------------------ inside `const_eval_select::<(f64,), [fn item {core::f64::<impl f64>::to_bits::ct_f64_to_u64}: fn(f64) -> u64], [closure@core::f64::<impl f64>::to_bits::{closure#0}], u64>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
   ::: $DIR/const-float-bits-reject-conv.rs:54:30
    |
@@ -149,12 +149,12 @@ LL |         unsafe { intrinsics::const_eval_select((self,), ct_f64_to_u64, rt_f
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL |     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
-   |     ------------------------------------------------------------------ inside `<fn(f64) -> u64 {core::f64::<impl f64>::to_bits::ct_f64_to_u64} as FnOnce<(f64,)>>::call_once - shim(fn(f64) -> u64 {core::f64::<impl f64>::to_bits::ct_f64_to_u64})` at $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |     ------------------------------------------------------------------ inside `<[fn item {core::f64::<impl f64>::to_bits::ct_f64_to_u64}: fn(f64) -> u64] as FnOnce<(f64,)>>::call_once - shim([fn item {core::f64::<impl f64>::to_bits::ct_f64_to_u64}: fn(f64) -> u64])` at $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
   ::: $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
 LL |     called_in_const.call_once(arg)
-   |     ------------------------------ inside `const_eval_select::<(f64,), fn(f64) -> u64 {core::f64::<impl f64>::to_bits::ct_f64_to_u64}, [closure@core::f64::<impl f64>::to_bits::{closure#0}], u64>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |     ------------------------------ inside `const_eval_select::<(f64,), [fn item {core::f64::<impl f64>::to_bits::ct_f64_to_u64}: fn(f64) -> u64], [closure@core::f64::<impl f64>::to_bits::{closure#0}], u64>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
   ::: $DIR/const-float-bits-reject-conv.rs:55:30
    |

--- a/src/test/ui/error-codes/E0617.rs
+++ b/src/test/ui/error-codes/E0617.rs
@@ -20,7 +20,7 @@ fn main() {
         //~^ ERROR can't pass `u16` to variadic function
         //~| HELP cast the value to `c_uint`
         printf(::std::ptr::null(), printf);
-        //~^ ERROR can't pass `unsafe extern "C" fn(*const i8, ...) {printf}` to variadic function
+        //~^ ERROR can't pass `[fn item {printf}: unsafe extern "C" fn(*const i8, ...)]` to variadic function
         //~| HELP cast the value to `unsafe extern "C" fn(*const i8, ...)`
     }
 }

--- a/src/test/ui/error-codes/E0617.stderr
+++ b/src/test/ui/error-codes/E0617.stderr
@@ -28,7 +28,7 @@ error[E0617]: can't pass `u16` to variadic function
 LL |         printf(::std::ptr::null(), 0u16);
    |                                    ^^^^ help: cast the value to `c_uint`: `0u16 as c_uint`
 
-error[E0617]: can't pass `unsafe extern "C" fn(*const i8, ...) {printf}` to variadic function
+error[E0617]: can't pass `[fn item {printf}: unsafe extern "C" fn(*const i8, ...)]` to variadic function
   --> $DIR/E0617.rs:22:36
    |
 LL |         printf(::std::ptr::null(), printf);

--- a/src/test/ui/expr/if/if-typeck.stderr
+++ b/src/test/ui/expr/if/if-typeck.stderr
@@ -5,7 +5,7 @@ LL |     if f { }
    |        ^ expected `bool`, found fn item
    |
    = note: expected type `bool`
-           found fn item `fn() {f}`
+           found fn item `[fn item {f}: fn()]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/extern/extern-wrong-value-type.rs
+++ b/src/test/ui/extern/extern-wrong-value-type.rs
@@ -7,5 +7,5 @@ fn main() {
     // extern functions are extern "C" fn
     let _x: extern "C" fn() = f; // OK
     is_fn(f);
-    //~^ ERROR expected a `Fn<()>` closure, found `extern "C" fn() {f}`
+    //~^ ERROR expected a `Fn<()>` closure, found `[fn item {f}: extern "C" fn()]`
 }

--- a/src/test/ui/extern/extern-wrong-value-type.stderr
+++ b/src/test/ui/extern/extern-wrong-value-type.stderr
@@ -1,13 +1,13 @@
-error[E0277]: expected a `Fn<()>` closure, found `extern "C" fn() {f}`
+error[E0277]: expected a `Fn<()>` closure, found `[fn item {f}: extern "C" fn()]`
   --> $DIR/extern-wrong-value-type.rs:9:11
    |
 LL |     is_fn(f);
-   |     ----- ^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
+   |     ----- ^ expected an `Fn<()>` closure, found `[fn item {f}: extern "C" fn()]`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for `extern "C" fn() {f}`
-   = note: wrap the `extern "C" fn() {f}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `Fn<()>` is not implemented for `[fn item {f}: extern "C" fn()]`
+   = note: wrap the `[fn item {f}: extern "C" fn()]` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `is_fn`
   --> $DIR/extern-wrong-value-type.rs:4:28
    |

--- a/src/test/ui/fn/fn-compare-mismatch.stderr
+++ b/src/test/ui/fn/fn-compare-mismatch.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `fn() {f}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {f}: fn()]`
   --> $DIR/fn-compare-mismatch.rs:4:15
    |
 LL |     let x = f == g;
-   |             - ^^ - fn() {g}
+   |             - ^^ - [fn item {g}: fn()]
    |             |
-   |             fn() {f}
+   |             [fn item {f}: fn()]
    |
 help: you might have forgotten to call this function
    |
@@ -21,8 +21,8 @@ error[E0308]: mismatched types
 LL |     let x = f == g;
    |                  ^ expected fn item, found a different fn item
    |
-   = note: expected fn item `fn() {f}`
-              found fn item `fn() {g}`
+   = note: expected fn item `[fn item {f}: fn()]`
+              found fn item `[fn item {g}: fn()]`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/fn/fn-item-type.rs
+++ b/src/test/ui/fn/fn-item-type.rs
@@ -12,8 +12,8 @@ impl<T> Foo for T { /* `foo` is still default here */ }
 fn main() {
     eq(foo::<u8>, bar::<u8>);
     //~^ ERROR mismatched types
-    //~| expected fn item `fn(_) -> _ {foo::<u8>}`
-    //~| found fn item `fn(_) -> _ {bar::<u8>}`
+    //~| expected fn item `[fn item {foo::<u8>}: fn(_) -> _]`
+    //~| found fn item `[fn item {bar::<u8>}: fn(_) -> _]`
     //~| expected fn item, found a different fn item
     //~| different `fn` items always have unique types, even if their signatures are the same
     //~| change the expected type to be function pointer
@@ -28,7 +28,7 @@ fn main() {
 
     eq(bar::<String>, bar::<Vec<u8>>);
     //~^ ERROR mismatched types
-    //~| found fn item `fn(_) -> _ {bar::<Vec<u8>>}`
+    //~| found fn item `[fn item {bar::<Vec<u8>>}: fn(_) -> _]`
     //~| expected struct `String`, found struct `Vec`
     //~| different `fn` items always have unique types, even if their signatures are the same
     //~| change the expected type to be function pointer

--- a/src/test/ui/fn/fn-item-type.stderr
+++ b/src/test/ui/fn/fn-item-type.stderr
@@ -6,8 +6,8 @@ LL |     eq(foo::<u8>, bar::<u8>);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected fn item `fn(_) -> _ {foo::<u8>}`
-              found fn item `fn(_) -> _ {bar::<u8>}`
+   = note: expected fn item `[fn item {foo::<u8>}: fn(_) -> _]`
+              found fn item `[fn item {bar::<u8>}: fn(_) -> _]`
    = note: different `fn` items always have unique types, even if their signatures are the same
    = help: change the expected type to be function pointer `fn(isize) -> isize`
    = help: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `foo::<u8> as fn(isize) -> isize`
@@ -25,8 +25,8 @@ LL |     eq(foo::<u8>, foo::<i8>);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected fn item `fn(_) -> _ {foo::<u8>}`
-              found fn item `fn(_) -> _ {foo::<i8>}`
+   = note: expected fn item `[fn item {foo::<u8>}: fn(_) -> _]`
+              found fn item `[fn item {foo::<i8>}: fn(_) -> _]`
    = note: different `fn` items always have unique types, even if their signatures are the same
    = help: change the expected type to be function pointer `fn(isize) -> isize`
    = help: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `foo::<u8> as fn(isize) -> isize`
@@ -44,8 +44,8 @@ LL |     eq(bar::<String>, bar::<Vec<u8>>);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected fn item `fn(_) -> _ {bar::<String>}`
-              found fn item `fn(_) -> _ {bar::<Vec<u8>>}`
+   = note: expected fn item `[fn item {bar::<String>}: fn(_) -> _]`
+              found fn item `[fn item {bar::<Vec<u8>>}: fn(_) -> _]`
    = note: different `fn` items always have unique types, even if their signatures are the same
    = help: change the expected type to be function pointer `fn(isize) -> isize`
    = help: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `bar::<String> as fn(isize) -> isize`
@@ -63,8 +63,8 @@ LL |     eq(<u8 as Foo>::foo, <u16 as Foo>::foo);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected fn item `fn() {<u8 as Foo>::foo}`
-              found fn item `fn() {<u16 as Foo>::foo}`
+   = note: expected fn item `[fn item {<u8 as Foo>::foo}: fn()]`
+              found fn item `[fn item {<u16 as Foo>::foo}: fn()]`
    = note: different `fn` items always have unique types, even if their signatures are the same
    = help: change the expected type to be function pointer `fn()`
    = help: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `<u8 as Foo>::foo as fn()`
@@ -82,7 +82,7 @@ LL |     eq(foo::<u8>, bar::<u8> as fn(isize) -> isize);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected fn item `fn(_) -> _ {foo::<u8>}`
+   = note: expected fn item `[fn item {foo::<u8>}: fn(_) -> _]`
            found fn pointer `fn(_) -> _`
    = help: change the expected type to be function pointer `fn(isize) -> isize`
    = help: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `foo::<u8> as fn(isize) -> isize`

--- a/src/test/ui/function-type-mismatch-color-highlights.rs
+++ b/src/test/ui/function-type-mismatch-color-highlights.rs
@@ -1,0 +1,49 @@
+// The .stderr file will contain the color highlighting in `mismatched types`
+// errors for function types and function pointers.
+//
+// If you want to view the .stderr file after changes occurred, there are extensions
+// for IDEs -- e.g. "ANSI Colors" for vscode -- to view ANSI-colored text properly.
+// Of course, alternatively, you can just view the file
+// `cat src/test/ui/function-type-mismatch-color-highlights.stderr`
+// and/or the `git diff` in a terminal that can render the colors for you.
+
+// compile-flags: --json=diagnostic-rendered-ansi
+
+fn main() {
+    fn f() {}
+    fn g() {}
+    fn g2() -> u8 {
+        0
+    }
+    fn g3(_: u8) {}
+
+    fn h<T>() {}
+    fn h2<T>(_: T) {}
+
+    struct Struct();
+
+    let mut x = f;
+    x = || (); //~ ERROR mismatched types [E0308]
+    x = (|| ()) as fn(); //~ ERROR mismatched types [E0308]
+    x = (|| 0) as fn() -> u8; //~ ERROR mismatched types [E0308]
+    x = (|_| ()) as fn(u8); //~ ERROR mismatched types [E0308]
+    x = g; //~ ERROR mismatched types [E0308]
+    x = g2; //~ ERROR mismatched types [E0308]
+    x = g3; //~ ERROR mismatched types [E0308]
+    x = Struct; //~ ERROR mismatched types [E0308]
+
+    let mut y = h::<()>;
+    y = h::<u8>; //~ ERROR mismatched types [E0308]
+
+    let mut y2 = h2::<()>;
+    y = h2::<u8>; //~ ERROR mismatched types [E0308]
+
+    let mut z = g3;
+    z = (|| ()) as fn(); //~ ERROR mismatched types [E0308]
+
+    let mut p = (|| ()) as fn();
+    p = (|| 0) as fn() -> u8; //~ ERROR mismatched types [E0308]
+    p = (|_| ()) as fn(u8); //~ ERROR mismatched types [E0308]
+    let _: fn() -> u8 = g3; //~ ERROR mismatched types [E0308]
+    let _: fn() -> u16 = g2; //~ ERROR mismatched types [E0308]
+}

--- a/src/test/ui/function-type-mismatch-color-highlights.stderr
+++ b/src/test/ui/function-type-mismatch-color-highlights.stderr
@@ -32,8 +32,8 @@
 [0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = (|| 0) as fn() -> u8;
 [0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found fn pointer[0m
 [0m   [0m[0m[1m[38;5;12m|[0m
-[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn[0m[0m[1m()[0m[0m]`[0m
-[0m           found fn pointer `fn[0m[0m[1m() -> u8[0m[0m`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn()]`[0m
+[0m           found fn pointer `fn()[0m[0m[1m -> u8[0m[0m`[0m
 
 [0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
 [0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:29:9[0m
@@ -44,8 +44,8 @@
 [0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = (|_| ()) as fn(u8);
 [0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found fn pointer[0m
 [0m   [0m[0m[1m[38;5;12m|[0m
-[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn[0m[0m[1m()[0m[0m]`[0m
-[0m           found fn pointer `fn[0m[0m[1m(u8)[0m[0m`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn()]`[0m
+[0m           found fn pointer `fn([0m[0m[1mu8[0m[0m)`[0m
 
 [0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
 [0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:30:9[0m
@@ -132,8 +132,8 @@
 [0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    z = (|| ()) as fn();
 [0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found fn pointer[0m
 [0m   [0m[0m[1m[38;5;12m|[0m
-[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mg3[0m[0m}: fn[0m[0m[1m(u8)[0m[0m]`[0m
-[0m           found fn pointer `fn[0m[0m[1m()[0m[0m`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mg3[0m[0m}: fn([0m[0m[1mu8[0m[0m)]`[0m
+[0m           found fn pointer `fn()`[0m
 
 [0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
 [0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:45:9[0m

--- a/src/test/ui/function-type-mismatch-color-highlights.stderr
+++ b/src/test/ui/function-type-mismatch-color-highlights.stderr
@@ -1,0 +1,180 @@
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:26:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = || ();
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found closure[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[0m[0m[1m[fn item {f}: fn()][0m[0m`[0m
+[0m              found closure `[0m[0m[1m[closure@$DIR/function-type-mismatch-color-highlights.rs:26:9: 26:11][0m[0m`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:27:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = || ();
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = (|| ()) as fn();
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found fn pointer[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn()]`[0m
+[0m           found fn pointer `fn()`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: change the expected type to be function pointer `fn()`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `f as fn()`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:28:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12m...[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = (|| 0) as fn() -> u8;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found fn pointer[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn[0m[0m[1m()[0m[0m]`[0m
+[0m           found fn pointer `fn[0m[0m[1m() -> u8[0m[0m`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:29:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12m...[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = (|_| ()) as fn(u8);
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found fn pointer[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn[0m[0m[1m()[0m[0m]`[0m
+[0m           found fn pointer `fn[0m[0m[1m(u8)[0m[0m`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:30:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12m...[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = g;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found a different fn item[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[fn item {[0m[0m[1mf[0m[0m}: fn()]`[0m
+[0m              found fn item `[fn item {[0m[0m[1mg[0m[0m}: fn()]`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: different `fn` items always have unique types, even if their signatures are the same[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: change the expected type to be function pointer `fn()`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `f as fn()`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:31:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12m...[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = g2;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found a different fn item[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[fn item {[0m[0m[1mf[0m[0m}: fn()]`[0m
+[0m              found fn item `[fn item {[0m[0m[1mg2[0m[0m}: fn()[0m[0m[1m -> u8[0m[0m]`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:32:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12m...[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = g3;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found a different fn item[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[fn item {[0m[0m[1mf[0m[0m}: fn()]`[0m
+[0m              found fn item `[fn item {[0m[0m[1mg3[0m[0m}: fn([0m[0m[1mu8[0m[0m)]`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:33:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut x = f;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12m...[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    x = Struct;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found a different fn item[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mf[0m[0m}: fn()]`[0m
+[0m              found fn item `[[0m[0m[1mconstructor of[0m[0m {[0m[0m[1mStruct[0m[0m}: fn()[0m[0m[1m -> Struct[0m[0m]`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:36:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut y = h::<()>;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-------[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    y = h::<u8>;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected `()`, found `u8`[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[fn item {[0m[0m[1mh::<()>[0m[0m}: fn()]`[0m
+[0m              found fn item `[fn item {[0m[0m[1mh::<u8>[0m[0m}: fn()]`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: different `fn` items always have unique types, even if their signatures are the same[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: change the expected type to be function pointer `fn()`[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mhelp[0m[0m: if the expected type is due to type inference, cast the expected `fn` to a function pointer: `h::<()> as fn()`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:39:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut y = h::<()>;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m-------[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12m...[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    y = h2::<u8>;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found a different fn item[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[fn item {[0m[0m[1mh::<()>[0m[0m}: fn()]`[0m
+[0m              found fn item `[fn item {[0m[0m[1mh2::<u8>[0m[0m}: fn([0m[0m[1mu8[0m[0m)]`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:42:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let mut z = g3;[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m                [0m[0m[1m[38;5;12m--[0m[0m [0m[0m[1m[38;5;12mexpected due to this value[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    z = (|| ()) as fn();
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected fn item, found fn pointer[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mg3[0m[0m}: fn[0m[0m[1m(u8)[0m[0m]`[0m
+[0m           found fn pointer `fn[0m[0m[1m()[0m[0m`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:45:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    p = (|| 0) as fn() -> u8;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mexpected `()`, found `u8`[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn pointer `fn()`[0m
+[0m              found fn pointer `fn()[0m[0m[1m -> u8[0m[0m`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:46:9[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    p = (|_| ()) as fn(u8);
+[0m   [0m[0m[1m[38;5;12m| [0m[0m        [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mincorrect number of function parameters[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn pointer `fn()`[0m
+[0m              found fn pointer `fn([0m[0m[1mu8[0m[0m)`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:47:25[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let _: fn() -> u8 = g3;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[38;5;12m----------[0m[0m   [0m[0m[1m[38;5;9m^^[0m[0m [0m[0m[1m[38;5;9mincorrect number of function parameters[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[38;5;12mexpected due to this[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn pointer `fn()[0m[0m[1m -> u8[0m[0m`[0m
+[0m                 found fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mg3[0m[0m}: fn([0m[0m[1mu8[0m[0m)]`[0m
+
+[0m[1m[38;5;9merror[E0308][0m[0m[1m: mismatched types[0m
+[0m  [0m[0m[1m[38;5;12m--> [0m[0m$DIR/function-type-mismatch-color-highlights.rs:48:26[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m[1m[38;5;12mLL[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    let _: fn() -> u16 = g2;
+[0m   [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[38;5;12m-----------[0m[0m   [0m[0m[1m[38;5;9m^^[0m[0m [0m[0m[1m[38;5;9mexpected `u16`, found `u8`[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[38;5;12mexpected due to this[0m
+[0m   [0m[0m[1m[38;5;12m|[0m
+[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: expected fn pointer `fn() -> [0m[0m[1mu16[0m[0m`[0m
+[0m                 found fn item `[[0m[0m[1mfn item[0m[0m {[0m[0m[1mg2[0m[0m}: fn() -> [0m[0m[1mu8[0m[0m]`[0m
+
+[0m[1m[38;5;9merror[0m[0m[1m: aborting due to 15 previous errors[0m
+
+[0m[1mFor more information about this error, try `rustc --explain E0308`.[0m

--- a/src/test/ui/hrtb/issue-30786.stderr
+++ b/src/test/ui/hrtb/issue-30786.stderr
@@ -23,7 +23,7 @@ help: one of the expressions' fields has a method of the same name
 LL |     let filter = map.stream.filterx(|x: &_| true);
    |                      +++++++
 
-error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>`, but its trait bounds were not satisfied
+error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, [fn item {identity::<u64>}: for<'r> fn(&'r u64) -> &'r u64]>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>`, but its trait bounds were not satisfied
   --> $DIR/issue-30786.rs:130:24
    |
 LL | pub struct Filter<S, F> {
@@ -33,12 +33,12 @@ LL | pub struct Filter<S, F> {
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let count = filter.countx();
-   |                        ^^^^^^ method cannot be called on `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>` due to unsatisfied trait bounds
+   |                        ^^^^^^ method cannot be called on `Filter<Map<Repeat, [fn item {identity::<u64>}: for<'r> fn(&'r u64) -> &'r u64]>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>` due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
-      `&'a mut &Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
-      `&'a mut &mut Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
-      `&'a mut Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
+      `&'a mut &Filter<Map<Repeat, [fn item {identity::<u64>}: for<'r> fn(&'r u64) -> &'r u64]>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
+      `&'a mut &mut Filter<Map<Repeat, [fn item {identity::<u64>}: for<'r> fn(&'r u64) -> &'r u64]>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
+      `&'a mut Filter<Map<Repeat, [fn item {identity::<u64>}: for<'r> fn(&'r u64) -> &'r u64]>, [closure@$DIR/issue-30786.rs:129:30: 129:37]>: Stream`
   --> $DIR/issue-30786.rs:96:50
    |
 LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}

--- a/src/test/ui/hygiene/impl_items.rs
+++ b/src/test/ui/hygiene/impl_items.rs
@@ -9,7 +9,7 @@ mod foo {
     }
 
     pub macro m() {
-        let _: () = S.f(); //~ ERROR type `for<'r> fn(&'r foo::S) {foo::S::f}` is private
+        let _: () = S.f(); //~ ERROR type `[fn item {foo::S::f}: for<'r> fn(&'r foo::S)]` is private
     }
 }
 

--- a/src/test/ui/hygiene/impl_items.stderr
+++ b/src/test/ui/hygiene/impl_items.stderr
@@ -1,4 +1,4 @@
-error: type `for<'r> fn(&'r foo::S) {foo::S::f}` is private
+error: type `[fn item {foo::S::f}: for<'r> fn(&'r foo::S)]` is private
   --> $DIR/impl_items.rs:12:23
    |
 LL |         let _: () = S.f();

--- a/src/test/ui/hygiene/intercrate.rs
+++ b/src/test/ui/hygiene/intercrate.rs
@@ -8,5 +8,5 @@ extern crate intercrate;
 
 fn main() {
     assert_eq!(intercrate::foo::m!(), 1);
-    //~^ ERROR type `fn() -> u32 {foo::bar::f}` is private
+    //~^ ERROR type `[fn item {foo::bar::f}: fn() -> u32]` is private
 }

--- a/src/test/ui/hygiene/intercrate.stderr
+++ b/src/test/ui/hygiene/intercrate.stderr
@@ -1,4 +1,4 @@
-error: type `fn() -> u32 {foo::bar::f}` is private
+error: type `[fn item {foo::bar::f}: fn() -> u32]` is private
   --> $DIR/intercrate.rs:10:16
    |
 LL |     assert_eq!(intercrate::foo::m!(), 1);

--- a/src/test/ui/intrinsics/const-eval-select-bad.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-bad.stderr
@@ -51,7 +51,7 @@ note: required by a bound in `const_eval_select`
 LL |     G: FnOnce<ARG, Output = RET> + ~const Destruct,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `const_eval_select`
 
-error[E0271]: type mismatch resolving `<fn(i32) -> bool {bar} as FnOnce<(i32,)>>::Output == i32`
+error[E0271]: type mismatch resolving `<[fn item {bar}: fn(i32) -> bool] as FnOnce<(i32,)>>::Output == i32`
   --> $DIR/const-eval-select-bad.rs:29:5
    |
 LL |     const_eval_select((1,), foo, bar);

--- a/src/test/ui/issues/issue-10764.stderr
+++ b/src/test/ui/issues/issue-10764.stderr
@@ -7,7 +7,7 @@ LL | fn main() { f(bar) }
    |             arguments to this function are incorrect
    |
    = note: expected fn pointer `fn()`
-                 found fn item `extern "C" fn() {bar}`
+                 found fn item `[fn item {bar}: extern "C" fn()]`
 note: function defined here
   --> $DIR/issue-10764.rs:1:4
    |

--- a/src/test/ui/issues/issue-21554.stderr
+++ b/src/test/ui/issues/issue-21554.stderr
@@ -1,4 +1,4 @@
-error[E0606]: casting `[fn item {Inches}: fn(i32) -> Inches]` as `f32` is invalid
+error[E0606]: casting `[constructor of {Inches}: fn(i32) -> Inches]` as `f32` is invalid
   --> $DIR/issue-21554.rs:4:5
    |
 LL |     Inches as f32;

--- a/src/test/ui/issues/issue-21554.stderr
+++ b/src/test/ui/issues/issue-21554.stderr
@@ -1,4 +1,4 @@
-error[E0606]: casting `fn(i32) -> Inches {Inches}` as `f32` is invalid
+error[E0606]: casting `[fn item {Inches}: fn(i32) -> Inches]` as `f32` is invalid
   --> $DIR/issue-21554.rs:4:5
    |
 LL |     Inches as f32;

--- a/src/test/ui/issues/issue-24322.stderr
+++ b/src/test/ui/issues/issue-24322.stderr
@@ -7,7 +7,7 @@ LL |     let x: &fn(&B) -> u32 = &B::func;
    |            expected due to this
    |
    = note: expected reference `&for<'r> fn(&'r B) -> u32`
-              found reference `&for<'r> fn(&'r B) -> u32 {B::func}`
+              found reference `&[fn item {B::func}: for<'r> fn(&'r B) -> u32]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-35241.rs:3:20
    |
 LL | struct Foo(u32);
-   | ---------- [fn item {Foo}: fn(u32) -> Foo] defined here
+   | ---------- [constructor of {Foo}: fn(u32) -> Foo] defined here
 LL |
 LL | fn test() -> Foo { Foo }
    |              ---   ^^^ expected struct `Foo`, found fn item
@@ -10,7 +10,7 @@ LL | fn test() -> Foo { Foo }
    |              expected `Foo` because of return type
    |
    = note: expected struct `Foo`
-             found fn item `[fn item {Foo}: fn(u32) -> Foo]`
+             found fn item `[constructor of {Foo}: fn(u32) -> Foo]`
 help: use parentheses to instantiate this tuple struct
    |
 LL | fn test() -> Foo { Foo(_) }

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-35241.rs:3:20
    |
 LL | struct Foo(u32);
-   | ---------- fn(u32) -> Foo {Foo} defined here
+   | ---------- [fn item {Foo}: fn(u32) -> Foo] defined here
 LL |
 LL | fn test() -> Foo { Foo }
    |              ---   ^^^ expected struct `Foo`, found fn item
@@ -10,7 +10,7 @@ LL | fn test() -> Foo { Foo }
    |              expected `Foo` because of return type
    |
    = note: expected struct `Foo`
-             found fn item `fn(u32) -> Foo {Foo}`
+             found fn item `[fn item {Foo}: fn(u32) -> Foo]`
 help: use parentheses to instantiate this tuple struct
    |
 LL | fn test() -> Foo { Foo(_) }

--- a/src/test/ui/issues/issue-5216.stderr
+++ b/src/test/ui/issues/issue-5216.stderr
@@ -7,7 +7,7 @@ LL | pub static C: S = S(f);
    |                   arguments to this struct are incorrect
    |
    = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
-             found fn item `fn() {f}`
+             found fn item `[fn item {f}: fn()]`
 note: tuple struct defined here
   --> $DIR/issue-5216.rs:2:8
    |
@@ -21,7 +21,7 @@ LL | pub static D: T = g;
    |                   ^ expected struct `Box`, found fn item
    |
    = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
-             found fn item `fn() {g}`
+             found fn item `[fn item {g}: fn()]`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-59488.rs
+++ b/src/test/ui/issues/issue-59488.rs
@@ -12,22 +12,22 @@ enum Foo {
 
 fn main() {
     foo > 12;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn() -> i32 {foo}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `[fn item {foo}: fn() -> i32]` [E0369]
     //~| ERROR mismatched types [E0308]
 
     bar > 13;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn(i64) -> i64 {bar}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `[fn item {bar}: fn(i64) -> i64]` [E0369]
     //~| ERROR mismatched types [E0308]
 
     foo > foo;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn() -> i32 {foo}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `[fn item {foo}: fn() -> i32]` [E0369]
 
     foo > bar;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn() -> i32 {foo}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `[fn item {foo}: fn() -> i32]` [E0369]
     //~| ERROR mismatched types [E0308]
 
     let i = Foo::Bar;
     assert_eq!(Foo::Bar, i);
-    //~^ ERROR binary operation `==` cannot be applied to type `fn(usize) -> Foo {Foo::Bar}` [E0369]
-    //~| ERROR `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug` [E0277]
+    //~^ ERROR binary operation `==` cannot be applied to type `[fn item {Foo::Bar}: fn(usize) -> Foo]` [E0369]
+    //~| ERROR `[fn item {Foo::Bar}: fn(usize) -> Foo]` doesn't implement `Debug` [E0277]
 }

--- a/src/test/ui/issues/issue-59488.rs
+++ b/src/test/ui/issues/issue-59488.rs
@@ -28,6 +28,6 @@ fn main() {
 
     let i = Foo::Bar;
     assert_eq!(Foo::Bar, i);
-    //~^ ERROR binary operation `==` cannot be applied to type `[fn item {Foo::Bar}: fn(usize) -> Foo]` [E0369]
-    //~| ERROR `[fn item {Foo::Bar}: fn(usize) -> Foo]` doesn't implement `Debug` [E0277]
+    //~^ ERROR binary operation `==` cannot be applied to type `[constructor of {Foo::Bar}: fn(usize) -> Foo]` [E0369]
+    //~| ERROR `[constructor of {Foo::Bar}: fn(usize) -> Foo]` doesn't implement `Debug` [E0277]
 }

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `>` cannot be applied to type `fn() -> i32 {foo}`
+error[E0369]: binary operation `>` cannot be applied to type `[fn item {foo}: fn() -> i32]`
   --> $DIR/issue-59488.rs:14:9
    |
 LL |     foo > 12;
    |     --- ^ -- {integer}
    |     |
-   |     fn() -> i32 {foo}
+   |     [fn item {foo}: fn() -> i32]
    |
 help: you might have forgotten to call this function
    |
@@ -17,16 +17,16 @@ error[E0308]: mismatched types
 LL |     foo > 12;
    |           ^^ expected fn item, found integer
    |
-   = note: expected fn item `fn() -> i32 {foo}`
+   = note: expected fn item `[fn item {foo}: fn() -> i32]`
                  found type `i32`
 
-error[E0369]: binary operation `>` cannot be applied to type `fn(i64) -> i64 {bar}`
+error[E0369]: binary operation `>` cannot be applied to type `[fn item {bar}: fn(i64) -> i64]`
   --> $DIR/issue-59488.rs:18:9
    |
 LL |     bar > 13;
    |     --- ^ -- {integer}
    |     |
-   |     fn(i64) -> i64 {bar}
+   |     [fn item {bar}: fn(i64) -> i64]
    |
 help: you might have forgotten to call this function
    |
@@ -39,16 +39,16 @@ error[E0308]: mismatched types
 LL |     bar > 13;
    |           ^^ expected fn item, found integer
    |
-   = note: expected fn item `fn(i64) -> i64 {bar}`
+   = note: expected fn item `[fn item {bar}: fn(i64) -> i64]`
                  found type `i64`
 
-error[E0369]: binary operation `>` cannot be applied to type `fn() -> i32 {foo}`
+error[E0369]: binary operation `>` cannot be applied to type `[fn item {foo}: fn() -> i32]`
   --> $DIR/issue-59488.rs:22:9
    |
 LL |     foo > foo;
-   |     --- ^ --- fn() -> i32 {foo}
+   |     --- ^ --- [fn item {foo}: fn() -> i32]
    |     |
-   |     fn() -> i32 {foo}
+   |     [fn item {foo}: fn() -> i32]
    |
 help: you might have forgotten to call this function
    |
@@ -59,13 +59,13 @@ help: you might have forgotten to call this function
 LL |     foo > foo();
    |              ++
 
-error[E0369]: binary operation `>` cannot be applied to type `fn() -> i32 {foo}`
+error[E0369]: binary operation `>` cannot be applied to type `[fn item {foo}: fn() -> i32]`
   --> $DIR/issue-59488.rs:25:9
    |
 LL |     foo > bar;
-   |     --- ^ --- fn(i64) -> i64 {bar}
+   |     --- ^ --- [fn item {bar}: fn(i64) -> i64]
    |     |
-   |     fn() -> i32 {foo}
+   |     [fn item {foo}: fn() -> i32]
 
 error[E0308]: mismatched types
   --> $DIR/issue-59488.rs:25:11
@@ -73,27 +73,27 @@ error[E0308]: mismatched types
 LL |     foo > bar;
    |           ^^^ expected fn item, found a different fn item
    |
-   = note: expected fn item `fn() -> i32 {foo}`
-              found fn item `fn(i64) -> i64 {bar}`
+   = note: expected fn item `[fn item {foo}: fn() -> i32]`
+              found fn item `[fn item {bar}: fn(i64) -> i64]`
 
-error[E0369]: binary operation `==` cannot be applied to type `fn(usize) -> Foo {Foo::Bar}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {Foo::Bar}: fn(usize) -> Foo]`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |     |
-   |     fn(usize) -> Foo {Foo::Bar}
-   |     fn(usize) -> Foo {Foo::Bar}
+   |     [fn item {Foo::Bar}: fn(usize) -> Foo]
+   |     [fn item {Foo::Bar}: fn(usize) -> Foo]
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug`
+error[E0277]: `[fn item {Foo::Bar}: fn(usize) -> Foo]` doesn't implement `Debug`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ `fn(usize) -> Foo {Foo::Bar}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ `[fn item {Foo::Bar}: fn(usize) -> Foo]` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for `fn(usize) -> Foo {Foo::Bar}`
+   = help: the trait `Debug` is not implemented for `[fn item {Foo::Bar}: fn(usize) -> Foo]`
    = help: the following other types implement trait `Debug`:
              extern "C" fn() -> Ret
              extern "C" fn(A, B) -> Ret

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -76,24 +76,24 @@ LL |     foo > bar;
    = note: expected fn item `[fn item {foo}: fn() -> i32]`
               found fn item `[fn item {bar}: fn(i64) -> i64]`
 
-error[E0369]: binary operation `==` cannot be applied to type `[fn item {Foo::Bar}: fn(usize) -> Foo]`
+error[E0369]: binary operation `==` cannot be applied to type `[constructor of {Foo::Bar}: fn(usize) -> Foo]`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |     |
-   |     [fn item {Foo::Bar}: fn(usize) -> Foo]
-   |     [fn item {Foo::Bar}: fn(usize) -> Foo]
+   |     [constructor of {Foo::Bar}: fn(usize) -> Foo]
+   |     [constructor of {Foo::Bar}: fn(usize) -> Foo]
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `[fn item {Foo::Bar}: fn(usize) -> Foo]` doesn't implement `Debug`
+error[E0277]: `[constructor of {Foo::Bar}: fn(usize) -> Foo]` doesn't implement `Debug`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ `[fn item {Foo::Bar}: fn(usize) -> Foo]` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ `[constructor of {Foo::Bar}: fn(usize) -> Foo]` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for `[fn item {Foo::Bar}: fn(usize) -> Foo]`
+   = help: the trait `Debug` is not implemented for `[constructor of {Foo::Bar}: fn(usize) -> Foo]`
    = help: the following other types implement trait `Debug`:
              extern "C" fn() -> Ret
              extern "C" fn(A, B) -> Ret

--- a/src/test/ui/issues/issue-62375.stderr
+++ b/src/test/ui/issues/issue-62375.stderr
@@ -2,7 +2,7 @@ error[E0369]: binary operation `==` cannot be applied to type `A`
   --> $DIR/issue-62375.rs:7:7
    |
 LL |     a == A::Value;
-   |     - ^^ -------- fn(()) -> A {A::Value}
+   |     - ^^ -------- [fn item {A::Value}: fn(()) -> A]
    |     |
    |     A
    |

--- a/src/test/ui/issues/issue-62375.stderr
+++ b/src/test/ui/issues/issue-62375.stderr
@@ -2,7 +2,7 @@ error[E0369]: binary operation `==` cannot be applied to type `A`
   --> $DIR/issue-62375.rs:7:7
    |
 LL |     a == A::Value;
-   |     - ^^ -------- [fn item {A::Value}: fn(()) -> A]
+   |     - ^^ -------- [constructor of {A::Value}: fn(()) -> A]
    |     |
    |     A
    |

--- a/src/test/ui/issues/issue-66667-function-cmp-cycle.stderr
+++ b/src/test/ui/issues/issue-66667-function-cmp-cycle.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `fn() {second}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {second}: fn()]`
   --> $DIR/issue-66667-function-cmp-cycle.rs:2:12
    |
 LL |     second == 1
    |     ------ ^^ - {integer}
    |     |
-   |     fn() {second}
+   |     [fn item {second}: fn()]
 
 error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:2:15
@@ -12,16 +12,16 @@ error[E0308]: mismatched types
 LL |     second == 1
    |               ^ expected fn item, found integer
    |
-   = note: expected fn item `fn() {second}`
+   = note: expected fn item `[fn item {second}: fn()]`
                  found type `{integer}`
 
-error[E0369]: binary operation `==` cannot be applied to type `fn() {first}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {first}: fn()]`
   --> $DIR/issue-66667-function-cmp-cycle.rs:7:11
    |
 LL |     first == 1
    |     ----- ^^ - {integer}
    |     |
-   |     fn() {first}
+   |     [fn item {first}: fn()]
 
 error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:7:14
@@ -29,16 +29,16 @@ error[E0308]: mismatched types
 LL |     first == 1
    |              ^ expected fn item, found integer
    |
-   = note: expected fn item `fn() {first}`
+   = note: expected fn item `[fn item {first}: fn()]`
                  found type `{integer}`
 
-error[E0369]: binary operation `==` cannot be applied to type `fn() {bar}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {bar}: fn()]`
   --> $DIR/issue-66667-function-cmp-cycle.rs:12:9
    |
 LL |     bar == 1
    |     --- ^^ - {integer}
    |     |
-   |     fn() {bar}
+   |     [fn item {bar}: fn()]
 
 error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:12:12
@@ -46,7 +46,7 @@ error[E0308]: mismatched types
 LL |     bar == 1
    |            ^ expected fn item, found integer
    |
-   = note: expected fn item `fn() {bar}`
+   = note: expected fn item `[fn item {bar}: fn()]`
                  found type `{integer}`
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
+++ b/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `fn() -> i32 {a}`
+error[E0369]: binary operation `==` cannot be applied to type `[fn item {a}: fn() -> i32]`
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
    |
 LL |     assert_eq!(a, 0);
    |     ^^^^^^^^^^^^^^^^
    |     |
-   |     fn() -> i32 {a}
+   |     [fn item {a}: fn() -> i32]
    |     {integer}
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -20,20 +20,20 @@ error[E0308]: mismatched types
 LL |     assert_eq!(a, 0);
    |     ^^^^^^^^^^^^^^^^ expected fn item, found integer
    |
-   = note: expected fn item `fn() -> i32 {a}`
+   = note: expected fn item `[fn item {a}: fn() -> i32]`
                  found type `i32`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `fn() -> i32 {a}` doesn't implement `Debug`
+error[E0277]: `[fn item {a}: fn() -> i32]` doesn't implement `Debug`
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
    |
 LL | fn a() -> i32 {
    |    - consider calling this function
 ...
 LL |     assert_eq!(a, 0);
-   |     ^^^^^^^^^^^^^^^^ `fn() -> i32 {a}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^ `[fn item {a}: fn() -> i32]` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for `fn() -> i32 {a}`
+   = help: the trait `Debug` is not implemented for `[fn item {a}: fn() -> i32]`
    = help: use parentheses to call the function: `a()`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-87490.stderr
+++ b/src/test/ui/issues/issue-87490.stderr
@@ -7,7 +7,7 @@ LL |     String::new
    |     ^^^^^^^^^^^ expected `usize`, found fn item
    |
    = note: expected type `usize`
-           found fn item `fn() -> String {String::new}`
+           found fn item `[fn item {String::new}: fn() -> String]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -29,7 +29,7 @@ error: implementation of `FnOnce` is not general enough
 LL |     f(data, identity)
    |     ^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&'2 T) -> &'2 T {identity::<&'2 T>}` must implement `FnOnce<(&'1 T,)>`, for any lifetime `'1`...
+   = note: `[fn item {identity::<&'2 T>}: fn(&'2 T) -> &'2 T]` must implement `FnOnce<(&'1 T,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 T,)>`, for some specific lifetime `'2`
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/lint/trivial_casts.rs
+++ b/src/test/ui/lint/trivial_casts.rs
@@ -67,7 +67,7 @@ pub fn main() {
 
     // functions
     fn baz(_x: i32) {}
-    let _ = &baz as &dyn Fn(i32); //~ERROR `&fn(i32) {baz}` as `&dyn Fn(i32)`
+    let _ = &baz as &dyn Fn(i32); //~ERROR `&[fn item {baz}: fn(i32)]` as `&dyn Fn(i32)`
     let _: &dyn Fn(i32) = &baz;
     let x = |_x: i32| {};
     let _ = &x as &dyn Fn(i32); //~ERROR trivial cast

--- a/src/test/ui/lint/trivial_casts.stderr
+++ b/src/test/ui/lint/trivial_casts.stderr
@@ -120,7 +120,7 @@ LL |     let _ = x as Box<dyn Foo>;
    |
    = help: cast can be replaced by coercion; this might require a temporary variable
 
-error: trivial cast: `&fn(i32) {baz}` as `&dyn Fn(i32)`
+error: trivial cast: `&[fn item {baz}: fn(i32)]` as `&dyn Fn(i32)`
   --> $DIR/trivial_casts.rs:70:13
    |
 LL |     let _ = &baz as &dyn Fn(i32);

--- a/src/test/ui/match/issue-82392.stdout
+++ b/src/test/ui/match/issue-82392.stdout
@@ -11,6 +11,6 @@ fn main() ({
                 ({ } as
                     ()) else if (let Some(a) =
                        ((Some as
-                               fn(i32) -> Option<i32> {Option::<i32>::Some})((3 as i32)) as
-                           Option<i32>) as bool) ({ } as ()) as ())
+                               [fn item {Option::<i32>::Some}: fn(i32) -> Option<i32>])((3
+                               as i32)) as Option<i32>) as bool) ({ } as ()) as ())
                } as ())

--- a/src/test/ui/match/issue-82392.stdout
+++ b/src/test/ui/match/issue-82392.stdout
@@ -11,6 +11,6 @@ fn main() ({
                 ({ } as
                     ()) else if (let Some(a) =
                        ((Some as
-                               [fn item {Option::<i32>::Some}: fn(i32) -> Option<i32>])((3
+                               [constructor of {Option::<i32>::Some}: fn(i32) -> Option<i32>])((3
                                as i32)) as Option<i32>) as bool) ({ } as ()) as ())
                } as ())

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -14,7 +14,7 @@ LL |     u as *const str
    |
    = note: vtable kinds may not match
 
-error[E0609]: no field `f` on type `fn() {main}`
+error[E0609]: no field `f` on type `[fn item {main}: fn()]`
   --> $DIR/cast-rfc0401.rs:65:18
    |
 LL |     let _ = main.f as *const u32;
@@ -62,7 +62,7 @@ error[E0606]: casting `*const u8` as `f32` is invalid
 LL |     let _ = v as f32;
    |             ^^^^^^^^
 
-error[E0606]: casting `fn() {main}` as `f64` is invalid
+error[E0606]: casting `[fn item {main}: fn()]` as `f64` is invalid
   --> $DIR/cast-rfc0401.rs:36:13
    |
 LL |     let _ = main as f64;
@@ -171,7 +171,7 @@ error[E0606]: casting `&dyn Foo` as `*mut str` is invalid
 LL |     let _ = foo as *mut str;
    |             ^^^^^^^^^^^^^^^
 
-error[E0606]: casting `fn() {main}` as `*mut str` is invalid
+error[E0606]: casting `[fn item {main}: fn()]` as `*mut str` is invalid
   --> $DIR/cast-rfc0401.rs:56:13
    |
 LL |     let _ = main as *mut str;

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -214,11 +214,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfied
+error[E0277]: the trait bound `[fn item {c::TS}: fn() -> c::TS]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:56:11
    |
 LL |     check(m3::TS);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `[fn item {c::TS}: fn() -> c::TS]`
    |     |
    |     required by a bound introduced by this call
    |
@@ -270,11 +270,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}: Impossible` is not satisfied
+error[E0277]: the trait bound `[fn item {namespace_mix::c::TS}: fn() -> namespace_mix::c::TS]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:62:11
    |
 LL |     check(xm3::TS);
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `[fn item {namespace_mix::c::TS}: fn() -> namespace_mix::c::TS]`
    |     |
    |     required by a bound introduced by this call
    |
@@ -522,11 +522,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satisfied
+error[E0277]: the trait bound `[fn item {c::E::TV}: fn() -> c::E]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:122:11
    |
 LL |     check(m9::TV);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `[fn item {c::E::TV}: fn() -> c::E]`
    |     |
    |     required by a bound introduced by this call
    |
@@ -578,11 +578,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}: Impossible` is not satisfied
+error[E0277]: the trait bound `[fn item {namespace_mix::xm7::TV}: fn() -> namespace_mix::c::E]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:128:11
    |
 LL |     check(xm9::TV);
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `[fn item {namespace_mix::xm7::TV}: fn() -> namespace_mix::c::E]`
    |     |
    |     required by a bound introduced by this call
    |

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -214,11 +214,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `[fn item {c::TS}: fn() -> c::TS]: Impossible` is not satisfied
+error[E0277]: the trait bound `[constructor of {c::TS}: fn() -> c::TS]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:56:11
    |
 LL |     check(m3::TS);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `[fn item {c::TS}: fn() -> c::TS]`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `[constructor of {c::TS}: fn() -> c::TS]`
    |     |
    |     required by a bound introduced by this call
    |
@@ -270,11 +270,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `[fn item {namespace_mix::c::TS}: fn() -> namespace_mix::c::TS]: Impossible` is not satisfied
+error[E0277]: the trait bound `[constructor of {namespace_mix::c::TS}: fn() -> namespace_mix::c::TS]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:62:11
    |
 LL |     check(xm3::TS);
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `[fn item {namespace_mix::c::TS}: fn() -> namespace_mix::c::TS]`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `[constructor of {namespace_mix::c::TS}: fn() -> namespace_mix::c::TS]`
    |     |
    |     required by a bound introduced by this call
    |
@@ -522,11 +522,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `[fn item {c::E::TV}: fn() -> c::E]: Impossible` is not satisfied
+error[E0277]: the trait bound `[constructor of {c::E::TV}: fn() -> c::E]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:122:11
    |
 LL |     check(m9::TV);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `[fn item {c::E::TV}: fn() -> c::E]`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `[constructor of {c::E::TV}: fn() -> c::E]`
    |     |
    |     required by a bound introduced by this call
    |
@@ -578,11 +578,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `[fn item {namespace_mix::xm7::TV}: fn() -> namespace_mix::c::E]: Impossible` is not satisfied
+error[E0277]: the trait bound `[constructor of {namespace_mix::xm7::TV}: fn() -> namespace_mix::c::E]: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:128:11
    |
 LL |     check(xm9::TV);
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `[fn item {namespace_mix::xm7::TV}: fn() -> namespace_mix::c::E]`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `[constructor of {namespace_mix::xm7::TV}: fn() -> namespace_mix::c::E]`
    |     |
    |     required by a bound introduced by this call
    |

--- a/src/test/ui/privacy/associated-item-privacy-inherent.rs
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.rs
@@ -11,11 +11,11 @@ mod priv_nominal {
 
     pub macro mac() {
         let value = Pub::method;
-        //~^ ERROR type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR type `[fn item {priv_nominal::Pub::method}: for<'r> fn(&'r priv_nominal::Pub)]` is private
         value;
-        //~^ ERROR type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR type `[fn item {priv_nominal::Pub::method}: for<'r> fn(&'r priv_nominal::Pub)]` is private
         Pub.method();
-        //~^ ERROR type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR type `[fn item {priv_nominal::Pub::method}: for<'r> fn(&'r priv_nominal::Pub)]` is private
         Pub::CONST;
         //~^ ERROR associated constant `CONST` is private
         // let _: Pub::AssocTy;

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -1,4 +1,4 @@
-error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: type `[fn item {priv_nominal::Pub::method}: for<'r> fn(&'r priv_nominal::Pub)]` is private
   --> $DIR/associated-item-privacy-inherent.rs:13:21
    |
 LL |         let value = Pub::method;
@@ -9,7 +9,7 @@ LL |     priv_nominal::mac!();
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: type `[fn item {priv_nominal::Pub::method}: for<'r> fn(&'r priv_nominal::Pub)]` is private
   --> $DIR/associated-item-privacy-inherent.rs:15:9
    |
 LL |         value;
@@ -20,7 +20,7 @@ LL |     priv_nominal::mac!();
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: type `[fn item {priv_nominal::Pub::method}: for<'r> fn(&'r priv_nominal::Pub)]` is private
   --> $DIR/associated-item-privacy-inherent.rs:17:13
    |
 LL |         Pub.method();

--- a/src/test/ui/privacy/associated-item-privacy-trait.rs
+++ b/src/test/ui/privacy/associated-item-privacy-trait.rs
@@ -13,11 +13,11 @@ mod priv_trait {
 
     pub macro mac() {
         let value = <Pub as PrivTr>::method;
-        //~^ ERROR type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+        //~^ ERROR type `[fn item {<priv_trait::Pub as PrivTr>::method}: for<'r> fn(&'r priv_trait::Pub)]` is private
         value;
-        //~^ ERROR type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+        //~^ ERROR type `[fn item {<priv_trait::Pub as PrivTr>::method}: for<'r> fn(&'r priv_trait::Pub)]` is private
         Pub.method();
-        //~^ ERROR type `for<'r> fn(&'r Self) {<Self as PrivTr>::method}` is private
+        //~^ ERROR type `[fn item {<Self as PrivTr>::method}: for<'r> fn(&'r Self)]` is private
         <Pub as PrivTr>::CONST;
         //~^ ERROR associated constant `<Pub as PrivTr>::CONST` is private
         let _: <Pub as PrivTr>::AssocTy;

--- a/src/test/ui/privacy/associated-item-privacy-trait.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-trait.stderr
@@ -1,4 +1,4 @@
-error: type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+error: type `[fn item {<priv_trait::Pub as PrivTr>::method}: for<'r> fn(&'r priv_trait::Pub)]` is private
   --> $DIR/associated-item-privacy-trait.rs:15:21
    |
 LL |         let value = <Pub as PrivTr>::method;
@@ -9,7 +9,7 @@ LL |     priv_trait::mac!();
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+error: type `[fn item {<priv_trait::Pub as PrivTr>::method}: for<'r> fn(&'r priv_trait::Pub)]` is private
   --> $DIR/associated-item-privacy-trait.rs:17:9
    |
 LL |         value;
@@ -20,7 +20,7 @@ LL |     priv_trait::mac!();
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'r> fn(&'r Self) {<Self as PrivTr>::method}` is private
+error: type `[fn item {<Self as PrivTr>::method}: for<'r> fn(&'r Self)]` is private
   --> $DIR/associated-item-privacy-trait.rs:19:13
    |
 LL |         Pub.method();

--- a/src/test/ui/privacy/private-inferred-type-3.rs
+++ b/src/test/ui/privacy/private-inferred-type-3.rs
@@ -1,12 +1,12 @@
 // aux-build:private-inferred-type.rs
 
-// error-pattern:type `fn() {ext::priv_fn}` is private
+// error-pattern:type `[fn item {ext::priv_fn}: fn()]` is private
 // error-pattern:static `PRIV_STATIC` is private
 // error-pattern:type `ext::PrivEnum` is private
-// error-pattern:type `fn() {<u8 as ext::PrivTrait>::method}` is private
-// error-pattern:type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
-// error-pattern:type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
-// error-pattern:type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
+// error-pattern:type `[fn item {<u8 as ext::PrivTrait>::method}: fn()]` is private
+// error-pattern:type `[fn item {ext::PrivTupleStruct}: fn(u8) -> ext::PrivTupleStruct]` is private
+// error-pattern:type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
+// error-pattern:type `[fn item {Pub::<u8>::priv_method}: for<'r> fn(&'r Pub<u8>)]` is private
 
 #![feature(decl_macro)]
 

--- a/src/test/ui/privacy/private-inferred-type-3.rs
+++ b/src/test/ui/privacy/private-inferred-type-3.rs
@@ -4,8 +4,8 @@
 // error-pattern:static `PRIV_STATIC` is private
 // error-pattern:type `ext::PrivEnum` is private
 // error-pattern:type `[fn item {<u8 as ext::PrivTrait>::method}: fn()]` is private
-// error-pattern:type `[fn item {ext::PrivTupleStruct}: fn(u8) -> ext::PrivTupleStruct]` is private
-// error-pattern:type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
+// error-pattern:type `[constructor of {ext::PrivTupleStruct}: fn(u8) -> ext::PrivTupleStruct]` is private
+// error-pattern:type `[constructor of {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
 // error-pattern:type `[fn item {Pub::<u8>::priv_method}: for<'r> fn(&'r Pub<u8>)]` is private
 
 #![feature(decl_macro)]

--- a/src/test/ui/privacy/private-inferred-type-3.stderr
+++ b/src/test/ui/privacy/private-inferred-type-3.stderr
@@ -30,7 +30,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `[fn item {ext::PrivTupleStruct}: fn(u8) -> ext::PrivTupleStruct]` is private
+error: type `[constructor of {ext::PrivTupleStruct}: fn(u8) -> ext::PrivTupleStruct]` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -38,7 +38,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
+error: type `[constructor of {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();

--- a/src/test/ui/privacy/private-inferred-type-3.stderr
+++ b/src/test/ui/privacy/private-inferred-type-3.stderr
@@ -1,4 +1,4 @@
-error: type `fn() {ext::priv_fn}` is private
+error: type `[fn item {ext::priv_fn}: fn()]` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -22,7 +22,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
+error: type `[fn item {<u8 as ext::PrivTrait>::method}: fn()]` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -30,7 +30,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
+error: type `[fn item {ext::PrivTupleStruct}: fn(u8) -> ext::PrivTupleStruct]` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -38,7 +38,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
+error: type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -46,7 +46,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
+error: type `[fn item {Pub::<u8>::priv_method}: for<'r> fn(&'r Pub<u8>)]` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();

--- a/src/test/ui/privacy/private-inferred-type.rs
+++ b/src/test/ui/privacy/private-inferred-type.rs
@@ -36,18 +36,18 @@ mod m {
     impl TraitWithAssocTy for Priv { type AssocTy = u8; }
 
     pub macro m() {
-        priv_fn; //~ ERROR type `fn() {priv_fn}` is private
+        priv_fn; //~ ERROR type `[fn item {priv_fn}: fn()]` is private
         PRIV_STATIC; // OK, not cross-crate
         PrivEnum::Variant; //~ ERROR type `PrivEnum` is private
         PubEnum::Variant; // OK
-        <u8 as PrivTrait>::method; //~ ERROR type `fn() {<u8 as PrivTrait>::method}` is private
+        <u8 as PrivTrait>::method; //~ ERROR type `[fn item {<u8 as PrivTrait>::method}: fn()]` is private
         <u8 as PubTrait>::method; // OK
         PrivTupleStruct;
-        //~^ ERROR type `fn(u8) -> PrivTupleStruct {PrivTupleStruct}` is private
+        //~^ ERROR type `[fn item {PrivTupleStruct}: fn(u8) -> PrivTupleStruct]` is private
         PubTupleStruct;
-        //~^ ERROR type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
+        //~^ ERROR type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
         Pub(0u8).priv_method();
-        //~^ ERROR type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
+        //~^ ERROR type `[fn item {Pub::<u8>::priv_method}: for<'r> fn(&'r Pub<u8>)]` is private
     }
 
     trait Trait {}

--- a/src/test/ui/privacy/private-inferred-type.rs
+++ b/src/test/ui/privacy/private-inferred-type.rs
@@ -43,9 +43,9 @@ mod m {
         <u8 as PrivTrait>::method; //~ ERROR type `[fn item {<u8 as PrivTrait>::method}: fn()]` is private
         <u8 as PubTrait>::method; // OK
         PrivTupleStruct;
-        //~^ ERROR type `[fn item {PrivTupleStruct}: fn(u8) -> PrivTupleStruct]` is private
+        //~^ ERROR type `[constructor of {PrivTupleStruct}: fn(u8) -> PrivTupleStruct]` is private
         PubTupleStruct;
-        //~^ ERROR type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
+        //~^ ERROR type `[constructor of {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
         Pub(0u8).priv_method();
         //~^ ERROR type `[fn item {Pub::<u8>::priv_method}: for<'r> fn(&'r Pub<u8>)]` is private
     }

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -139,7 +139,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `[fn item {PrivTupleStruct}: fn(u8) -> PrivTupleStruct]` is private
+error: type `[constructor of {PrivTupleStruct}: fn(u8) -> PrivTupleStruct]` is private
   --> $DIR/private-inferred-type.rs:45:9
    |
 LL |         PrivTupleStruct;
@@ -150,7 +150,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
+error: type `[constructor of {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
   --> $DIR/private-inferred-type.rs:47:9
    |
 LL |         PubTupleStruct;

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -106,7 +106,7 @@ error: type `S2` is private
 LL |     adjust::S1.method_s3();
    |     ^^^^^^^^^^ private type
 
-error: type `fn() {priv_fn}` is private
+error: type `[fn item {priv_fn}: fn()]` is private
   --> $DIR/private-inferred-type.rs:39:9
    |
 LL |         priv_fn;
@@ -128,7 +128,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn() {<u8 as PrivTrait>::method}` is private
+error: type `[fn item {<u8 as PrivTrait>::method}: fn()]` is private
   --> $DIR/private-inferred-type.rs:43:9
    |
 LL |         <u8 as PrivTrait>::method;
@@ -139,7 +139,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> PrivTupleStruct {PrivTupleStruct}` is private
+error: type `[fn item {PrivTupleStruct}: fn(u8) -> PrivTupleStruct]` is private
   --> $DIR/private-inferred-type.rs:45:9
    |
 LL |         PrivTupleStruct;
@@ -150,7 +150,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
+error: type `[fn item {PubTupleStruct}: fn(u8) -> PubTupleStruct]` is private
   --> $DIR/private-inferred-type.rs:47:9
    |
 LL |         PubTupleStruct;
@@ -161,7 +161,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
+error: type `[fn item {Pub::<u8>::priv_method}: for<'r> fn(&'r Pub<u8>)]` is private
   --> $DIR/private-inferred-type.rs:49:18
    |
 LL |         Pub(0u8).priv_method();

--- a/src/test/ui/privacy/where-priv-type.stderr
+++ b/src/test/ui/privacy/where-priv-type.stderr
@@ -52,14 +52,14 @@ LL | |         PrivTy:
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
-error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+error[E0446]: private type `[fn item {my_const_fn}: fn(u8) -> u8]` in public interface
   --> $DIR/where-priv-type.rs:80:5
    |
 LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   | ----------------------------------- `[fn item {my_const_fn}: fn(u8) -> u8]` declared as private
 
 error: aborting due to 2 previous errors; 4 warnings emitted
 

--- a/src/test/ui/proc-macro/signature.rs
+++ b/src/test/ui/proc-macro/signature.rs
@@ -8,6 +8,6 @@ extern crate proc_macro;
 
 #[proc_macro_derive(A)]
 pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-    //~^ ERROR: expected a `Fn<(proc_macro::TokenStream,)>` closure, found `unsafe extern "C" fn
+    //~^ ERROR: expected a `Fn<(proc_macro::TokenStream,)>` closure, found `[fn item {foo}: unsafe extern "C" fn
     loop {}
 }

--- a/src/test/ui/proc-macro/signature.stderr
+++ b/src/test/ui/proc-macro/signature.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn<(proc_macro::TokenStream,)>` closure, found `unsafe extern "C" fn(i32, u32) -> u32 {foo}`
+error[E0277]: expected a `Fn<(proc_macro::TokenStream,)>` closure, found `[fn item {foo}: unsafe extern "C" fn(i32, u32) -> u32]`
   --> $DIR/signature.rs:10:1
    |
 LL | / pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
@@ -7,7 +7,7 @@ LL | |     loop {}
 LL | | }
    | |_^ call the function in a closure: `|| unsafe { /* code */ }`
    |
-   = help: the trait `Fn<(proc_macro::TokenStream,)>` is not implemented for `unsafe extern "C" fn(i32, u32) -> u32 {foo}`
+   = help: the trait `Fn<(proc_macro::TokenStream,)>` is not implemented for `[fn item {foo}: unsafe extern "C" fn(i32, u32) -> u32]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `ProcMacro::custom_derive`
   --> $SRC_DIR/proc_macro/src/bridge/client.rs:LL:COL

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -8,7 +8,7 @@ error[E0029]: only `char` and numeric types are allowed in range patterns
   --> $DIR/qualified-path-params.rs:22:15
    |
 LL |         0 ..= <S as Tr>::A::f::<u8> => {}
-   |         -     ^^^^^^^^^^^^^^^^^^^^^ this is of type `fn() {S::f::<u8>}` but it should be `char` or numeric
+   |         -     ^^^^^^^^^^^^^^^^^^^^^ this is of type `[fn item {S::f::<u8>}: fn()]` but it should be `char` or numeric
    |         |
    |         this is of type `{integer}`
 

--- a/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -5,7 +5,7 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    |                                           ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-                 found fn item `for<'r, 's> fn(&'r mut &isize, &'s mut &isize) {a::<'_, '_>}`
+                 found fn item `[fn item {a::<'_, '_>}: for<'r, 's> fn(&'r mut &isize, &'s mut &isize)]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -5,7 +5,7 @@ LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
    |                                                        ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1, 't2, 't3> fn(&'r mut &'s isize, &'t0 mut &'t1 isize, &'t2 mut &'t3 isize)`
-                 found fn item `for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize) {a::<'_, '_, '_>}`
+                 found fn item `[fn item {a::<'_, '_, '_>}: for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize)]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-fn-subtyping-return-static-fail.stderr
+++ b/src/test/ui/regions/regions-fn-subtyping-return-static-fail.stderr
@@ -7,7 +7,7 @@ LL |     want_G(baz);
    |     arguments to this function are incorrect
    |
    = note: expected fn pointer `for<'cx> fn(&'cx S) -> &'static S`
-                 found fn item `for<'r> fn(&'r S) -> &'r S {baz}`
+                 found fn item `[fn item {baz}: for<'r> fn(&'r S) -> &'r S]`
 note: function defined here
   --> $DIR/regions-fn-subtyping-return-static-fail.rs:20:4
    |

--- a/src/test/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/src/test/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -5,7 +5,7 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    |                                           ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-                 found fn item `for<'r, 's> fn(&'r mut &isize, &'s mut &isize) {a::<'_, '_>}`
+                 found fn item `[fn item {a::<'_, '_>}: for<'r, 's> fn(&'r mut &isize, &'s mut &isize)]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/reify-intrinsic.stderr
+++ b/src/test/ui/reify-intrinsic.stderr
@@ -7,9 +7,9 @@ LL |     let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::tr
    |            expected due to this
    |
    = note: expected fn pointer `unsafe extern "rust-intrinsic" fn(isize) -> usize`
-                 found fn item `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+                 found fn item `[fn item {transmute::<_, _>}: unsafe extern "rust-intrinsic" fn(_) -> _]`
 
-error[E0606]: casting `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}` as `unsafe extern "rust-intrinsic" fn(isize) -> usize` is invalid
+error[E0606]: casting `[fn item {transmute::<_, _>}: unsafe extern "rust-intrinsic" fn(_) -> _]` as `unsafe extern "rust-intrinsic" fn(isize) -> usize` is invalid
   --> $DIR/reify-intrinsic.rs:11:13
    |
 LL |     let _ = std::mem::transmute as unsafe extern "rust-intrinsic" fn(isize) -> usize;
@@ -21,8 +21,8 @@ error[E0308]: cannot coerce intrinsics to function pointers
 LL |         std::intrinsics::unlikely,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot coerce intrinsics to function pointers
    |
-   = note: expected fn item `extern "rust-intrinsic" fn(_) -> _ {likely}`
-              found fn item `extern "rust-intrinsic" fn(_) -> _ {unlikely}`
+   = note: expected fn item `[fn item {likely}: extern "rust-intrinsic" fn(_) -> _]`
+              found fn item `[fn item {unlikely}: extern "rust-intrinsic" fn(_) -> _]`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -318,7 +318,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:27:20
    |
 LL |             Fn(u8),
-   |             -- fn(u8) -> Z {Z::Fn} defined here
+   |             -- [fn item {Z::Fn}: fn(u8) -> Z] defined here
 ...
 LL |         let _: Z = Z::Fn;
    |                -   ^^^^^ expected enum `Z`, found fn item
@@ -326,7 +326,7 @@ LL |         let _: Z = Z::Fn;
    |                expected due to this
    |
    = note: expected enum `Z`
-           found fn item `fn(u8) -> Z {Z::Fn}`
+           found fn item `[fn item {Z::Fn}: fn(u8) -> Z]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |         let _: Z = Z::Fn(_);
@@ -353,7 +353,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
    |
 LL |         Fn(u8),
-   |         -- fn(u8) -> E {E::Fn} defined here
+   |         -- [fn item {E::Fn}: fn(u8) -> E] defined here
 ...
 LL |     let _: E = m::E::Fn;
    |            -   ^^^^^^^^ expected enum `E`, found fn item
@@ -361,7 +361,7 @@ LL |     let _: E = m::E::Fn;
    |            expected due to this
    |
    = note: expected enum `E`
-           found fn item `fn(u8) -> E {E::Fn}`
+           found fn item `[fn item {E::Fn}: fn(u8) -> E]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |     let _: E = m::E::Fn(_);
@@ -388,7 +388,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
    |
 LL |         Fn(u8),
-   |         -- fn(u8) -> E {E::Fn} defined here
+   |         -- [fn item {E::Fn}: fn(u8) -> E] defined here
 ...
 LL |     let _: E = E::Fn;
    |            -   ^^^^^ expected enum `E`, found fn item
@@ -396,7 +396,7 @@ LL |     let _: E = E::Fn;
    |            expected due to this
    |
    = note: expected enum `E`
-           found fn item `fn(u8) -> E {E::Fn}`
+           found fn item `[fn item {E::Fn}: fn(u8) -> E]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |     let _: E = E::Fn(_);

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -318,7 +318,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:27:20
    |
 LL |             Fn(u8),
-   |             -- [fn item {Z::Fn}: fn(u8) -> Z] defined here
+   |             -- [constructor of {Z::Fn}: fn(u8) -> Z] defined here
 ...
 LL |         let _: Z = Z::Fn;
    |                -   ^^^^^ expected enum `Z`, found fn item
@@ -326,7 +326,7 @@ LL |         let _: Z = Z::Fn;
    |                expected due to this
    |
    = note: expected enum `Z`
-           found fn item `[fn item {Z::Fn}: fn(u8) -> Z]`
+           found fn item `[constructor of {Z::Fn}: fn(u8) -> Z]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |         let _: Z = Z::Fn(_);
@@ -353,7 +353,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
    |
 LL |         Fn(u8),
-   |         -- [fn item {E::Fn}: fn(u8) -> E] defined here
+   |         -- [constructor of {E::Fn}: fn(u8) -> E] defined here
 ...
 LL |     let _: E = m::E::Fn;
    |            -   ^^^^^^^^ expected enum `E`, found fn item
@@ -361,7 +361,7 @@ LL |     let _: E = m::E::Fn;
    |            expected due to this
    |
    = note: expected enum `E`
-           found fn item `[fn item {E::Fn}: fn(u8) -> E]`
+           found fn item `[constructor of {E::Fn}: fn(u8) -> E]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |     let _: E = m::E::Fn(_);
@@ -388,7 +388,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
    |
 LL |         Fn(u8),
-   |         -- [fn item {E::Fn}: fn(u8) -> E] defined here
+   |         -- [constructor of {E::Fn}: fn(u8) -> E] defined here
 ...
 LL |     let _: E = E::Fn;
    |            -   ^^^^^ expected enum `E`, found fn item
@@ -396,7 +396,7 @@ LL |     let _: E = E::Fn;
    |            expected due to this
    |
    = note: expected enum `E`
-           found fn item `[fn item {E::Fn}: fn(u8) -> E]`
+           found fn item `[constructor of {E::Fn}: fn(u8) -> E]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |     let _: E = E::Fn(_);

--- a/src/test/ui/rfc1623-2.stderr
+++ b/src/test/ui/rfc1623-2.stderr
@@ -23,7 +23,7 @@ help: consider making the type lifetime-generic with a new `'a` lifetime
 LL |     &(non_elidable as for<'a> fn(&'a u8, &'a u8) -> &'a u8);
    |                       +++++++     ++      ++         ++
 
-error[E0605]: non-primitive cast: `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8 {non_elidable}` as `for<'r, 's> fn(&'r u8, &'s u8) -> &u8`
+error[E0605]: non-primitive cast: `[fn item {non_elidable}: for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8]` as `for<'r, 's> fn(&'r u8, &'s u8) -> &u8`
   --> $DIR/rfc1623-2.rs:10:6
    |
 LL |     &(non_elidable as fn(&u8, &u8) -> &u8);

--- a/src/test/ui/rfc1623.stderr
+++ b/src/test/ui/rfc1623.stderr
@@ -22,7 +22,7 @@ error: implementation of `FnOnce` is not general enough
 LL |     f: &id,
    |        ^^^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&'2 Foo<'_>) -> &'2 Foo<'_> {id::<&'2 Foo<'_>>}` must implement `FnOnce<(&'1 Foo<'b>,)>`, for any lifetime `'1`...
+   = note: `[fn item {id::<&'2 Foo<'_>>}: fn(&'2 Foo<'_>) -> &'2 Foo<'_>]` must implement `FnOnce<(&'1 Foo<'b>,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 Foo<'_>,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
@@ -31,7 +31,7 @@ error: implementation of `FnOnce` is not general enough
 LL |     f: &id,
    |        ^^^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&Foo<'2>) -> &Foo<'2> {id::<&Foo<'2>>}` must implement `FnOnce<(&'a Foo<'1>,)>`, for any lifetime `'1`...
+   = note: `[fn item {id::<&Foo<'2>>}: fn(&Foo<'2>) -> &Foo<'2>]` must implement `FnOnce<(&'a Foo<'1>,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&Foo<'2>,)>`, for some specific lifetime `'2`
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.mir.stderr
@@ -10,7 +10,7 @@ LL |     let foo: fn() = foo;
    |              expected due to this
    |
    = note: expected fn pointer `fn()`
-                 found fn item `fn() {foo}`
+                 found fn item `[fn item {foo}: fn()]`
    = note: functions with `#[target_feature]` can only be coerced to `unsafe` function pointers
 
 error: aborting due to previous error

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.thir.stderr
@@ -10,7 +10,7 @@ LL |     let foo: fn() = foo;
    |              expected due to this
    |
    = note: expected fn pointer `fn()`
-                 found fn item `fn() {foo}`
+                 found fn item `[fn item {foo}: fn()]`
    = note: functions with `#[target_feature]` can only be coerced to `unsafe` function pointers
 
 error: aborting due to previous error

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -21,14 +21,14 @@ fn call_once(f: impl FnOnce()) {
 }
 
 fn main() {
-    call(foo); //~ ERROR expected a `Fn<()>` closure, found `fn() {foo}`
-    call_mut(foo); //~ ERROR expected a `FnMut<()>` closure, found `fn() {foo}`
-    call_once(foo); //~ ERROR expected a `FnOnce<()>` closure, found `fn() {foo}`
+    call(foo); //~ ERROR expected a `Fn<()>` closure, found `[fn item {foo}: fn()]`
+    call_mut(foo); //~ ERROR expected a `FnMut<()>` closure, found `[fn item {foo}: fn()]`
+    call_once(foo); //~ ERROR expected a `FnOnce<()>` closure, found `[fn item {foo}: fn()]`
 
     call(foo_unsafe);
-    //~^ ERROR expected a `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `Fn<()>` closure, found `[fn item {foo_unsafe}: unsafe fn()]`
     call_mut(foo_unsafe);
-    //~^ ERROR expected a `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `FnMut<()>` closure, found `[fn item {foo_unsafe}: unsafe fn()]`
     call_once(foo_unsafe);
-    //~^ ERROR expected a `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `FnOnce<()>` closure, found `[fn item {foo_unsafe}: unsafe fn()]`
 }

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -1,13 +1,13 @@
-error[E0277]: expected a `Fn<()>` closure, found `fn() {foo}`
+error[E0277]: expected a `Fn<()>` closure, found `[fn item {foo}: fn()]`
   --> $DIR/fn-traits.rs:24:10
    |
 LL |     call(foo);
-   |     ---- ^^^ expected an `Fn<()>` closure, found `fn() {foo}`
+   |     ---- ^^^ expected an `Fn<()>` closure, found `[fn item {foo}: fn()]`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `Fn<()>` is not implemented for `[fn item {foo}: fn()]`
+   = note: wrap the `[fn item {foo}: fn()]` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call`
   --> $DIR/fn-traits.rs:11:17
@@ -15,16 +15,16 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut<()>` closure, found `fn() {foo}`
+error[E0277]: expected a `FnMut<()>` closure, found `[fn item {foo}: fn()]`
   --> $DIR/fn-traits.rs:25:14
    |
 LL |     call_mut(foo);
-   |     -------- ^^^ expected an `FnMut<()>` closure, found `fn() {foo}`
+   |     -------- ^^^ expected an `FnMut<()>` closure, found `[fn item {foo}: fn()]`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut<()>` is not implemented for `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnMut<()>` is not implemented for `[fn item {foo}: fn()]`
+   = note: wrap the `[fn item {foo}: fn()]` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
   --> $DIR/fn-traits.rs:15:21
@@ -32,16 +32,16 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(f: impl FnMut()) {
    |                     ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce<()>` closure, found `fn() {foo}`
+error[E0277]: expected a `FnOnce<()>` closure, found `[fn item {foo}: fn()]`
   --> $DIR/fn-traits.rs:26:15
    |
 LL |     call_once(foo);
-   |     --------- ^^^ expected an `FnOnce<()>` closure, found `fn() {foo}`
+   |     --------- ^^^ expected an `FnOnce<()>` closure, found `[fn item {foo}: fn()]`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnOnce<()>` is not implemented for `[fn item {foo}: fn()]`
+   = note: wrap the `[fn item {foo}: fn()]` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_once`
   --> $DIR/fn-traits.rs:19:22
@@ -49,7 +49,7 @@ note: required by a bound in `call_once`
 LL | fn call_once(f: impl FnOnce()) {
    |                      ^^^^^^^^ required by this bound in `call_once`
 
-error[E0277]: expected a `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `Fn<()>` closure, found `[fn item {foo_unsafe}: unsafe fn()]`
   --> $DIR/fn-traits.rs:28:10
    |
 LL |     call(foo_unsafe);
@@ -57,8 +57,8 @@ LL |     call(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for `unsafe fn() {foo_unsafe}`
-   = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `Fn<()>` is not implemented for `[fn item {foo_unsafe}: unsafe fn()]`
+   = note: wrap the `[fn item {foo_unsafe}: unsafe fn()]` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call`
   --> $DIR/fn-traits.rs:11:17
@@ -66,7 +66,7 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `FnMut<()>` closure, found `[fn item {foo_unsafe}: unsafe fn()]`
   --> $DIR/fn-traits.rs:30:14
    |
 LL |     call_mut(foo_unsafe);
@@ -74,8 +74,8 @@ LL |     call_mut(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut<()>` is not implemented for `unsafe fn() {foo_unsafe}`
-   = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnMut<()>` is not implemented for `[fn item {foo_unsafe}: unsafe fn()]`
+   = note: wrap the `[fn item {foo_unsafe}: unsafe fn()]` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
   --> $DIR/fn-traits.rs:15:21
@@ -83,7 +83,7 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(f: impl FnMut()) {
    |                     ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `FnOnce<()>` closure, found `[fn item {foo_unsafe}: unsafe fn()]`
   --> $DIR/fn-traits.rs:32:15
    |
 LL |     call_once(foo_unsafe);
@@ -91,8 +91,8 @@ LL |     call_once(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for `unsafe fn() {foo_unsafe}`
-   = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnOnce<()>` is not implemented for `[fn item {foo_unsafe}: unsafe fn()]`
+   = note: wrap the `[fn item {foo_unsafe}: unsafe fn()]` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_once`
   --> $DIR/fn-traits.rs:19:22

--- a/src/test/ui/static/static-reference-to-fn-1.stderr
+++ b/src/test/ui/static/static-reference-to-fn-1.stderr
@@ -5,7 +5,7 @@ LL |         func: &foo,
    |               ^^^^ expected fn pointer, found fn item
    |
    = note: expected reference `&fn() -> Option<isize>`
-              found reference `&fn() -> Option<isize> {foo}`
+              found reference `&[fn item {foo}: fn() -> Option<isize>]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,16 +1,16 @@
-error[E0277]: `fn() -> impl Future<Output = ()> {foo}` is not a future
+error[E0277]: `[fn item {foo}: fn() -> impl Future<Output = ()>]` is not a future
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:9
    |
 LL | async fn foo() {}
    |          --- consider calling this function
 ...
 LL |     bar(foo);
-   |     --- ^^^ `fn() -> impl Future<Output = ()> {foo}` is not a future
+   |     --- ^^^ `[fn item {foo}: fn() -> impl Future<Output = ()>]` is not a future
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Future` is not implemented for `fn() -> impl Future<Output = ()> {foo}`
-   = note: fn() -> impl Future<Output = ()> {foo} must be a future or must implement `IntoFuture` to be awaited
+   = help: the trait `Future` is not implemented for `[fn item {foo}: fn() -> impl Future<Output = ()>]`
+   = note: [fn item {foo}: fn() -> impl Future<Output = ()>] must be a future or must implement `IntoFuture` to be awaited
 note: required by a bound in `bar`
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
    |

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `fn() -> impl T<O = ()> {foo}: T` is not satisfied
+error[E0277]: the trait bound `[fn item {foo}: fn() -> impl T<O = ()>]: T` is not satisfied
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:17:9
    |
 LL | fn foo() -> impl T<O=()> { S }
    |    --- consider calling this function
 ...
 LL |     bar(foo);
-   |     --- ^^^ the trait `T` is not implemented for `fn() -> impl T<O = ()> {foo}`
+   |     --- ^^^ the trait `T` is not implemented for `[fn item {foo}: fn() -> impl T<O = ()>]`
    |     |
    |     required by a bound introduced by this call
    |

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -22,7 +22,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:29:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
-   | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
+   | ----------------------------------- [fn item {foo}: fn(usize, usize) -> usize] defined here
 ...
 LL |     let _: usize = foo;
    |            -----   ^^^ expected `usize`, found fn item
@@ -30,7 +30,7 @@ LL |     let _: usize = foo;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize, usize) -> usize {foo}`
+           found fn item `[fn item {foo}: fn(usize, usize) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = foo(_, _);
@@ -40,7 +40,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:30:16
    |
 LL | struct S(usize, usize);
-   | -------- fn(usize, usize) -> S {S} defined here
+   | -------- [fn item {S}: fn(usize, usize) -> S] defined here
 ...
 LL |     let _: S = S;
    |            -   ^ expected struct `S`, found fn item
@@ -48,7 +48,7 @@ LL |     let _: S = S;
    |            expected due to this
    |
    = note: expected struct `S`
-             found fn item `fn(usize, usize) -> S {S}`
+             found fn item `[fn item {S}: fn(usize, usize) -> S]`
 help: use parentheses to instantiate this tuple struct
    |
 LL |     let _: S = S(_, _);
@@ -58,7 +58,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:31:20
    |
 LL | fn bar() -> usize { 42 }
-   | ----------------- fn() -> usize {bar} defined here
+   | ----------------- [fn item {bar}: fn() -> usize] defined here
 ...
 LL |     let _: usize = bar;
    |            -----   ^^^ expected `usize`, found fn item
@@ -66,7 +66,7 @@ LL |     let _: usize = bar;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn() -> usize {bar}`
+           found fn item `[fn item {bar}: fn() -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = bar();
@@ -76,7 +76,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:32:16
    |
 LL | struct V();
-   | -------- fn() -> V {V} defined here
+   | -------- [fn item {V}: fn() -> V] defined here
 ...
 LL |     let _: V = V;
    |            -   ^ expected struct `V`, found fn item
@@ -84,7 +84,7 @@ LL |     let _: V = V;
    |            expected due to this
    |
    = note: expected struct `V`
-             found fn item `fn() -> V {V}`
+             found fn item `[fn item {V}: fn() -> V]`
 help: use parentheses to instantiate this tuple struct
    |
 LL |     let _: V = V();
@@ -94,7 +94,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:33:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
-   |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
+   |     ----------------------------------- [fn item {<_ as T>::baz}: fn(usize, usize) -> usize] defined here
 ...
 LL |     let _: usize = T::baz;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -102,7 +102,7 @@ LL |     let _: usize = T::baz;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize, usize) -> usize {<_ as T>::baz}`
+           found fn item `[fn item {<_ as T>::baz}: fn(usize, usize) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = T::baz(_, _);
@@ -112,7 +112,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:34:20
    |
 LL |     fn bat(x: usize) -> usize { 42 }
-   |     ------------------------- fn(usize) -> usize {<_ as T>::bat} defined here
+   |     ------------------------- [fn item {<_ as T>::bat}: fn(usize) -> usize] defined here
 ...
 LL |     let _: usize = T::bat;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -120,7 +120,7 @@ LL |     let _: usize = T::bat;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<_ as T>::bat}`
+           found fn item `[fn item {<_ as T>::bat}: fn(usize) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = T::bat(_);
@@ -130,7 +130,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
    |
 LL |     A(usize),
-   |     - fn(usize) -> E {E::A} defined here
+   |     - [fn item {E::A}: fn(usize) -> E] defined here
 ...
 LL |     let _: E = E::A;
    |            -   ^^^^ expected enum `E`, found fn item
@@ -138,7 +138,7 @@ LL |     let _: E = E::A;
    |            expected due to this
    |
    = note: expected enum `E`
-           found fn item `fn(usize) -> E {E::A}`
+           found fn item `[fn item {E::A}: fn(usize) -> E]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |     let _: E = E::A(_);
@@ -148,7 +148,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:37:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
-   |     ----------------------------------- fn(usize, usize) -> usize {<X as T>::baz} defined here
+   |     ----------------------------------- [fn item {<X as T>::baz}: fn(usize, usize) -> usize] defined here
 ...
 LL |     let _: usize = X::baz;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -156,7 +156,7 @@ LL |     let _: usize = X::baz;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize, usize) -> usize {<X as T>::baz}`
+           found fn item `[fn item {<X as T>::baz}: fn(usize, usize) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = X::baz(_, _);
@@ -166,7 +166,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:38:20
    |
 LL |     fn bat(x: usize) -> usize { 42 }
-   |     ------------------------- fn(usize) -> usize {<X as T>::bat} defined here
+   |     ------------------------- [fn item {<X as T>::bat}: fn(usize) -> usize] defined here
 ...
 LL |     let _: usize = X::bat;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -174,7 +174,7 @@ LL |     let _: usize = X::bat;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<X as T>::bat}`
+           found fn item `[fn item {<X as T>::bat}: fn(usize) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = X::bat(_);
@@ -184,7 +184,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:39:20
    |
 LL |     fn bax(x: usize) -> usize { 42 }
-   |     ------------------------- fn(usize) -> usize {<X as T>::bax} defined here
+   |     ------------------------- [fn item {<X as T>::bax}: fn(usize) -> usize] defined here
 ...
 LL |     let _: usize = X::bax;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -192,7 +192,7 @@ LL |     let _: usize = X::bax;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<X as T>::bax}`
+           found fn item `[fn item {<X as T>::bax}: fn(usize) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = X::bax(_);
@@ -202,7 +202,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:40:20
    |
 LL |     fn bach(x: usize) -> usize;
-   |     --------------------------- fn(usize) -> usize {<X as T>::bach} defined here
+   |     --------------------------- [fn item {<X as T>::bach}: fn(usize) -> usize] defined here
 ...
 LL |     let _: usize = X::bach;
    |            -----   ^^^^^^^ expected `usize`, found fn item
@@ -210,7 +210,7 @@ LL |     let _: usize = X::bach;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<X as T>::bach}`
+           found fn item `[fn item {<X as T>::bach}: fn(usize) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = X::bach(_);
@@ -220,7 +220,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:41:20
    |
 LL |     fn ban(&self) -> usize { 42 }
-   |     ---------------------- for<'r> fn(&'r X) -> usize {<X as T>::ban} defined here
+   |     ---------------------- [fn item {<X as T>::ban}: for<'r> fn(&'r X) -> usize] defined here
 ...
 LL |     let _: usize = X::ban;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -228,7 +228,7 @@ LL |     let _: usize = X::ban;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `for<'r> fn(&'r X) -> usize {<X as T>::ban}`
+           found fn item `[fn item {<X as T>::ban}: for<'r> fn(&'r X) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = X::ban(_);
@@ -238,7 +238,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:42:20
    |
 LL |     fn bal(&self) -> usize;
-   |     ----------------------- for<'r> fn(&'r X) -> usize {<X as T>::bal} defined here
+   |     ----------------------- [fn item {<X as T>::bal}: for<'r> fn(&'r X) -> usize] defined here
 ...
 LL |     let _: usize = X::bal;
    |            -----   ^^^^^^ expected `usize`, found fn item
@@ -246,7 +246,7 @@ LL |     let _: usize = X::bal;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `for<'r> fn(&'r X) -> usize {<X as T>::bal}`
+           found fn item `[fn item {<X as T>::bal}: for<'r> fn(&'r X) -> usize]`
 help: use parentheses to call this function
    |
 LL |     let _: usize = X::bal(_);

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -40,7 +40,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:30:16
    |
 LL | struct S(usize, usize);
-   | -------- [fn item {S}: fn(usize, usize) -> S] defined here
+   | -------- [constructor of {S}: fn(usize, usize) -> S] defined here
 ...
 LL |     let _: S = S;
    |            -   ^ expected struct `S`, found fn item
@@ -48,7 +48,7 @@ LL |     let _: S = S;
    |            expected due to this
    |
    = note: expected struct `S`
-             found fn item `[fn item {S}: fn(usize, usize) -> S]`
+             found fn item `[constructor of {S}: fn(usize, usize) -> S]`
 help: use parentheses to instantiate this tuple struct
    |
 LL |     let _: S = S(_, _);
@@ -76,7 +76,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:32:16
    |
 LL | struct V();
-   | -------- [fn item {V}: fn() -> V] defined here
+   | -------- [constructor of {V}: fn() -> V] defined here
 ...
 LL |     let _: V = V;
    |            -   ^ expected struct `V`, found fn item
@@ -84,7 +84,7 @@ LL |     let _: V = V;
    |            expected due to this
    |
    = note: expected struct `V`
-             found fn item `[fn item {V}: fn() -> V]`
+             found fn item `[constructor of {V}: fn() -> V]`
 help: use parentheses to instantiate this tuple struct
    |
 LL |     let _: V = V();
@@ -130,7 +130,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
    |
 LL |     A(usize),
-   |     - [fn item {E::A}: fn(usize) -> E] defined here
+   |     - [constructor of {E::A}: fn(usize) -> E] defined here
 ...
 LL |     let _: E = E::A;
    |            -   ^^^^ expected enum `E`, found fn item
@@ -138,7 +138,7 @@ LL |     let _: E = E::A;
    |            expected due to this
    |
    = note: expected enum `E`
-           found fn item `[fn item {E::A}: fn(usize) -> E]`
+           found fn item `[constructor of {E::A}: fn(usize) -> E]`
 help: use parentheses to instantiate this tuple variant
    |
 LL |     let _: E = E::A(_);

--- a/src/test/ui/transmute/transmute-from-fn-item-types-error.stderr
+++ b/src/test/ui/transmute/transmute-from-fn-item-types-error.stderr
@@ -4,7 +4,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     let i = mem::transmute(bar);
    |             ^^^^^^^^^^^^^^
    |
-   = note: source type: `unsafe fn() {bar}` (0 bits)
+   = note: source type: `[fn item {bar}: unsafe fn()]` (0 bits)
    = note: target type: `i8` (8 bits)
 
 error[E0591]: can't transmute zero-sized type
@@ -13,7 +13,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     let p = mem::transmute(foo);
    |             ^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() -> (i8, *const (), Option<fn()>) {foo}
+   = note: source type: [fn item {foo}: unsafe fn() -> (i8, *const (), Option<fn()>)]
    = note: target type: *const ()
    = help: cast with `as` to a pointer instead
 
@@ -23,7 +23,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     let of = mem::transmute(main);
    |              ^^^^^^^^^^^^^^
    |
-   = note: source type: fn() {main}
+   = note: source type: [fn item {main}: fn()]
    = note: target type: Option<fn()>
    = help: cast with `as` to a pointer instead
 
@@ -33,7 +33,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     mem::transmute::<_, u8>(main);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `fn() {main}` (0 bits)
+   = note: source type: `[fn item {main}: fn()]` (0 bits)
    = note: target type: `u8` (8 bits)
 
 error[E0591]: can't transmute zero-sized type
@@ -42,7 +42,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, *mut ()>(foo);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() -> (i8, *const (), Option<fn()>) {foo}
+   = note: source type: [fn item {foo}: unsafe fn() -> (i8, *const (), Option<fn()>)]
    = note: target type: *mut ()
    = help: cast with `as` to a pointer instead
 
@@ -52,7 +52,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, fn()>(bar);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() {bar}
+   = note: source type: [fn item {bar}: unsafe fn()]
    = note: target type: fn()
    = help: cast with `as` to a pointer instead
 
@@ -62,7 +62,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, *mut ()>(Some(foo));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() -> (i8, *const (), Option<fn()>) {foo}
+   = note: source type: [fn item {foo}: unsafe fn() -> (i8, *const (), Option<fn()>)]
    = note: target type: *mut ()
    = help: cast with `as` to a pointer instead
 
@@ -72,7 +72,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, fn()>(Some(bar));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() {bar}
+   = note: source type: [fn item {bar}: unsafe fn()]
    = note: target type: fn()
    = help: cast with `as` to a pointer instead
 
@@ -82,7 +82,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, Option<fn()>>(Some(baz));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() {baz}
+   = note: source type: [fn item {baz}: unsafe fn()]
    = note: target type: Option<fn()>
    = help: cast with `as` to a pointer instead
 

--- a/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `fn() -> Foo {foo}: Sized`
+error[E0275]: overflow evaluating the requirement `[fn item {foo}: fn() -> Foo]: Sized`
   --> $DIR/issue-53398-cyclic-types.rs:5:13
    |
 LL | fn foo() -> Foo {

--- a/src/test/ui/type-alias-impl-trait/issue-98604.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-98604.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<fn() -> impl Future<Output = ()> {test} as FnOnce<()>>::Output == Pin<Box<(dyn Future<Output = ()> + 'static)>>`
+error[E0271]: type mismatch resolving `<[fn item {test}: fn() -> impl Future<Output = ()>] as FnOnce<()>>::Output == Pin<Box<(dyn Future<Output = ()> + 'static)>>`
   --> $DIR/issue-98604.rs:11:5
    |
 LL |     Box::new(test) as AsyncFnPtr;
@@ -11,7 +11,7 @@ LL | async fn test() {}
    |                 ^ checked the `Output` of this `async fn`, found opaque type
    = note:   expected struct `Pin<Box<(dyn Future<Output = ()> + 'static)>>`
            found opaque type `impl Future<Output = ()>`
-   = note: required for the cast from `fn() -> impl Future<Output = ()> {test}` to the object type `dyn Fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>>`
+   = note: required for the cast from `[fn item {test}: fn() -> impl Future<Output = ()>]` to the object type `dyn Fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/issue-98608.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-98608.rs
@@ -2,7 +2,7 @@ fn hi() -> impl Sized { std::ptr::null::<u8>() }
 
 fn main() {
     let b: Box<dyn Fn() -> Box<u8>> = Box::new(hi);
-    //~^ ERROR type mismatch resolving `<fn() -> impl Sized {hi} as FnOnce<()>>::Output == Box<u8>`
+    //~^ ERROR type mismatch resolving `<[fn item {hi}: fn() -> impl Sized] as FnOnce<()>>::Output == Box<u8>`
     let boxed = b();
     let null = *boxed;
     println!("{null:?}");

--- a/src/test/ui/type-alias-impl-trait/issue-98608.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-98608.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<fn() -> impl Sized {hi} as FnOnce<()>>::Output == Box<u8>`
+error[E0271]: type mismatch resolving `<[fn item {hi}: fn() -> impl Sized] as FnOnce<()>>::Output == Box<u8>`
   --> $DIR/issue-98608.rs:4:39
    |
 LL | fn hi() -> impl Sized { std::ptr::null::<u8>() }
@@ -9,7 +9,7 @@ LL |     let b: Box<dyn Fn() -> Box<u8>> = Box::new(hi);
    |
    = note:   expected struct `Box<u8>`
            found opaque type `impl Sized`
-   = note: required for the cast from `fn() -> impl Sized {hi}` to the object type `dyn Fn() -> Box<u8>`
+   = note: required for the cast from `[fn item {hi}: fn() -> impl Sized]` to the object type `dyn Fn() -> Box<u8>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/issue-29124.stderr
+++ b/src/test/ui/typeck/issue-29124.stderr
@@ -1,16 +1,16 @@
-error[E0599]: no method named `x` found for fn item `fn() -> Ret {Obj::func}` in the current scope
+error[E0599]: no method named `x` found for fn item `[fn item {Obj::func}: fn() -> Ret]` in the current scope
   --> $DIR/issue-29124.rs:15:15
    |
 LL |     Obj::func.x();
-   |     --------- ^ method not found in `fn() -> Ret {Obj::func}`
+   |     --------- ^ method not found in `[fn item {Obj::func}: fn() -> Ret]`
    |     |
    |     this is a function, perhaps you wish to call it
 
-error[E0599]: no method named `x` found for fn item `fn() -> Ret {func}` in the current scope
+error[E0599]: no method named `x` found for fn item `[fn item {func}: fn() -> Ret]` in the current scope
   --> $DIR/issue-29124.rs:17:10
    |
 LL |     func.x();
-   |     ---- ^ method not found in `fn() -> Ret {func}`
+   |     ---- ^ method not found in `[fn item {func}: fn() -> Ret]`
    |     |
    |     this is a function, perhaps you wish to call it
 

--- a/src/test/ui/typeck/issue-87181/empty-tuple-method.rs
+++ b/src/test/ui/typeck/issue-87181/empty-tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `[fn item {Foo}: fn() -> Foo]` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for fn item `[constructor of {Foo}: fn() -> Foo]` in the current scope [E0599]
 }

--- a/src/test/ui/typeck/issue-87181/empty-tuple-method.rs
+++ b/src/test/ui/typeck/issue-87181/empty-tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `fn() -> Foo {Foo}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for fn item `[fn item {Foo}: fn() -> Foo]` in the current scope [E0599]
 }

--- a/src/test/ui/typeck/issue-87181/empty-tuple-method.stderr
+++ b/src/test/ui/typeck/issue-87181/empty-tuple-method.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for fn item `[fn item {Foo}: fn() -> Foo]` in the current scope
+error[E0599]: no method named `foo` found for fn item `[constructor of {Foo}: fn() -> Foo]` in the current scope
   --> $DIR/empty-tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();
-   |     --------- ^^^ method not found in `[fn item {Foo}: fn() -> Foo]`
+   |     --------- ^^^ method not found in `[constructor of {Foo}: fn() -> Foo]`
    |     |
    |     this is the constructor of a struct
    |

--- a/src/test/ui/typeck/issue-87181/empty-tuple-method.stderr
+++ b/src/test/ui/typeck/issue-87181/empty-tuple-method.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for fn item `fn() -> Foo {Foo}` in the current scope
+error[E0599]: no method named `foo` found for fn item `[fn item {Foo}: fn() -> Foo]` in the current scope
   --> $DIR/empty-tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();
-   |     --------- ^^^ method not found in `fn() -> Foo {Foo}`
+   |     --------- ^^^ method not found in `[fn item {Foo}: fn() -> Foo]`
    |     |
    |     this is the constructor of a struct
    |

--- a/src/test/ui/typeck/issue-87181/enum-variant.rs
+++ b/src/test/ui/typeck/issue-87181/enum-variant.rs
@@ -12,5 +12,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo::Tup };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `fn() -> Foo {Foo::Tup}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for fn item `[fn item {Foo::Tup}: fn() -> Foo]` in the current scope [E0599]
 }

--- a/src/test/ui/typeck/issue-87181/enum-variant.rs
+++ b/src/test/ui/typeck/issue-87181/enum-variant.rs
@@ -12,5 +12,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo::Tup };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `[fn item {Foo::Tup}: fn() -> Foo]` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for fn item `[constructor of {Foo::Tup}: fn() -> Foo]` in the current scope [E0599]
 }

--- a/src/test/ui/typeck/issue-87181/enum-variant.stderr
+++ b/src/test/ui/typeck/issue-87181/enum-variant.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for fn item `[fn item {Foo::Tup}: fn() -> Foo]` in the current scope
+error[E0599]: no method named `foo` found for fn item `[constructor of {Foo::Tup}: fn() -> Foo]` in the current scope
   --> $DIR/enum-variant.rs:14:15
    |
 LL |     thing.bar.foo();
-   |     --------- ^^^ method not found in `[fn item {Foo::Tup}: fn() -> Foo]`
+   |     --------- ^^^ method not found in `[constructor of {Foo::Tup}: fn() -> Foo]`
    |     |
    |     this is the constructor of an enum variant
    |

--- a/src/test/ui/typeck/issue-87181/enum-variant.stderr
+++ b/src/test/ui/typeck/issue-87181/enum-variant.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for fn item `fn() -> Foo {Foo::Tup}` in the current scope
+error[E0599]: no method named `foo` found for fn item `[fn item {Foo::Tup}: fn() -> Foo]` in the current scope
   --> $DIR/enum-variant.rs:14:15
    |
 LL |     thing.bar.foo();
-   |     --------- ^^^ method not found in `fn() -> Foo {Foo::Tup}`
+   |     --------- ^^^ method not found in `[fn item {Foo::Tup}: fn() -> Foo]`
    |     |
    |     this is the constructor of an enum variant
    |

--- a/src/test/ui/typeck/issue-87181/tuple-field.rs
+++ b/src/test/ui/typeck/issue-87181/tuple-field.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.0;
-    //~^ ERROR no field `0` on type `fn(char, u16) -> Foo {Foo}` [E0609]
+    //~^ ERROR no field `0` on type `[fn item {Foo}: fn(char, u16) -> Foo]` [E0609]
 }

--- a/src/test/ui/typeck/issue-87181/tuple-field.rs
+++ b/src/test/ui/typeck/issue-87181/tuple-field.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.0;
-    //~^ ERROR no field `0` on type `[fn item {Foo}: fn(char, u16) -> Foo]` [E0609]
+    //~^ ERROR no field `0` on type `[constructor of {Foo}: fn(char, u16) -> Foo]` [E0609]
 }

--- a/src/test/ui/typeck/issue-87181/tuple-field.stderr
+++ b/src/test/ui/typeck/issue-87181/tuple-field.stderr
@@ -1,4 +1,4 @@
-error[E0609]: no field `0` on type `fn(char, u16) -> Foo {Foo}`
+error[E0609]: no field `0` on type `[fn item {Foo}: fn(char, u16) -> Foo]`
   --> $DIR/tuple-field.rs:12:15
    |
 LL |     thing.bar.0;

--- a/src/test/ui/typeck/issue-87181/tuple-field.stderr
+++ b/src/test/ui/typeck/issue-87181/tuple-field.stderr
@@ -1,4 +1,4 @@
-error[E0609]: no field `0` on type `[fn item {Foo}: fn(char, u16) -> Foo]`
+error[E0609]: no field `0` on type `[constructor of {Foo}: fn(char, u16) -> Foo]`
   --> $DIR/tuple-field.rs:12:15
    |
 LL |     thing.bar.0;

--- a/src/test/ui/typeck/issue-87181/tuple-method.rs
+++ b/src/test/ui/typeck/issue-87181/tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `[fn item {Foo}: fn(u8, i32) -> Foo]` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for fn item `[constructor of {Foo}: fn(u8, i32) -> Foo]` in the current scope [E0599]
 }

--- a/src/test/ui/typeck/issue-87181/tuple-method.rs
+++ b/src/test/ui/typeck/issue-87181/tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for fn item `fn(u8, i32) -> Foo {Foo}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for fn item `[fn item {Foo}: fn(u8, i32) -> Foo]` in the current scope [E0599]
 }

--- a/src/test/ui/typeck/issue-87181/tuple-method.stderr
+++ b/src/test/ui/typeck/issue-87181/tuple-method.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for fn item `[fn item {Foo}: fn(u8, i32) -> Foo]` in the current scope
+error[E0599]: no method named `foo` found for fn item `[constructor of {Foo}: fn(u8, i32) -> Foo]` in the current scope
   --> $DIR/tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();
-   |     --------- ^^^ method not found in `[fn item {Foo}: fn(u8, i32) -> Foo]`
+   |     --------- ^^^ method not found in `[constructor of {Foo}: fn(u8, i32) -> Foo]`
    |     |
    |     this is the constructor of a struct
    |

--- a/src/test/ui/typeck/issue-87181/tuple-method.stderr
+++ b/src/test/ui/typeck/issue-87181/tuple-method.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for fn item `fn(u8, i32) -> Foo {Foo}` in the current scope
+error[E0599]: no method named `foo` found for fn item `[fn item {Foo}: fn(u8, i32) -> Foo]` in the current scope
   --> $DIR/tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();
-   |     --------- ^^^ method not found in `fn(u8, i32) -> Foo {Foo}`
+   |     --------- ^^^ method not found in `[fn item {Foo}: fn(u8, i32) -> Foo]`
    |     |
    |     this is the constructor of a struct
    |

--- a/src/test/ui/typeck/issue-96738.stderr
+++ b/src/test/ui/typeck/issue-96738.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `nonexistent_method` found for fn item `fn(_) -> Option<_> {Option::<_>::Some}` in the current scope
+error[E0599]: no method named `nonexistent_method` found for fn item `[fn item {Option::<_>::Some}: fn(_) -> Option<_>]` in the current scope
   --> $DIR/issue-96738.rs:2:10
    |
 LL |     Some.nonexistent_method();
-   |     ---- ^^^^^^^^^^^^^^^^^^ method not found in `fn(_) -> Option<_> {Option::<_>::Some}`
+   |     ---- ^^^^^^^^^^^^^^^^^^ method not found in `[fn item {Option::<_>::Some}: fn(_) -> Option<_>]`
    |     |
    |     this is the constructor of an enum variant
    |
@@ -11,7 +11,7 @@ help: call the constructor
 LL |     (Some)(_).nonexistent_method();
    |     +    ++++
 
-error[E0609]: no field `nonexistent_field` on type `fn(_) -> Option<_> {Option::<_>::Some}`
+error[E0609]: no field `nonexistent_field` on type `[fn item {Option::<_>::Some}: fn(_) -> Option<_>]`
   --> $DIR/issue-96738.rs:3:10
    |
 LL |     Some.nonexistent_field;

--- a/src/test/ui/typeck/issue-96738.stderr
+++ b/src/test/ui/typeck/issue-96738.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `nonexistent_method` found for fn item `[fn item {Option::<_>::Some}: fn(_) -> Option<_>]` in the current scope
+error[E0599]: no method named `nonexistent_method` found for fn item `[constructor of {Option::<_>::Some}: fn(_) -> Option<_>]` in the current scope
   --> $DIR/issue-96738.rs:2:10
    |
 LL |     Some.nonexistent_method();
-   |     ---- ^^^^^^^^^^^^^^^^^^ method not found in `[fn item {Option::<_>::Some}: fn(_) -> Option<_>]`
+   |     ---- ^^^^^^^^^^^^^^^^^^ method not found in `[constructor of {Option::<_>::Some}: fn(_) -> Option<_>]`
    |     |
    |     this is the constructor of an enum variant
    |
@@ -11,7 +11,7 @@ help: call the constructor
 LL |     (Some)(_).nonexistent_method();
    |     +    ++++
 
-error[E0609]: no field `nonexistent_field` on type `[fn item {Option::<_>::Some}: fn(_) -> Option<_>]`
+error[E0609]: no field `nonexistent_field` on type `[constructor of {Option::<_>::Some}: fn(_) -> Option<_>]`
   --> $DIR/issue-96738.rs:3:10
    |
 LL |     Some.nonexistent_field;

--- a/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+error[E0277]: expected a `Fn<(&isize,)>` closure, found `[fn item {square}: for<'r> unsafe fn(&'r isize) -> isize]`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
@@ -6,7 +6,7 @@ LL |     let x = call_it(&square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `[fn item {square}: for<'r> unsafe fn(&'r isize) -> isize]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:9:15
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+error[E0277]: expected a `FnMut<(&isize,)>` closure, found `[fn item {square}: for<'r> unsafe fn(&'r isize) -> isize]`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -22,7 +22,7 @@ LL |     let y = call_it_mut(&mut square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `[fn item {square}: for<'r> unsafe fn(&'r isize) -> isize]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:19
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `[fn item {square}: for<'r> unsafe fn(&'r isize) -> isize]`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);
@@ -38,7 +38,7 @@ LL |     let z = call_it_once(square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `[fn item {square}: for<'r> unsafe fn(&'r isize) -> isize]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:15:20

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -1,42 +1,42 @@
-error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+error[E0277]: expected a `Fn<(&isize,)>` closure, found `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
   --> $DIR/unboxed-closures-wrong-abi.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
-   |             ------- ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             ------- ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-wrong-abi.rs:9:15
    |
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+error[E0277]: expected a `FnMut<(&isize,)>` closure, found `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
   --> $DIR/unboxed-closures-wrong-abi.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ----------- ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             ----------- ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-wrong-abi.rs:12:19
    |
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
   --> $DIR/unboxed-closures-wrong-abi.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);
-   |             ------------ ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             ------------ ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `[fn item {square}: for<'r> extern "C" fn(&'r isize) -> isize]`
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-wrong-abi.rs:15:20
    |

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `Fn<(&isize,)>` closure, found `[fn item {square}: unsafe fn(isize) -> isize]`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:21:21
    |
 LL |     let x = call_it(&square, 22);
@@ -6,7 +6,7 @@ LL |     let x = call_it(&square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `[fn item {square}: unsafe fn(isize) -> isize]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:10:15
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `FnMut<(&isize,)>` closure, found `[fn item {square}: unsafe fn(isize) -> isize]`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:26:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -22,7 +22,7 @@ LL |     let y = call_it_mut(&mut square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `[fn item {square}: unsafe fn(isize) -> isize]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:19
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `[fn item {square}: unsafe fn(isize) -> isize]`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:31:26
    |
 LL |     let z = call_it_once(square, 22);
@@ -38,7 +38,7 @@ LL |     let z = call_it_once(square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `[fn item {square}: unsafe fn(isize) -> isize]`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:16:20

--- a/src/test/ui/while-type-error.stderr
+++ b/src/test/ui/while-type-error.stderr
@@ -5,7 +5,7 @@ LL | fn main() { while main { } }
    |                   ^^^^ expected `bool`, found fn item
    |
    = note: expected type `bool`
-           found fn item `fn() {main}`
+           found fn item `[fn item {main}: fn()]`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Change the way “fn item” types are displayed: make them easier to distinguish from fn pointers.

My first point here is to figure out if CI passes, or how much more needs to be done to *make* it pass. (_Edit: It does pass 🥳_) Then there still needs to be discussion *if* we want such a change, and also *how exactly* they should best be rendered.

As you can see, this affects quite a lot of output. In particular, not only error messages but also pretty printed MIR (with types), as far as I can tell.

Context: https://internals.rust-lang.org/t/extending-implicit-coercion-of-function-items-to-function-pointers-during-trait-resolution/17093/6

My initial idea was to use something like ``[function item `guess`: for<'r> fn(&'r [Guess]) -> String]``, but `fn item` is more consistent with other parts of the error messages, and the backticks don’t look nice in an error message that also puts backticks around the whole type, so it became `[fn item {guess}: for<'r> fn(&'r [Guess]) -> String]`. I’ve also considered something like `[fn-item guess: for<'r> fn(&'r [Guess]) -> String]`, but the colon looks suboptimal after a longer path; wrapping the path into an extra set of parentheses works nicely IMO, and it could also be seen as a reference to the previous way of rendering the type, `for<'r> fn(&'r [Guess]) -> String {guess}`, which used the curly braces, too.

Really, all that changes now is: the order is switched, the thing becomes more clearly grouped as one coherent thing with the `[]`s (which are also meant to make the thing look more similar to a closure type, and more clearly different from a fn pointer type), and the thing becomes more self-describing (since it *is* special diagnostics-only syntax, after all) with the string “fn item” included.

As of now, there’s a minor downside that tuple-structs’ and tuple-struct-style-enum-variants’ constructors render as something like `[fn item {Foo}: u8 -> Foo]`, too, whereas something like e.g. `[tuple struct constructor {Foo}: u8 -> Foo]` might be nicer. It’s also already described as “'fn item`” currently though anyway, by error messages such as
```rs
struct Foo(u8);
fn f() {
    let _: () = Foo;
}
```
```
error[E0308]: mismatched types
 --> src/lib.rs:3:17
  |
3 |     let _: () = Foo;
  |            --   ^^^ expected `()`, found fn item
  |            |
  |            expected due to this
  |
  = note: expected unit type `()`
               found fn item `fn(u8) -> Foo {Foo}`
``` 

_(which would after this PR look like this instead:)_
```
error[E0308]: mismatched types
 --> src/lib.rs:3:17
  |
3 |     let _: () = Foo;
  |            --   ^^^ expected `()`, found fn item
  |            |
  |            expected due to this
  |
  = note: expected unit type `()`
               found fn item `[fn item {Foo}: fn(u8) -> Foo]`
```