### PR TITLE
Fix nonsense non-tupled `Fn` trait error

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1750,6 +1750,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         if let Some(ValuePairs::PolyTraitRefs(exp_found)) = values
             && let ty::Closure(def_id, _) = exp_found.expected.skip_binder().self_ty().kind()
             && let Some(def_id) = def_id.as_local()
+            && terr.involves_regions()
         {
             let span = self.tcx.def_span(def_id);
             diag.span_note(span, "this closure does not fulfill the lifetime requirements");

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1935,6 +1935,18 @@ impl<'tcx> TypeTrace<'tcx> {
         }
     }
 
+    pub fn poly_trait_refs(
+        cause: &ObligationCause<'tcx>,
+        a_is_expected: bool,
+        a: ty::PolyTraitRef<'tcx>,
+        b: ty::PolyTraitRef<'tcx>,
+    ) -> TypeTrace<'tcx> {
+        TypeTrace {
+            cause: cause.clone(),
+            values: PolyTraitRefs(ExpectedFound::new(a_is_expected, a.into(), b.into())),
+        }
+    }
+
     pub fn consts(
         cause: &ObligationCause<'tcx>,
         a_is_expected: bool,

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -74,6 +74,18 @@ pub enum TypeError<'tcx> {
     TargetFeatureCast(DefId),
 }
 
+impl TypeError<'_> {
+    pub fn involves_regions(self) -> bool {
+        match self {
+            TypeError::RegionsDoesNotOutlive(_, _)
+            | TypeError::RegionsInsufficientlyPolymorphic(_, _)
+            | TypeError::RegionsOverlyPolymorphic(_, _)
+            | TypeError::RegionsPlaceholderMismatch => true,
+            _ => false,
+        }
+    }
+}
+
 /// Explains the source of a type err in a short, human readable way. This is meant to be placed
 /// in parentheses after some larger message. You should also invoke `note_and_explain_type_err()`
 /// afterwards to present additional details, particularly when it comes to lifetime-related

--- a/src/test/ui/mismatched_types/E0631.rs
+++ b/src/test/ui/mismatched_types/E0631.rs
@@ -5,7 +5,7 @@ fn bar<F: Fn<usize>>(_: F) {}
 fn main() {
     fn f(_: u64) {}
     foo(|_: isize| {}); //~ ERROR type mismatch
-    bar(|_: isize| {}); //~ ERROR type mismatch
+    bar(|_: isize| {}); //~ ERROR mismatched types
     foo(f); //~ ERROR type mismatch
-    bar(f); //~ ERROR type mismatch
+    bar(f); //~ ERROR mismatched types
 }

--- a/src/test/ui/mismatched_types/E0631.rs
+++ b/src/test/ui/mismatched_types/E0631.rs
@@ -1,11 +1,11 @@
 #![feature(unboxed_closures)]
 
 fn foo<F: Fn(usize)>(_: F) {}
-fn bar<F: Fn<usize>>(_: F) {}
+fn bar<F: Fn<(usize,)>>(_: F) {}
 fn main() {
     fn f(_: u64) {}
     foo(|_: isize| {}); //~ ERROR type mismatch
-    bar(|_: isize| {}); //~ ERROR mismatched types
+    bar(|_: isize| {}); //~ ERROR type mismatch
     foo(f); //~ ERROR type mismatch
-    bar(f); //~ ERROR mismatched types
+    bar(f); //~ ERROR type mismatch
 }

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -14,19 +14,21 @@ note: required by a bound in `foo`
 LL | fn foo<F: Fn(usize)>(_: F) {}
    |           ^^^^^^^^^ required by this bound in `foo`
 
-error[E0308]: mismatched types
+error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
 LL |     bar(|_: isize| {});
-   |     ^^^ types differ
+   |     ^^^ ---------- found signature defined here
+   |     |
+   |     expected due to this
    |
