### PR TITLE
Avoid invalidating the CFG in `MirPatch`

### DIFF
--- a/compiler/rustc_middle/src/mir/patch.rs
+++ b/compiler/rustc_middle/src/mir/patch.rs
@@ -11,7 +11,8 @@ pub struct MirPatch<'tcx> {
     new_blocks: Vec<BasicBlockData<'tcx>>,
     new_statements: Vec<(Location, StatementKind<'tcx>)>,
     new_locals: Vec<LocalDecl<'tcx>>,
-    resume_block: BasicBlock,
+    resume_block: Option<BasicBlock>,
+    body_span: Span,
     next_local: usize,
 }
 
@@ -23,47 +24,36 @@ impl<'tcx> MirPatch<'tcx> {
             new_statements: vec![],
             new_locals: vec![],
             next_local: body.local_decls.len(),
-            resume_block: START_BLOCK,
+            resume_block: None,
+            body_span: body.span,
         };
 
-        // make sure the MIR we create has a resume block. It is
-        // completely legal to convert jumps to the resume block
-        // to jumps to None, but we occasionally have to add
-        // instructions just before that.
-
-        let mut resume_block = None;
-        let mut resume_stmt_block = None;
+        // Check if we already have a resume block
         for (bb, block) in body.basic_blocks().iter_enumerated() {
-            if let TerminatorKind::Resume = block.terminator().kind {
-                if !block.statements.is_empty() {
-                    assert!(resume_stmt_block.is_none());
-                    resume_stmt_block = Some(bb);
-                } else {
-                    resume_block = Some(bb);
-                }
+            if let TerminatorKind::Resume = block.terminator().kind && block.statements.is_empty() {
+                result.resume_block = Some(bb);
                 break;
             }
         }
-        let resume_block = resume_block.unwrap_or_else(|| {
-            result.new_block(BasicBlockData {
-                statements: vec![],
-                terminator: Some(Terminator {
-                    source_info: SourceInfo::outermost(body.span),
-                    kind: TerminatorKind::Resume,
-                }),
-                is_cleanup: true,
-            })
-        });
-        result.resume_block = resume_block;
-        if let Some(resume_stmt_block) = resume_stmt_block {
-            result
-                .patch_terminator(resume_stmt_block, TerminatorKind::Goto { target: resume_block });
-        }
+
         result
     }
 
-    pub fn resume_block(&self) -> BasicBlock {
-        self.resume_block
+    pub fn resume_block(&mut self) -> BasicBlock {
+        if let Some(bb) = self.resume_block {
+            return bb;
+        }
+
+        let bb = self.new_block(BasicBlockData {
+            statements: vec![],
+            terminator: Some(Terminator {
+                source_info: SourceInfo::outermost(self.body_span),
+                kind: TerminatorKind::Resume,
+            }),
+            is_cleanup: true,
+        });
+        self.resume_block = Some(bb);
+        bb
     }
 
     pub fn is_patched(&self, bb: BasicBlock) -> bool {
@@ -138,12 +128,17 @@ impl<'tcx> MirPatch<'tcx> {
             self.new_blocks.len(),
             body.basic_blocks().len()
         );
-        body.basic_blocks_mut().extend(self.new_blocks);
+        let bbs = if self.patch_map.is_empty() && self.new_blocks.is_empty() {
+            body.basic_blocks.as_mut_preserves_cfg()
+        } else {
+            body.basic_blocks.as_mut()
+        };
+        bbs.extend(self.new_blocks);
         body.local_decls.extend(self.new_locals);
         for (src, patch) in self.patch_map.into_iter_enumerated() {
             if let Some(patch) = patch {
                 debug!("MirPatch: patching block {:?}", src);
-                body[src].terminator_mut().kind = patch;
+                bbs[src].terminator_mut().kind = patch;
             }
         }
 

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -83,9 +83,9 @@ impl RemoveNoopLandingPads {
     fn remove_nop_landing_pads(&self, body: &mut Body<'_>) {
         debug!("body: {:#?}", body);
 
-        // make sure there's a single resume block
+        // make sure there's a resume block
         let resume_block = {
-            let patch = MirPatch::new(body);
+            let mut patch = MirPatch::new(body);
             let resume_block = patch.resume_block();
             patch.apply(body);
             resume_block

--- a/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
@@ -102,10 +102,6 @@
           StorageDead(_6);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:39: +1:40
           _5 = const ();                   // scope 1 at $DIR/derefer_complex_case.rs:+1:5: +1:40
           goto -> bb2;                     // scope 1 at $DIR/derefer_complex_case.rs:+1:5: +1:40
-+     }
-+ 
-+     bb8 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_complex_case.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/derefer_terminator_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_terminator_test.main.Derefer.diff
@@ -94,10 +94,6 @@
           StorageDead(_2);                 // scope 1 at $DIR/derefer_terminator_test.rs:+8:1: +8:2
           StorageDead(_1);                 // scope 0 at $DIR/derefer_terminator_test.rs:+8:1: +8:2
           return;                          // scope 0 at $DIR/derefer_terminator_test.rs:+8:2: +8:2
-+     }
-+ 
-+     bb6 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_terminator_test.rs:+0:1: +8:2
       }
   }
   

--- a/src/test/mir-opt/derefer_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test.main.Derefer.diff
@@ -49,10 +49,6 @@
           StorageDead(_2);                 // scope 1 at $DIR/derefer_test.rs:+5:1: +5:2
           StorageDead(_1);                 // scope 0 at $DIR/derefer_test.rs:+5:1: +5:2
           return;                          // scope 0 at $DIR/derefer_test.rs:+5:2: +5:2
-+     }
-+ 
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_test.rs:+0:1: +5:2
       }
   }
   

