### PR TITLE
RISC-V ASM test: relax label name constraint.

### DIFF
--- a/src/test/assembly/asm/riscv-types.rs
+++ b/src/test/assembly/asm/riscv-types.rs
@@ -56,7 +56,7 @@ pub unsafe fn sym_fn() {
 // CHECK-LABEL: sym_static:
 // CHECK: #APP
 // CHECK: auipc t0, %pcrel_hi(extern_static)
-// CHECK: lb t0, %pcrel_lo(.Lpcrel_hi0)(t0)
+// CHECK: lb t0, %pcrel_lo(.Lpcrel_hi{{[0-9]+}})(t0)
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_static() {


### PR DESCRIPTION
The test is currently [broken at LLVM Head](https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/12425#01825d5b-c3d1-4fdc-a98d-5956b246aee2), likely since https://github.com/llvm/llvm-project/commit/260a64106854986a981e49ed87ee740460a23eb5:

```plain
/var/lib/buildkite-agent/builds/rust-llvm-integrate/llvm-project/rust-llvm-integrate-prototype/src/test/assembly/asm/riscv-types.rs:59:11: error: CHECK: expected string not found in input
--
  | // CHECK: lb t0, %pcrel_lo(.Lpcrel_hi0)(t0)
  | ^
  | /var/lib/buildkite-agent/builds/rust-llvm-integrate/llvm-project/rust-llvm-integrate-prototype/build/x86_64-unknown-linux-gnu/test/assembly/asm/riscv-types.riscv64/riscv-types.s:24:36: note: scanning from here
  | auipc t0, %pcrel_hi(extern_static)
  | ^
  | /var/lib/buildkite-agent/builds/rust-llvm-integrate/llvm-project/rust-llvm-integrate-prototype/build/x86_64-unknown-linux-gnu/test/assembly/asm/riscv-types.riscv64/riscv-types.s:25:2: note: possible intended match here
  | lb t0, %pcrel_lo(.Lpcrel_hi18)(t0)
  | ^
```

As far as I can tell, the exact index in the label probably doesn't matter for the test, especially if LLVM can change it to ~arbitrary values, though I'm not an ASM or RISC-V expert.

This [fixes the test](https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/12427).