### PR TITLE
Fixes bootstrap panic when running x fmt --check 

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1631,10 +1631,11 @@ fn chmod(_path: &Path, _perms: u32) {}
 /// If code is not 0 (successful exit status), exit status is 101 (rust's default error code.)
 /// If the test is running and code is an error code, it will cause a panic.
 fn detail_exit(code: i32) -> ! {
-    // Successful exit
+    // if in test and code is an error code, panic with staus code provided
     if cfg!(test) && code != 0 {
         panic!("status code: {}", code);
     } else {
+        //otherwise,exit with provided status code
         std::process::exit(code);
     }
 }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1632,13 +1632,10 @@ fn chmod(_path: &Path, _perms: u32) {}
 /// If the test is running and code is an error code, it will cause a panic.
 fn detail_exit(code: i32) -> ! {
     // Successful exit
-    if code == 0 {
-        std::process::exit(0);
-    }
-    if cfg!(test) {
+    if cfg!(test) && code != 0 {
         panic!("status code: {}", code);
     } else {
-        std::panic::resume_unwind(Box::new(code));
+        std::process::exit(code);
     }
 }
 


### PR DESCRIPTION
closes #100258 wherein bootstrap panics when running x fmt --check. Fixed by replacing resume_unwind  in #98994. with process::exit.
