### PR TITLE
Suggest associated method on deref types when path syntax method fails

### DIFF
--- a/src/test/ui/suggestions/deref-path-method.rs
+++ b/src/test/ui/suggestions/deref-path-method.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let vec = Vec::new();
+    Vec::contains(&vec, &0);
+    //~^ ERROR no function or associated item named `contains` found for struct `Vec<_, _>` in the current scope
+    //~| HELP the function `contains` is implemented on `[_]`
+}

--- a/src/test/ui/suggestions/deref-path-method.stderr
+++ b/src/test/ui/suggestions/deref-path-method.stderr
@@ -1,0 +1,14 @@
+error[E0599]: no function or associated item named `contains` found for struct `Vec<_, _>` in the current scope
+  --> $DIR/deref-path-method.rs:3:10
+   |
+LL |     Vec::contains(&vec, &0);
+   |          ^^^^^^^^ function or associated item not found in `Vec<_, _>`
+   |
+help: the function `contains` is implemented on `[_]`
+   |
+LL |     <[_]>::contains(&vec, &0);
+   |     ~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes #100278