### PR TITLE
kmc-solid: Update `Socket::connect_timeout` to be in line with #78802

### DIFF
--- a/library/std/src/sys/solid/net.rs
+++ b/library/std/src/sys/solid/net.rs
@@ -230,8 +230,8 @@ impl Socket {
     pub fn connect_timeout(&self, addr: &SocketAddr, timeout: Duration) -> io::Result<()> {
         self.set_nonblocking(true)?;
         let r = unsafe {
-            let (addrp, len) = addr.into_inner();
-            cvt(netc::connect(self.0.raw(), addrp, len))
+            let (addr, len) = addr.into_inner();
+            cvt(netc::connect(self.0.raw(), addr.as_ptr(), len))
         };
         self.set_nonblocking(false)?;
 


### PR DESCRIPTION
Fixes the build failure of the [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) Tier 3 targets after #78802.

```
error[E0308]: mismatched types
   --> library\std\src\sys\solid\net.rs:234:45
    |
234 |             cvt(netc::connect(self.0.raw(), addrp, len))
    |                 -------------               ^^^^^ expected *-ptr, found union `SocketAddrCRepr`
    |                 |
    |                 arguments to this function are incorrect
    |
    = note: expected raw pointer `*const sockets::sockaddr`
                     found union `SocketAddrCRepr`
note: function defined here
   --> library\std\src\sys\solid\abi\sockets.rs:173:12
    |
    173 |     pub fn connect(s: c_int, name: *const sockaddr, namelen: socklen_t) -> c_int;
    |            ^^^^^^^
```