### PR TITLE
Bump cc version in bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,9 +525,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]


### PR DESCRIPTION
Among other changes, the newer cc release pulls in this fix:
https://github.com/rust-lang/cc-rs/commit/b2792e33ff91b92e2e920e54d582b0c334670c37

This fixes errors when building compiler_builtins for UEFI targets.
