### PR TITLE
Stabilize `std::io::read_to_string`

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1037,8 +1037,6 @@ pub trait Read {
 /// # Examples
 ///
 /// ```no_run
-/// #![feature(io_read_to_string)]
-///
 /// # use std::io;
 /// fn main() -> io::Result<()> {
 ///     let stdin = io::read_to_string(io::stdin())?;
@@ -1047,7 +1045,7 @@ pub trait Read {
 ///     Ok(())
 /// }
 /// ```
-#[unstable(feature = "io_read_to_string", issue = "80218")]
+#[stable(feature = "io_read_to_string", since = "CURRENT_RUSTC_VERSION")]
 pub fn read_to_string<R: Read>(mut reader: R) -> Result<String> {
     let mut buf = String::new();
     reader.read_to_string(&mut buf)?;


### PR DESCRIPTION
Closes #80218. :tada:

This PR stabilizes the `std::io::read_to_string` function, with the following public API:

```rust
pub fn read_to_string<R: Read>(reader: R) -> Result<String>;
```

It's analogous to `std::fs::read_to_string` for files, but it works on anything that implements `io::Read`, including `io::stdin()`.

See the tracking issue (#80218) or documentation for details.