### PR TITLE
Fix unwinding on certain platforms when debug assertions are enabled

### DIFF
--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -306,7 +306,9 @@ unsafe fn find_eh_action(context: *mut uw::_Unwind_Context) -> Result<EHAction, 
     let eh_context = EHContext {
         // The return address points 1 byte past the call instruction,
         // which could be in the next IP range in LSDA range table.
-        ip: if ip_before_instr != 0 { ip } else { ip - 1 },
+        //
+        // `ip = -1` has special meaning, so use wrapping sub to allow for that
+        ip: if ip_before_instr != 0 { ip } else { ip.wrapping_sub(1) },
         func_start: uw::_Unwind_GetRegionStart(context),
         get_text_start: &|| uw::_Unwind_GetTextRelBase(context),
         get_data_start: &|| uw::_Unwind_GetDataRelBase(context),


### PR DESCRIPTION
This came up on `armv7-apple-ios` when using `-Zbuild-std`.

Looks like this is a leftover from a [conversion from C to Rust](https://github.com/rust-lang/rust/commit/051c2d14fb1e73866376668088971605d38f0c65), where integer wrapping is implicit.

Not at all sure how the unwinding code works!