-   = note: expected trait `Fn<usize>`
-              found trait `Fn<(isize,)>`
+   = note: expected closure signature `fn(usize) -> _`
+              found closure signature `fn(isize) -> _`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |
-LL | fn bar<F: Fn<usize>>(_: F) {}
-   |           ^^^^^^^^^ required by this bound in `bar`
+LL | fn bar<F: Fn<(usize,)>>(_: F) {}
+   |           ^^^^^^^^^^^^ required by this bound in `bar`
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:9:9
@@ -47,23 +49,25 @@ note: required by a bound in `foo`
 LL | fn foo<F: Fn(usize)>(_: F) {}
    |           ^^^^^^^^^ required by this bound in `foo`
 
-error[E0308]: mismatched types
+error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:10:9
    |
+LL |     fn f(_: u64) {}
+   |     ------------ found signature defined here
+...
 LL |     bar(f);
-   |     --- ^ types differ
+   |     --- ^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
-   = note: expected trait `Fn<usize>`
-              found trait `Fn<(u64,)>`
+   = note: expected function signature `fn(usize) -> _`
+              found function signature `fn(u64) -> _`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |
-LL | fn bar<F: Fn<usize>>(_: F) {}
-   |           ^^^^^^^^^ required by this bound in `bar`
+LL | fn bar<F: Fn<(usize,)>>(_: F) {}
+   |           ^^^^^^^^^^^^ required by this bound in `bar`
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0308, E0631.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -14,16 +14,14 @@ note: required by a bound in `foo`
 LL | fn foo<F: Fn(usize)>(_: F) {}
    |           ^^^^^^^^^ required by this bound in `foo`
 
-error[E0631]: type mismatch in closure arguments
+error[E0308]: mismatched types
   --> $DIR/E0631.rs:8:5
    |
 LL |     bar(|_: isize| {});
-   |     ^^^ ---------- found signature defined here
-   |     |
-   |     expected due to this
+   |     ^^^ types differ
    |
-   = note: expected closure signature `fn(usize) -> _`
-              found closure signature `fn(isize) -> _`
+   = note: expected trait `Fn<usize>`
+              found trait `Fn<(isize,)>`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |
@@ -49,19 +47,16 @@ note: required by a bound in `foo`
 LL | fn foo<F: Fn(usize)>(_: F) {}
    |           ^^^^^^^^^ required by this bound in `foo`
 
-error[E0631]: type mismatch in function arguments
+error[E0308]: mismatched types
   --> $DIR/E0631.rs:10:9
    |
-LL |     fn f(_: u64) {}
-   |     ------------ found signature defined here
-...
 LL |     bar(f);
-   |     --- ^ expected due to this
+   |     --- ^ types differ
    |     |
    |     required by a bound introduced by this call
    |