--- a/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
@@ -87,10 +87,6 @@
           StorageDead(_2);                 // scope 1 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
           StorageDead(_1);                 // scope 0 at $DIR/derefer_test_multiple.rs:+7:1: +7:2
           return;                          // scope 0 at $DIR/derefer_test_multiple.rs:+7:2: +7:2
-+     }
-+ 
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/derefer_test_multiple.rs:+0:1: +7:2
       }
   }
   

--- a/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.get_query.Inline.diff
@@ -57,10 +57,6 @@
           StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:+2:24: +2:25
           StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:+3:1: +3:2
           return;                          // scope 0 at $DIR/dyn-trait.rs:+3:2: +3:2
-+     }
-+ 
-+     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/dyn-trait.rs:+0:1: +3:2
       }
   }
   

--- a/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
+++ b/src/test/mir-opt/inline/dyn_trait.try_execute_query.Inline.diff
@@ -32,10 +32,6 @@
 +         StorageDead(_4);                 // scope 1 at $DIR/dyn-trait.rs:+0:21: +0:22
           StorageDead(_2);                 // scope 0 at $DIR/dyn-trait.rs:+1:15: +1:16
           return;                          // scope 0 at $DIR/dyn-trait.rs:+2:2: +2:2
-+     }
-+ 
-+     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/dyn-trait.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -41,8 +41,4 @@ fn bar() -> bool {
         StorageDead(_1);                 // scope 0 at $DIR/inline-any-operand.rs:+3:1: +3:2
         return;                          // scope 0 at $DIR/inline-any-operand.rs:+3:2: +3:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-any-operand.rs:+0:1: +3:2
-    }
 }

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -46,8 +46,4 @@ fn foo(_1: T, _2: i32) -> i32 {
         StorageDead(_3);                 // scope 0 at $DIR/inline-closure.rs:+3:1: +3:2
         return;                          // scope 0 at $DIR/inline-closure.rs:+3:2: +3:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-closure.rs:+0:1: +3:2
-    }
 }

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -53,8 +53,4 @@ fn foo(_1: T, _2: &i32) -> i32 {
         StorageDead(_3);                 // scope 0 at $DIR/inline-closure-borrows-arg.rs:+6:1: +6:2
         return;                          // scope 0 at $DIR/inline-closure-borrows-arg.rs:+6:2: +6:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-closure-borrows-arg.rs:+0:1: +6:2
-    }
 }

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -66,8 +66,4 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         StorageDead(_3);                 // scope 0 at $DIR/inline-closure-captures.rs:+3:1: +3:2
         return;                          // scope 0 at $DIR/inline-closure-captures.rs:+3:2: +3:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-closure-captures.rs:+0:1: +3:2
-    }
 }

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
@@ -19,10 +19,6 @@
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:18: +1:19
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:+0:37: +2:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:+2:2: +2:2
-+     }
-+ 
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-compatibility.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
@@ -19,10 +19,6 @@
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:+1:21: +1:22
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:+0:40: +2:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:+2:2: +2:2
-+     }
-+ 
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-compatibility.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
@@ -25,10 +25,6 @@
           StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:24: +1:25
           _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:+0:10: +2:2
           return;                          // scope 0 at $DIR/inline-cycle.rs:+2:2: +2:2
-+     }
-+ 
-+     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-cycle.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -50,10 +50,6 @@
           StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:+1:12: +1:13
           _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:+0:10: +2:2
           return;                          // scope 0 at $DIR/inline-cycle.rs:+2:2: +2:2
-+     }
-+ 
-+     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-cycle.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
@@ -27,10 +27,6 @@
           StorageDead(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:+1:24: +1:25
           _0 = const ();                   // scope 0 at $DIR/inline-cycle-generic.rs:+0:11: +2:2
           return;                          // scope 0 at $DIR/inline-cycle-generic.rs:+2:2: +2:2
-+     }
-+ 
-+     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-cycle-generic.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
@@ -19,10 +19,6 @@
 + 
 +     bb1: {
 +         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:+32:5: +32:12
-+     }
-+ 
-+     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-diverging.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -44,10 +44,6 @@
 +                                          // mir::Constant
 +                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
 +                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
-+     }
-+ 
-+     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-diverging.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -51,10 +51,6 @@
 + 
 +     bb1: {
 +         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:+18:5: +18:12
-+     }
-+ 
-+     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-diverging.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
@@ -39,10 +39,6 @@
           StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:+3:30: +3:31
           _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:+0:18: +4:2
           return;                          // scope 0 at $DIR/inline-instruction-set.rs:+4:2: +4:2
