### PR TITLE
interpret: only consider 1-ZST when searching for receiver

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -534,7 +534,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                             let mut non_zst_field = None;
                             for i in 0..receiver.layout.fields.count() {
                                 let field = self.operand_field(&receiver, i)?;
-                                if !field.layout.is_zst() {
+                                let zst =
+                                    field.layout.is_zst() && field.layout.align.abi.bytes() == 1;
+                                if !zst {
                                     assert!(
                                         non_zst_field.is_none(),
                                         "multiple non-ZST fields in dyn receiver type {}",


### PR DESCRIPTION
`repr(transparent)` currently entirely rejects ZST with alignment larger than 1 (which is odd, arguably [this](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=02870f29396fa948c3123cb53d869ad1) should be accepted), so this should be safe. And if it ever isn't safe then that is very likely a bug elsewhere in the compiler.