### PR TITLE
Implement `std::marker::Tuple`

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -290,6 +290,8 @@ language_item_table! {
 
     Try,                     sym::Try,                 try_trait,                  Target::Trait,          GenericRequirement::None;
 
+    Tuple,                   sym::tuple_trait,         tuple_trait,                Target::Trait,          GenericRequirement::Exact(0);
+
     SliceLen,                sym::slice_len_fn,        slice_len_fn,               Target::Method(MethodKind::Inherent), GenericRequirement::None;
 
     // Language items from AST lowering

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -634,6 +634,10 @@ pub enum ImplSource<'tcx, N> {
 
     /// ImplSource for a `const Drop` implementation.
     ConstDestruct(ImplSourceConstDestructData<N>),
+
+    /// ImplSource for a `std::marker::Tuple` implementation.
+    /// This has no nested predicates ever, so no data.
+    Tuple,
 }
 
 impl<'tcx, N> ImplSource<'tcx, N> {
@@ -648,7 +652,8 @@ impl<'tcx, N> ImplSource<'tcx, N> {
             ImplSource::Object(d) => d.nested,
             ImplSource::FnPointer(d) => d.nested,
             ImplSource::DiscriminantKind(ImplSourceDiscriminantKindData)
-            | ImplSource::Pointee(ImplSourcePointeeData) => Vec::new(),
+            | ImplSource::Pointee(ImplSourcePointeeData)
+            | ImplSource::Tuple => Vec::new(),
             ImplSource::TraitAlias(d) => d.nested,
             ImplSource::TraitUpcasting(d) => d.nested,
             ImplSource::ConstDestruct(i) => i.nested,
@@ -666,7 +671,8 @@ impl<'tcx, N> ImplSource<'tcx, N> {
             ImplSource::Object(d) => &d.nested,
             ImplSource::FnPointer(d) => &d.nested,
             ImplSource::DiscriminantKind(ImplSourceDiscriminantKindData)
-            | ImplSource::Pointee(ImplSourcePointeeData) => &[],
+            | ImplSource::Pointee(ImplSourcePointeeData)
+            | ImplSource::Tuple => &[],
             ImplSource::TraitAlias(d) => &d.nested,
             ImplSource::TraitUpcasting(d) => &d.nested,
             ImplSource::ConstDestruct(i) => &i.nested,
@@ -733,6 +739,7 @@ impl<'tcx, N> ImplSource<'tcx, N> {
                     nested: i.nested.into_iter().map(f).collect(),
                 })
             }
+            ImplSource::Tuple => ImplSource::Tuple,
         }
     }
 }

--- a/compiler/rustc_middle/src/traits/select.rs
+++ b/compiler/rustc_middle/src/traits/select.rs
@@ -160,6 +160,9 @@ pub enum SelectionCandidate<'tcx> {
 
     /// Implementation of `const Destruct`, optionally from a custom `impl const Drop`.
     ConstDestructCandidate(Option<DefId>),
+
+    /// Witnesses the fact that a type is a tuple.
+    TupleCandidate,
 }
 
 /// The result of trait evaluation. The order is important

--- a/compiler/rustc_middle/src/traits/structural_impls.rs
+++ b/compiler/rustc_middle/src/traits/structural_impls.rs
@@ -34,6 +34,8 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::ImplSource<'tcx, N> {
             super::ImplSource::TraitUpcasting(ref d) => write!(f, "{:?}", d),
 
             super::ImplSource::ConstDestruct(ref d) => write!(f, "{:?}", d),
