### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -353,9 +353,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
         // We use the statements were the binding was initialized, and inspect the HIR to look
         // for the branching codepaths that aren't covered, to point at them.
-        let hir_id = self.mir_hir_id();
         let map = self.infcx.tcx.hir();
-        let body_id = map.body_owned_by(hir_id);
+        let body_id = map.body_owned_by(self.mir_def_id());
         let body = map.body(body_id);
 
         let mut visitor = ConditionVisitor { spans: &spans, name: &name, errors: vec![] };

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -853,7 +853,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         let closure_id = self.mir_hir_id();
         let fn_call_id = hir.get_parent_node(closure_id);
         let node = hir.get(fn_call_id);
-        let item_id = hir.enclosing_body_owner(fn_call_id);
+        let def_id = hir.enclosing_body_owner(fn_call_id);
         let mut look_at_return = true;
         // If we can detect the expression to be an `fn` call where the closure was an argument,
         // we point at the `fn` definition argument...
@@ -864,7 +864,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 .filter(|(_, arg)| arg.hir_id == closure_id)
                 .map(|(pos, _)| pos)
                 .next();
-            let def_id = hir.local_def_id(item_id);
             let tables = self.infcx.tcx.typeck(def_id);
             if let Some(ty::FnDef(def_id, _)) =
                 tables.node_type_opt(func.hir_id).as_ref().map(|ty| ty.kind())

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -3,6 +3,7 @@ use rustc_index::bit_set;
 use rustc_index::vec;
 use smallvec::SmallVec;
 use std::hash::{BuildHasher, Hash, Hasher};
+use std::marker::PhantomData;
 use std::mem;
 
 #[cfg(test)]
@@ -259,6 +260,10 @@ impl<CTX> HashStable<CTX> for ! {
     fn hash_stable(&self, _ctx: &mut CTX, _hasher: &mut StableHasher) {
         unreachable!()
     }
+}
+
+impl<CTX, T> HashStable<CTX> for PhantomData<T> {
+    fn hash_stable(&self, _ctx: &mut CTX, _hasher: &mut StableHasher) {}
 }
 
 impl<CTX> HashStable<CTX> for ::std::num::NonZeroU32 {

--- a/compiler/rustc_driver/src/pretty.rs
+++ b/compiler/rustc_driver/src/pretty.rs
@@ -328,7 +328,7 @@ impl<'tcx> pprust_hir::PpAnn for TypedAnnotation<'tcx> {
             let typeck_results = self.maybe_typeck_results.get().or_else(|| {
                 self.tcx
                     .hir()
-                    .maybe_body_owned_by(self.tcx.hir().local_def_id_to_hir_id(expr.hir_id.owner))
+                    .maybe_body_owned_by(self.tcx.hir().local_def_id(expr.hir_id))
                     .map(|body_id| self.tcx.typeck_body(body_id))
             });
 

--- a/compiler/rustc_driver/src/pretty.rs
+++ b/compiler/rustc_driver/src/pretty.rs
@@ -328,7 +328,7 @@ impl<'tcx> pprust_hir::PpAnn for TypedAnnotation<'tcx> {
             let typeck_results = self.maybe_typeck_results.get().or_else(|| {
                 self.tcx
                     .hir()
-                    .maybe_body_owned_by(self.tcx.hir().local_def_id(expr.hir_id))
+                    .maybe_body_owned_by(expr.hir_id.owner)
                     .map(|body_id| self.tcx.typeck_body(body_id))
             });
 

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/util.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/util.rs
@@ -49,8 +49,8 @@ pub fn find_param_with_region<'tcx>(
     };
 
     let hir = &tcx.hir();
-    let local_did = id.as_local()?;
-    let hir_id = hir.local_def_id_to_hir_id(local_did);
+    let def_id = id.as_local()?;
+    let hir_id = hir.local_def_id_to_hir_id(def_id);
 
     // FIXME: use def_kind
     // Don't perform this on closures
@@ -61,7 +61,7 @@ pub fn find_param_with_region<'tcx>(
         _ => {}
     }
 
-    let body_id = hir.maybe_body_owned_by(local_did)?;
+    let body_id = hir.maybe_body_owned_by(def_id)?;
 
     let owner_id = hir.body_owner(body_id);
     let fn_decl = hir.fn_decl_by_hir_id(owner_id).unwrap();

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/util.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/util.rs
@@ -49,10 +49,10 @@ pub fn find_param_with_region<'tcx>(
     };
 
     let hir = &tcx.hir();
-    let hir_id = hir.local_def_id_to_hir_id(id.as_local()?);
-    let body_id = hir.maybe_body_owned_by(hir_id)?;
-    let body = hir.body(body_id);
+    let local_did = id.as_local()?;
+    let hir_id = hir.local_def_id_to_hir_id(local_did);
 
+    // FIXME: use def_kind
     // Don't perform this on closures
     match hir.get(hir_id) {
         hir::Node::Expr(&hir::Expr { kind: hir::ExprKind::Closure { .. }, .. }) => {
@@ -61,11 +61,14 @@ pub fn find_param_with_region<'tcx>(
         _ => {}
     }
 
+    let body_id = hir.maybe_body_owned_by(local_did)?;
+
     let owner_id = hir.body_owner(body_id);
     let fn_decl = hir.fn_decl_by_hir_id(owner_id).unwrap();
     let poly_fn_sig = tcx.fn_sig(id);
 
     let fn_sig = tcx.liberate_late_bound_regions(id, poly_fn_sig);
+    let body = hir.body(body_id);
     body.params
         .iter()
         .take(if fn_sig.c_variadic {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1614,16 +1614,16 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     }
 
     fn encode_info_for_anon_const(&mut self, id: hir::HirId) {
-        let def_id = self.tcx.hir().local_def_id(id);
-        debug!("EncodeContext::encode_info_for_anon_const({:?})", def_id);
-        let body_id = self.tcx.hir().body_owned_by(id);
+        let local_did = self.tcx.hir().local_def_id(id);
+        debug!("EncodeContext::encode_info_for_anon_const({:?})", local_did);
+        let body_id = self.tcx.hir().body_owned_by(local_did);
         let const_data = self.encode_rendered_const_for_body(body_id);
-        let qualifs = self.tcx.mir_const_qualif(def_id);
+        let qualifs = self.tcx.mir_const_qualif(local_did);
 
-        record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::AnonConst);
-        record!(self.tables.mir_const_qualif[def_id.to_def_id()] <- qualifs);
-        record!(self.tables.rendered_const[def_id.to_def_id()] <- const_data);
-        self.encode_item_type(def_id.to_def_id());
+        record!(self.tables.kind[local_did.to_def_id()] <- EntryKind::AnonConst);
+        record!(self.tables.mir_const_qualif[local_did.to_def_id()] <- qualifs);
+        record!(self.tables.rendered_const[local_did.to_def_id()] <- const_data);
+        self.encode_item_type(local_did.to_def_id());
     }
 
     fn encode_native_libraries(&mut self) -> LazyArray<NativeLib> {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1614,16 +1614,16 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     }
 
     fn encode_info_for_anon_const(&mut self, id: hir::HirId) {
-        let local_did = self.tcx.hir().local_def_id(id);
-        debug!("EncodeContext::encode_info_for_anon_const({:?})", local_did);
-        let body_id = self.tcx.hir().body_owned_by(local_did);
+        let def_id = self.tcx.hir().local_def_id(id);
+        debug!("EncodeContext::encode_info_for_anon_const({:?})", def_id);
+        let body_id = self.tcx.hir().body_owned_by(def_id);
         let const_data = self.encode_rendered_const_for_body(body_id);
-        let qualifs = self.tcx.mir_const_qualif(local_did);
+        let qualifs = self.tcx.mir_const_qualif(def_id);
 
-        record!(self.tables.kind[local_did.to_def_id()] <- EntryKind::AnonConst);
-        record!(self.tables.mir_const_qualif[local_did.to_def_id()] <- qualifs);
-        record!(self.tables.rendered_const[local_did.to_def_id()] <- const_data);
-        self.encode_item_type(local_did.to_def_id());
+        record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::AnonConst);
+        record!(self.tables.mir_const_qualif[def_id.to_def_id()] <- qualifs);
+        record!(self.tables.rendered_const[def_id.to_def_id()] <- const_data);
+        self.encode_item_type(def_id.to_def_id());
     }
 
     fn encode_native_libraries(&mut self) -> LazyArray<NativeLib> {

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -396,10 +396,10 @@ impl<'hir> Map<'hir> {
         }
     }
 
