### PR TITLE
Try normalizing types without RevealAll in ParamEnv in MIR validation

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -181,16 +181,28 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         if (src, dest).has_opaque_types() {
             return true;
         }
-        // Normalize projections and things like that.
-        let param_env = self.param_env.with_reveal_all_normalized(self.tcx);
-        let src = self.tcx.normalize_erasing_regions(param_env, src);
-        let dest = self.tcx.normalize_erasing_regions(param_env, dest);
 
-        // Type-changing assignments can happen when subtyping is used. While
-        // all normal lifetimes are erased, higher-ranked types with their
-        // late-bound lifetimes are still around and can lead to type
-        // differences. So we compare ignoring lifetimes.
-        equal_up_to_regions(self.tcx, param_env, src, dest)
+        let try_equal_with_param_env = |param_env| {
+            let src = self.tcx.normalize_erasing_regions(param_env, src);
+            let dest = self.tcx.normalize_erasing_regions(param_env, dest);
+            // Type-changing assignments can happen when subtyping is used. While
+            // all normal lifetimes are erased, higher-ranked types with their
+            // late-bound lifetimes are still around and can lead to type
+            // differences. So we compare ignoring lifetimes.
+            equal_up_to_regions(self.tcx, param_env, src, dest)
+        };
+
+        // Normalize projections and things like that.
+        // First, try with reveal_all. This might not work in some cases, as the predicates
+        // can be cleared in reveal_all mode. We try the reveal first anyways as it is used
+        // by some other passes like inlining as well.
+        let param_env = self.param_env.with_reveal_all_normalized(self.tcx);
+        if try_equal_with_param_env(param_env) {
+            true
+        } else {
+            // If this fails, we can try it without the reveal.
+            try_equal_with_param_env(self.param_env)
+        }
     }
 }
 

--- a/src/test/ui/mir/issue-99866.rs
+++ b/src/test/ui/mir/issue-99866.rs
@@ -1,0 +1,25 @@
+// check-pass
+pub trait Backend {
+    type DescriptorSetLayout;
+}
+
+pub struct Back;
+
+impl Backend for Back {
+    type DescriptorSetLayout = u32;
+}
+
+pub struct HalSetLayouts {
+    vertex_layout: <Back as Backend>::DescriptorSetLayout,
+}
+
+impl HalSetLayouts {
+    pub fn iter<DSL>(self) -> DSL
+    where
+        Back: Backend<DescriptorSetLayout = DSL>,
+    {
+        self.vertex_layout
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Before, the MIR validator used RevealAll in its ParamEnv for type
checking. This could cause false negatives in some cases due to
RevealAll ParamEnvs not always use all predicates as expected here.

Since some MIR passes like inlining use RevealAll as well, keep using
it in the MIR validator too, but when it fails usign RevealAll, also
try the check without it, to stop false negatives.

Fixes #99866

cc @compiler-errors who nicely helped me on zulip