### PR TITLE
Add standard C error function aliases to last_os_error

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -564,6 +564,8 @@ impl Error {
     /// println!("last OS error: {os_error:?}");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "GetLastError")]
+    #[doc(alias = "errno")]
     #[must_use]
     #[inline]
     pub fn last_os_error() -> Error {


### PR DESCRIPTION
This aids the discoverability of `io::Error::last_os_error()` by linking to commonly used error number functions from C/C++.

I've seen a few people not realize this exists, so hopefully this helps draw attention to the API to encourage using it over integer error codes.