### PR TITLE
Use start_point instead of next_point to point to elided lifetime amp…

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1228,7 +1228,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     } else {
                         self.next_node_id()
                     };
-                    let span = self.tcx.sess.source_map().next_point(t.span.shrink_to_lo());
+                    let span = self.tcx.sess.source_map().start_point(t.span);
                     Lifetime { ident: Ident::new(kw::UnderscoreLifetime, span), id }
                 });
                 let lifetime = self.lower_lifetime(&region);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -629,7 +629,7 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
                 // Elided lifetime in reference: we resolve as if there was some lifetime `'_` with
                 // NodeId `ty.id`.
                 // This span will be used in case of elision failure.
-                let span = self.r.session.source_map().next_point(ty.span.shrink_to_lo());
+                let span = self.r.session.source_map().start_point(ty.span);
                 self.resolve_elided_lifetime(ty.id, span);
                 visit::walk_ty(self, ty);
             }

--- a/src/test/ui/lifetimes/fullwidth-ampersand.rs
+++ b/src/test/ui/lifetimes/fullwidth-ampersand.rs
@@ -1,0 +1,7 @@
+// Verify that we do not ICE when the user uses a multubyte ampersand.
+
+fn f(_: &＆()) -> &() { todo!() }
+//~^ ERROR unknown start of token: \u{ff06}
+//~| ERROR missing lifetime specifier [E0106]
+
+fn main() {}

--- a/src/test/ui/lifetimes/fullwidth-ampersand.stderr
+++ b/src/test/ui/lifetimes/fullwidth-ampersand.stderr
@@ -1,0 +1,26 @@
+error: unknown start of token: \u{ff06}
+  --> $DIR/fullwidth-ampersand.rs:3:10
+   |
+LL | fn f(_: &＆()) -> &() { todo!() }
+   |          ^^
+   |
+help: Unicode character '＆' (Fullwidth Ampersand) looks like '&' (Ampersand), but it is not
+   |
+LL | fn f(_: &&()) -> &() { todo!() }
+   |          ~
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/fullwidth-ampersand.rs:3:18
+   |
+LL | fn f(_: &＆()) -> &() { todo!() }
+   |         -----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
+help: consider introducing a named lifetime parameter
+   |
+LL | fn f<'a>(_: &'a ＆'a ()) -> &'a () { todo!() }
+   |     ++++     ++   ++         ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
Using `next_point` creates a span which points inside the multibyte token, ICEing.

Fixes https://github.com/rust-lang/rust/issues/100224