### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1761,13 +1761,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             .filter_map(|seg| seg.args.as_ref())
                             .flat_map(|a| a.args.iter())
                         {
-                            if let hir::GenericArg::Type(hir_ty) = &arg {
-                                let ty = self.resolve_vars_if_possible(
-                                    self.typeck_results.borrow().node_type(hir_ty.hir_id),
-                                );
-                                if ty == predicate.self_ty() {
-                                    error.obligation.cause.span = hir_ty.span;
-                                }
+                            if let hir::GenericArg::Type(hir_ty) = &arg
+                                && let Some(ty) =
+                                    self.typeck_results.borrow().node_type_opt(hir_ty.hir_id)
+                                && self.resolve_vars_if_possible(ty) == predicate.self_ty()
+                            {
+                                error.obligation.cause.span = hir_ty.span;
+                                break;
                             }
                         }
                     }

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -617,7 +617,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // If there are multiple arms, make sure they all agree on
         // what the type of the binding `x` ought to be.
         if var_id != pat.hir_id {
-            self.check_binding_alt_eq_ty(pat.span, var_id, local_ty, ti);
+            self.check_binding_alt_eq_ty(ba, pat.span, var_id, local_ty, ti);
         }
 
         if let Some(p) = sub {
@@ -627,7 +627,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         local_ty
     }
 
