### PR TITLE
Add wrap suggestions for record variants

### DIFF
--- a/src/test/ui/did_you_mean/compatible-variants.rs
+++ b/src/test/ui/did_you_mean/compatible-variants.rs
@@ -66,7 +66,7 @@ fn main() {
 }
 
 enum A {
-    B { b: B},
+    B { b: B },
 }
 
 struct A2(B);
@@ -77,13 +77,12 @@ enum B {
 }
 
 fn foo() {
-    // We don't want to suggest `A::B(B::Fst)` here.
     let a: A = B::Fst;
     //~^ ERROR mismatched types
+    //~| HELP try wrapping
 }
 
 fn bar() {
-    // But we _do_ want to suggest `A2(B::Fst)` here!
     let a: A2 = B::Fst;
     //~^ ERROR mismatched types
     //~| HELP try wrapping

--- a/src/test/ui/did_you_mean/compatible-variants.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants.stderr
@@ -191,15 +191,20 @@ LL |     let _ = Foo { bar: Some(bar) };
    |                   ++++++++++   +
 
 error[E0308]: mismatched types
-  --> $DIR/compatible-variants.rs:81:16
+  --> $DIR/compatible-variants.rs:80:16
    |
 LL |     let a: A = B::Fst;
    |            -   ^^^^^^ expected enum `A`, found enum `B`
    |            |
    |            expected due to this
+   |
+help: try wrapping the expression in `A::B`
+   |
+LL |     let a: A = A::B { b: B::Fst };
+   |                +++++++++        +
 
 error[E0308]: mismatched types
-  --> $DIR/compatible-variants.rs:87:17
+  --> $DIR/compatible-variants.rs:86:17
    |
 LL |     let a: A2 = B::Fst;
    |            --   ^^^^^^ expected struct `A2`, found enum `B`

--- a/src/test/ui/did_you_mean/issue-42764.rs
+++ b/src/test/ui/did_you_mean/issue-42764.rs
@@ -26,4 +26,5 @@ struct Context { wrapper: Wrapper }
 fn overton() {
     let _c = Context { wrapper: Payload{} };
     //~^ ERROR mismatched types
+    //~| try wrapping the expression in `Wrapper`
 }

--- a/src/test/ui/did_you_mean/issue-42764.stderr
+++ b/src/test/ui/did_you_mean/issue-42764.stderr
@@ -25,6 +25,11 @@ error[E0308]: mismatched types
    |
 LL |     let _c = Context { wrapper: Payload{} };
    |                                 ^^^^^^^^^ expected struct `Wrapper`, found struct `Payload`
+   |
+help: try wrapping the expression in `Wrapper`
+   |
+LL |     let _c = Context { wrapper: Wrapper { payload: Payload{} } };
+   |                                 ++++++++++++++++++           +
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This PR adds a suggestions to wrap an expression in a record struct/variant when encountering mismatched types, similarly to a suggestion to wrap expression in a tuple struct that was added before.

An example:
```rust
struct B {
    f: u8,
}

enum E {
    A(u32),
    B { f: u8 },
}

fn main() {
    let _: B = 1;
    let _: E = 1;
}
```
```text
error[E0308]: mismatched types
  --> ./t.rs:11:16
   |
11 |     let _: B = 1;
   |            -   ^ expected struct `B`, found integer
   |            |
   |            expected due to this
   |
help: try wrapping the expression in `B`
   |
11 |     let _: B = B { f: 1 };
   |                ++++++   +

error[E0308]: mismatched types
  --> ./t.rs:12:16
   |
12 |     let _: E = 1;
   |            -   ^ expected enum `E`, found integer
   |            |
   |            expected due to this
   |
help: try wrapping the expression in a variant of `E`
   |
12 |     let _: E = E::A(1);
   |                +++++ +
12 |     let _: E = E::B { f: 1 };
   |                +++++++++   +
```

r? @compiler-errors 