### PR TITLE
Do not leak type variables from opaque type relation

### DIFF
--- a/src/test/ui/impl-trait/issue-99914.rs
+++ b/src/test/ui/impl-trait/issue-99914.rs
@@ -1,0 +1,13 @@
+// edition:2021
+
+fn main() {}
+
+struct Error;
+struct Okay;
+
+fn foo(t: Result<Okay, Error>) {
+    t.and_then(|t| -> _ { bar(t) });
+    //~^ ERROR mismatched types
+}
+
+async fn bar(t: Okay) {}

--- a/src/test/ui/impl-trait/issue-99914.stderr
+++ b/src/test/ui/impl-trait/issue-99914.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-99914.rs:9:27
+   |
+LL |     t.and_then(|t| -> _ { bar(t) });
+   |                           ^^^^^^ expected enum `Result`, found opaque type
+   |
+note: while checking the return type of the `async fn`
+  --> $DIR/issue-99914.rs:13:23
+   |
+LL | async fn bar(t: Okay) {}
+   |                       ^ checked the `Output` of this `async fn`, found opaque type
+   = note:     expected enum `Result<_, Error>`
+           found opaque type `impl Future<Output = ()>`
+help: try wrapping the expression in `Ok`
+   |
+LL |     t.and_then(|t| -> _ { Ok(bar(t)) });
+   |                           +++      +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
The "root cause" is that we call `InferCtxt::resolve_vars_if_possible` (3d9dd681f520d1d59f38aed0056cf9474894cc74) on the types we get back in `TypeError::Sorts` since I added a call to it in `InferCtxt::same_type_modulo_infer`. However if this `TypeError` comes from a `InferCtxt::commit_if_ok`, then it may reference type variables that do not exist anymore, which is problematic.

We avoid this by substituting the `TypeError` with the types we had before being generalized while handling opaques.

This is kinda gross, and I feel like we can get the same issue from other places where we generalize type/const inference variables. Maybe not? I don't know.

Fixes #99914
Fixes #99970
Fixes #100463