+
+            super::ImplSource::Tuple => write!(f, "ImplSource::Tuple"),
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1481,6 +1481,7 @@ symbols! {
         tuple,
         tuple_from_req,
         tuple_indexing,
+        tuple_trait,
         two_phase,
         ty,
         type_alias_enum_variants,

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1625,7 +1625,8 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
             super::ImplSource::AutoImpl(..)
             | super::ImplSource::Builtin(..)
             | super::ImplSource::TraitUpcasting(_)
-            | super::ImplSource::ConstDestruct(_) => {
+            | super::ImplSource::ConstDestruct(_)
+            | super::ImplSource::Tuple => {
                 // These traits have no associated types.
                 selcx.tcx().sess.delay_span_bug(
                     obligation.cause.span,
@@ -1700,7 +1701,8 @@ fn confirm_select_candidate<'cx, 'tcx>(
         | super::ImplSource::Builtin(..)
         | super::ImplSource::TraitUpcasting(_)
         | super::ImplSource::TraitAlias(..)
-        | super::ImplSource::ConstDestruct(_) => {
+        | super::ImplSource::ConstDestruct(_)
+        | super::ImplSource::Tuple => {
             // we don't create Select candidates with this kind of resolution
             span_bug!(
                 obligation.cause.span,

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -126,6 +126,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 let data = self.confirm_const_destruct_candidate(obligation, def_id)?;
                 ImplSource::ConstDestruct(data)
             }
+
+            TupleCandidate => ImplSource::Tuple,
         };
 
         if !obligation.predicate.is_const_if_const() {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1618,7 +1618,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         };
 
         // (*) Prefer `BuiltinCandidate { has_nested: false }`, `PointeeCandidate`,
-        // `DiscriminantKindCandidate`, and `ConstDestructCandidate` to anything else.
+        // `DiscriminantKindCandidate`, `ConstDestructCandidate`, and `TupleCandidate`
+        // to anything else.
         //
         // This is a fix for #53123 and prevents winnowing from accidentally extending the
         // lifetime of a variable.
@@ -1638,7 +1639,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 BuiltinCandidate { has_nested: false }
                 | DiscriminantKindCandidate
                 | PointeeCandidate
-                | ConstDestructCandidate(_),
+                | ConstDestructCandidate(_)
+                | TupleCandidate,
                 _,
             ) => true,
             (
@@ -1646,7 +1648,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 BuiltinCandidate { has_nested: false }
                 | DiscriminantKindCandidate
                 | PointeeCandidate
-                | ConstDestructCandidate(_),
+                | ConstDestructCandidate(_)
+                | TupleCandidate,
             ) => false,
 
             (ParamCandidate(other), ParamCandidate(victim)) => {

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -397,7 +397,8 @@ fn resolve_associated_item<'tcx>(
         | traits::ImplSource::DiscriminantKind(..)
         | traits::ImplSource::Pointee(..)
         | traits::ImplSource::TraitUpcasting(_)
-        | traits::ImplSource::ConstDestruct(_) => None,
+        | traits::ImplSource::ConstDestruct(_)
+        | traits::ImplSource::Tuple => None,
     })
 }
 

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -800,6 +800,15 @@ impl<T: ?Sized> Unpin for *mut T {}
 #[rustc_on_unimplemented(message = "can't drop `{Self}`", append_const_msg)]
 pub trait Destruct {}
 
+/// A marker for tuple types.
+///
+/// The implementation of this trait is built-in and cannot be implemented
+/// for any user type.
+#[unstable(feature = "tuple_trait", issue = "none")]
+#[cfg_attr(not(bootstrap), lang = "tuple_trait")]
+#[rustc_on_unimplemented(message = "`{Self}` is not a tuple")]
+pub trait Tuple {}
+
 /// Implementations of `Copy` for primitive types.
 ///
 /// Implementations that cannot be described in Rust

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -43,19 +43,19 @@ LL |     t.2;
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
-error[E0616]: field `3` of struct `Tuple` is private
+error[E0616]: field `3` of struct `pub_and_stability::Tuple` is private
   --> $DIR/explore-issue-38412.rs:36:7
    |
 LL |     t.3;
    |       ^ private field
 
-error[E0616]: field `4` of struct `Tuple` is private
+error[E0616]: field `4` of struct `pub_and_stability::Tuple` is private
   --> $DIR/explore-issue-38412.rs:37:7
    |
 LL |     t.4;
    |       ^ private field
 
-error[E0616]: field `5` of struct `Tuple` is private
+error[E0616]: field `5` of struct `pub_and_stability::Tuple` is private
   --> $DIR/explore-issue-38412.rs:38:7
    |
 LL |     t.5;

--- a/src/test/ui/tuple/builtin-fail.rs
+++ b/src/test/ui/tuple/builtin-fail.rs
@@ -1,0 +1,19 @@
+#![feature(tuple_trait)]
+
+fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
+
+struct TupleStruct(i32, i32);
+
+fn from_param_env<T>() {
+    assert_is_tuple::<T>();
+    //~^ ERROR `T` is not a tuple
+}
+
+fn main() {
+    assert_is_tuple::<i32>();
+    //~^ ERROR `i32` is not a tuple
+    assert_is_tuple::<(i32)>();
+    //~^ ERROR `i32` is not a tuple
+    assert_is_tuple::<TupleStruct>();
+    //~^ ERROR `TupleStruct` is not a tuple
+}

--- a/src/test/ui/tuple/builtin-fail.stderr
+++ b/src/test/ui/tuple/builtin-fail.stderr
@@ -1,0 +1,55 @@
+error[E0277]: `T` is not a tuple
+  --> $DIR/builtin-fail.rs:8:23
+   |
+LL |     assert_is_tuple::<T>();
+   |                       ^ the trait `Tuple` is not implemented for `T`
+   |
+note: required by a bound in `assert_is_tuple`
+  --> $DIR/builtin-fail.rs:3:23
+   |
+LL | fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
+   |                       ^^^^^^^^^^^^^^^^^^ required by this bound in `assert_is_tuple`
+help: consider restricting type parameter `T`
+   |
+LL | fn from_param_env<T: std::marker::Tuple>() {
+   |                    ++++++++++++++++++++
+
+error[E0277]: `i32` is not a tuple
+  --> $DIR/builtin-fail.rs:13:23
+   |
+LL |     assert_is_tuple::<i32>();
+   |                       ^^^ the trait `Tuple` is not implemented for `i32`
+   |
+note: required by a bound in `assert_is_tuple`
+  --> $DIR/builtin-fail.rs:3:23
+   |
+LL | fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
+   |                       ^^^^^^^^^^^^^^^^^^ required by this bound in `assert_is_tuple`
+
+error[E0277]: `i32` is not a tuple
+  --> $DIR/builtin-fail.rs:15:24
+   |
+LL |     assert_is_tuple::<(i32)>();
+   |                        ^^^ the trait `Tuple` is not implemented for `i32`
+   |
+note: required by a bound in `assert_is_tuple`
+  --> $DIR/builtin-fail.rs:3:23
+   |
+LL | fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
+   |                       ^^^^^^^^^^^^^^^^^^ required by this bound in `assert_is_tuple`
+
+error[E0277]: `TupleStruct` is not a tuple
+  --> $DIR/builtin-fail.rs:17:23
+   |
+LL |     assert_is_tuple::<TupleStruct>();
+   |                       ^^^^^^^^^^^ the trait `Tuple` is not implemented for `TupleStruct`
+   |
+note: required by a bound in `assert_is_tuple`
+  --> $DIR/builtin-fail.rs:3:23
+   |
+LL | fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
+   |                       ^^^^^^^^^^^^^^^^^^ required by this bound in `assert_is_tuple`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/tuple/builtin.rs
+++ b/src/test/ui/tuple/builtin.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+#![feature(tuple_trait)]
+
+fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
+
+struct Unsized([u8]);
+
+fn from_param_env<T: std::marker::Tuple + ?Sized>() {
+    assert_is_tuple::<T>();
+}
+
+fn main() {
+    assert_is_tuple::<()>();
+    assert_is_tuple::<(i32,)>();
+    assert_is_tuple::<(Unsized,)>();
+    from_param_env::<()>();
+    from_param_env::<(i32,)>();
+    from_param_env::<(Unsized,)>();
+}


### PR DESCRIPTION
Split out from #99943 (https://github.com/rust-lang/rust/pull/99943#pullrequestreview-1064459183).

Implements part of rust-lang/compiler-team#537
r? @jackh726 