### PR TITLE
Add error if link_ordinal used with unsupported link kind

### DIFF
--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.rs
@@ -1,0 +1,18 @@
+#![feature(raw_dylib)]
+//~^ WARN the feature `raw_dylib` is incomplete
+
+#[link(name = "foo")]
+extern "C" {
+    #[link_ordinal(3)]
+    //~^ ERROR `#[link_ordinal]` is only supported if link kind is `raw-dylib`
+    fn foo();
+}
+
+#[link(name = "bar", kind = "static")]
+extern "C" {
+    #[link_ordinal(3)]
+    //~^ ERROR `#[link_ordinal]` is only supported if link kind is `raw-dylib`
+    fn bar();
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.stderr
@@ -1,0 +1,23 @@
+warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/link-ordinal-unsupported-link-kind.rs:1:12
+   |
+LL | #![feature(raw_dylib)]
+   |            ^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
+
+error: `#[link_ordinal]` is only supported if link kind is `raw-dylib`
+  --> $DIR/link-ordinal-unsupported-link-kind.rs:6:5
+   |
+LL |     #[link_ordinal(3)]
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: `#[link_ordinal]` is only supported if link kind is `raw-dylib`
+  --> $DIR/link-ordinal-unsupported-link-kind.rs:13:5
+   |
+LL |     #[link_ordinal(3)]
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+


### PR DESCRIPTION
The `link_ordinal` attribute only has an affect if the `raw-dylib` link kind is used, so add an error if it is used with any other link kind.