### PR TITLE
Refuse to codegen an upstream static.

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1027,6 +1027,11 @@ fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>) ->
         return false;
     }
 
+    if let DefKind::Static(_) = tcx.def_kind(def_id) {
+        // We cannot monomorphize statics from upstream crates.
+        return false;
+    }
+
     if !tcx.is_mir_available(def_id) {
         bug!("no MIR available for {:?}", def_id);
     }

--- a/src/test/run-make/issue-85401-static-mir/Makefile
+++ b/src/test/run-make/issue-85401-static-mir/Makefile
@@ -1,0 +1,16 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# Regression test for issue #85401
+# Verify that we do not ICE when trying to access MIR for statics,
+# but emit an error when linking.
+
+OUTPUT_FILE := $(TMPDIR)/build-output
+
+all:
+	$(RUSTC) --crate-type rlib --crate-name foo -Crelocation-model=pic --edition=2018 foo.rs -Zalways-encode-mir=yes --emit metadata -o $(TMPDIR)/libfoo.rmeta
+	$(RUSTC) --crate-type rlib --crate-name bar -Crelocation-model=pic --edition=2018 bar.rs -o $(TMPDIR)/libbar.rlib --extern=foo=$(TMPDIR)/libfoo.rmeta
+	$(RUSTC) --crate-type bin --crate-name baz -Crelocation-model=pic --edition=2018 baz.rs -o $(TMPDIR)/baz -L $(TMPDIR) --extern=bar=$(TMPDIR)/libbar.rlib > $(OUTPUT_FILE) 2>&1; [ $$? -eq 1 ]
+	cat  $(OUTPUT_FILE)
+	$(CGREP) 'crate `foo` required to be available in rlib format, but was not found in this form' < $(OUTPUT_FILE)
+	# -v tests are fragile, hopefully this text won't change
+	$(CGREP) -v "internal compiler error" < $(OUTPUT_FILE)

--- a/src/test/run-make/issue-85401-static-mir/bar.rs
+++ b/src/test/run-make/issue-85401-static-mir/bar.rs
@@ -1,0 +1,4 @@
+pub fn bar() {
+    println!("bar {}", foo::FOO);
+    foo::foo();
+}

--- a/src/test/run-make/issue-85401-static-mir/baz.rs
+++ b/src/test/run-make/issue-85401-static-mir/baz.rs
@@ -1,0 +1,3 @@
+fn main() {
+    bar::bar()
+}

--- a/src/test/run-make/issue-85401-static-mir/foo.rs
+++ b/src/test/run-make/issue-85401-static-mir/foo.rs
@@ -1,0 +1,5 @@
+pub static FOO: &str = "foo";
+
+pub fn foo() {
+    println!("foo");
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/85401 