-   = note: expected function signature `fn(usize) -> _`
-              found function signature `fn(u64) -> _`
+   = note: expected trait `Fn<usize>`
+              found trait `Fn<(u64,)>`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |
@@ -70,4 +65,5 @@ LL | fn bar<F: Fn<usize>>(_: F) {}
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0631`.
+Some errors have detailed explanations: E0308, E0631.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/closure-arg-count.rs
+++ b/src/test/ui/mismatched_types/closure-arg-count.rs
@@ -1,6 +1,6 @@
 #![feature(unboxed_closures)]
 
-fn f<F: Fn<usize>>(_: F) {}
+fn f<F: Fn<(usize,)>>(_: F) {}
 fn main() {
     [1, 2, 3].sort_by(|| panic!());
     //~^ ERROR closure is expected to take
@@ -11,9 +11,9 @@ fn main() {
     [1, 2, 3].sort_by(|(tuple, tuple2): (usize, _)| panic!());
     //~^ ERROR closure is expected to take
     f(|| panic!());
-    //~^ ERROR mismatched types
+    //~^ ERROR closure is expected to take
     f(  move    || panic!());
-    //~^ ERROR mismatched types
+    //~^ ERROR closure is expected to take
 
     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
     //~^ ERROR closure is expected to take

--- a/src/test/ui/mismatched_types/closure-arg-count.rs
+++ b/src/test/ui/mismatched_types/closure-arg-count.rs
@@ -11,9 +11,9 @@ fn main() {
     [1, 2, 3].sort_by(|(tuple, tuple2): (usize, _)| panic!());
     //~^ ERROR closure is expected to take
     f(|| panic!());
-    //~^ ERROR closure is expected to take
+    //~^ ERROR mismatched types
     f(  move    || panic!());
-    //~^ ERROR closure is expected to take
+    //~^ ERROR mismatched types
 
     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
     //~^ ERROR closure is expected to take

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -45,41 +45,33 @@ help: change the closure to take multiple arguments instead of a single tuple
 LL |     [1, 2, 3].sort_by(|tuple, tuple2| panic!());
    |                       ~~~~~~~~~~~~~~~
 
-error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
+error[E0308]: mismatched types
   --> $DIR/closure-arg-count.rs:13:5
    |
 LL |     f(|| panic!());
-   |     ^ -- takes 0 arguments
-   |     |
-   |     expected closure that takes 1 argument
+   |     ^ types differ
    |
+   = note: expected trait `Fn<usize>`
+              found trait `Fn<()>`
 note: required by a bound in `f`
   --> $DIR/closure-arg-count.rs:3:9
    |
 LL | fn f<F: Fn<usize>>(_: F) {}
    |         ^^^^^^^^^ required by this bound in `f`
-help: consider changing the closure to take and ignore the expected argument
-   |
-LL |     f(|_| panic!());
-   |       ~~~
 
-error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
+error[E0308]: mismatched types
   --> $DIR/closure-arg-count.rs:15:5
    |
 LL |     f(  move    || panic!());
-   |     ^   ---------- takes 0 arguments
-   |     |
-   |     expected closure that takes 1 argument
+   |     ^ types differ
    |
+   = note: expected trait `Fn<usize>`
+              found trait `Fn<()>`
 note: required by a bound in `f`
   --> $DIR/closure-arg-count.rs:3:9
    |
 LL | fn f<F: Fn<usize>>(_: F) {}
    |         ^^^^^^^^^ required by this bound in `f`
-help: consider changing the closure to take and ignore the expected argument
-   |
-LL |     f(  move    |_| panic!());
-   |                 ~~~
 
 error[E0593]: closure is expected to take a single 2-tuple as argument, but it takes 2 distinct arguments
   --> $DIR/closure-arg-count.rs:18:53
@@ -198,4 +190,5 @@ LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
 
 error: aborting due to 14 previous errors
 
-For more information about this error, try `rustc --explain E0593`.
+Some errors have detailed explanations: E0308, E0593.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -45,33 +45,41 @@ help: change the closure to take multiple arguments instead of a single tuple
 LL |     [1, 2, 3].sort_by(|tuple, tuple2| panic!());
    |                       ~~~~~~~~~~~~~~~
 
-error[E0308]: mismatched types
+error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:13:5
    |
 LL |     f(|| panic!());
-   |     ^ types differ
+   |     ^ -- takes 0 arguments
+   |     |
+   |     expected closure that takes 1 argument
    |
-   = note: expected trait `Fn<usize>`
-              found trait `Fn<()>`
 note: required by a bound in `f`
   --> $DIR/closure-arg-count.rs:3:9
    |
-LL | fn f<F: Fn<usize>>(_: F) {}
-   |         ^^^^^^^^^ required by this bound in `f`
+LL | fn f<F: Fn<(usize,)>>(_: F) {}
+   |         ^^^^^^^^^^^^ required by this bound in `f`
+help: consider changing the closure to take and ignore the expected argument
+   |
+LL |     f(|_| panic!());
+   |       ~~~
 
-error[E0308]: mismatched types
+error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:5
    |
 LL |     f(  move    || panic!());
-   |     ^ types differ
+   |     ^   ---------- takes 0 arguments
+   |     |
+   |     expected closure that takes 1 argument
    |
-   = note: expected trait `Fn<usize>`
-              found trait `Fn<()>`
 note: required by a bound in `f`
   --> $DIR/closure-arg-count.rs:3:9
    |
-LL | fn f<F: Fn<usize>>(_: F) {}
-   |         ^^^^^^^^^ required by this bound in `f`
+LL | fn f<F: Fn<(usize,)>>(_: F) {}
+   |         ^^^^^^^^^^^^ required by this bound in `f`
+help: consider changing the closure to take and ignore the expected argument
+   |
+LL |     f(  move    |_| panic!());
+   |                 ~~~
 
 error[E0593]: closure is expected to take a single 2-tuple as argument, but it takes 2 distinct arguments
   --> $DIR/closure-arg-count.rs:18:53
@@ -190,5 +198,4 @@ LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
 
 error: aborting due to 14 previous errors
 
-Some errors have detailed explanations: E0308, E0593.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0593`.

