### PR TITLE
Register wf obligation before normalizing in wfcheck 

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -288,7 +288,8 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
 
         let infcx = self.selcx.infcx();
 
-        if obligation.predicate.has_projections() {
+        // Normalizing WellFormed predicates is not sound, see #100041
+        if obligation.predicate.has_projections() && obligation.predicate.allow_normalization() {
             let mut obligations = Vec::new();
             let predicate = crate::traits::project::try_normalize_with_depth_to(
                 self.selcx,

--- a/src/test/ui/associated-types/defaults-cyclic-fail-1.rs
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-1.rs
@@ -24,9 +24,7 @@ impl Tr for u32 {
 // ...but not in an impl that redefines one of the types.
 impl Tr for bool {
     type A = Box<Self::B>;
-    //~^ ERROR overflow evaluating the requirement `<bool as Tr>::B == _`
 }
-// (the error is shown twice for some reason)
 
 impl Tr for usize {
     type B = &'static Self::A;

--- a/src/test/ui/associated-types/defaults-cyclic-fail-1.stderr
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-1.stderr
@@ -1,15 +1,9 @@
-error[E0275]: overflow evaluating the requirement `<bool as Tr>::B == _`
-  --> $DIR/defaults-cyclic-fail-1.rs:26:14
-   |
-LL |     type A = Box<Self::B>;
-   |              ^^^^^^^^^^^^
-
 error[E0275]: overflow evaluating the requirement `<usize as Tr>::A == _`
-  --> $DIR/defaults-cyclic-fail-1.rs:32:14
+  --> $DIR/defaults-cyclic-fail-1.rs:30:14
    |
 LL |     type B = &'static Self::A;
    |              ^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0275`.

--- a/src/test/ui/associated-types/defaults-cyclic-fail-2.rs
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-2.rs
@@ -25,9 +25,7 @@ impl Tr for u32 {
 
 impl Tr for bool {
     type A = Box<Self::B>;
-    //~^ ERROR overflow evaluating the requirement `<bool as Tr>::B == _`
 }
-// (the error is shown twice for some reason)
 
 impl Tr for usize {
     type B = &'static Self::A;

--- a/src/test/ui/associated-types/defaults-cyclic-fail-2.stderr
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-2.stderr
@@ -1,15 +1,9 @@
-error[E0275]: overflow evaluating the requirement `<bool as Tr>::B == _`
-  --> $DIR/defaults-cyclic-fail-2.rs:27:14
-   |
-LL |     type A = Box<Self::B>;
-   |              ^^^^^^^^^^^^
-
 error[E0275]: overflow evaluating the requirement `<usize as Tr>::A == _`
-  --> $DIR/defaults-cyclic-fail-2.rs:33:14
+  --> $DIR/defaults-cyclic-fail-2.rs:31:14
    |
 LL |     type B = &'static Self::A;
    |              ^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0275`.

--- a/src/test/ui/associated-types/issue-100041.rs
+++ b/src/test/ui/associated-types/issue-100041.rs
@@ -1,0 +1,23 @@
+trait Wf {
+    type Ty;
+}
+
+impl<T: ?Sized> Wf for T {
+    type Ty = ();
+}
+
+const _: <Vec<str> as Wf>::Ty = ();
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+
+struct Foo {
+    x: <Vec<str> as Wf>::Ty,
+    //~^ ERROR the size for values of type `str` cannot be known at compilation time
+}
+
+fn foo(x: <Vec<str> as Wf>::Ty) {}
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+
+fn bar() -> <Vec<str> as Wf>::Ty {}
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+
+fn main() {}

--- a/src/test/ui/associated-types/issue-100041.stderr
+++ b/src/test/ui/associated-types/issue-100041.stderr
@@ -1,0 +1,55 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-100041.rs:9:11
+   |
+LL | const _: <Vec<str> as Wf>::Ty = ();
+   |           ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                ^ required by this bound in `Vec`
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-100041.rs:13:9
+   |
+LL |     x: <Vec<str> as Wf>::Ty,
+   |         ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                ^ required by this bound in `Vec`
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-100041.rs:17:12
+   |
+LL | fn foo(x: <Vec<str> as Wf>::Ty) {}
+   |            ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                ^ required by this bound in `Vec`
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-100041.rs:20:13
+   |
+LL | fn bar() -> <Vec<str> as Wf>::Ty {}
+   |             ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                ^ required by this bound in `Vec`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/associated-types/issue-59324.rs
+++ b/src/test/ui/associated-types/issue-59324.rs
@@ -22,5 +22,6 @@ pub trait ThriftService<Bug: NotFoo>:
 
 fn with_factory<H>(factory: dyn ThriftService<()>) {}
 //~^ ERROR the trait bound `(): Foo` is not satisfied
+//~| ERROR the trait bound `(): NotFoo` is not satisfied
 
 fn main() {}

--- a/src/test/ui/associated-types/issue-59324.stderr
+++ b/src/test/ui/associated-types/issue-59324.stderr
@@ -50,6 +50,18 @@ error[E0277]: the trait bound `(): Foo` is not satisfied
 LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `()`
 
+error[E0277]: the trait bound `(): NotFoo` is not satisfied
+  --> $DIR/issue-59324.rs:23:29
+   |
+LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
+   |                             ^^^^^^^^^^^^^^^^^^^^^ the trait `NotFoo` is not implemented for `()`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/issue-59324.rs:3:16
+   |
+LL | pub trait Foo: NotFoo {
+   |                ^^^^^^ required by this bound in `Foo`
+
 error[E0277]: the trait bound `Bug: Foo` is not satisfied
   --> $DIR/issue-59324.rs:16:5
    |
@@ -65,6 +77,6 @@ help: consider further restricting this bound
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/consts/const-size_of-cycle.stderr
+++ b/src/test/ui/consts/const-size_of-cycle.stderr
@@ -1,28 +1,28 @@
-error[E0391]: cycle detected when evaluating type-level constant
+error[E0391]: cycle detected when const-evaluating + checking `Foo::bytes::{constant#0}`
   --> $DIR/const-size_of-cycle.rs:4:17
    |
 LL |     bytes: [u8; std::mem::size_of::<Foo>()]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/const-size_of-cycle.rs:4:17
-   |
-LL |     bytes: [u8; std::mem::size_of::<Foo>()]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/const-size_of-cycle.rs:4:17
-   |
-LL |     bytes: [u8; std::mem::size_of::<Foo>()]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires computing layout of `Foo`...
    = note: ...which requires computing layout of `[u8; _]`...
    = note: ...which requires normalizing `[u8; _]`...
-   = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `Foo` is well-formed
-  --> $DIR/const-size_of-cycle.rs:3:1
+note: ...which requires evaluating type-level constant...
+  --> $DIR/const-size_of-cycle.rs:4:17
    |
-LL | struct Foo {
-   | ^^^^^^^^^^
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
+  --> $DIR/const-size_of-cycle.rs:4:17
+   |
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating + checking `Foo::bytes::{constant#0}`, completing the cycle
+note: cycle used when evaluating type-level constant
+  --> $DIR/const-size_of-cycle.rs:4:17
+   |
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-44415.rs
+++ b/src/test/ui/consts/issue-44415.rs
@@ -4,7 +4,7 @@ use std::intrinsics;
 
 struct Foo {
     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-    //~^ ERROR cycle detected when evaluating type-level constant
+    //~^ ERROR cycle detected when const-evaluating + checking `Foo::bytes::{constant#0}`
     x: usize,
 }
 

--- a/src/test/ui/consts/issue-44415.stderr
+++ b/src/test/ui/consts/issue-44415.stderr
@@ -1,28 +1,28 @@
-error[E0391]: cycle detected when evaluating type-level constant
+error[E0391]: cycle detected when const-evaluating + checking `Foo::bytes::{constant#0}`
   --> $DIR/issue-44415.rs:6:17
    |
 LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/issue-44415.rs:6:17
-   |
-LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/issue-44415.rs:6:17
-   |
-LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires computing layout of `Foo`...
    = note: ...which requires computing layout of `[u8; _]`...
    = note: ...which requires normalizing `[u8; _]`...
-   = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `Foo` is well-formed
-  --> $DIR/issue-44415.rs:5:1
+note: ...which requires evaluating type-level constant...
+  --> $DIR/issue-44415.rs:6:17
    |
-LL | struct Foo {
-   | ^^^^^^^^^^
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
+  --> $DIR/issue-44415.rs:6:17
+   |
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating + checking `Foo::bytes::{constant#0}`, completing the cycle
+note: cycle used when evaluating type-level constant
+  --> $DIR/issue-44415.rs:6:17
+   |
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/fn/implied-bounds-unnorm-associated-type-2.rs
+++ b/src/test/ui/fn/implied-bounds-unnorm-associated-type-2.rs
@@ -9,6 +9,7 @@ impl<T> Trait for T {
 }
 
 fn f<'a, 'b>(_: <&'a &'b () as Trait>::Type)
+//~^ ERROR in type `&'a &'b ()`, reference has a longer lifetime than the data it references
 where
     'a: 'a,
     'b: 'b,
@@ -17,7 +18,6 @@ where
 
 fn g<'a, 'b>() {
     f::<'a, 'b>(());
-    //~^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/src/test/ui/fn/implied-bounds-unnorm-associated-type-2.stderr
+++ b/src/test/ui/fn/implied-bounds-unnorm-associated-type-2.stderr
@@ -1,17 +1,20 @@
-error: lifetime may not live long enough
-  --> $DIR/implied-bounds-unnorm-associated-type-2.rs:19:5
+error[E0491]: in type `&'a &'b ()`, reference has a longer lifetime than the data it references
+  --> $DIR/implied-bounds-unnorm-associated-type-2.rs:11:17
    |
-LL | fn g<'a, 'b>() {
-   |      --  -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-LL |     f::<'a, 'b>(());
-   |     ^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+LL | fn f<'a, 'b>(_: <&'a &'b () as Trait>::Type)
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a function pointer to `f`
-   = note: the function `f` is invariant over the parameter `'a`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+note: the pointer is valid for the lifetime `'a` as defined here
+  --> $DIR/implied-bounds-unnorm-associated-type-2.rs:11:6
+   |
+LL | fn f<'a, 'b>(_: <&'a &'b () as Trait>::Type)
+   |      ^^
+note: but the referenced data is only valid for the lifetime `'b` as defined here
+  --> $DIR/implied-bounds-unnorm-associated-type-2.rs:11:10
+   |
+LL | fn f<'a, 'b>(_: <&'a &'b () as Trait>::Type)
+   |          ^^
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0491`.

--- a/src/test/ui/fn/implied-bounds-unnorm-associated-type.rs
+++ b/src/test/ui/fn/implied-bounds-unnorm-associated-type.rs
@@ -11,6 +11,7 @@ impl<T> Trait for T {
 }
 
 fn f<'a, 'b>(s: &'b str, _: <&'a &'b () as Trait>::Type) -> &'a str {
+    //~^ ERROR in type `&'a &'b ()`, reference has a longer lifetime than the data it references
     s
 }
 
@@ -18,6 +19,5 @@ fn main() {
     let x = String::from("Hello World!");
     let y = f(&x, ());
     drop(x);
-    //~^ ERROR cannot move out of `x` because it is borrowed
     println!("{}", y);
 }

--- a/src/test/ui/fn/implied-bounds-unnorm-associated-type.stderr
+++ b/src/test/ui/fn/implied-bounds-unnorm-associated-type.stderr
@@ -1,14 +1,20 @@
-error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/implied-bounds-unnorm-associated-type.rs:20:10
+error[E0491]: in type `&'a &'b ()`, reference has a longer lifetime than the data it references
+  --> $DIR/implied-bounds-unnorm-associated-type.rs:13:29
    |
-LL |     let y = f(&x, ());
-   |               -- borrow of `x` occurs here
-LL |     drop(x);
-   |          ^ move out of `x` occurs here
-LL |
-LL |     println!("{}", y);
-   |                    - borrow later used here
+LL | fn f<'a, 'b>(s: &'b str, _: <&'a &'b () as Trait>::Type) -> &'a str {
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the pointer is valid for the lifetime `'a` as defined here
+  --> $DIR/implied-bounds-unnorm-associated-type.rs:13:6
+   |
+LL | fn f<'a, 'b>(s: &'b str, _: <&'a &'b () as Trait>::Type) -> &'a str {
+   |      ^^
+note: but the referenced data is only valid for the lifetime `'b` as defined here
+  --> $DIR/implied-bounds-unnorm-associated-type.rs:13:10
+   |
+LL | fn f<'a, 'b>(s: &'b str, _: <&'a &'b () as Trait>::Type) -> &'a str {
+   |          ^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0505`.
+For more information about this error, try `rustc --explain E0491`.

--- a/src/test/ui/issues/issue-20831-debruijn.rs
+++ b/src/test/ui/issues/issue-20831-debruijn.rs
@@ -28,6 +28,7 @@ impl<'a> Publisher<'a> for MyStruct<'a> {
     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
         // Not obvious, but there is an implicit lifetime here -------^
         //~^^ ERROR cannot infer
+        //~| ERROR cannot infer
         //
         // The fact that `Publisher` is using an implicit lifetime is
         // what was causing the debruijn accounting to be off, so

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
 LL | |         // Not obvious, but there is an implicit lifetime here -------^
 LL | |
-LL | |         //
+LL | |
 ...  |
 LL | |         self.sub = t;
 LL | |     }
@@ -26,7 +26,7 @@ note: ...so that the types are compatible
 LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
 LL | |         // Not obvious, but there is an implicit lifetime here -------^
 LL | |
-LL | |         //
+LL | |
 ...  |
 LL | |         self.sub = t;
 LL | |     }
@@ -34,6 +34,30 @@ LL | |     }
    = note: expected `<MyStruct<'a> as Publisher<'_>>`
               found `<MyStruct<'_> as Publisher<'_>>`
 
-error: aborting due to previous error
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+  --> $DIR/issue-20831-debruijn.rs:28:33
+   |
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the anonymous lifetime defined here...
+  --> $DIR/issue-20831-debruijn.rs:28:58
+   |
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...but the lifetime must also be valid for the lifetime `'a` as defined here...
+  --> $DIR/issue-20831-debruijn.rs:26:6
+   |
+LL | impl<'a> Publisher<'a> for MyStruct<'a> {
+   |      ^^
+note: ...so that the types are compatible
+  --> $DIR/issue-20831-debruijn.rs:28:33
+   |
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected `<MyStruct<'a> as Publisher<'_>>`
+              found `<MyStruct<'_> as Publisher<'_>>`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/issues/issue-35570.rs
+++ b/src/test/ui/issues/issue-35570.rs
@@ -7,7 +7,6 @@ trait Trait2<'a> {
 
 fn _ice(param: Box<dyn for <'a> Trait1<<() as Trait2<'a>>::Ty>>) {
     //~^ ERROR the trait bound `for<'a> (): Trait2<'a>` is not satisfied
-    //~| ERROR the trait bound `for<'a> (): Trait2<'a>` is not satisfied
     let _e: (usize, usize) = unsafe{mem::transmute(param)};
 }
 

--- a/src/test/ui/issues/issue-35570.stderr
+++ b/src/test/ui/issues/issue-35570.stderr
@@ -3,17 +3,10 @@ error[E0277]: the trait bound `for<'a> (): Trait2<'a>` is not satisfied
    |
 LL | / fn _ice(param: Box<dyn for <'a> Trait1<<() as Trait2<'a>>::Ty>>) {
 LL | |
-LL | |
 LL | |     let _e: (usize, usize) = unsafe{mem::transmute(param)};
 LL | | }
    | |_^ the trait `for<'a> Trait2<'a>` is not implemented for `()`
 
-error[E0277]: the trait bound `for<'a> (): Trait2<'a>` is not satisfied
-  --> $DIR/issue-35570.rs:8:40
-   |
-LL | fn _ice(param: Box<dyn for <'a> Trait1<<() as Trait2<'a>>::Ty>>) {
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Trait2<'a>` is not implemented for `()`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/nll/normalization-bounds-error.rs
+++ b/src/test/ui/nll/normalization-bounds-error.rs
@@ -11,5 +11,6 @@ impl<'a, 'd: 'a> Visitor<'d> for &'a () {
 
 fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
 //~^ ERROR
+//~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'d` due to conflicting requirements
 
 fn main() {}

--- a/src/test/ui/nll/normalization-bounds-error.stderr
+++ b/src/test/ui/nll/normalization-bounds-error.stderr
@@ -22,6 +22,30 @@ LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
    = note: expected `Visitor<'d>`
               found `Visitor<'_>`
 
-error: aborting due to previous error
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'d` due to conflicting requirements
+  --> $DIR/normalization-bounds-error.rs:12:31
+   |
+LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime `'d` as defined here...
+  --> $DIR/normalization-bounds-error.rs:12:14
+   |
+LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
+   |              ^^
+note: ...but the lifetime must also be valid for the lifetime `'a` as defined here...
+  --> $DIR/normalization-bounds-error.rs:12:18
+   |
+LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
+   |                  ^^
+note: ...so that the types are compatible
+  --> $DIR/normalization-bounds-error.rs:12:31
+   |
+LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected `Visitor<'d>`
+              found `Visitor<'_>`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-hr-1.rs
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-hr-1.rs
@@ -8,7 +8,7 @@
 // regions as opaque entities, just like projections without escaping
 // regions.
 
-trait Trait1<T> { }
+trait Trait1<T> {}
 
 trait Trait2<'a, 'b> {
     type Foo;
@@ -18,10 +18,10 @@ trait Trait2<'a, 'b> {
 // this argument `t` is not automatically considered well-formed,
 // since for it to be WF, we would need to know that `'y: 'x`, but we
 // do not infer that.
-fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
-    //~^ ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
-    //~| ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
+fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1<<T as Trait2<'y, 'z>>::Foo>)
+//~^ ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
+//~| ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
 {
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
   --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:21:1
    |
-LL | / fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
+LL | / fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1<<T as Trait2<'y, 'z>>::Foo>)
 LL | |
 LL | |
 LL | | {
@@ -10,18 +10,18 @@ LL | | }
    |
 help: consider restricting type parameter `T`
    |
-LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
+LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1<<T as Trait2<'y, 'z>>::Foo>)
    |                    ++++++++++++++++++++++++
 
 error[E0277]: the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
-  --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:21:49
+  --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:21:48
    |
-LL | fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
+LL | fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1<<T as Trait2<'y, 'z>>::Foo>)
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |
-LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
+LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1<<T as Trait2<'y, 'z>>::Foo>)
    |                    ++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.rs
@@ -14,12 +14,16 @@ where
 type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out;
 
 enum Ref1<'a, T> {
-    Ref1Variant1(RequireOutlives<'a, T>), //~ ERROR the parameter type `T` may not live long enough
+    Ref1Variant1(RequireOutlives<'a, T>),
+    //~^ the parameter type `T` may not live long enough [E0309]
+    //~| the parameter type `T` may not live long enough [E0309]
 }
 
 enum Ref2<'a, T> {
     Ref2Variant1,
-    Ref2Variant2(isize, RequireOutlives<'a, T>), //~ ERROR the parameter type `T` may not live long enough
+    Ref2Variant2(isize, RequireOutlives<'a, T>),
+    //~^ the parameter type `T` may not live long enough [E0309]
+    //~| the parameter type `T` may not live long enough [E0309]
 }
 
 enum RefOk<'a, T: 'a> {
@@ -32,6 +36,7 @@ enum RefIndirect<'a, T> {
 }
 
 enum RefDouble<'a, 'b, T> {
+    //~^ the parameter type `T` may not live long enough [E0309]
     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
     //~^ the parameter type `T` may not live long enough [E0309]
 }

--- a/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
@@ -10,7 +10,18 @@ LL | enum Ref1<'a, T: 'a> {
    |                ++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/regions-enum-not-wf.rs:22:25
+  --> $DIR/regions-enum-not-wf.rs:17:18
+   |
+LL |     Ref1Variant1(RequireOutlives<'a, T>),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | enum Ref1<'a, T: 'a> {
+   |                ++++
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/regions-enum-not-wf.rs:24:25
    |
 LL |     Ref2Variant2(isize, RequireOutlives<'a, T>),
    |                         ^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
@@ -21,7 +32,33 @@ LL | enum Ref2<'a, T: 'a> {
    |                ++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/regions-enum-not-wf.rs:35:23
+  --> $DIR/regions-enum-not-wf.rs:24:25
+   |
+LL |     Ref2Variant2(isize, RequireOutlives<'a, T>),
+   |                         ^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | enum Ref2<'a, T: 'a> {
+   |                ++++
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/regions-enum-not-wf.rs:38:1
+   |
+LL | / enum RefDouble<'a, 'b, T> {
+LL | |
+LL | |     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
+LL | |
+LL | | }
+   | |_^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | enum RefDouble<'a, 'b, T: 'b> {
+   |                         ++++
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/regions-enum-not-wf.rs:40:23
    |
 LL |     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
@@ -31,6 +68,6 @@ help: consider adding an explicit lifetime bound...
 LL | enum RefDouble<'a, 'b, T: 'b> {
    |                         ++++
 
-error: aborting due to 3 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0309`.

--- a/src/test/ui/traits/issue-82830.stderr
+++ b/src/test/ui/traits/issue-82830.stderr
@@ -4,11 +4,11 @@ error[E0275]: overflow evaluating the requirement `P: Sized`
 LL |     t: MaybeBox<P>,
    |        ^^^^^^^^^^^
    |
-note: required for `P` to implement `A<P, Box<P>>`
-  --> $DIR/issue-82830.rs:10:12
+note: required by a bound in `A`
+  --> $DIR/issue-82830.rs:1:9
    |
-LL | impl<Y, N> A<Y, N> for P {
-   |            ^^^^^^^     ^
+LL | trait A<Y, N> {
+   |         ^ required by this bound in `A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-enum2.stderr
+++ b/src/test/ui/unsized/unsized-enum2.stderr
@@ -242,78 +242,6 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VP{u: isize, x: Box<dyn BarFoo>},
    |                     ++++          +
 
-error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:63:8
-   |
-LL |     VQ(<&'static [i8] as Deref>::Target),
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[i8]`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL |     VQ(&<&'static [i8] as Deref>::Target),
-   |        +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL |     VQ(Box<<&'static [i8] as Deref>::Target>),
-   |        ++++                                +
-
-error[E0277]: the size for values of type `[char]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:65:11
-   |
-LL |     VR{x: <&'static [char] as Deref>::Target},
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[char]`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL |     VR{x: &<&'static [char] as Deref>::Target},
-   |           +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL |     VR{x: Box<<&'static [char] as Deref>::Target>},
-   |           ++++                                  +
-
-error[E0277]: the size for values of type `[f64]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:67:15
-   |
-LL |     VS(isize, <&'static [f64] as Deref>::Target),
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[f64]`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL |     VS(isize, &<&'static [f64] as Deref>::Target),
-   |               +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL |     VS(isize, Box<<&'static [f64] as Deref>::Target>),
-   |               ++++                                 +
-
-error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:69:21
-   |
-LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[i32]`
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
-   |
-LL |     VT{u: isize, x: &<&'static [i32] as Deref>::Target},
-   |                     +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL |     VT{u: isize, x: Box<<&'static [i32] as Deref>::Target>},
-   |                     ++++                                 +
-
 error[E0277]: the size for values of type `(dyn PathHelper1 + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:43:8
    |
@@ -405,6 +333,78 @@ help: the `Box` type always has a statically known size and allocates its conten
    |
 LL |     VL{u: isize, x: Box<Path4>},
    |                     ++++     +
+
+error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
+  --> $DIR/unsized-enum2.rs:63:8
+   |
+LL |     VQ(<&'static [i8] as Deref>::Target),
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[i8]`
+   = note: no field of an enum variant may have a dynamically sized type
+   = help: change the field's type to have a statically known size
+help: borrowed types always have a statically known size
+   |
+LL |     VQ(&<&'static [i8] as Deref>::Target),
+   |        +
+help: the `Box` type always has a statically known size and allocates its contents in the heap
+   |
+LL |     VQ(Box<<&'static [i8] as Deref>::Target>),
+   |        ++++                                +
+
+error[E0277]: the size for values of type `[char]` cannot be known at compilation time
+  --> $DIR/unsized-enum2.rs:65:11
+   |
+LL |     VR{x: <&'static [char] as Deref>::Target},
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[char]`
+   = note: no field of an enum variant may have a dynamically sized type
+   = help: change the field's type to have a statically known size
+help: borrowed types always have a statically known size
+   |
+LL |     VR{x: &<&'static [char] as Deref>::Target},
+   |           +
+help: the `Box` type always has a statically known size and allocates its contents in the heap
+   |
+LL |     VR{x: Box<<&'static [char] as Deref>::Target>},
+   |           ++++                                  +
+
+error[E0277]: the size for values of type `[f64]` cannot be known at compilation time
+  --> $DIR/unsized-enum2.rs:67:15
+   |
+LL |     VS(isize, <&'static [f64] as Deref>::Target),
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[f64]`
+   = note: no field of an enum variant may have a dynamically sized type
+   = help: change the field's type to have a statically known size
+help: borrowed types always have a statically known size
+   |
+LL |     VS(isize, &<&'static [f64] as Deref>::Target),
+   |               +
+help: the `Box` type always has a statically known size and allocates its contents in the heap
+   |
+LL |     VS(isize, Box<<&'static [f64] as Deref>::Target>),
+   |               ++++                                 +
+
+error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
+  --> $DIR/unsized-enum2.rs:69:21
+   |
+LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[i32]`
+   = note: no field of an enum variant may have a dynamically sized type
+   = help: change the field's type to have a statically known size
+help: borrowed types always have a statically known size
+   |
+LL |     VT{u: isize, x: &<&'static [i32] as Deref>::Target},
+   |                     +
+help: the `Box` type always has a statically known size and allocates its contents in the heap
+   |
+LL |     VT{u: isize, x: Box<<&'static [i32] as Deref>::Target>},
+   |                     ++++                                 +
 
 error: aborting due to 20 previous errors
 

--- a/src/test/ui/wf/hir-wf-check-erase-regions.rs
+++ b/src/test/ui/wf/hir-wf-check-erase-regions.rs
@@ -7,7 +7,7 @@ impl<'a, T, const N: usize> IntoIterator for &'a Table<T, N> {
     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>; //~ ERROR `&T` is not an iterator
     type Item = &'a T;
 
-    fn into_iter(self) -> Self::IntoIter { //~ ERROR `&T` is not an iterator
+    fn into_iter(self) -> Self::IntoIter {
         unimplemented!()
     }
 }

--- a/src/test/ui/wf/hir-wf-check-erase-regions.stderr
+++ b/src/test/ui/wf/hir-wf-check-erase-regions.stderr
@@ -13,21 +13,6 @@ note: required by a bound in `Flatten`
 LL | pub struct Flatten<I: Iterator<Item: IntoIterator>> {
    |                                      ^^^^^^^^^^^^ required by this bound in `Flatten`
 
-error[E0277]: `&T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:10:27
-   |
-LL |     fn into_iter(self) -> Self::IntoIter {
-   |                           ^^^^^^^^^^^^^^ `&T` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `&T`
-   = help: the trait `Iterator` is implemented for `&mut I`
-   = note: required for `&T` to implement `IntoIterator`
-note: required by a bound in `Flatten`
-  --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
-   |
-LL | pub struct Flatten<I: Iterator<Item: IntoIterator>> {
-   |                                      ^^^^^^^^^^^^ required by this bound in `Flatten`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/wf/wf-packed-on-proj-of-type-as-unimpl-trait.stderr
+++ b/src/test/ui/wf/wf-packed-on-proj-of-type-as-unimpl-trait.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `DefaultAllocator: Allocator` is not satisfied
-  --> $DIR/wf-packed-on-proj-of-type-as-unimpl-trait.rs:28:12
+  --> $DIR/wf-packed-on-proj-of-type-as-unimpl-trait.rs:28:19
    |
 LL | struct Foo(Matrix<<DefaultAllocator as Allocator>::Buffer>);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Allocator` is not implemented for `DefaultAllocator`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Allocator` is not implemented for `DefaultAllocator`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #100041.

Why are we normalizing in wfcheck at all? Should we just be dealing w unnormalized types? I guess whether we normalize or not at all has effects on implied bounds...

cc @rust-lang/types

r? types