### PR TITLE
Allow try-perf branch to run in CI

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -43,7 +43,7 @@ else
     PYTHON="python2"
 fi
 
-if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try; then
+if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch try-perf; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.metrics"
 fi

--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
-if isCiBranch auto || isCiBranch try; then
+if isCiBranch auto || isCiBranch try || isCiBranch try-perf; then
     echo "channel verification is only executed on PR builds"
     exit
 fi


### PR DESCRIPTION
We want to be able to build artifacts through the try-perf branch but without this change the CI fails early. 

r? @Mark-Simulacrum 