### PR TITLE
Remove more Clean trait implementations

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1884,7 +1884,8 @@ impl<'tcx> Clean<'tcx, GenericArgs> for hir::GenericArgs<'tcx> {
                 })
                 .collect::<Vec<_>>()
                 .into();
-            let bindings = self.bindings.iter().map(|x| x.clean(cx)).collect::<Vec<_>>().into();
+            let bindings =
+                self.bindings.iter().map(|x| clean_type_binding(x, cx)).collect::<Vec<_>>().into();
             GenericArgs::AngleBracketed { args, bindings }
         }
     }
@@ -2250,12 +2251,13 @@ fn clean_maybe_renamed_foreign_item<'tcx>(
     })
 }
 
-impl<'tcx> Clean<'tcx, TypeBinding> for hir::TypeBinding<'tcx> {
-    fn clean(&self, cx: &mut DocContext<'tcx>) -> TypeBinding {
-        TypeBinding {
-            assoc: PathSegment { name: self.ident.name, args: self.gen_args.clean(cx) },
-            kind: self.kind.clean(cx),
-        }
+fn clean_type_binding<'tcx>(
+    type_binding: &hir::TypeBinding<'tcx>,
+    cx: &mut DocContext<'tcx>,
+) -> TypeBinding {
+    TypeBinding {
+        assoc: PathSegment { name: type_binding.ident.name, args: type_binding.gen_args.clean(cx) },
+        kind: type_binding.kind.clean(cx),
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2257,19 +2257,13 @@ fn clean_type_binding<'tcx>(
 ) -> TypeBinding {
     TypeBinding {
         assoc: PathSegment { name: type_binding.ident.name, args: type_binding.gen_args.clean(cx) },
-        kind: type_binding.kind.clean(cx),
-    }
-}
-
-impl<'tcx> Clean<'tcx, TypeBindingKind> for hir::TypeBindingKind<'tcx> {
-    fn clean(&self, cx: &mut DocContext<'tcx>) -> TypeBindingKind {
-        match *self {
+        kind: match type_binding.kind {
             hir::TypeBindingKind::Equality { ref term } => {
                 TypeBindingKind::Equality { term: clean_hir_term(term, cx) }
             }
             hir::TypeBindingKind::Constraint { bounds } => TypeBindingKind::Constraint {
                 bounds: bounds.iter().filter_map(|b| b.clean(cx)).collect(),
             },
-        }
+        },
     }
 }


### PR DESCRIPTION
This time as well it allowed to remove a function.

Follow-up of https://github.com/rust-lang/rust/pull/99638.

r? @notriddle 