-+     }
-+ 
-+     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-instruction-set.rs:+0:1: +4:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
@@ -41,10 +41,6 @@
           StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:+5:30: +5:31
           _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:+0:14: +6:2
           return;                          // scope 0 at $DIR/inline-instruction-set.rs:+6:2: +6:2
-+     }
-+ 
-+     bb3 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-instruction-set.rs:+0:1: +6:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
@@ -52,8 +52,4 @@ fn main() -> () {
         _0 = const ();                   // scope 0 at $DIR/inline-options.rs:+0:11: +3:2
         return;                          // scope 0 at $DIR/inline-options.rs:+3:2: +3:2
     }
-
-    bb5 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-options.rs:+0:1: +3:2
-    }
 }

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -69,8 +69,4 @@ fn bar() -> bool {
         StorageDead(_4);                 // scope 0 at $DIR/inline-retag.rs:+3:1: +3:2
         return;                          // scope 0 at $DIR/inline-retag.rs:+3:2: +3:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-retag.rs:+0:1: +3:2
-    }
 }

--- a/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
@@ -21,10 +21,6 @@
 +         _0 = (*_2);                      // scope 1 at $SRC_DIR/core/src/clone.rs:LL:COL
           StorageDead(_2);                 // scope 0 at $DIR/inline-shims.rs:+1:13: +1:14
           return;                          // scope 0 at $DIR/inline-shims.rs:+2:2: +2:2
-+     }
-+ 
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-shims.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
@@ -51,10 +51,6 @@
 + 
 +     bb3: {
 +         drop((((*_5) as Some).0: B)) -> bb2; // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-+     }
-+ 
-+     bb4 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-shims.rs:+0:1: +3:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -23,10 +23,6 @@
           _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:+0:11: +2:2
           StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:+2:1: +2:2
           return;                          // scope 0 at $DIR/inline-specialization.rs:+2:2: +2:2
-+     }
-+ 
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-specialization.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -29,8 +29,4 @@ fn test2(_1: &dyn X) -> bool {
         StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:+1:11: +1:12
         return;                          // scope 0 at $DIR/inline-trait-method_2.rs:+2:2: +2:2
     }
-
-    bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/inline-trait-method_2.rs:+0:1: +2:2
-    }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -27,8 +27,4 @@ fn a(_1: &mut [T]) -> &mut [T] {
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
         return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
-    }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -39,8 +39,4 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
         return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
-    }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
@@ -19,8 +19,4 @@ fn c(_1: &[T]) -> &[T] {
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
         return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
-    }
 }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -27,8 +27,4 @@ fn d(_1: &Box<T>) -> &T {
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:1: +2:2
         return;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+2:2: +2:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:+0:1: +2:2
-    }
 }

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -39,8 +39,4 @@ fn main() -> () {
         StorageDead(_1);                 // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+3:1: +3:2
         return;                          // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+3:2: +3:2
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:+0:1: +3:2
-    }
 }

--- a/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
@@ -16,9 +16,5 @@
       bb1: {
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
       }
-  
-      bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
-      }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
@@ -111,9 +111,5 @@
       bb5: {
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:+5:2: +5:2
       }
-  
-      bb6 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +5:2
-      }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
@@ -25,9 +25,5 @@
       bb2: {
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
       }
-  
-      bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
-      }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
@@ -27,9 +27,5 @@
           StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:+4:1: +4:2
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:+4:2: +4:2
       }
-  
-      bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +4:2
-      }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
@@ -16,9 +16,5 @@
       bb1: {
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
       }
-  
-      bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
-      }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
@@ -18,9 +18,5 @@
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn() -> ! {std::intrinsics::unreachable}, val: Value(<ZST>) }
 +         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:45
       }
-  
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +2:2
-      }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
@@ -79,9 +79,5 @@
           StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:+4:1: +4:2
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:+4:2: +4:2
       }
-  
-      bb4 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:+0:1: +4:2
-      }
   }
   

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -96,9 +96,5 @@
           _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
           switchInt(move _10) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/remove_storage_markers.rs:+2:14: +2:19
       }
-  
-      bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/remove_storage_markers.rs:+0:1: +5:2
-      }
   }
   

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -22,10 +22,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
 -         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:17: +2:2
           return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
--     }
-- 
--     bb2 (cleanup): {
--         resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -22,10 +22,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:+1:12: +1:13
 -         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:+0:36: +2:2
           return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+2:2: +2:2
--     }
-- 
--     bb2 (cleanup): {
--         resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:+0:1: +2:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -85,9 +85,5 @@
       bb4: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
-  
-      bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify-arm.rs:+0:1: +6:2
-      }
   }
   

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -85,9 +85,5 @@
       bb4: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:+6:2: +6:2
       }
-  
-      bb5 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify-arm.rs:+0:1: +6:2
-      }
   }
   


### PR DESCRIPTION
As a part of this change, we adjust `MirPatch` to not needlessly create unnecessary resume blocks.

r? @tmiasko