### PR TITLE
Emit warning when bound is trivially false

### DIFF
--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `for<'a> <Parameterized<'a> as Foo>::Item == &'a i32` is trivially false
+warning: the where-clause bound `for<'a> <Parameterized<'a> as Foo>::Item == &'a i32` is impossible to satisfy
   --> $DIR/bound-lifetime-in-binding-only.rs:67:19
    |
 LL |   fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
@@ -6,9 +6,11 @@ LL |   fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
 LL | |
 LL | |
 LL | | }
-   | |_- this cannot be referenced without causing an error
+   | |_- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
-warning: the where-clause bound `for<'a> Parameterized<'a>: Foo` is trivially false
+warning: the where-clause bound `for<'a> Parameterized<'a>: Foo` is impossible to satisfy
   --> $DIR/bound-lifetime-in-binding-only.rs:67:19
    |
 LL |   fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
@@ -16,7 +18,9 @@ LL |   fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
 LL | |
 LL | |
 LL | | }
-   | |_- this cannot be referenced without causing an error
+   | |_- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 error: fatal error triggered by #[rustc_error]
   --> $DIR/bound-lifetime-in-binding-only.rs:73:1

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
@@ -1,8 +1,28 @@
+warning: the where-clause bound `for<'a> <Parameterized<'a> as Foo>::Item == &'a i32` is trivially false
+  --> $DIR/bound-lifetime-in-binding-only.rs:67:19
+   |
+LL |   fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
+   |  _-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |
+LL | |
+LL | | }
+   | |_- this cannot be referenced without causing an error
+
+warning: the where-clause bound `for<'a> Parameterized<'a>: Foo` is trivially false
+  --> $DIR/bound-lifetime-in-binding-only.rs:67:19
+   |
+LL |   fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
+   |  _-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |
+LL | |
+LL | | }
+   | |_- this cannot be referenced without causing an error
+
 error: fatal error triggered by #[rustc_error]
-  --> $DIR/bound-lifetime-in-binding-only.rs:71:1
+  --> $DIR/bound-lifetime-in-binding-only.rs:73:1
    |
 LL | fn main() { }
    | ^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.rs
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.rs
@@ -65,6 +65,8 @@ fn ok2<T: for<'a,'b> Fn<(&'b Parameterized<'a>,), Output=&'a i32>>() {
 
 #[cfg(ok)]
 fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
+    //[ok]~^ WARNING the where-clause bound
+    //[ok]~| WARNING the where-clause bound
 }
 
 #[rustc_error]

--- a/src/test/ui/associated-types/issue-59324.rs
+++ b/src/test/ui/associated-types/issue-59324.rs
@@ -12,7 +12,7 @@ pub trait ThriftService<Bug: NotFoo>:
 //~^ ERROR the trait bound `Bug: Foo` is not satisfied
 //~| ERROR the trait bound `Bug: Foo` is not satisfied
     Service<AssocType = <Bug as Foo>::OnlyFoo>
