### PR TITLE
docs: remove repetition in `is_numeric` function docs

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -892,8 +892,7 @@ impl char {
     ///
     /// The general categories for numbers (`Nd` for decimal digits, `Nl` for letter-like numeric
     /// characters, and `No` for other numeric characters) are specified in the [Unicode Character
-    /// Database][ucd] [`UnicodeData.txt`]. Note that this means ideographic numbers like '三'
-    /// are considered alphabetic, not numeric. Please consider to use `is_ascii_digit` or `is_digit`.
+    /// Database][ucd] [`UnicodeData.txt`].
     ///
     /// This method doesn't cover everything that could be considered a number, e.g. ideographic numbers like '三'.
     /// If you want everything including characters with overlapping purposes then you might want to use


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/99628 we introduce new docs for the `is_numeric` function, and this is a follow-up PR that removes some unnecessary repetition that may be introduced by some rebasing.

@rustbot r? @joshtriplett