### PR TITLE
Publish compiletest as a rustc-tools component

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -724,6 +724,7 @@ impl<'a> Builder<'a> {
                 dist::LlvmTools,
                 dist::RustDev,
                 dist::Extended,
+                dist::RustcTools,
                 // It seems that PlainSourceTarball somehow changes how some of the tools
                 // perceive their dependencies (see #93033) which would invalidate fingerprints
                 // and force us to rebuild tools after vendoring dependencies.

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -547,7 +547,12 @@ impl Builder {
                 if target_name.contains(substr) {
                     let t = Target::from_compressed_tar(self, &tarball_name!(fallback_target));
                     // Fallbacks must always be available.
-                    assert!(t.available);
+                    assert!(
+                        t.available,
+                        "{} fallback for {} not available",
+                        tarball_name!(target_name),
+                        tarball_name!(fallback_target)
+                    );
                     return t;
                 }
             }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -184,7 +184,7 @@ static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"
 
 static MINGW: &[&str] = &["i686-pc-windows-gnu", "x86_64-pc-windows-gnu"];
 
-static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview"];
+static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview", "rustc-tools-preview"];
 
 macro_rules! t {
     ($e:expr) => {
@@ -323,6 +323,7 @@ impl Builder {
         package!("rust-analyzer-preview", HOSTS);
         package!("clippy-preview", HOSTS);
         package!("miri-preview", HOSTS);
+        package!("rustc-tools-preview", HOSTS);
         package!("rustfmt-preview", HOSTS);
         package!("rust-analysis", TARGETS);
         package!("llvm-tools-preview", TARGETS);
@@ -403,6 +404,7 @@ impl Builder {
         rename("rustfmt", "rustfmt-preview");
         rename("clippy", "clippy-preview");
         rename("miri", "miri-preview");
+        rename("rustc-tools", "rustc-tools-preview");
         rename("rust-analyzer", "rust-analyzer-preview");
     }
 
@@ -454,6 +456,7 @@ impl Builder {
         extensions.extend(vec![
             host_component("clippy-preview"),
             host_component("miri-preview"),
+            host_component("rustc-tools-preview"),
             host_component("rls-preview"),
             host_component("rust-analyzer-preview"),
             host_component("rustfmt-preview"),


### PR DESCRIPTION
The goal of this PR is to just get the publishing working in a way that'll hopefully let clippy consume the resulting binary without too much trouble. If there's a desire to use compiletest as a library rather than a binary, I see no reason why we couldn't publish an rlib/.so/whatever, just like we do for std or the rustc libraries, that'll just take more plumbing. My hope is that the binary is a sufficient interface for now, since that works for rustc itself (bootstrap calls the binary), but if not, we can modify this PR to publish an rlib into the sysroot too, when the compiletest component is installed.

It looks like as-is clippy does use the library compiletest-rs as a library for its testing, I would need to do more digging to tell if that's an intrinsic dependency or not.

cc @Manishearth @oli-obk https://github.com/rust-lang/compiler-team/issues/536

r? @jyn514 