--- a/src/test/ui/unboxed-closures/non-tupled-arg-mismatch.rs
+++ b/src/test/ui/unboxed-closures/non-tupled-arg-mismatch.rs
@@ -1,0 +1,8 @@
+#![feature(unboxed_closures)]
+
+fn a<F: Fn<usize>>(f: F) {}
+
+fn main() {
+    a(|_: usize| {});
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/unboxed-closures/non-tupled-arg-mismatch.stderr
+++ b/src/test/ui/unboxed-closures/non-tupled-arg-mismatch.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/non-tupled-arg-mismatch.rs:6:5
+   |
+LL |     a(|_: usize| {});
+   |     ^ types differ
+   |
+   = note: expected trait `Fn<usize>`
+              found trait `Fn<(usize,)>`
+note: required by a bound in `a`
+  --> $DIR/non-tupled-arg-mismatch.rs:3:9
+   |
+LL | fn a<F: Fn<usize>>(f: F) {}
+   |         ^^^^^^^^^ required by this bound in `a`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Given this code:

```rust
#![feature(unboxed_closures)]

fn a<F: Fn<usize>>(f: F) {}

fn main() {
    a(|_: usize| {});
}
```

We currently emit this error:
```
error[E0631]: type mismatch in closure arguments
 --> src/main.rs:6:5
  |
6 |     a(|_: usize| {});
  |     ^ ---------- found signature of `fn(usize) -> _`
  |     |
  |     expected signature of `fn(usize) -> _`
  |
note: required by a bound in `a`
 --> src/main.rs:3:9
  |
3 | fn a<F: Fn<usize>>(f: F) {}
  |         ^^^^^^^^^ required by this bound in `a`

For more information about this error, try `rustc --explain E0631`.
error: could not compile `playground` due to previous error
```
Notably, it says the same thing for "expected" and "found"!

Fix the output so that we instead emit:
```
error[E0308]: mismatched types
 --> /home/gh-compiler-errors/test.rs:6:5
  |
6 |     a(|_: usize| {});
  |     ^ types differ
  |
  = note: expected trait `Fn<usize>`
             found trait `Fn<(usize,)>`
note: required by a bound in `a`
 --> /home/gh-compiler-errors/test.rs:3:9
  |
3 | fn a<F: Fn<usize>>(f: F) {}
  |         ^^^^^^^^^ required by this bound in `a`

error: aborting due to previous error
```

The error could still use some work, namely the "mismatched types" part, but I'm leaving it a bit rough since the only way you'd ever get this error is when you're messing with `#![feature(unboxed_closures)]`. 

Simply making sure we actually print out the difference in trait-refs is good enough for me. I could probably factor in some additional improvements if those are desired.