### PR TITLE
Properly forward `ByRefSized::fold` to the inner iterator

### DIFF
--- a/library/core/tests/iter/adapters/by_ref_sized.rs
+++ b/library/core/tests/iter/adapters/by_ref_sized.rs
@@ -1,0 +1,20 @@
+use core::iter::*;
+
+#[test]
+fn test_iterator_by_ref_sized() {
+    let a = ['a', 'b', 'c', 'd'];
+
+    let mut s = String::from("Z");
+    let mut it = a.iter().copied();
+    ByRefSized(&mut it).take(2).for_each(|x| s.push(x));
+    assert_eq!(s, "Zab");
+    ByRefSized(&mut it).fold((), |(), x| s.push(x));
+    assert_eq!(s, "Zabcd");
+
+    let mut s = String::from("Z");
+    let mut it = a.iter().copied();
+    ByRefSized(&mut it).rev().take(2).for_each(|x| s.push(x));
+    assert_eq!(s, "Zdc");
+    ByRefSized(&mut it).rfold((), |(), x| s.push(x));
+    assert_eq!(s, "Zdcba");
+}

--- a/library/core/tests/iter/adapters/mod.rs
+++ b/library/core/tests/iter/adapters/mod.rs
@@ -1,4 +1,5 @@
 mod array_chunks;
+mod by_ref_sized;
 mod chain;
 mod cloned;
 mod copied;


### PR DESCRIPTION
cc @timvermeulen, who noticed this mistake in https://github.com/rust-lang/rust/pull/100214#issuecomment-1207317625 