### PR TITLE
Provide suggestion on missing `let` in binding statement

### DIFF
--- a/src/test/ui/type/missing-let-in-binding.fixed
+++ b/src/test/ui/type/missing-let-in-binding.fixed
@@ -1,0 +1,5 @@
+// run-rustfix
+fn main() {
+    let mut _foo: i32 = 1;
+    let _foo: i32 = 4; //~ ERROR type ascription is experimental
+}

--- a/src/test/ui/type/missing-let-in-binding.rs
+++ b/src/test/ui/type/missing-let-in-binding.rs
@@ -1,0 +1,5 @@
+// run-rustfix
+fn main() {
+    let mut _foo: i32 = 1;
+    _foo: i32 = 4; //~ ERROR type ascription is experimental
+}

--- a/src/test/ui/type/missing-let-in-binding.stderr
+++ b/src/test/ui/type/missing-let-in-binding.stderr
@@ -1,0 +1,16 @@
+error[E0658]: type ascription is experimental
+  --> $DIR/missing-let-in-binding.rs:4:5
+   |
+LL |     _foo: i32 = 4;
+   |     ^^^^^^^^^
+   |
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
+   = help: add `#![feature(type_ascription)]` to the crate attributes to enable
+help: you might have meant to introduce a new binding
+   |
+LL |     let _foo: i32 = 4;
+   |     +++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fix #78907.

Fallout from the type ascription syntax.