### PR TITLE
rustc_span: encode 1-based line number as it's own type, not usize

### DIFF
--- a/compiler/rustc_ast/src/util/comments.rs
+++ b/compiler/rustc_ast/src/util/comments.rs
@@ -225,7 +225,8 @@ pub fn gather_comments(sm: &SourceMap, path: FileName, src: String) -> Vec<Comme
                     let pos_in_file = start_bpos + BytePos(pos as u32);
                     let line_begin_in_file = source_file.line_begin_pos(pos_in_file);
                     let line_begin_pos = (line_begin_in_file - start_bpos).to_usize();
-                    let col = CharPos(text[line_begin_pos..pos].chars().count());
+                    // FIXME: maybe simpler way?
+                    let col = CharPos::from_usize(text[line_begin_pos..pos].chars().count());
 
                     let lines = split_block_comment_into_lines(token_text, col);
                     comments.push(Comment { style, lines, pos: pos_in_file })

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -30,7 +30,7 @@ pub fn expand_line(
     let topmost = cx.expansion_cause().unwrap_or(sp);
     let loc = cx.source_map().lookup_char_pos(topmost.lo());
 
-    base::MacEager::expr(cx.expr_u32(topmost, loc.line as u32))
+    base::MacEager::expr(cx.expr_u32(topmost, loc.line.to_u32()))
 }
 
 /* column!(): expands to the current column number */

--- a/compiler/rustc_codegen_cranelift/src/common.rs
+++ b/compiler/rustc_codegen_cranelift/src/common.rs
@@ -349,7 +349,7 @@ impl<'tcx> FunctionCx<'_, '_, 'tcx> {
                 rustc_span::symbol::Symbol::intern(
                     &caller.file.name.prefer_remapped().to_string_lossy(),
                 ),
-                caller.line as u32,
+                caller.line.to_u32(),
                 caller.col_display as u32 + 1,
             ));
             crate::constant::codegen_const_value(fx, const_loc, fx.tcx.caller_location_ty())

--- a/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
@@ -109,7 +109,7 @@ impl<'tcx> DebugContext<'tcx> {
         let entry = self.dwarf.unit.get_mut(entry_id);
 
         entry.set(gimli::DW_AT_decl_file, AttributeValue::FileIndex(Some(file_id)));
-        entry.set(gimli::DW_AT_decl_line, AttributeValue::Udata(loc.line as u64));
+        entry.set(gimli::DW_AT_decl_line, AttributeValue::Udata(loc.line.to_usize() as u64));
         entry.set(gimli::DW_AT_decl_column, AttributeValue::Udata(loc.col.to_usize() as u64));
     }
 

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -71,7 +71,7 @@ mod value_and_place;
 mod vtable;
 
 mod prelude {
-    pub(crate) use rustc_span::{FileNameDisplayPreference, Span};
+    pub(crate) use rustc_span::{FileNameDisplayPreference, Pos, Span};
 
     pub(crate) use rustc_hir::def_id::{DefId, LOCAL_CRATE};
     pub(crate) use rustc_middle::bug;

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -19,7 +19,7 @@ use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, Instance, Ty, TypeVisitable};
 use rustc_span::source_map::Span;
-use rustc_span::{sym, Symbol};
+use rustc_span::{sym, Pos, Symbol};
 use rustc_symbol_mangling::typeid::typeid_for_fnabi;
 use rustc_target::abi::call::{ArgAbi, FnAbi, PassMode};
 use rustc_target::abi::{self, HasDataLayout, WrappingRange};
@@ -1290,7 +1290,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             let caller = tcx.sess.source_map().lookup_char_pos(topmost.lo());
             let const_loc = tcx.const_caller_location((
                 Symbol::intern(&caller.file.name.prefer_remapped().to_string_lossy()),
-                caller.line as u32,
+                caller.line.to_u32(),
                 caller.col_display as u32 + 1,
             ));
             OperandRef::from_const(bx, const_loc, bx.tcx().caller_location_ty())

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -270,7 +270,7 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
                     f,
                     " at {}:{}:{}",
                     sm.filename_for_diagnostics(&lo.file.name),
