### PR TITLE
Rustdoc-Json: Don't remove impls for items imported from private modules

### DIFF
--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -84,7 +84,17 @@ impl<'a> DocFolder for Stripper<'a> {
             }
 
             // handled in the `strip-priv-imports` pass
-            clean::ExternCrateItem { .. } | clean::ImportItem(..) => {}
+            clean::ExternCrateItem { .. } => {}
+            clean::ImportItem(ref imp) => {
+                // Because json doesn't inline imports from private modules, we need to mark
+                // the imported item as retained so it's impls won't be stripped.i
+                //
+                // FIXME: Is it necessary to check for json output here: See
+                // https://github.com/rust-lang/rust/pull/100325#discussion_r941495215
+                if let Some(did) = imp.source.did && self.is_json_output {
+                    self.retained.insert(did.into());
+                }
+            }
 
             clean::ImplItem(..) => {}
 

--- a/src/test/rustdoc-json/impls/import_from_private.rs
+++ b/src/test/rustdoc-json/impls/import_from_private.rs
@@ -1,0 +1,24 @@
+// https://github.com/rust-lang/rust/issues/100252
+
+#![feature(no_core)]
+#![no_core]
+
+mod bar {
+    // @set baz = import_from_private.json "$.index[*][?(@.kind=='struct')].id"
+    pub struct Baz;
+    // @set impl = - "$.index[*][?(@.kind=='impl')].id"
+    impl Baz {
+        // @set doit = - "$.index[*][?(@.kind=='method')].id"
+        pub fn doit() {}
+    }
+}
+
+// @set import = - "$.index[*][?(@.kind=='import')].id"
+pub use bar::Baz;
+
+// FIXME(adotinthevoid): Use hasexact once #99474 lands
+
+// @has - "$.index[*][?(@.kind=='module')].inner.items[*]" $import
+// @is  - "$.index[*][?(@.kind=='import')].inner.id" $baz
+// @has - "$.index[*][?(@.kind=='struct')].inner.impls[*]" $impl
+// @has - "$.index[*][?(@.kind=='impl')].inner.items[*]" $doit


### PR DESCRIPTION
After #99287, items in private modules may still be in the json output, if a public import accesses them. To reflect this, items that are imported need to be marked as retained in the `Stripper` pass, so their impls arn't removed by `ImplStripper`.

[More context on zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Populating.20cache.2Eimpls), thanks to @ jyn514 for helping debug this.

@rustbot modify labels: +A-rustdoc-json +T-rustdoc

r? @GuillaumeGomez 

Fixes #100252
Fixes #100242