### PR TITLE
Add feature to disable the panic_impl provided by std

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -68,6 +68,9 @@ system-llvm-libunwind = ["unwind/system-llvm-libunwind"]
 # Make panics and failed asserts immediately abort without formatting any message
 panic_immediate_abort = ["core/panic_immediate_abort"]
 
+# Disables the `panic_impl` lang item
+no_panic_impl = []
+
 # Enable std_detect default features for stdarch/crates/std_detect:
 # https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/Cargo.toml
 std_detect_file_io = ["std_detect/std_detect_file_io"]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -528,7 +528,7 @@ pub fn panicking() -> bool {
 
 /// Entry point of panics from the libcore crate (`panic_impl` lang item).
 #[cfg(not(test))]
-#[panic_handler]
+#[cfg_attr(not(feature = "no_panic_impl"), panic_handler)]
 pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
     struct PanicPayload<'a> {
         inner: &'a fmt::Arguments<'a>,


### PR DESCRIPTION
Currently is only possible to mark a function with #[panic_handler] in no_std environments. This pr adds a feature to disable the `panic_impl` provided by std so that it can be defined in normal programs. Since the feature is not enabled by default it does not affect existing code.

Should fix #59222 and hopefully a small but useful step towards custom panic implementation: #32837

ACP: https://github.com/rust-lang/libs-team/issues/80