### PR TITLE
Rename integer log* methods to ilog*

### DIFF
--- a/library/core/benches/num/int_log/mod.rs
+++ b/library/core/benches/num/int_log/mod.rs
@@ -9,7 +9,7 @@ macro_rules! int_log_bench {
                 for n in 0..(<$t>::BITS / 8) {
                     for i in 1..=(100 as $t) {
                         let x = black_box(i << (n * 8));
-                        black_box(x.log10());
+                        black_box(x.ilog10());
                     }
                 }
             });
@@ -27,7 +27,7 @@ macro_rules! int_log_bench {
                 .collect();
             bench.iter(|| {
                 for x in &numbers {
-                    black_box(black_box(x).log10());
+                    black_box(black_box(x).ilog10());
                 }
             });
         }
@@ -44,7 +44,7 @@ macro_rules! int_log_bench {
                 .collect();
             bench.iter(|| {
                 for x in &numbers {
-                    black_box(black_box(x).log10());
+                    black_box(black_box(x).ilog10());
                 }
             });
         }

--- a/library/core/src/num/bignum.rs
+++ b/library/core/src/num/bignum.rs
@@ -137,7 +137,7 @@ macro_rules! define_bignum {
                 // Find the most significant non-zero digit.
                 let msd = digits.iter().rposition(|&x| x != 0);
                 match msd {
-                    Some(msd) => msd * digitbits + digits[msd].log2() as usize + 1,
+                    Some(msd) => msd * digitbits + digits[msd].ilog2() as usize + 1,
                     // There are no non-zero digits, i.e., the number is zero.
                     _ => 0,
                 }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2204,7 +2204,7 @@ macro_rules! int_impl {
         /// rounded down.
         ///
         /// This method might not be optimized owing to implementation details;
-        /// `log2` can produce results more efficiently for base 2, and `log10`
+        /// `ilog2` can produce results more efficiently for base 2, and `ilog10`
         /// can produce results more efficiently for base 10.
         ///
         /// # Panics
@@ -2217,7 +2217,7 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".log(5), 1);")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".ilog(5), 1);")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
@@ -2226,8 +2226,8 @@ macro_rules! int_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log(self, base: Self) -> u32 {
-            match self.checked_log(base) {
+        pub const fn ilog(self, base: Self) -> u32 {
+            match self.checked_ilog(base) {
                 Some(n) => n,
                 None => {
                     // In debug builds, trigger a panic on None.
@@ -2250,7 +2250,7 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".log2(), 1);")]
+        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".ilog2(), 1);")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
@@ -2259,8 +2259,8 @@ macro_rules! int_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log2(self) -> u32 {
-            match self.checked_log2() {
+        pub const fn ilog2(self) -> u32 {
+            match self.checked_ilog2() {
                 Some(n) => n,
                 None => {
                     // In debug builds, trigger a panic on None.
@@ -2283,7 +2283,7 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".log10(), 1);")]
+        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".ilog10(), 1);")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
@@ -2292,8 +2292,8 @@ macro_rules! int_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log10(self) -> u32 {
-            match self.checked_log10() {
+        pub const fn ilog10(self) -> u32 {
+            match self.checked_ilog10() {
                 Some(n) => n,
                 None => {
                     // In debug builds, trigger a panic on None.
@@ -2311,20 +2311,20 @@ macro_rules! int_impl {
         /// Returns `None` if the number is negative or zero, or if the base is not at least 2.
         ///
         /// This method might not be optimized owing to implementation details;
-        /// `checked_log2` can produce results more efficiently for base 2, and
-        /// `checked_log10` can produce results more efficiently for base 10.
+        /// `checked_ilog2` can produce results more efficiently for base 2, and
+        /// `checked_ilog10` can produce results more efficiently for base 10.
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".checked_log(5), Some(1));")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".checked_ilog(5), Some(1));")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_log(self, base: Self) -> Option<u32> {
+        pub const fn checked_ilog(self, base: Self) -> Option<u32> {
             if self <= 0 || base <= 1 {
                 None
             } else {
@@ -2333,7 +2333,7 @@ macro_rules! int_impl {
 
                 // Optimization for 128 bit wide integers.
                 if Self::BITS == 128 {
-                    let b = Self::log2(self) / (Self::log2(base) + 1);
+                    let b = Self::ilog2(self) / (Self::ilog2(base) + 1);
                     n += b;
                     r /= base.pow(b as u32);
                 }
@@ -2354,13 +2354,13 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".checked_log2(), Some(1));")]
+        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".checked_ilog2(), Some(1));")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_log2(self) -> Option<u32> {
+        pub const fn checked_ilog2(self) -> Option<u32> {
             if self <= 0 {
                 None
             } else {
@@ -2378,13 +2378,13 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".checked_log10(), Some(1));")]
+        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".checked_ilog10(), Some(1));")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_log10(self) -> Option<u32> {
+        pub const fn checked_ilog10(self) -> Option<u32> {
             if self > 0 {
                 Some(int_log10::$ActualT(self as $ActualT))
             } else {

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -450,7 +450,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// Returns the base 2 logarithm of the number, rounded down.
                 ///
                 /// This is the same operation as
-                #[doc = concat!("[`", stringify!($Int), "::log2`],")]
+                #[doc = concat!("[`", stringify!($Int), "::ilog2`],")]
                 /// except that it has no failure cases to worry about
                 /// since this value can never be zero.
                 ///
@@ -460,22 +460,22 @@ macro_rules! nonzero_unsigned_operations {
                 /// #![feature(int_log)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(7).unwrap().log2(), 2);")]
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(8).unwrap().log2(), 3);")]
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(9).unwrap().log2(), 3);")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(7).unwrap().ilog2(), 2);")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(8).unwrap().ilog2(), 3);")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(9).unwrap().ilog2(), 3);")]
                 /// ```
                 #[unstable(feature = "int_log", issue = "70887")]
                 #[must_use = "this returns the result of the operation, \
                               without modifying the original"]
                 #[inline]
-                pub const fn log2(self) -> u32 {
+                pub const fn ilog2(self) -> u32 {
                     Self::BITS - 1 - self.leading_zeros()
                 }
 
                 /// Returns the base 10 logarithm of the number, rounded down.
                 ///
                 /// This is the same operation as
-                #[doc = concat!("[`", stringify!($Int), "::log10`],")]
+                #[doc = concat!("[`", stringify!($Int), "::ilog10`],")]
                 /// except that it has no failure cases to worry about
                 /// since this value can never be zero.
                 ///
@@ -485,15 +485,15 @@ macro_rules! nonzero_unsigned_operations {
                 /// #![feature(int_log)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(99).unwrap().log10(), 1);")]
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(100).unwrap().log10(), 2);")]
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(101).unwrap().log10(), 2);")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(99).unwrap().ilog10(), 1);")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(100).unwrap().ilog10(), 2);")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::new(101).unwrap().ilog10(), 2);")]
                 /// ```
                 #[unstable(feature = "int_log", issue = "70887")]
                 #[must_use = "this returns the result of the operation, \
                               without modifying the original"]
                 #[inline]
-                pub const fn log10(self) -> u32 {
+                pub const fn ilog10(self) -> u32 {
                     super::int_log10::$Int(self.0)
                 }
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -700,7 +700,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".log(5), 1);")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".ilog(5), 1);")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
@@ -709,8 +709,8 @@ macro_rules! uint_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log(self, base: Self) -> u32 {
-            match self.checked_log(base) {
+        pub const fn ilog(self, base: Self) -> u32 {
+            match self.checked_ilog(base) {
                 Some(n) => n,
                 None => {
                     // In debug builds, trigger a panic on None.
@@ -733,7 +733,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".log2(), 1);")]
+        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".ilog2(), 1);")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
@@ -742,8 +742,8 @@ macro_rules! uint_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log2(self) -> u32 {
-            match self.checked_log2() {
+        pub const fn ilog2(self) -> u32 {
+            match self.checked_ilog2() {
                 Some(n) => n,
                 None => {
                     // In debug builds, trigger a panic on None.
@@ -766,7 +766,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".log10(), 1);")]
+        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".ilog10(), 1);")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
@@ -775,8 +775,8 @@ macro_rules! uint_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log10(self) -> u32 {
-            match self.checked_log10() {
+        pub const fn ilog10(self) -> u32 {
+            match self.checked_ilog10() {
                 Some(n) => n,
                 None => {
                     // In debug builds, trigger a panic on None.
@@ -794,20 +794,20 @@ macro_rules! uint_impl {
         /// Returns `None` if the number is zero, or if the base is not at least 2.
         ///
         /// This method might not be optimized owing to implementation details;
-        /// `checked_log2` can produce results more efficiently for base 2, and
-        /// `checked_log10` can produce results more efficiently for base 10.
+        /// `checked_ilog2` can produce results more efficiently for base 2, and
+        /// `checked_ilog10` can produce results more efficiently for base 10.
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".checked_log(5), Some(1));")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".checked_ilog(5), Some(1));")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_log(self, base: Self) -> Option<u32> {
+        pub const fn checked_ilog(self, base: Self) -> Option<u32> {
             if self <= 0 || base <= 1 {
                 None
             } else {
@@ -816,7 +816,7 @@ macro_rules! uint_impl {
 
                 // Optimization for 128 bit wide integers.
                 if Self::BITS == 128 {
-                    let b = Self::log2(self) / (Self::log2(base) + 1);
+                    let b = Self::ilog2(self) / (Self::ilog2(base) + 1);
                     n += b;
                     r /= base.pow(b as u32);
                 }
@@ -837,15 +837,15 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".checked_log2(), Some(1));")]
+        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".checked_ilog2(), Some(1));")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_log2(self) -> Option<u32> {
+        pub const fn checked_ilog2(self) -> Option<u32> {
             if let Some(x) = <$NonZeroT>::new(self) {
-                Some(x.log2())
+                Some(x.ilog2())
             } else {
                 None
             }
@@ -859,15 +859,15 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_log)]
-        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".checked_log10(), Some(1));")]
+        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".checked_ilog10(), Some(1));")]
         /// ```
         #[unstable(feature = "int_log", issue = "70887")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_log10(self) -> Option<u32> {
+        pub const fn checked_ilog10(self) -> Option<u32> {
             if let Some(x) = <$NonZeroT>::new(self) {
-                Some(x.log10())
+                Some(x.ilog10())
             } else {
                 None
             }

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -1135,7 +1135,7 @@ impl fmt::Debug for Duration {
                     // 2. The postfix: can be "µs" so we have to count UTF8 characters.
                     let mut actual_w = prefix.len() + postfix.chars().count();
                     // 3. The integer part:
-                    if let Some(log) = integer_part.checked_log10() {
+                    if let Some(log) = integer_part.checked_ilog10() {
                         // integer_part is > 0, so has length log10(x)+1
                         actual_w += 1 + log as usize;
                     } else {

--- a/library/core/tests/num/int_log.rs
+++ b/library/core/tests/num/int_log.rs
@@ -1,166 +1,166 @@
-//! This tests the `Integer::{log,log2,log10}` methods. These tests are in a
+//! This tests the `Integer::{ilog,log2,log10}` methods. These tests are in a
 //! separate file because there's both a large number of them, and not all tests
-//! can be run on Android. This is because in Android `log2` uses an imprecise
+//! can be run on Android. This is because in Android `ilog2` uses an imprecise
 //! approximation:https://github.com/rust-lang/rust/blob/4825e12fc9c79954aa0fe18f5521efa6c19c7539/src/libstd/sys/unix/android.rs#L27-L53
 
 #[test]
-fn checked_log() {
-    assert_eq!(999u32.checked_log(10), Some(2));
-    assert_eq!(1000u32.checked_log(10), Some(3));
-    assert_eq!(555u32.checked_log(13), Some(2));
-    assert_eq!(63u32.checked_log(4), Some(2));
-    assert_eq!(64u32.checked_log(4), Some(3));
-    assert_eq!(10460353203u64.checked_log(3), Some(21));
-    assert_eq!(10460353202u64.checked_log(3), Some(20));
-    assert_eq!(147808829414345923316083210206383297601u128.checked_log(3), Some(80));
-    assert_eq!(147808829414345923316083210206383297600u128.checked_log(3), Some(79));
-    assert_eq!(22528399544939174411840147874772641u128.checked_log(19683), Some(8));
-    assert_eq!(22528399544939174411840147874772631i128.checked_log(19683), Some(7));
+fn checked_ilog() {
+    assert_eq!(999u32.checked_ilog(10), Some(2));
+    assert_eq!(1000u32.checked_ilog(10), Some(3));
+    assert_eq!(555u32.checked_ilog(13), Some(2));
+    assert_eq!(63u32.checked_ilog(4), Some(2));
+    assert_eq!(64u32.checked_ilog(4), Some(3));
+    assert_eq!(10460353203u64.checked_ilog(3), Some(21));
+    assert_eq!(10460353202u64.checked_ilog(3), Some(20));
+    assert_eq!(147808829414345923316083210206383297601u128.checked_ilog(3), Some(80));
+    assert_eq!(147808829414345923316083210206383297600u128.checked_ilog(3), Some(79));
+    assert_eq!(22528399544939174411840147874772641u128.checked_ilog(19683), Some(8));
+    assert_eq!(22528399544939174411840147874772631i128.checked_ilog(19683), Some(7));
 
-    assert_eq!(0u8.checked_log(4), None);
-    assert_eq!(0u16.checked_log(4), None);
-    assert_eq!(0i8.checked_log(4), None);
-    assert_eq!(0i16.checked_log(4), None);
+    assert_eq!(0u8.checked_ilog(4), None);
+    assert_eq!(0u16.checked_ilog(4), None);
+    assert_eq!(0i8.checked_ilog(4), None);
+    assert_eq!(0i16.checked_ilog(4), None);
 
     #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
-        assert_eq!(i.checked_log(4), None);
+        assert_eq!(i.checked_ilog(4), None);
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
-        assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as u32));
+        assert_eq!(i.checked_ilog(13), Some((i as f32).log(13.0) as u32));
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
-        assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as u32));
+        assert_eq!(i.checked_ilog(13), Some((i as f32).log(13.0) as u32));
     }
 }
 
 #[test]
-fn checked_log2() {
-    assert_eq!(5u32.checked_log2(), Some(2));
-    assert_eq!(0u64.checked_log2(), None);
-    assert_eq!(128i32.checked_log2(), Some(7));
-    assert_eq!((-55i16).checked_log2(), None);
+fn checked_ilog2() {
+    assert_eq!(5u32.checked_ilog2(), Some(2));
+    assert_eq!(0u64.checked_ilog2(), None);
+    assert_eq!(128i32.checked_ilog2(), Some(7));
+    assert_eq!((-55i16).checked_ilog2(), None);
 
-    assert_eq!(0u8.checked_log2(), None);
-    assert_eq!(0u16.checked_log2(), None);
-    assert_eq!(0i8.checked_log2(), None);
-    assert_eq!(0i16.checked_log2(), None);
+    assert_eq!(0u8.checked_ilog2(), None);
+    assert_eq!(0u16.checked_ilog2(), None);
+    assert_eq!(0i8.checked_ilog2(), None);
+    assert_eq!(0i16.checked_ilog2(), None);
 
     for i in 1..=u8::MAX {
-        assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
+        assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
-        // Guard against Android's imprecise f32::log2 implementation.
+        // Guard against Android's imprecise f32::ilog2 implementation.
         if i != 8192 && i != 32768 {
-            assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
+            assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
         }
     }
     for i in i8::MIN..=0 {
-        assert_eq!(i.checked_log2(), None);
+        assert_eq!(i.checked_ilog2(), None);
     }
     for i in 1..=i8::MAX {
-        assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
+        assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
-        assert_eq!(i.checked_log2(), None);
+        assert_eq!(i.checked_ilog2(), None);
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
-        // Guard against Android's imprecise f32::log2 implementation.
+        // Guard against Android's imprecise f32::ilog2 implementation.
         if i != 8192 {
-            assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
+            assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
         }
     }
 }
 
-// Validate cases that fail on Android's imprecise float log2 implementation.
+// Validate cases that fail on Android's imprecise float ilog2 implementation.
 #[test]
 #[cfg(not(target_os = "android"))]
-fn checked_log2_not_android() {
-    assert_eq!(8192u16.checked_log2(), Some((8192f32).log2() as u32));
-    assert_eq!(32768u16.checked_log2(), Some((32768f32).log2() as u32));
-    assert_eq!(8192i16.checked_log2(), Some((8192f32).log2() as u32));
+fn checked_ilog2_not_android() {
+    assert_eq!(8192u16.checked_ilog2(), Some((8192f32).log2() as u32));
+    assert_eq!(32768u16.checked_ilog2(), Some((32768f32).log2() as u32));
+    assert_eq!(8192i16.checked_ilog2(), Some((8192f32).log2() as u32));
 }
 
 #[test]
-fn checked_log10() {
-    assert_eq!(0u8.checked_log10(), None);
-    assert_eq!(0u16.checked_log10(), None);
-    assert_eq!(0i8.checked_log10(), None);
-    assert_eq!(0i16.checked_log10(), None);
+fn checked_ilog10() {
+    assert_eq!(0u8.checked_ilog10(), None);
+    assert_eq!(0u16.checked_ilog10(), None);
+    assert_eq!(0i8.checked_ilog10(), None);
+    assert_eq!(0i16.checked_ilog10(), None);
 
     #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
-        assert_eq!(i.checked_log10(), None);
+        assert_eq!(i.checked_ilog10(), None);
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
-        assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
+        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32));
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
-        assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
+        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32));
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=100_000u32 {
-        assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
+        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32));
     }
 }
 
-macro_rules! log10_loop {
-    ($T:ty, $log10_max:expr) => {
-        assert_eq!(<$T>::MAX.log10(), $log10_max);
-        for i in 0..=$log10_max {
+macro_rules! ilog10_loop {
+    ($T:ty, $ilog10_max:expr) => {
+        assert_eq!(<$T>::MAX.ilog10(), $ilog10_max);
+        for i in 0..=$ilog10_max {
             let p = (10 as $T).pow(i as u32);
             if p >= 10 {
-                assert_eq!((p - 9).log10(), i - 1);
-                assert_eq!((p - 1).log10(), i - 1);
+                assert_eq!((p - 9).ilog10(), i - 1);
+                assert_eq!((p - 1).ilog10(), i - 1);
             }
-            assert_eq!(p.log10(), i);
-            assert_eq!((p + 1).log10(), i);
+            assert_eq!(p.ilog10(), i);
+            assert_eq!((p + 1).ilog10(), i);
             if p >= 10 {
-                assert_eq!((p + 9).log10(), i);
+                assert_eq!((p + 9).ilog10(), i);
             }
 
-            // also check `x.log(10)`
+            // also check `x.ilog(10)`
             if p >= 10 {
-                assert_eq!((p - 9).log(10), i - 1);
-                assert_eq!((p - 1).log(10), i - 1);
+                assert_eq!((p - 9).ilog(10), i - 1);
+                assert_eq!((p - 1).ilog(10), i - 1);
             }
-            assert_eq!(p.log(10), i);
-            assert_eq!((p + 1).log(10), i);
+            assert_eq!(p.ilog(10), i);
+            assert_eq!((p + 1).ilog(10), i);
             if p >= 10 {
-                assert_eq!((p + 9).log(10), i);
+                assert_eq!((p + 9).ilog(10), i);
             }
         }
     };
 }
 
 #[test]
-fn log10_u8() {
-    log10_loop! { u8, 2 }
+fn ilog10_u8() {
+    ilog10_loop! { u8, 2 }
 }
 
 #[test]
-fn log10_u16() {
-    log10_loop! { u16, 4 }
+fn ilog10_u16() {
+    ilog10_loop! { u16, 4 }
 }
 
 #[test]
-fn log10_u32() {
-    log10_loop! { u32, 9 }
+fn ilog10_u32() {
+    ilog10_loop! { u32, 9 }
 }
 
 #[test]
-fn log10_u64() {
-    log10_loop! { u64, 19 }
+fn ilog10_u64() {
+    ilog10_loop! { u64, 19 }
 }
 
 #[test]
-fn log10_u128() {
-    log10_loop! { u128, 38 }
+fn ilog10_u128() {
+    ilog10_loop! { u128, 38 }
 }

--- a/src/test/rustdoc-json/primitive.rs
+++ b/src/test/rustdoc-json/primitive.rs
@@ -7,8 +7,8 @@ mod usize {}
 
 // @set local_crate_id = primitive.json "$.index[*][?(@.name=='primitive')].crate_id"
 
-// @has - "$.index[*][?(@.name=='log10')]"
-// @!is - "$.index[*][?(@.name=='log10')].crate_id" $local_crate_id
+// @has - "$.index[*][?(@.name=='ilog10')]"
+// @!is - "$.index[*][?(@.name=='ilog10')].crate_id" $local_crate_id
 // @has - "$.index[*][?(@.name=='checked_add')]"
 // @!is - "$.index[*][?(@.name=='checked_add')]" $local_crate_id
 // @!has - "$.index[*][?(@.name=='is_ascii_uppercase')]"


### PR DESCRIPTION
This reflects the concensus from the libs team as reported at https://github.com/rust-lang/rust/issues/70887#issuecomment-1209513261.

Joint work with @yoshuawuyts.
