### PR TITLE
fix rustc_llvm spurious rebuilds

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -103,8 +103,10 @@ fn main() {
         println!("cargo:rustc-check-cfg=values(llvm_component,\"{}\")", component);
     }
 
-    if tracked_env_var_os("RUST_CHECK").is_some() {
+    if env::var_os("RUST_CHECK").is_some() {
         // If we're just running `check`, there's no need for LLVM to be built.
+        // We only track the RUST_CHECK var if it exists to prevent spurious rebuilds.
+        println!("cargo:rerun-if-env-changed=RUST_CHECK");
         return;
     }
 


### PR DESCRIPTION
This PR fixes 2 sources of unnecessary rebuilds in `rustc_llvm`'s build script:
1. On Windows, the `LLVM_CONFIG` and `CFG_LLVM_ROOT` env variables tracked by the build script can have different casing between rust-analyzer and the terminal. This is solved by lowercasing the paths before setting the vars.
2. `rustc_llvm`'s build script checks for the `RUST_CHECK` env var to avoid doing any work while just checking. However, it always tracked the var when doing so, causing it to rerun when checking after building. Then, this would cause it to rerun on the next build unnecessarily. This is solved by only tracking `RUST_CHECK` when it is present, causing it to only rebuild when needed.