### PR TITLE
kmc-solid: Add a stub implementation of #98246 (`File::set_times`)

### DIFF
--- a/library/std/src/sys/solid/fs.rs
+++ b/library/std/src/sys/solid/fs.rs
@@ -77,6 +77,9 @@ pub struct OpenOptions {
     custom_flags: i32,
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+pub struct FileTimes {}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct FilePermissions(c_short);
 
@@ -124,6 +127,11 @@ impl FilePermissions {
             self.0 |= abi::S_IWRITE;
         }
     }
+}
+
+impl FileTimes {
+    pub fn set_accessed(&mut self, _t: SystemTime) {}
+    pub fn set_modified(&mut self, _t: SystemTime) {}
 }
 
 impl FileType {
@@ -450,6 +458,10 @@ impl File {
     }
 
     pub fn set_permissions(&self, _perm: FilePermissions) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn set_times(&self, _times: FileTimes) -> io::Result<()> {
         unsupported()
     }
 }


### PR DESCRIPTION
 Fixes the build failure of the [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) Tier 3 targets after #98246.

This target does not support setting a modification time and access time separately, hence stubbing out the implementation.
