### PR TITLE
Enable unused_parens for match arms

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -377,7 +377,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
 
     fn print_string(&mut self, st: &str, style: ast::StrStyle) {
         let st = match style {
-            ast::StrStyle::Cooked => (format!("\"{}\"", st.escape_debug())),
+            ast::StrStyle::Cooked => format!("\"{}\"", st.escape_debug()),
             ast::StrStyle::Raw(n) => {
                 format!("r{delim}\"{string}\"{delim}", delim = "#".repeat(n as usize), string = st)
             }

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -839,7 +839,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             hir::Node::Expr(hir::Expr {
                 kind: hir::ExprKind::Closure(&hir::Closure { fn_decl_span, .. }),
                 ..
-            }) => (tcx.sess.source_map().end_point(fn_decl_span)),
+            }) => tcx.sess.source_map().end_point(fn_decl_span),
             _ => self.body.span,
         };
 

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -396,6 +396,7 @@ enum UnusedDelimsCtx {
     LetScrutineeExpr,
     ArrayLenExpr,
     AnonConst,
+    MatchArmExpr,
 }
 
 impl From<UnusedDelimsCtx> for &'static str {
@@ -414,6 +415,7 @@ impl From<UnusedDelimsCtx> for &'static str {
             UnusedDelimsCtx::BlockRetValue => "block return value",
             UnusedDelimsCtx::LetScrutineeExpr => "`let` scrutinee expression",
             UnusedDelimsCtx::ArrayLenExpr | UnusedDelimsCtx::AnonConst => "const expression",
+            UnusedDelimsCtx::MatchArmExpr => "match arm expression",
         }
     }
 }
@@ -804,6 +806,18 @@ impl EarlyLintPass for UnusedParens {
                     <Self as UnusedDelimLint>::check_expr(self, cx, e);
                 }
                 return;
+            }
+            ExprKind::Match(ref _expr, ref arm) => {
+                for a in arm {
+                    self.check_unused_delims_expr(
+                        cx,
+                        &a.body,
+                        UnusedDelimsCtx::MatchArmExpr,
+                        false,
+                        None,
+                        None,
+                    );
+                }
             }
             _ => {}
         }

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -617,7 +617,7 @@ impl SplitVarLenSlice {
             // The only admissible fixed-length slice is one of the array size. Whether `max_slice`
             // is fixed-length or variable-length, it will be the only relevant slice to output
             // here.
-            Some(_) => (0..0), // empty range
+            Some(_) => 0..0, // empty range
             // We cover all arities in the range `(self.arity..infinity)`. We split that range into
             // two: lengths smaller than `max_slice.arity()` are treated independently as
             // fixed-lengths slices, and lengths above are captured by `max_slice`.

--- a/src/test/ui/lint/unused/issue-92751.rs
+++ b/src/test/ui/lint/unused/issue-92751.rs
@@ -1,0 +1,9 @@
+#[deny(unused)]
+pub fn broken(x: Option<()>) -> i32 {
+    match x {
+        Some(()) => (1), //~ ERROR unnecessary parentheses around match arm expression
+        None => (2), //~ ERROR unnecessary parentheses around match arm expression
+    }
+}
+
+fn main() { }

--- a/src/test/ui/lint/unused/issue-92751.stderr
+++ b/src/test/ui/lint/unused/issue-92751.stderr
@@ -1,0 +1,32 @@
+error: unnecessary parentheses around match arm expression
+  --> $DIR/issue-92751.rs:4:21
+   |
+LL |         Some(()) => (1),
+   |                     ^ ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-92751.rs:1:8
+   |
+LL | #[deny(unused)]
+   |        ^^^^^^
+   = note: `#[deny(unused_parens)]` implied by `#[deny(unused)]`
+help: remove these parentheses
+   |
+LL -         Some(()) => (1),
+LL +         Some(()) => 1,
+   |
+
+error: unnecessary parentheses around match arm expression
+  --> $DIR/issue-92751.rs:5:17
+   |
+LL |         None => (2),
+   |                 ^ ^
+   |
+help: remove these parentheses
+   |
+LL -         None => (2),
+LL +         None => 2,
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/rust/issues/92751


Currently I can't get the `stderr` to work with `./x.py test`, but this should fix the issue. Help would be appreciated!