### PR TITLE
Check link ordinal to make sure it is targetted  for foreign function

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -263,5 +263,5 @@ passes-rustc-lint-opt-ty = `#[rustc_lint_opt_ty]` should be applied to a struct
 passes-rustc-lint-opt-deny-field-access = `#[rustc_lint_opt_deny_field_access]` should be applied to a field
     .label = not a field
 
-passes-link-ordinal = attribute should be applied to a foreign function
-    .label = not a foreign function
+passes-link-ordinal = attribute should be applied to a foreign function or static
+    .label = not a foreign function or static

--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -262,3 +262,6 @@ passes-rustc-lint-opt-ty = `#[rustc_lint_opt_ty]` should be applied to a struct
 
 passes-rustc-lint-opt-deny-field-access = `#[rustc_lint_opt_deny_field_access]` should be applied to a field
     .label = not a field
+
+passes-link-ordinal = attribute should be applied to a foreign function
+    .label = not a foreign function

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -146,6 +146,9 @@ impl CheckAttrVisitor<'_> {
                 | sym::stable
                 | sym::rustc_allowed_through_unstable_modules
                 | sym::rustc_promotable => self.check_stability_promotable(&attr, span, target),
+                sym::link_ordinal => {
+                    self.check_link_ordinal(&attr, span, target)
+                },
                 _ => true,
             };
             is_valid &= attr_is_valid;
@@ -1858,6 +1861,16 @@ impl CheckAttrVisitor<'_> {
                 false
             }
             _ => true,
+        }
+    }
+
+    fn check_link_ordinal(&self, attr: &Attribute, _span: Span, target: Target) -> bool {
+        match target {
+            Target::ForeignFn => true,
+            _ => {
+                self.tcx.sess.emit_err(errors::LinkOrdinal { attr_span: attr.span });
+                false
+            }
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -146,9 +146,7 @@ impl CheckAttrVisitor<'_> {
                 | sym::stable
                 | sym::rustc_allowed_through_unstable_modules
                 | sym::rustc_promotable => self.check_stability_promotable(&attr, span, target),
-                sym::link_ordinal => {
-                    self.check_link_ordinal(&attr, span, target)
-                },
+                sym::link_ordinal => self.check_link_ordinal(&attr, span, target),
                 _ => true,
             };
             is_valid &= attr_is_valid;

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1864,7 +1864,7 @@ impl CheckAttrVisitor<'_> {
 
     fn check_link_ordinal(&self, attr: &Attribute, _span: Span, target: Target) -> bool {
         match target {
-            Target::ForeignFn => true,
+            Target::ForeignFn | Target::ForeignStatic => true,
             _ => {
                 self.tcx.sess.emit_err(errors::LinkOrdinal { attr_span: attr.span });
                 false

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -555,7 +555,7 @@ pub struct ConstTrait {
 #[error(passes::link_ordinal)]
 pub struct LinkOrdinal {
     #[primary_span]
-    pub attr_span: Span
+    pub attr_span: Span,
 }
 
 #[derive(SessionDiagnostic)]

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -552,6 +552,13 @@ pub struct ConstTrait {
 }
 
 #[derive(SessionDiagnostic)]
+#[error(passes::link_ordinal)]
+pub struct LinkOrdinal {
+    #[primary_span]
+    pub attr_span: Span
+}
+
+#[derive(SessionDiagnostic)]
 #[error(passes::stability_promotable)]
 pub struct StabilityPromotable {
     #[primary_span]

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
@@ -1,0 +1,18 @@
+#![feature(raw_dylib)]
+//~^ WARN the feature `raw_dylib` is incomplete
+
+#[link_ordinal(123)]
+//~^ ERROR attribute should be applied to a foreign function
+struct Foo {}
+
+#[link_ordinal(123)]
+//~^ ERROR attribute should be applied to a foreign function
+fn test() {}
+
+#[link(name = "exporter", kind = "raw-dylib")]
+extern {
+    #[link_ordinal(13)]
+    fn imported_function();
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
@@ -2,17 +2,24 @@
 //~^ WARN the feature `raw_dylib` is incomplete
 
 #[link_ordinal(123)]
-//~^ ERROR attribute should be applied to a foreign function
+//~^ ERROR attribute should be applied to a foreign function or static
 struct Foo {}
 
 #[link_ordinal(123)]
-//~^ ERROR attribute should be applied to a foreign function
+//~^ ERROR attribute should be applied to a foreign function or static
 fn test() {}
+
+#[link_ordinal(42)]
+//~^ ERROR attribute should be applied to a foreign function or static
+static mut imported_val: i32 = 123;
 
 #[link(name = "exporter", kind = "raw-dylib")]
 extern {
     #[link_ordinal(13)]
     fn imported_function();
+
+    #[link_ordinal(42)]
+    static mut imported_variable: i32;
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.stderr
@@ -7,17 +7,23 @@ LL | #![feature(raw_dylib)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
 
-error: attribute should be applied to a foreign function
+error: attribute should be applied to a foreign function or static
   --> $DIR/link-ordinal-not-foreign-fn.rs:4:1
    |
 LL | #[link_ordinal(123)]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: attribute should be applied to a foreign function
+error: attribute should be applied to a foreign function or static
   --> $DIR/link-ordinal-not-foreign-fn.rs:8:1
    |
 LL | #[link_ordinal(123)]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: attribute should be applied to a foreign function or static
+  --> $DIR/link-ordinal-not-foreign-fn.rs:12:1
+   |
+LL | #[link_ordinal(42)]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.stderr
@@ -1,0 +1,23 @@
+warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/link-ordinal-not-foreign-fn.rs:1:12
+   |
+LL | #![feature(raw_dylib)]
+   |            ^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
+
+error: attribute should be applied to a foreign function
+  --> $DIR/link-ordinal-not-foreign-fn.rs:4:1
+   |
+LL | #[link_ordinal(123)]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: attribute should be applied to a foreign function
+  --> $DIR/link-ordinal-not-foreign-fn.rs:8:1
+   |
+LL | #[link_ordinal(123)]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+


### PR DESCRIPTION
Fix #100009, when link ordinal is not target for foreign functions, emit an error.

cc @dpaoliello 