-                    lo.line,
+                    lo.line.to_usize(),
                     lo.col.to_usize() + 1
                 )?;
             }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/caller_location.rs
@@ -5,7 +5,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_middle::mir::TerminatorKind;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::subst::Subst;
-use rustc_span::{Span, Symbol};
+use rustc_span::{Pos, Span, Symbol};
 
 use crate::interpret::{
     intrinsics::{InterpCx, Machine},
@@ -118,7 +118,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let caller = self.tcx.sess.source_map().lookup_char_pos(topmost.lo());
         (
             Symbol::intern(&caller.file.name.prefer_remapped().to_string_lossy()),
-            u32::try_from(caller.line).unwrap(),
+            caller.line.to_u32(),
             u32::try_from(caller.col_display).unwrap().checked_add(1).unwrap(),
         )
     }

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1499,7 +1499,7 @@ impl EmitterWriter {
                             "{}:{}:{}",
                             sm.filename_for_diagnostics(&loc.file.name),
                             sm.doctest_offset_line(&loc.file.name, loc.line.to_usize()),
-                            loc.col.0 + 1,
+                            loc.col.to_usize() + 1,
                         ),
                         Style::LineAndColumn,
                     );
@@ -1513,7 +1513,7 @@ impl EmitterWriter {
                             "{}:{}:{}: ",
                             sm.filename_for_diagnostics(&loc.file.name),
                             sm.doctest_offset_line(&loc.file.name, loc.line.to_usize()),
-                            loc.col.0 + 1,
+                            loc.col.to_usize() + 1,
                         ),
                         Style::LineAndColumn,
                     );
@@ -1796,7 +1796,7 @@ impl EmitterWriter {
                             "{}:{}:{}",
                             sm.filename_for_diagnostics(&loc.file.name),
                             sm.doctest_offset_line(&loc.file.name, loc.line.to_usize()),
-                            loc.col.0 + 1,
+                            loc.col.to_usize() + 1,
                         ),
                         Style::LineAndColumn,
                     );

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -22,7 +22,7 @@ use rustc_lint_defs::Applicability;
 use rustc_data_structures::sync::Lrc;
 use rustc_error_messages::FluentArgs;
 use rustc_span::hygiene::ExpnData;
