### PR TITLE
Always create elided lifetimes, even if inferred.

### DIFF
--- a/src/test/ui/lifetimes/elided-lifetime-in-path-in-type-relative-expression.rs
+++ b/src/test/ui/lifetimes/elided-lifetime-in-path-in-type-relative-expression.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+struct Sqlite {}
+
+trait HasArguments<'q> {
+    type Arguments;
+}
+
+impl<'q> HasArguments<'q> for Sqlite {
+    type Arguments = std::marker::PhantomData<&'q ()>;
+}
+
+fn foo() {
+    let _ = <Sqlite as HasArguments>::Arguments::default();
+}
+
+fn main() {}


### PR DESCRIPTION
`PathSource` gives the context in which a path is encountered.  The same `PathSource` is used for the full path and the `QSelf` part.

Therefore, we can only rely on `PathSource` to know whether typechecking will be able to infer the lifetimes, not whether we need to insert them at all.

Fixes https://github.com/rust-lang/rust/issues/99949