### PR TITLE
provide correct size hint for unsupported platform `CommandArgs`

### DIFF
--- a/library/std/src/sys/unsupported/process.rs
+++ b/library/std/src/sys/unsupported/process.rs
@@ -200,6 +200,9 @@ impl<'a> Iterator for CommandArgs<'a> {
     fn next(&mut self) -> Option<&'a OsStr> {
         None
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
 }
 
 impl<'a> ExactSizeIterator for CommandArgs<'a> {}


### PR DESCRIPTION
Split from https://github.com/rust-lang/rust/pull/99880#discussion_r932994172