### PR TITLE
Add test for raw-dylib with an external variable

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -209,7 +209,14 @@ impl CheckAttrVisitor<'_> {
         }
 
         // FIXME(@lcnr): this doesn't belong here.
-        if matches!(target, Target::Closure | Target::Fn | Target::Method(_) | Target::ForeignFn) {
+        if matches!(
+            target,
+            Target::Closure
+                | Target::Fn
+                | Target::Method(_)
+                | Target::ForeignFn
+                | Target::ForeignStatic
+        ) {
             self.tcx.ensure().codegen_fn_attrs(self.tcx.hir().local_def_id(hir_id));
         }
 

--- a/src/test/run-make/raw-dylib-c/extern_1.c
+++ b/src/test/run-make/raw-dylib-c/extern_1.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+__declspec(dllexport) int extern_variable = 0;
+
 __declspec(dllexport) void extern_fn_1() {
     printf("extern_fn_1\n");
     fflush(stdout);
@@ -7,6 +9,11 @@ __declspec(dllexport) void extern_fn_1() {
 
 __declspec(dllexport) void extern_fn_2() {
     printf("extern_fn_2; didn't get the rename\n");
+    fflush(stdout);
+}
+
+__declspec(dllexport) void print_extern_variable() {
+    printf("extern_variable value: %d\n", extern_variable);
     fflush(stdout);
 }
 

--- a/src/test/run-make/raw-dylib-c/lib.rs
+++ b/src/test/run-make/raw-dylib-c/lib.rs
@@ -12,12 +12,20 @@ extern {
 
 pub fn library_function() {
     #[link(name = "extern_1", kind = "raw-dylib")]
-    extern { fn extern_fn_2(); }
+    extern {
+        fn extern_fn_2();
+        fn print_extern_variable();
+        static mut extern_variable: i32;
+    }
 
     unsafe {
         extern_fn_1();
         extern_fn_2();
         extern_fn_3();
+        extern_variable = 42;
+        print_extern_variable();
+        extern_variable = -42;
+        print_extern_variable();
     }
 }
 

--- a/src/test/run-make/raw-dylib-c/output.txt
+++ b/src/test/run-make/raw-dylib-c/output.txt
@@ -1,3 +1,5 @@
 extern_fn_1
 extern_fn_2; didn't get the rename
 extern_fn_3
+extern_variable value: 42
+extern_variable value: -42

--- a/src/test/run-make/raw-dylib-link-ordinal/exporter.c
+++ b/src/test/run-make/raw-dylib-link-ordinal/exporter.c
@@ -3,3 +3,10 @@
 void exported_function() {
     printf("exported_function\n");
 }
+
+int exported_variable = 0;
+
+void print_exported_variable() {
+    printf("exported_variable value: %d\n", exported_variable);
+    fflush(stdout);
+}

--- a/src/test/run-make/raw-dylib-link-ordinal/exporter.def
+++ b/src/test/run-make/raw-dylib-link-ordinal/exporter.def
@@ -1,3 +1,5 @@
 LIBRARY exporter
 EXPORTS
     exported_function @13 NONAME
+    exported_variable @5 NONAME
+    print_exported_variable @9 NONAME

--- a/src/test/run-make/raw-dylib-link-ordinal/lib.rs
+++ b/src/test/run-make/raw-dylib-link-ordinal/lib.rs
@@ -4,10 +4,18 @@
 extern {
     #[link_ordinal(13)]
     fn imported_function();
+    #[link_ordinal(5)]
+    static mut imported_variable: i32;
+    #[link_ordinal(9)]
+    fn print_imported_variable();
 }
 
 pub fn library_function() {
     unsafe {
         imported_function();
+        imported_variable = 42;
+        print_imported_variable();
+        imported_variable = -42;
+        print_imported_variable();
     }
 }

--- a/src/test/run-make/raw-dylib-link-ordinal/output.txt
+++ b/src/test/run-make/raw-dylib-link-ordinal/output.txt
@@ -1,1 +1,3 @@
 exported_function
+exported_variable value: 42
+exported_variable value: -42

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib-2.rs
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib-2.rs
@@ -3,6 +3,9 @@ extern "C" {
     #[link_ordinal(42)]
     //~^ ERROR: the `#[link_ordinal]` attribute is an experimental feature
     fn foo();
+    #[link_ordinal(5)]
+    //~^ ERROR: the `#[link_ordinal]` attribute is an experimental feature
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-raw-dylib-2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-raw-dylib-2.stderr
@@ -7,6 +7,15 @@ LL |     #[link_ordinal(42)]
    = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
    = help: add `#![feature(raw_dylib)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: the `#[link_ordinal]` attribute is an experimental feature
+  --> $DIR/feature-gate-raw-dylib-2.rs:6:5
+   |
+LL |     #[link_ordinal(5)]
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
+   = help: add `#![feature(raw_dylib)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
@@ -7,6 +7,10 @@ extern "C" {
     #[link_ordinal(42)]
     //~^ ERROR cannot use `#[link_name]` with `#[link_ordinal]`
     fn foo();
+    #[link_name="foo"]
+    #[link_ordinal(5)]
+    //~^ ERROR cannot use `#[link_name]` with `#[link_ordinal]`
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
@@ -13,5 +13,11 @@ error: cannot use `#[link_name]` with `#[link_ordinal]`
 LL |     #[link_ordinal(42)]
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: cannot use `#[link_name]` with `#[link_ordinal]`
+  --> $DIR/link-ordinal-and-name.rs:11:5
+   |
+LL |     #[link_ordinal(5)]
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
@@ -6,6 +6,9 @@ extern "C" {
     #[link_ordinal("JustMonika")]
     //~^ ERROR illegal ordinal format in `link_ordinal`
     fn foo();
+    #[link_ordinal("JustMonika")]
+    //~^ ERROR illegal ordinal format in `link_ordinal`
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
@@ -15,5 +15,13 @@ LL |     #[link_ordinal("JustMonika")]
    |
    = note: an unsuffixed integer value, e.g., `1`, is expected
 
-error: aborting due to previous error; 1 warning emitted
+error: illegal ordinal format in `link_ordinal`
+  --> $DIR/link-ordinal-invalid-format.rs:9:5
+   |
+LL |     #[link_ordinal("JustMonika")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: an unsuffixed integer value, e.g., `1`, is expected
+
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.rs
@@ -6,6 +6,9 @@ extern "C" {
     #[link_ordinal()]
     //~^ ERROR incorrect number of arguments to `#[link_ordinal]`
     fn foo();
+    #[link_ordinal()]
+    //~^ ERROR incorrect number of arguments to `#[link_ordinal]`
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-missing-argument.stderr
@@ -15,5 +15,13 @@ LL |     #[link_ordinal()]
    |
    = note: the attribute requires exactly one argument
 
-error: aborting due to previous error; 1 warning emitted
+error: incorrect number of arguments to `#[link_ordinal]`
+  --> $DIR/link-ordinal-missing-argument.rs:9:5
+   |
+LL |     #[link_ordinal()]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: the attribute requires exactly one argument
+
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.rs
@@ -7,6 +7,9 @@ extern "C" {
     #[link_ordinal(1)] //~ ERROR multiple `link_ordinal` attributes
     #[link_ordinal(2)]
     fn foo();
+    #[link_ordinal(1)] //~ ERROR multiple `link_ordinal` attributes
+    #[link_ordinal(2)]
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-multiple.stderr
@@ -19,5 +19,17 @@ note: attribute also specified here
 LL |     #[link_ordinal(2)]
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: multiple `link_ordinal` attributes
+  --> $DIR/link-ordinal-multiple.rs:10:5
+   |
+LL |     #[link_ordinal(1)]
+   |     ^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/link-ordinal-multiple.rs:11:5
+   |
+LL |     #[link_ordinal(2)]
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
@@ -6,6 +6,9 @@ extern "C" {
     #[link_ordinal(72436)]
     //~^ ERROR ordinal value in `link_ordinal` is too large: `72436`
     fn foo();
+    #[link_ordinal(72436)]
+    //~^ ERROR ordinal value in `link_ordinal` is too large: `72436`
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
@@ -15,5 +15,13 @@ LL |     #[link_ordinal(72436)]
    |
    = note: the value may not exceed `u16::MAX`
 
-error: aborting due to previous error; 1 warning emitted
+error: ordinal value in `link_ordinal` is too large: `72436`
+  --> $DIR/link-ordinal-too-large.rs:9:5
+   |
+LL |     #[link_ordinal(72436)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the value may not exceed `u16::MAX`
+
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.rs
@@ -6,6 +6,9 @@ extern "C" {
     #[link_ordinal(3, 4)]
     //~^ ERROR incorrect number of arguments to `#[link_ordinal]`
     fn foo();
+    #[link_ordinal(3, 4)]
+    //~^ ERROR incorrect number of arguments to `#[link_ordinal]`
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.stderr
@@ -15,5 +15,13 @@ LL |     #[link_ordinal(3, 4)]
    |
    = note: the attribute requires exactly one argument
 
-error: aborting due to previous error; 1 warning emitted
+error: incorrect number of arguments to `#[link_ordinal]`
+  --> $DIR/link-ordinal-too-many-arguments.rs:9:5
+   |
+LL |     #[link_ordinal(3, 4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the attribute requires exactly one argument
+
+error: aborting due to 2 previous errors; 1 warning emitted
 


### PR DESCRIPTION
All existing tests of link kind `raw-dylib` only validate the ability to link against functions, but it is also possible to link against variables.

This adds tests for linking against a variable using `raw-dylib` both by-name and by-ordinal.