### PR TITLE
deps: dedupe `annotate-snippets` crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,12 +84,6 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78ea013094e5ea606b1c05fe35f1dd7ea1eb1ea259908d040b25bd5ec677ee5"
-
-[[package]]
-name = "annotate-snippets"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36"
@@ -3861,7 +3855,7 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.8.0",
+ "annotate-snippets",
  "atty",
  "rustc_data_structures",
  "rustc_error_messages",
@@ -4113,7 +4107,7 @@ dependencies = [
 name = "rustc_macros"
 version = "0.1.0"
 dependencies = [
- "annotate-snippets 0.8.0",
+ "annotate-snippets",
  "fluent-bundle",
  "fluent-syntax",
  "proc-macro2",
@@ -4713,7 +4707,7 @@ dependencies = [
 name = "rustfmt-nightly"
 version = "1.5.1"
 dependencies = [
- "annotate-snippets 0.9.1",
+ "annotate-snippets",
  "anyhow",
  "bytecount",
  "cargo_metadata 0.14.0",

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -18,7 +18,7 @@ rustc_lint_defs = { path = "../rustc_lint_defs" }
 unicode-width = "0.1.4"
 atty = "0.2"
 termcolor = "1.0"
-annotate-snippets = "0.8.0"
+annotate-snippets = "0.9"
 termize = "0.1.1"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -183,7 +183,11 @@ impl AnnotateSnippetEmitterWriter {
                     annotation_type: annotation_type_for_level(*level),
                 }),
                 footer: vec![],
-                opt: FormatOptions { color: true, anonymized_line_numbers: self.ui_testing },
+                opt: FormatOptions {
+                    color: true,
+                    anonymized_line_numbers: self.ui_testing,
+                    margin: None,
+                },
                 slices: annotated_files
                     .iter()
                     .map(|(source, line_index, annotations)| {

--- a/compiler/rustc_macros/Cargo.toml
+++ b/compiler/rustc_macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-annotate-snippets = "0.8.0"
+annotate-snippets = "0.9"
 fluent-bundle = "0.15.2"
 fluent-syntax = "0.11"
 synstructure = "0.12.1"


### PR DESCRIPTION
Dedupes `annotate-snippets` crate versions (https://github.com/rust-lang/annotate-snippets-rs/blob/0.9.1/CHANGELOG.md). Should work, but there is not a lot of tests.

Looks like switching to that crate a bit stalled.