### PR TITLE
proc_macro/bridge: send diagnostics over the bridge as a struct

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -6,7 +6,7 @@ use rustc_ast::tokenstream::{self, Spacing::*, TokenStream};
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{Diagnostic, MultiSpan, PResult};
+use rustc_errors::{MultiSpan, PResult};
 use rustc_parse::lexer::nfc_normalize;
 use rustc_parse::parse_stream_from_source_str;
 use rustc_session::parse::ParseSess;
@@ -15,7 +15,7 @@ use rustc_span::symbol::{self, sym, Symbol};
 use rustc_span::{BytePos, FileName, Pos, SourceFile, Span};
 
 use pm::bridge::{
-    server, DelimSpan, ExpnGlobals, Group, Ident, LitKind, Literal, Punct, TokenTree,
+    server, DelimSpan, Diagnostic, ExpnGlobals, Group, Ident, LitKind, Literal, Punct, TokenTree,
 };
 use pm::{Delimiter, Level, LineColumn};
 use std::ops::Bound;
@@ -368,8 +368,6 @@ impl server::Types for Rustc<'_, '_> {
     type FreeFunctions = FreeFunctions;
     type TokenStream = TokenStream;
     type SourceFile = Lrc<SourceFile>;
-    type MultiSpan = Vec<Span>;
-    type Diagnostic = Diagnostic;
     type Span = Span;
     type Symbol = Symbol;
 }
@@ -435,6 +433,21 @@ impl server::FreeFunctions for Rustc<'_, '_> {
             suffix,
             span: self.call_site,
         })
+    }
+
+    fn emit_diagnostic(&mut self, diagnostic: Diagnostic<Self::Span>) {
+        let mut diag =
+            rustc_errors::Diagnostic::new(diagnostic.level.to_internal(), diagnostic.message);
+        diag.set_span(MultiSpan::from_spans(diagnostic.spans));
+        for child in diagnostic.children {
+            diag.sub(
+                child.level.to_internal(),
+                child.message,
+                MultiSpan::from_spans(child.spans),
+                None,
+            );
+        }
+        self.sess().span_diagnostic.emit_diagnostic(&mut diag);
     }
 }
 
