### PR TITLE
Recover from mutable variable declaration where `mut` is placed before `let`

### DIFF
--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -55,6 +55,19 @@ impl<'a> Parser<'a> {
             return Ok(Some(stmt.into_inner()));
         }
 
+        if self.token.is_keyword(kw::Mut) && self.is_keyword_ahead(1, &[kw::Let]) {
+            self.bump();
+            let mut_let_span = lo.to(self.token.span);
+            self.struct_span_err(mut_let_span, "invalid variable declaration")
+                .span_suggestion(
+                    mut_let_span,
+                    "switch the order of `mut` and `let`",
+                    "let mut",
+                    Applicability::MaybeIncorrect,
+                )
+                .emit();
+        }
+
         Ok(Some(if self.token.is_keyword(kw::Let) {
             self.parse_local_mk(lo, attrs, capture_semi, force_collect)?
         } else if self.is_kw_followed_by_ident(kw::Mut) {

--- a/src/test/ui/parser/issue-100197-mut-let.fixed
+++ b/src/test/ui/parser/issue-100197-mut-let.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+
+fn main() {
+    let mut _x = 123;
+    //~^ ERROR invalid variable declaration
+}

--- a/src/test/ui/parser/issue-100197-mut-let.rs
+++ b/src/test/ui/parser/issue-100197-mut-let.rs
@@ -1,0 +1,6 @@
+// run-rustfix
+
+fn main() {
+    mut let _x = 123;
+    //~^ ERROR invalid variable declaration
+}

--- a/src/test/ui/parser/issue-100197-mut-let.stderr
+++ b/src/test/ui/parser/issue-100197-mut-let.stderr
@@ -1,0 +1,8 @@
+error: invalid variable declaration
+  --> $DIR/issue-100197-mut-let.rs:4:5
+   |
+LL |     mut let _x = 123;
+   |     ^^^^^^^ help: switch the order of `mut` and `let`: `let mut`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #100197