### PR TITLE
Make typeck aware of uninhabited types

### DIFF
--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -1,5 +1,5 @@
 use crate::coercion::{AsCoercionSite, CoerceMany};
-use crate::{Diverges, Expectation, FnCtxt, Needs};
+use crate::{DivergeReason, Diverges, Expectation, FnCtxt, Needs};
 use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::{self as hir, ExprKind};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
@@ -29,7 +29,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // If there are no arms, that is a diverging match; a special case.
         if arms.is_empty() {
-            self.diverges.set(self.diverges.get() | Diverges::always(expr.span));
+            self.diverges.set(self.diverges.get() | Diverges::Always(DivergeReason::Other, expr));
             return tcx.types.never;
         }
 
@@ -204,13 +204,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // we can emit a better note. Rather than pointing
         // at a diverging expression in an arbitrary arm,
         // we can point at the entire `match` expression
-        if let (Diverges::Always { .. }, hir::MatchSource::Normal) = (all_arms_diverge, match_src) {
-            all_arms_diverge = Diverges::Always {
-                span: expr.span,
-                custom_note: Some(
-                    "any code following this `match` expression is unreachable, as all arms diverge",
-                ),
-            };
+        if let (Diverges::Always(..), hir::MatchSource::Normal) = (all_arms_diverge, match_src) {
+            all_arms_diverge = Diverges::Always(DivergeReason::AllArmsDiverge, expr);
         }
 
         // We won't diverge unless the scrutinee or all arms diverge.

--- a/compiler/rustc_hir_typeck/src/diverges.rs
+++ b/compiler/rustc_hir_typeck/src/diverges.rs
@@ -71,5 +71,6 @@ impl Diverges<'_> {
 #[derive(Clone, Copy, Debug)]
 pub enum DivergeReason {
     AllArmsDiverge,
+    Uninhabited,
     Other,
 }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -249,7 +249,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if matches!(
                     self.diverges.get(),
                     Diverges::Always(DivergeReason::Uninhabited, _)
-                ) && self.tcx.is_ty_uninhabited_from(self.parent_module, ty, self.param_env) => {}
+                ) && self.tcx.is_ty_uninhabited_from(
+                    self.parent_module,
+                    self.freshen(ty),
+                    self.param_env,
+                ) => {}
             _ => self.warn_if_unreachable(expr.hir_id, expr.span, "expression"),
         }
 
@@ -258,7 +262,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if ty.is_never() {
                 self.diverges.set(Diverges::Always(DivergeReason::Other, expr));
             } else if expr_may_be_uninhabited(expr)
-                && self.tcx.is_ty_uninhabited_from(self.parent_module, ty, self.param_env)
+                && self.tcx.is_ty_uninhabited_from(
+                    self.parent_module,
+                    self.freshen(ty),
+                    self.param_env,
+                )
             {
                 self.diverges.set(Diverges::Always(DivergeReason::Uninhabited, expr));
             }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -15,7 +15,7 @@ use crate::method::SelfSource;
 use crate::type_error_struct;
 use crate::Expectation::{self, ExpectCastableToType, ExpectHasType, NoExpectation};
 use crate::{
-    report_unexpected_variant_res, BreakableCtxt, Diverges, FnCtxt, Needs,
+    report_unexpected_variant_res, BreakableCtxt, DivergeReason, Diverges, FnCtxt, Needs,
     TupleArgumentsFlag::DontTupleArguments,
 };
 use rustc_ast as ast;
@@ -249,7 +249,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Any expression that produces a value of type `!` must have diverged
         if ty.is_never() {
-            self.diverges.set(self.diverges.get() | Diverges::always(expr.span));
+            self.diverges.set(self.diverges.get() | Diverges::Always(DivergeReason::Other, expr));
         }
 
         // Record the type, which applies it effects.
@@ -1306,7 +1306,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     })
                 });
             let mut coerce = CoerceMany::with_coercion_sites(coerce_to, args);
