### PR TITLE
Set tainted errors bit before emitting coerce suggestions.

### DIFF
--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1479,6 +1479,10 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 }
             }
             Err(coercion_error) => {
+                // Mark that we've failed to coerce the types here to suppress
+                // any superfluous errors we might encounter while trying to
+                // emit or provide suggestions on how to fix the initial error.
+                fcx.set_tainted_by_errors();
                 let (expected, found) = if label_expression_as_expected {
                     // In the case where this is a "forced unit", like
                     // `break`, we want to call the `()` "expected"

--- a/src/test/ui/typeck/issue-100246.rs
+++ b/src/test/ui/typeck/issue-100246.rs
@@ -1,0 +1,30 @@
+#![recursion_limit = "5"] // To reduce noise
+
+//expect incompatible type error when ambiguous traits are in scope
+//and not an overflow error on the span in the main function.
+
+struct Ratio<T>(T);
+
+pub trait Pow {
+    fn pow(self) -> Self;
+}
+
+impl<'a, T> Pow for &'a Ratio<T>
+where
+    &'a T: Pow,
+{
+    fn pow(self) -> Self {
+        self
+    }
+}
+
+fn downcast<'a, W: ?Sized>() -> std::io::Result<&'a W> {
+    todo!()
+}
+
+struct Other;
+
+fn main() -> std::io::Result<()> {
+    let other: Other = downcast()?;//~ERROR 28:24: 28:35: `?` operator has incompatible types
+    Ok(())
+}

--- a/src/test/ui/typeck/issue-100246.stderr
+++ b/src/test/ui/typeck/issue-100246.stderr
@@ -1,0 +1,13 @@
+error[E0308]: `?` operator has incompatible types
+  --> $DIR/issue-100246.rs:28:24
+   |
+LL |     let other: Other = downcast()?;
+   |                        ^^^^^^^^^^^ expected struct `Other`, found reference
+   |
+   = note: `?` operator cannot convert from `&_` to `Other`
+   = note: expected struct `Other`
+           found reference `&_`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #100246.

#89576 basically got 99% of the way there but the match typechecking code (which calls `coerce_inner`) also needed a similar fix.