### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -87,8 +87,10 @@ enum LLVMRustAttribute {
   NoCfCheck = 35,
   ShadowCallStack = 36,
   AllocSize = 37,
+#if LLVM_VERSION_GE(15, 0)
   AllocatedPointer = 38,
   AllocAlign = 39,
+#endif
 };
 
 typedef struct OpaqueRustString *RustStringRef;

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -72,22 +72,6 @@ struct TopInfo<'tcx> {
     ///              found type `std::result::Result<_, _>`
     /// ```
     span: Option<Span>,
-    /// This refers to the parent pattern. Used to provide extra diagnostic information on errors.
-    /// ```text
-    /// error[E0308]: mismatched types
-    ///   --> $DIR/const-in-struct-pat.rs:8:17
-    ///   |
-    /// L | struct f;
-    ///   | --------- unit struct defined here
-    /// ...
-    /// L |     let Thing { f } = t;
-    ///   |                 ^
-    ///   |                 |
-    ///   |                 expected struct `std::string::String`, found struct `f`
-    ///   |                 `f` is interpreted as a unit struct, not a new binding
-    ///   |                 help: bind the struct field to a different name instead: `f: other_f`
-    /// ```
-    parent_pat: Option<&'tcx Pat<'tcx>>,
 }
 
 impl<'tcx> FnCtxt<'_, 'tcx> {
@@ -147,7 +131,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Option<Span>,
         origin_expr: bool,
     ) {
-        let info = TopInfo { expected, origin_expr, span, parent_pat: None };
+        let info = TopInfo { expected, origin_expr, span };
         self.check_pat(pat, expected, INITIAL_BM, info);
     }
 
@@ -190,9 +174,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.check_pat_struct(pat, qpath, fields, has_rest_pat, expected, def_bm, ti)
             }
             PatKind::Or(pats) => {
-                let parent_pat = Some(pat);
                 for pat in pats {
-                    self.check_pat(pat, expected, def_bm, TopInfo { parent_pat, ..ti });
+                    self.check_pat(pat, expected, def_bm, ti);
                 }
                 expected
             }