-    pub fn enclosing_body_owner(self, hir_id: HirId) -> HirId {
+    pub fn enclosing_body_owner(self, hir_id: HirId) -> LocalDefId {
         for (parent, _) in self.parent_iter(hir_id) {
-            if let Some(local_did) = parent.as_owner() && let Some(body) = self.maybe_body_owned_by(local_did) {
-                return self.body_owner(body);
+            if let Some(body) = self.find(parent).map(associated_body).flatten() {
+                return self.body_owner_def_id(body);
             }
         }
 
@@ -671,7 +671,7 @@ impl<'hir> Map<'hir> {
     /// Whether the expression pointed at by `hir_id` belongs to a `const` evaluation context.
     /// Used exclusively for diagnostics, to avoid suggestion function calls.
     pub fn is_inside_const_context(self, hir_id: HirId) -> bool {
-        self.body_const_context(self.local_def_id(self.enclosing_body_owner(hir_id))).is_some()
+        self.body_const_context(self.enclosing_body_owner(hir_id)).is_some()
     }
 
     /// Retrieves the `HirId` for `id`'s enclosing method, unless there's a

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -157,8 +157,9 @@ pub fn provide(providers: &mut Providers) {
     };
     providers.fn_arg_names = |tcx, id| {
         let hir = tcx.hir();
-        let hir_id = hir.local_def_id_to_hir_id(id.expect_local());
-        if let Some(body_id) = hir.maybe_body_owned_by(hir_id) {
+        let local_did = id.expect_local();
+        let hir_id = hir.local_def_id_to_hir_id(local_did);
+        if let Some(body_id) = hir.maybe_body_owned_by(local_did) {
             tcx.arena.alloc_from_iter(hir.body_param_names(body_id))
         } else if let Node::TraitItem(&TraitItem {
             kind: TraitItemKind::Fn(_, TraitFn::Required(idents)),

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -157,9 +157,9 @@ pub fn provide(providers: &mut Providers) {
     };
     providers.fn_arg_names = |tcx, id| {
         let hir = tcx.hir();
-        let local_did = id.expect_local();
-        let hir_id = hir.local_def_id_to_hir_id(local_did);
-        if let Some(body_id) = hir.maybe_body_owned_by(local_did) {
+        let def_id = id.expect_local();
+        let hir_id = hir.local_def_id_to_hir_id(def_id);
+        if let Some(body_id) = hir.maybe_body_owned_by(def_id) {
             tcx.arena.alloc_from_iter(hir.body_param_names(body_id))
         } else if let Node::TraitItem(&TraitItem {
             kind: TraitItemKind::Fn(_, TraitFn::Required(idents)),

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -9,13 +9,9 @@ use crate::infer::canonical::{Canonical, QueryResponse};
 use crate::ty::error::TypeError;
 use crate::ty::subst::GenericArg;
 use crate::ty::{self, Ty, TyCtxt};
-
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_errors::struct_span_err;
-use rustc_query_system::ich::StableHashingContext;
 use rustc_span::source_map::Span;
 use std::iter::FromIterator;
-use std::mem;
 
 pub mod type_op {
     use crate::ty::fold::TypeFoldable;
@@ -226,29 +222,9 @@ pub struct NormalizationResult<'tcx> {
 /// case they are called implied bounds). They are fed to the
 /// `OutlivesEnv` which in turn is supplied to the region checker and
 /// other parts of the inference system.
-#[derive(Clone, Debug, TypeFoldable, TypeVisitable, Lift)]
+#[derive(Clone, Debug, TypeFoldable, TypeVisitable, Lift, HashStable)]
 pub enum OutlivesBound<'tcx> {
     RegionSubRegion(ty::Region<'tcx>, ty::Region<'tcx>),
     RegionSubParam(ty::Region<'tcx>, ty::ParamTy),
     RegionSubProjection(ty::Region<'tcx>, ty::ProjectionTy<'tcx>),
-}
-
-impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for OutlivesBound<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        mem::discriminant(self).hash_stable(hcx, hasher);
-        match *self {
-            OutlivesBound::RegionSubRegion(ref a, ref b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher);
-            }
-            OutlivesBound::RegionSubParam(ref a, ref b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher);
-            }
-            OutlivesBound::RegionSubProjection(ref a, ref b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher);
-            }
-        }
-    }
 }

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -101,46 +101,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::GenericArgKin
     }
 }
 
-impl<'a> HashStable<StableHashingContext<'a>> for ty::EarlyBoundRegion {
-    #[inline]
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        self.def_id.hash_stable(hcx, hasher);
-        self.index.hash_stable(hcx, hasher);
-        self.name.hash_stable(hcx, hasher);
-    }
-}
-
-impl<'a> HashStable<StableHashingContext<'a>> for ty::RegionVid {
-    #[inline]
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        self.index().hash_stable(hcx, hasher);
-    }
-}
-
-impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::ConstVid<'tcx> {
-    #[inline]
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        self.index.hash_stable(hcx, hasher);
-    }
-}
-
-impl<'tcx> HashStable<StableHashingContext<'tcx>> for ty::BoundVar {
-    #[inline]
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
-        self.index().hash_stable(hcx, hasher);
-    }
-}
-
-impl<'a, 'tcx, T> HashStable<StableHashingContext<'a>> for ty::Binder<'tcx, T>
-where
-    T: HashStable<StableHashingContext<'a>>,
-{
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        self.as_ref().skip_binder().hash_stable(hcx, hasher);
-        self.bound_vars().hash_stable(hcx, hasher);
-    }
-}
-
 // AllocIds get resolved to whatever they point to (to be stable)
 impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1182,20 +1182,11 @@ impl<'tcx> OpaqueHiddenType<'tcx> {
 /// identified by both a universe, as well as a name residing within that universe. Distinct bound
 /// regions/types/consts within the same universe simply have an unknown relationship to one
 /// another.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TyEncodable, TyDecodable, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(HashStable, TyEncodable, TyDecodable)]
 pub struct Placeholder<T> {
     pub universe: UniverseIndex,
     pub name: T,
-}
-
-impl<'a, T> HashStable<StableHashingContext<'a>> for Placeholder<T>
-where
-    T: HashStable<StableHashingContext<'a>>,
-{
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        self.universe.hash_stable(hcx, hasher);
-        self.name.hash_stable(hcx, hasher);
-    }
 }
 
 pub type PlaceholderRegion = Placeholder<BoundRegionKind>;
@@ -1581,6 +1572,7 @@ impl<'tcx> PolyTraitRef<'tcx> {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable)]
+#[derive(HashStable)]
 pub struct ParamEnvAnd<'tcx, T> {
     pub param_env: ParamEnv<'tcx>,
     pub value: T,
@@ -1595,18 +1587,6 @@ impl<'tcx, T> ParamEnvAnd<'tcx, T> {
     pub fn without_const(mut self) -> Self {
         self.param_env = self.param_env.without_const();
         self
-    }
-}
-
-impl<'a, 'tcx, T> HashStable<StableHashingContext<'a>> for ParamEnvAnd<'tcx, T>
-where
-    T: HashStable<StableHashingContext<'a>>,
-{
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        let ParamEnvAnd { ref param_env, ref value } = *self;
-
-        param_env.hash_stable(hcx, hasher);
-        value.hash_stable(hcx, hasher);
     }
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -986,6 +986,7 @@ pub enum BoundVariableKind {
 ///
 /// `Decodable` and `Encodable` are implemented for `Binder<T>` using the `impl_binder_encode_decode!` macro.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(HashStable)]
 pub struct Binder<'tcx, T>(T, &'tcx List<BoundVariableKind>);
 
 impl<'tcx, T> Binder<'tcx, T>