-use rustc_span::Span;
+use rustc_span::{Pos, Span};
 use std::io::{self, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -453,8 +453,8 @@ impl DiagnosticSpan {
             file_name: je.sm.filename_for_diagnostics(&start.file.name).to_string(),
             byte_start: start.file.original_relative_byte_pos(span.lo()).0,
             byte_end: start.file.original_relative_byte_pos(span.hi()).0,
-            line_start: start.line,
-            line_end: end.line,
+            line_start: start.line.to_usize(),
+            line_end: end.line.to_usize(),
             column_start: start.col.0 + 1,
             column_end: end.col.0 + 1,
             is_primary,

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -455,8 +455,8 @@ impl DiagnosticSpan {
             byte_end: start.file.original_relative_byte_pos(span.hi()).0,
             line_start: start.line.to_usize(),
             line_end: end.line.to_usize(),
-            column_start: start.col.0 + 1,
-            column_end: end.col.0 + 1,
+            column_start: start.col.to_usize() + 1,
+            column_end: end.col.to_usize() + 1,
             is_primary,
             text: DiagnosticSpanLine::from_span(span, je),
             suggested_replacement: suggestion.map(|x| x.0.clone()),
@@ -535,8 +535,8 @@ impl DiagnosticSpanLine {
                         DiagnosticSpanLine::line_from_source_file(
                             sf,
                             line.line_index,
-                            line.start_col.0 + 1,
-                            line.end_col.0 + 1,
+                            line.start_col.to_usize() + 1,
+                            line.end_col.to_usize() + 1,
                         )
                     })
                     .collect()

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -284,14 +284,14 @@ impl CodeSuggestion {
                             count -= 1;
                         }
                         // push lines between the previous and current span (if any)
-                        for idx in prev_hi.line..(cur_lo.line - 1) {
+                        for idx in prev_hi.line.to_usize()..(cur_lo.line.to_usize() - 1) {
                             if let Some(line) = sf.get_line(idx) {
                                 buf.push_str(line.as_ref());
                                 buf.push('\n');
                                 highlights.push(std::mem::take(&mut line_highlight));
                             }
                         }
-                        if let Some(cur_line) = sf.get_line(cur_lo.line - 1) {
+                        if let Some(cur_line) = sf.get_line(cur_lo.line.to_usize() - 1) {
                             let end = match cur_line.char_indices().nth(cur_lo.col.to_usize()) {
                                 Some((i, _)) => i,
                                 None => cur_line.len(),
@@ -324,7 +324,7 @@ impl CodeSuggestion {
                         acc += len as isize - (cur_hi.col.0 - cur_lo.col.0) as isize;
                     }
                     prev_hi = cur_hi;
-                    prev_line = sf.get_line(prev_hi.line - 1);
+                    prev_line = sf.get_line(prev_hi.line.to_usize() - 1);
                     for line in part.snippet.split('\n').skip(1) {
                         acc = 0;
                         highlights.push(std::mem::take(&mut line_highlight));

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -312,8 +312,8 @@ impl CodeSuggestion {
                         })
                         .sum();
                     line_highlight.push(SubstitutionHighlight {
-                        start: (cur_lo.col.0 as isize + acc) as usize,
-                        end: (cur_lo.col.0 as isize + acc + len) as usize,
+                        start: (cur_lo.col.to_usize() as isize + acc) as usize,
+                        end: (cur_lo.col.to_usize() as isize + acc + len) as usize,
                     });
                     buf.push_str(&part.snippet);
                     let cur_hi = sm.lookup_char_pos(part.span.hi());
@@ -321,7 +321,8 @@ impl CodeSuggestion {
                         // Account for the difference between the width of the current code and the
                         // snippet being suggested, so that the *later* suggestions are correctly
                         // aligned on the screen.
-                        acc += len as isize - (cur_hi.col.0 - cur_lo.col.0) as isize;
+                        acc +=
+                            len as isize - (cur_hi.col.to_usize() - cur_lo.col.to_usize()) as isize;
                     }
                     prev_hi = cur_hi;
                     prev_line = sf.get_line(prev_hi.line.to_usize() - 1);

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -633,13 +633,13 @@ impl server::Span for Rustc<'_, '_> {
     fn start(&mut self, span: Self::Span) -> LineColumn {
         let loc = self.sess().source_map().lookup_char_pos(span.lo());
         //FIXME: LineColumn.column is 1-based, but loc.col is 0-based
-        LineColumn { line: loc.line.to_usize(), column: loc.col.to_usize() }
+        LineColumn { line: loc.line.to_usize(), column: loc.col.to_usize() + 1 }
     }
 
     fn end(&mut self, span: Self::Span) -> LineColumn {
         let loc = self.sess().source_map().lookup_char_pos(span.hi());
         //FIXME: and here
-        LineColumn { line: loc.line.to_usize(), column: loc.col.to_usize() }
+        LineColumn { line: loc.line.to_usize(), column: loc.col.to_usize() + 1 }
     }
 
     fn before(&mut self, span: Self::Span) -> Self::Span {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -632,12 +632,14 @@ impl server::Span for Rustc<'_, '_> {
 
     fn start(&mut self, span: Self::Span) -> LineColumn {
         let loc = self.sess().source_map().lookup_char_pos(span.lo());
-        LineColumn { line: loc.line, column: loc.col.to_usize() }
+        //FIXME: LineColumn.column is 1-based, but loc.col is 0-based
+        LineColumn { line: loc.line.to_usize(), column: loc.col.to_usize() }
     }
 
     fn end(&mut self, span: Self::Span) -> LineColumn {
         let loc = self.sess().source_map().lookup_char_pos(span.hi());
-        LineColumn { line: loc.line, column: loc.col.to_usize() }
+        //FIXME: and here
+        LineColumn { line: loc.line.to_usize(), column: loc.col.to_usize() }
     }
 
     fn before(&mut self, span: Self::Span) -> Self::Span {

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1658,7 +1658,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             format!(
                                 " (opaque type at <{}:{}:{}>)",
                                 sm.filename_for_diagnostics(&pos.file.name),
-                                pos.line,
+                                pos.line.to_usize(),
                                 pos.col.to_usize() + 1,
                             )
                         }

--- a/compiler/rustc_middle/src/mir/spanview.rs
+++ b/compiler/rustc_middle/src/mir/spanview.rs
@@ -165,7 +165,7 @@ where
     write!(
         w,
         r#"<div class="code" style="counter-reset: line {}"><span class="line">{}"#,
-        start.line - 1,
+        start.line.to_usize() - 1,
         indent_to_initial_start_col,
     )?;
     span_viewables.sort_unstable_by(|a, b| {
@@ -234,7 +234,13 @@ pub fn source_range_no_file<'tcx>(tcx: TyCtxt<'tcx>, span: Span) -> String {
     let source_map = tcx.sess.source_map();
     let start = source_map.lookup_char_pos(span.lo());
     let end = source_map.lookup_char_pos(span.hi());
-    format!("{}:{}-{}:{}", start.line, start.col.to_usize() + 1, end.line, end.col.to_usize() + 1)
+    format!(
+        "{}:{}-{}:{}",
+        start.line.to_usize(),
+        start.col.to_usize() + 1,
+        end.line.to_usize(),
+        end.col.to_usize() + 1
+    )
 }
 
 pub fn statement_kind_name(statement: &Statement<'_>) -> &'static str {

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -512,11 +512,10 @@ fn make_code_region(
     let (end_line, end_col) = if span.hi() == span.lo() {
         let (end_line, mut end_col) = (start_line, start_col);
         // Extend an empty span by one character so the region will be counted.
-        let CharPos(char_pos) = start_col;
         if span.hi() == body_span.hi() {
-            start_col = CharPos(char_pos - 1);
+            start_col = start_col - CharPos::from_u32(1);
         } else {
-            end_col = CharPos(char_pos + 1);
+            end_col = start_col + CharPos::from_u32(1);
         }
         (end_line, end_col)
     } else {

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -522,8 +522,8 @@ fn make_code_region(
     } else {
         source_file.lookup_file_pos(span.hi())
     };
-    let start_line = source_map.doctest_offset_line(&source_file.name, start_line);
-    let end_line = source_map.doctest_offset_line(&source_file.name, end_line);
+    let start_line = source_map.doctest_offset_line(&source_file.name, start_line.to_usize());
+    let end_line = source_map.doctest_offset_line(&source_file.name, end_line.to_usize());
     CodeRegion {
         file_name,
         start_line: start_line as u32,

--- a/compiler/rustc_save_analysis/src/lib.rs
+++ b/compiler/rustc_save_analysis/src/lib.rs
@@ -83,8 +83,8 @@ impl<'tcx> SaveContext<'tcx> {
             file_name: start.file.name.prefer_remapped().to_string().into(),
             byte_start: span.lo().0,
             byte_end: span.hi().0,
-            line_start: Row::new_one_indexed(start.line as u32),
-            line_end: Row::new_one_indexed(end.line as u32),
+            line_start: Row::new_one_indexed(start.line.to_u32()),
+            line_end: Row::new_one_indexed(end.line.to_u32()),
             column_start: Column::new_one_indexed(start.col.0 as u32 + 1),
             column_end: Column::new_one_indexed(end.col.0 as u32 + 1),
         }

--- a/compiler/rustc_save_analysis/src/lib.rs
+++ b/compiler/rustc_save_analysis/src/lib.rs
@@ -85,8 +85,8 @@ impl<'tcx> SaveContext<'tcx> {
             byte_end: span.hi().0,
             line_start: Row::new_one_indexed(start.line.to_u32()),
             line_end: Row::new_one_indexed(end.line.to_u32()),
-            column_start: Column::new_one_indexed(start.col.0 as u32 + 1),
-            column_end: Column::new_one_indexed(end.col.0 as u32 + 1),
+            column_start: Column::new_one_indexed(start.col.to_u32() + 1),
+            column_end: Column::new_one_indexed(end.col.to_u32() + 1),
         }
     }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1860,22 +1860,22 @@ macro_rules! impl_pos {
             impl Pos for $ident {
                 #[inline(always)]
                 fn from_usize(n: usize) -> $ident {
-                    $ident(n as $inner_ty)
+                    $ident(<$inner_ty>::try_from(n).unwrap())
                 }
 
                 #[inline(always)]
                 fn to_usize(&self) -> usize {
-                    self.0 as usize
+                    self.0.try_into().unwrap()
                 }
 
                 #[inline(always)]
                 fn from_u32(n: u32) -> $ident {
-                    $ident(n as $inner_ty)
+                    $ident(<$inner_ty>::try_from(n).unwrap())
                 }
 
                 #[inline(always)]
                 fn to_u32(&self) -> u32 {
-                    self.0 as u32
+                    self.0.try_into().unwrap()
                 }
             }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1687,7 +1687,7 @@ impl SourceFile {
         }
 
         assert!(self.start_pos.to_u32() + total_extra_bytes <= bpos.to_u32());
-        CharPos(bpos.to_usize() - self.start_pos.to_usize() - total_extra_bytes as usize)
+        CharPos(bpos.to_u32() - self.start_pos.to_u32() - total_extra_bytes)
     }
 
     /// Looks up the file's (1-based) line number and (0-based `CharPos`) column offset, for a
@@ -1712,7 +1712,7 @@ impl SourceFile {
 
     /// Looks up the file's (1-based) line number, (0-based `CharPos`) column offset, and (0-based)
     /// column offset when displayed, for a given `BytePos`.
-    pub fn lookup_file_pos_with_col_display(&self, pos: BytePos) -> (LineNum, CharPos, usize) {
+    pub fn lookup_file_pos_with_col_display(&self, pos: BytePos) -> (LineNum, CharPos, u32) {
         let (line, col_or_chpos) = self.lookup_file_pos(pos);
         if line.to_usize() > 0 {
             let col = col_or_chpos;
@@ -1731,7 +1731,8 @@ impl SourceFile {
                     .iter()
                     .map(|x| x.width())
                     .sum();
-                col.0 - special_chars + non_narrow
+                col.to_u32() - u32::try_from(special_chars).unwrap()
+                    + u32::try_from(non_narrow).unwrap()
             };
             (line, col, col_display)
         } else {
@@ -1743,7 +1744,8 @@ impl SourceFile {
                     .unwrap_or_else(|x| x);
                 let non_narrow: usize =
                     self.non_narrow_chars[0..end_width_idx].iter().map(|x| x.width()).sum();
-                chpos.0 - end_width_idx + non_narrow
+                chpos.to_u32() - u32::try_from(end_width_idx).unwrap()
+                    + u32::try_from(non_narrow).unwrap()
             };
             (LineNum(0), chpos, col_display)
         }
@@ -1911,7 +1913,7 @@ impl_pos! {
     /// is not equivalent to a character offset. The [`SourceMap`] will convert [`BytePos`]
     /// values to `CharPos` values as necessary.
     #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
-    pub struct CharPos(pub usize);
+    pub struct CharPos(u32);
 
     /// A Line number
     ///

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -428,7 +428,7 @@ impl SourceMap {
     pub fn lookup_char_pos(&self, pos: BytePos) -> Loc {
         let sf = self.lookup_source_file(pos);
         let (line, col, col_display) = sf.lookup_file_pos_with_col_display(pos);
-        Loc { file: sf, line, col, col_display }
+        Loc { file: sf, line, col, col_display: col_display as usize }
     }
 
     // If the corresponding `SourceFile` is empty, does not return a line number.

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -451,9 +451,9 @@ impl SourceMap {
         format!(
             "{}:{}:{}: {}:{}",
             lo.file.name.display(filename_display_pref),
-            lo.line,
+            lo.line.to_usize(),
             lo.col.to_usize() + 1,
-            hi.line,
+            hi.line.to_usize(),
             hi.col.to_usize() + 1,
         )
     }
@@ -477,8 +477,8 @@ impl SourceMap {
             return self.span_to_embeddable_string(sp);
         }
 
-        let lo_line = lo.line.saturating_sub(offset.line);
-        let hi_line = hi.line.saturating_sub(offset.line);
+        let lo_line = lo.line.to_usize().saturating_sub(offset.line.to_usize());
+        let hi_line = hi.line.to_usize().saturating_sub(offset.line.to_usize());
 
         format!(
             "{}:+{}:{}: +{}:{}",
@@ -546,7 +546,7 @@ impl SourceMap {
             return Ok(FileLines { file: lo.file, lines: Vec::new() });
         }
 
-        let mut lines = Vec::with_capacity(hi.line - lo.line + 1);
+        let mut lines = Vec::with_capacity(hi.line.to_usize() - lo.line.to_usize() + 1);
 
         // The span starts partway through the first line,
         // but after that it starts from offset 0.
@@ -559,8 +559,8 @@ impl SourceMap {
         //
         // FIXME: now that we handle DUMMY_SP up above, we should consider
         // asserting that the line numbers here are all indeed 1-based.
-        let hi_line = hi.line.saturating_sub(1);
-        for line_index in lo.line.saturating_sub(1)..hi_line {
+        let hi_line = hi.line.to_usize().saturating_sub(1);
+        for line_index in lo.line.to_usize().saturating_sub(1)..hi_line {
             let line_len = lo.file.get_line(line_index).map_or(0, |s| s.chars().count());
             lines.push(LineInfo { line_index, start_col, end_col: CharPos::from_usize(line_len) });
             start_col = CharPos::from_usize(0);

--- a/compiler/rustc_span/src/source_map/tests.rs
+++ b/compiler/rustc_span/src/source_map/tests.rs
@@ -91,12 +91,12 @@ fn t5() {
 
     let loc1 = sm.lookup_char_pos(BytePos(22));
     assert_eq!(loc1.file.name, PathBuf::from("blork.rs").into());
-    assert_eq!(loc1.line, 2);
+    assert_eq!(loc1.line.to_usize(), 2);
     assert_eq!(loc1.col, CharPos(10));
 
     let loc2 = sm.lookup_char_pos(BytePos(25));
     assert_eq!(loc2.file.name, PathBuf::from("blork2.rs").into());
-    assert_eq!(loc2.line, 1);
+    assert_eq!(loc2.line.to_usize(), 1);
     assert_eq!(loc2.col, CharPos(0));
 }
 

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1142,7 +1142,7 @@ impl Tester for Collector {
         if let Some(ref source_map) = self.source_map {
             let line = self.position.lo().to_usize();
             let line = source_map.lookup_char_pos(BytePos(line as u32)).line;
-            if line > 0 { line - 1 } else { line }
+            if line.to_usize() > 0 { line.to_usize() - 1 } else { line.to_usize() }
         } else {
             0
         }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::edition::Edition;
 use rustc_span::source_map::FileName;
-use rustc_span::{sym, Symbol};
+use rustc_span::{sym, Pos, Symbol};
 
 use super::print_item::{full_path, item_path, print_item};
 use super::search_index::build_index;
@@ -357,9 +357,9 @@ impl<'tcx> Context<'tcx> {
             format!(
                 "#{}",
                 if loline == hiline {
-                    loline.to_string()
+                    loline.to_usize().to_string()
                 } else {
-                    format!("{}-{}", loline, hiline)
+                    format!("{}-{}", loline.to_usize(), hiline.to_usize())
                 }
             )
         } else {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -77,8 +77,8 @@ impl JsonRenderer<'_> {
                     let lo = span.lo(self.sess());
                     Some(Span {
                         filename: local_path,
-                        begin: (lo.line, lo.col.to_usize()),
-                        end: (hi.line, hi.col.to_usize()),
+                        begin: (lo.line.to_usize(), lo.col.to_usize()),
+                        end: (hi.line.to_usize(), hi.col.to_usize()),
                     })
                 } else {
                     None

--- a/src/tools/clippy/clippy_lints/src/formatting.rs
+++ b/src/tools/clippy/clippy_lints/src/formatting.rs
@@ -5,7 +5,7 @@ use rustc_ast::ast::{BinOpKind, Block, Expr, ExprKind, StmtKind, UnOp};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::source_map::Span;
+use rustc_span::source_map::{Pos, Span};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -264,7 +264,7 @@ fn has_unary_equivalent(bin_op: BinOpKind) -> bool {
 }
 
 fn indentation(cx: &EarlyContext<'_>, span: Span) -> usize {
-    cx.sess().source_map().lookup_char_pos(span.lo()).col.0
+    cx.sess().source_map().lookup_char_pos(span.lo()).col.to_usize()
 }
 
 /// Implementation of the `POSSIBLE_MISSING_COMMA` lint for array

--- a/src/tools/clippy/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -23,7 +23,7 @@ use rustc_lint::{CheckLintNameResult, LateContext, LateLintPass, LintContext, Li
 use rustc_middle::hir::nested_filter;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::symbol::Ident;
-use rustc_span::{sym, Loc, Span, Symbol};
+use rustc_span::{sym, Loc, Pos, Span, Symbol};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::collections::BinaryHeap;
 use std::fmt;
@@ -474,7 +474,7 @@ impl SerializableSpan {
 
         Self {
             path: format!("{}", loc.file.name.prefer_remapped()),
-            line: loc.line,
+            line: loc.line.to_usize(),
         }
     }
 }

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -657,7 +657,7 @@ fn astbinop2assignop(op: ast::BinOp) -> AssocOp {
 fn indentation<T: LintContext>(cx: &T, span: Span) -> Option<String> {
     let lo = cx.sess().source_map().lookup_char_pos(span.lo());
     lo.file
-        .get_line(lo.line - 1 /* line numbers in `Loc` are 1-based */)
+        .get_line(lo.line.to_usize() - 1 /* line numbers in `Loc` are 1-based */)
         .and_then(|line| {
             if let Some((pos, _)) = line.char_indices().find(|&(_, c)| c != ' ' && c != '\t') {
                 // We can mix char and byte positions here because we only consider `[ \t]`.

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -661,7 +661,7 @@ fn indentation<T: LintContext>(cx: &T, span: Span) -> Option<String> {
         .and_then(|line| {
             if let Some((pos, _)) = line.char_indices().find(|&(_, c)| c != ' ' && c != '\t') {
                 // We can mix char and byte positions here because we only consider `[ \t]`.
-                if lo.col == CharPos(pos) {
+                if lo.col == CharPos::from_usize(pos) {
                     Some(line[..pos].into())
                 } else {
                     None

--- a/src/tools/rustfmt/src/parse/session.rs
+++ b/src/tools/rustfmt/src/parse/session.rs
@@ -7,7 +7,7 @@ use rustc_errors::{ColorConfig, Diagnostic, Handler, Level as DiagnosticLevel};
 use rustc_session::parse::ParseSess as RawParseSess;
 use rustc_span::{
     source_map::{FilePathMapping, SourceMap},
-    symbol, BytePos, Span,
+    symbol, BytePos, Pos, Span,
 };
 
 use crate::config::file_lines::LineRange;
@@ -233,7 +233,13 @@ impl ParseSess {
     }
 
     pub(crate) fn line_of_byte_pos(&self, pos: BytePos) -> usize {
-        self.parse_sess.source_map().lookup_char_pos(pos).line
+        //FIXME: this returns 1-based line number conveted into usize.
+        //Should it's base type be used instead?
+        self.parse_sess
+            .source_map()
+            .lookup_char_pos(pos)
+            .line
+            .to_usize()
     }
 
     // TODO(calebcartwright): Preemptive, currently unused addition


### PR DESCRIPTION
r? @ghost

Want to see what/where will be broken.