### PR TITLE
Prevent unused_qualifications when path is alloc

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3597,9 +3597,12 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             && path[0].ident.name != kw::DollarCrate
         {
             let unqualified_result = {
-                match self.resolve_path(&[*path.last().unwrap()], Some(ns), None) {
-                    PathResult::NonModule(path_res) => path_res.base_res(),
-                    PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
+                match (
+                    self.resolve_path(&[*path.last().unwrap()], Some(ns), None),
+                    (path[0].ident.as_str().as_bytes() == b"alloc"),
+                ) {
+                    (PathResult::NonModule(path_res), false) => path_res.base_res(),
+                    (PathResult::Module(ModuleOrUniformRoot::Module(module)), false) => {
                         module.res().unwrap()
                     }
                     _ => return Ok(Some(result)),

--- a/src/test/ui/lint/lint-qualification.rs
+++ b/src/test/ui/lint/lint-qualification.rs
@@ -1,5 +1,8 @@
 #![deny(unused_qualifications)]
 #![allow(deprecated)]
+extern crate alloc;
+type _Foo = alloc::string::String;
+type _Bar = core::task::Poll<i32>;
 
 mod foo {
     pub fn bar() {}

--- a/src/test/ui/lint/lint-qualification.stderr
+++ b/src/test/ui/lint/lint-qualification.stderr
@@ -1,5 +1,5 @@
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:10:5
+  --> $DIR/lint-qualification.rs:13:5
    |
 LL |     foo::bar();
    |     ^^^^^^^^


### PR DESCRIPTION
Fixes #99971 

If there is a better way to check this instead of `path[0].index == "alloc"`, let me know.