### PR TITLE
Remove manual implementations of HashStable for hir::Expr and hir::Ty.

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -631,14 +631,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ) -> (Fingerprint, Fingerprint) {
         self.tcx.with_stable_hashing_context(|mut hcx| {
             let mut stable_hasher = StableHasher::new();
-            hcx.with_hir_bodies(true, node.def_id(), bodies, |hcx| {
+            hcx.with_hir_bodies(node.def_id(), bodies, |hcx| {
                 node.hash_stable(hcx, &mut stable_hasher)
             });
             let hash_including_bodies = stable_hasher.finish();
             let mut stable_hasher = StableHasher::new();
-            hcx.with_hir_bodies(false, node.def_id(), bodies, |hcx| {
-                node.hash_stable(hcx, &mut stable_hasher)
-            });
+            hcx.without_hir_bodies(|hcx| node.hash_stable(hcx, &mut stable_hasher));
             let hash_without_bodies = stable_hasher.finish();
             (hash_including_bodies, hash_without_bodies)
         })

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1626,7 +1626,7 @@ pub struct AnonConst {
 }
 
 /// An expression.
-#[derive(Debug)]
+#[derive(Debug, HashStable_Generic)]
 pub struct Expr<'hir> {
     pub hir_id: HirId,
     pub kind: ExprKind<'hir>,
@@ -2380,7 +2380,7 @@ impl TypeBinding<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, HashStable_Generic)]
 pub struct Ty<'hir> {
     pub hir_id: HirId,
     pub kind: TyKind<'hir>,

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -1,8 +1,7 @@
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
 
 use crate::hir::{
-    AttributeMap, BodyId, Crate, Expr, ForeignItemId, ImplItemId, ItemId, OwnerNodes, TraitItemId,
-    Ty,
+    AttributeMap, BodyId, Crate, ForeignItemId, ImplItemId, ItemId, OwnerNodes, TraitItemId,
 };
 use crate::hir_id::{HirId, ItemLocalId};
 use rustc_span::def_id::DefPathHash;
@@ -14,8 +13,6 @@ pub trait HashStableContext:
     rustc_ast::HashStableContext + rustc_target::HashStableContext
 {
     fn hash_body_id(&mut self, _: BodyId, hasher: &mut StableHasher);
-    fn hash_hir_expr(&mut self, _: &Expr<'_>, hasher: &mut StableHasher);
-    fn hash_hir_ty(&mut self, _: &Ty<'_>, hasher: &mut StableHasher);
 }
 
 impl<HirCtx: crate::HashStableContext> ToStableHashKey<HirCtx> for HirId {
@@ -95,18 +92,6 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for BodyId {
 // are used when another item in the HIR is *referenced* and we certainly
 // want to pick up on a reference changing its target, so we hash the NodeIds
 // in "DefPath Mode".
-
-impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Expr<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
-        hcx.hash_hir_expr(self, hasher)
-    }
-}
-
-impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Ty<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
-        hcx.hash_hir_ty(self, hasher)
-    }
-}
 
 impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for OwnerNodes<'tcx> {
     fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {

--- a/compiler/rustc_query_system/src/ich/impls_hir.rs
+++ b/compiler/rustc_query_system/src/ich/impls_hir.rs
@@ -21,22 +21,16 @@ impl<'ctx> rustc_hir::HashStableContext for StableHashingContext<'ctx> {
     }
 
     fn hash_hir_expr(&mut self, expr: &hir::Expr<'_>, hasher: &mut StableHasher) {
-        self.while_hashing_hir_bodies(true, |hcx| {
-            let hir::Expr { hir_id, ref span, ref kind } = *expr;
-
-            hir_id.hash_stable(hcx, hasher);
-            span.hash_stable(hcx, hasher);
-            kind.hash_stable(hcx, hasher);
-        })
+        let hir::Expr { hir_id, ref span, ref kind } = *expr;
+        hir_id.hash_stable(self, hasher);
+        span.hash_stable(self, hasher);
+        kind.hash_stable(self, hasher);
     }
 
     fn hash_hir_ty(&mut self, ty: &hir::Ty<'_>, hasher: &mut StableHasher) {
-        self.while_hashing_hir_bodies(true, |hcx| {
-            let hir::Ty { hir_id, ref kind, ref span } = *ty;
-
-            hir_id.hash_stable(hcx, hasher);
-            kind.hash_stable(hcx, hasher);
-            span.hash_stable(hcx, hasher);
-        })
+        let hir::Ty { hir_id, ref kind, ref span } = *ty;
+        hir_id.hash_stable(self, hasher);
+        kind.hash_stable(self, hasher);
+        span.hash_stable(self, hasher);
     }
 }

--- a/compiler/rustc_query_system/src/ich/impls_hir.rs
+++ b/compiler/rustc_query_system/src/ich/impls_hir.rs
@@ -19,18 +19,4 @@ impl<'ctx> rustc_hir::HashStableContext for StableHashingContext<'ctx> {
             }
         }
     }
-
-    fn hash_hir_expr(&mut self, expr: &hir::Expr<'_>, hasher: &mut StableHasher) {
-        let hir::Expr { hir_id, ref span, ref kind } = *expr;
-        hir_id.hash_stable(self, hasher);
-        span.hash_stable(self, hasher);
-        kind.hash_stable(self, hasher);
-    }
-
-    fn hash_hir_ty(&mut self, ty: &hir::Ty<'_>, hasher: &mut StableHasher) {
-        let hir::Ty { hir_id, ref kind, ref span } = *ty;
-        hir_id.hash_stable(self, hasher);
-        kind.hash_stable(self, hasher);
-        span.hash_stable(self, hasher);
-    }
 }

--- a/compiler/rustc_query_system/src/ich/impls_hir.rs
+++ b/compiler/rustc_query_system/src/ich/impls_hir.rs
@@ -12,8 +12,8 @@ impl<'ctx> rustc_hir::HashStableContext for StableHashingContext<'ctx> {
         let hcx = self;
         match hcx.body_resolver {
             BodyResolver::Forbidden => panic!("Hashing HIR bodies is forbidden."),
-            BodyResolver::Traverse { hash_bodies: false, .. } => {}
-            BodyResolver::Traverse { hash_bodies: true, owner, bodies } => {
+            BodyResolver::Ignore => {}
+            BodyResolver::Traverse { owner, bodies } => {
                 assert_eq!(id.hir_id.owner, owner);
                 bodies[&id.hir_id.local_id].hash_stable(hcx, hasher);
             }


### PR DESCRIPTION
We do not need to force hashing HIR bodies inside those nodes. The contents of bodies are not accessible from the `hir_owner` query which used `hash_without_bodies`. When the content of a body is required, the access is still done using `hir_owner_nodes`, which continues hashing HIR bodies.