### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1228,7 +1228,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     } else {
                         self.next_node_id()
                     };
-                    let span = self.tcx.sess.source_map().next_point(t.span.shrink_to_lo());
+                    let span = self.tcx.sess.source_map().start_point(t.span);
                     Lifetime { ident: Ident::new(kw::UnderscoreLifetime, span), id }
                 });
                 let lifetime = self.lower_lifetime(&region);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -629,7 +629,7 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
                 // Elided lifetime in reference: we resolve as if there was some lifetime `'_` with
                 // NodeId `ty.id`.
                 // This span will be used in case of elision failure.
-                let span = self.r.session.source_map().next_point(ty.span.shrink_to_lo());
+                let span = self.r.session.source_map().start_point(ty.span);
                 self.resolve_elided_lifetime(ty.id, span);
                 visit::walk_ty(self, ty);
             }

--- a/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
@@ -1,0 +1,54 @@
+//! Targets the ARMv4T, with code as `a32` code by default.
+//!
+//! Primarily of use for the GBA, but usable with other devices too.
+//!
+//! Please ping @Lokathor if changes are needed.
+//!
+//! This target profile assumes that you have the ARM binutils in your path
+//! (specifically the linker, `arm-none-eabi-ld`). They can be obtained for free
+//! for all major OSes from the ARM developer's website, and they may also be
+//! available in your system's package manager. Unfortunately, the standard
+//! linker that Rust uses (`lld`) only supports as far back as `ARMv5TE`, so we
+//! must use the GNU `ld` linker.
+//!
+//! **Important:** This target profile **does not** specify a linker script. You
+//! just get the default link script when you build a binary for this target.
+//! The default link script is very likely wrong, so you should use
+//! `-Clink-arg=-Tmy_script.ld` to override that with a correct linker script.
+
+use crate::spec::{cvs, LinkerFlavor, PanicStrategy, RelocModel, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "armv4t-none-eabi".into(),
+        pointer_width: 32,
+        arch: "arm".into(),
+        /* Data layout args are '-' separated:
+         * little endian
+         * stack is 64-bit aligned (EABI)
+         * pointers are 32-bit
+         * i64 must be 64-bit aligned (EABI)
+         * mangle names with ELF style
+         * native integers are 32-bit
+         * All other elements are default
+         */
+        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
+        options: TargetOptions {
+            abi: "eabi".into(),
+            linker_flavor: LinkerFlavor::Ld,
+            linker: Some("arm-none-eabi-ld".into()),
+            asm_args: cvs!["-mthumb-interwork", "-march=armv4t", "-mlittle-endian",],
+            features: "+soft-float,+strict-align".into(),
+            main_needs_argc_argv: false,
+            atomic_cas: false,
+            has_thumb_interworking: true,
+            relocation_model: RelocModel::Static,
+            panic_strategy: PanicStrategy::Abort,
+            // from thumb_base, rust-lang/rust#44993.
+            emit_debug_gdb_scripts: false,
+            // from thumb_base, apparently gcc/clang give enums a minimum of 8 bits on no-os targets
+            c_enum_min_bits: 8,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -4,7 +4,7 @@ use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::{self as hir, ExprKind};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::traits::Obligation;
-use rustc_middle::ty::{self, ToPredicate, Ty, TypeVisitable};
+use rustc_middle::ty::{self, ToPredicate, Ty};
 use rustc_span::Span;
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
 use rustc_trait_selection::traits::{
@@ -479,7 +479,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match orig_expected {
             Expectation::ExpectHasType(expected)
                 if self.in_tail_expr
-                    && self.ret_coercion.as_ref()?.borrow().merged_ty().has_opaque_types()
+                    && self.return_type_has_opaque
                     && self.can_coerce(outer_ty, expected) =>
             {
                 let obligations = self.fulfillment_cx.borrow().pending_obligations();

--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -94,7 +94,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let arm_ty = self.check_expr_with_expectation(&arm.body, expected);
             all_arms_diverge &= self.diverges.get();
 
-            let opt_suggest_box_span = self.opt_suggest_box_span(arm_ty, orig_expected);
+            let opt_suggest_box_span = prior_arm.and_then(|(_, prior_arm_ty, _)| {
+                self.opt_suggest_box_span(prior_arm_ty, arm_ty, orig_expected)
+            });
 
             let (arm_block_id, arm_span) = if let hir::ExprKind::Block(blk, _) = arm.body.kind {
                 (Some(blk.hir_id), self.find_block_span(blk))
@@ -473,43 +475,48 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     // provide a structured suggestion in that case.
     pub(crate) fn opt_suggest_box_span(
         &self,
-        outer_ty: Ty<'tcx>,
+        first_ty: Ty<'tcx>,
+        second_ty: Ty<'tcx>,
         orig_expected: Expectation<'tcx>,
     ) -> Option<Span> {
         match orig_expected {
             Expectation::ExpectHasType(expected)
                 if self.in_tail_expr
                     && self.return_type_has_opaque
-                    && self.can_coerce(outer_ty, expected) =>
+                    && self.can_coerce(first_ty, expected)
+                    && self.can_coerce(second_ty, expected) =>
             {
                 let obligations = self.fulfillment_cx.borrow().pending_obligations();
                 let mut suggest_box = !obligations.is_empty();
-                for o in obligations {
-                    match o.predicate.kind().skip_binder() {
-                        ty::PredicateKind::Trait(t) => {
-                            let pred =
-                                ty::Binder::dummy(ty::PredicateKind::Trait(ty::TraitPredicate {
-                                    trait_ref: ty::TraitRef {
-                                        def_id: t.def_id(),
-                                        substs: self.tcx.mk_substs_trait(outer_ty, &[]),
+                'outer: for o in obligations {
+                    for outer_ty in &[first_ty, second_ty] {
+                        match o.predicate.kind().skip_binder() {
+                            ty::PredicateKind::Trait(t) => {
+                                let pred = ty::Binder::dummy(ty::PredicateKind::Trait(
+                                    ty::TraitPredicate {
+                                        trait_ref: ty::TraitRef {
+                                            def_id: t.def_id(),
+                                            substs: self.tcx.mk_substs_trait(*outer_ty, &[]),
+                                        },
+                                        constness: t.constness,
+                                        polarity: t.polarity,
                                     },
-                                    constness: t.constness,
-                                    polarity: t.polarity,
-                                }));
-                            let obl = Obligation::new(
-                                o.cause.clone(),
-                                self.param_env,
-                                pred.to_predicate(self.tcx),
-                            );
-                            suggest_box &= self.predicate_must_hold_modulo_regions(&obl);
-                            if !suggest_box {
-                                // We've encountered some obligation that didn't hold, so the
-                                // return expression can't just be boxed. We don't need to
-                                // evaluate the rest of the obligations.
-                                break;
+                                ));
+                                let obl = Obligation::new(
+                                    o.cause.clone(),
+                                    self.param_env,
+                                    pred.to_predicate(self.tcx),
+                                );
+                                suggest_box &= self.predicate_must_hold_modulo_regions(&obl);
+                                if !suggest_box {
+                                    // We've encountered some obligation that didn't hold, so the
+                                    // return expression can't just be boxed. We don't need to
+                                    // evaluate the rest of the obligations.
+                                    break 'outer;
+                                }
                             }
+                            _ => {}
                         }
-                        _ => {}
                     }
                 }
                 // If all the obligations hold (or there are no obligations) the tail expression

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1002,7 +1002,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let else_ty = self.check_expr_with_expectation(else_expr, expected);
             let else_diverges = self.diverges.get();
 
-            let opt_suggest_box_span = self.opt_suggest_box_span(else_ty, orig_expected);
+            let opt_suggest_box_span = self.opt_suggest_box_span(then_ty, else_ty, orig_expected);
             let if_cause = self.if_cause(
                 sp,
                 cond_expr.span,

--- a/config.toml.example
+++ b/config.toml.example
@@ -721,6 +721,10 @@ changelog-seen = 2
 # probably don't want to use this.
 #qemu-rootfs = <none> (path)
 
+# Skip building the `std` library for this target. Enabled by default for
+# target triples containing `-none`, `nvptx`, `switch`, or `-uefi`.
+#no-std = <platform-specific> (bool)
+
 # =============================================================================
 # Distribution options
 #

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -18,6 +18,7 @@
     - [aarch64-apple-ios-sim](platform-support/aarch64-apple-ios-sim.md)
     - [\*-apple-watchos\*](platform-support/apple-watchos.md)
     - [aarch64-nintendo-switch-freestanding](platform-support/aarch64-nintendo-switch-freestanding.md)
+    - [armv4t-none-eabi](platform-support/armv4t-none-eabi.md)
     - [armv6k-nintendo-3ds](platform-support/armv6k-nintendo-3ds.md)
     - [armv7-unknown-linux-uclibceabi](platform-support/armv7-unknown-linux-uclibceabi.md)
     - [armv7-unknown-linux-uclibceabihf](platform-support/armv7-unknown-linux-uclibceabihf.md)

--- a/src/doc/rustc/src/platform-support/armv4t_none_eabi.md
+++ b/src/doc/rustc/src/platform-support/armv4t_none_eabi.md
@@ -1,0 +1,70 @@
+# armv4t-none-eabi
+
+Tier 3
+
+Bare-metal target for any cpu in the ARMv4T architecture family, supporting
+ARM/Thumb code interworking (aka `a32`/`t32`), with ARM code as the default code
+generation.
+
+In particular this supports the Gameboy Advance (GBA), but there's nothing GBA
+specific with this target, so any ARMv4T device should work fine.
+
+## Target Maintainers
+
+* [@Lokathor](https://github.com/lokathor)
+
+## Requirements
+
+The target is cross-compiled, and uses static linking.
+
+The linker that comes with rustc cannot link for this platform (the platform is
+too old). You will need the `arm-none-eabi-ld` linker from a GNU Binutils
+targeting ARM. This can be obtained for Windows/Mac/Linux from the [ARM
+Developer Website][arm-dev], or possibly from your OS's package manager.
+
+[arm-dev]: https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain
+
+This target doesn't provide a linker script, you'll need to bring your own
+according to the specific device you want to target. Pass
+`-Clink-arg=-Tyour_script.ld` as a rustc argument to make the linker use
+`your_script.ld` during linking.
+
+## Building Rust Programs
+
+Because it is Tier 3, rust does not yet ship pre-compiled artifacts for this target.
+
+Just use the `build-std` nightly cargo feature to build the `core` library. You
+can pass this as a command line argument to cargo, or your `.cargo/config.toml`
+file might include the following lines:
+
+```toml
+[unstable]
+build-std = ["core"]
+```
+
+Most of `core` should work as expected, with the following notes:
+* the target is "soft float", so `f32` and `f64` operations are emulated in
+  software.
+* integer division is also emulated in software.
+* the target is old enough that it doesn't have atomic instructions.
+
+Rust programs are output as ELF files.
+
+For running on hardware, you'll generally need to extract the "raw" program code
+out of the ELF and into a file of its own. The `objcopy` program provided as
+part of the GNU Binutils can do this:
+
+```shell
+arm-none-eabi-objcopy --output-target binary [in_file] [out_file]
+```
+
+## Testing
+
+This is a cross-compiled target that you will need to emulate during testing.
+
+Because this is a device-agnostic target, and the exact emulator that you'll
+need depends on the specific device you want to run your code on.
+
+For example, when programming for the Gameboy Advance, the
+[mgba-test-runner](https://github.com/agbrs/agb) program could be used to make a
+normal set of rust tests be run within the `mgba` emulator.

--- a/src/test/mir-opt/simplify-locals.rs
+++ b/src/test/mir-opt/simplify-locals.rs
@@ -1,6 +1,6 @@
 // unit-test: SimplifyLocals
 
-#![feature(box_syntax)]
+
 #![feature(thread_local)]
 
 #[derive(Copy, Clone)]

--- a/src/test/run-make-fulldeps/save-analysis-fail/foo.rs
+++ b/src/test/run-make-fulldeps/save-analysis-fail/foo.rs
@@ -1,5 +1,4 @@
 #![crate_name = "test"]
-#![feature(box_syntax)]
 #![feature(rustc_private)]
 
 extern crate rustc_graphviz;
@@ -261,9 +260,9 @@ fn hello<X: SomeTrait>((z, a): (u32, String), ex: X) {
     let x = 32.0f32;
     let _ = (x + ((x * x) + 1.0).sqrt()).ln();
 
-    let s: Box<SomeTrait> = box some_fields { field1: 43 };
-    let s2: Box<some_fields> = box some_fields { field1: 43 };
-    let s3 = box nofields;
+    let s: Box<SomeTrait> = Box::new(some_fields { field1: 43 });
+    let s2: Box<some_fields> = Box::new(some_fields { field1: 43 });
+    let s3 = Box::new(nofields);
 
     s.Method(43);
     s3.Method(43);
@@ -317,7 +316,7 @@ mod macro_use_test {
 
 fn main() {
     // foo
-    let s = box some_fields { field1: 43 };
+    let s = Box::new(some_fields { field1: 43 });
     hello((43, "a".to_string()), *s);
     sub::sub2::hello();
     sub2::sub3::hello();
@@ -345,17 +344,17 @@ fn main() {
     let s4: msalias::nested_struct = sub::sub2::nested_struct { field2: 55 };
     let s4: msalias::nested_struct = sub2::nested_struct { field2: 55 };
     println(&s2.field1.to_string());
-    let s5: MyType = box some_fields { field1: 55 };
+    let s5: MyType = Box::new(some_fields { field1: 55 });
     let s = SameDir::SameStruct { name: "Bob".to_string() };
     let s = SubDir::SubStruct { name: "Bob".to_string() };
-    let s6: SomeEnum = SomeEnum::MyTypes(box s2.clone(), s5);
+    let s6: SomeEnum = SomeEnum::MyTypes(Box::new(s2.clone()), s5);
     let s7: SomeEnum = SomeEnum::Strings("one", "two", "three");
     matchSomeEnum(s6);
     matchSomeEnum(s7);
     let s8: SomeOtherEnum = SomeOtherEnum::SomeConst2;
     matchSomeOtherEnum(s8);
     let s9: SomeStructEnum =
-        SomeStructEnum::EnumStruct2 { f1: box some_fields { field1: 10 }, f2: box s2 };
+        SomeStructEnum::EnumStruct2 { f1: Box::new(some_fields { field1: 10 }), f2: Box::new(s2) };
     matchSomeStructEnum(s9);
 
     for x in &vec![1, 2, 3] {

--- a/src/test/run-make-fulldeps/save-analysis/foo.rs
+++ b/src/test/run-make-fulldeps/save-analysis/foo.rs
@@ -1,5 +1,4 @@
 #![crate_name = "test"]
-#![feature(box_syntax)]
 #![feature(rustc_private)]
 #![feature(associated_type_defaults)]
 
@@ -255,9 +254,9 @@ fn hello<X: SomeTrait>((z, a): (u32, String), ex: X) {
     let x = 32.0f32;
     let _ = (x + ((x * x) + 1.0).sqrt()).ln();
 
-    let s: Box<SomeTrait> = box some_fields { field1: 43 };
-    let s2: Box<some_fields> = box some_fields { field1: 43 };
-    let s3 = box nofields;
+    let s: Box<SomeTrait> = Box::new(some_fields { field1: 43 });
+    let s2: Box<some_fields> = Box::new(some_fields { field1: 43 });
+    let s3 = Box::new(nofields);
 
     s.Method(43);
     s3.Method(43);
@@ -311,7 +310,7 @@ mod macro_use_test {
 
 fn main() {
     // foo
-    let s = box some_fields { field1: 43 };
+    let s = Box::new(some_fields { field1: 43 });
     hello((43, "a".to_string()), *s);
     sub::sub2::hello();
     sub2::sub3::hello();
@@ -339,17 +338,17 @@ fn main() {
     let s4: msalias::nested_struct = sub::sub2::nested_struct { field2: 55 };
     let s4: msalias::nested_struct = sub2::nested_struct { field2: 55 };
     println(&s2.field1.to_string());
-    let s5: MyType = box some_fields { field1: 55 };
+    let s5: MyType = Box::new(some_fields { field1: 55 });
     let s = SameDir::SameStruct { name: "Bob".to_string() };
     let s = SubDir::SubStruct { name: "Bob".to_string() };
-    let s6: SomeEnum = SomeEnum::MyTypes(box s2.clone(), s5);
+    let s6: SomeEnum = SomeEnum::MyTypes(Box::new(s2.clone()), s5);
     let s7: SomeEnum = SomeEnum::Strings("one", "two", "three");
     matchSomeEnum(s6);
     matchSomeEnum(s7);
     let s8: SomeOtherEnum = SomeOtherEnum::SomeConst2;
     matchSomeOtherEnum(s8);
     let s9: SomeStructEnum =
-        SomeStructEnum::EnumStruct2 { f1: box some_fields { field1: 10 }, f2: box s2 };
+        SomeStructEnum::EnumStruct2 { f1: Box::new(some_fields { field1: 10 }), f2: Box::new(s2) };
     matchSomeStructEnum(s9);
 
     for x in &vec![1, 2, 3] {

--- a/src/test/run-pass-valgrind/cleanup-auto-borrow-obj.rs
+++ b/src/test/run-pass-valgrind/cleanup-auto-borrow-obj.rs
@@ -2,8 +2,6 @@
 // schedule cleanups when auto borrowing trait objects.
 // This program should be valgrind clean.
 
-#![feature(box_syntax)]
-
 static mut DROP_RAN: bool = false;
 
 struct Foo;
@@ -19,7 +17,7 @@ impl Trait for Foo {}
 
 pub fn main() {
     {
-        let _x: &Trait = &*(box Foo as Box<Trait>);
+        let _x: &Trait = &*(Box::new(Foo) as Box<Trait>);
     }
     unsafe {
         assert!(DROP_RAN);

--- a/src/test/run-pass-valgrind/coerce-match.rs
+++ b/src/test/run-pass-valgrind/coerce-match.rs
@@ -2,15 +2,18 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let _: Box<[isize]> =
-        if true { let b: Box<_> = box [1, 2, 3]; b } else { let b: Box<_> = box [1]; b };
+    let _: Box<[isize]> = if true {
+        let b: Box<_> = Box::new([1, 2, 3]);
+        b
+    } else {
+        let b: Box<_> = Box::new([1]);
+        b
+    };
 
     let _: Box<[isize]> = match true {
-        true => { let b: Box<_> = box [1, 2, 3]; b }
-        false => { let b: Box<_> = box [1]; b }
+        true => { let b: Box<_> = Box::new([1, 2, 3]); b }
+        false => { let b: Box<_> = Box::new([1]); b }
     };
 
     // Check we don't get over-keen at propagating coercions in the case of casts.

--- a/src/test/rustdoc-ui/rustc-check-passes.rs
+++ b/src/test/rustdoc-ui/rustc-check-passes.rs
@@ -1,4 +1,4 @@
-#![feature(box_syntax)]
-#![feature(box_syntax)] //~ ERROR
+#![feature(rustdoc_internals)]
+#![feature(rustdoc_internals)] //~ ERROR
 
 pub fn foo() {}

--- a/src/test/rustdoc-ui/rustc-check-passes.stderr
+++ b/src/test/rustdoc-ui/rustc-check-passes.stderr
@@ -1,8 +1,8 @@
-error[E0636]: the feature `box_syntax` has already been declared
+error[E0636]: the feature `rustdoc_internals` has already been declared
   --> $DIR/rustc-check-passes.rs:2:12
    |
-LL | #![feature(box_syntax)]
-   |            ^^^^^^^^^^
+LL | #![feature(rustdoc_internals)]
+   |            ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/issue-10398.rs
+++ b/src/test/ui/closures/issue-10398.rs
@@ -1,7 +1,5 @@
-#![feature(box_syntax)]
-
 fn main() {
-    let x: Box<_> = box 1;
+    let x: Box<_> = Box::new(1);
     let f = move|| {
         let _a = x;
         drop(x);

--- a/src/test/ui/closures/issue-10398.stderr
+++ b/src/test/ui/closures/issue-10398.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/issue-10398.rs:7:14
+  --> $DIR/issue-10398.rs:5:14
    |
 LL |         let _a = x;
    |                  - value moved here

--- a/src/test/ui/closures/issue-6801.rs
+++ b/src/test/ui/closures/issue-6801.rs
@@ -2,7 +2,7 @@
 // transferring ownership of the box before invoking the stack
 // closure results in a crash.
 
-#![feature(box_syntax)]
+
 
 fn twice(x: Box<usize>) -> usize {
      *x * 2
@@ -13,7 +13,7 @@ fn invoke<F>(f: F) where F: FnOnce() -> usize {
 }
 
 fn main() {
-      let x  : Box<usize>  = box 9;
+      let x  : Box<usize>  = Box::new(9);
       let sq =  || { *x * *x };
 
       twice(x); //~ ERROR: cannot move out of

--- a/src/test/ui/dst/dst-rvalue.rs
+++ b/src/test/ui/dst/dst-rvalue.rs
@@ -1,12 +1,10 @@
 // Check that dynamically sized rvalues are forbidden
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let _x: Box<str> = box *"hello world";
+    let _x: Box<str> = Box::new(*"hello world");
     //~^ ERROR E0277
 
     let array: &[isize] = &[1, 2, 3];
-    let _x: Box<[isize]> = box *array;
+    let _x: Box<[isize]> = Box::new(*array);
     //~^ ERROR E0277
 }

--- a/src/test/ui/dst/dst-rvalue.stderr
+++ b/src/test/ui/dst/dst-rvalue.stderr
@@ -1,20 +1,32 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/dst-rvalue.rs:6:28
+  --> $DIR/dst-rvalue.rs:4:33
    |
-LL |     let _x: Box<str> = box *"hello world";
-   |                            ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+LL |     let _x: Box<str> = Box::new(*"hello world");
+   |                        -------- ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                        |
+   |                        required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: the type of a box expression must have a statically known size
+note: required by a bound in `Box::<T>::new`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+LL | impl<T> Box<T> {
+   |      ^ required by this bound in `Box::<T>::new`
 
 error[E0277]: the size for values of type `[isize]` cannot be known at compilation time
-  --> $DIR/dst-rvalue.rs:10:32
+  --> $DIR/dst-rvalue.rs:8:37
    |
-LL |     let _x: Box<[isize]> = box *array;
-   |                                ^^^^^^ doesn't have a size known at compile-time
+LL |     let _x: Box<[isize]> = Box::new(*array);
+   |                            -------- ^^^^^^ doesn't have a size known at compile-time
+   |                            |
+   |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[isize]`
-   = note: the type of a box expression must have a statically known size
+note: required by a bound in `Box::<T>::new`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+LL | impl<T> Box<T> {
+   |      ^ required by this bound in `Box::<T>::new`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/dynamically-sized-types/dst-struct.rs
+++ b/src/test/ui/dynamically-sized-types/dst-struct.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct Fat<T: ?Sized> {
     f1: isize,
@@ -111,7 +110,7 @@ pub fn main() {
     assert_eq!((*f2)[1], 2);
 
     // Nested Box.
-    let f1 : Box<Fat<[isize; 3]>> = box Fat { f1: 5, f2: "some str", ptr: [1, 2, 3] };
+    let f1 : Box<Fat<[isize; 3]>> = Box::new(Fat { f1: 5, f2: "some str", ptr: [1, 2, 3] });
     foo(&*f1);
     let f2 : Box<Fat<[isize]>> = f1;
     foo(&*f2);

--- a/src/test/ui/dynamically-sized-types/dst-trait.rs
+++ b/src/test/ui/dynamically-sized-types/dst-trait.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct Fat<T: ?Sized> {
     f1: isize,

--- a/src/test/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/src/test/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -52,6 +52,16 @@ LL | |         1u32
 LL | |     }
    | |_____- `if` and `else` have incompatible types
    |
+help: you could change the return type to be a boxed trait object
+   |
+LL | fn qux() -> Box<dyn std::fmt::Display> {
+   |             ~~~~~~~                  +
+help: if you change the return type to expect trait objects, box the returned expressions
+   |
+LL ~         Box::new(0i32)
+LL |     } else {
+LL ~         Box::new(1u32)
+   |
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |         1i32
@@ -114,6 +124,15 @@ LL | |         _ => 2u32,
 LL | |     }
    | |_____- `match` arms have incompatible types
    |
+help: you could change the return type to be a boxed trait object
+   |
+LL | fn dog() -> Box<dyn std::fmt::Display> {
+   |             ~~~~~~~                  +
+help: if you change the return type to expect trait objects, box the returned expressions
+   |
+LL ~         0 => Box::new(0i32),
+LL ~         1 => Box::new(1u32),
+   |
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |         1 => 1i32,
@@ -130,6 +149,16 @@ LL | |         1u32
    | |         ^^^^ expected `i32`, found `u32`
 LL | |     }
    | |_____- `if` and `else` have incompatible types
+   |
+help: you could change the return type to be a boxed trait object
+   |
+LL | fn apt() -> Box<dyn std::fmt::Display> {
+   |             ~~~~~~~                  +
+help: if you change the return type to expect trait objects, box the returned expressions
+   |
+LL ~         Box::new(0i32)
+LL |     } else {
+LL ~         Box::new(1u32)
    |
 help: change the type of the numeric literal from `u32` to `i32`
    |

--- a/src/test/ui/issues/auxiliary/issue-2380.rs
+++ b/src/test/ui/issues/auxiliary/issue-2380.rs
@@ -1,8 +1,6 @@
 #![crate_name="a"]
 #![crate_type = "lib"]
 
-#![feature(box_syntax)]
-
 pub trait i<T>
 {
     fn dummy(&self, t: T) -> T { panic!() }
@@ -11,5 +9,5 @@ pub trait i<T>
 pub fn f<T>() -> Box<i<T>+'static> {
     impl<T> i<T> for () { }
 
-    box () as Box<i<T>+'static>
+    Box::new(()) as Box<i<T>+'static>
 }

--- a/src/test/ui/issues/issue-10682.rs
+++ b/src/test/ui/issues/issue-10682.rs
@@ -4,12 +4,10 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 fn work(_: Box<isize>) {}
 fn foo<F:FnOnce()>(_: F) {}
 
 pub fn main() {
-  let a = box 1;
+  let a = Box::new(1);
   foo(move|| { foo(move|| { work(a) }) })
 }

--- a/src/test/ui/issues/issue-10767.rs
+++ b/src/test/ui/issues/issue-10767.rs
@@ -1,10 +1,8 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
     fn f() {
     }
-    let _: Box<fn()> = box (f as fn());
+    let _: Box<fn()> = Box::new(f as fn());
 }

--- a/src/test/ui/issues/issue-10802.rs
+++ b/src/test/ui/issues/issue-10802.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 struct DroppableStruct;
 enum DroppableEnum {
@@ -33,14 +32,14 @@ impl  Whatever {
 
 fn main() {
     {
-        let f: Box<_> = box DroppableStruct;
-        let _a = Whatever::new(box f as Box<dyn MyTrait>);
+        let f: Box<_> = Box::new(DroppableStruct);
+        let _a = Whatever::new(Box::new(f) as Box<dyn MyTrait>);
     }
     assert!(unsafe { DROPPED });
     unsafe { DROPPED = false; }
     {
-        let f: Box<_> = box DroppableEnum::DroppableVariant1;
-        let _a = Whatever::new(box f as Box<dyn MyTrait>);
+        let f: Box<_> = Box::new(DroppableEnum::DroppableVariant1);
+        let _a = Whatever::new(Box::new(f) as Box<dyn MyTrait>);
     }
     assert!(unsafe { DROPPED });
 }

--- a/src/test/ui/issues/issue-11192.rs
+++ b/src/test/ui/issues/issue-11192.rs
@@ -1,8 +1,7 @@
-#![feature(box_syntax)]
-
 struct Foo {
     x: isize
 }
+
 
 impl Drop for Foo {
     fn drop(&mut self) {
@@ -10,11 +9,12 @@ impl Drop for Foo {
     }
 }
 
+
 fn main() {
-    let mut ptr: Box<_> = box Foo { x: 0 };
+    let mut ptr: Box<_> = Box::new(Foo { x: 0 });
     let mut test = |foo: &Foo| {
         println!("access {}", foo.x);
-        ptr = box Foo { x: ptr.x + 1 };
+        ptr = Box::new(Foo { x: ptr.x + 1 });
         println!("access {}", foo.x);
     };
     test(&*ptr);

--- a/src/test/ui/issues/issue-11192.stderr
+++ b/src/test/ui/issues/issue-11192.stderr
@@ -4,7 +4,7 @@ error[E0502]: cannot borrow `*ptr` as immutable because it is also borrowed as m
 LL |     let mut test = |foo: &Foo| {
    |                    ----------- mutable borrow occurs here
 LL |         println!("access {}", foo.x);
-LL |         ptr = box Foo { x: ptr.x + 1 };
+LL |         ptr = Box::new(Foo { x: ptr.x + 1 });
    |         --- first borrow occurs due to use of `ptr` in closure
 ...
 LL |     test(&*ptr);

--- a/src/test/ui/issues/issue-11515.rs
+++ b/src/test/ui/issues/issue-11515.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax)]
-
 struct Test {
     func: Box<dyn FnMut() + 'static>,
 }
 
+
+
 fn main() {
     let closure: Box<dyn Fn() + 'static> = Box::new(|| ());
-    let test = box Test { func: closure }; //~ ERROR trait upcasting coercion is experimental [E0658]
+    let test = Box::new(Test { func: closure }); //~ ERROR trait upcasting coercion is experimental [E0658]
 }

--- a/src/test/ui/issues/issue-11515.stderr
+++ b/src/test/ui/issues/issue-11515.stderr
@@ -1,8 +1,8 @@
 error[E0658]: cannot cast `dyn Fn()` to `dyn FnMut()`, trait upcasting coercion is experimental
-  --> $DIR/issue-11515.rs:9:33
+  --> $DIR/issue-11515.rs:9:38
    |
-LL |     let test = box Test { func: closure };
-   |                                 ^^^^^^^
+LL |     let test = Box::new(Test { func: closure });
+   |                                      ^^^^^^^
    |
    = note: see issue #65991 <https://github.com/rust-lang/rust/issues/65991> for more information
    = help: add `#![feature(trait_upcasting)]` to the crate attributes to enable

--- a/src/test/ui/issues/issue-11552.rs
+++ b/src/test/ui/issues/issue-11552.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 #[derive(Clone)]
 enum Noun
@@ -18,5 +17,8 @@ fn fas(n: &Noun) -> Noun
 }
 
 pub fn main() {
-    fas(&Noun::Cell(box Noun::Atom(2), box Noun::Cell(box Noun::Atom(2), box Noun::Atom(3))));
+    fas(
+        &Noun::Cell(Box::new(Noun::Atom(2)),
+        Box::new(Noun::Cell(Box::new(Noun::Atom(2)), Box::new(Noun::Atom(3)))))
+    );
 }

--- a/src/test/ui/issues/issue-11844.rs
+++ b/src/test/ui/issues/issue-11844.rs
@@ -1,7 +1,5 @@
-#![feature(box_syntax)]
-
 fn main() {
-    let a = Some(box 1);
+    let a = Some(Box::new(1));
     match a {
         Ok(a) => //~ ERROR: mismatched types
             println!("{}",a),

--- a/src/test/ui/issues/issue-11844.stderr
+++ b/src/test/ui/issues/issue-11844.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-11844.rs:6:9
+  --> $DIR/issue-11844.rs:4:9
    |
 LL |     match a {
    |           - this expression has type `Option<Box<{integer}>>`

--- a/src/test/ui/issues/issue-12127.rs
+++ b/src/test/ui/issues/issue-12127.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 fn to_fn_once<A,F:FnOnce<A>>(f: F) -> F { f }
 fn do_it(x: &isize) { }
 
 fn main() {
-    let x: Box<_> = box 22;
+    let x: Box<_> = Box::new(22);
     let f = to_fn_once(move|| do_it(&*x));
     to_fn_once(move|| {
         f();

--- a/src/test/ui/issues/issue-13323.rs
+++ b/src/test/ui/issues/issue-13323.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct StrWrap {
     s: String
@@ -48,7 +47,7 @@ impl<T: Eq> Matcher<T> for EqualTo<T> {
 }
 
 fn equal_to<T: Eq>(expected: T) -> Box<EqualTo<T>> {
-    box EqualTo { expected: expected }
+    Box::new(EqualTo { expected: expected })
 }
 
 pub fn main() {

--- a/src/test/ui/issues/issue-14399.rs
+++ b/src/test/ui/issues/issue-14399.rs
@@ -6,8 +6,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 #[derive(Clone)]
 struct B1;
 
@@ -15,6 +13,6 @@ trait A { fn foo(&self) {} }
 impl A for B1 {}
 
 fn main() {
-    let v: Box<_> = box B1;
+    let v: Box<_> = Box::new(B1);
     let _c: Box<dyn A> = v.clone();
 }

--- a/src/test/ui/issues/issue-14915.rs
+++ b/src/test/ui/issues/issue-14915.rs
@@ -1,7 +1,5 @@
-#![feature(box_syntax)]
-
 fn main() {
-    let x: Box<isize> = box 0;
+    let x: Box<isize> = Box::new(0);
 
     println!("{}", x + 1);
     //~^ ERROR cannot add `{integer}` to `Box<isize>`

--- a/src/test/ui/issues/issue-14915.stderr
+++ b/src/test/ui/issues/issue-14915.stderr
@@ -1,5 +1,5 @@
 error[E0369]: cannot add `{integer}` to `Box<isize>`
-  --> $DIR/issue-14915.rs:6:22
+  --> $DIR/issue-14915.rs:4:22
    |
 LL |     println!("{}", x + 1);
    |                    - ^ - {integer}

--- a/src/test/ui/issues/issue-15571.rs
+++ b/src/test/ui/issues/issue-15571.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn match_on_local() {
-    let mut foo: Option<Box<_>> = Some(box 5);
+    let mut foo: Option<Box<_>> = Some(Box::new(5));
     match foo {
         None => {},
         Some(x) => {
@@ -37,7 +36,7 @@ fn match_on_binding() {
 }
 
 fn match_on_upvar() {
-    let mut foo: Option<Box<_>> = Some(box 8);
+    let mut foo: Option<Box<_>> = Some(Box::new(8));
     let f = move|| {
         match foo {
             None => {},
@@ -52,7 +51,7 @@ fn match_on_upvar() {
 
 fn main() {
     match_on_local();
-    match_on_arg(Some(box 6));
+    match_on_arg(Some(Box::new(6)));
     match_on_binding();
     match_on_upvar();
 }

--- a/src/test/ui/issues/issue-15763.rs
+++ b/src/test/ui/issues/issue-15763.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(unreachable_code)]
-#![feature(box_syntax)]
 
 #[derive(PartialEq, Debug)]
 struct Bar {
@@ -78,12 +77,12 @@ fn main() {
     assert_eq!(cc().unwrap(), 3);
     assert_eq!(dd().unwrap(), 3);
 
-    let i = box 32isize as Box<dyn A>;
+    let i = Box::new(32isize) as Box<dyn A>;
     assert_eq!(i.aaa(), 3);
-    let i = box 32isize as Box<dyn A>;
+    let i = Box::new(32isize) as Box<dyn A>;
     assert_eq!(i.bbb(), 3);
-    let i = box 32isize as Box<dyn A>;
+    let i = Box::new(32isize) as Box<dyn A>;
     assert_eq!(i.ccc().unwrap(), 3);
-    let i = box 32isize as Box<dyn A>;
+    let i = Box::new(32isize) as Box<dyn A>;
     assert_eq!(i.ddd().unwrap(), 3);
 }

--- a/src/test/ui/issues/issue-16739.rs
+++ b/src/test/ui/issues/issue-16739.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 #![feature(unboxed_closures, fn_traits)]
 
 // Test that unboxing shim for calling rust-call ABI methods through a
@@ -35,12 +34,12 @@ impl FnOnce<(u32,u32)> for Foo {
 }
 
 fn main() {
-    let mut f = box Foo { foo: 42 } as Box<dyn FnMut() -> u32>;
+    let mut f = Box::new(Foo { foo: 42 }) as Box<dyn FnMut() -> u32>;
     assert_eq!(f.call_mut(()), 42);
 
-    let mut f = box Foo { foo: 40 } as Box<dyn FnMut(u32) -> u32>;
+    let mut f = Box::new(Foo { foo: 40 }) as Box<dyn FnMut(u32) -> u32>;
     assert_eq!(f.call_mut((2,)), 42);
 
-    let mut f = box Foo { foo: 40 } as Box<dyn FnMut(u32, u32) -> u32>;
+    let mut f = Box::new(Foo { foo: 40 }) as Box<dyn FnMut(u32, u32) -> u32>;
     assert_eq!(f.call_mut((1, 1)), 42);
 }

--- a/src/test/ui/issues/issue-16774.rs
+++ b/src/test/ui/issues/issue-16774.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 #![feature(box_patterns)]
 
 use std::ops::{Deref, DerefMut};
@@ -35,7 +34,7 @@ impl DerefMut for X {
 
 fn main() {
     {
-        let mut test = X(box 5);
+        let mut test = X(Box::new(5));
         {
             let mut change = || { *test = 10 };
             change();

--- a/src/test/ui/issues/issue-17322.rs
+++ b/src/test/ui/issues/issue-17322.rs
@@ -1,8 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 use std::io::{self, Write};
 
 fn f(wr: &mut dyn Write) {
@@ -10,6 +8,6 @@ fn f(wr: &mut dyn Write) {
 }
 
 fn main() {
-    let mut wr = box io::stdout() as Box<dyn Write>;
+    let mut wr = Box::new(io::stdout()) as Box<dyn Write>;
     f(&mut wr);
 }

--- a/src/test/ui/issues/issue-21033.rs
+++ b/src/test/ui/issues/issue-21033.rs
@@ -4,7 +4,6 @@
 // pretty-expanded FIXME #23616
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 enum E {
     StructVar { boxed: Box<i32> }
@@ -13,7 +12,7 @@ enum E {
 fn main() {
 
     // Test matching each shorthand notation for field patterns.
-    let mut a = E::StructVar { boxed: box 3 };
+    let mut a = E::StructVar { boxed: Box::new(3) };
     match a {
         E::StructVar { box boxed } => { }
     }
@@ -38,7 +37,7 @@ fn main() {
 
     // Test matching non shorthand notation. Recreate a since last test
     // moved `boxed`
-    let mut a = E::StructVar { boxed: box 3 };
+    let mut a = E::StructVar { boxed: Box::new(3) };
     match a {
         E::StructVar { boxed: box ref mut num } => { }
     }

--- a/src/test/ui/issues/issue-2288.rs
+++ b/src/test/ui/issues/issue-2288.rs
@@ -1,8 +1,6 @@
 // run-pass
 #![allow(non_camel_case_types)]
 
-#![feature(box_syntax)]
-
 trait clam<A> {
   fn chowder(&self, y: A);
 }
@@ -30,6 +28,6 @@ fn f<A>(x: Box<dyn clam<A>>, a: A) {
 pub fn main() {
 
   let c = foo(42);
-  let d: Box<dyn clam<isize>> = box c as Box<dyn clam<isize>>;
+  let d: Box<dyn clam<isize>> = Box::new(c) as Box<dyn clam<isize>>;
   f(d, c.x);
 }

--- a/src/test/ui/issues/issue-23024.rs
+++ b/src/test/ui/issues/issue-23024.rs
@@ -1,11 +1,10 @@
-#![feature(box_syntax)]
 use std::any::Any;
 
 fn main()
 {
     fn h(x:i32) -> i32 {3*x}
     let mut vfnfer:Vec<Box<dyn Any>> = vec![];
-    vfnfer.push(box h);
+    vfnfer.push(Box::new(h));
     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
     //~^ ERROR the precise format of `Fn`-family traits'
     //~| ERROR missing generics for trait `Fn`

--- a/src/test/ui/issues/issue-23024.stderr
+++ b/src/test/ui/issues/issue-23024.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/issue-23024.rs:9:39
+  --> $DIR/issue-23024.rs:8:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |                                       ^^ help: use parenthetical notation instead: `Fn() -> ()`
@@ -8,7 +8,7 @@ LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0107]: missing generics for trait `Fn`
-  --> $DIR/issue-23024.rs:9:39
+  --> $DIR/issue-23024.rs:8:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |                                       ^^ expected 1 generic argument
@@ -24,7 +24,7 @@ LL |     println!("{:?}",(vfnfer[0] as dyn Fn<Args>)(3));
    |                                       ~~~~~~~~
 
 error[E0191]: the value of the associated type `Output` (from trait `FnOnce`) must be specified
-  --> $DIR/issue-23024.rs:9:39
+  --> $DIR/issue-23024.rs:8:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |                                       ^^ help: specify the associated type: `Fn<Output = Type>`

--- a/src/test/ui/issues/issue-23491.rs
+++ b/src/test/ui/issues/issue-23491.rs
@@ -1,9 +1,8 @@
 // run-pass
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 
 struct Node<T: ?Sized>(#[allow(unused_tuple_struct_fields)] T);
 
 fn main() {
-    let x: Box<Node<[isize]>> = box Node([]);
+    let x: Box<Node<[isize]>> = Box::new(Node([]));
 }

--- a/src/test/ui/issues/issue-2708.rs
+++ b/src/test/ui/issues/issue-2708.rs
@@ -4,7 +4,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
+
 
 struct Font {
     fontbuf: usize,
@@ -26,5 +26,5 @@ fn Font() -> Font {
 }
 
 pub fn main() {
-    let _f: Box<_> = box Font();
+    let _f: Box<_> = Box::new(Font());
 }

--- a/src/test/ui/issues/issue-2734.rs
+++ b/src/test/ui/issues/issue-2734.rs
@@ -4,21 +4,19 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 trait hax {
     fn dummy(&self) { }
 }
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<dyn hax+'static> {
-    box x as Box<dyn hax+'static>
+    Box::new(x) as Box<dyn hax+'static>
 }
 
 fn deadcode() {
-    perform_hax(box "deadcode".to_string());
+    perform_hax(Box::new("deadcode".to_string()));
 }
 
 pub fn main() {
-    let _ = perform_hax(box 42);
+    let _ = perform_hax(Box::new(42));
 }

--- a/src/test/ui/issues/issue-2735.rs
+++ b/src/test/ui/issues/issue-2735.rs
@@ -4,21 +4,19 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 trait hax {
     fn dummy(&self) { }
 }
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<dyn hax+'static> {
-    box x as Box<dyn hax+'static>
+    Box::new(x) as Box<dyn hax+'static>
 }
 
 fn deadcode() {
-    perform_hax(box "deadcode".to_string());
+    perform_hax(Box::new("deadcode".to_string()));
 }
 
 pub fn main() {
-    perform_hax(box 42);
+    perform_hax(Box::new(42));
 }

--- a/src/test/ui/issues/issue-2935.rs
+++ b/src/test/ui/issues/issue-2935.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 //type t = { a: isize };
 // type t = { a: bool };
@@ -20,7 +19,7 @@ pub fn main() {
   //   let y = box ({a: 4});
   //    let z = box ({a: 4} as it);
   //    let z = box ({a: true} as it);
-    let z: Box<_> = box (box true as Box<dyn it>);
+    let z: Box<_> = Box::new(Box::new(true) as Box<dyn it>);
     //  x.f();
     // y.f();
     // (*z).f();

--- a/src/test/ui/issues/issue-3026.rs
+++ b/src/test/ui/issues/issue-3026.rs
@@ -1,13 +1,11 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 use std::collections::HashMap;
 
 pub fn main() {
     let x: Box<_>;
     let mut buggy_map: HashMap<usize, &usize> = HashMap::new();
-    x = box 1;
+    x = Box::new(1);
     buggy_map.insert(42, &*x);
 }

--- a/src/test/ui/issues/issue-3121.rs
+++ b/src/test/ui/issues/issue-3121.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 #[derive(Copy, Clone)]
 enum side { mayo, catsup, vinegar }
@@ -21,5 +20,5 @@ fn foo(m: Box<meal>, cond: bool) {
 }
 
 pub fn main() {
-    foo(box meal::for_here(order::hamburger), true)
+    foo(Box::new(meal::for_here(order::hamburger)), true)
 }

--- a/src/test/ui/issues/issue-3290.rs
+++ b/src/test/ui/issues/issue-3290.rs
@@ -1,9 +1,8 @@
 // run-pass
-#![feature(box_syntax)]
 #![allow(dead_code)]
 
 pub fn main() {
-   let mut x: Box<_> = box 3;
+   let mut x: Box<_> = Box::new(3);
    x = x;
    assert_eq!(*x, 3);
 }

--- a/src/test/ui/issues/issue-3447.rs
+++ b/src/test/ui/issues/issue-3447.rs
@@ -2,7 +2,6 @@
 #![allow(dead_code)]
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 use std::cell::RefCell;
 
@@ -20,7 +19,7 @@ impl<T:'static> list<T> {
             next: None
         };
 
-        self.next = Some(box RefCell::new(newList));
+        self.next = Some(Box::new(RefCell::new(newList)));
     }
 }
 

--- a/src/test/ui/issues/issue-3794.rs
+++ b/src/test/ui/issues/issue-3794.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 #![allow(dead_code)]
 
 trait T {
@@ -26,7 +25,7 @@ fn print_s(s: &S) {
 }
 
 pub fn main() {
-    let s: Box<S> = box S { s: 5 };
+    let s: Box<S> = Box::new(S { s: 5 });
     print_s(&*s);
     let t: Box<dyn T> = s as Box<dyn T>;
     print_t(&*t);

--- a/src/test/ui/issues/issue-3878.rs
+++ b/src/test/ui/issues/issue-3878.rs
@@ -2,9 +2,8 @@
 // pretty-expanded FIXME #23616
 
 #![allow(path_statements)]
-#![feature(box_syntax)]
 
 pub fn main() {
-    let y: Box<_> = box 1;
+    let y: Box<_> = Box::new(1);
     y;
 }

--- a/src/test/ui/issues/issue-4759.rs
+++ b/src/test/ui/issues/issue-4759.rs
@@ -2,8 +2,6 @@
 // pretty-expanded FIXME #23616
 #![allow(non_shorthand_field_patterns)]
 
-#![feature(box_syntax)]
-
 struct T { a: Box<isize> }
 
 trait U {
@@ -15,6 +13,6 @@ impl U for Box<isize> {
 }
 
 pub fn main() {
-    let T { a: a } = T { a: box 0 };
+    let T { a: a } = T { a: Box::new(0) };
     a.f();
 }

--- a/src/test/ui/issues/issue-4972.rs
+++ b/src/test/ui/issues/issue-4972.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 trait MyTrait {
     fn dummy(&self) {}

--- a/src/test/ui/issues/issue-4972.stderr
+++ b/src/test/ui/issues/issue-4972.stderr
@@ -1,5 +1,5 @@
 error[E0033]: type `Box<(dyn MyTrait + 'static)>` cannot be dereferenced
-  --> $DIR/issue-4972.rs:14:25
+  --> $DIR/issue-4972.rs:13:25
    |
 LL |         TraitWrapper::A(box ref map) => map,
    |                         ^^^^^^^^^^^ type `Box<(dyn MyTrait + 'static)>` cannot be dereferenced

--- a/src/test/ui/issues/issue-5100.rs
+++ b/src/test/ui/issues/issue-5100.rs
@@ -1,5 +1,5 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
+
 
 enum A { B, C }
 

--- a/src/test/ui/issues/issue-5192.rs
+++ b/src/test/ui/issues/issue-5192.rs
@@ -2,8 +2,6 @@
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub trait EventLoop {
     fn dummy(&self) { }
 }
@@ -37,5 +35,5 @@ impl Scheduler {
 }
 
 pub fn main() {
-    let _sched = Scheduler::new(box UvEventLoop::new() as Box<dyn EventLoop>);
+    let _sched = Scheduler::new(Box::new(UvEventLoop::new()) as Box<dyn EventLoop>);
 }

--- a/src/test/ui/issues/issue-5439.rs
+++ b/src/test/ui/issues/issue-5439.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 struct Foo {
     foo: isize,
 }
@@ -10,7 +8,7 @@ struct Bar {
 
 impl Bar {
     fn make_foo (&self, i: isize) -> Box<Foo> {
-        return box Foo { nonexistent: self, foo: i }; //~ ERROR: no field named
+        return Box::new(Foo { nonexistent: self, foo: i }); //~ ERROR: no field named
     }
 }
 

--- a/src/test/ui/issues/issue-5439.stderr
+++ b/src/test/ui/issues/issue-5439.stderr
@@ -1,8 +1,8 @@
 error[E0560]: struct `Foo` has no field named `nonexistent`
-  --> $DIR/issue-5439.rs:13:26
+  --> $DIR/issue-5439.rs:11:31
    |
-LL |         return box Foo { nonexistent: self, foo: i };
-   |                          ^^^^^^^^^^^ `Foo` does not have this field
+LL |         return Box::new(Foo { nonexistent: self, foo: i });
+   |                               ^^^^^^^^^^^ `Foo` does not have this field
    |
    = note: available fields are: `foo`
 

--- a/src/test/ui/issues/issue-5666.rs
+++ b/src/test/ui/issues/issue-5666.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct Dog {
     name : String
@@ -17,8 +16,8 @@ impl Barks for Dog {
 
 
 pub fn main() {
-    let snoopy = box Dog{name: "snoopy".to_string()};
-    let bubbles = box Dog{name: "bubbles".to_string()};
+    let snoopy = Box::new(Dog{name: "snoopy".to_string()});
+    let bubbles = Box::new(Dog{name: "bubbles".to_string()});
     let barker = [snoopy as Box<dyn Barks>, bubbles as Box<dyn Barks>];
 
     for pup in &barker {

--- a/src/test/ui/issues/issue-5718.rs
+++ b/src/test/ui/issues/issue-5718.rs
@@ -1,14 +1,12 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 struct Element;
 
 macro_rules! foo {
     ($tag: expr, $string: expr) => {
         if $tag == $string {
-            let element: Box<_> = box Element;
+            let element: Box<_> = Box::new(Element);
             unsafe {
                 return std::mem::transmute::<_, usize>(element);
             }

--- a/src/test/ui/issues/issue-5884.rs
+++ b/src/test/ui/issues/issue-5884.rs
@@ -2,8 +2,6 @@
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub struct Foo {
     a: isize,
 }
@@ -14,7 +12,7 @@ struct Bar<'a> {
 }
 
 fn check(a: Box<Foo>) {
-    let _ic = Bar{ b: &*a, a: box None };
+    let _ic = Bar{ b: &*a, a: Box::new(None) };
 }
 
 pub fn main(){}

--- a/src/test/ui/issues/issue-6318.rs
+++ b/src/test/ui/issues/issue-6318.rs
@@ -1,8 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub enum Thing {
     A(Box<dyn Foo+'static>)
 }
@@ -16,7 +14,7 @@ pub struct Struct;
 impl Foo for Struct {}
 
 pub fn main() {
-    match Thing::A(box Struct as Box<dyn Foo + 'static>) {
+    match Thing::A(Box::new(Struct) as Box<dyn Foo + 'static>) {
         Thing::A(_a) => 0,
     };
 }

--- a/src/test/ui/issues/issue-6557.rs
+++ b/src/test/ui/issues/issue-6557.rs
@@ -3,7 +3,6 @@
 // pretty-expanded FIXME #23616
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 fn foo(box (_x, _y): Box<(isize, isize)>) {}
 

--- a/src/test/ui/issues/issue-7013.rs
+++ b/src/test/ui/issues/issue-7013.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -23,6 +21,6 @@ struct A {
 }
 
 fn main() {
-    let a = A {v: box B{v: None} as Box<dyn Foo + Send>};
+    let a = A {v: Box::new(B{v: None}) as Box<dyn Foo + Send>};
     //~^ ERROR `Rc<RefCell<A>>` cannot be sent between threads safely
 }

--- a/src/test/ui/issues/issue-7013.stderr
+++ b/src/test/ui/issues/issue-7013.stderr
@@ -1,13 +1,13 @@
 error[E0277]: `Rc<RefCell<A>>` cannot be sent between threads safely
-  --> $DIR/issue-7013.rs:26:19
+  --> $DIR/issue-7013.rs:24:19
    |
-LL |     let a = A {v: box B{v: None} as Box<dyn Foo + Send>};
-   |                   ^^^^^^^^^^^^^^ `Rc<RefCell<A>>` cannot be sent between threads safely
+LL |     let a = A {v: Box::new(B{v: None}) as Box<dyn Foo + Send>};
+   |                   ^^^^^^^^^^^^^^^^^^^^ `Rc<RefCell<A>>` cannot be sent between threads safely
    |
    = help: within `B`, the trait `Send` is not implemented for `Rc<RefCell<A>>`
    = note: required because it appears within the type `Option<Rc<RefCell<A>>>`
 note: required because it appears within the type `B`
-  --> $DIR/issue-7013.rs:10:8
+  --> $DIR/issue-7013.rs:8:8
    |
 LL | struct B {
    |        ^

--- a/src/test/ui/issues/issue-7364.rs
+++ b/src/test/ui/issues/issue-7364.rs
@@ -1,9 +1,7 @@
-#![feature(box_syntax)]
-
 use std::cell::RefCell;
 
 // Regression test for issue 7364
-static boxed: Box<RefCell<isize>> = box RefCell::new(0);
+static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
 //~^ ERROR `RefCell<isize>` cannot be shared between threads safely [E0277]
 
 fn main() { }

--- a/src/test/ui/issues/issue-7364.stderr
+++ b/src/test/ui/issues/issue-7364.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `RefCell<isize>` cannot be shared between threads safely
-  --> $DIR/issue-7364.rs:6:15
+  --> $DIR/issue-7364.rs:4:15
    |
-LL | static boxed: Box<RefCell<isize>> = box RefCell::new(0);
+LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
    |               ^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<isize>`

--- a/src/test/ui/issues/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/ui/issues/issue-7673-cast-generically-implemented-trait.rs
@@ -8,8 +8,6 @@
 
 */
 
-#![feature(box_syntax)]
-
 pub fn main() {}
 
 trait A {
@@ -19,4 +17,4 @@ trait A {
 impl<T: 'static> A for T {}
 
 fn owned2<T: 'static>(a: Box<T>) { a as Box<dyn A>; }
-fn owned3<T: 'static>(a: Box<T>) { box a as Box<dyn A>; }
+fn owned3<T: 'static>(a: Box<T>) { Box::new(a) as Box<dyn A>; }

--- a/src/test/ui/issues/issue-9129.rs
+++ b/src/test/ui/issues/issue-9129.rs
@@ -4,8 +4,6 @@
 #![allow(non_snake_case)]
 // ignore-pretty unreported
 
-#![feature(box_syntax)]
-
 pub trait bomb { fn boom(&self, _: Ident); }
 pub struct S;
 impl bomb for S { fn boom(&self, _: Ident) { } }
@@ -29,6 +27,6 @@ pub fn light_fuse(fld: Box<dyn bomb>) {
 }
 
 pub fn main() {
-    let b = box S as Box<dyn bomb>;
+    let b = Box::new(S) as Box<dyn bomb>;
     light_fuse(b);
 }

--- a/src/test/ui/issues/issue-9382.rs
+++ b/src/test/ui/issues/issue-9382.rs
@@ -3,7 +3,6 @@
 
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 // Tests for a previous bug that occurred due to an interaction
 // between struct field initialization and the auto-coercion
@@ -24,11 +23,11 @@ struct Thing2<'a> {
 pub fn main() {
     let _t1_fixed = Thing1 {
         baz: &[],
-        bar: box 32,
+        bar: Box::new(32),
     };
     Thing1 {
         baz: &Vec::new(),
-        bar: box 32,
+        bar: Box::new(32),
     };
     let _t2_fixed = Thing2 {
         baz: &[],

--- a/src/test/ui/lifetimes/fullwidth-ampersand.rs
+++ b/src/test/ui/lifetimes/fullwidth-ampersand.rs
@@ -1,0 +1,7 @@
+// Verify that we do not ICE when the user uses a multubyte ampersand.
+
+fn f(_: &＆()) -> &() { todo!() }
+//~^ ERROR unknown start of token: \u{ff06}
+//~| ERROR missing lifetime specifier [E0106]
+
+fn main() {}

--- a/src/test/ui/lifetimes/fullwidth-ampersand.stderr
+++ b/src/test/ui/lifetimes/fullwidth-ampersand.stderr
@@ -1,0 +1,26 @@
+error: unknown start of token: \u{ff06}
+  --> $DIR/fullwidth-ampersand.rs:3:10
+   |
+LL | fn f(_: &＆()) -> &() { todo!() }
+   |          ^^
+   |
+help: Unicode character '＆' (Fullwidth Ampersand) looks like '&' (Ampersand), but it is not
+   |
+LL | fn f(_: &&()) -> &() { todo!() }
+   |          ~
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/fullwidth-ampersand.rs:3:18
+   |
+LL | fn f(_: &＆()) -> &() { todo!() }
+   |         -----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
+help: consider introducing a named lifetime parameter
+   |
+LL | fn f<'a>(_: &'a ＆'a ()) -> &'a () { todo!() }
+   |     ++++     ++   ++         ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/limits/issue-17913.rs
+++ b/src/test/ui/limits/issue-17913.rs
@@ -6,18 +6,16 @@
 // normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
 // normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 
-#![feature(box_syntax)]
-
 #[cfg(target_pointer_width = "64")]
 fn main() {
     let n = 0_usize;
-    let a: Box<_> = box [&n; 0xF000000000000000_usize];
+    let a: Box<_> = Box::new([&n; 0xF000000000000000_usize]);
     println!("{}", a[0xFFFFFF_usize]);
 }
 
 #[cfg(target_pointer_width = "32")]
 fn main() {
     let n = 0_usize;
-    let a: Box<_> = box [&n; 0xFFFFFFFF_usize];
+    let a: Box<_> = Box::new([&n; 0xFFFFFFFF_usize]);
     println!("{}", a[0xFFFFFF_usize]);
 }

--- a/src/test/ui/match/issue-42679.rs
+++ b/src/test/ui/match/issue-42679.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 #![feature(box_patterns)]
 
 #[derive(Debug, PartialEq)]
@@ -9,13 +8,13 @@ enum Test {
 }
 
 fn main() {
-    let a = box Test::Foo(10);
-    let b = box Test::Bar(-20);
+    let a = Box::new(Test::Foo(10));
+    let b = Box::new(Test::Bar(-20));
     match (a, b) {
         (_, box Test::Foo(_)) => unreachable!(),
         (box Test::Foo(x), b) => {
             assert_eq!(x, 10);
-            assert_eq!(b, box Test::Bar(-20));
+            assert_eq!(b, Box::new(Test::Bar(-20)));
         },
         _ => unreachable!(),
     }

--- a/src/test/ui/mismatched_types/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.rs
+++ b/src/test/ui/mismatched_types/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.rs
@@ -1,13 +1,8 @@
-// run-rustfix
-
-#![allow(dead_code)]
-
 struct S;
 struct Y;
 
 trait Trait {}
 
-impl Trait for S {}
 impl Trait for Y {}
 
 fn foo() -> impl Trait {

--- a/src/test/ui/mismatched_types/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.stderr
+++ b/src/test/ui/mismatched_types/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.stderr
@@ -1,0 +1,26 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.rs:12:9
+   |
+LL | /     if true {
+LL | |         S
+   | |         - expected because of this
+LL | |     } else {
+LL | |         Y
+   | |         ^ expected struct `S`, found struct `Y`
+LL | |     }
+   | |_____- `if` and `else` have incompatible types
+
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.rs:19:18
+   |
+LL | /     match true {
+LL | |         true => S,
+   | |                 - this is found to be of type `S`
+LL | |         false => Y,
+   | |                  ^ expected struct `S`, found struct `Y`
+LL | |     }
+   | |_____- `match` arms have incompatible types
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.fixed
+++ b/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.fixed
@@ -10,11 +10,18 @@ trait Trait {}
 impl Trait for S {}
 impl Trait for Y {}
 
-fn baz() -> Box<dyn Trait> {
+fn foo() -> Box<dyn Trait> {
     if true {
         Box::new(S)
     } else {
         Box::new(Y) //~ ERROR `if` and `else` have incompatible types
+    }
+}
+
+fn bar() -> Box<dyn Trait> {
+    match true {
+        true => Box::new(S),
+        false => Box::new(Y), //~ ERROR `match` arms have incompatible types
     }
 }
 

--- a/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.fixed
+++ b/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.fixed
@@ -1,0 +1,21 @@
+// run-rustfix
+
+#![allow(dead_code)]
+
+struct S;
+struct Y;
+
+trait Trait {}
+
+impl Trait for S {}
+impl Trait for Y {}
+
+fn baz() -> Box<dyn Trait> {
+    if true {
+        Box::new(S)
+    } else {
+        Box::new(Y) //~ ERROR `if` and `else` have incompatible types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.rs
+++ b/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.rs
@@ -1,0 +1,21 @@
+// run-rustfix
+
+#![allow(dead_code)]
+
+struct S;
+struct Y;
+
+trait Trait {}
+
+impl Trait for S {}
+impl Trait for Y {}
+
+fn baz() -> impl Trait {
+    if true {
+        S
+    } else {
+        Y //~ ERROR `if` and `else` have incompatible types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.stderr
+++ b/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.stderr
@@ -12,7 +12,7 @@ LL | |     }
    |
 help: you could change the return type to be a boxed trait object
    |
-LL | fn baz() -> Box<dyn Trait> {
+LL | fn foo() -> Box<dyn Trait> {
    |             ~~~~~~~      +
 help: if you change the return type to expect trait objects, box the returned expressions
    |
@@ -21,6 +21,27 @@ LL |     } else {
 LL ~         Box::new(Y)
    |
 
-error: aborting due to previous error
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/suggest-boxed-trait-objects-instead-of-impl-trait.rs:24:18
+   |
+LL | /     match true {
+LL | |         true => S,
+   | |                 - this is found to be of type `S`
+LL | |         false => Y,
+   | |                  ^ expected struct `S`, found struct `Y`
+LL | |     }
+   | |_____- `match` arms have incompatible types
+   |
+help: you could change the return type to be a boxed trait object
+   |
+LL | fn bar() -> Box<dyn Trait> {
+   |             ~~~~~~~      +
+help: if you change the return type to expect trait objects, box the returned expressions
+   |
+LL ~         true => Box::new(S),
+LL ~         false => Box::new(Y),
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.stderr
+++ b/src/test/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.stderr
@@ -1,0 +1,26 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/suggest-boxed-trait-objects-instead-of-impl-trait.rs:17:9
+   |
+LL | /     if true {
+LL | |         S
+   | |         - expected because of this
+LL | |     } else {
+LL | |         Y
+   | |         ^ expected struct `S`, found struct `Y`
+LL | |     }
+   | |_____- `if` and `else` have incompatible types
+   |
+help: you could change the return type to be a boxed trait object
+   |
+LL | fn baz() -> Box<dyn Trait> {
+   |             ~~~~~~~      +
+help: if you change the return type to expect trait objects, box the returned expressions
+   |
+LL ~         Box::new(S)
+LL |     } else {
+LL ~         Box::new(Y)
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/structs-enums/align-struct.rs
+++ b/src/test/ui/structs-enums/align-struct.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 use std::mem;
 
@@ -232,9 +231,9 @@ pub fn main() {
     assert_eq!(mem::size_of_val(&a), 32);
     assert!(is_aligned_to(&a, 16));
 
-    let mut large = box AlignLarge {
+    let mut large = Box::new(AlignLarge {
         stuff: [0; 0x10000],
-    };
+    });
     large.stuff[0] = 132;
     *large.stuff.last_mut().unwrap() = 102;
     assert_eq!(large.stuff[0], 132);


### PR DESCRIPTION
Successful merges:

 - #100019 (Revive suggestions for boxed trait objects instead of impl Trait)
 - #100038 (Document the `no-std` target option in config.toml.example)
 - #100194 (Remove even more box syntax uses from src/test)
 - #100206 (test: skip terminfo parsing in Miri)
 - #100230 (Use start_point instead of next_point to point to elided lifetime amp…)
 - #100244 (Add armv4t-none-eabi take2)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100019,100038,100194,100206,100230,100244)
<!-- homu-ignore:end -->