### PR TITLE
env::temp_dir returns /private/tmp on Apple instead while /tmp is

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -586,6 +586,9 @@ pub fn temp_dir() -> PathBuf {
     crate::env::var_os("TMPDIR").map(PathBuf::from).unwrap_or_else(|| {
         if cfg!(target_os = "android") {
             PathBuf::from("/data/local/tmp")
+        } else if cfg!(target_vendor = "apple") {
+            // on Apple devices, /tmp is a symlink
+            PathBuf::from("/private/tmp")
         } else {
             PathBuf::from("/tmp")
         }


### PR DESCRIPTION
a symlink in fact.

ref #99608