### PR TITLE
better error when python is not found in x - issue #99648

### DIFF
--- a/src/tools/x/src/main.rs
+++ b/src/tools/x/src/main.rs
@@ -41,9 +41,9 @@ fn python() -> &'static str {
     } else if python2 {
         PYTHON2
     } else {
-        // We would have returned early if we found that python is installed ...
-        // maybe this should panic with an error instead?
-        PYTHON
+        // Python was not found on path, so exit
+        eprintln!("Unable to find python in your PATH. Please check it is installed.");
+        process::exit(1);
     }
 }
 


### PR DESCRIPTION
`x` now shows an appropriate error message and exits, when a version of `python` is not found on the users `PATH`.

Resolves #99648  