@@ -574,38 +587,6 @@ impl server::SourceFile for Rustc<'_, '_> {
 
     fn is_real(&mut self, file: &Self::SourceFile) -> bool {
         file.is_real_file()
-    }
-}
-
-impl server::MultiSpan for Rustc<'_, '_> {
-    fn new(&mut self) -> Self::MultiSpan {
-        vec![]
-    }
-
-    fn push(&mut self, spans: &mut Self::MultiSpan, span: Self::Span) {
-        spans.push(span)
-    }
-}
-
-impl server::Diagnostic for Rustc<'_, '_> {
-    fn new(&mut self, level: Level, msg: &str, spans: Self::MultiSpan) -> Self::Diagnostic {
-        let mut diag = Diagnostic::new(level.to_internal(), msg);
-        diag.set_span(MultiSpan::from_spans(spans));
-        diag
-    }
-
-    fn sub(
-        &mut self,
-        diag: &mut Self::Diagnostic,
-        level: Level,
-        msg: &str,
-        spans: Self::MultiSpan,
-    ) {
-        diag.sub(level.to_internal(), msg, MultiSpan::from_spans(spans), None);
-    }
-
-    fn emit(&mut self, mut diag: Self::Diagnostic) {
-        self.sess().span_diagnostic.emit_diagnostic(&mut diag);
     }
 }
 

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -176,8 +176,6 @@ define_handles! {
     FreeFunctions,
     TokenStream,
     SourceFile,
-    MultiSpan,
-    Diagnostic,
 
     'interned:
     Span,

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -57,6 +57,7 @@ macro_rules! with_api {
                 fn track_env_var(var: &str, value: Option<&str>);
                 fn track_path(path: &str);
                 fn literal_from_str(s: &str) -> Result<Literal<$S::Span, $S::Symbol>, ()>;
+                fn emit_diagnostic(diagnostic: Diagnostic<$S::Span>);
             },
             TokenStream {
                 fn drop($self: $S::TokenStream);
@@ -86,22 +87,6 @@ macro_rules! with_api {
                 fn eq($self: &$S::SourceFile, other: &$S::SourceFile) -> bool;
                 fn path($self: &$S::SourceFile) -> String;
                 fn is_real($self: &$S::SourceFile) -> bool;
-            },
-            MultiSpan {
-                fn drop($self: $S::MultiSpan);
-                fn new() -> $S::MultiSpan;
-                fn push($self: &mut $S::MultiSpan, span: $S::Span);
-            },
-            Diagnostic {
-                fn drop($self: $S::Diagnostic);
-                fn new(level: Level, msg: &str, span: $S::MultiSpan) -> $S::Diagnostic;
-                fn sub(
-                    $self: &mut $S::Diagnostic,
-                    level: Level,
-                    msg: &str,
-                    span: $S::MultiSpan,
-                );
-                fn emit($self: $S::Diagnostic);
             },
             Span {
                 fn debug($self: $S::Span) -> String;
@@ -508,6 +493,18 @@ compound_traits!(
         Ident(tt),
         Literal(tt),
     }
+);
+
+#[derive(Clone, Debug)]
+pub struct Diagnostic<Span> {
+    pub level: Level,
+    pub message: String,
+    pub spans: Vec<Span>,
+    pub children: Vec<Diagnostic<Span>>,
+}
+
+compound_traits!(
+    struct Diagnostic<Span> { level, message, spans, children }
 );
 
 /// Globals provided alongside the initial inputs for a macro expansion.

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -11,8 +11,6 @@ pub trait Types {
     type FreeFunctions: 'static;
     type TokenStream: 'static + Clone;
     type SourceFile: 'static + Clone;
-    type MultiSpan: 'static;
-    type Diagnostic: 'static;
     type Span: 'static + Copy + Eq + Hash;
     type Symbol: 'static;
 }

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
@@ -37,23 +37,6 @@ pub struct SourceFile {
 type Level = super::proc_macro::Level;
 type LineColumn = super::proc_macro::LineColumn;
 
-/// A structure representing a diagnostic message and associated children
-/// messages.
-#[derive(Clone, Debug)]
-pub struct Diagnostic {
-    level: Level,
-    message: String,
-    spans: Vec<Span>,
-    children: Vec<Diagnostic>,
-}
-
-impl Diagnostic {
-    /// Creates a new diagnostic with the given `level` and `message`.
-    pub fn new<T: Into<String>>(level: Level, message: T) -> Diagnostic {
-        Diagnostic { level, message: message.into(), spans: vec![], children: vec![] }
-    }
-}
-
 pub struct FreeFunctions;
 
 #[derive(Default)]
@@ -65,8 +48,6 @@ impl server::Types for RustAnalyzer {
     type FreeFunctions = FreeFunctions;
     type TokenStream = TokenStream;
     type SourceFile = SourceFile;
-    type MultiSpan = Vec<Span>;
-    type Diagnostic = Diagnostic;
     type Span = Span;
     type Symbol = Symbol;
 }
@@ -89,6 +70,10 @@ impl server::FreeFunctions for RustAnalyzer {
             suffix: None,
             span: tt::TokenId::unspecified(),
         })
+    }
+
+    fn emit_diagnostic(&mut self, _: bridge::Diagnostic<Self::Span>) {
+        // FIXME handle diagnostic
     }
 }
 
@@ -282,30 +267,6 @@ impl server::SourceFile for RustAnalyzer {
     }
 }
 
-impl server::Diagnostic for RustAnalyzer {
-    fn new(&mut self, level: Level, msg: &str, spans: Self::MultiSpan) -> Self::Diagnostic {
-        let mut diag = Diagnostic::new(level, msg);
-        diag.spans = spans;
-        diag
-    }
-
-    fn sub(
-        &mut self,
-        _diag: &mut Self::Diagnostic,
-        _level: Level,
-        _msg: &str,
-        _spans: Self::MultiSpan,
-    ) {
-        // FIXME handle diagnostic
-        //
-    }
-
-    fn emit(&mut self, _diag: Self::Diagnostic) {
-        // FIXME handle diagnostic
-        // diag.emit()
-    }
-}
-
 impl server::Span for RustAnalyzer {
     fn debug(&mut self, span: Self::Span) -> String {
         format!("{:?}", span.0)
@@ -369,18 +330,6 @@ impl server::Span for RustAnalyzer {
 
     fn before(&mut self, _self_: Self::Span) -> Self::Span {
         tt::TokenId::unspecified()
-    }
-}
-
-impl server::MultiSpan for RustAnalyzer {
-    fn new(&mut self) -> Self::MultiSpan {
-        // FIXME handle span
-        vec![]
-    }
-
-    fn push(&mut self, other: &mut Self::MultiSpan, span: Self::Span) {
-        //TODP
-        other.push(span)
     }
 }
 


### PR DESCRIPTION
This removes some RPC when creating and emitting diagnostics, and
simplifies the bridge slightly.

After this change, there are no remaining methods which take advantage
of the support for `&mut` references to objects in the store as
arguments, meaning that support for them could technically be removed if
we wanted. The only remaining uses of immutable references into the
store are `TokenStream` and `SourceFile`.

r? @eddyb