### PR TITLE
Fail gracefully when const pattern is not structural match.

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -168,7 +168,12 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
         // once indirect_structural_match is a full fledged error, this
         // level of indirection can be eliminated
 
-        let inlined_const_as_pat = self.recur(cv, mir_structural_match_violation).unwrap();
+        let inlined_const_as_pat =
+            self.recur(cv, mir_structural_match_violation).unwrap_or_else(|_| Pat {
+                span: self.span,
+                ty: cv.ty(),
+                kind: Box::new(PatKind::Constant { value: cv }),
+            });
 
         if self.include_lint_checks && !self.saw_const_match_error.get() {
             // If we were able to successfully convert the const to some pat,

--- a/src/test/ui/consts/const_in_pattern/incomplete-slice.rs
+++ b/src/test/ui/consts/const_in_pattern/incomplete-slice.rs
@@ -1,0 +1,15 @@
+#[derive(PartialEq)]
+enum E {
+    A,
+}
+
+const E_SL: &[E] = &[E::A];
+
+fn main() {
+    match &[][..] {
+        //~^ ERROR non-exhaustive patterns: `&_` not covered [E0004]
+        E_SL => {}
+        //~^ WARN to use a constant of type `E` in a pattern, `E` must be annotated with `#[derive(PartialEq, Eq)]`
+        //~| WARN this was previously accepted by the compiler but is being phased out
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/incomplete-slice.stderr
+++ b/src/test/ui/consts/const_in_pattern/incomplete-slice.stderr
@@ -1,0 +1,26 @@
+warning: to use a constant of type `E` in a pattern, `E` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/incomplete-slice.rs:11:9
+   |
+LL |         E_SL => {}
+   |         ^^^^
+   |
+   = note: `#[warn(indirect_structural_match)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+
+error[E0004]: non-exhaustive patterns: `&_` not covered
+  --> $DIR/incomplete-slice.rs:9:11
+   |
+LL |     match &[][..] {
+   |           ^^^^^^^ pattern `&_` not covered
+   |
+   = note: the matched value is of type `&[E]`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         E_SL => {}
+LL +         &_ => todo!()
+   |
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/82909