### PR TITLE
made `unreachable_unchecked` panic in debug mode

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -98,9 +98,13 @@ use crate::intrinsics;
 #[rustc_const_stable(feature = "const_unreachable_unchecked", since = "1.57.0")]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub const unsafe fn unreachable_unchecked() -> ! {
-    // SAFETY: the safety contract for `intrinsics::unreachable` must
-    // be upheld by the caller.
-    unsafe { intrinsics::unreachable() }
+    if cfg!(debug_assertions) {
+        unreachable!()
+    } else {
+        // SAFETY: the safety contract for `intrinsics::unreachable` must
+        // be upheld by the caller.
+        unsafe { intrinsics::unreachable() }
+    }
 }
 
 /// Emits a machine instruction to signal the processor that it is running in


### PR DESCRIPTION
Added a call to `unreachable` when `unreachable_unchecked` is compiled with `debug_assertions` enabled. I don't know if this is an issue, but this shouldn't cause any problems with const fns, as panicking in const fns was added in the release that this was made const.