### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "termcolor",
  "toml_edit",
  "url 2.2.2",
+ "winapi",
 ]
 
 [[package]]
@@ -2655,9 +2656,9 @@ checksum = "dd20eec3dbe4376829cb7d80ae6ac45e0a766831dca50202ff2d40db46a8a024"
 
 [[package]]
 name = "os_info"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eca3ecae1481e12c3d9379ec541b238a16f0b75c9a409942daa8ec20dbfdb62"
+checksum = "5209b2162b2c140df493a93689e04f8deab3a67634f5bc7a553c0a98e5b8d399"
 dependencies = [
  "log",
  "serde",


### PR DESCRIPTION
7 commits in 4fd148c47e733770c537efac5220744945d572ef..ce40690a5e4e315d3dab0aae1eae69d0252c52ac
2022-08-03 15:03:52 +0000 to 2022-08-09 22:32:17 +0000
- Make the `rust-version` error recommend `cargo update --precise -p crate@ver` (rust-lang/cargo#10891)
- resolver docs: link to version requirements syntax full explanation (rust-lang/cargo#10946)
- Bump os_info to 3.5.0 (rust-lang/cargo#10943)
- Mark --timings=html unstable in the document (rust-lang/cargo#10941)
- Mention that aliases are recursive (rust-lang/cargo#10935)
- Test if reserved filenames are allowed in Windows (rust-lang/cargo#10322)
- improve error message for `no such subcommand` (rust-lang/cargo#10924)