-            assert_eq!(self.diverges.get(), Diverges::Maybe);
+            assert!(matches!(self.diverges.get(), Diverges::Maybe));
             for e in args {
                 let e_ty = self.check_expr_with_hint(e, coerce_to);
                 let cause = self.misc(e.span);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -48,6 +48,8 @@ pub struct FnCtxt<'a, 'tcx> {
     /// eventually).
     pub(super) param_env: ty::ParamEnv<'tcx>,
 
+    pub(super) parent_module: DefId,
+
     /// Number of errors that had been reported when we started
     /// checking this function. On exit, if we find that *more* errors
     /// have been reported, we will skip regionck and other work that
@@ -138,6 +140,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         FnCtxt {
             body_id,
             param_env,
+            parent_module: inh.tcx.parent_module(body_id).to_def_id(),
             err_count_on_creation: inh.tcx.sess.err_count(),
             ret_coercion: None,
             in_tail_expr: false,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -110,7 +110,7 @@ pub struct FnCtxt<'a, 'tcx> {
     ///
     /// An expression represents dead code if, after checking it,
     /// the diverges flag is set to something other than `Maybe`.
-    pub(super) diverges: Cell<Diverges>,
+    pub(super) diverges: Cell<Diverges<'tcx>>,
 
     /// Whether any child nodes have any type errors.
     pub(super) has_errors: Cell<bool>,

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -44,7 +44,7 @@ mod rvalue_scopes;
 mod upvar;
 mod writeback;
 
-pub use diverges::Diverges;
+pub use diverges::{DivergeReason, Diverges};
 pub use expectation::Expectation;
 pub use fn_ctxt::*;
 pub use inherited::{Inherited, InheritedBuilder};

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -300,6 +300,7 @@ impl InlineAsmReg {
         }
     }
 
+    #[allow(unreachable_code)]
     pub fn parse(arch: InlineAsmArch, name: Symbol) -> Result<Self, &'static str> {
         // FIXME: use direct symbol comparison for register names
         // Use `Symbol::as_str` instead of `Symbol::with` here because `has_feature` may access `Symbol`.

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -3,23 +3,24 @@
   
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/invalid_constant.rs:+0:11: +0:11
-      let _1: char;                        // in scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
-      let mut _2: main::InvalidChar;       // in scope 0 at $DIR/invalid_constant.rs:+6:34: +6:63
-      let mut _4: E;                       // in scope 0 at $DIR/invalid_constant.rs:+13:25: +13:59
-      let mut _5: main::InvalidTag;        // in scope 0 at $DIR/invalid_constant.rs:+13:34: +13:55
-      let mut _7: Empty;                   // in scope 0 at $DIR/invalid_constant.rs:+20:35: +20:73
-      let mut _8: main::NoVariants;        // in scope 0 at $DIR/invalid_constant.rs:+20:44: +20:65
+      let mut _1: !;                       // in scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
+      let _2: char;                        // in scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
+      let mut _3: main::InvalidChar;       // in scope 0 at $DIR/invalid_constant.rs:+6:34: +6:63
+      let mut _5: E;                       // in scope 0 at $DIR/invalid_constant.rs:+13:25: +13:59
+      let mut _6: main::InvalidTag;        // in scope 0 at $DIR/invalid_constant.rs:+13:34: +13:55
+      let mut _8: Empty;                   // in scope 0 at $DIR/invalid_constant.rs:+20:35: +20:73
+      let mut _9: main::NoVariants;        // in scope 0 at $DIR/invalid_constant.rs:+20:44: +20:65
       scope 1 {
-          debug _invalid_char => _1;       // in scope 1 at $DIR/invalid_constant.rs:+6:9: +6:22
-          let _3: [E; 1];                  // in scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
+          debug _invalid_char => _2;       // in scope 1 at $DIR/invalid_constant.rs:+6:9: +6:22
+          let _4: [E; 1];                  // in scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
           scope 3 {
-              debug _invalid_tag => _3;    // in scope 3 at $DIR/invalid_constant.rs:+13:9: +13:21
-              let _6: [Empty; 1];          // in scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
+              debug _invalid_tag => _4;    // in scope 3 at $DIR/invalid_constant.rs:+13:9: +13:21
+              let _7: [Empty; 1];          // in scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
               scope 5 {
-                  debug _enum_without_variants => _6; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
-                  let _9: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
+                  debug _enum_without_variants => _7; // in scope 5 at $DIR/invalid_constant.rs:+20:9: +20:31
+                  let _10: main::Str<"���">; // in scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
                   scope 7 {
-                      debug _non_utf8_str => _9; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
+                      debug _non_utf8_str => _10; // in scope 7 at $DIR/invalid_constant.rs:+24:9: +24:22
                   }
               }
               scope 6 {
@@ -32,46 +33,7 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/invalid_constant.rs:+6:9: +6:22
-          StorageLive(_2);                 // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
-          Deinit(_2);                      // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
-          (_2.0: u32) = const 1114113_u32; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:63
--         _1 = (_2.1: char);               // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
-+         _1 = const {transmute(0x00110001): char}; // scope 2 at $DIR/invalid_constant.rs:+6:34: +6:67
-          StorageDead(_2);                 // scope 0 at $DIR/invalid_constant.rs:+6:69: +6:70
-          StorageLive(_3);                 // scope 1 at $DIR/invalid_constant.rs:+13:9: +13:21
-          StorageLive(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:25: +13:59
-          StorageLive(_5);                 // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
-          Deinit(_5);                      // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
-          (_5.0: u32) = const 4_u32;       // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:55
--         _4 = (_5.1: E);                  // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
--         _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
-+         _4 = const Scalar(0x00000004): E; // scope 4 at $DIR/invalid_constant.rs:+13:34: +13:57
-+                                          // mir::Constant
-+                                          // + span: $DIR/invalid_constant.rs:28:34: 28:57
-+                                          // + literal: Const { ty: E, val: Value(Scalar(0x00000004)) }
-+         _3 = [const Scalar(0x00000004): E]; // scope 1 at $DIR/invalid_constant.rs:+13:24: +13:60
-+                                          // mir::Constant
-+                                          // + span: $DIR/invalid_constant.rs:28:24: 28:60
-+                                          // + literal: Const { ty: E, val: Value(Scalar(0x00000004)) }
-          StorageDead(_4);                 // scope 1 at $DIR/invalid_constant.rs:+13:59: +13:60
-          StorageDead(_5);                 // scope 1 at $DIR/invalid_constant.rs:+13:60: +13:61
-          StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:+20:9: +20:31
-          StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:35: +20:73
-          StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
-          Deinit(_8);                      // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
-          (_8.0: u32) = const 0_u32;       // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:65
-          nop;                             // scope 6 at $DIR/invalid_constant.rs:+20:44: +20:71
-          nop;                             // scope 3 at $DIR/invalid_constant.rs:+20:34: +20:74
-          StorageDead(_7);                 // scope 3 at $DIR/invalid_constant.rs:+20:73: +20:74
-          StorageDead(_8);                 // scope 3 at $DIR/invalid_constant.rs:+20:74: +20:75
-          StorageLive(_9);                 // scope 5 at $DIR/invalid_constant.rs:+24:9: +24:22
-          nop;                             // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
-          StorageDead(_9);                 // scope 5 at $DIR/invalid_constant.rs:+27:1: +27:2
-          StorageDead(_6);                 // scope 3 at $DIR/invalid_constant.rs:+27:1: +27:2
-          StorageDead(_3);                 // scope 1 at $DIR/invalid_constant.rs:+27:1: +27:2
-          StorageDead(_1);                 // scope 0 at $DIR/invalid_constant.rs:+27:1: +27:2
-          return;                          // scope 0 at $DIR/invalid_constant.rs:+27:2: +27:2
+          unreachable;                     // scope 0 at $DIR/invalid_constant.rs:+0:11: +27:2
       }
   }
   

--- a/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
@@ -11,8 +11,6 @@ fn process_void(_1: *const Void) -> () {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+1:8: +1:14
-        StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:+4:1: +4:2
-        return;                          // scope 0 at $DIR/uninhabited-enum.rs:+4:2: +4:2
+        unreachable;                     // scope 0 at $DIR/uninhabited-enum.rs:+0:41: +4:2
     }
 }

--- a/src/test/ui/break-diverging-value.rs
+++ b/src/test/ui/break-diverging-value.rs
@@ -22,8 +22,8 @@ fn get_void() -> Void {
     panic!()
 }
 
-fn loop_break_void() -> i32 { //~ ERROR mismatched types
-    let loop_value = loop { break get_void() };
+fn loop_break_void() -> i32 {
+    let loop_value = loop { break get_void() }; // ok
 }
 
 fn get_never() -> ! {

--- a/src/test/ui/break-diverging-value.stderr
+++ b/src/test/ui/break-diverging-value.stderr
@@ -6,14 +6,6 @@ LL | fn loop_break_break() -> i32 {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 
-error[E0308]: mismatched types
-  --> $DIR/break-diverging-value.rs:25:25
-   |
-LL | fn loop_break_void() -> i32 {
-   |    ---------------      ^^^ expected `i32`, found `()`
-   |    |
-   |    implicitly returns `()` as its body has no tail or `return` expression
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/consts/const-eval/write-to-uninhabited-enum-variant.rs
+++ b/src/test/ui/consts/const-eval/write-to-uninhabited-enum-variant.rs
@@ -19,10 +19,10 @@ fn bar() -> Option<Empty> {
 
 fn main() {
     if let Some(x) = bar() {
-        Test1::B(x);
+        Test1::B(x); //~ unreachable call
     }
 
     if let Some(x) = bar() {
-        Test2::B(x);
+        Test2::B(x); //~ unreachable call
     }
 }

--- a/src/test/ui/consts/const-eval/write-to-uninhabited-enum-variant.stderr
+++ b/src/test/ui/consts/const-eval/write-to-uninhabited-enum-variant.stderr
@@ -1,0 +1,20 @@
+warning: unreachable call
+  --> $DIR/write-to-uninhabited-enum-variant.rs:22:9
+   |
+LL |         Test1::B(x);
+   |         ^^^^^^^^ - this expression has type `Empty`, which is uninhabited
+   |         |
+   |         unreachable call
+   |
+   = note: `#[warn(unreachable_code)]` on by default
+
+warning: unreachable call
+  --> $DIR/write-to-uninhabited-enum-variant.rs:26:9
+   |
+LL |         Test2::B(x);
+   |         ^^^^^^^^ - this expression has type `Empty`, which is uninhabited
+   |         |
+   |         unreachable call
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -15,7 +15,12 @@ const TEST_A: Discriminant<Test> = discriminant(&Test::A(5));
 const TEST_A_OTHER: Discriminant<Test> = discriminant(&Test::A(17));
 const TEST_B: Discriminant<Test> = discriminant(&Test::B);
 
-enum Void {}
+mod private {
+    enum PrivateVoid {}
+    pub struct VoidS(PrivateVoid);
+    pub enum Void { X(VoidS) }
+}
+use private::Void;
 
 enum SingleVariant {
     V,

--- a/src/test/ui/consts/issue-64506.rs
+++ b/src/test/ui/consts/issue-64506.rs
@@ -6,7 +6,14 @@ pub struct ChildStdin {
 }
 
 #[derive(Copy, Clone)]
-enum AnonPipe {}
+struct AnonPipe(private::Void);
+
+mod private {
+    #[derive(Copy, Clone)]
+    pub struct Void(PrivateVoid);
+    #[derive(Copy, Clone)]
+    enum PrivateVoid {}
+}
 
 const FOO: () = {
     union Foo {

--- a/src/test/ui/deriving/deriving-all-codegen.rs
+++ b/src/test/ui/deriving/deriving-all-codegen.rs
@@ -1,6 +1,7 @@
 // check-pass
-// compile-flags: -Zunpretty=expanded
 // edition:2021
+// revisions: check unpretty
+// [unpretty] compile-flags: -Zunpretty=expanded
 //
 // This test checks the code generated for all[*] the builtin derivable traits
 // on a variety of structs and enums. It protects against accidental changes to
@@ -14,34 +15,33 @@
 // also require the `rustc_serialize` crate.
 
 #![crate_type = "lib"]
-#![allow(dead_code)]
-#![allow(deprecated)]
+#![warn(unused)] // test that lints are not triggerred in derived code
 
 // Empty struct.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Empty;
+pub struct Empty;
 
 // A basic struct.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Point {
+pub struct Point {
     x: u32,
     y: u32,
 }
 
 // A large struct.
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Big {
+pub struct Big {
     b1: u32, b2: u32, b3: u32, b4: u32, b5: u32, b6: u32, b7: u32, b8: u32,
 }
 
 // A struct with an unsized field. Some derives are not usable in this case.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Unsized([u32]);
+pub struct Unsized([u32]);
 
 // A packed tuple struct that impls `Copy`.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(packed)]
-struct PackedCopy(u32);
+pub struct PackedCopy(u32);
 
 // A packed tuple struct that does not impl `Copy`. Note that the alignment of
 // the field must be 1 for this code to be valid. Otherwise it triggers an
@@ -50,28 +50,28 @@ struct PackedCopy(u32);
 // it's possible that this struct is not supposed to work, but for now it does.
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(packed)]
-struct PackedNonCopy(u8);
+pub struct PackedNonCopy(u8);
 
 // An empty enum.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-enum Enum0 {}
+pub enum Enum0 {}
 
 // A single-variant enum.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-enum Enum1 {
+pub enum Enum1 {
     Single { x: u32 }
 }
 
 // A C-like, fieldless enum with a single variant.
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-enum Fieldless1 {
+pub enum Fieldless1 {
     #[default]
     A,
 }
 
 // A C-like, fieldless enum.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-enum Fieldless {
+pub enum Fieldless {
     #[default]
     A,
     B,
@@ -80,7 +80,7 @@ enum Fieldless {
 
 // An enum with multiple fieldless and fielded variants.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-enum Mixed {
+pub enum Mixed {
     #[default]
     P,
     Q,
@@ -91,7 +91,7 @@ enum Mixed {
 // An enum with no fieldless variants. Note that `Default` cannot be derived
 // for this enum.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-enum Fielded {
+pub enum Fielded {
     X(u32),
     Y(bool),
     Z(Option<i32>),
@@ -103,4 +103,21 @@ pub union Union {
     pub b: bool,
     pub u: u32,
     pub i: i32,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Void {}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WithUninhabited {
+    x: u32,
+    v: Void,
+    y: u32,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EnumWithUninhabited {
+    A(u32),
+    B(Void),
+    C(u16),
 }

--- a/src/test/ui/deriving/deriving-all-codegen.unpretty.stdout
+++ b/src/test/ui/deriving/deriving-all-codegen.unpretty.stdout
@@ -1,7 +1,8 @@
 #![feature(prelude_import)]
 // check-pass
-// compile-flags: -Zunpretty=expanded
 // edition:2021
+// revisions: check unpretty
+// [unpretty] compile-flags: -Zunpretty=expanded
 //
 // This test checks the code generated for all[*] the builtin derivable traits
 // on a variety of structs and enums. It protects against accidental changes to
@@ -15,15 +16,15 @@
 // also require the `rustc_serialize` crate.
 
 #![crate_type = "lib"]
-#![allow(dead_code)]
-#![allow(deprecated)]
+#![warn(unused)]
 #[prelude_import]
 use std::prelude::rust_2021::*;
 #[macro_use]
 extern crate std;
+// test that lints are not triggerred in derived code
 
 // Empty struct.
-struct Empty;
+pub struct Empty;
 #[automatically_derived]
 impl ::core::clone::Clone for Empty {
     #[inline]
@@ -79,7 +80,7 @@ impl ::core::cmp::Ord for Empty {
 }
 
 // A basic struct.
-struct Point {
+pub struct Point {
     x: u32,
     y: u32,
 }
@@ -162,7 +163,7 @@ impl ::core::cmp::Ord for Point {
 }
 
 // A large struct.
-struct Big {
+pub struct Big {
     b1: u32,
     b2: u32,
     b3: u32,
@@ -337,7 +338,7 @@ impl ::core::cmp::Ord for Big {
 }
 
 // A struct with an unsized field. Some derives are not usable in this case.
-struct Unsized([u32]);
+pub struct Unsized([u32]);
 #[automatically_derived]
 impl ::core::fmt::Debug for Unsized {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -387,7 +388,7 @@ impl ::core::cmp::Ord for Unsized {
 
 // A packed tuple struct that impls `Copy`.
 #[repr(packed)]
-struct PackedCopy(u32);
+pub struct PackedCopy(u32);
 #[automatically_derived]
 impl ::core::clone::Clone for PackedCopy {
     #[inline]
@@ -458,7 +459,7 @@ impl ::core::cmp::Ord for PackedCopy {
 // derive Copy (error E0133)" at MIR building time. This is a weird case and
 // it's possible that this struct is not supposed to work, but for now it does.
 #[repr(packed)]
-struct PackedNonCopy(u8);
+pub struct PackedNonCopy(u8);
 #[automatically_derived]
 impl ::core::clone::Clone for PackedNonCopy {
     #[inline]
@@ -532,7 +533,7 @@ impl ::core::cmp::Ord for PackedNonCopy {
 }
 
 // An empty enum.
-enum Enum0 {}
+pub enum Enum0 {}
 #[automatically_derived]
 impl ::core::clone::Clone for Enum0 {
     #[inline]
@@ -587,7 +588,7 @@ impl ::core::cmp::Ord for Enum0 {
 }
 
 // A single-variant enum.
-enum Enum1 {
+pub enum Enum1 {
     Single {
         x: u32,
     },
@@ -667,7 +668,7 @@ impl ::core::cmp::Ord for Enum1 {
 }
 
 // A C-like, fieldless enum with a single variant.
-enum Fieldless1 {
+pub enum Fieldless1 {
 
     #[default]
     A,
@@ -725,7 +726,7 @@ impl ::core::cmp::Ord for Fieldless1 {
 }
 
 // A C-like, fieldless enum.
-enum Fieldless {
+pub enum Fieldless {
 
     #[default]
     A,
@@ -802,7 +803,7 @@ impl ::core::cmp::Ord for Fieldless {
 }
 
 // An enum with multiple fieldless and fielded variants.
-enum Mixed {
+pub enum Mixed {
 
     #[default]
     P,
@@ -946,7 +947,7 @@ impl ::core::cmp::Ord for Mixed {
 
 // An enum with no fieldless variants. Note that `Default` cannot be derived
 // for this enum.
-enum Fielded { X(u32), Y(bool), Z(Option<i32>), }
+pub enum Fielded { X(u32), Y(bool), Z(Option<i32>), }
 #[automatically_derived]
 impl ::core::clone::Clone for Fielded {
     #[inline]
@@ -1082,3 +1083,263 @@ impl ::core::clone::Clone for Union {
 }
 #[automatically_derived]
 impl ::core::marker::Copy for Union { }
+
+pub enum Void {}
+#[automatically_derived]
+impl ::core::clone::Clone for Void {
+    #[inline]
+    fn clone(&self) -> Void { *self }
+}
+#[automatically_derived]
+impl ::core::marker::Copy for Void { }
+#[automatically_derived]
+impl ::core::fmt::Debug for Void {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        unsafe { ::core::intrinsics::unreachable() }
+    }
+}
+#[automatically_derived]
+impl ::core::hash::Hash for Void {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+        unsafe { ::core::intrinsics::unreachable() }
+    }
+}
+impl ::core::marker::StructuralPartialEq for Void {}
+#[automatically_derived]
+impl ::core::cmp::PartialEq for Void {
+    #[inline]
+    fn eq(&self, other: &Void) -> bool {
+        unsafe { ::core::intrinsics::unreachable() }
+    }
+}
+impl ::core::marker::StructuralEq for Void {}
+#[automatically_derived]
+impl ::core::cmp::Eq for Void {
+    #[inline]
+    #[doc(hidden)]
+    #[no_coverage]
+    fn assert_receiver_is_total_eq(&self) -> () {}
+}
+#[automatically_derived]
+impl ::core::cmp::PartialOrd for Void {
+    #[inline]
+    fn partial_cmp(&self, other: &Void)
+        -> ::core::option::Option<::core::cmp::Ordering> {
+        unsafe { ::core::intrinsics::unreachable() }
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::Ord for Void {
+    #[inline]
+    fn cmp(&self, other: &Void) -> ::core::cmp::Ordering {
+        unsafe { ::core::intrinsics::unreachable() }
+    }
+}
+
+pub struct WithUninhabited {
+    x: u32,
+    v: Void,
+    y: u32,
+}
+#[automatically_derived]
+impl ::core::clone::Clone for WithUninhabited {
+    #[inline]
+    fn clone(&self) -> WithUninhabited {
+        let _: ::core::clone::AssertParamIsClone<u32>;
+        let _: ::core::clone::AssertParamIsClone<Void>;
+        *self
+    }
+}
+#[automatically_derived]
+impl ::core::marker::Copy for WithUninhabited { }
+#[automatically_derived]
+impl ::core::fmt::Debug for WithUninhabited {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field3_finish(f,
+            "WithUninhabited", "x", &&self.x, "v", &&self.v, "y", &&self.y)
+    }
+}
+#[automatically_derived]
+impl ::core::hash::Hash for WithUninhabited {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+        ::core::hash::Hash::hash(&self.x, state);
+        ::core::hash::Hash::hash(&self.v, state);
+        ::core::hash::Hash::hash(&self.y, state)
+    }
+}
+impl ::core::marker::StructuralPartialEq for WithUninhabited {}
+#[automatically_derived]
+impl ::core::cmp::PartialEq for WithUninhabited {
+    #[inline]
+    fn eq(&self, other: &WithUninhabited) -> bool {
+        self.x == other.x && self.v == other.v && self.y == other.y
+    }
+}
+impl ::core::marker::StructuralEq for WithUninhabited {}
+#[automatically_derived]
+impl ::core::cmp::Eq for WithUninhabited {
+    #[inline]
+    #[doc(hidden)]
+    #[no_coverage]
+    fn assert_receiver_is_total_eq(&self) -> () {
+        let _: ::core::cmp::AssertParamIsEq<u32>;
+        let _: ::core::cmp::AssertParamIsEq<Void>;
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::PartialOrd for WithUninhabited {
+    #[inline]
+    fn partial_cmp(&self, other: &WithUninhabited)
+        -> ::core::option::Option<::core::cmp::Ordering> {
+        match ::core::cmp::PartialOrd::partial_cmp(&self.x, &other.x) {
+            ::core::option::Option::Some(::core::cmp::Ordering::Equal) =>
+                match ::core::cmp::PartialOrd::partial_cmp(&self.v, &other.v)
+                    {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal)
+                        => ::core::cmp::PartialOrd::partial_cmp(&self.y, &other.y),
+                    cmp => cmp,
+                },
+            cmp => cmp,
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::Ord for WithUninhabited {
+    #[inline]
+    fn cmp(&self, other: &WithUninhabited) -> ::core::cmp::Ordering {
+        match ::core::cmp::Ord::cmp(&self.x, &other.x) {
+            ::core::cmp::Ordering::Equal =>
+                match ::core::cmp::Ord::cmp(&self.v, &other.v) {
+                    ::core::cmp::Ordering::Equal =>
+                        ::core::cmp::Ord::cmp(&self.y, &other.y),
+                    cmp => cmp,
+                },
+            cmp => cmp,
+        }
+    }
+}
+
+pub enum EnumWithUninhabited { A(u32), B(Void), C(u16), }
+#[automatically_derived]
+impl ::core::clone::Clone for EnumWithUninhabited {
+    #[inline]
+    fn clone(&self) -> EnumWithUninhabited {
+        let _: ::core::clone::AssertParamIsClone<u32>;
+        let _: ::core::clone::AssertParamIsClone<Void>;
+        let _: ::core::clone::AssertParamIsClone<u16>;
+        *self
+    }
+}
+#[automatically_derived]
+impl ::core::marker::Copy for EnumWithUninhabited { }
+#[automatically_derived]
+impl ::core::fmt::Debug for EnumWithUninhabited {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        match self {
+            EnumWithUninhabited::A(__self_0) =>
+                ::core::fmt::Formatter::debug_tuple_field1_finish(f, "A",
+                    &__self_0),
+            EnumWithUninhabited::B(__self_0) =>
+                ::core::fmt::Formatter::debug_tuple_field1_finish(f, "B",
+                    &__self_0),
+            EnumWithUninhabited::C(__self_0) =>
+                ::core::fmt::Formatter::debug_tuple_field1_finish(f, "C",
+                    &__self_0),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::hash::Hash for EnumWithUninhabited {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+        let __self_tag = ::core::intrinsics::discriminant_value(self);
+        ::core::hash::Hash::hash(&__self_tag, state);
+        match self {
+            EnumWithUninhabited::A(__self_0) =>
+                ::core::hash::Hash::hash(__self_0, state),
+            EnumWithUninhabited::B(__self_0) =>
+                ::core::hash::Hash::hash(__self_0, state),
+            EnumWithUninhabited::C(__self_0) =>
+                ::core::hash::Hash::hash(__self_0, state),
+        }
+    }
+}
+impl ::core::marker::StructuralPartialEq for EnumWithUninhabited {}
+#[automatically_derived]
+impl ::core::cmp::PartialEq for EnumWithUninhabited {
+    #[inline]
+    fn eq(&self, other: &EnumWithUninhabited) -> bool {
+        let __self_tag = ::core::intrinsics::discriminant_value(self);
+        let __arg1_tag = ::core::intrinsics::discriminant_value(other);
+        __self_tag == __arg1_tag &&
+            match (self, other) {
+                (EnumWithUninhabited::A(__self_0),
+                    EnumWithUninhabited::A(__arg1_0)) => *__self_0 == *__arg1_0,
+                (EnumWithUninhabited::B(__self_0),
+                    EnumWithUninhabited::B(__arg1_0)) => *__self_0 == *__arg1_0,
+                (EnumWithUninhabited::C(__self_0),
+                    EnumWithUninhabited::C(__arg1_0)) => *__self_0 == *__arg1_0,
+                _ => unsafe { ::core::intrinsics::unreachable() }
+            }
+    }
+}
+impl ::core::marker::StructuralEq for EnumWithUninhabited {}
+#[automatically_derived]
+impl ::core::cmp::Eq for EnumWithUninhabited {
+    #[inline]
+    #[doc(hidden)]
+    #[no_coverage]
+    fn assert_receiver_is_total_eq(&self) -> () {
+        let _: ::core::cmp::AssertParamIsEq<u32>;
+        let _: ::core::cmp::AssertParamIsEq<Void>;
+        let _: ::core::cmp::AssertParamIsEq<u16>;
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::PartialOrd for EnumWithUninhabited {
+    #[inline]
+    fn partial_cmp(&self, other: &EnumWithUninhabited)
+        -> ::core::option::Option<::core::cmp::Ordering> {
+        let __self_tag = ::core::intrinsics::discriminant_value(self);
+        let __arg1_tag = ::core::intrinsics::discriminant_value(other);
+        match ::core::cmp::PartialOrd::partial_cmp(&__self_tag, &__arg1_tag) {
+            ::core::option::Option::Some(::core::cmp::Ordering::Equal) =>
+                match (self, other) {
+                    (EnumWithUninhabited::A(__self_0),
+                        EnumWithUninhabited::A(__arg1_0)) =>
+                        ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (EnumWithUninhabited::B(__self_0),
+                        EnumWithUninhabited::B(__arg1_0)) =>
+                        ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (EnumWithUninhabited::C(__self_0),
+                        EnumWithUninhabited::C(__arg1_0)) =>
+                        ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() }
+                },
+            cmp => cmp,
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::cmp::Ord for EnumWithUninhabited {
+    #[inline]
+    fn cmp(&self, other: &EnumWithUninhabited) -> ::core::cmp::Ordering {
+        let __self_tag = ::core::intrinsics::discriminant_value(self);
+        let __arg1_tag = ::core::intrinsics::discriminant_value(other);
+        match ::core::cmp::Ord::cmp(&__self_tag, &__arg1_tag) {
+            ::core::cmp::Ordering::Equal =>
+                match (self, other) {
+                    (EnumWithUninhabited::A(__self_0),
+                        EnumWithUninhabited::A(__arg1_0)) =>
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (EnumWithUninhabited::B(__self_0),
+                        EnumWithUninhabited::B(__arg1_0)) =>
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (EnumWithUninhabited::C(__self_0),
+                        EnumWithUninhabited::C(__arg1_0)) =>
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() }
+                },
+            cmp => cmp,
+        }
+    }
+}

--- a/src/test/ui/generator/issue-93161.rs
+++ b/src/test/ui/generator/issue-93161.rs
@@ -39,8 +39,8 @@ async fn includes_never(crash: bool, x: u32) -> u32 {
     }
     #[allow(unused)]
     let bad = never();
-    result *= async { x + x }.await;
-    drop(bad);
+    result *= async { x + x }.await; //~ unreachable statement
+    drop(bad); //~ unreachable call
     result
 }
 

--- a/src/test/ui/generator/issue-93161.stderr
+++ b/src/test/ui/generator/issue-93161.stderr
@@ -1,0 +1,20 @@
+warning: unreachable statement
+  --> $DIR/issue-93161.rs:42:5
+   |
+LL |     let bad = never();
+   |               ------- this expression has type `Never`, which is uninhabited
+LL |     result *= async { x + x }.await;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |
+   = note: `#[warn(unreachable_code)]` on by default
+
+warning: unreachable call
+  --> $DIR/issue-93161.rs:43:5
+   |
+LL |     drop(bad);
+   |     ^^^^ --- this expression has type `Never`, which is uninhabited
+   |     |
+   |     unreachable call
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/issues/issue-46519.rs
+++ b/src/test/ui/issues/issue-46519.rs
@@ -6,7 +6,7 @@
 #[test]
 #[should_panic(expected = "creating inhabited type")]
 fn test() {
-    FontLanguageOverride::system_font(SystemFont::new());
+    FontLanguageOverride::system_font(SystemFont::new()); //~ unreachable call
 }
 
 pub enum FontLanguageOverride {
@@ -19,7 +19,7 @@ pub enum SystemFont {}
 
 impl FontLanguageOverride {
     fn system_font(f: SystemFont) -> Self {
-        FontLanguageOverride::System(f)
+        FontLanguageOverride::System(f) //~ unreachable call
     }
 }
 

--- a/src/test/ui/issues/issue-46519.stderr
+++ b/src/test/ui/issues/issue-46519.stderr
@@ -1,0 +1,20 @@
+warning: unreachable call
+  --> $DIR/issue-46519.rs:9:5
+   |
+LL |     FontLanguageOverride::system_font(SystemFont::new());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ----------------- this expression has type `SystemFont`, which is uninhabited
+   |     |
+   |     unreachable call
+   |
+   = note: `#[warn(unreachable_code)]` on by default
+
+warning: unreachable call
+  --> $DIR/issue-46519.rs:22:9
+   |
+LL |         FontLanguageOverride::System(f)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - this expression has type `SystemFont`, which is uninhabited
+   |         |
+   |         unreachable call
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/issues/issue-46855.rs
+++ b/src/test/ui/issues/issue-46855.rs
@@ -12,7 +12,7 @@ union Foo {
     b: Never
 }
 
-fn foo(xs: [(Never, u32); 1]) -> u32 { xs[0].1 }
+fn foo(xs: [(Never, u32); 1]) -> u32 { xs[0].1 } //~ unreachable expression
 
 fn bar([(_, x)]: [(Never, u32); 1]) -> u32 { x }
 

--- a/src/test/ui/issues/issue-46855.stderr
+++ b/src/test/ui/issues/issue-46855.stderr
@@ -1,0 +1,12 @@
+warning: unreachable expression
+  --> $DIR/issue-46855.rs:15:43
+   |
+LL | fn foo(xs: [(Never, u32); 1]) -> u32 { xs[0].1 }
+   |                                        -- ^ unreachable expression
+   |                                        |
+   |                                        this expression has type `[(Never, u32); 1]`, which is uninhabited
+   |
+   = note: `#[warn(unreachable_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/dead-code/issue-85071-2.rs
+++ b/src/test/ui/lint/dead-code/issue-85071-2.rs
@@ -18,5 +18,5 @@ fn main() {
     let x = s.f();
     //~^ WARNING: unused variable: `x`
     let _y = x;
-    //~^ WARNING: unreachable definition
+    //~^ WARNING: unreachable statement
 }

--- a/src/test/ui/lint/dead-code/issue-85071-2.stderr
+++ b/src/test/ui/lint/dead-code/issue-85071-2.stderr
@@ -1,17 +1,12 @@
-warning: unreachable definition
-  --> $DIR/issue-85071-2.rs:20:9
+warning: unreachable statement
+  --> $DIR/issue-85071-2.rs:20:5
    |
 LL |     let x = s.f();
-   |             ----- any code following this expression is unreachable
+   |             ----- this expression has type `Foo`, which is uninhabited
 LL |
 LL |     let _y = x;
-   |         ^^ unreachable definition
+   |     ^^^^^^^^^^^ unreachable statement
    |
-note: this expression has type `Foo`, which is uninhabited
-  --> $DIR/issue-85071-2.rs:18:13
-   |
-LL |     let x = s.f();
-   |             ^^^^^
 note: the lint level is defined here
   --> $DIR/issue-85071-2.rs:7:26
    |

--- a/src/test/ui/lint/dead-code/issue-85071.rs
+++ b/src/test/ui/lint/dead-code/issue-85071.rs
@@ -15,5 +15,5 @@ fn main() {
     let x = f();
     //~^ WARNING: unused variable: `x`
     let _ = x;
-    //~^ WARNING: unreachable expression
+    //~^ WARNING: unreachable statement
 }

--- a/src/test/ui/lint/dead-code/issue-85071.stderr
+++ b/src/test/ui/lint/dead-code/issue-85071.stderr
@@ -1,17 +1,12 @@
-warning: unreachable expression
-  --> $DIR/issue-85071.rs:17:13
+warning: unreachable statement
+  --> $DIR/issue-85071.rs:17:5
    |
 LL |     let x = f();
-   |             --- any code following this expression is unreachable
+   |             --- this expression has type `Foo`, which is uninhabited
 LL |
 LL |     let _ = x;
-   |             ^ unreachable expression
+   |     ^^^^^^^^^^ unreachable statement
    |
-note: this expression has type `Foo`, which is uninhabited
-  --> $DIR/issue-85071.rs:15:13
-   |
-LL |     let x = f();
-   |             ^^^
 note: the lint level is defined here
   --> $DIR/issue-85071.rs:9:26
    |

--- a/src/test/ui/match/match-no-arms-unreachable-after.stderr
+++ b/src/test/ui/match/match-no-arms-unreachable-after.stderr
@@ -2,7 +2,7 @@ error: unreachable statement
   --> $DIR/match-no-arms-unreachable-after.rs:8:5
    |
 LL |     match v { }
-   |     ----------- any code following this expression is unreachable
+   |           - this expression has type `Void`, which is uninhabited
 LL |     let x = 2;
    |     ^^^^^^^^^^ unreachable statement
    |

--- a/src/test/ui/reachable/unreachable-try-pattern.rs
+++ b/src/test/ui/reachable/unreachable-try-pattern.rs
@@ -27,8 +27,11 @@ fn qux(x: Result<u32, Void>) -> Result<u32, i32> {
 }
 
 fn vom(x: Result<u32, Void>) -> Result<u32, i32> {
-    let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
-    //~^ WARN unreachable pattern
+    let y = (match x {
+        Ok(n) => Ok(n),
+        Err(e) => Err(e) //~  WARN unreachable call
+                         //~| WARN unreachable pattern
+    })?;
     Ok(y)
 }
 

--- a/src/test/ui/reachable/unreachable-try-pattern.stderr
+++ b/src/test/ui/reachable/unreachable-try-pattern.stderr
@@ -13,6 +13,14 @@ note: the lint level is defined here
 LL | #![warn(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
+warning: unreachable call
+  --> $DIR/unreachable-try-pattern.rs:32:19
+   |
+LL |         Err(e) => Err(e)
+   |                   ^^^ - this expression has type `Void`, which is uninhabited
+   |                   |
+   |                   unreachable call
+
 warning: unreachable pattern
   --> $DIR/unreachable-try-pattern.rs:19:24
    |
@@ -26,10 +34,10 @@ LL | #![warn(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 warning: unreachable pattern
-  --> $DIR/unreachable-try-pattern.rs:30:40
+  --> $DIR/unreachable-try-pattern.rs:32:9
    |
-LL |     let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
-   |                                        ^^^^^^
+LL |         Err(e) => Err(e)
+   |         ^^^^^^
 
-warning: 3 warnings emitted
+warning: 4 warnings emitted
 

--- a/src/test/ui/uninhabited/uninhabited-struct-match.rs
+++ b/src/test/ui/uninhabited/uninhabited-struct-match.rs
@@ -1,0 +1,24 @@
+#![crate_type = "lib"]
+
+#![warn(unused)]
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Void {}
+
+pub struct UnStruct {
+    x: u32,
+    v: Void
+}
+
+pub fn match_struct(x: UnStruct) {
+    match x {} //~ non-exhaustive patterns: type `UnStruct` is non-empty
+}
+
+pub fn match_inhabited_field(x: UnStruct) {
+    match x.x {} //~  non-exhaustive patterns: type `u32` is non-empty
+                 //~| unreachable expression
+}
+
+pub fn match_uninhabited_field(x: UnStruct) {
+    match x.v {} // ok
+}

--- a/src/test/ui/uninhabited/uninhabited-struct-match.stderr
+++ b/src/test/ui/uninhabited/uninhabited-struct-match.stderr
@@ -1,0 +1,52 @@
+warning: unreachable expression
+  --> $DIR/uninhabited-struct-match.rs:18:11
+   |
+LL |     match x.x {}
+   |           -^^
+   |           |
+   |           unreachable expression
+   |           this expression has type `UnStruct`, which is uninhabited
+   |
+note: the lint level is defined here
+  --> $DIR/uninhabited-struct-match.rs:3:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
+
+error[E0004]: non-exhaustive patterns: type `UnStruct` is non-empty
+  --> $DIR/uninhabited-struct-match.rs:14:11
+   |
+LL |     match x {}
+   |           ^
+   |
+note: `UnStruct` defined here
+  --> $DIR/uninhabited-struct-match.rs:8:12
+   |
+LL | pub struct UnStruct {
+   |            ^^^^^^^^
+   = note: the matched value is of type `UnStruct`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match x {
+LL +         _ => todo!(),
+LL ~     }
+   |
+
+error[E0004]: non-exhaustive patterns: type `u32` is non-empty
+  --> $DIR/uninhabited-struct-match.rs:18:11
+   |
+LL |     match x.x {}
+   |           ^^^
+   |
+   = note: the matched value is of type `u32`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match x.x {
+LL +         _ => todo!(),
+LL ~     }
+   |
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/tools/rust-analyzer/crates/hir-ty/src/diagnostics/match_check/deconstruct_pat.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/diagnostics/match_check/deconstruct_pat.rs
@@ -348,6 +348,7 @@ impl Constructor {
 
     fn as_slice(&self) -> Option<Slice> {
         match self {
+            #[allow(unreachable_code)]
             Slice(slice) => Some(*slice),
             _ => None,
         }
@@ -470,6 +471,7 @@ impl Constructor {
             (IntRange(self_range), IntRange(other_range)) => self_range.is_covered_by(other_range),
             (FloatRange(void), FloatRange(..)) => match *void {},
             (Str(void), Str(..)) => match *void {},
+            #[allow(unreachable_code)]
             (Slice(self_slice), Slice(other_slice)) => self_slice.is_covered_by(*other_slice),
 
             // We are trying to inspect an opaque constant. Thus we skip the row.
@@ -502,6 +504,7 @@ impl Constructor {
                 .iter()
                 .filter_map(|c| c.as_int_range())
                 .any(|other| range.is_covered_by(other)),
+            #[allow(unreachable_code)]
             Slice(slice) => used_ctors
                 .iter()
                 .filter_map(|c| c.as_slice())

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
 const ROOT_ENTRY_LIMIT: usize = 948;
-const ISSUES_ENTRY_LIMIT: usize = 2117;
+const ISSUES_ENTRY_LIMIT: usize = 2118;
 
 fn check_entries(path: &Path, bad: &mut bool) {
     let dirs = walkdir::WalkDir::new(&path.join("test/ui"))


### PR DESCRIPTION
It was previously assumed in #85556 that we can't check if an expression has an uninhabited type in typeck. So an `unreachable_code` case was added to the liveness pass instead. This PR moves that case back into typeck. It just requires adding `cycle_delay_bug` to the uninhabited query.

Incidentally this leads to some new cases for `unreachable_code`. But it should simply be consistent with how `!` is currently handled.

My original motivation is to remove a blocker to doing some refactoring on liveness.

r? rust-lang/compiler