-{
+    {
     fn get_service(
     //~^ ERROR the trait bound `Bug: Foo` is not satisfied
         &self,

--- a/src/test/ui/associated-types/issue-69398.rs
+++ b/src/test/ui/associated-types/issue-69398.rs
@@ -12,6 +12,7 @@ pub trait Broken {
 impl<T> Broken for T {
     type Assoc = ();
     fn broken(&self) where Self::Assoc: Foo {
+        //~^ WARNING the where-clause bound
         let _x: <Self::Assoc as Foo>::Bar;
     }
 }

--- a/src/test/ui/associated-types/issue-69398.stderr
+++ b/src/test/ui/associated-types/issue-69398.stderr
@@ -1,0 +1,12 @@
+warning: the where-clause bound `<T as Broken>::Assoc: Foo` is trivially false
+  --> $DIR/issue-69398.rs:14:28
+   |
+LL |       fn broken(&self) where Self::Assoc: Foo {
+   |  _____-                      ^^^^^^^^^^^^^^^^
+LL | |
+LL | |         let _x: <Self::Assoc as Foo>::Bar;
+LL | |     }
+   | |_____- this cannot be referenced without causing an error
+
+warning: 1 warning emitted
+

--- a/src/test/ui/associated-types/issue-69398.stderr
+++ b/src/test/ui/associated-types/issue-69398.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `<T as Broken>::Assoc: Foo` is trivially false
+warning: the where-clause bound `<T as Broken>::Assoc: Foo` is impossible to satisfy
   --> $DIR/issue-69398.rs:14:28
    |
 LL |       fn broken(&self) where Self::Assoc: Foo {
@@ -6,7 +6,9 @@ LL |       fn broken(&self) where Self::Assoc: Foo {
 LL | |
 LL | |         let _x: <Self::Assoc as Foo>::Bar;
 LL | |     }
-   | |_____- this cannot be referenced without causing an error
+   | |_____- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/issue-67696-const-prop-ice.rs
+++ b/src/test/ui/consts/issue-67696-const-prop-ice.rs
@@ -11,6 +11,9 @@ trait A {
 
 impl A for [fn(&())] {
     fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
+    //~^ WARNING the where-clause bound
+    //~| WARNING the where-clause bound
+    //~| WARNING the where-clause bound
 }
 
 impl A for i32 {

--- a/src/test/ui/consts/issue-67696-const-prop-ice.stderr
+++ b/src/test/ui/consts/issue-67696-const-prop-ice.stderr
@@ -1,0 +1,20 @@
+warning: the where-clause bound `[for<'r> fn(&'r ())]: Copy` is trivially false
+  --> $DIR/issue-67696-const-prop-ice.rs:13:33
+   |
+LL |     fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
+   |     ----------------------------^^^^^^^^^^------------------- this cannot be referenced without causing an error
+
+warning: the where-clause bound `[for<'r> fn(&'r ())]: Clone` is trivially false
+  --> $DIR/issue-67696-const-prop-ice.rs:13:33
+   |
+LL |     fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
+   |     ----------------------------^^^^^^^^^^------------------- this cannot be referenced without causing an error
+
+warning: the where-clause bound `[for<'r> fn(&'r ())]: Sized` is trivially false
+  --> $DIR/issue-67696-const-prop-ice.rs:13:33
+   |
+LL |     fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
+   |     ----------------------------^^^^^^^^^^------------------- this cannot be referenced without causing an error
+
+warning: 3 warnings emitted
+

--- a/src/test/ui/consts/issue-67696-const-prop-ice.stderr
+++ b/src/test/ui/consts/issue-67696-const-prop-ice.stderr
@@ -1,20 +1,26 @@
-warning: the where-clause bound `[for<'r> fn(&'r ())]: Copy` is trivially false
+warning: the where-clause bound `[for<'r> fn(&'r ())]: Copy` is impossible to satisfy
   --> $DIR/issue-67696-const-prop-ice.rs:13:33
    |
 LL |     fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
-   |     ----------------------------^^^^^^^^^^------------------- this cannot be referenced without causing an error
+   |     ----------------------------^^^^^^^^^^------------------- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
-warning: the where-clause bound `[for<'r> fn(&'r ())]: Clone` is trivially false
+warning: the where-clause bound `[for<'r> fn(&'r ())]: Clone` is impossible to satisfy
   --> $DIR/issue-67696-const-prop-ice.rs:13:33
    |
 LL |     fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
-   |     ----------------------------^^^^^^^^^^------------------- this cannot be referenced without causing an error
+   |     ----------------------------^^^^^^^^^^------------------- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
-warning: the where-clause bound `[for<'r> fn(&'r ())]: Sized` is trivially false
+warning: the where-clause bound `[for<'r> fn(&'r ())]: Sized` is impossible to satisfy
   --> $DIR/issue-67696-const-prop-ice.rs:13:33
    |
 LL |     fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
-   |     ----------------------------^^^^^^^^^^------------------- this cannot be referenced without causing an error
+   |     ----------------------------^^^^^^^^^^------------------- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
@@ -63,6 +63,7 @@ fn return_str() -> str where str: Sized { //~ ERROR
 // This is currently accepted because the function pointer isn't
 // considered global.
 fn global_hr(x: fn(&())) where fn(&()): Foo { // OK
+    //~^ WARNING the where-clause bound
     x.test();
 }
 

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -113,6 +113,16 @@ LL | fn return_str() -> str where str: Sized {
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+warning: the where-clause bound `for<'r> fn(&'r ()): Foo` is trivially false
+  --> $DIR/feature-gate-trivial_bounds.rs:65:32
+   |
+LL |   fn global_hr(x: fn(&())) where fn(&()): Foo { // OK
+   |  _-                              ^^^^^^^^^^^^
+LL | |
+LL | |     x.test();
+LL | | }
+   | |_- this cannot be referenced without causing an error
+
+error: aborting due to 11 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -113,7 +113,7 @@ LL | fn return_str() -> str where str: Sized {
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-warning: the where-clause bound `for<'r> fn(&'r ()): Foo` is trivially false
+warning: the where-clause bound `for<'r> fn(&'r ()): Foo` is impossible to satisfy
   --> $DIR/feature-gate-trivial_bounds.rs:65:32
    |
 LL |   fn global_hr(x: fn(&())) where fn(&()): Foo { // OK
@@ -121,7 +121,9 @@ LL |   fn global_hr(x: fn(&())) where fn(&()): Foo { // OK
 LL | |
 LL | |     x.test();
 LL | | }
-   | |_- this cannot be referenced without causing an error
+   | |_- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 error: aborting due to 11 previous errors; 1 warning emitted
 

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.rs
@@ -7,6 +7,7 @@ impl<B: BufferMut, C> BufferUdpStateContext<B> for C {}
 trait StackContext
 where
     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
+    //~^ WARNING the where-clause bound
 {
     type Dispatcher;
 }
@@ -26,6 +27,7 @@ where
 struct EthernetWorker<C>(C)
 where
     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
+    //~^ WARNING the where-clause bound
 impl<C> EthernetWorker<C> {}
 //~^ ERROR: is not satisfied [E0277]
 

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` is trivially false
+warning: the where-clause bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` is impossible to satisfy
   --> $DIR/issue-89118.rs:9:5
    |
 LL | / trait StackContext
@@ -9,7 +9,9 @@ LL | |
 LL | | {
 LL | |     type Dispatcher;
 LL | | }
-   | |_- this cannot be referenced without causing an error
+   | |_- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
   --> $DIR/issue-89118.rs:20:8
@@ -31,13 +33,15 @@ LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
 
-warning: the where-clause bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` is trivially false
+warning: the where-clause bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` is impossible to satisfy
   --> $DIR/issue-89118.rs:29:5
    |
 LL | / struct EthernetWorker<C>(C)
 LL | | where
 LL | |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
-   | |_____^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- this cannot be referenced without causing an error
+   | |_____^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
   --> $DIR/issue-89118.rs:31:9

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
@@ -1,5 +1,18 @@
+warning: the where-clause bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` is trivially false
+  --> $DIR/issue-89118.rs:9:5
+   |
+LL | / trait StackContext
+LL | | where
+LL | |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |
+LL | | {
+LL | |     type Dispatcher;
+LL | | }
+   | |_- this cannot be referenced without causing an error
+
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
-  --> $DIR/issue-89118.rs:19:8
+  --> $DIR/issue-89118.rs:20:8
    |
 LL |     C: StackContext,
    |        ^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
@@ -18,8 +31,16 @@ LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
 
+warning: the where-clause bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` is trivially false
+  --> $DIR/issue-89118.rs:29:5
+   |
+LL | / struct EthernetWorker<C>(C)
+LL | | where
+LL | |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
+   | |_____^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- this cannot be referenced without causing an error
+
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
-  --> $DIR/issue-89118.rs:29:9
+  --> $DIR/issue-89118.rs:31:9
    |
 LL | impl<C> EthernetWorker<C> {}
    |         ^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
@@ -30,7 +51,7 @@ note: required because of the requirements on the impl of `for<'a> BufferUdpStat
 LL | impl<B: BufferMut, C> BufferUdpStateContext<B> for C {}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^     ^
 note: required by a bound in `EthernetWorker`
-  --> $DIR/issue-89118.rs:28:14
+  --> $DIR/issue-89118.rs:29:14
    |
 LL | struct EthernetWorker<C>(C)
    |        -------------- required by a bound in this
@@ -39,7 +60,7 @@ LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EthernetWorker`
 
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
-  --> $DIR/issue-89118.rs:22:20
+  --> $DIR/issue-89118.rs:23:20
    |
 LL |     type Handler = Ctx<C::Dispatcher>;
    |                    ^^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
@@ -58,6 +79,6 @@ LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-36839.rs
+++ b/src/test/ui/issues/issue-36839.rs
@@ -12,6 +12,7 @@ pub trait Broken {
 impl<T> Broken for T {
     type Assoc = ();
     fn broken(&self) where Self::Assoc: Foo {
+        //~^ WARNING the where-clause bound
         let _x: <Self::Assoc as Foo>::Bar;
     }
 }

--- a/src/test/ui/issues/issue-36839.stderr
+++ b/src/test/ui/issues/issue-36839.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `<T as Broken>::Assoc: Foo` is trivially false
+warning: the where-clause bound `<T as Broken>::Assoc: Foo` is impossible to satisfy
   --> $DIR/issue-36839.rs:14:28
    |
 LL |       fn broken(&self) where Self::Assoc: Foo {
@@ -6,7 +6,9 @@ LL |       fn broken(&self) where Self::Assoc: Foo {
 LL | |
 LL | |         let _x: <Self::Assoc as Foo>::Bar;
 LL | |     }
-   | |_____- this cannot be referenced without causing an error
+   | |_____- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 warning: 1 warning emitted
 

--- a/src/test/ui/issues/issue-36839.stderr
+++ b/src/test/ui/issues/issue-36839.stderr
@@ -1,0 +1,12 @@
+warning: the where-clause bound `<T as Broken>::Assoc: Foo` is trivially false
+  --> $DIR/issue-36839.rs:14:28
+   |
+LL |       fn broken(&self) where Self::Assoc: Foo {
+   |  _____-                      ^^^^^^^^^^^^^^^^
+LL | |
+LL | |         let _x: <Self::Assoc as Foo>::Bar;
+LL | |     }
+   | |_____- this cannot be referenced without causing an error
+
+warning: 1 warning emitted
+

--- a/src/test/ui/issues/issue-39970.rs
+++ b/src/test/ui/issues/issue-39970.rs
@@ -13,6 +13,7 @@ impl<'a> Array<'a> for () {
 impl Visit for () where
     //(): for<'a> Array<'a, Element=&'a ()>, // No ICE
     (): for<'a> Array<'a, Element=()>, // ICE
+    //~^ WARNING the where-clause bound
 {}
 
 fn main() {

--- a/src/test/ui/issues/issue-39970.stderr
+++ b/src/test/ui/issues/issue-39970.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `for<'a> <() as Array<'a>>::Element == ()` is trivially false
+warning: the where-clause bound `for<'a> <() as Array<'a>>::Element == ()` is impossible to satisfy
   --> $DIR/issue-39970.rs:15:5
    |
 LL | / impl Visit for () where
@@ -7,7 +7,9 @@ LL | |     (): for<'a> Array<'a, Element=()>, // ICE
    | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL | |
 LL | | {}
-   | |__- this cannot be referenced without causing an error
+   | |__- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 error[E0271]: type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
   --> $DIR/issue-39970.rs:20:5

--- a/src/test/ui/issues/issue-39970.stderr
+++ b/src/test/ui/issues/issue-39970.stderr
@@ -1,5 +1,16 @@
+warning: the where-clause bound `for<'a> <() as Array<'a>>::Element == ()` is trivially false
+  --> $DIR/issue-39970.rs:15:5
+   |
+LL | / impl Visit for () where
+LL | |     //(): for<'a> Array<'a, Element=&'a ()>, // No ICE
+LL | |     (): for<'a> Array<'a, Element=()>, // ICE
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |
+LL | | {}
+   | |__- this cannot be referenced without causing an error
+
 error[E0271]: type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
-  --> $DIR/issue-39970.rs:19:5
+  --> $DIR/issue-39970.rs:20:5
    |
 LL |     <() as Visit>::visit();
    |     ^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
@@ -15,6 +26,6 @@ note: required because of the requirements on the impl of `Visit` for `()`
 LL | impl Visit for () where
    |      ^^^^^     ^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/issues/issue-42796.rs
+++ b/src/test/ui/issues/issue-42796.rs
@@ -7,6 +7,7 @@ impl<T, Smoke> Mirror<Smoke> for T {
 }
 
 pub fn poison<S>(victim: String) where <String as Mirror<S>>::Image: Copy {
+    //~^ WARNING the where-clause bound
     loop { drop(victim); }
 }
 

--- a/src/test/ui/issues/issue-42796.stderr
+++ b/src/test/ui/issues/issue-42796.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `<String as Mirror<S>>::Image: Copy` is trivially false
+warning: the where-clause bound `<String as Mirror<S>>::Image: Copy` is impossible to satisfy
   --> $DIR/issue-42796.rs:9:40
    |
 LL |   pub fn poison<S>(victim: String) where <String as Mirror<S>>::Image: Copy {
@@ -6,7 +6,9 @@ LL |   pub fn poison<S>(victim: String) where <String as Mirror<S>>::Image: Copy
 LL | |
 LL | |     loop { drop(victim); }
 LL | | }
-   | |_- this cannot be referenced without causing an error
+   | |_- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 error[E0382]: borrow of moved value: `s`
   --> $DIR/issue-42796.rs:19:20

--- a/src/test/ui/issues/issue-42796.stderr
+++ b/src/test/ui/issues/issue-42796.stderr
@@ -1,5 +1,15 @@
+warning: the where-clause bound `<String as Mirror<S>>::Image: Copy` is trivially false
+  --> $DIR/issue-42796.rs:9:40
+   |
+LL |   pub fn poison<S>(victim: String) where <String as Mirror<S>>::Image: Copy {
+   |  _-                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |
+LL | |     loop { drop(victim); }
+LL | | }
+   | |_- this cannot be referenced without causing an error
+
 error[E0382]: borrow of moved value: `s`
-  --> $DIR/issue-42796.rs:18:20
+  --> $DIR/issue-42796.rs:19:20
    |
 LL |     let s = "Hello!".to_owned();
    |         - move occurs because `s` has type `String`, which does not implement the `Copy` trait
@@ -11,6 +21,6 @@ LL |     println!("{}", s);
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/issues/issue-50714-1.rs
+++ b/src/test/ui/issues/issue-50714-1.rs
@@ -6,6 +6,7 @@
 extern crate std;
 
 #[start]
-fn start(_: isize, _: *const *const u8) -> isize where fn(&()): Eq { //~ ERROR [E0647]
+fn start(_: isize, _: *const *const u8) -> isize where fn(&()): Eq {
+    //~^ ERROR start function is not allowed to have a `where` clause
     0
 }

--- a/src/test/ui/issues/issue-50714.rs
+++ b/src/test/ui/issues/issue-50714.rs
@@ -1,3 +1,8 @@
 // Regression test for issue 50714, make sure that this isn't a linker error.
 
-fn main() where fn(&()): Eq {} //~ ERROR [E0646]
+fn main()
+where
+//~^ ERROR `main` function is not allowed to have a `where` clause
+    fn(&()): Eq,
+{
+}

--- a/src/test/ui/issues/issue-50714.stderr
+++ b/src/test/ui/issues/issue-50714.stderr
@@ -1,8 +1,10 @@
 error[E0646]: `main` function is not allowed to have a `where` clause
-  --> $DIR/issue-50714.rs:3:11
+  --> $DIR/issue-50714.rs:4:1
    |
-LL | fn main() where fn(&()): Eq {}
-   |           ^^^^^^^^^^^^^^^^^ `main` cannot have a `where` clause
+LL | / where
+LL | |
+LL | |     fn(&()): Eq,
+   | |________________^ `main` cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/mir/issue-91745.rs
+++ b/src/test/ui/mir/issue-91745.rs
@@ -12,6 +12,7 @@ pub trait Broken {
 impl<T> Broken for T {
     type Assoc = ();
     fn broken(&self) where Self::Assoc: Foo {
+        //~^ WARNING the where-clause bound
         let _x: <Self::Assoc as Foo>::Bar;
     }
 }

--- a/src/test/ui/mir/issue-91745.stderr
+++ b/src/test/ui/mir/issue-91745.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `<T as Broken>::Assoc: Foo` is trivially false
+warning: the where-clause bound `<T as Broken>::Assoc: Foo` is impossible to satisfy
   --> $DIR/issue-91745.rs:14:28
    |
 LL |       fn broken(&self) where Self::Assoc: Foo {
@@ -6,7 +6,9 @@ LL |       fn broken(&self) where Self::Assoc: Foo {
 LL | |
 LL | |         let _x: <Self::Assoc as Foo>::Bar;
 LL | |     }
-   | |_____- this cannot be referenced without causing an error
+   | |_____- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 warning: 1 warning emitted
 

--- a/src/test/ui/mir/issue-91745.stderr
+++ b/src/test/ui/mir/issue-91745.stderr
@@ -1,0 +1,12 @@
+warning: the where-clause bound `<T as Broken>::Assoc: Foo` is trivially false
+  --> $DIR/issue-91745.rs:14:28
+   |
+LL |       fn broken(&self) where Self::Assoc: Foo {
+   |  _____-                      ^^^^^^^^^^^^^^^^
+LL | |
+LL | |         let _x: <Self::Assoc as Foo>::Bar;
+LL | |     }
+   | |_____- this cannot be referenced without causing an error
+
+warning: 1 warning emitted
+

--- a/src/test/ui/trait-bounds/issue-94680.rs
+++ b/src/test/ui/trait-bounds/issue-94680.rs
@@ -7,6 +7,7 @@ fn main() {
         pub fn cloneit(it: &'_ mut T) -> (&'_ mut T, &'_ mut T)
         where
             for<'any> &'any mut T: Clone,
+            //~^ WARNING the where-clause bound
         {
             (it.clone(), it)
         }

--- a/src/test/ui/trait-bounds/issue-94680.stderr
+++ b/src/test/ui/trait-bounds/issue-94680.stderr
@@ -1,0 +1,15 @@
+warning: the where-clause bound `for<'any> &'any mut (): Clone` is trivially false
+  --> $DIR/issue-94680.rs:9:13
+   |
+LL | /         pub fn cloneit(it: &'_ mut T) -> (&'_ mut T, &'_ mut T)
+LL | |         where
+LL | |             for<'any> &'any mut T: Clone,
+   | |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |
+LL | |         {
+LL | |             (it.clone(), it)
+LL | |         }
+   | |_________- this cannot be referenced without causing an error
+
+warning: 1 warning emitted
+

--- a/src/test/ui/trait-bounds/issue-94680.stderr
+++ b/src/test/ui/trait-bounds/issue-94680.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `for<'any> &'any mut (): Clone` is trivially false
+warning: the where-clause bound `for<'any> &'any mut (): Clone` is impossible to satisfy
   --> $DIR/issue-94680.rs:9:13
    |
 LL | /         pub fn cloneit(it: &'_ mut T) -> (&'_ mut T, &'_ mut T)
@@ -9,7 +9,9 @@ LL | |
 LL | |         {
 LL | |             (it.clone(), it)
 LL | |         }
-   | |_________- this cannot be referenced without causing an error
+   | |_________- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 warning: 1 warning emitted
 

--- a/src/test/ui/trait-bounds/issue-94999.rs
+++ b/src/test/ui/trait-bounds/issue-94999.rs
@@ -24,6 +24,7 @@ impl Holds for X {
 impl<Q> Clone for X
 where
     <S as Identity<Q>>::T: Clone,
+    //~^ WARNING the where-clause bound
     X: Holds<Q = Q>,
 {
     fn clone(&self) -> Self {

--- a/src/test/ui/trait-bounds/issue-94999.stderr
+++ b/src/test/ui/trait-bounds/issue-94999.stderr
@@ -1,4 +1,4 @@
-warning: the where-clause bound `<S as Identity<Q>>::T: Clone` is trivially false
+warning: the where-clause bound `<S as Identity<Q>>::T: Clone` is impossible to satisfy
   --> $DIR/issue-94999.rs:26:5
    |
 LL | / impl<Q> Clone for X
@@ -9,7 +9,9 @@ LL | |
 ...  |
 LL | |     }
 LL | | }
-   | |_- this cannot be referenced without causing an error
+   | |_- this item cannot be referenced without causing an error
+   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
 
 warning: 1 warning emitted
 

--- a/src/test/ui/trait-bounds/issue-94999.stderr
+++ b/src/test/ui/trait-bounds/issue-94999.stderr
@@ -1,0 +1,15 @@
+warning: the where-clause bound `<S as Identity<Q>>::T: Clone` is trivially false
+  --> $DIR/issue-94999.rs:26:5
+   |
+LL | / impl<Q> Clone for X
+LL | | where
+LL | |     <S as Identity<Q>>::T: Clone,
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |
+...  |
+LL | |     }
+LL | | }
+   | |_- this cannot be referenced without causing an error
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
We really should be rejecting bounds that are global, even if they have higher-ranked lifetimes. We have the ability to prove whether `for<'a> &'a mut String: Clone` is true or not, so there's no reason to silently allow this to typecheck, especially because it's inconsistent with a non-HRTB like `&'static mut String: Clone` and is the source of ICEs.

For now, though, just add a warning, so that when an ICE _does_ occur (because sometimes it will), then the user knows what might've caused it.

This is a revival of #95611.