### PR TITLE
internal iteration for `&mut I`

### DIFF
--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -254,6 +254,7 @@ mod impls {
     where
         F: Fn<A>,
     {
+        #[inline]
         extern "rust-call" fn call(&self, args: A) -> F::Output {
             (**self).call(args)
         }
@@ -264,6 +265,7 @@ mod impls {
     where
         F: Fn<A>,
     {
+        #[inline]
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (**self).call(args)
         }
@@ -276,6 +278,7 @@ mod impls {
     {
         type Output = F::Output;
 
+        #[inline]
         extern "rust-call" fn call_once(self, args: A) -> F::Output {
             (*self).call(args)
         }
@@ -286,6 +289,7 @@ mod impls {
     where
         F: FnMut<A>,
     {
+        #[inline]
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (*self).call_mut(args)
         }
@@ -297,6 +301,7 @@ mod impls {
         F: FnMut<A>,
     {
         type Output = F::Output;
+        #[inline]
         extern "rust-call" fn call_once(self, args: A) -> F::Output {
             (*self).call_mut(args)
         }

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -254,7 +254,6 @@ mod impls {
     where
         F: Fn<A>,
     {
-        #[inline]
         extern "rust-call" fn call(&self, args: A) -> F::Output {
             (**self).call(args)
         }
@@ -265,7 +264,6 @@ mod impls {
     where
         F: Fn<A>,
     {
-        #[inline]
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (**self).call(args)
         }
@@ -278,7 +276,6 @@ mod impls {
     {
         type Output = F::Output;
 
-        #[inline]
         extern "rust-call" fn call_once(self, args: A) -> F::Output {
             (*self).call(args)
         }
@@ -289,7 +286,6 @@ mod impls {
     where
         F: FnMut<A>,
     {
-        #[inline]
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (*self).call_mut(args)
         }
@@ -301,7 +297,6 @@ mod impls {
         F: FnMut<A>,
     {
         type Output = F::Output;
-        #[inline]
         extern "rust-call" fn call_once(self, args: A) -> F::Output {
             (*self).call_mut(args)
         }


### PR DESCRIPTION
this pr implements internal iteration for `&mut I` when `I: Sized`. it additionally inlines some wrapper functions that were not previously inline, which seems to speed things up by a fair amount in some cases.

this lead to up to 3x performance gains across the board for `iter::` benches, with only a minor regression for `iter::bench_filter_sum`