### PR TITLE
Update rustc man page to match `rustc --help`

### DIFF
--- a/src/doc/man/rustc.1
+++ b/src/doc/man/rustc.1
@@ -44,18 +44,18 @@ The optional \fIKIND\fR can be one of \fIstatic\fR, \fIdylib\fR, or
 \fIframework\fR.
 If omitted, \fIdylib\fR is assumed.
 .TP
-\fB\-\-crate\-type\fR [bin|lib|rlib|dylib|cdylib|staticlib]
+\fB\-\-crate\-type\fR [bin|lib|rlib|dylib|cdylib|staticlib|proc\-macro]
 Comma separated list of types of crates for the compiler to emit.
 .TP
 \fB\-\-crate\-name\fR \fINAME\fR
 Specify the name of the crate being built.
 .TP
-\fB\-\-emit\fR [asm|llvm\-bc|llvm\-ir|obj|link|dep\-info|mir][=\fIPATH\fR]
+\fB\-\-emit\fR [asm|llvm\-bc|llvm\-ir|obj|metadata|link|dep\-info|mir][=\fIPATH\fR]
 Configure the output that \fBrustc\fR will produce. Each emission may also have
 an optional explicit output \fIPATH\fR specified for that particular emission
 kind. This path takes precedence over the \fB-o\fR option.
 .TP
-\fB\-\-print\fR [crate\-name|\:file\-names|\:sysroot|\:cfg|\:target\-list|\:target\-cpus|\:target\-features|\:relocation\-models|\:code\-models|\:tls\-models|\:target\-spec\-json|\:native\-static\-libs]
+\fB\-\-print\fR [crate\-name|\:file\-names|\:sysroot|\:target\-libdir|\:cfg|\:target\-list|\:target\-cpus|\:target\-features|\:relocation\-models|\:code\-models|\:tls\-models|\:target\-spec\-json|\:native\-static\-libs|\:stack\-protector\-strategies|\:link\-args]
 Comma separated list of compiler information to print on stdout.
 .TP
 \fB\-g\fR


### PR DESCRIPTION
This brings the `--crate-type`,  `--emit`, and `--print` options' allowed arguments into sync with that printed by `rustc --help`.

c.f. the `opt::multi_s` calls for `"crate-type"`, `"emit"`, and `"print"` here: https://github.com/rust-lang/rust/blob/master/compiler/rustc_session/src/config.rs