@@ -1332,6 +1333,7 @@ impl<'tcx> fmt::Debug for Region<'tcx> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, PartialOrd, Ord)]
+#[derive(HashStable)]
 pub struct EarlyBoundRegion {
     pub def_id: DefId,
     pub index: u32,
@@ -1345,7 +1347,8 @@ impl fmt::Debug for EarlyBoundRegion {
 }
 
 /// A **`const`** **v**ariable **ID**.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, TyEncodable, TyDecodable)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(HashStable, TyEncodable, TyDecodable)]
 pub struct ConstVid<'tcx> {
     pub index: u32,
     pub phantom: PhantomData<&'tcx ()>,
@@ -1353,6 +1356,7 @@ pub struct ConstVid<'tcx> {
 
 rustc_index::newtype_index! {
     /// A **region** (lifetime) **v**ariable **ID**.
+    #[derive(HashStable)]
     pub struct RegionVid {
         DEBUG_FORMAT = custom,
     }
@@ -1365,6 +1369,7 @@ impl Atom for RegionVid {
 }
 
 rustc_index::newtype_index! {
+    #[derive(HashStable)]
     pub struct BoundVar { .. }
 }
 

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -626,7 +626,7 @@ pub fn check_unsafety<'tcx>(tcx: TyCtxt<'tcx>, def: ty::WithOptConstParam<LocalD
     if tcx.is_closure(def.did.to_def_id()) {
         let hir = tcx.hir();
         let owner = hir.enclosing_body_owner(hir.local_def_id_to_hir_id(def.did));
-        tcx.ensure().thir_check_unsafety(hir.local_def_id(owner));
+        tcx.ensure().thir_check_unsafety(owner);
         return;
     }
 

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -21,7 +21,7 @@ pub(crate) fn thir_body<'tcx>(
     owner_def: ty::WithOptConstParam<LocalDefId>,
 ) -> Result<(&'tcx Steal<Thir<'tcx>>, ExprId), ErrorGuaranteed> {
     let hir = tcx.hir();
-    let body = hir.body(hir.body_owned_by(hir.local_def_id_to_hir_id(owner_def.did)));
+    let body = hir.body(hir.body_owned_by(owner_def.did));
     let mut cx = Cx::new(tcx, owner_def);
     if let Some(reported) = cx.typeck_results.tainted_by_errors {
         return Err(reported);

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -26,7 +26,7 @@ use rustc_span::{BytePos, Span};
 pub(crate) fn check_match(tcx: TyCtxt<'_>, def_id: DefId) {
     let body_id = match def_id.as_local() {
         None => return,
-        Some(did) => tcx.hir().body_owned_by(did),
+        Some(def_id) => tcx.hir().body_owned_by(def_id),
     };
 
     let pattern_arena = TypedArena::default();

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -26,7 +26,7 @@ use rustc_span::{BytePos, Span};
 pub(crate) fn check_match(tcx: TyCtxt<'_>, def_id: DefId) {
     let body_id = match def_id.as_local() {
         None => return,
-        Some(id) => tcx.hir().body_owned_by(tcx.hir().local_def_id_to_hir_id(id)),
+        Some(did) => tcx.hir().body_owned_by(did),
     };
 
     let pattern_arena = TypedArena::default();

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -464,15 +464,15 @@ fn check_unused_unsafe(
     def_id: LocalDefId,
     used_unsafe_blocks: &FxHashMap<HirId, UsedUnsafeBlockData>,
 ) -> Vec<(HirId, UnusedUnsafe)> {
-    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
-    let body_id = tcx.hir().maybe_body_owned_by(hir_id);
+    let body_id = tcx.hir().maybe_body_owned_by(def_id);
 
     let Some(body_id) = body_id else {
         debug!("check_unused_unsafe({:?}) - no body found", def_id);
         return vec![];
     };
-    let body = tcx.hir().body(body_id);
 
+    let body = tcx.hir().body(body_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
     let context = match tcx.hir().fn_sig_by_hir_id(hir_id) {
         Some(sig) if sig.header.unsafety == hir::Unsafety::Unsafe => Context::UnsafeFn(hir_id),
         _ => Context::Safe,

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -601,6 +601,17 @@ impl<'a> Parser<'a> {
         self.last_unexpected_token_span = Some(self.token.span);
         let mut err = self.struct_span_err(self.token.span, &msg_exp);
 
+        if let TokenKind::Ident(symbol, _) = &self.prev_token.kind {
+            if symbol.as_str() == "public" {
+                err.span_suggestion_short(
+                    self.prev_token.span,
+                    "write `pub` instead of `public` to make the item public",
+                    "pub",
+                    appl,
+                );
+            }
+        }
+
         // Add suggestion for a missing closing angle bracket if '>' is included in expected_tokens
         // there are unclosed angle brackets
         if self.unmatched_angle_bracket_count > 0

--- a/compiler/rustc_passes/src/upvars.rs
+++ b/compiler/rustc_passes/src/upvars.rs
@@ -15,8 +15,8 @@ pub fn provide(providers: &mut Providers) {
             return None;
         }
 
-        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
-        let body = tcx.hir().body(tcx.hir().maybe_body_owned_by(hir_id)?);
+        let local_did = def_id.expect_local();
+        let body = tcx.hir().body(tcx.hir().maybe_body_owned_by(local_did)?);
 
         let mut local_collector = LocalCollector::default();
         local_collector.visit_body(body);

--- a/compiler/rustc_passes/src/upvars.rs
+++ b/compiler/rustc_passes/src/upvars.rs
@@ -15,8 +15,8 @@ pub fn provide(providers: &mut Providers) {
             return None;
         }
 
-        let local_did = def_id.expect_local();
-        let body = tcx.hir().body(tcx.hir().maybe_body_owned_by(local_did)?);
+        let local_def_id = def_id.expect_local();
+        let body = tcx.hir().body(tcx.hir().maybe_body_owned_by(local_def_id)?);
 
         let mut local_collector = LocalCollector::default();
         local_collector.visit_body(body);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1783,7 +1783,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         let generator_body = generator_did
             .as_local()
-            .and_then(|local_did| hir.maybe_body_owned_by(local_did))
+            .and_then(|def_id| hir.maybe_body_owned_by(def_id))
             .map(|body_id| hir.body(body_id));
         let is_async = match generator_did.as_local() {
             Some(_) => generator_body

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1783,8 +1783,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         let generator_body = generator_did
             .as_local()
-            .map(|def_id| hir.local_def_id_to_hir_id(def_id))
-            .and_then(|hir_id| hir.maybe_body_owned_by(hir_id))
+            .and_then(|local_did| hir.maybe_body_owned_by(local_did))
             .map(|body_id| hir.body(body_id));
         let is_async = match generator_did.as_local() {
             Some(_) => generator_body
@@ -2752,7 +2751,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let body_hir_id = obligation.cause.body_id;
         let item_id = self.tcx.hir().get_parent_node(body_hir_id);
 
-        if let Some(body_id) = self.tcx.hir().maybe_body_owned_by(item_id) {
+        if let Some(body_id) =
+            self.tcx.hir().maybe_body_owned_by(self.tcx.hir().local_def_id(item_id))
+        {
             let body = self.tcx.hir().body(body_id);
             if let Some(hir::GeneratorKind::Async(_)) = body.generator_kind {
                 let future_trait = self.tcx.require_lang_item(LangItem::Future, None);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -20,6 +20,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{AsyncGeneratorKind, GeneratorKind, Node};
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::hir::map;
 use rustc_middle::ty::{
     self, suggest_arbitrary_trait_bound, suggest_constraining_type_param, AdtKind, DefIdTree,
@@ -253,8 +254,8 @@ pub trait InferCtxtExt<'tcx> {
         &self,
         span: Span,
         found_span: Option<Span>,
-        expected_ref: ty::PolyTraitRef<'tcx>,
         found: ty::PolyTraitRef<'tcx>,
+        expected: ty::PolyTraitRef<'tcx>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed>;
 
     fn suggest_fully_qualified_path(
@@ -1529,13 +1530,13 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         &self,
         span: Span,
         found_span: Option<Span>,
-        expected_ref: ty::PolyTraitRef<'tcx>,
         found: ty::PolyTraitRef<'tcx>,
+        expected: ty::PolyTraitRef<'tcx>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        pub(crate) fn build_fn_sig_string<'tcx>(
+        pub(crate) fn build_fn_sig_ty<'tcx>(
             tcx: TyCtxt<'tcx>,
             trait_ref: ty::PolyTraitRef<'tcx>,
-        ) -> String {
+        ) -> Ty<'tcx> {
             let inputs = trait_ref.skip_binder().substs.type_at(1);
             let sig = match inputs.kind() {
                 ty::Tuple(inputs)
@@ -1557,10 +1558,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     abi::Abi::Rust,
                 ),
             };
-            trait_ref.rebind(sig).to_string()
+
+            tcx.mk_fn_ptr(trait_ref.rebind(sig))
         }
 
-        let argument_kind = match expected_ref.skip_binder().self_ty().kind() {
+        let argument_kind = match expected.skip_binder().self_ty().kind() {
             ty::Closure(..) => "closure",
             ty::Generator(..) => "generator",
             _ => "function",
@@ -1569,17 +1571,22 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             self.tcx.sess,
             span,
             E0631,
-            "type mismatch in {} arguments",
-            argument_kind
+            "type mismatch in {argument_kind} arguments",
         );
 
-        let found_str = format!("expected signature of `{}`", build_fn_sig_string(self.tcx, found));
-        err.span_label(span, found_str);
+        err.span_label(span, "expected due to this");
 
         let found_span = found_span.unwrap_or(span);
-        let expected_str =
-            format!("found signature of `{}`", build_fn_sig_string(self.tcx, expected_ref));
-        err.span_label(found_span, expected_str);
+        err.span_label(found_span, "found signature defined here");
+
+        let expected = build_fn_sig_ty(self.tcx, expected);
+        let found = build_fn_sig_ty(self.tcx, found);
+
+        let (expected_str, found_str) =
+            self.tcx.infer_ctxt().enter(|infcx| infcx.cmp(expected, found));
+
+        let signature_kind = format!("{argument_kind} signature");
+        err.note_expected_found(&signature_kind, expected_str, &signature_kind, found_str);
 
         err
     }

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -207,9 +207,10 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
         constness,
     );
 
-    let body_id = hir_id.map_or(hir::CRATE_HIR_ID, |id| {
-        tcx.hir().maybe_body_owned_by(id).map_or(id, |body| body.hir_id)
-    });
+    let body_id = local_did
+        .and_then(|id| tcx.hir().maybe_body_owned_by(id).map(|body| body.hir_id))
+        .or(hir_id)
+        .map_or(hir::CRATE_HIR_ID, |did| did);
     let cause = traits::ObligationCause::misc(tcx.def_span(def_id), body_id);
     traits::normalize_param_env_or_error(tcx, unnormalized_env, cause)
 }

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -207,10 +207,14 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
         constness,
     );
 
-    let body_id = local_did
-        .and_then(|id| tcx.hir().maybe_body_owned_by(id).map(|body| body.hir_id))
-        .or(hir_id)
-        .map_or(hir::CRATE_HIR_ID, |did| did);
+    let body_id =
+        local_did.and_then(|id| tcx.hir().maybe_body_owned_by(id).map(|body| body.hir_id));
+    let body_id = match body_id {
+        Some(id) => id,
+        None if hir_id.is_some() => hir_id.unwrap(),
+        _ => hir::CRATE_HIR_ID,
+    };
+
     let cause = traits::ObligationCause::misc(tcx.def_span(def_id), body_id);
     traits::normalize_param_env_or_error(tcx, unnormalized_env, cause)
 }

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -768,7 +768,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // the first place.
                 assert_ne!(hir::HirId::make_owner(encl_item_id), encl_body_owner_id);
 
-                let encl_body_id = self.tcx.hir().body_owned_by(encl_body_owner_id);
+                let encl_body_id =
+                    self.tcx.hir().body_owned_by(self.tcx.hir().local_def_id(encl_body_owner_id));
                 let encl_body = self.tcx.hir().body(encl_body_id);
 
                 err.encl_body_span = Some(encl_body.value.span);

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -766,10 +766,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 // If this didn't hold, we would not have to report an error in
                 // the first place.
-                assert_ne!(hir::HirId::make_owner(encl_item_id), encl_body_owner_id);
+                assert_ne!(encl_item_id, encl_body_owner_id);
 
-                let encl_body_id =
-                    self.tcx.hir().body_owned_by(self.tcx.hir().local_def_id(encl_body_owner_id));
+                let encl_body_id = self.tcx.hir().body_owned_by(encl_body_owner_id);
                 let encl_body = self.tcx.hir().body(encl_body_id);
 
                 err.encl_body_span = Some(encl_body.value.span);

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -58,7 +58,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         debug!("FnCtxt::check_asm: {} deferred checks", deferred_asm_checks.len());
         for (asm, hir_id) in deferred_asm_checks.drain(..) {
             let enclosing_id = self.tcx.hir().enclosing_body_owner(hir_id);
-            InlineAsmCtxt::new_in_fn(self).check_asm(asm, enclosing_id);
+            InlineAsmCtxt::new_in_fn(self)
+                .check_asm(asm, self.tcx.hir().local_def_id_to_hir_id(enclosing_id));
         }
     }
 

--- a/compiler/rustc_typeck/src/check/inherited.rs
+++ b/compiler/rustc_typeck/src/check/inherited.rs
@@ -107,8 +107,7 @@ impl<'tcx> InheritedBuilder<'tcx> {
 impl<'a, 'tcx> Inherited<'a, 'tcx> {
     fn new(infcx: InferCtxt<'a, 'tcx>, def_id: LocalDefId) -> Self {
         let tcx = infcx.tcx;
-        let item_id = tcx.hir().local_def_id_to_hir_id(def_id);
-        let body_id = tcx.hir().maybe_body_owned_by(item_id);
+        let body_id = tcx.hir().maybe_body_owned_by(def_id);
         let typeck_results =
             infcx.in_progress_typeck_results.expect("building `FnCtxt` without typeck results");
 

--- a/compiler/rustc_typeck/src/check/region.rs
+++ b/compiler/rustc_typeck/src/check/region.rs
@@ -814,8 +814,7 @@ pub fn region_scope_tree(tcx: TyCtxt<'_>, def_id: DefId) -> &ScopeTree {
         return tcx.region_scope_tree(typeck_root_def_id);
     }
 
-    let id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
-    let scope_tree = if let Some(body_id) = tcx.hir().maybe_body_owned_by(id) {
+    let scope_tree = if let Some(body_id) = tcx.hir().maybe_body_owned_by(def_id.expect_local()) {
         let mut visitor = RegionResolutionVisitor {
             tcx,
             scope_tree: ScopeTree::default(),

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -100,7 +100,7 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                 ExprKind::MethodCall(segment, ..) | ExprKind::Path(QPath::TypeRelative(_, segment)),
             ..
         }) => {
-            let body_owner = tcx.hir().local_def_id(tcx.hir().enclosing_body_owner(hir_id));
+            let body_owner = tcx.hir().enclosing_body_owner(hir_id);
             let tables = tcx.typeck(body_owner);
             // This may fail in case the method/path does not actually exist.
             // As there is no relevant param for `def_id`, we simply return
@@ -134,7 +134,7 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                         | ExprKind::Struct(&QPath::Resolved(_, path), ..),
                     ..
                 }) => {
-                    let body_owner = tcx.hir().local_def_id(tcx.hir().enclosing_body_owner(hir_id));
+                    let body_owner = tcx.hir().enclosing_body_owner(hir_id);
                     let _tables = tcx.typeck(body_owner);
                     &*path
                 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -236,8 +236,7 @@ pub(crate) fn print_const(cx: &DocContext<'_>, n: ty::Const<'_>) -> String {
     match n.kind() {
         ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs: _, promoted }) => {
             let mut s = if let Some(def) = def.as_local() {
-                let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def.did);
-                print_const_expr(cx.tcx, cx.tcx.hir().body_owned_by(hir_id))
+                print_const_expr(cx.tcx, cx.tcx.hir().body_owned_by(def.did))
             } else {
                 inline::print_inlined_const(cx.tcx, def.did)
             };

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -313,7 +313,7 @@ pub(crate) fn create_config(
                 }
 
                 let hir = tcx.hir();
-                let body = hir.body(hir.body_owned_by(hir.local_def_id_to_hir_id(def_id)));
+                let body = hir.body(hir.body_owned_by(def_id));
                 debug!("visiting body for {:?}", def_id);
                 EmitIgnoredResolutionErrors::new(tcx).visit_body(body);
                 (rustc_interface::DEFAULT_QUERY_PROVIDERS.typeck)(tcx, def_id)

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -143,8 +143,7 @@ where
         // then we need to exit before calling typeck (which will panic). See
         // test/run-make/rustdoc-scrape-examples-invalid-expr for an example.
         let hir = tcx.hir();
-        let owner = hir.local_def_id_to_hir_id(ex.hir_id.owner);
-        if hir.maybe_body_owned_by(owner).is_none() {
+        if hir.maybe_body_owned_by(ex.hir_id.owner).is_none() {
             return;
         }
 

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:2:5
    |
 LL |     f1(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r, 's> fn(&'r (), &'s ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r, 's> fn(&'r (), &'s ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:25
    |
@@ -16,10 +18,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:3:5
    |
 LL |     f2(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'a, 'r> fn(&'a (), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'a, 'r> fn(&'a (), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:17:25
    |
@@ -30,10 +34,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
    |
 LL |     f3(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&(), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&(), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f3`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:29
    |
@@ -44,10 +50,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:5:5
    |
 LL |     f4(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'s, 'r> fn(&'s (), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r, 's> fn(&'s (), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f4`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:19:25
    |
@@ -58,10 +66,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
    |
 LL |     f5(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&'r (), &'r ()) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r (), &'r ()) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `f5`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:25
    |
@@ -72,10 +82,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:7:5
    |
 LL |     g1(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&'r (), Box<(dyn for<'s> Fn(&'s ()) + 'static)>) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:23:25
    |
@@ -86,10 +98,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
    |
 LL |     g2(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'r> fn(&'r (), for<'s> fn(&'s ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r (), for<'r> fn(&'r ())) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:24:25
    |
@@ -100,10 +114,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:9:5
    |
 LL |     g3(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'s> fn(&'s (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'s> fn(&'s (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g3`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:25:25
    |
@@ -114,10 +130,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
    |
 LL |     g4(|_: (), _: ()| {});
-   |     ^^ -------------- found signature of `fn((), ()) -> _`
+   |     ^^ -------------- found signature defined here
    |     |
-   |     expected signature of `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
+              found closure signature `fn((), ()) -> _`
 note: required by a bound in `g4`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:26:25
    |
@@ -128,10 +146,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:11:5
    |
 LL |     h1(|_: (), _: (), _: (), _: ()| {});
-   |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
+   |     ^^ ---------------------------- found signature defined here
    |     |
-   |     expected signature of `for<'r, 's> fn(&'r (), Box<(dyn for<'t0> Fn(&'t0 ()) + 'static)>, &'s (), for<'t0, 't1> fn(&'t0 (), &'t1 ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'r, 's> fn(&'r (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>, &'s (), for<'r, 's> fn(&'r (), &'s ())) -> _`
+              found closure signature `fn((), (), (), ()) -> _`
 note: required by a bound in `h1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:29:25
    |
@@ -142,10 +162,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
    |
 LL |     h2(|_: (), _: (), _: (), _: ()| {});
-   |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
+   |     ^^ ---------------------------- found signature defined here
    |     |
-   |     expected signature of `for<'r, 't0> fn(&'r (), Box<(dyn for<'s> Fn(&'s ()) + 'static)>, &'t0 (), for<'s, 't1> fn(&'s (), &'t1 ())) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `for<'t0, 'r> fn(&'r (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>, &'t0 (), for<'r, 's> fn(&'r (), &'s ())) -> _`
+              found closure signature `fn((), (), (), ()) -> _`
 note: required by a bound in `h2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:30:25
    |

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-infer-var-appearing-twice.rs:14:5
    |
 LL |     with_closure(|x: u32, y: i32| {
-   |     ^^^^^^^^^^^^ ---------------- found signature of `fn(u32, i32) -> _`
+   |     ^^^^^^^^^^^^ ---------------- found signature defined here
    |     |
-   |     expected signature of `fn(_, _) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `fn(_, _) -> _`
+              found closure signature `fn(u32, i32) -> _`
 note: required by a bound in `with_closure`
   --> $DIR/expect-infer-var-appearing-twice.rs:2:14
    |

--- a/src/test/ui/generator/issue-88653.rs
+++ b/src/test/ui/generator/issue-88653.rs
@@ -7,10 +7,12 @@ use std::ops::Generator;
 
 fn foo(bar: bool) -> impl Generator<(bool,)> {
     //~^ ERROR: type mismatch in generator arguments [E0631]
-    //~| NOTE: expected signature of `fn((bool,)) -> _`
+    //~| NOTE: expected due to this
+    //~| NOTE: expected generator signature `fn((bool,)) -> _`
+    //~| NOTE: in this expansion of desugaring of `impl Trait`
     //~| NOTE: in this expansion of desugaring of `impl Trait`
     |bar| {
-        //~^ NOTE: found signature of `fn(bool) -> _`
+        //~^ NOTE: found signature defined here
         if bar {
             yield bar;
         }

--- a/src/test/ui/generator/issue-88653.stderr
+++ b/src/test/ui/generator/issue-88653.stderr
@@ -2,10 +2,13 @@ error[E0631]: type mismatch in generator arguments
   --> $DIR/issue-88653.rs:8:22
    |
 LL | fn foo(bar: bool) -> impl Generator<(bool,)> {
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^ expected signature of `fn((bool,)) -> _`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
 ...
 LL |     |bar| {
-   |     ----- found signature of `fn(bool) -> _`
+   |     ----- found signature defined here
+   |
+   = note: expected generator signature `fn((bool,)) -> _`
+              found generator signature `fn(bool) -> _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/bugs/issue-88382.stderr
+++ b/src/test/ui/generic-associated-types/bugs/issue-88382.stderr
@@ -2,13 +2,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/issue-88382.rs:28:40
    |
 LL |     do_something(SomeImplementation(), test);
-   |     ------------                       ^^^^ expected signature of `for<'r> fn(&'r mut std::iter::Empty<usize>) -> _`
+   |     ------------                       ^^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
 ...
 LL | fn test<'a, I: Iterable>(_: &mut I::Iterator<'a>) {}
-   | ------------------------------------------------- found signature of `for<'r, 'a> fn(&'r mut <_ as Iterable>::Iterator<'a>) -> _`
+   | ------------------------------------------------- found signature defined here
    |
+   = note: expected function signature `for<'r> fn(&'r mut std::iter::Empty<usize>) -> _`
+              found function signature `for<'a, 'r> fn(&'r mut <_ as Iterable>::Iterator<'a>) -> _`
 note: required by a bound in `do_something`
   --> $DIR/issue-88382.rs:22:48
    |

--- a/src/test/ui/intrinsics/const-eval-select-bad.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-bad.stderr
@@ -67,13 +67,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/const-eval-select-bad.rs:34:32
    |
 LL | const fn foo(n: i32) -> i32 {
-   | --------------------------- found signature of `fn(i32) -> _`
+   | --------------------------- found signature defined here
 ...
 LL |     const_eval_select((true,), foo, baz);
-   |     -----------------          ^^^ expected signature of `fn(bool) -> _`
+   |     -----------------          ^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(bool) -> _`
+              found function signature `fn(i32) -> _`
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:7:5
    |
 LL |     foo(|_: isize| {});
-   |     ^^^ ---------- found signature of `fn(isize) -> _`
+   |     ^^^ ---------- found signature defined here
    |     |
-   |     expected signature of `fn(usize) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `fn(usize) -> _`
+              found closure signature `fn(isize) -> _`
 note: required by a bound in `foo`
   --> $DIR/E0631.rs:3:11
    |
@@ -16,10 +18,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
 LL |     bar(|_: isize| {});
-   |     ^^^ ---------- found signature of `fn(isize) -> _`
+   |     ^^^ ---------- found signature defined here
    |     |
-   |     expected signature of `fn(usize) -> _`
+   |     expected due to this
    |
+   = note: expected closure signature `fn(usize) -> _`
+              found closure signature `fn(isize) -> _`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |
@@ -30,13 +34,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:9:9
    |
 LL |     fn f(_: u64) {}
-   |     ------------ found signature of `fn(u64) -> _`
+   |     ------------ found signature defined here
 ...
 LL |     foo(f);
-   |     --- ^ expected signature of `fn(usize) -> _`
+   |     --- ^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(usize) -> _`
+              found function signature `fn(u64) -> _`
 note: required by a bound in `foo`
   --> $DIR/E0631.rs:3:11
    |
@@ -47,13 +53,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:10:9
    |
 LL |     fn f(_: u64) {}
-   |     ------------ found signature of `fn(u64) -> _`
+   |     ------------ found signature defined here
 ...
 LL |     bar(f);
-   |     --- ^ expected signature of `fn(usize) -> _`
+   |     --- ^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(usize) -> _`
+              found function signature `fn(u64) -> _`
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11
    |

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:3:14
    |
 LL |     a.iter().map(|_: (u32, u32)| 45);
-   |              ^^^ --------------- found signature of `fn((u32, u32)) -> _`
+   |              ^^^ --------------- found signature defined here
    |              |
-   |              expected signature of `fn(&(u32, u32)) -> _`
+   |              expected due to this
    |
+   = note: expected closure signature `fn(&(u32, u32)) -> _`
+              found closure signature `fn((u32, u32)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
@@ -16,10 +18,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:4:14
    |
 LL |     a.iter().map(|_: &(u16, u16)| 45);
-   |              ^^^ ---------------- found signature of `for<'r> fn(&'r (u16, u16)) -> _`
+   |              ^^^ ---------------- found signature defined here
    |              |
-   |              expected signature of `fn(&(u32, u32)) -> _`
+   |              expected due to this
    |
+   = note: expected closure signature `fn(&(u32, u32)) -> _`
+              found closure signature `for<'r> fn(&'r (u16, u16)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
@@ -30,10 +34,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:5:14
    |
 LL |     a.iter().map(|_: (u16, u16)| 45);
-   |              ^^^ --------------- found signature of `fn((u16, u16)) -> _`
+   |              ^^^ --------------- found signature defined here
    |              |
-   |              expected signature of `fn(&(u32, u32)) -> _`
+   |              expected due to this
    |
+   = note: expected closure signature `fn(&(u32, u32)) -> _`
+              found closure signature `fn((u16, u16)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -2,13 +2,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:11:15
    |
 LL | fn takes_mut(x: &mut isize) { }
-   | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
+   | --------------------------- found signature defined here
 ...
 LL |     apply(&3, takes_mut);
-   |     -----     ^^^^^^^^^ expected signature of `fn(&{integer}) -> _`
+   |     -----     ^^^^^^^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(&{integer}) -> _`
+              found function signature `for<'r> fn(&'r mut isize) -> _`
 note: required by a bound in `apply`
   --> $DIR/fn-variance-1.rs:5:37
    |
@@ -19,13 +21,15 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:15:19
    |
 LL | fn takes_imm(x: &isize) { }
-   | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
+   | ----------------------- found signature defined here
 ...
 LL |     apply(&mut 3, takes_imm);
-   |     -----         ^^^^^^^^^ expected signature of `fn(&mut {integer}) -> _`
+   |     -----         ^^^^^^^^^ expected due to this
    |     |
    |     required by a bound introduced by this call
    |
+   = note: expected function signature `fn(&mut {integer}) -> _`
+              found function signature `for<'r> fn(&'r isize) -> _`
 note: required by a bound in `apply`
   --> $DIR/fn-variance-1.rs:5:37
    |

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -2,10 +2,12 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/issue-36053-2.rs:7:32
    |
 LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
-   |                                ^^^^^^ --------- found signature of `for<'r> fn(&'r str) -> _`
+   |                                ^^^^^^ --------- found signature defined here
    |                                |
-   |                                expected signature of `for<'r> fn(&'r &str) -> _`
+   |                                expected due to this
    |
+   = note: expected closure signature `for<'r> fn(&'r &str) -> _`
+              found closure signature `for<'r> fn(&'r str) -> _`
 note: required by a bound in `filter`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
@@ -2,20 +2,21 @@
 
 use std::ops::FnMut;
 
-fn to_fn_mut<A,F:FnMut<A>>(f: F) -> F { f }
+fn to_fn_mut<A, F: FnMut<A>>(f: F) -> F { f }
 
-fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-//~^ NOTE required by this bound in `call_it`
-//~| NOTE required by a bound in `call_it`
+fn call_it<F: FnMut(isize, isize) -> isize>(y: isize, mut f: F) -> isize {
+    //~^ NOTE required by this bound in `call_it`
+    //~| NOTE required by a bound in `call_it`
     f(2, y)
 }
 
 pub fn main() {
     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
-    //~^ NOTE found signature of `fn(usize, isize) -> _`
+    //~^ NOTE found signature defined here
     let z = call_it(3, f);
     //~^ ERROR type mismatch
-    //~| NOTE expected signature of `fn(isize, isize) -> _`
+    //~| NOTE expected due to this
+    //~| NOTE expected closure signature `fn(isize, _) -> _`
     //~| NOTE required by a bound introduced by this call
     println!("{}", z);
 }

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -2,18 +2,20 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/unboxed-closures-vtable-mismatch.rs:16:24
    |
 LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
-   |                       ----------------------------- found signature of `fn(usize, isize) -> _`
+   |                       ----------------------------- found signature defined here
 LL |
 LL |     let z = call_it(3, f);
-   |             -------    ^ expected signature of `fn(isize, isize) -> _`
+   |             -------    ^ expected due to this
    |             |
    |             required by a bound introduced by this call
    |
+   = note: expected closure signature `fn(isize, _) -> _`
+              found closure signature `fn(usize, _) -> _`
 note: required by a bound in `call_it`
-  --> $DIR/unboxed-closures-vtable-mismatch.rs:7:14
+  --> $DIR/unboxed-closures-vtable-mismatch.rs:7:15
    |
-LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
+LL | fn call_it<F: FnMut(isize, isize) -> isize>(y: isize, mut f: F) -> isize {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-35813-postfix-after-cast.rs
+++ b/src/test/ui/parser/issues/issue-35813-postfix-after-cast.rs
@@ -8,16 +8,16 @@ use std::pin::Pin;
 // errors and parse such that further code gives useful errors.
 pub fn index_after_as_cast() {
     vec![1, 2, 3] as Vec<i32>[0];
-    //~^ ERROR: casts cannot be followed by indexing
+    //~^ ERROR: cast cannot be followed by indexing
     vec![1, 2, 3]: Vec<i32>[0];
-    //~^ ERROR: casts cannot be followed by indexing
+    //~^ ERROR: type ascription cannot be followed by indexing
 }
 
 pub fn index_after_cast_to_index() {
     (&[0]) as &[i32][0];
-    //~^ ERROR: casts cannot be followed by indexing
+    //~^ ERROR: cast cannot be followed by indexing
     (&[0i32]): &[i32; 1][0];
-    //~^ ERROR: casts cannot be followed by indexing
+    //~^ ERROR: type ascription cannot be followed by indexing
 }
 
 pub fn cast_after_cast() {
@@ -37,89 +37,89 @@ pub fn cast_after_cast() {
 
 pub fn cast_cast_method_call() {
     let _ = 0i32: i32: i32.count_ones();
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: type ascription cannot be followed by a method call
     let _ = 0 as i32: i32.count_ones();
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: type ascription cannot be followed by a method call
     let _ = 0i32: i32 as i32.count_ones();
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: cast cannot be followed by a method call
     let _ = 0 as i32 as i32.count_ones();
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: cast cannot be followed by a method call
     let _ = 0i32: i32: i32 as u32 as i32.count_ones();
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: cast cannot be followed by a method call
     let _ = 0i32: i32.count_ones(): u32;
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: type ascription cannot be followed by a method call
     let _ = 0 as i32.count_ones(): u32;
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: cast cannot be followed by a method call
     let _ = 0i32: i32.count_ones() as u32;
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: type ascription cannot be followed by a method call
     let _ = 0 as i32.count_ones() as u32;
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: cast cannot be followed by a method call
     let _ = 0i32: i32: i32.count_ones() as u32 as i32;
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: type ascription cannot be followed by a method call
 }
 
 pub fn multiline_error() {
     let _ = 0
         as i32
         .count_ones();
-    //~^^^ ERROR: casts cannot be followed by a method call
+    //~^^^ ERROR: cast cannot be followed by a method call
 }
 
 // this tests that the precedence for `!x as Y.Z` is still what we expect
 pub fn precedence() {
     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
-    //~^ ERROR: casts cannot be followed by indexing
+    //~^ ERROR: cast cannot be followed by indexing
 }
 
 pub fn method_calls() {
     0 as i32.max(0);
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: cast cannot be followed by a method call
     0: i32.max(0);
-    //~^ ERROR: casts cannot be followed by a method call
+    //~^ ERROR: type ascription cannot be followed by a method call
 }
 
 pub fn complex() {
     let _ = format!(
         "{} and {}",
         if true { 33 } else { 44 } as i32.max(0),
-        //~^ ERROR: casts cannot be followed by a method call
+        //~^ ERROR: cast cannot be followed by a method call
         if true { 33 } else { 44 }: i32.max(0)
-        //~^ ERROR: casts cannot be followed by a method call
+        //~^ ERROR: type ascription cannot be followed by a method call
     );
 }
 
 pub fn in_condition() {
     if 5u64 as i32.max(0) == 0 {
-        //~^ ERROR: casts cannot be followed by a method call
+        //~^ ERROR: cast cannot be followed by a method call
     }
     if 5u64: u64.max(0) == 0 {
-        //~^ ERROR: casts cannot be followed by a method call
+        //~^ ERROR: type ascription cannot be followed by a method call
     }
 }
 
 pub fn inside_block() {
     let _ = if true {
         5u64 as u32.max(0) == 0
-        //~^ ERROR: casts cannot be followed by a method call
+        //~^ ERROR: cast cannot be followed by a method call
     } else { false };
     let _ = if true {
         5u64: u64.max(0) == 0
-        //~^ ERROR: casts cannot be followed by a method call
+        //~^ ERROR: type ascription cannot be followed by a method call
     } else { false };
 }
 
 static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
-//~^ ERROR: casts cannot be followed by indexing
+//~^ ERROR: cast cannot be followed by indexing
 
 static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
-//~^ ERROR: casts cannot be followed by indexing
+//~^ ERROR: type ascription cannot be followed by indexing
 
 
 pub fn cast_then_try() -> Result<u64,u64> {
     Err(0u64) as Result<u64,u64>?;
-    //~^ ERROR: casts cannot be followed by `?`
+    //~^ ERROR: cast cannot be followed by `?`
     Err(0u64): Result<u64,u64>?;
-    //~^ ERROR: casts cannot be followed by `?`
+    //~^ ERROR: type ascription cannot be followed by `?`
     Ok(1)
 }
 
@@ -143,17 +143,17 @@ pub fn cast_to_fn_should_work() {
 pub fn parens_after_cast_error() {
     let drop_ptr = drop as fn(u8);
     drop as fn(u8)(0);
-    //~^ ERROR: casts cannot be followed by a function call
+    //~^ ERROR: cast cannot be followed by a function call
     drop_ptr: fn(u8)(0);
-    //~^ ERROR: casts cannot be followed by a function call
+    //~^ ERROR: type ascription cannot be followed by a function call
 }
 
 pub async fn cast_then_await() {
     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
-    //~^ ERROR: casts cannot be followed by `.await`
+    //~^ ERROR: cast cannot be followed by `.await`
 
     Box::pin(noop()): Pin<Box<_>>.await;
-    //~^ ERROR: casts cannot be followed by `.await`
+    //~^ ERROR: type ascription cannot be followed by `.await`
 }
 
 pub async fn noop() {}
@@ -167,5 +167,5 @@ pub fn struct_field() {
     Foo::default() as Foo.bar;
     //~^ ERROR: cannot be followed by a field access
     Foo::default(): Foo.bar;
-    //~^ ERROR: cannot be followed by a field access
+    //~^ ERROR: type ascription cannot be followed by a field access
 }

--- a/src/test/ui/parser/issues/issue-35813-postfix-after-cast.stderr
+++ b/src/test/ui/parser/issues/issue-35813-postfix-after-cast.stderr
@@ -1,4 +1,4 @@
-error: casts cannot be followed by indexing
+error: cast cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:10:5
    |
 LL |     vec![1, 2, 3] as Vec<i32>[0];
@@ -9,7 +9,7 @@ help: try surrounding the expression in parentheses
 LL |     (vec![1, 2, 3] as Vec<i32>)[0];
    |     +                         +
 
-error: casts cannot be followed by indexing
+error: type ascription cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:12:5
    |
 LL |     vec![1, 2, 3]: Vec<i32>[0];
@@ -25,7 +25,7 @@ LL -     vec![1, 2, 3]: Vec<i32>[0];
 LL +     vec![1, 2, 3][0];
    |
 
-error: casts cannot be followed by indexing
+error: cast cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:17:5
    |
 LL |     (&[0]) as &[i32][0];
@@ -36,7 +36,7 @@ help: try surrounding the expression in parentheses
 LL |     ((&[0]) as &[i32])[0];
    |     +                +
 
-error: casts cannot be followed by indexing
+error: type ascription cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:19:5
    |
 LL |     (&[0i32]): &[i32; 1][0];
@@ -52,7 +52,7 @@ LL -     (&[0i32]): &[i32; 1][0];
 LL +     (&[0i32])[0];
    |
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:39:13
    |
 LL |     let _ = 0i32: i32: i32.count_ones();
@@ -68,7 +68,7 @@ LL -     let _ = 0i32: i32: i32.count_ones();
 LL +     let _ = 0i32: i32.count_ones();
    |
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:41:13
    |
 LL |     let _ = 0 as i32: i32.count_ones();
@@ -84,7 +84,7 @@ LL -     let _ = 0 as i32: i32.count_ones();
 LL +     let _ = 0 as i32.count_ones();
    |
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:43:13
    |
 LL |     let _ = 0i32: i32 as i32.count_ones();
@@ -95,7 +95,7 @@ help: try surrounding the expression in parentheses
 LL |     let _ = (0i32: i32 as i32).count_ones();
    |             +                +
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:45:13
    |
 LL |     let _ = 0 as i32 as i32.count_ones();
@@ -106,7 +106,7 @@ help: try surrounding the expression in parentheses
 LL |     let _ = (0 as i32 as i32).count_ones();
    |             +               +
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:47:13
    |
 LL |     let _ = 0i32: i32: i32 as u32 as i32.count_ones();
@@ -117,7 +117,7 @@ help: try surrounding the expression in parentheses
 LL |     let _ = (0i32: i32: i32 as u32 as i32).count_ones();
    |             +                            +
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:49:13
    |
 LL |     let _ = 0i32: i32.count_ones(): u32;
@@ -133,7 +133,7 @@ LL -     let _ = 0i32: i32.count_ones(): u32;
 LL +     let _ = 0i32.count_ones(): u32;
    |
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:51:13
    |
 LL |     let _ = 0 as i32.count_ones(): u32;
@@ -144,7 +144,7 @@ help: try surrounding the expression in parentheses
 LL |     let _ = (0 as i32).count_ones(): u32;
    |             +        +
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:53:13
    |
 LL |     let _ = 0i32: i32.count_ones() as u32;
@@ -160,7 +160,7 @@ LL -     let _ = 0i32: i32.count_ones() as u32;
 LL +     let _ = 0i32.count_ones() as u32;
    |
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:55:13
    |
 LL |     let _ = 0 as i32.count_ones() as u32;
@@ -171,7 +171,7 @@ help: try surrounding the expression in parentheses
 LL |     let _ = (0 as i32).count_ones() as u32;
    |             +        +
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:57:13
    |
 LL |     let _ = 0i32: i32: i32.count_ones() as u32 as i32;
@@ -187,7 +187,7 @@ LL -     let _ = 0i32: i32: i32.count_ones() as u32 as i32;
 LL +     let _ = 0i32: i32.count_ones() as u32 as i32;
    |
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:62:13
    |
 LL |       let _ = 0
@@ -201,7 +201,7 @@ LL ~     let _ = (0
 LL ~         as i32)
    |
 
-error: casts cannot be followed by indexing
+error: cast cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:70:18
    |
 LL |     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
@@ -212,7 +212,7 @@ help: try surrounding the expression in parentheses
 LL |     let x: i32 = (&vec![1, 2, 3] as &Vec<i32>)[0];
    |                  +                           +
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:75:5
    |
 LL |     0 as i32.max(0);
@@ -223,7 +223,7 @@ help: try surrounding the expression in parentheses
 LL |     (0 as i32).max(0);
    |     +        +
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:77:5
    |
 LL |     0: i32.max(0);
@@ -239,7 +239,7 @@ LL -     0: i32.max(0);
 LL +     0.max(0);
    |
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:92:8
    |
 LL |     if 5u64 as i32.max(0) == 0 {
@@ -250,7 +250,7 @@ help: try surrounding the expression in parentheses
 LL |     if (5u64 as i32).max(0) == 0 {
    |        +           +
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:95:8
    |
 LL |     if 5u64: u64.max(0) == 0 {
@@ -266,7 +266,7 @@ LL -     if 5u64: u64.max(0) == 0 {
 LL +     if 5u64.max(0) == 0 {
    |
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:102:9
    |
 LL |         5u64 as u32.max(0) == 0
@@ -277,7 +277,7 @@ help: try surrounding the expression in parentheses
 LL |         (5u64 as u32).max(0) == 0
    |         +           +
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:106:9
    |
 LL |         5u64: u64.max(0) == 0
@@ -293,7 +293,7 @@ LL -         5u64: u64.max(0) == 0
 LL +         5u64.max(0) == 0
    |
 
-error: casts cannot be followed by indexing
+error: cast cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:111:24
    |
 LL | static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
@@ -304,7 +304,7 @@ help: try surrounding the expression in parentheses
 LL | static bar: &[i32] = &((&[1,2,3] as &[i32])[0..1]);
    |                        +                  +
 
-error: casts cannot be followed by indexing
+error: type ascription cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:114:25
    |
 LL | static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
@@ -320,7 +320,7 @@ LL - static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
 LL + static bar2: &[i32] = &(&[1i32,2,3][0..1]);
    |
 
-error: casts cannot be followed by `?`
+error: cast cannot be followed by `?`
   --> $DIR/issue-35813-postfix-after-cast.rs:119:5
    |
 LL |     Err(0u64) as Result<u64,u64>?;
@@ -331,7 +331,7 @@ help: try surrounding the expression in parentheses
 LL |     (Err(0u64) as Result<u64,u64>)?;
    |     +                            +
 
-error: casts cannot be followed by `?`
+error: type ascription cannot be followed by `?`
   --> $DIR/issue-35813-postfix-after-cast.rs:121:5
    |
 LL |     Err(0u64): Result<u64,u64>?;
@@ -347,7 +347,7 @@ LL -     Err(0u64): Result<u64,u64>?;
 LL +     Err(0u64)?;
    |
 
-error: casts cannot be followed by a function call
+error: cast cannot be followed by a function call
   --> $DIR/issue-35813-postfix-after-cast.rs:145:5
    |
 LL |     drop as fn(u8)(0);
@@ -358,7 +358,7 @@ help: try surrounding the expression in parentheses
 LL |     (drop as fn(u8))(0);
    |     +              +
 
-error: casts cannot be followed by a function call
+error: type ascription cannot be followed by a function call
   --> $DIR/issue-35813-postfix-after-cast.rs:147:5
    |
 LL |     drop_ptr: fn(u8)(0);
@@ -374,7 +374,7 @@ LL -     drop_ptr: fn(u8)(0);
 LL +     drop_ptr(0);
    |
 
-error: casts cannot be followed by `.await`
+error: cast cannot be followed by `.await`
   --> $DIR/issue-35813-postfix-after-cast.rs:152:5
    |
 LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
@@ -385,7 +385,7 @@ help: try surrounding the expression in parentheses
 LL |     (Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>).await;
    |     +                                                     +
 
-error: casts cannot be followed by `.await`
+error: type ascription cannot be followed by `.await`
   --> $DIR/issue-35813-postfix-after-cast.rs:155:5
    |
 LL |     Box::pin(noop()): Pin<Box<_>>.await;
@@ -401,7 +401,7 @@ LL -     Box::pin(noop()): Pin<Box<_>>.await;
 LL +     Box::pin(noop()).await;
    |
 
-error: casts cannot be followed by a field access
+error: cast cannot be followed by a field access
   --> $DIR/issue-35813-postfix-after-cast.rs:167:5
    |
 LL |     Foo::default() as Foo.bar;
@@ -412,7 +412,7 @@ help: try surrounding the expression in parentheses
 LL |     (Foo::default() as Foo).bar;
    |     +                     +
 
-error: casts cannot be followed by a field access
+error: type ascription cannot be followed by a field access
   --> $DIR/issue-35813-postfix-after-cast.rs:169:5
    |
 LL |     Foo::default(): Foo.bar;
@@ -428,7 +428,7 @@ LL -     Foo::default(): Foo.bar;
 LL +     Foo::default().bar;
    |
 
-error: casts cannot be followed by a method call
+error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:84:9
    |
 LL |         if true { 33 } else { 44 } as i32.max(0),
@@ -439,7 +439,7 @@ help: try surrounding the expression in parentheses
 LL |         (if true { 33 } else { 44 } as i32).max(0),
    |         +                                 +
 
-error: casts cannot be followed by a method call
+error: type ascription cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:86:9
    |
 LL |         if true { 33 } else { 44 }: i32.max(0)

--- a/src/test/ui/parser/public-instead-of-pub.fixed
+++ b/src/test/ui/parser/public-instead-of-pub.fixed
@@ -1,0 +1,8 @@
+// Checks what happens when `public` is used instead of the correct, `pub`
+// edition:2018
+// run-rustfix
+pub struct X;
+//~^ ERROR expected one of `!` or `::`, found keyword `struct`
+//~^^ HELP write `pub` instead of `public` to make the item public
+
+fn main() {}

--- a/src/test/ui/parser/public-instead-of-pub.rs
+++ b/src/test/ui/parser/public-instead-of-pub.rs
@@ -1,0 +1,8 @@
+// Checks what happens when `public` is used instead of the correct, `pub`
+// edition:2018
+// run-rustfix
+public struct X;
+//~^ ERROR expected one of `!` or `::`, found keyword `struct`
+//~^^ HELP write `pub` instead of `public` to make the item public
+
+fn main() {}

--- a/src/test/ui/parser/public-instead-of-pub.stderr
+++ b/src/test/ui/parser/public-instead-of-pub.stderr
@@ -1,0 +1,13 @@
+error: expected one of `!` or `::`, found keyword `struct`
+  --> $DIR/public-instead-of-pub.rs:4:8
+   |
+LL | public struct X;
+   |        ^^^^^^ expected one of `!` or `::`
+   |
+help: write `pub` instead of `public` to make the item public
+   |
+LL | pub struct X;
+   | ~~~
+
+error: aborting due to previous error
+

--- a/src/test/ui/type/ascription/issue-54516.fixed
+++ b/src/test/ui/type/ascription/issue-54516.fixed
@@ -3,5 +3,5 @@ use std::collections::BTreeMap;
 
 fn main() {
     println!("{}", std::mem::size_of::<BTreeMap<u32, u32>>());
-    //~^ ERROR casts cannot be followed by a function call
+    //~^ ERROR type ascription cannot be followed by a function call
 }

--- a/src/test/ui/type/ascription/issue-54516.rs
+++ b/src/test/ui/type/ascription/issue-54516.rs
@@ -3,5 +3,5 @@ use std::collections::BTreeMap;
 
 fn main() {
     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
-    //~^ ERROR casts cannot be followed by a function call
+    //~^ ERROR type ascription cannot be followed by a function call
 }

--- a/src/test/ui/type/ascription/issue-54516.stderr
+++ b/src/test/ui/type/ascription/issue-54516.stderr
@@ -1,4 +1,4 @@
-error: casts cannot be followed by a function call
+error: type ascription cannot be followed by a function call
   --> $DIR/issue-54516.rs:5:20
    |
 LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());

--- a/src/test/ui/type/ascription/issue-60933.fixed
+++ b/src/test/ui/type/ascription/issue-60933.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
 fn main() {
     let _: usize = std::mem::size_of::<u32>();
-    //~^ ERROR casts cannot be followed by a function call
+    //~^ ERROR type ascription cannot be followed by a function call
 }

--- a/src/test/ui/type/ascription/issue-60933.rs
+++ b/src/test/ui/type/ascription/issue-60933.rs
@@ -1,5 +1,5 @@
 // run-rustfix
 fn main() {
     let _: usize = std::mem:size_of::<u32>();
-    //~^ ERROR casts cannot be followed by a function call
+    //~^ ERROR type ascription cannot be followed by a function call
 }

--- a/src/test/ui/type/ascription/issue-60933.stderr
+++ b/src/test/ui/type/ascription/issue-60933.stderr
@@ -1,4 +1,4 @@
-error: casts cannot be followed by a function call
+error: type ascription cannot be followed by a function call
   --> $DIR/issue-60933.rs:3:20
    |
 LL |     let _: usize = std::mem:size_of::<u32>();

--- a/src/tools/clippy/clippy_lints/src/methods/suspicious_map.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/suspicious_map.rs
@@ -12,7 +12,8 @@ pub fn check<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, count_recv: &hi
     if_chain! {
         if is_trait_method(cx, count_recv, sym::Iterator);
         let closure = expr_or_init(cx, map_arg);
-        if let Some(body_id) = cx.tcx.hir().maybe_body_owned_by(closure.hir_id);
+        if let Some(def_id) = cx.tcx.hir().opt_local_def_id(closure.hir_id);
+        if let Some(body_id) = cx.tcx.hir().maybe_body_owned_by(def_id);
         let closure_body = cx.tcx.hir().body(body_id);
         if !cx.typeck_results().expr_ty(&closure_body.value).is_unit();
         then {

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -138,7 +138,7 @@ impl<'tcx> LateLintPass<'tcx> for Author {
 
 fn check_item(cx: &LateContext<'_>, hir_id: HirId) {
     let hir = cx.tcx.hir();
-    if let Some(body_id) = hir.maybe_body_owned_by(hir_id) {
+    if let Some(body_id) = hir.maybe_body_owned_by(hir.local_def_id(hir_id)) {
         check_node(cx, hir_id, |v| {
             v.expr(&v.bind("expr", &hir.body(body_id).value));
         });

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -138,7 +138,7 @@ impl<'tcx> LateLintPass<'tcx> for Author {
 
 fn check_item(cx: &LateContext<'_>, hir_id: HirId) {
     let hir = cx.tcx.hir();
-    if let Some(body_id) = hir.maybe_body_owned_by(hir.local_def_id(hir_id)) {
+    if let Some(body_id) = hir.maybe_body_owned_by(hir_id.expect_owner()) {
         check_node(cx, hir_id, |v| {
             v.expr(&v.bind("expr", &hir.body(body_id).value));
         });

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -1353,7 +1353,7 @@ pub fn is_integer_const(cx: &LateContext<'_>, e: &Expr<'_>, value: u128) -> bool
     if is_integer_literal(e, value) {
         return true;
     }
-    let enclosing_body = cx.tcx.hir().local_def_id(cx.tcx.hir().enclosing_body_owner(e.hir_id));
+    let enclosing_body = cx.tcx.hir().enclosing_body_owner(e.hir_id);
     if let Some((Constant::Int(v), _)) = constant(cx, cx.tcx.typeck(enclosing_body), e) {
         return value == v;
     }


### PR DESCRIPTION
Successful merges:

 - #99311 (change maybe_body_owned_by to take local def id)
 - #99862 (Improve type mismatch w/ function signatures)
 - #99895 (don't call type ascription "cast")
 - #99900 (remove some manual hash stable impls)
 - #99903 (Add diagnostic when using public instead of pub)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99311,99862,99895,99900,99903)
<!-- homu-ignore:end -->