### PR TITLE
Make Rustdoc exit with correct error code when scraping examples from invalid files

### DIFF
--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -304,6 +304,12 @@ pub(crate) fn run(
         let mut finder = FindCalls { calls: &mut calls, tcx, map: tcx.hir(), cx, target_crates };
         tcx.hir().visit_all_item_likes_in_crate(&mut finder);
 
+        // The visitor might have found a type error, which we need to
+        // promote to a fatal error
+        if tcx.sess.diagnostic().has_errors_or_lint_errors().is_some() {
+            return Err(String::from("Compilation failed, aborting rustdoc"));
+        }
+
         // Sort call locations within a given file in document order
         for fn_calls in calls.values_mut() {
             for file_calls in fn_calls.values_mut() {

--- a/src/test/rustdoc-ui/scrape-examples-fail-if-type-error.rs
+++ b/src/test/rustdoc-ui/scrape-examples-fail-if-type-error.rs
@@ -1,0 +1,7 @@
+// check-fail
+// compile-flags: -Z unstable-options --scrape-examples-output-path {{build-base}}/t.calls --scrape-examples-target-crate foobar
+
+pub fn foo() {
+  INVALID_FUNC();
+  //~^ ERROR could not resolve path
+}

--- a/src/test/rustdoc-ui/scrape-examples-fail-if-type-error.stderr
+++ b/src/test/rustdoc-ui/scrape-examples-fail-if-type-error.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve: could not resolve path `INVALID_FUNC`
+  --> $DIR/scrape-examples-fail-if-type-error.rs:5:3
+   |
+LL |   INVALID_FUNC();
+   |   ^^^^^^^^^^^^ could not resolve path `INVALID_FUNC`
+   |
+   = note: this error was originally ignored because you are running `rustdoc`
+   = note: try running again with `rustc` or `cargo check` and you may get a more detailed error
+
+error: Compilation failed, aborting rustdoc
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
This PR fixes a small issue with the new Rustdoc scrape-examples feature. If a file that is being scraped has a type error, then currently that error is printed out, but the rustdoc process exits as if it succeeded. This is a problem for Cargo, which needs to track whether scraping succeeded (see rust-lang/cargo#10343).

This PR fixes the issue by checking whether an error is emitted, and aborting if so.