### PR TITLE
Move `x test --skip` to be part of `--exclude`

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -547,7 +547,6 @@ mod dist {
         config.stage = 0;
         config.cmd = Subcommand::Test {
             paths: vec!["library/std".into()],
-            skip: vec![],
             test_args: vec![],
             rustc_args: vec![],
             fail_fast: true,
@@ -618,7 +617,6 @@ mod dist {
         let mut config = configure(&["A"], &["A"]);
         config.cmd = Subcommand::Test {
             paths: vec![],
-            skip: vec![],
             test_args: vec![],
             rustc_args: vec![],
             fail_fast: true,

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -115,7 +115,6 @@ pub enum Subcommand {
         compare_mode: Option<String>,
         pass: Option<String>,
         run: Option<String>,
-        skip: Vec<String>,
         test_args: Vec<String>,
         rustc_args: Vec<String>,
         fail_fast: bool,
@@ -568,7 +567,6 @@ Arguments:
                 compare_mode: matches.opt_str("compare-mode"),
                 pass: matches.opt_str("pass"),
                 run: matches.opt_str("run"),
-                skip: matches.opt_strs("skip"),
                 test_args: matches.opt_strs("test-args"),
                 rustc_args: matches.opt_strs("rustc-args"),
                 fail_fast: !matches.opt_present("no-fail-fast"),
@@ -706,16 +704,6 @@ impl Subcommand {
 
     pub fn test_args(&self) -> Vec<&str> {
         let mut args = vec![];
-
-        match *self {
-            Subcommand::Test { ref skip, .. } => {
-                for s in skip {
-                    args.push("--skip");
-                    args.push(s.as_str());
-                }
-            }
-            _ => (),
-        };
 
         match *self {
             Subcommand::Test { ref test_args, .. } | Subcommand::Bench { ref test_args, .. } => {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1488,6 +1488,11 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             cmd.arg("--run-clang-based-tests-with").arg(clang_exe);
         }
 
+        for exclude in &builder.config.exclude {
+            cmd.arg("--skip");
+            cmd.arg(&exclude.path);
+        }
+
         // Get paths from cmd args
         let paths = match &builder.config.cmd {
             Subcommand::Test { ref paths, .. } => &paths[..],


### PR DESCRIPTION
`--skip` is inconsistent with the rest of the interface and redundant with `--exclude`.
Fix --exclude to work properly for files and directories rather than having a separate flag.

Fixes https://github.com/rust-lang/rust/issues/96342. cc https://github.com/rust-lang/rust/pull/96493#issuecomment-1200521720

r? @Mark-Simulacrum