-    fn check_binding_alt_eq_ty(&self, span: Span, var_id: HirId, ty: Ty<'tcx>, ti: TopInfo<'tcx>) {
+    fn check_binding_alt_eq_ty(
+        &self,
+        ba: hir::BindingAnnotation,
+        span: Span,
+        var_id: HirId,
+        ty: Ty<'tcx>,
+        ti: TopInfo<'tcx>,
+    ) {
         let var_ty = self.local_ty(span, var_id).decl_ty;
         if let Some(mut err) = self.demand_eqtype_pat_diag(span, var_ty, ty, ti) {
             let hir = self.tcx.hir();
@@ -645,9 +652,47 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             });
             let pre = if in_match { "in the same arm, " } else { "" };
             err.note(&format!("{}a binding must have the same type in all alternatives", pre));
-            // FIXME: check if `var_ty` and `ty` can be made the same type by adding or removing
-            // `ref` or `&` to the pattern.
+            self.suggest_adding_missing_ref_or_removing_ref(
+                &mut err,
+                span,
+                var_ty,
+                self.resolve_vars_with_obligations(ty),
+                ba,
+            );
             err.emit();
+        }
+    }
+
+    fn suggest_adding_missing_ref_or_removing_ref(
+        &self,
+        err: &mut Diagnostic,
+        span: Span,
+        expected: Ty<'tcx>,
+        actual: Ty<'tcx>,
+        ba: hir::BindingAnnotation,
+    ) {
+        match (expected.kind(), actual.kind(), ba) {
+            (ty::Ref(_, inner_ty, _), _, hir::BindingAnnotation::Unannotated)
+                if self.can_eq(self.param_env, *inner_ty, actual).is_ok() =>
+            {
+                err.span_suggestion_verbose(
+                    span.shrink_to_lo(),
+                    "consider adding `ref`",
+                    "ref ",
+                    Applicability::MaybeIncorrect,
+                );
+            }
+            (_, ty::Ref(_, inner_ty, _), hir::BindingAnnotation::Ref)
+                if self.can_eq(self.param_env, expected, *inner_ty).is_ok() =>
+            {
+                err.span_suggestion_verbose(
+                    span.with_hi(span.lo() + BytePos(4)),
+                    "consider removing `ref`",
+                    "",
+                    Applicability::MaybeIncorrect,
+                );
+            }
+            _ => (),
         }
     }
 

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -801,6 +801,9 @@ fn infer_placeholder_type<'a>(
     match tcx.sess.diagnostic().steal_diagnostic(span, StashKey::ItemNoType) {
         Some(mut err) => {
             if !ty.references_error() {
+                // Only suggest adding `:` if it was missing (and suggested by parsing diagnostic)
+                let colon = if span == item_ident.span.shrink_to_hi() { ":" } else { "" };
+
                 // The parser provided a sub-optimal `HasPlaceholders` suggestion for the type.
                 // We are typeck and have the real type, so remove that and suggest the actual type.
                 // FIXME(eddyb) this looks like it should be functionality on `Diagnostic`.
@@ -816,7 +819,7 @@ fn infer_placeholder_type<'a>(
                     err.span_suggestion(
                         span,
                         &format!("provide a type for the {item}", item = kind),
-                        format!("{}: {}", item_ident, sugg_ty),
+                        format!("{colon} {sugg_ty}"),
                         Applicability::MachineApplicable,
                     );
                 } else {

--- a/library/std/src/sys/solid/fs.rs
+++ b/library/std/src/sys/solid/fs.rs
@@ -77,6 +77,9 @@ pub struct OpenOptions {
     custom_flags: i32,
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+pub struct FileTimes {}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct FilePermissions(c_short);
 
@@ -124,6 +127,11 @@ impl FilePermissions {
             self.0 |= abi::S_IWRITE;
         }
     }
+}
+
+impl FileTimes {
+    pub fn set_accessed(&mut self, _t: SystemTime) {}
+    pub fn set_modified(&mut self, _t: SystemTime) {}
 }
 
 impl FileType {
@@ -450,6 +458,10 @@ impl File {
     }
 
     pub fn set_permissions(&self, _perm: FilePermissions) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn set_times(&self, _times: FileTimes) -> io::Result<()> {
         unsupported()
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1640,9 +1640,9 @@ pub(crate) fn clean_middle_ty<'tcx>(
                 bounds.push(bound);
             }
 
-            let mut bindings = vec![];
-            for pb in obj.projection_bounds() {
-                bindings.push(TypeBinding {
+            let bindings = obj
+                .projection_bounds()
+                .map(|pb| TypeBinding {
                     assoc: projection_to_path_segment(
                         pb.skip_binder()
                             .lift_to_tcx(cx.tcx)
@@ -1656,8 +1656,8 @@ pub(crate) fn clean_middle_ty<'tcx>(
                     kind: TypeBindingKind::Equality {
                         term: clean_middle_term(pb.skip_binder().term, cx),
                     },
-                });
-            }
+                })
+                .collect();
 
             let path = external_path(cx, did, false, bindings, substs);
             bounds.insert(0, PolyTrait { trait_: path, generic_params: Vec::new() });

--- a/src/test/ui/argument-suggestions/issue-100154.rs
+++ b/src/test/ui/argument-suggestions/issue-100154.rs
@@ -1,0 +1,7 @@
+fn foo(i: impl std::fmt::Display) {}
+
+fn main() {
+    foo::<()>(());
+    //~^ ERROR this function takes 0 generic arguments but 1 generic argument was supplied
+    //~| ERROR `()` doesn't implement `std::fmt::Display`
+}

--- a/src/test/ui/argument-suggestions/issue-100154.stderr
+++ b/src/test/ui/argument-suggestions/issue-100154.stderr
@@ -1,0 +1,35 @@
+error[E0107]: this function takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-100154.rs:4:5
+   |
+LL |     foo::<()>(());
+   |     ^^^------ help: remove these generics
+   |     |
+   |     expected 0 generic arguments
+   |
+note: function defined here, with 0 generic parameters
+  --> $DIR/issue-100154.rs:1:4
+   |
+LL | fn foo(i: impl std::fmt::Display) {}
+   |    ^^^
+   = note: `impl Trait` cannot be explicitly specified as a generic argument
+
+error[E0277]: `()` doesn't implement `std::fmt::Display`
+  --> $DIR/issue-100154.rs:4:15
+   |
+LL |     foo::<()>(());
+   |     --------- ^^ `()` cannot be formatted with the default formatter
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `()`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `foo`
+  --> $DIR/issue-100154.rs:1:16
+   |
+LL | fn foo(i: impl std::fmt::Display) {}
+   |                ^^^^^^^^^^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0277.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/attributes/issue-90873.stderr
+++ b/src/test/ui/attributes/issue-90873.stderr
@@ -34,10 +34,10 @@ LL | #![a={impl std::ops::Neg for i8 {}}]
    |                                     ^ consider adding a `main` function to `$DIR/issue-90873.rs`
 
 error: missing type for `static` item
-  --> $DIR/issue-90873.rs:1:16
+  --> $DIR/issue-90873.rs:1:17
    |
 LL | #![u=||{static d=||1;}]
-   |                ^ help: provide a type for the item: `d: <type>`
+   |                 ^ help: provide a type for the item: `: <type>`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
@@ -17,10 +17,10 @@ LL | | }
    = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: missing type for `const` item
-  --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
+  --> $DIR/issue-69396-const-no-type-in-macro.rs:4:20
    |
 LL |               const A = "A".$fn();
-   |                     ^ help: provide a type for the constant: `A: usize`
+   |                      ^ help: provide a type for the constant: `: usize`
 ...
 LL | / suite! {
 LL | |     len;
@@ -31,13 +31,13 @@ LL | | }
    = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
+  --> $DIR/issue-69396-const-no-type-in-macro.rs:4:20
    |
 LL |               const A = "A".$fn();
-   |                     ^
-   |                     |
-   |                     not allowed in type signatures
-   |                     help: replace with the correct type: `bool`
+   |                      ^
+   |                      |
+   |                      not allowed in type signatures
+   |                      help: replace with the correct type: `bool`
 ...
 LL | / suite! {
 LL | |     len;

--- a/src/test/ui/mismatched_types/E0409.stderr
+++ b/src/test/ui/mismatched_types/E0409.stderr
@@ -17,6 +17,10 @@ LL |         (0, ref y) | (y, 0) => {}
    |             first introduced with type `&{integer}` here
    |
    = note: in the same arm, a binding must have the same type in all alternatives
+help: consider adding `ref`
+   |
+LL |         (0, ref y) | (ref y, 0) => {}
+   |                       +++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.fixed
+++ b/src/test/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.fixed
@@ -1,0 +1,21 @@
+// run-rustfix
+#![allow(dead_code, unused_variables)]
+
+fn main() {
+    enum Blah {
+        A(isize, isize, usize),
+        B(isize, usize),
+    }
+
+    match Blah::A(1, 1, 2) {
+        Blah::A(_, x, ref y) | Blah::B(x, ref y) => {}
+        //~^ ERROR mismatched types
+        //~| ERROR variable `y` is bound inconsistently across alternatives separated by `|`
+    }
+
+    match Blah::A(1, 1, 2) {
+        Blah::A(_, x, y) | Blah::B(x, y) => {}
+        //~^ ERROR mismatched types
+        //~| variable `y` is bound inconsistently across alternatives separated by `|`
+    }
+}

--- a/src/test/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.rs
+++ b/src/test/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.rs
@@ -1,0 +1,21 @@
+// run-rustfix
+#![allow(dead_code, unused_variables)]
+
+fn main() {
+    enum Blah {
+        A(isize, isize, usize),
+        B(isize, usize),
+    }
+
+    match Blah::A(1, 1, 2) {
+        Blah::A(_, x, ref y) | Blah::B(x, y) => {}
+        //~^ ERROR mismatched types
+        //~| ERROR variable `y` is bound inconsistently across alternatives separated by `|`
+    }
+
+    match Blah::A(1, 1, 2) {
+        Blah::A(_, x, y) | Blah::B(x, ref y) => {}
+        //~^ ERROR mismatched types
+        //~| variable `y` is bound inconsistently across alternatives separated by `|`
+    }
+}

--- a/src/test/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.stderr
+++ b/src/test/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.stderr
@@ -1,0 +1,49 @@
+error[E0409]: variable `y` is bound inconsistently across alternatives separated by `|`
+  --> $DIR/suggest-adding-or-removing-ref-for-binding-pattern.rs:11:43
+   |
+LL |         Blah::A(_, x, ref y) | Blah::B(x, y) => {}
+   |                           - first binding ^ bound in different ways
+
+error[E0409]: variable `y` is bound inconsistently across alternatives separated by `|`
+  --> $DIR/suggest-adding-or-removing-ref-for-binding-pattern.rs:17:43
+   |
+LL |         Blah::A(_, x, y) | Blah::B(x, ref y) => {}
+   |                       - first binding     ^ bound in different ways
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-adding-or-removing-ref-for-binding-pattern.rs:11:43
+   |
+LL |     match Blah::A(1, 1, 2) {
+   |           ---------------- this expression has type `Blah`
+LL |         Blah::A(_, x, ref y) | Blah::B(x, y) => {}
+   |                       -----               ^ expected `&usize`, found `usize`
+   |                       |
+   |                       first introduced with type `&usize` here
+   |
+   = note: in the same arm, a binding must have the same type in all alternatives
+help: consider adding `ref`
+   |
+LL |         Blah::A(_, x, ref y) | Blah::B(x, ref y) => {}
+   |                                           +++
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-adding-or-removing-ref-for-binding-pattern.rs:17:39
+   |
+LL |     match Blah::A(1, 1, 2) {
+   |           ---------------- this expression has type `Blah`
+LL |         Blah::A(_, x, y) | Blah::B(x, ref y) => {}
+   |                       -               ^^^^^ expected `usize`, found `&usize`
+   |                       |
+   |                       first introduced with type `usize` here
+   |
+   = note: in the same arm, a binding must have the same type in all alternatives
+help: consider removing `ref`
+   |
+LL -         Blah::A(_, x, y) | Blah::B(x, ref y) => {}
+LL +         Blah::A(_, x, y) | Blah::B(x, y) => {}
+   |
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0409.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/issues/issue-89574.stderr
+++ b/src/test/ui/parser/issues/issue-89574.stderr
@@ -1,8 +1,8 @@
 error: missing type for `const` item
-  --> $DIR/issue-89574.rs:2:11
+  --> $DIR/issue-89574.rs:2:22
    |
 LL |     const EMPTY_ARRAY = [];
-   |           ^^^^^^^^^^^ help: provide a type for the item: `EMPTY_ARRAY: <type>`
+   |                      ^ help: provide a type for the item: `: <type>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/item-free-const-no-body-semantic-fail.stderr
+++ b/src/test/ui/parser/item-free-const-no-body-semantic-fail.stderr
@@ -15,10 +15,10 @@ LL | const B;
    |        help: provide a definition for the constant: `= <expr>;`
 
 error: missing type for `const` item
-  --> $DIR/item-free-const-no-body-semantic-fail.rs:6:7
+  --> $DIR/item-free-const-no-body-semantic-fail.rs:6:8
    |
 LL | const B;
-   |       ^ help: provide a type for the item: `B: <type>`
+   |        ^ help: provide a type for the item: `: <type>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/item-free-static-no-body-semantic-fail.stderr
+++ b/src/test/ui/parser/item-free-static-no-body-semantic-fail.stderr
@@ -31,16 +31,16 @@ LL | static mut D;
    |             help: provide a definition for the static: `= <expr>;`
 
 error: missing type for `static` item
-  --> $DIR/item-free-static-no-body-semantic-fail.rs:6:8
+  --> $DIR/item-free-static-no-body-semantic-fail.rs:6:9
    |
 LL | static B;
-   |        ^ help: provide a type for the item: `B: <type>`
+   |         ^ help: provide a type for the item: `: <type>`
 
 error: missing type for `static mut` item
-  --> $DIR/item-free-static-no-body-semantic-fail.rs:10:12
+  --> $DIR/item-free-static-no-body-semantic-fail.rs:10:13
    |
 LL | static mut D;
-   |            ^ help: provide a type for the item: `D: <type>`
+   |             ^ help: provide a type for the item: `: <type>`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/parser/removed-syntax-static-fn.stderr
+++ b/src/test/ui/parser/removed-syntax-static-fn.stderr
@@ -16,10 +16,10 @@ LL | }
    | - the item list ends here
 
 error: missing type for `static` item
-  --> $DIR/removed-syntax-static-fn.rs:4:12
+  --> $DIR/removed-syntax-static-fn.rs:4:14
    |
 LL |     static fn f() {}
-   |            ^^ help: provide a type for the item: `r#fn: <type>`
+   |              ^ help: provide a type for the item: `: <type>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/resolve-inconsistent-binding-mode.stderr
+++ b/src/test/ui/resolve/resolve-inconsistent-binding-mode.stderr
@@ -31,6 +31,10 @@ LL |         Opts::A(ref i) | Opts::B(i) => {}
    |                 first introduced with type `&isize` here
    |
    = note: in the same arm, a binding must have the same type in all alternatives
+help: consider adding `ref`
+   |
+LL |         Opts::A(ref i) | Opts::B(ref i) => {}
+   |                                  +++
 
 error[E0308]: mismatched types
   --> $DIR/resolve-inconsistent-binding-mode.rs:18:34
@@ -43,6 +47,10 @@ LL |         Opts::A(ref i) | Opts::B(i) => {}
    |                 first introduced with type `&isize` here
    |
    = note: in the same arm, a binding must have the same type in all alternatives
+help: consider adding `ref`
+   |
+LL |         Opts::A(ref i) | Opts::B(ref i) => {}
+   |                                  +++
 
 error[E0308]: mismatched types
   --> $DIR/resolve-inconsistent-binding-mode.rs:27:38

--- a/src/test/ui/resolve/resolve-inconsistent-names.rs
+++ b/src/test/ui/resolve/resolve-inconsistent-names.rs
@@ -23,6 +23,7 @@ fn main() {
         //~| ERROR mismatched types
         //~| ERROR variable `c` is not bound in all patterns
         //~| HELP if you meant to match on unit variant `E::A`, use the full path in the pattern
+        //~| HELP consider removing `ref`
     }
 
     let z = (10, 20);

--- a/src/test/ui/resolve/resolve-inconsistent-names.stderr
+++ b/src/test/ui/resolve/resolve-inconsistent-names.stderr
@@ -55,7 +55,7 @@ LL |         (A, B) | (ref B, c) | (c, A) => ()
    |             first binding
 
 error[E0408]: variable `CONST1` is not bound in all patterns
-  --> $DIR/resolve-inconsistent-names.rs:30:23
+  --> $DIR/resolve-inconsistent-names.rs:31:23
    |
 LL |         (CONST1, _) | (_, Const2) => ()
    |          ------       ^^^^^^^^^^^ pattern doesn't bind `CONST1`
@@ -69,7 +69,7 @@ LL |     const CONST1: usize = 10;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ not accessible
 
 error[E0408]: variable `Const2` is not bound in all patterns
-  --> $DIR/resolve-inconsistent-names.rs:30:9
+  --> $DIR/resolve-inconsistent-names.rs:31:9
    |
 LL |         (CONST1, _) | (_, Const2) => ()
    |         ^^^^^^^^^^^       ------ variable not in all patterns
@@ -92,6 +92,11 @@ LL |         (A, B) | (ref B, c) | (c, A) => ()
    |             first introduced with type `E` here
    |
    = note: in the same arm, a binding must have the same type in all alternatives
+help: consider removing `ref`
+   |
+LL -         (A, B) | (ref B, c) | (c, A) => ()
+LL +         (A, B) | (B, c) | (c, A) => ()
+   |
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/suggestions/const-no-type.rs
+++ b/src/test/ui/suggestions/const-no-type.rs
@@ -14,38 +14,38 @@ fn main() {}
 const C2 = 42;
 //~^ ERROR missing type for `const` item
 //~| HELP provide a type for the item
-//~| SUGGESTION C2: <type>
+//~| SUGGESTION : <type>
 
 #[cfg(FALSE)]
 static S2 = "abc";
 //~^ ERROR missing type for `static` item
 //~| HELP provide a type for the item
-//~| SUGGESTION S2: <type>
+//~| SUGGESTION : <type>
 
 #[cfg(FALSE)]
 static mut SM2 = "abc";
 //~^ ERROR missing type for `static mut` item
 //~| HELP provide a type for the item
-//~| SUGGESTION SM2: <type>
+//~| SUGGESTION : <type>
 
 // These will, so the diagnostics should be stolen by typeck:
 
 const C = 42;
 //~^ ERROR missing type for `const` item
 //~| HELP provide a type for the constant
-//~| SUGGESTION C: i32
+//~| SUGGESTION : i32
 
 const D = &&42;
 //~^ ERROR missing type for `const` item
 //~| HELP provide a type for the constant
-//~| SUGGESTION D: &&i32
+//~| SUGGESTION : &&i32
 
 static S = Vec::<String>::new();
 //~^ ERROR missing type for `static` item
 //~| HELP provide a type for the static variable
-//~| SUGGESTION S: Vec<String>
+//~| SUGGESTION : Vec<String>
 
 static mut SM = "abc";
 //~^ ERROR missing type for `static mut` item
 //~| HELP provide a type for the static variable
-//~| SUGGESTION &str
+//~| SUGGESTION : &str

--- a/src/test/ui/suggestions/const-no-type.stderr
+++ b/src/test/ui/suggestions/const-no-type.stderr
@@ -1,44 +1,44 @@
 error: missing type for `const` item
-  --> $DIR/const-no-type.rs:33:7
+  --> $DIR/const-no-type.rs:33:8
    |
 LL | const C = 42;
-   |       ^ help: provide a type for the constant: `C: i32`
+   |        ^ help: provide a type for the constant: `: i32`
 
 error: missing type for `const` item
-  --> $DIR/const-no-type.rs:38:7
+  --> $DIR/const-no-type.rs:38:8
    |
 LL | const D = &&42;
-   |       ^ help: provide a type for the constant: `D: &&i32`
+   |        ^ help: provide a type for the constant: `: &&i32`
 
 error: missing type for `static` item
-  --> $DIR/const-no-type.rs:43:8
+  --> $DIR/const-no-type.rs:43:9
    |
 LL | static S = Vec::<String>::new();
-   |        ^ help: provide a type for the static variable: `S: Vec<String>`
+   |         ^ help: provide a type for the static variable: `: Vec<String>`
 
 error: missing type for `static mut` item
-  --> $DIR/const-no-type.rs:48:12
+  --> $DIR/const-no-type.rs:48:14
    |
 LL | static mut SM = "abc";
-   |            ^^ help: provide a type for the static variable: `SM: &str`
+   |              ^ help: provide a type for the static variable: `: &str`
 
 error: missing type for `const` item
-  --> $DIR/const-no-type.rs:14:7
+  --> $DIR/const-no-type.rs:14:9
    |
 LL | const C2 = 42;
-   |       ^^ help: provide a type for the item: `C2: <type>`
+   |         ^ help: provide a type for the item: `: <type>`
 
 error: missing type for `static` item
-  --> $DIR/const-no-type.rs:20:8
+  --> $DIR/const-no-type.rs:20:10
    |
 LL | static S2 = "abc";
-   |        ^^ help: provide a type for the item: `S2: <type>`
+   |          ^ help: provide a type for the item: `: <type>`
 
 error: missing type for `static mut` item
-  --> $DIR/const-no-type.rs:26:12
+  --> $DIR/const-no-type.rs:26:15
    |
 LL | static mut SM2 = "abc";
-   |            ^^^ help: provide a type for the item: `SM2: <type>`
+   |               ^ help: provide a type for the item: `: <type>`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/suggestions/unnamable-types.stderr
+++ b/src/test/ui/suggestions/unnamable-types.stderr
@@ -1,8 +1,8 @@
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:6:7
+  --> $DIR/unnamable-types.rs:6:8
    |
 LL | const A = 5;
-   |       ^ help: provide a type for the constant: `A: i32`
+   |        ^ help: provide a type for the constant: `: i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/unnamable-types.rs:10:11
@@ -26,10 +26,10 @@ LL | const C: _ = || 42;
    |              ^^^^^
 
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:23:7
+  --> $DIR/unnamable-types.rs:23:8
    |
 LL | const D = S { t: { let i = 0; move || -> i32 { i } } };
-   |       ^
+   |        ^
    |
 note: however, the inferred type `S<[closure@$DIR/unnamable-types.rs:23:31: 23:45]>` cannot be named
   --> $DIR/unnamable-types.rs:23:11
@@ -38,22 +38,22 @@ LL | const D = S { t: { let i = 0; move || -> i32 { i } } };
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:29:7
+  --> $DIR/unnamable-types.rs:29:8
    |
 LL | const E = foo;
-   |       ^ help: provide a type for the constant: `E: fn() -> i32`
+   |        ^ help: provide a type for the constant: `: fn() -> i32`
 
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:32:7
+  --> $DIR/unnamable-types.rs:32:8
    |
 LL | const F = S { t: foo };
-   |       ^ help: provide a type for the constant: `F: S<fn() -> i32>`
+   |        ^ help: provide a type for the constant: `: S<fn() -> i32>`
 
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:37:7
+  --> $DIR/unnamable-types.rs:37:8
    |
 LL | const G = || -> i32 { yield 0; return 1; };
-   |       ^
+   |        ^
    |
 note: however, the inferred type `[generator@$DIR/unnamable-types.rs:37:11: 37:20]` cannot be named
   --> $DIR/unnamable-types.rs:37:11

--- a/src/test/ui/transmutability/references.stderr
+++ b/src/test/ui/transmutability/references.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
-  --> $DIR/references.rs:19:52
+  --> $DIR/references.rs:19:37
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static Unit>();
-   |                                                    ^^^^^^^^^^^^^ `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
+   |                                     ^^^^^^^^^^^^^ `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
    |
    = help: the trait `BikeshedIntrinsicFrom<&'static Unit, assert::Context, true, true, true, true>` is not implemented for `&'static Unit`
 note: required by a bound in `is_maybe_transmutable`

--- a/src/test/ui/typeck/issue-100164.fixed
+++ b/src/test/ui/typeck/issue-100164.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+const _A: i32 = 123;
+//~^ ERROR: missing type for `const` item
+
+fn main() {
+    const _B: i32 = 123;
+    //~^ ERROR: missing type for `const` item
+}

--- a/src/test/ui/typeck/issue-100164.rs
+++ b/src/test/ui/typeck/issue-100164.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+
+const _A: = 123;
+//~^ ERROR: missing type for `const` item
+
+fn main() {
+    const _B: = 123;
+    //~^ ERROR: missing type for `const` item
+}

--- a/src/test/ui/typeck/issue-100164.stderr
+++ b/src/test/ui/typeck/issue-100164.stderr
@@ -1,0 +1,14 @@
+error: missing type for `const` item
+  --> $DIR/issue-100164.rs:3:10
+   |
+LL | const _A: = 123;
+   |          ^ help: provide a type for the constant: `i32`
+
+error: missing type for `const` item
+  --> $DIR/issue-100164.rs:7:14
+   |
+LL |     const _B: = 123;
+   |              ^ help: provide a type for the constant: `i32`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/typeck/issue-79040.stderr
+++ b/src/test/ui/typeck/issue-79040.stderr
@@ -7,10 +7,10 @@ LL |     const FOO = "hello" + 1;
    |                 &str
 
 error: missing type for `const` item
-  --> $DIR/issue-79040.rs:2:11
+  --> $DIR/issue-79040.rs:2:14
    |
 LL |     const FOO = "hello" + 1;
-   |           ^^^ help: provide a type for the item: `FOO: <type>`
+   |              ^ help: provide a type for the item: `: <type>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -189,10 +189,10 @@ LL ~     b: (T, T),
    |
 
 error: missing type for `static` item
-  --> $DIR/typeck_type_placeholder_item.rs:73:12
+  --> $DIR/typeck_type_placeholder_item.rs:73:13
    |
 LL |     static A = 42;
-   |            ^ help: provide a type for the static variable: `A: i32`
+   |             ^ help: provide a type for the static variable: `: i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:75:15


### PR DESCRIPTION
Successful merges:

 - #99835 (Suggest adding/removing `ref` for binding patterns)
 - #100155 (Use `node_type_opt` to skip over generics that were not expected)
 - #100157 (rustdoc: use `collect()` instead of repeatedly pushing)
 - #100158 (kmc-solid: Add a stub implementation of #98246 (`File::set_times`))
 - #100166 (Remove more Clean trait implementations)
 - #100168 (Improve diagnostics for `const a: = expr;`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99835,100155,100157,100158,100166,100168)
<!-- homu-ignore:end -->