### PR TITLE
hir::Generics: convert `has_where_clause_predicates` field into method

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1376,7 +1376,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             self.lifetime_res_to_generic_param(ident, node_id, res)
         }));
 
-        let has_where_clause_predicates = !generics.where_clause.predicates.is_empty();
         let where_clause_span = self.lower_span(generics.where_clause.span);
         let span = self.lower_span(generics.span);
         let res = f(self);
@@ -1390,7 +1389,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let lowered_generics = self.arena.alloc(hir::Generics {
             params: self.arena.alloc_from_iter(params),
             predicates: self.arena.alloc_from_iter(predicates),
-            has_where_clause_predicates,
             where_clause_span,
             span,
         });

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1401,7 +1401,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 generics: self.arena.alloc(hir::Generics {
                     params: lifetime_defs,
                     predicates: &[],
-                    has_where_clause_predicates: false,
                     where_clause_span: lctx.lower_span(span),
                     span: lctx.lower_span(span),
                 }),
@@ -1717,7 +1716,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 generics: this.arena.alloc(hir::Generics {
                     params: generic_params,
                     predicates: &[],
-                    has_where_clause_predicates: false,
                     where_clause_span: this.lower_span(span),
                     span: this.lower_span(span),
                 }),

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -528,20 +528,14 @@ pub struct GenericParamCount {
 pub struct Generics<'hir> {
     pub params: &'hir [GenericParam<'hir>],
     pub predicates: &'hir [WherePredicate<'hir>],
-    pub has_where_clause_predicates: bool,
     pub where_clause_span: Span,
     pub span: Span,
 }
 
 impl<'hir> Generics<'hir> {
     pub const fn empty() -> &'hir Generics<'hir> {
-        const NOPE: Generics<'_> = Generics {
-            params: &[],
-            predicates: &[],
-            has_where_clause_predicates: false,
-            where_clause_span: DUMMY_SP,
-            span: DUMMY_SP,
-        };
+        const NOPE: Generics<'_> =
+            Generics { params: &[], predicates: &[], where_clause_span: DUMMY_SP, span: DUMMY_SP };
         &NOPE
     }
 
@@ -578,7 +572,7 @@ impl<'hir> Generics<'hir> {
     ///  in `fn foo<T>(t: T) where T: Foo,` so we don't suggest two trailing commas.
     pub fn tail_span_for_predicate_suggestion(&self) -> Span {
         let end = self.where_clause_span.shrink_to_hi();
-        if self.has_where_clause_predicates {
+        if self.has_where_clause_predicates() {
             self.predicates
                 .iter()
                 .filter(|p| p.in_where_clause())
@@ -592,7 +586,7 @@ impl<'hir> Generics<'hir> {
     }
 
     pub fn add_where_or_trailing_comma(&self) -> &'static str {
-        if self.has_where_clause_predicates {
+        if self.has_where_clause_predicates() {
             ","
         } else if self.where_clause_span.is_empty() {
             " where"
@@ -688,6 +682,10 @@ impl<'hir> Generics<'hir> {
             //             ^^^^^^^^^
             bounds[bound_pos - 1].span().shrink_to_hi().to(span)
         }
+    }
+
+    pub fn has_where_clause_predicates(&self) -> bool {
+        !self.where_clause_span.is_empty()
     }
 }
 
@@ -3495,7 +3493,7 @@ mod size_asserts {
     rustc_data_structures::static_assert_size!(Expr<'static>, 56);
     rustc_data_structures::static_assert_size!(ForeignItem<'static>, 72);
     rustc_data_structures::static_assert_size!(GenericBound<'_>, 48);
-    rustc_data_structures::static_assert_size!(Generics<'static>, 56);
+    rustc_data_structures::static_assert_size!(Generics<'static>, 48);
     rustc_data_structures::static_assert_size!(ImplItem<'static>, 88);
     rustc_data_structures::static_assert_size!(Impl<'static>, 80);
     rustc_data_structures::static_assert_size!(Item<'static>, 80);

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2244,7 +2244,8 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitOutlivesRequirements {
 
             // If all predicates are inferable, drop the entire clause
             // (including the `where`)
-            if hir_generics.has_where_clause_predicates && dropped_predicate_count == num_predicates
+            if hir_generics.has_where_clause_predicates()
+                && dropped_predicate_count == num_predicates
             {
                 let where_span = hir_generics.where_clause_span;
                 // Extend the where clause back to the closing `>` of the

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -277,7 +277,7 @@ pub fn suggest_constraining_type_params<'a>(
             continue;
         }
 
-        if generics.has_where_clause_predicates {
+        if generics.has_where_clause_predicates() {
             // This part is a bit tricky, because using the `where` clause user can
             // provide zero, one or many bounds for the same type parameter, so we
             // have following cases to consider:

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -393,7 +393,7 @@ fn check_start_fn_ty(tcx: TyCtxt<'_>, start_def_id: DefId) {
                         .emit();
                         error = true;
                     }
-                    if generics.has_where_clause_predicates {
+                    if generics.has_where_clause_predicates() {
                         struct_span_err!(
                             tcx.sess,
                             generics.where_clause_span,


### PR DESCRIPTION
Thus reducing struct size.

Recently changed, so r? @compiler-errors