### PR TITLE
Also gate AllocatedPointer and AllocAlign definitions by LLVM_VERSION_GE

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -87,8 +87,10 @@ enum LLVMRustAttribute {
   NoCfCheck = 35,
   ShadowCallStack = 36,
   AllocSize = 37,
+#if LLVM_VERSION_GE(15, 0)
   AllocatedPointer = 38,
   AllocAlign = 39,
+#endif
 };
 
 typedef struct OpaqueRustString *RustStringRef;


### PR DESCRIPTION
Fixes a warning:

```
warning: llvm-wrapper/RustWrapper.cpp:159:11: warning: enumeration values 'AllocatedPointer' and 'AllocAlign' not handled in switch [-Wswitch]
warning:   switch (Kind) {
warning:           ^
```

Which was fall out from 130a1df71ea73ab9d66d3cb8fc9cdb43155d514b.

Fixes #99955