### PR TITLE
Recover `require`, `include` instead of `use` in item

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -271,7 +271,10 @@ impl<'a> Parser<'a> {
             // MACRO_RULES ITEM
             self.parse_item_macro_rules(vis, has_bang)?
         } else if self.isnt_macro_invocation()
-            && (self.token.is_ident_named(sym::import) || self.token.is_ident_named(sym::using))
+            && (self.token.is_ident_named(sym::import)
+                || self.token.is_ident_named(sym::using)
+                || self.token.is_ident_named(sym::include)
+                || self.token.is_ident_named(sym::require))
         {
             return self.recover_import_as_use();
         } else if self.isnt_macro_invocation() && vis.kind.is_pub() {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1170,6 +1170,7 @@ symbols! {
         repr_packed,
         repr_simd,
         repr_transparent,
+        require,
         residual,
         result,
         rhs,

--- a/src/test/ui/did_you_mean/use_instead_of_import.fixed
+++ b/src/test/ui/did_you_mean/use_instead_of_import.fixed
@@ -6,10 +6,18 @@ use std::{
     rc::Rc,
 };
 
+use std::time::Duration;
+//~^ ERROR expected item, found `require`
+
+use std::time::Instant;
+//~^ ERROR expected item, found `include`
+
 pub use std::io;
 //~^ ERROR expected item, found `using`
 
 fn main() {
     let x = Rc::new(1);
     let _ = write!(io::stdout(), "{:?}", x);
+    let _ = Duration::new(5, 0);
+    let _ = Instant::now();
 }

--- a/src/test/ui/did_you_mean/use_instead_of_import.rs
+++ b/src/test/ui/did_you_mean/use_instead_of_import.rs
@@ -6,10 +6,18 @@ import std::{
     rc::Rc,
 };
 
+require std::time::Duration;
+//~^ ERROR expected item, found `require`
+
+include std::time::Instant;
+//~^ ERROR expected item, found `include`
+
 pub using std::io;
 //~^ ERROR expected item, found `using`
 
 fn main() {
     let x = Rc::new(1);
     let _ = write!(io::stdout(), "{:?}", x);
+    let _ = Duration::new(5, 0);
+    let _ = Instant::now();
 }

--- a/src/test/ui/did_you_mean/use_instead_of_import.stderr
+++ b/src/test/ui/did_you_mean/use_instead_of_import.stderr
@@ -4,11 +4,23 @@ error: expected item, found `import`
 LL | import std::{
    | ^^^^^^ help: items are imported using the `use` keyword
 
+error: expected item, found `require`
+  --> $DIR/use_instead_of_import.rs:9:1
+   |
+LL | require std::time::Duration;
+   | ^^^^^^^ help: items are imported using the `use` keyword
+
+error: expected item, found `include`
+  --> $DIR/use_instead_of_import.rs:12:1
+   |
+LL | include std::time::Instant;
+   | ^^^^^^^ help: items are imported using the `use` keyword
+
 error: expected item, found `using`
-  --> $DIR/use_instead_of_import.rs:9:5
+  --> $DIR/use_instead_of_import.rs:15:5
    |
 LL | pub using std::io;
    |     ^^^^^ help: items are imported using the `use` keyword
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fix #100140