### PR TITLE
Dont ICE when encountering indeterminate paths in rustdoc

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1916,8 +1916,9 @@ impl<'a> Resolver<'a> {
             }
             PathResult::Module(ModuleOrUniformRoot::ExternPrelude)
             | PathResult::NonModule(..)
-            | PathResult::Failed { .. } => None,
-            PathResult::Module(..) | PathResult::Indeterminate => unreachable!(),
+            | PathResult::Failed { .. }
+            | PathResult::Indeterminate => None,
+            PathResult::Module(..) => unreachable!(),
         }
     }
 

--- a/src/test/rustdoc/issue-100241.rs
+++ b/src/test/rustdoc/issue-100241.rs
@@ -1,0 +1,13 @@
+//! See [`S`].
+
+// Check that this isn't an ICE
+// should-fail
+
+mod foo {
+    pub use inner::S;
+    //~^ ERROR unresolved imports `inner`, `foo::S`
+}
+
+pub use foo::*;
+
+use foo::S;


### PR DESCRIPTION
Not sure if we can avoid having indeterminate paths due to the way that we handle globs (see test), so just suppress the ICE here.

Fixes #100241

---

Note: The UI test I provided is literally wrong, I don't know how to make a rustdoc test distinguish ICE (bad) and regular fail (good), since we don't have any sort of granularity in failure mode except for `// should-fail`, which triggers any time rustdoc fails at all. 

Perhaps someone knows how to fix this at the compiletest level?