@@ -621,7 +604,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         if let Some(p) = sub {
-            self.check_pat(p, expected, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+            self.check_pat(p, expected, def_bm, ti);
         }
 
         local_ty
@@ -782,7 +765,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let Some((variant, pat_ty)) = self.check_struct_path(qpath, pat.hir_id) else {
             let err = self.tcx.ty_error();
             for field in fields {
-                let ti = TopInfo { parent_pat: Some(pat), ..ti };
+                let ti = ti;
                 self.check_pat(field.pat, err, def_bm, ti);
             }
             return err;
@@ -799,11 +782,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn check_pat_path<'b>(
+    fn check_pat_path(
         &self,
-        pat: &Pat<'_>,
+        pat: &Pat<'tcx>,
         qpath: &hir::QPath<'_>,
-        path_resolution: (Res, Option<Ty<'tcx>>, &'b [hir::PathSegment<'b>]),
+        path_resolution: (Res, Option<Ty<'tcx>>, &'tcx [hir::PathSegment<'tcx>]),
         expected: Ty<'tcx>,
         ti: TopInfo<'tcx>,
     ) -> Ty<'tcx> {
@@ -837,7 +820,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Some(err) =
             self.demand_suptype_with_origin(&self.pattern_cause(ti, pat.span), expected, pat_ty)
         {
-            self.emit_bad_pat_path(err, pat.span, res, pat_res, pat_ty, segments, ti.parent_pat);
+            self.emit_bad_pat_path(err, pat, res, pat_res, pat_ty, segments);
         }
         pat_ty
     }
@@ -876,16 +859,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         false
     }
 
-    fn emit_bad_pat_path<'b>(
+    fn emit_bad_pat_path(
         &self,
         mut e: DiagnosticBuilder<'_, ErrorGuaranteed>,
-        pat_span: Span,
+        pat: &hir::Pat<'tcx>,
         res: Res,
         pat_res: Res,
         pat_ty: Ty<'tcx>,
-        segments: &'b [hir::PathSegment<'b>],
-        parent_pat: Option<&Pat<'_>>,
+        segments: &'tcx [hir::PathSegment<'tcx>],
     ) {
+        let pat_span = pat.span;
         if let Some(span) = self.tcx.hir().res_span(pat_res) {
             e.span_label(span, &format!("{} defined here", res.descr()));
             if let [hir::PathSegment { ident, .. }] = &*segments {
@@ -898,8 +881,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         res.descr(),
                     ),
                 );
-                match parent_pat {
-                    Some(Pat { kind: hir::PatKind::Struct(..), .. }) => {
+                match self.tcx.hir().get(self.tcx.hir().get_parent_node(pat.hir_id)) {
+                    hir::Node::Pat(Pat { kind: hir::PatKind::Struct(..), .. }) => {
                         e.span_suggestion_verbose(
                             ident.span.shrink_to_hi(),
                             "bind the struct field to a different name instead",
@@ -960,9 +943,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let on_error = || {
-            let parent_pat = Some(pat);
             for pat in subpats {
-                self.check_pat(pat, tcx.ty_error(), def_bm, TopInfo { parent_pat, ..ti });
+                self.check_pat(pat, tcx.ty_error(), def_bm, ti);
             }
         };
         let report_unexpected_res = |res: Res| {
@@ -1046,7 +1028,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
             for (i, subpat) in subpats.iter().enumerate_and_adjust(variant.fields.len(), ddpos) {
                 let field_ty = self.field_ty(subpat.span, &variant.fields[i], substs);
-                self.check_pat(subpat, field_ty, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+                self.check_pat(subpat, field_ty, def_bm, ti);
 
                 self.tcx.check_stability(
                     variant.fields[i].did,
@@ -1324,7 +1306,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             };
 
-            self.check_pat(field.pat, field_ty, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+            self.check_pat(field.pat, field_ty, def_bm, ti);
         }
 
         let mut unmentioned_fields = variant
@@ -1936,7 +1918,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let err = tcx.ty_error();
             (err, err)
         };
-        self.check_pat(inner, inner_ty, def_bm, TopInfo { parent_pat: Some(pat), ..ti });
+        self.check_pat(inner, inner_ty, def_bm, ti);
         rptr_ty
     }
 

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -1035,11 +1035,13 @@ fn remove_dir_all_iterative(f: &File, delete: fn(&File) -> io::Result<()>) -> io
         unsafe { mem::ManuallyDrop::new(File::from_raw_handle(f.as_raw_handle())) }
     }
 
+    let mut restart = true;
     while let Some(dir) = dirlist.last() {
         let dir = copy_handle(dir);
 
         // Fill the buffer and iterate the entries.
-        let more_data = dir.fill_dir_buff(&mut buffer, false)?;
+        let more_data = dir.fill_dir_buff(&mut buffer, restart)?;
+        restart = false;
         for (name, is_directory) in buffer.iter() {
             if is_directory {
                 let child_dir = open_link_no_reparse(

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -623,15 +623,6 @@ Arguments:
             }
         };
 
-        if let Subcommand::Check { .. } = &cmd {
-            if matches.opt_str("keep-stage").is_some()
-                || matches.opt_str("keep-stage-std").is_some()
-            {
-                eprintln!("--keep-stage not yet supported for x.py check");
-                crate::detail_exit(1);
-            }
-        }
-
         Flags {
             verbose: matches.opt_count("verbose"),
             stage: matches.opt_str("stage").map(|j| j.parse().expect("`stage` should be a number")),

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -189,7 +189,8 @@ fn download_ci_llvm(builder: &Builder<'_>, llvm_sha: &str) {
     } else {
         &builder.config.stage0_metadata.config.artifacts_server
     };
-    let filename = format!("rust-dev-nightly-{}.tar.xz", builder.build.build.triple);
+    let channel = builder.config.artifact_channel(llvm_sha);
+    let filename = format!("rust-dev-{}-{}.tar.xz", channel, builder.build.build.triple);
     let tarball = rustc_cache.join(&filename);
     if !tarball.exists() {
         let help_on_error = "error: failed to download llvm from ci

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -17,8 +17,8 @@ use rustc_span::symbol::{kw, sym, Symbol};
 
 use crate::clean::{
     self, clean_fn_decl_from_did_and_sig, clean_middle_field, clean_middle_ty, clean_ty,
-    clean_ty_generics, clean_visibility, utils, Attributes, AttributesExt, Clean, ImplKind, ItemId,
-    Type, Visibility,
+    clean_ty_generics, clean_variant_def, clean_visibility, utils, Attributes, AttributesExt,
+    Clean, ImplKind, ItemId, Type, Visibility,
 };
 use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
@@ -236,7 +236,7 @@ fn build_enum(cx: &mut DocContext<'_>, did: DefId) -> clean::Enum {
 
     clean::Enum {
         generics: clean_ty_generics(cx, cx.tcx.generics_of(did), predicates),
-        variants: cx.tcx.adt_def(did).variants().iter().map(|v| v.clean(cx)).collect(),
+        variants: cx.tcx.adt_def(did).variants().iter().map(|v| clean_variant_def(v, cx)).collect(),
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1824,16 +1824,6 @@ pub(crate) fn clean_visibility(vis: ty::Visibility) -> Visibility {
     }
 }
 
-fn clean_variant_data<'tcx>(
-    variant: &hir::VariantData<'tcx>,
-    cx: &mut DocContext<'tcx>,
-) -> VariantStruct {
-    VariantStruct {
-        struct_type: CtorKind::from_hir(variant),
-        fields: variant.fields().iter().map(|x| clean_field(x, cx)).collect(),
-    }
-}
-
 pub(crate) fn clean_variant_def<'tcx>(variant: &ty::VariantDef, cx: &mut DocContext<'tcx>) -> Item {
     let kind = match variant.ctor_kind {
         CtorKind::Const => Variant::CLike,
@@ -1851,15 +1841,19 @@ pub(crate) fn clean_variant_def<'tcx>(variant: &ty::VariantDef, cx: &mut DocCont
     Item { visibility: Inherited, ..what_rustc_thinks }
 }
 
-impl<'tcx> Clean<'tcx, Variant> for hir::VariantData<'tcx> {
-    fn clean(&self, cx: &mut DocContext<'tcx>) -> Variant {
-        match self {
-            hir::VariantData::Struct(..) => Variant::Struct(clean_variant_data(self, cx)),
-            hir::VariantData::Tuple(..) => {
-                Variant::Tuple(self.fields().iter().map(|x| clean_field(x, cx)).collect())
-            }
-            hir::VariantData::Unit(..) => Variant::CLike,
+fn clean_variant_data<'tcx>(
+    variant: &hir::VariantData<'tcx>,
+    cx: &mut DocContext<'tcx>,
+) -> Variant {
+    match variant {
+        hir::VariantData::Struct(..) => Variant::Struct(VariantStruct {
+            struct_type: CtorKind::from_hir(variant),
+            fields: variant.fields().iter().map(|x| clean_field(x, cx)).collect(),
+        }),
+        hir::VariantData::Tuple(..) => {
+            Variant::Tuple(variant.fields().iter().map(|x| clean_field(x, cx)).collect())
         }
+        hir::VariantData::Unit(..) => Variant::CLike,
     }
 }
 
@@ -2007,7 +2001,7 @@ fn clean_maybe_renamed_item<'tcx>(
 
 impl<'tcx> Clean<'tcx, Item> for hir::Variant<'tcx> {
     fn clean(&self, cx: &mut DocContext<'tcx>) -> Item {
-        let kind = VariantItem(self.data.clean(cx));
+        let kind = VariantItem(clean_variant_data(&self.data, cx));
         let what_rustc_thinks =
             Item::from_hir_id_and_parts(self.id, Some(self.ident.name), kind, cx);
         // don't show `pub` for variants, which are always public

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1834,23 +1834,21 @@ fn clean_variant_data<'tcx>(
     }
 }
 
-impl<'tcx> Clean<'tcx, Item> for ty::VariantDef {
-    fn clean(&self, cx: &mut DocContext<'tcx>) -> Item {
-        let kind = match self.ctor_kind {
-            CtorKind::Const => Variant::CLike,
-            CtorKind::Fn => Variant::Tuple(
-                self.fields.iter().map(|field| clean_middle_field(field, cx)).collect(),
-            ),
-            CtorKind::Fictive => Variant::Struct(VariantStruct {
-                struct_type: CtorKind::Fictive,
-                fields: self.fields.iter().map(|field| clean_middle_field(field, cx)).collect(),
-            }),
-        };
-        let what_rustc_thinks =
-            Item::from_def_id_and_parts(self.def_id, Some(self.name), VariantItem(kind), cx);
-        // don't show `pub` for variants, which always inherit visibility
-        Item { visibility: Inherited, ..what_rustc_thinks }
-    }
+pub(crate) fn clean_variant_def<'tcx>(variant: &ty::VariantDef, cx: &mut DocContext<'tcx>) -> Item {
+    let kind = match variant.ctor_kind {
+        CtorKind::Const => Variant::CLike,
+        CtorKind::Fn => Variant::Tuple(
+            variant.fields.iter().map(|field| clean_middle_field(field, cx)).collect(),
+        ),
+        CtorKind::Fictive => Variant::Struct(VariantStruct {
+            struct_type: CtorKind::Fictive,
+            fields: variant.fields.iter().map(|field| clean_middle_field(field, cx)).collect(),
+        }),
+    };
+    let what_rustc_thinks =
+        Item::from_def_id_and_parts(variant.def_id, Some(variant.name), VariantItem(kind), cx);
+    // don't show `pub` for variants, which always inherit visibility
+    Item { visibility: Inherited, ..what_rustc_thinks }
 }
 
 impl<'tcx> Clean<'tcx, Variant> for hir::VariantData<'tcx> {

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -94,6 +94,14 @@ fn extract_path_backwards(text: &str, end_pos: usize) -> Option<usize> {
     if current_pos == end_pos { None } else { Some(current_pos) }
 }
 
+fn is_valid_for_html_tag_name(c: char, is_empty: bool) -> bool {
+    // https://spec.commonmark.org/0.30/#raw-html
+    //
+    // > A tag name consists of an ASCII letter followed by zero or more ASCII letters, digits, or
+    // > hyphens (-).
+    c.is_ascii_alphabetic() || (c.is_ascii_digit() && !is_empty) || (c == '-' && !is_empty)
+}
+
 fn extract_html_tag(
     tags: &mut Vec<(String, Range<usize>)>,
     text: &str,
@@ -117,7 +125,7 @@ fn extract_html_tag(
         // Checking if this is a closing tag (like `</a>` for `<a>`).
         if c == '/' && tag_name.is_empty() {
             is_closing = true;
-        } else if c.is_ascii_alphanumeric() {
+        } else if is_valid_for_html_tag_name(c, tag_name.is_empty()) {
             tag_name.push(c);
         } else {
             if !tag_name.is_empty() {

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -99,7 +99,7 @@ fn is_valid_for_html_tag_name(c: char, is_empty: bool) -> bool {
     //
     // > A tag name consists of an ASCII letter followed by zero or more ASCII letters, digits, or
     // > hyphens (-).
-    c.is_ascii_alphabetic() || (c.is_ascii_digit() && !is_empty) || (c == '-' && !is_empty)
+    c.is_ascii_alphabetic() || !is_empty && (c == '-' || c.is_ascii_digit())
 }
 
 fn extract_html_tag(

--- a/src/test/rustdoc-ui/invalid-html-tags.rs
+++ b/src/test/rustdoc-ui/invalid-html-tags.rs
@@ -108,3 +108,9 @@ pub fn j() {}
 /// <Vec<_> shouldn't warn!
 /// ``````
 pub fn k() {}
+
+/// Web Components style <dashed-tags>
+//~^ ERROR unclosed HTML tag `dashed-tags`
+/// Web Components style </unopened-tag>
+//~^ ERROR unopened HTML tag `unopened-tag`
+pub fn m() {}

--- a/src/test/rustdoc-ui/invalid-html-tags.stderr
+++ b/src/test/rustdoc-ui/invalid-html-tags.stderr
@@ -82,5 +82,17 @@ error: Unclosed HTML comment
 LL | /// <!--
    |     ^^^
 
-error: aborting due to 13 previous errors
+error: unopened HTML tag `unopened-tag`
+  --> $DIR/invalid-html-tags.rs:114:26
+   |
+LL | /// Web Components style </unopened-tag>
+   |                          ^^^^^^^^^^^^^^^
+
+error: unclosed HTML tag `dashed-tags`
+  --> $DIR/invalid-html-tags.rs:112:26
+   |
+LL | /// Web Components style <dashed-tags>
+   |                          ^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
 

--- a/src/test/ui/associated-consts/assoc-const-ty-mismatch.rs
+++ b/src/test/ui/associated-consts/assoc-const-ty-mismatch.rs
@@ -21,9 +21,9 @@ impl FooTy for Bar {
 
 
 fn foo<F: Foo<N=usize>>() {}
-//~^ ERROR mismatch in
+//~^ ERROR expected associated constant bound, found type
 fn foo2<F: FooTy<T=3usize>>() {}
-//~^ ERROR mismatch in
+//~^ ERROR expected associated type bound, found constant
 
 fn main() {
   foo::<Bar>();

--- a/src/test/ui/associated-consts/assoc-const-ty-mismatch.stderr
+++ b/src/test/ui/associated-consts/assoc-const-ty-mismatch.stderr
@@ -1,22 +1,22 @@
-error: mismatch in bind of associated constant, got type
+error: expected associated constant bound, found type
   --> $DIR/assoc-const-ty-mismatch.rs:23:15
    |
 LL | fn foo<F: Foo<N=usize>>() {}
    |               ^^^^^^^
    |
-note: associated constant defined here does not match type
+note: associated constant defined here
   --> $DIR/assoc-const-ty-mismatch.rs:5:3
    |
 LL |   const N: usize;
    |   ^^^^^^^^^^^^^^
 
-error: mismatch in bind of associated type, got const
+error: expected associated type bound, found constant
   --> $DIR/assoc-const-ty-mismatch.rs:25:18
    |
 LL | fn foo2<F: FooTy<T=3usize>>() {}
    |                  ^^^^^^^^
    |
-note: associated type defined here does not match const
+note: associated type defined here
   --> $DIR/assoc-const-ty-mismatch.rs:9:3
    |
 LL |   type T;

--- a/src/test/ui/associated-type-bounds/issue-99828.rs
+++ b/src/test/ui/associated-type-bounds/issue-99828.rs
@@ -1,0 +1,11 @@
+fn get_iter(vec: &[i32]) -> impl Iterator<Item = {}> + '_ {
+    //~^ ERROR expected associated type bound, found constant
+    //~| ERROR associated const equality is incomplete
+    vec.iter()
+}
+
+fn main() {
+    let vec = Vec::new();
+    let mut iter = get_iter(&vec);
+    iter.next();
+}

--- a/src/test/ui/associated-type-bounds/issue-99828.stderr
+++ b/src/test/ui/associated-type-bounds/issue-99828.stderr
@@ -1,0 +1,24 @@
+error[E0658]: associated const equality is incomplete
+  --> $DIR/issue-99828.rs:1:43
+   |
+LL | fn get_iter(vec: &[i32]) -> impl Iterator<Item = {}> + '_ {
+   |                                           ^^^^^^^^^
+   |
+   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
+   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+
+error: expected associated type bound, found constant
+  --> $DIR/issue-99828.rs:1:43
+   |
+LL | fn get_iter(vec: &[i32]) -> impl Iterator<Item = {}> + '_ {
+   |                                           ^^^^^^^^^
+   |
+note: associated type defined here
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     type Item;
+   |     ^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - #99650 (Support `x --keep-stage 0 check`)
 - #99873 (rustdoc: align invalid-html-tags lint with commonmark spec)
 - #99889 (Remove `parent_pat` from `TopInfo`)
 - #99890 (Do not allow bad projection term to leak into the type checker)
 - #99937 (Reset directory iteration in remove_dir_all)
 - #99950 (Remove more Clean trait implementations)
 - #99956 (Also gate AllocatedPointer and AllocAlign definitions by LLVM_VERSION_GE)
 - #99962 (Discover channel for LLVM download)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99650,99873,99889,99890,99937,99950,99956,99962)
<!-- homu-ignore:end -->