### PR TITLE
Add inline-llvm option for disabling/enabling LLVM inlining

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -35,6 +35,10 @@ pub fn apply_to_callsite(callsite: &Value, idx: AttributePlace, attrs: &[&Attrib
 /// Get LLVM attribute for the provided inline heuristic.
 #[inline]
 fn inline_attr<'ll>(cx: &CodegenCx<'ll, '_>, inline: InlineAttr) -> Option<&'ll Attribute> {
+    if !cx.tcx.sess.opts.unstable_opts.inline_llvm {
+        // disable LLVM inlining
+        return Some(AttributeKind::NoInline.create_attr(cx.llcx));
+    }
     match inline {
         InlineAttr::Hint => Some(AttributeKind::InlineHint.create_attr(cx.llcx)),
         InlineAttr::Always => Some(AttributeKind::AlwaysInline.create_attr(cx.llcx)),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1345,6 +1345,8 @@ options! {
         "hash spans relative to their parent item for incr. comp. (default: no)"),
     incremental_verify_ich: bool = (false, parse_bool, [UNTRACKED],
         "verify incr. comp. hashes of green query instances (default: no)"),
+    inline_llvm: bool = (true, parse_bool, [TRACKED],
+        "enable LLVM inlining (default: yes)"),
     inline_mir: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "enable MIR inlining (default: no)"),
     inline_mir_threshold: Option<usize> = (None, parse_opt_number, [TRACKED],

--- a/src/test/rustdoc-ui/z-help.stdout
+++ b/src/test/rustdoc-ui/z-help.stdout
@@ -54,6 +54,7 @@
     -Z                        incremental-info=val -- print high-level information about incremental reuse (or the lack thereof) (default: no)
     -Z              incremental-relative-spans=val -- hash spans relative to their parent item for incr. comp. (default: no)
     -Z                  incremental-verify-ich=val -- verify incr. comp. hashes of green query instances (default: no)
+    -Z                             inline-llvm=val -- enable LLVM inlining (default: yes)
     -Z                              inline-mir=val -- enable MIR inlining (default: no)
     -Z                    inline-mir-threshold=val -- a default MIR inlining threshold (default: 50)
     -Z               inline-mir-hint-threshold=val -- inlining threshold for functions with inline hint (default: 100)


### PR DESCRIPTION
In this PR, a new -Z option `inline-llvm` is added in order to be able to turn on/off LLVM inlining. 

The capability of turning on/off inlining in LLVM backend is needed for testing performance implications of using recently enabled inlining in rustc's frontend (with -Z inline-mir=yes option, #91743). It would be interesting to see the performance effect using rustc's frontend inlining only without LLVM inlining enabled. Currently LLVM is still doing inlining no mater what value inline-mir is set to. With the option `inline-llvm` being added in this PR, user can turn off LLVM inlining by using `-Z inline-llvm=no` option (the default of inline-llvm is 'yes', LLVM inlining enabled).

