### PR TITLE
rustdoc: Rename `@has FILE PATTERN` to `@hasraw FILE PATTERN`

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -41,15 +41,15 @@ There are a number of supported commands:
   `PATH` is relative to the output directory. It can be given as `-`
   which repeats the most recently used `PATH`.
 
-* `@has-literal PATH PATTERN` and `@matches-literal PATH PATTERN` checks
+* `@hastext PATH PATTERN` and `@matchestext PATH PATTERN` checks
   for the occurrence of the given pattern `PATTERN` in the specified file.
   Only one occurrence of the pattern is enough.
 
-  For `@has-literal`, `PATTERN` is a whitespace-normalized (every consecutive
+  For `@hastext`, `PATTERN` is a whitespace-normalized (every consecutive
   whitespace being replaced by one single space character) string.
   The entire file is also whitespace-normalized including newlines.
 
-  For `@matches-literal`, `PATTERN` is a Python-supported regular expression.
+  For `@matchestext`, `PATTERN` is a Python-supported regular expression.
   The file remains intact but the regexp is matched without the `MULTILINE`
   and `IGNORECASE` options. You can still use a prefix `(?m)` or `(?i)`
   to override them, and `\A` and `\Z` for definitely matching
@@ -542,19 +542,19 @@ ERR_COUNT = 0
 def check_command(c, cache):
     try:
         cerr = ""
-        if c.cmd in ['has', 'has-literal', 'matches', 'matches-literal']:  # string test
+        if c.cmd in ['has', 'hastext', 'matches', 'matchestext']:  # string test
             regexp = c.cmd.startswith('matches')
-            if len(c.args) == 1 and not regexp and 'literal' not in c.cmd:  # @has <path> = file existence
+            if len(c.args) == 1 and not regexp and 'text' not in c.cmd:  # @has <path> = file existence
                 try:
                     cache.get_file(c.args[0])
                     ret = True
                 except FailedCheck as err:
                     cerr = str(err)
                     ret = False
-            elif len(c.args) == 2 and 'literal' in c.cmd:  # @has-literal/matches-literal <path> <pat> = string test
+            elif len(c.args) == 2 and 'text' in c.cmd:  # @hastext/matchestext <path> <pat> = string test
                 cerr = "`PATTERN` did not match"
                 ret = check_string(cache.get_file(c.args[0]), c.args[1], regexp)
-            elif len(c.args) == 3 and 'literal' not in c.cmd:  # @has/matches <path> <pat> <match> = XML tree test
+            elif len(c.args) == 3 and 'text' not in c.cmd:  # @has/matches <path> <pat> <match> = XML tree test
                 cerr = "`XPATH PATTERN` did not match"
                 ret = get_nb_matching_elements(cache, c, regexp, True) != 0
             else:

--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -544,17 +544,21 @@ def check_command(c, cache):
         cerr = ""
         if c.cmd in ['has', 'hasraw', 'matches', 'matchesraw']:  # string test
             regexp = c.cmd.startswith('matches')
-            if len(c.args) == 1 and not regexp and 'raw' not in c.cmd:  # @has <path> = file existence
+
+            # @has <path> = file existence
+            if len(c.args) == 1 and not regexp and 'raw' not in c.cmd:
                 try:
                     cache.get_file(c.args[0])
                     ret = True
                 except FailedCheck as err:
                     cerr = str(err)
                     ret = False
-            elif len(c.args) == 2 and 'raw' in c.cmd:  # @hasraw/matchesraw <path> <pat> = string test
+            # @hasraw/matchesraw <path> <pat> = string test
+            elif len(c.args) == 2 and 'raw' in c.cmd:
                 cerr = "`PATTERN` did not match"
                 ret = check_string(cache.get_file(c.args[0]), c.args[1], regexp)
-            elif len(c.args) == 3 and 'raw' not in c.cmd:  # @has/matches <path> <pat> <match> = XML tree test
+            # @has/matches <path> <pat> <match> = XML tree test
+            elif len(c.args) == 3 and 'raw' not in c.cmd:
                 cerr = "`XPATH PATTERN` did not match"
                 ret = get_nb_matching_elements(cache, c, regexp, True) != 0
             else:

--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -41,15 +41,15 @@ There are a number of supported commands:
   `PATH` is relative to the output directory. It can be given as `-`
   which repeats the most recently used `PATH`.
 
-* `@has PATH PATTERN` and `@matches PATH PATTERN` checks for
-  the occurrence of the given pattern `PATTERN` in the specified file.
+* `@has-literal PATH PATTERN` and `@matches-literal PATH PATTERN` checks
+  for the occurrence of the given pattern `PATTERN` in the specified file.
   Only one occurrence of the pattern is enough.
 
-  For `@has`, `PATTERN` is a whitespace-normalized (every consecutive
+  For `@has-literal`, `PATTERN` is a whitespace-normalized (every consecutive
   whitespace being replaced by one single space character) string.
   The entire file is also whitespace-normalized including newlines.
 
-  For `@matches`, `PATTERN` is a Python-supported regular expression.
+  For `@matches-literal`, `PATTERN` is a Python-supported regular expression.
   The file remains intact but the regexp is matched without the `MULTILINE`
   and `IGNORECASE` options. You can still use a prefix `(?m)` or `(?i)`
   to override them, and `\A` and `\Z` for definitely matching
@@ -542,19 +542,19 @@ ERR_COUNT = 0
 def check_command(c, cache):
     try:
         cerr = ""
-        if c.cmd == 'has' or c.cmd == 'matches':  # string test
-            regexp = (c.cmd == 'matches')
-            if len(c.args) == 1 and not regexp:  # @has <path> = file existence
+        if c.cmd in ['has', 'has-literal', 'matches', 'matches-literal']:  # string test
+            regexp = c.cmd.startswith('matches')
+            if len(c.args) == 1 and not regexp and 'literal' not in c.cmd:  # @has <path> = file existence
                 try:
                     cache.get_file(c.args[0])
                     ret = True
                 except FailedCheck as err:
                     cerr = str(err)
                     ret = False
-            elif len(c.args) == 2:  # @has/matches <path> <pat> = string test
+            elif len(c.args) == 2 and 'literal' in c.cmd:  # @has-literal/matches-literal <path> <pat> = string test
                 cerr = "`PATTERN` did not match"
                 ret = check_string(cache.get_file(c.args[0]), c.args[1], regexp)
-            elif len(c.args) == 3:  # @has/matches <path> <pat> <match> = XML tree test
+            elif len(c.args) == 3 and 'literal' not in c.cmd:  # @has/matches <path> <pat> <match> = XML tree test
                 cerr = "`XPATH PATTERN` did not match"
                 ret = get_nb_matching_elements(cache, c, regexp, True) != 0
             else:

--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -41,15 +41,15 @@ There are a number of supported commands:
   `PATH` is relative to the output directory. It can be given as `-`
   which repeats the most recently used `PATH`.
 
-* `@hastext PATH PATTERN` and `@matchestext PATH PATTERN` checks
+* `@hasraw PATH PATTERN` and `@matchesraw PATH PATTERN` checks
   for the occurrence of the given pattern `PATTERN` in the specified file.
   Only one occurrence of the pattern is enough.
 
-  For `@hastext`, `PATTERN` is a whitespace-normalized (every consecutive
+  For `@hasraw`, `PATTERN` is a whitespace-normalized (every consecutive
   whitespace being replaced by one single space character) string.
   The entire file is also whitespace-normalized including newlines.
 
-  For `@matchestext`, `PATTERN` is a Python-supported regular expression.
+  For `@matchesraw`, `PATTERN` is a Python-supported regular expression.
   The file remains intact but the regexp is matched without the `MULTILINE`
   and `IGNORECASE` options. You can still use a prefix `(?m)` or `(?i)`
   to override them, and `\A` and `\Z` for definitely matching
@@ -542,19 +542,19 @@ ERR_COUNT = 0
 def check_command(c, cache):
     try:
         cerr = ""
-        if c.cmd in ['has', 'hastext', 'matches', 'matchestext']:  # string test
+        if c.cmd in ['has', 'hasraw', 'matches', 'matchesraw']:  # string test
             regexp = c.cmd.startswith('matches')
-            if len(c.args) == 1 and not regexp and 'text' not in c.cmd:  # @has <path> = file existence
+            if len(c.args) == 1 and not regexp and 'raw' not in c.cmd:  # @has <path> = file existence
                 try:
                     cache.get_file(c.args[0])
                     ret = True
                 except FailedCheck as err:
                     cerr = str(err)
                     ret = False
-            elif len(c.args) == 2 and 'text' in c.cmd:  # @hastext/matchestext <path> <pat> = string test
+            elif len(c.args) == 2 and 'raw' in c.cmd:  # @hasraw/matchesraw <path> <pat> = string test
                 cerr = "`PATTERN` did not match"
                 ret = check_string(cache.get_file(c.args[0]), c.args[1], regexp)
-            elif len(c.args) == 3 and 'text' not in c.cmd:  # @has/matches <path> <pat> <match> = XML tree test
+            elif len(c.args) == 3 and 'raw' not in c.cmd:  # @has/matches <path> <pat> <match> = XML tree test
                 cerr = "`XPATH PATTERN` did not match"
                 ret = get_nb_matching_elements(cache, c, regexp, True) != 0
             else:

--- a/src/test/rustdoc/all.rs
+++ b/src/test/rustdoc/all.rs
@@ -24,5 +24,5 @@ mod private_module {
 }
 
 // @has foo/all.html '//a[@href="struct.ReexportedStruct.html"]' 'ReexportedStruct'
-// @!has foo/all.html 'private_module'
+// @!hasraw foo/all.html 'private_module'
 pub use private_module::ReexportedStruct;

--- a/src/test/rustdoc/assoc-consts.rs
+++ b/src/test/rustdoc/assoc-consts.rs
@@ -5,7 +5,7 @@ pub trait Foo {
     const FOO: usize = 12 + 1;
     // @has - '//*[@id="associatedconstant.FOO_NO_DEFAULT"]' 'const FOO_NO_DEFAULT: bool'
     const FOO_NO_DEFAULT: bool;
-    // @!has - FOO_HIDDEN
+    // @!hasraw - FOO_HIDDEN
     #[doc(hidden)]
     const FOO_HIDDEN: u8 = 0;
 }
@@ -18,7 +18,7 @@ impl Foo for Bar {
     const FOO: usize = 12;
     // @has - '//*[@id="associatedconstant.FOO_NO_DEFAULT"]' 'const FOO_NO_DEFAULT: bool'
     const FOO_NO_DEFAULT: bool = false;
-    // @!has - FOO_HIDDEN
+    // @!hasraw - FOO_HIDDEN
     #[doc(hidden)]
     const FOO_HIDDEN: u8 = 0;
 }
@@ -50,9 +50,9 @@ impl Bar {
 }
 
 impl Bar {
-    // @!has assoc_consts/struct.Bar.html 'BAR_PRIVATE'
+    // @!hasraw assoc_consts/struct.Bar.html 'BAR_PRIVATE'
     const BAR_PRIVATE: char = 'a';
-    // @!has assoc_consts/struct.Bar.html 'BAR_HIDDEN'
+    // @!hasraw assoc_consts/struct.Bar.html 'BAR_HIDDEN'
     #[doc(hidden)]
     pub const BAR_HIDDEN: &'static str = "a";
 }

--- a/src/test/rustdoc/const-display.rs
+++ b/src/test/rustdoc/const-display.rs
@@ -20,7 +20,7 @@ pub const fn foo() -> u32 { 42 }
 pub const unsafe fn foo_unsafe() -> u32 { 42 }
 
 // @has 'foo/fn.foo2.html' '//pre' 'pub const fn foo2() -> u32'
-// @!has - '//span[@class="since"]'
+// @!hasraw - '//span[@class="since"]'
 #[unstable(feature = "humans", issue = "none")]
 pub const fn foo2() -> u32 { 42 }
 
@@ -32,7 +32,7 @@ pub const fn bar2() -> u32 { 42 }
 
 
 // @has 'foo/fn.foo2_gated.html' '//pre' 'pub const unsafe fn foo2_gated() -> u32'
-// @!has - '//span[@class="since"]'
+// @!hasraw - '//span[@class="since"]'
 #[unstable(feature = "foo2", issue = "none")]
 pub const unsafe fn foo2_gated() -> u32 { 42 }
 
@@ -43,7 +43,7 @@ pub const unsafe fn foo2_gated() -> u32 { 42 }
 pub const unsafe fn bar2_gated() -> u32 { 42 }
 
 // @has 'foo/fn.bar_not_gated.html' '//pre' 'pub const unsafe fn bar_not_gated() -> u32'
-// @!has - '//span[@class="since"]'
+// @!hasraw - '//span[@class="since"]'
 pub const unsafe fn bar_not_gated() -> u32 { 42 }
 
 pub struct Foo;

--- a/src/test/rustdoc/deprecated-impls.rs
+++ b/src/test/rustdoc/deprecated-impls.rs
@@ -75,7 +75,7 @@ impl Bar for Foo1 {
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
     // @hasraw - 'fn_def_def_with_doc short'
-    // @!has - 'fn_def_def_with_doc full'
+    // @!hasraw - 'fn_def_def_with_doc full'
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'
 }
@@ -86,7 +86,7 @@ pub struct Foo2;
 impl Bar for Foo2 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.3: fn_empty_with_doc'
     // @hasraw - 'fn_empty_with_doc short'
-    // @!has - 'fn_empty_with_doc full'
+    // @!hasraw - 'fn_empty_with_doc full'
     fn fn_empty_with_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.4: fn_empty_without_doc'
@@ -99,7 +99,7 @@ impl Bar for Foo2 {
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
     // @hasraw - 'fn_def_with_doc short'
-    // @!has - 'fn_def_with_doc full'
+    // @!hasraw - 'fn_def_with_doc full'
     fn fn_def_with_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.6: fn_def_without_doc'
@@ -112,7 +112,7 @@ impl Bar for Foo2 {
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
     // @hasraw - 'fn_def_def_with_doc short'
-    // @!has - 'fn_def_def_with_doc full'
+    // @!hasraw - 'fn_def_def_with_doc full'
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'
 }

--- a/src/test/rustdoc/deprecated-impls.rs
+++ b/src/test/rustdoc/deprecated-impls.rs
@@ -5,8 +5,8 @@ pub struct Foo0;
 
 impl Foo0 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.1: fn_with_doc'
-    // @hastext - 'fn_with_doc short'
-    // @hastext - 'fn_with_doc full'
+    // @hasraw - 'fn_with_doc short'
+    // @hasraw - 'fn_with_doc full'
     /// fn_with_doc short
     ///
     /// fn_with_doc full
@@ -52,8 +52,8 @@ pub struct Foo1;
 
 impl Bar for Foo1 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.3: fn_empty_with_doc'
-    // @hastext - 'fn_empty_with_doc_impl short'
-    // @hastext - 'fn_empty_with_doc_impl full'
+    // @hasraw - 'fn_empty_with_doc_impl short'
+    // @hasraw - 'fn_empty_with_doc_impl full'
     /// fn_empty_with_doc_impl short
     ///
     /// fn_empty_with_doc_impl full
@@ -63,8 +63,8 @@ impl Bar for Foo1 {
     fn fn_empty_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
-    // @hastext - 'fn_def_with_doc_impl short'
-    // @hastext - 'fn_def_with_doc_impl full'
+    // @hasraw - 'fn_def_with_doc_impl short'
+    // @hasraw - 'fn_def_with_doc_impl full'
     /// fn_def_with_doc_impl short
     ///
     /// fn_def_with_doc_impl full
@@ -74,7 +74,7 @@ impl Bar for Foo1 {
     fn fn_def_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
-    // @hastext - 'fn_def_def_with_doc short'
+    // @hasraw - 'fn_def_def_with_doc short'
     // @!has - 'fn_def_def_with_doc full'
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'
@@ -85,33 +85,33 @@ pub struct Foo2;
 
 impl Bar for Foo2 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.3: fn_empty_with_doc'
-    // @hastext - 'fn_empty_with_doc short'
+    // @hasraw - 'fn_empty_with_doc short'
     // @!has - 'fn_empty_with_doc full'
     fn fn_empty_with_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.4: fn_empty_without_doc'
-    // @hastext - 'fn_empty_without_doc_impl short'
-    // @hastext - 'fn_empty_without_doc_impl full'
+    // @hasraw - 'fn_empty_without_doc_impl short'
+    // @hasraw - 'fn_empty_without_doc_impl full'
     /// fn_empty_without_doc_impl short
     ///
     /// fn_empty_without_doc_impl full
     fn fn_empty_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
-    // @hastext - 'fn_def_with_doc short'
+    // @hasraw - 'fn_def_with_doc short'
     // @!has - 'fn_def_with_doc full'
     fn fn_def_with_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.6: fn_def_without_doc'
-    // @hastext - 'fn_def_without_doc_impl short'
-    // @hastext - 'fn_def_without_doc_impl full'
+    // @hasraw - 'fn_def_without_doc_impl short'
+    // @hasraw - 'fn_def_without_doc_impl full'
     /// fn_def_without_doc_impl short
     ///
     /// fn_def_without_doc_impl full
     fn fn_def_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
-    // @hastext - 'fn_def_def_with_doc short'
+    // @hasraw - 'fn_def_def_with_doc short'
     // @!has - 'fn_def_def_with_doc full'
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'

--- a/src/test/rustdoc/deprecated-impls.rs
+++ b/src/test/rustdoc/deprecated-impls.rs
@@ -5,8 +5,8 @@ pub struct Foo0;
 
 impl Foo0 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.1: fn_with_doc'
-    // @has - 'fn_with_doc short'
-    // @has - 'fn_with_doc full'
+    // @hastext - 'fn_with_doc short'
+    // @hastext - 'fn_with_doc full'
     /// fn_with_doc short
     ///
     /// fn_with_doc full
@@ -52,8 +52,8 @@ pub struct Foo1;
 
 impl Bar for Foo1 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.3: fn_empty_with_doc'
-    // @has - 'fn_empty_with_doc_impl short'
-    // @has - 'fn_empty_with_doc_impl full'
+    // @hastext - 'fn_empty_with_doc_impl short'
+    // @hastext - 'fn_empty_with_doc_impl full'
     /// fn_empty_with_doc_impl short
     ///
     /// fn_empty_with_doc_impl full
@@ -63,8 +63,8 @@ impl Bar for Foo1 {
     fn fn_empty_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
-    // @has - 'fn_def_with_doc_impl short'
-    // @has - 'fn_def_with_doc_impl full'
+    // @hastext - 'fn_def_with_doc_impl short'
+    // @hastext - 'fn_def_with_doc_impl full'
     /// fn_def_with_doc_impl short
     ///
     /// fn_def_with_doc_impl full
@@ -74,7 +74,7 @@ impl Bar for Foo1 {
     fn fn_def_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
-    // @has - 'fn_def_def_with_doc short'
+    // @hastext - 'fn_def_def_with_doc short'
     // @!has - 'fn_def_def_with_doc full'
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'
@@ -85,33 +85,33 @@ pub struct Foo2;
 
 impl Bar for Foo2 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.3: fn_empty_with_doc'
-    // @has - 'fn_empty_with_doc short'
+    // @hastext - 'fn_empty_with_doc short'
     // @!has - 'fn_empty_with_doc full'
     fn fn_empty_with_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.4: fn_empty_without_doc'
-    // @has - 'fn_empty_without_doc_impl short'
-    // @has - 'fn_empty_without_doc_impl full'
+    // @hastext - 'fn_empty_without_doc_impl short'
+    // @hastext - 'fn_empty_without_doc_impl full'
     /// fn_empty_without_doc_impl short
     ///
     /// fn_empty_without_doc_impl full
     fn fn_empty_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
-    // @has - 'fn_def_with_doc short'
+    // @hastext - 'fn_def_with_doc short'
     // @!has - 'fn_def_with_doc full'
     fn fn_def_with_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.6: fn_def_without_doc'
-    // @has - 'fn_def_without_doc_impl short'
-    // @has - 'fn_def_without_doc_impl full'
+    // @hastext - 'fn_def_without_doc_impl short'
+    // @hastext - 'fn_def_without_doc_impl full'
     /// fn_def_without_doc_impl short
     ///
     /// fn_def_without_doc_impl full
     fn fn_def_without_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
-    // @has - 'fn_def_def_with_doc short'
+    // @hastext - 'fn_def_def_with_doc short'
     // @!has - 'fn_def_def_with_doc full'
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'

--- a/src/test/rustdoc/elided-lifetime.rs
+++ b/src/test/rustdoc/elided-lifetime.rs
@@ -11,33 +11,33 @@ pub struct Ref<'a>(&'a u32);
 type ARef<'a> = Ref<'a>;
 
 // @has foo/fn.test1.html
-// @matchestext - "Ref</a>&lt;'_&gt;"
+// @matchesraw - "Ref</a>&lt;'_&gt;"
 pub fn test1(a: &u32) -> Ref {
     Ref(a)
 }
 
 // @has foo/fn.test2.html
-// @matchestext - "Ref</a>&lt;'_&gt;"
+// @matchesraw - "Ref</a>&lt;'_&gt;"
 pub fn test2(a: &u32) -> Ref<'_> {
     Ref(a)
 }
 
 // @has foo/fn.test3.html
-// @matchestext - "Ref</a>&lt;'_&gt;"
+// @matchesraw - "Ref</a>&lt;'_&gt;"
 pub fn test3(a: &u32) -> ARef {
     Ref(a)
 }
 
 // @has foo/fn.test4.html
-// @matchestext - "Ref</a>&lt;'_&gt;"
+// @matchesraw - "Ref</a>&lt;'_&gt;"
 pub fn test4(a: &u32) -> ARef<'_> {
     Ref(a)
 }
 
 // Ensure external paths in inlined docs also display elided lifetime
 // @has foo/bar/fn.test5.html
-// @matchestext - "Ref</a>&lt;'_&gt;"
+// @matchesraw - "Ref</a>&lt;'_&gt;"
 // @has foo/bar/fn.test6.html
-// @matchestext - "Ref</a>&lt;'_&gt;"
+// @matchesraw - "Ref</a>&lt;'_&gt;"
 #[doc(inline)]
 pub extern crate bar;

--- a/src/test/rustdoc/elided-lifetime.rs
+++ b/src/test/rustdoc/elided-lifetime.rs
@@ -11,33 +11,33 @@ pub struct Ref<'a>(&'a u32);
 type ARef<'a> = Ref<'a>;
 
 // @has foo/fn.test1.html
-// @matches - "Ref</a>&lt;'_&gt;"
+// @matchestext - "Ref</a>&lt;'_&gt;"
 pub fn test1(a: &u32) -> Ref {
     Ref(a)
 }
 
 // @has foo/fn.test2.html
-// @matches - "Ref</a>&lt;'_&gt;"
+// @matchestext - "Ref</a>&lt;'_&gt;"
 pub fn test2(a: &u32) -> Ref<'_> {
     Ref(a)
 }
 
 // @has foo/fn.test3.html
-// @matches - "Ref</a>&lt;'_&gt;"
+// @matchestext - "Ref</a>&lt;'_&gt;"
 pub fn test3(a: &u32) -> ARef {
     Ref(a)
 }
 
 // @has foo/fn.test4.html
-// @matches - "Ref</a>&lt;'_&gt;"
+// @matchestext - "Ref</a>&lt;'_&gt;"
 pub fn test4(a: &u32) -> ARef<'_> {
     Ref(a)
 }
 
 // Ensure external paths in inlined docs also display elided lifetime
 // @has foo/bar/fn.test5.html
-// @matches - "Ref</a>&lt;'_&gt;"
+// @matchestext - "Ref</a>&lt;'_&gt;"
 // @has foo/bar/fn.test6.html
-// @matches - "Ref</a>&lt;'_&gt;"
+// @matchestext - "Ref</a>&lt;'_&gt;"
 #[doc(inline)]
 pub extern crate bar;

--- a/src/test/rustdoc/empty-mod-private.rs
+++ b/src/test/rustdoc/empty-mod-private.rs
@@ -1,16 +1,16 @@
 // compile-flags: --document-private-items
 
 // @has 'empty_mod_private/index.html' '//a[@href="foo/index.html"]' 'foo'
-// @has 'empty_mod_private/sidebar-items.js' 'foo'
+// @hastext 'empty_mod_private/sidebar-items.js' 'foo'
 // @matches 'empty_mod_private/foo/index.html' '//h1' 'Module empty_mod_private::foo'
 mod foo {}
 
 // @has 'empty_mod_private/index.html' '//a[@href="bar/index.html"]' 'bar'
-// @has 'empty_mod_private/sidebar-items.js' 'bar'
+// @hastext 'empty_mod_private/sidebar-items.js' 'bar'
 // @matches 'empty_mod_private/bar/index.html' '//h1' 'Module empty_mod_private::bar'
 mod bar {
     // @has 'empty_mod_private/bar/index.html' '//a[@href="baz/index.html"]' 'baz'
-    // @has 'empty_mod_private/bar/sidebar-items.js' 'baz'
+    // @hastext 'empty_mod_private/bar/sidebar-items.js' 'baz'
     // @matches 'empty_mod_private/bar/baz/index.html' '//h1' 'Module empty_mod_private::bar::baz'
     mod baz {}
 }

--- a/src/test/rustdoc/empty-mod-private.rs
+++ b/src/test/rustdoc/empty-mod-private.rs
@@ -1,16 +1,16 @@
 // compile-flags: --document-private-items
 
 // @has 'empty_mod_private/index.html' '//a[@href="foo/index.html"]' 'foo'
-// @hastext 'empty_mod_private/sidebar-items.js' 'foo'
+// @hasraw 'empty_mod_private/sidebar-items.js' 'foo'
 // @matches 'empty_mod_private/foo/index.html' '//h1' 'Module empty_mod_private::foo'
 mod foo {}
 
 // @has 'empty_mod_private/index.html' '//a[@href="bar/index.html"]' 'bar'
-// @hastext 'empty_mod_private/sidebar-items.js' 'bar'
+// @hasraw 'empty_mod_private/sidebar-items.js' 'bar'
 // @matches 'empty_mod_private/bar/index.html' '//h1' 'Module empty_mod_private::bar'
 mod bar {
     // @has 'empty_mod_private/bar/index.html' '//a[@href="baz/index.html"]' 'baz'
-    // @hastext 'empty_mod_private/bar/sidebar-items.js' 'baz'
+    // @hasraw 'empty_mod_private/bar/sidebar-items.js' 'baz'
     // @matches 'empty_mod_private/bar/baz/index.html' '//h1' 'Module empty_mod_private::bar::baz'
     mod baz {}
 }

--- a/src/test/rustdoc/empty-mod-public.rs
+++ b/src/test/rustdoc/empty-mod-public.rs
@@ -1,14 +1,14 @@
 // @has 'empty_mod_public/index.html' '//a[@href="foo/index.html"]' 'foo'
-// @hastext 'empty_mod_public/sidebar-items.js' 'foo'
+// @hasraw 'empty_mod_public/sidebar-items.js' 'foo'
 // @matches 'empty_mod_public/foo/index.html' '//h1' 'Module empty_mod_public::foo'
 pub mod foo {}
 
 // @has 'empty_mod_public/index.html' '//a[@href="bar/index.html"]' 'bar'
-// @hastext 'empty_mod_public/sidebar-items.js' 'bar'
+// @hasraw 'empty_mod_public/sidebar-items.js' 'bar'
 // @matches 'empty_mod_public/bar/index.html' '//h1' 'Module empty_mod_public::bar'
 pub mod bar {
     // @has 'empty_mod_public/bar/index.html' '//a[@href="baz/index.html"]' 'baz'
-    // @hastext 'empty_mod_public/bar/sidebar-items.js' 'baz'
+    // @hasraw 'empty_mod_public/bar/sidebar-items.js' 'baz'
     // @matches 'empty_mod_public/bar/baz/index.html' '//h1' 'Module empty_mod_public::bar::baz'
     pub mod baz {}
 }

--- a/src/test/rustdoc/empty-mod-public.rs
+++ b/src/test/rustdoc/empty-mod-public.rs
@@ -1,14 +1,14 @@
 // @has 'empty_mod_public/index.html' '//a[@href="foo/index.html"]' 'foo'
-// @has 'empty_mod_public/sidebar-items.js' 'foo'
+// @hastext 'empty_mod_public/sidebar-items.js' 'foo'
 // @matches 'empty_mod_public/foo/index.html' '//h1' 'Module empty_mod_public::foo'
 pub mod foo {}
 
 // @has 'empty_mod_public/index.html' '//a[@href="bar/index.html"]' 'bar'
-// @has 'empty_mod_public/sidebar-items.js' 'bar'
+// @hastext 'empty_mod_public/sidebar-items.js' 'bar'
 // @matches 'empty_mod_public/bar/index.html' '//h1' 'Module empty_mod_public::bar'
 pub mod bar {
     // @has 'empty_mod_public/bar/index.html' '//a[@href="baz/index.html"]' 'baz'
-    // @has 'empty_mod_public/bar/sidebar-items.js' 'baz'
+    // @hastext 'empty_mod_public/bar/sidebar-items.js' 'baz'
     // @matches 'empty_mod_public/bar/baz/index.html' '//h1' 'Module empty_mod_public::bar::baz'
     pub mod baz {}
 }

--- a/src/test/rustdoc/empty-section.rs
+++ b/src/test/rustdoc/empty-section.rs
@@ -5,7 +5,7 @@
 pub struct Foo;
 
 // @has foo/struct.Foo.html
-// @!has - 'Auto Trait Implementations'
+// @!hasraw - 'Auto Trait Implementations'
 impl !Send for Foo {}
 impl !Sync for Foo {}
 impl !std::marker::Unpin for Foo {}

--- a/src/test/rustdoc/generic-associated-types/issue-94683.rs
+++ b/src/test/rustdoc/generic-associated-types/issue-94683.rs
@@ -8,6 +8,6 @@ pub trait Trait {
 // Make sure that the elided lifetime shows up
 
 // @has foo/type.T.html
-// @has - "pub type T = "
-// @has - "&lt;'_&gt;"
+// @hastext - "pub type T = "
+// @hastext - "&lt;'_&gt;"
 pub type T = fn(&<() as Trait>::Gat<'_>);

--- a/src/test/rustdoc/generic-associated-types/issue-94683.rs
+++ b/src/test/rustdoc/generic-associated-types/issue-94683.rs
@@ -8,6 +8,6 @@ pub trait Trait {
 // Make sure that the elided lifetime shows up
 
 // @has foo/type.T.html
-// @hastext - "pub type T = "
-// @hastext - "&lt;'_&gt;"
+// @hasraw - "pub type T = "
+// @hasraw - "&lt;'_&gt;"
 pub type T = fn(&<() as Trait>::Gat<'_>);

--- a/src/test/rustdoc/hidden-impls.rs
+++ b/src/test/rustdoc/hidden-impls.rs
@@ -11,7 +11,7 @@ pub mod __hidden {
 }
 
 // @has foo/trait.Clone.html
-// @!has - 'Foo'
+// @!hasraw - 'Foo'
 // @has implementors/core/clone/trait.Clone.js
-// @!has - 'Foo'
+// @!hasraw - 'Foo'
 pub use std::clone::Clone;

--- a/src/test/rustdoc/hidden-line.rs
+++ b/src/test/rustdoc/hidden-line.rs
@@ -15,5 +15,5 @@
 /// ```
 pub fn foo() {}
 
-// @!has hidden_line/fn.foo.html invisible
+// @!hasraw hidden_line/fn.foo.html invisible
 // @matches - //pre "#\[derive\(PartialEq\)\] // Bar"

--- a/src/test/rustdoc/hidden-methods.rs
+++ b/src/test/rustdoc/hidden-methods.rs
@@ -17,13 +17,13 @@ pub mod hidden {
 }
 
 // @has foo/struct.Foo.html
-// @!has - 'Methods'
+// @!hasraw - 'Methods'
 // @!has - '//code' 'impl Foo'
-// @!has - 'this_should_be_hidden'
+// @!hasraw - 'this_should_be_hidden'
 pub use hidden::Foo;
 
 // @has foo/struct.Bar.html
-// @!has - 'Methods'
+// @!hasraw - 'Methods'
 // @!has - '//code' 'impl Bar'
-// @!has - 'this_should_be_hidden'
+// @!hasraw - 'this_should_be_hidden'
 pub use hidden::Bar;

--- a/src/test/rustdoc/hide-unstable-trait.rs
+++ b/src/test/rustdoc/hide-unstable-trait.rs
@@ -5,7 +5,7 @@
 
 extern crate unstable_trait;
 
-// @hastext foo/struct.Foo.html 'bar'
-// @hastext foo/struct.Foo.html 'bar2'
+// @hasraw foo/struct.Foo.html 'bar'
+// @hasraw foo/struct.Foo.html 'bar2'
 #[doc(inline)]
 pub use unstable_trait::Foo;

--- a/src/test/rustdoc/hide-unstable-trait.rs
+++ b/src/test/rustdoc/hide-unstable-trait.rs
@@ -5,7 +5,7 @@
 
 extern crate unstable_trait;
 
-// @has foo/struct.Foo.html 'bar'
-// @has foo/struct.Foo.html 'bar2'
+// @hastext foo/struct.Foo.html 'bar'
+// @hastext foo/struct.Foo.html 'bar2'
 #[doc(inline)]
 pub use unstable_trait::Foo;

--- a/src/test/rustdoc/impl-parts-crosscrate.rs
+++ b/src/test/rustdoc/impl-parts-crosscrate.rs
@@ -12,9 +12,9 @@ pub struct Bar<T> { t: T }
 // full impl string.  Instead, just make sure something from each part
 // is mentioned.
 
-// @has implementors/rustdoc_impl_parts_crosscrate/trait.AnAutoTrait.js Bar
-// @has - Send
-// @has - !AnAutoTrait
-// @has - Copy
+// @hastext implementors/rustdoc_impl_parts_crosscrate/trait.AnAutoTrait.js Bar
+// @hastext - Send
+// @hastext - !AnAutoTrait
+// @hastext - Copy
 impl<T: Send> !rustdoc_impl_parts_crosscrate::AnAutoTrait for Bar<T>
     where T: Copy {}

--- a/src/test/rustdoc/impl-parts-crosscrate.rs
+++ b/src/test/rustdoc/impl-parts-crosscrate.rs
@@ -12,9 +12,9 @@ pub struct Bar<T> { t: T }
 // full impl string.  Instead, just make sure something from each part
 // is mentioned.
 
-// @hastext implementors/rustdoc_impl_parts_crosscrate/trait.AnAutoTrait.js Bar
-// @hastext - Send
-// @hastext - !AnAutoTrait
-// @hastext - Copy
+// @hasraw implementors/rustdoc_impl_parts_crosscrate/trait.AnAutoTrait.js Bar
+// @hasraw - Send
+// @hasraw - !AnAutoTrait
+// @hasraw - Copy
 impl<T: Send> !rustdoc_impl_parts_crosscrate::AnAutoTrait for Bar<T>
     where T: Copy {}

--- a/src/test/rustdoc/impl-trait-alias.rs
+++ b/src/test/rustdoc/impl-trait-alias.rs
@@ -3,11 +3,11 @@
 trait MyTrait {}
 impl MyTrait for i32 {}
 
-// @has impl_trait_alias/type.Foo.html 'Foo'
+// @hastext impl_trait_alias/type.Foo.html 'Foo'
 /// debug type
 pub type Foo = impl MyTrait;
 
-// @has impl_trait_alias/fn.foo.html 'foo'
+// @hastext impl_trait_alias/fn.foo.html 'foo'
 /// debug function
 pub fn foo() -> Foo {
     1

--- a/src/test/rustdoc/impl-trait-alias.rs
+++ b/src/test/rustdoc/impl-trait-alias.rs
@@ -3,11 +3,11 @@
 trait MyTrait {}
 impl MyTrait for i32 {}
 
-// @hastext impl_trait_alias/type.Foo.html 'Foo'
+// @hasraw impl_trait_alias/type.Foo.html 'Foo'
 /// debug type
 pub type Foo = impl MyTrait;
 
-// @hastext impl_trait_alias/fn.foo.html 'foo'
+// @hasraw impl_trait_alias/fn.foo.html 'foo'
 /// debug function
 pub fn foo() -> Foo {
     1

--- a/src/test/rustdoc/inline_cross/add-docs.rs
+++ b/src/test/rustdoc/inline_cross/add-docs.rs
@@ -4,6 +4,6 @@ extern crate inner;
 
 
 // @has add_docs/struct.MyStruct.html
-// @hastext add_docs/struct.MyStruct.html "Doc comment from ‘pub use’, Doc comment from definition"
+// @hasraw add_docs/struct.MyStruct.html "Doc comment from ‘pub use’, Doc comment from definition"
 /// Doc comment from 'pub use',
 pub use inner::MyStruct;

--- a/src/test/rustdoc/inline_cross/add-docs.rs
+++ b/src/test/rustdoc/inline_cross/add-docs.rs
@@ -4,6 +4,6 @@ extern crate inner;
 
 
 // @has add_docs/struct.MyStruct.html
-// @has add_docs/struct.MyStruct.html "Doc comment from ‘pub use’, Doc comment from definition"
+// @hastext add_docs/struct.MyStruct.html "Doc comment from ‘pub use’, Doc comment from definition"
 /// Doc comment from 'pub use',
 pub use inner::MyStruct;

--- a/src/test/rustdoc/inline_cross/assoc-items.rs
+++ b/src/test/rustdoc/inline_cross/assoc-items.rs
@@ -7,10 +7,10 @@
 extern crate assoc_items;
 
 // @has foo/struct.MyStruct.html
-// @!has - 'PrivateConst'
+// @!hasraw - 'PrivateConst'
 // @has - '//*[@id="associatedconstant.PublicConst"]' 'pub const PublicConst: u8'
 // @has - '//*[@class="docblock"]' 'docs for PublicConst'
-// @!has - 'private_method'
+// @!hasraw - 'private_method'
 // @has - '//*[@id="method.public_method"]' 'pub fn public_method()'
 // @has - '//*[@class="docblock"]' 'docs for public_method'
 // @has - '//*[@id="associatedconstant.ConstNoDefault"]' 'const ConstNoDefault: i16'

--- a/src/test/rustdoc/inline_cross/hidden-use.rs
+++ b/src/test/rustdoc/inline_cross/hidden-use.rs
@@ -5,8 +5,8 @@
 extern crate rustdoc_hidden;
 
 // @has hidden_use/index.html
-// @!has - 'rustdoc_hidden'
-// @!has - 'Bar'
+// @!hasraw - 'rustdoc_hidden'
+// @!hasraw - 'Bar'
 // @!has hidden_use/struct.Bar.html
 #[doc(hidden)]
 pub use rustdoc_hidden::Bar;

--- a/src/test/rustdoc/inline_cross/proc_macro.rs
+++ b/src/test/rustdoc/inline_cross/proc_macro.rs
@@ -12,25 +12,25 @@ extern crate some_macros;
 // @has proc_macro/derive.SomeDerive.html
 
 // @has proc_macro/macro.some_proc_macro.html
-// @has - 'a proc-macro that swallows its input and does nothing.'
+// @hastext - 'a proc-macro that swallows its input and does nothing.'
 pub use some_macros::some_proc_macro;
 
 // @has proc_macro/macro.reexported_macro.html
-// @has - 'Doc comment from the original crate'
+// @hastext - 'Doc comment from the original crate'
 pub use some_macros::reexported_macro;
 
 // @has proc_macro/attr.some_proc_attr.html
-// @has - 'a proc-macro attribute that passes its item through verbatim.'
+// @hastext - 'a proc-macro attribute that passes its item through verbatim.'
 pub use some_macros::some_proc_attr;
 
 // @has proc_macro/derive.SomeDerive.html
-// @has - 'a derive attribute that adds nothing to its input.'
+// @hastext - 'a derive attribute that adds nothing to its input.'
 pub use some_macros::SomeDerive;
 
 // @has proc_macro/attr.first_attr.html
-// @has - 'Generated doc comment'
+// @hastext - 'Generated doc comment'
 pub use some_macros::first_attr;
 
 // @has proc_macro/attr.second_attr.html
-// @has - 'Generated doc comment'
+// @hastext - 'Generated doc comment'
 pub use some_macros::second_attr;

--- a/src/test/rustdoc/inline_cross/proc_macro.rs
+++ b/src/test/rustdoc/inline_cross/proc_macro.rs
@@ -12,25 +12,25 @@ extern crate some_macros;
 // @has proc_macro/derive.SomeDerive.html
 
 // @has proc_macro/macro.some_proc_macro.html
-// @hastext - 'a proc-macro that swallows its input and does nothing.'
+// @hasraw - 'a proc-macro that swallows its input and does nothing.'
 pub use some_macros::some_proc_macro;
 
 // @has proc_macro/macro.reexported_macro.html
-// @hastext - 'Doc comment from the original crate'
+// @hasraw - 'Doc comment from the original crate'
 pub use some_macros::reexported_macro;
 
 // @has proc_macro/attr.some_proc_attr.html
-// @hastext - 'a proc-macro attribute that passes its item through verbatim.'
+// @hasraw - 'a proc-macro attribute that passes its item through verbatim.'
 pub use some_macros::some_proc_attr;
 
 // @has proc_macro/derive.SomeDerive.html
-// @hastext - 'a derive attribute that adds nothing to its input.'
+// @hasraw - 'a derive attribute that adds nothing to its input.'
 pub use some_macros::SomeDerive;
 
 // @has proc_macro/attr.first_attr.html
-// @hastext - 'Generated doc comment'
+// @hasraw - 'Generated doc comment'
 pub use some_macros::first_attr;
 
 // @has proc_macro/attr.second_attr.html
-// @hastext - 'Generated doc comment'
+// @hasraw - 'Generated doc comment'
 pub use some_macros::second_attr;

--- a/src/test/rustdoc/inline_local/glob-extern-document-private-items.rs
+++ b/src/test/rustdoc/inline_local/glob-extern-document-private-items.rs
@@ -12,14 +12,14 @@ mod mod1 {
 pub use mod1::*;
 
 // @has foo/index.html
-// @has - "mod1"
-// @has - "public_fn"
+// @hastext - "mod1"
+// @hastext - "public_fn"
 // @!has - "private_fn"
 // @has foo/fn.public_fn.html
 // @!has foo/fn.private_fn.html
 
 // @has foo/mod1/index.html
-// @has - "public_fn"
-// @has - "private_fn"
+// @hastext - "public_fn"
+// @hastext - "private_fn"
 // @has foo/mod1/fn.public_fn.html
 // @has foo/mod1/fn.private_fn.html

--- a/src/test/rustdoc/inline_local/glob-extern-document-private-items.rs
+++ b/src/test/rustdoc/inline_local/glob-extern-document-private-items.rs
@@ -12,14 +12,14 @@ mod mod1 {
 pub use mod1::*;
 
 // @has foo/index.html
-// @hastext - "mod1"
-// @hastext - "public_fn"
+// @hasraw - "mod1"
+// @hasraw - "public_fn"
 // @!has - "private_fn"
 // @has foo/fn.public_fn.html
 // @!has foo/fn.private_fn.html
 
 // @has foo/mod1/index.html
-// @hastext - "public_fn"
-// @hastext - "private_fn"
+// @hasraw - "public_fn"
+// @hasraw - "private_fn"
 // @has foo/mod1/fn.public_fn.html
 // @has foo/mod1/fn.private_fn.html

--- a/src/test/rustdoc/inline_local/glob-extern-document-private-items.rs
+++ b/src/test/rustdoc/inline_local/glob-extern-document-private-items.rs
@@ -14,7 +14,7 @@ pub use mod1::*;
 // @has foo/index.html
 // @hasraw - "mod1"
 // @hasraw - "public_fn"
-// @!has - "private_fn"
+// @!hasraw - "private_fn"
 // @has foo/fn.public_fn.html
 // @!has foo/fn.private_fn.html
 

--- a/src/test/rustdoc/inline_local/glob-extern.rs
+++ b/src/test/rustdoc/inline_local/glob-extern.rs
@@ -11,7 +11,7 @@ pub use mod1::*;
 
 // @has foo/index.html
 // @!has - "mod1"
-// @has - "public_fn"
+// @hastext - "public_fn"
 // @!has - "private_fn"
 // @has foo/fn.public_fn.html
 // @!has foo/fn.private_fn.html

--- a/src/test/rustdoc/inline_local/glob-extern.rs
+++ b/src/test/rustdoc/inline_local/glob-extern.rs
@@ -11,7 +11,7 @@ pub use mod1::*;
 
 // @has foo/index.html
 // @!has - "mod1"
-// @hastext - "public_fn"
+// @hasraw - "public_fn"
 // @!has - "private_fn"
 // @has foo/fn.public_fn.html
 // @!has foo/fn.private_fn.html

--- a/src/test/rustdoc/inline_local/glob-extern.rs
+++ b/src/test/rustdoc/inline_local/glob-extern.rs
@@ -10,9 +10,9 @@ mod mod1 {
 pub use mod1::*;
 
 // @has foo/index.html
-// @!has - "mod1"
+// @!hasraw - "mod1"
 // @hasraw - "public_fn"
-// @!has - "private_fn"
+// @!hasraw - "private_fn"
 // @has foo/fn.public_fn.html
 // @!has foo/fn.private_fn.html
 

--- a/src/test/rustdoc/inline_local/glob-private-document-private-items.rs
+++ b/src/test/rustdoc/inline_local/glob-private-document-private-items.rs
@@ -15,11 +15,11 @@ mod mod1 {
 pub use mod1::*;
 
 // @has foo/index.html
-// @has - "mod1"
-// @has - "Mod1Public"
+// @hastext - "mod1"
+// @hastext - "Mod1Public"
 // @!has - "Mod1Private"
 // @!has - "mod2"
-// @has - "Mod2Public"
+// @hastext - "Mod2Public"
 // @!has - "Mod2Private"
 // @has foo/struct.Mod1Public.html
 // @!has foo/struct.Mod1Private.html
@@ -27,9 +27,9 @@ pub use mod1::*;
 // @!has foo/struct.Mod2Private.html
 
 // @has foo/mod1/index.html
-// @has - "mod2"
-// @has - "Mod1Public"
-// @has - "Mod1Private"
+// @hastext - "mod2"
+// @hastext - "Mod1Public"
+// @hastext - "Mod1Private"
 // @!has - "Mod2Public"
 // @!has - "Mod2Private"
 // @has foo/mod1/struct.Mod1Public.html
@@ -38,8 +38,8 @@ pub use mod1::*;
 // @!has foo/mod1/struct.Mod2Private.html
 
 // @has foo/mod1/mod2/index.html
-// @has - "Mod2Public"
-// @has - "Mod2Private"
+// @hastext - "Mod2Public"
+// @hastext - "Mod2Private"
 // @has foo/mod1/mod2/struct.Mod2Public.html
 // @has foo/mod1/mod2/struct.Mod2Private.html
 

--- a/src/test/rustdoc/inline_local/glob-private-document-private-items.rs
+++ b/src/test/rustdoc/inline_local/glob-private-document-private-items.rs
@@ -15,11 +15,11 @@ mod mod1 {
 pub use mod1::*;
 
 // @has foo/index.html
-// @hastext - "mod1"
-// @hastext - "Mod1Public"
+// @hasraw - "mod1"
+// @hasraw - "Mod1Public"
 // @!has - "Mod1Private"
 // @!has - "mod2"
-// @hastext - "Mod2Public"
+// @hasraw - "Mod2Public"
 // @!has - "Mod2Private"
 // @has foo/struct.Mod1Public.html
 // @!has foo/struct.Mod1Private.html
@@ -27,9 +27,9 @@ pub use mod1::*;
 // @!has foo/struct.Mod2Private.html
 
 // @has foo/mod1/index.html
-// @hastext - "mod2"
-// @hastext - "Mod1Public"
-// @hastext - "Mod1Private"
+// @hasraw - "mod2"
+// @hasraw - "Mod1Public"
+// @hasraw - "Mod1Private"
 // @!has - "Mod2Public"
 // @!has - "Mod2Private"
 // @has foo/mod1/struct.Mod1Public.html
@@ -38,8 +38,8 @@ pub use mod1::*;
 // @!has foo/mod1/struct.Mod2Private.html
 
 // @has foo/mod1/mod2/index.html
-// @hastext - "Mod2Public"
-// @hastext - "Mod2Private"
+// @hasraw - "Mod2Public"
+// @hasraw - "Mod2Private"
 // @has foo/mod1/mod2/struct.Mod2Public.html
 // @has foo/mod1/mod2/struct.Mod2Private.html
 

--- a/src/test/rustdoc/inline_local/glob-private-document-private-items.rs
+++ b/src/test/rustdoc/inline_local/glob-private-document-private-items.rs
@@ -17,10 +17,10 @@ pub use mod1::*;
 // @has foo/index.html
 // @hasraw - "mod1"
 // @hasraw - "Mod1Public"
-// @!has - "Mod1Private"
-// @!has - "mod2"
+// @!hasraw - "Mod1Private"
+// @!hasraw - "mod2"
 // @hasraw - "Mod2Public"
-// @!has - "Mod2Private"
+// @!hasraw - "Mod2Private"
 // @has foo/struct.Mod1Public.html
 // @!has foo/struct.Mod1Private.html
 // @has foo/struct.Mod2Public.html
@@ -30,8 +30,8 @@ pub use mod1::*;
 // @hasraw - "mod2"
 // @hasraw - "Mod1Public"
 // @hasraw - "Mod1Private"
-// @!has - "Mod2Public"
-// @!has - "Mod2Private"
+// @!hasraw - "Mod2Public"
+// @!hasraw - "Mod2Private"
 // @has foo/mod1/struct.Mod1Public.html
 // @has foo/mod1/struct.Mod1Private.html
 // @!has foo/mod1/struct.Mod2Public.html

--- a/src/test/rustdoc/inline_local/glob-private.rs
+++ b/src/test/rustdoc/inline_local/glob-private.rs
@@ -13,12 +13,12 @@ mod mod1 {
 pub use mod1::*;
 
 // @has foo/index.html
-// @!has - "mod1"
+// @!hasraw - "mod1"
 // @hasraw - "Mod1Public"
-// @!has - "Mod1Private"
-// @!has - "mod2"
+// @!hasraw - "Mod1Private"
+// @!hasraw - "mod2"
 // @hasraw - "Mod2Public"
-// @!has - "Mod2Private"
+// @!hasraw - "Mod2Private"
 // @has foo/struct.Mod1Public.html
 // @!has foo/struct.Mod1Private.html
 // @has foo/struct.Mod2Public.html

--- a/src/test/rustdoc/inline_local/glob-private.rs
+++ b/src/test/rustdoc/inline_local/glob-private.rs
@@ -14,10 +14,10 @@ pub use mod1::*;
 
 // @has foo/index.html
 // @!has - "mod1"
-// @has - "Mod1Public"
+// @hastext - "Mod1Public"
 // @!has - "Mod1Private"
 // @!has - "mod2"
-// @has - "Mod2Public"
+// @hastext - "Mod2Public"
 // @!has - "Mod2Private"
 // @has foo/struct.Mod1Public.html
 // @!has foo/struct.Mod1Private.html

--- a/src/test/rustdoc/inline_local/glob-private.rs
+++ b/src/test/rustdoc/inline_local/glob-private.rs
@@ -14,10 +14,10 @@ pub use mod1::*;
 
 // @has foo/index.html
 // @!has - "mod1"
-// @hastext - "Mod1Public"
+// @hasraw - "Mod1Public"
 // @!has - "Mod1Private"
 // @!has - "mod2"
-// @hastext - "Mod2Public"
+// @hasraw - "Mod2Public"
 // @!has - "Mod2Private"
 // @has foo/struct.Mod1Public.html
 // @!has foo/struct.Mod1Private.html

--- a/src/test/rustdoc/inline_local/hidden-use.rs
+++ b/src/test/rustdoc/inline_local/hidden-use.rs
@@ -3,8 +3,8 @@ mod private {
 }
 
 // @has hidden_use/index.html
-// @!has - 'private'
-// @!has - 'Foo'
+// @!hasraw - 'private'
+// @!hasraw - 'Foo'
 // @!has hidden_use/struct.Foo.html
 #[doc(hidden)]
 pub use private::Foo;

--- a/src/test/rustdoc/inline_local/macro_by_example.rs
+++ b/src/test/rustdoc/inline_local/macro_by_example.rs
@@ -7,7 +7,7 @@ macro_rules! foo {
 
 // @has macro_by_example/macros/index.html
 pub mod macros {
-    // @!has - 'pub use foo as bar;'
+    // @!hasraw - 'pub use foo as bar;'
     // @has macro_by_example/macros/macro.bar.html
     // @has - '//*[@class="docblock"]' 'docs for foo'
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.2.3: text'

--- a/src/test/rustdoc/inline_local/please_inline.rs
+++ b/src/test/rustdoc/inline_local/please_inline.rs
@@ -12,7 +12,7 @@ pub mod a {
 
 // @has please_inline/b/index.html
 pub mod b {
-    // @has - 'pub use foo::'
+    // @hastext - 'pub use foo::'
     // @!has please_inline/b/struct.Foo.html
     #[feature(inline)]
     pub use foo::Foo;

--- a/src/test/rustdoc/inline_local/please_inline.rs
+++ b/src/test/rustdoc/inline_local/please_inline.rs
@@ -4,7 +4,7 @@ pub mod foo {
 
 // @has please_inline/a/index.html
 pub mod a {
-    // @!has - 'pub use foo::'
+    // @!hasraw - 'pub use foo::'
     // @has please_inline/a/struct.Foo.html
     #[doc(inline)]
     pub use foo::Foo;

--- a/src/test/rustdoc/inline_local/please_inline.rs
+++ b/src/test/rustdoc/inline_local/please_inline.rs
@@ -12,7 +12,7 @@ pub mod a {
 
 // @has please_inline/b/index.html
 pub mod b {
-    // @hastext - 'pub use foo::'
+    // @hasraw - 'pub use foo::'
     // @!has please_inline/b/struct.Foo.html
     #[feature(inline)]
     pub use foo::Foo;

--- a/src/test/rustdoc/internal.rs
+++ b/src/test/rustdoc/internal.rs
@@ -2,14 +2,14 @@
 
 // Check that the unstable marker is not added for "rustc_private".
 
-// @!matches internal/index.html \
+// @!matchesraw internal/index.html \
 //      '//*[@class="item-right docblock-short"]/span[@class="stab unstable"]'
-// @!matches internal/index.html \
+// @!matchesraw internal/index.html \
 //      '//*[@class="item-right docblock-short"]/span[@class="stab internal"]'
 // @matches - '//*[@class="item-right docblock-short"]' 'Docs'
 
-// @!has internal/struct.S.html '//*[@class="stab unstable"]'
-// @!has internal/struct.S.html '//*[@class="stab internal"]'
+// @!hasraw internal/struct.S.html '//*[@class="stab unstable"]'
+// @!hasraw internal/struct.S.html '//*[@class="stab internal"]'
 /// Docs
 pub struct S;
 

--- a/src/test/rustdoc/internal.rs
+++ b/src/test/rustdoc/internal.rs
@@ -2,14 +2,16 @@
 
 // Check that the unstable marker is not added for "rustc_private".
 
-// @!matchesraw internal/index.html \
-//      '//*[@class="item-right docblock-short"]/span[@class="stab unstable"]'
-// @!matchesraw internal/index.html \
-//      '//*[@class="item-right docblock-short"]/span[@class="stab internal"]'
+// @!matches internal/index.html \
+//      '//*[@class="item-right docblock-short"]/span[@class="stab unstable"]' \
+//      ''
+// @!matches internal/index.html \
+//      '//*[@class="item-right docblock-short"]/span[@class="stab internal"]' \
+//      ''
 // @matches - '//*[@class="item-right docblock-short"]' 'Docs'
 
-// @!hasraw internal/struct.S.html '//*[@class="stab unstable"]'
-// @!hasraw internal/struct.S.html '//*[@class="stab internal"]'
+// @!has internal/struct.S.html '//*[@class="stab unstable"]' ''
+// @!has internal/struct.S.html '//*[@class="stab internal"]' ''
 /// Docs
 pub struct S;
 

--- a/src/test/rustdoc/intra-doc/extern-type.rs
+++ b/src/test/rustdoc/intra-doc/extern-type.rs
@@ -25,11 +25,11 @@ impl G<usize> for ExternType {
 }
 
 // @has 'extern_type/foreigntype.ExternType.html'
-// @hastext 'extern_type/fn.links_to_extern_type.html' \
+// @hasraw 'extern_type/fn.links_to_extern_type.html' \
 // 'href="foreigntype.ExternType.html#method.f"'
-// @hastext 'extern_type/fn.links_to_extern_type.html' \
+// @hasraw 'extern_type/fn.links_to_extern_type.html' \
 // 'href="foreigntype.ExternType.html#method.test"'
-// @hastext 'extern_type/fn.links_to_extern_type.html' \
+// @hasraw 'extern_type/fn.links_to_extern_type.html' \
 // 'href="foreigntype.ExternType.html#method.g"'
 /// See also [ExternType::f]
 /// See also [ExternType::test]

--- a/src/test/rustdoc/intra-doc/extern-type.rs
+++ b/src/test/rustdoc/intra-doc/extern-type.rs
@@ -25,11 +25,11 @@ impl G<usize> for ExternType {
 }
 
 // @has 'extern_type/foreigntype.ExternType.html'
-// @has 'extern_type/fn.links_to_extern_type.html' \
+// @hastext 'extern_type/fn.links_to_extern_type.html' \
 // 'href="foreigntype.ExternType.html#method.f"'
-// @has 'extern_type/fn.links_to_extern_type.html' \
+// @hastext 'extern_type/fn.links_to_extern_type.html' \
 // 'href="foreigntype.ExternType.html#method.test"'
-// @has 'extern_type/fn.links_to_extern_type.html' \
+// @hastext 'extern_type/fn.links_to_extern_type.html' \
 // 'href="foreigntype.ExternType.html#method.g"'
 /// See also [ExternType::f]
 /// See also [ExternType::test]

--- a/src/test/rustdoc/issue-16265-1.rs
+++ b/src/test/rustdoc/issue-16265-1.rs
@@ -1,6 +1,6 @@
 pub struct Foo;
 
-// @hastext issue_16265_1/traits/index.html 'source'
+// @hasraw issue_16265_1/traits/index.html 'source'
 pub mod traits {
     impl PartialEq for super::Foo {
         fn eq(&self, _: &super::Foo) -> bool {

--- a/src/test/rustdoc/issue-16265-1.rs
+++ b/src/test/rustdoc/issue-16265-1.rs
@@ -1,6 +1,6 @@
 pub struct Foo;
 
-// @has issue_16265_1/traits/index.html 'source'
+// @hastext issue_16265_1/traits/index.html 'source'
 pub mod traits {
     impl PartialEq for super::Foo {
         fn eq(&self, _: &super::Foo) -> bool {

--- a/src/test/rustdoc/issue-16265-2.rs
+++ b/src/test/rustdoc/issue-16265-2.rs
@@ -1,4 +1,4 @@
-// @has issue_16265_2/index.html 'source'
+// @hastext issue_16265_2/index.html 'source'
 
 trait Y {}
 impl Y for Option<u32> {}

--- a/src/test/rustdoc/issue-16265-2.rs
+++ b/src/test/rustdoc/issue-16265-2.rs
@@ -1,4 +1,4 @@
-// @hastext issue_16265_2/index.html 'source'
+// @hasraw issue_16265_2/index.html 'source'
 
 trait Y {}
 impl Y for Option<u32> {}

--- a/src/test/rustdoc/issue-23511.rs
+++ b/src/test/rustdoc/issue-23511.rs
@@ -6,7 +6,7 @@ pub mod str {
     #![doc(primitive = "str")]
 
     impl str {
-        // @has search-index.js foo
+        // @hastext search-index.js foo
         #[rustc_allow_incoherent_impl]
         pub fn foo(&self) {}
     }

--- a/src/test/rustdoc/issue-23511.rs
+++ b/src/test/rustdoc/issue-23511.rs
@@ -6,7 +6,7 @@ pub mod str {
     #![doc(primitive = "str")]
 
     impl str {
-        // @hastext search-index.js foo
+        // @hasraw search-index.js foo
         #[rustc_allow_incoherent_impl]
         pub fn foo(&self) {}
     }

--- a/src/test/rustdoc/issue-23812.rs
+++ b/src/test/rustdoc/issue-23812.rs
@@ -17,9 +17,9 @@ doc! {
 
 // @has issue_23812/Foo/index.html
 // @hasraw - 'Outer comment'
-// @!has - '/// Outer comment'
+// @!hasraw - '/// Outer comment'
 // @hasraw - 'Inner comment'
-// @!has - '//! Inner comment'
+// @!hasraw - '//! Inner comment'
 
 
 doc! {
@@ -31,6 +31,6 @@ doc! {
 
 // @has issue_23812/Bar/index.html
 // @hasraw - 'Outer block comment'
-// @!has - '/** Outer block comment */'
+// @!hasraw - '/** Outer block comment */'
 // @hasraw - 'Inner block comment'
-// @!has - '/*! Inner block comment */'
+// @!hasraw - '/*! Inner block comment */'

--- a/src/test/rustdoc/issue-23812.rs
+++ b/src/test/rustdoc/issue-23812.rs
@@ -16,9 +16,9 @@ doc! {
 }
 
 // @has issue_23812/Foo/index.html
-// @has - 'Outer comment'
+// @hastext - 'Outer comment'
 // @!has - '/// Outer comment'
-// @has - 'Inner comment'
+// @hastext - 'Inner comment'
 // @!has - '//! Inner comment'
 
 
@@ -30,7 +30,7 @@ doc! {
 }
 
 // @has issue_23812/Bar/index.html
-// @has - 'Outer block comment'
+// @hastext - 'Outer block comment'
 // @!has - '/** Outer block comment */'
-// @has - 'Inner block comment'
+// @hastext - 'Inner block comment'
 // @!has - '/*! Inner block comment */'

--- a/src/test/rustdoc/issue-23812.rs
+++ b/src/test/rustdoc/issue-23812.rs
@@ -16,9 +16,9 @@ doc! {
 }
 
 // @has issue_23812/Foo/index.html
-// @hastext - 'Outer comment'
+// @hasraw - 'Outer comment'
 // @!has - '/// Outer comment'
-// @hastext - 'Inner comment'
+// @hasraw - 'Inner comment'
 // @!has - '//! Inner comment'
 
 
@@ -30,7 +30,7 @@ doc! {
 }
 
 // @has issue_23812/Bar/index.html
-// @hastext - 'Outer block comment'
+// @hasraw - 'Outer block comment'
 // @!has - '/** Outer block comment */'
-// @hastext - 'Inner block comment'
+// @hasraw - 'Inner block comment'
 // @!has - '/*! Inner block comment */'

--- a/src/test/rustdoc/issue-27104.rs
+++ b/src/test/rustdoc/issue-27104.rs
@@ -6,5 +6,5 @@
 // @!has - 'extern crate std'
 // @!has - 'use std::prelude::'
 
-// @hastext - 'pub extern crate empty'
+// @hasraw - 'pub extern crate empty'
 pub extern crate empty;

--- a/src/test/rustdoc/issue-27104.rs
+++ b/src/test/rustdoc/issue-27104.rs
@@ -3,8 +3,8 @@
 // ignore-cross-compile
 
 // @has issue_27104/index.html
-// @!has - 'extern crate std'
-// @!has - 'use std::prelude::'
+// @!hasraw - 'extern crate std'
+// @!hasraw - 'use std::prelude::'
 
 // @hasraw - 'pub extern crate empty'
 pub extern crate empty;

--- a/src/test/rustdoc/issue-27104.rs
+++ b/src/test/rustdoc/issue-27104.rs
@@ -6,5 +6,5 @@
 // @!has - 'extern crate std'
 // @!has - 'use std::prelude::'
 
-// @has - 'pub extern crate empty'
+// @hastext - 'pub extern crate empty'
 pub extern crate empty;

--- a/src/test/rustdoc/issue-27759.rs
+++ b/src/test/rustdoc/issue-27759.rs
@@ -4,11 +4,11 @@
 #![unstable(feature="test", issue="27759")]
 
 // @has issue_27759/unstable/index.html
-// @hastext - '<code>test</code>&nbsp;<a href="http://issue_url/27759">#27759</a>'
+// @hasraw - '<code>test</code>&nbsp;<a href="http://issue_url/27759">#27759</a>'
 #[unstable(feature="test", issue="27759")]
 pub mod unstable {
     // @has issue_27759/unstable/fn.issue.html
-    // @hastext - '<code>test_function</code>&nbsp;<a href="http://issue_url/12345">#12345</a>'
+    // @hasraw - '<code>test_function</code>&nbsp;<a href="http://issue_url/12345">#12345</a>'
     #[unstable(feature="test_function", issue="12345")]
     pub fn issue() {}
 }

--- a/src/test/rustdoc/issue-27759.rs
+++ b/src/test/rustdoc/issue-27759.rs
@@ -4,11 +4,11 @@
 #![unstable(feature="test", issue="27759")]
 
 // @has issue_27759/unstable/index.html
-// @has - '<code>test</code>&nbsp;<a href="http://issue_url/27759">#27759</a>'
+// @hastext - '<code>test</code>&nbsp;<a href="http://issue_url/27759">#27759</a>'
 #[unstable(feature="test", issue="27759")]
 pub mod unstable {
     // @has issue_27759/unstable/fn.issue.html
-    // @has - '<code>test_function</code>&nbsp;<a href="http://issue_url/12345">#12345</a>'
+    // @hastext - '<code>test_function</code>&nbsp;<a href="http://issue_url/12345">#12345</a>'
     #[unstable(feature="test_function", issue="12345")]
     pub fn issue() {}
 }

--- a/src/test/rustdoc/issue-29584.rs
+++ b/src/test/rustdoc/issue-29584.rs
@@ -4,5 +4,5 @@
 extern crate issue_29584;
 
 // @has issue_29584/struct.Foo.html
-// @!has - 'impl Bar for'
+// @!hasraw - 'impl Bar for'
 pub use issue_29584::Foo;

--- a/src/test/rustdoc/issue-31899.rs
+++ b/src/test/rustdoc/issue-31899.rs
@@ -1,8 +1,8 @@
 // @has issue_31899/index.html
 // @hasraw - 'Make this line a bit longer.'
-// @!has - 'rust rust-example-rendered'
-// @!has - 'use ndarray::arr2'
-// @!has - 'prohibited'
+// @!hasraw - 'rust rust-example-rendered'
+// @!hasraw - 'use ndarray::arr2'
+// @!hasraw - 'prohibited'
 
 /// A tuple or fixed size array that can be used to index an array.
 /// Make this line a bit longer.

--- a/src/test/rustdoc/issue-31899.rs
+++ b/src/test/rustdoc/issue-31899.rs
@@ -1,5 +1,5 @@
 // @has issue_31899/index.html
-// @hastext - 'Make this line a bit longer.'
+// @hasraw - 'Make this line a bit longer.'
 // @!has - 'rust rust-example-rendered'
 // @!has - 'use ndarray::arr2'
 // @!has - 'prohibited'

--- a/src/test/rustdoc/issue-31899.rs
+++ b/src/test/rustdoc/issue-31899.rs
@@ -1,5 +1,5 @@
 // @has issue_31899/index.html
-// @has - 'Make this line a bit longer.'
+// @hastext - 'Make this line a bit longer.'
 // @!has - 'rust rust-example-rendered'
 // @!has - 'use ndarray::arr2'
 // @!has - 'prohibited'

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -10,7 +10,7 @@
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
 //      '👎 Deprecated since 1.0.0: text'
-// @has - '<code>test</code>&nbsp;<a href="https://issue_url/32374">#32374</a>'
+// @hastext - '<code>test</code>&nbsp;<a href="https://issue_url/32374">#32374</a>'
 // @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. \(test\s#32374\)$'
 /// Docs

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -10,7 +10,7 @@
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
 //      '👎 Deprecated since 1.0.0: text'
-// @hastext - '<code>test</code>&nbsp;<a href="https://issue_url/32374">#32374</a>'
+// @hasraw - '<code>test</code>&nbsp;<a href="https://issue_url/32374">#32374</a>'
 // @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. \(test\s#32374\)$'
 /// Docs

--- a/src/test/rustdoc/issue-32395.rs
+++ b/src/test/rustdoc/issue-32395.rs
@@ -3,13 +3,13 @@
 // ignore-cross-compile
 
 // @has variant_struct/enum.Foo.html
-// @!has - 'pub qux'
-// @!has - 'pub(crate) qux'
-// @!has - 'pub Bar'
+// @!hasraw - 'pub qux'
+// @!hasraw - 'pub(crate) qux'
+// @!hasraw - 'pub Bar'
 extern crate variant_struct;
 
 // @has issue_32395/enum.Foo.html
-// @!has - 'pub qux'
-// @!has - 'pub(crate) qux'
-// @!has - 'pub Bar'
+// @!hasraw - 'pub qux'
+// @!hasraw - 'pub(crate) qux'
+// @!hasraw - 'pub Bar'
 pub use variant_struct::Foo;

--- a/src/test/rustdoc/issue-34473.rs
+++ b/src/test/rustdoc/issue-34473.rs
@@ -5,7 +5,7 @@ mod second {
 }
 
 // @has foo/index.html
-// @!has - SomeTypeWithLongName
+// @!hasraw - SomeTypeWithLongName
 // @has foo/struct.SomeType.html
 // @!has foo/struct.SomeTypeWithLongName.html
 pub use second::{SomeTypeWithLongName as SomeType};

--- a/src/test/rustdoc/issue-41783.rs
+++ b/src/test/rustdoc/issue-41783.rs
@@ -1,11 +1,11 @@
 // @has issue_41783/struct.Foo.html
 // @!has - 'space'
 // @!has - 'comment'
-// @hastext - '# <span class="ident">single'
-// @hastext - '## <span class="ident">double</span>'
-// @hastext - '### <span class="ident">triple</span>'
-// @hastext - '<span class="attribute">#[<span class="ident">outer</span>]</span>'
-// @hastext - '<span class="attribute">#![<span class="ident">inner</span>]</span>'
+// @hasraw - '# <span class="ident">single'
+// @hasraw - '## <span class="ident">double</span>'
+// @hasraw - '### <span class="ident">triple</span>'
+// @hasraw - '<span class="attribute">#[<span class="ident">outer</span>]</span>'
+// @hasraw - '<span class="attribute">#![<span class="ident">inner</span>]</span>'
 
 /// ```no_run
 /// # # space

--- a/src/test/rustdoc/issue-41783.rs
+++ b/src/test/rustdoc/issue-41783.rs
@@ -1,6 +1,6 @@
 // @has issue_41783/struct.Foo.html
-// @!has - 'space'
-// @!has - 'comment'
+// @!hasraw - 'space'
+// @!hasraw - 'comment'
 // @hasraw - '# <span class="ident">single'
 // @hasraw - '## <span class="ident">double</span>'
 // @hasraw - '### <span class="ident">triple</span>'

--- a/src/test/rustdoc/issue-41783.rs
+++ b/src/test/rustdoc/issue-41783.rs
@@ -1,11 +1,11 @@
 // @has issue_41783/struct.Foo.html
 // @!has - 'space'
 // @!has - 'comment'
-// @has - '# <span class="ident">single'
-// @has - '## <span class="ident">double</span>'
-// @has - '### <span class="ident">triple</span>'
-// @has - '<span class="attribute">#[<span class="ident">outer</span>]</span>'
-// @has - '<span class="attribute">#![<span class="ident">inner</span>]</span>'
+// @hastext - '# <span class="ident">single'
+// @hastext - '## <span class="ident">double</span>'
+// @hastext - '### <span class="ident">triple</span>'
+// @hastext - '<span class="attribute">#[<span class="ident">outer</span>]</span>'
+// @hastext - '<span class="attribute">#![<span class="ident">inner</span>]</span>'
 
 /// ```no_run
 /// # # space

--- a/src/test/rustdoc/issue-53689.rs
+++ b/src/test/rustdoc/issue-53689.rs
@@ -5,7 +5,7 @@
 extern crate issue_53689;
 
 // @has foo/trait.MyTrait.html
-// @!has - 'MyStruct'
+// @!hasraw - 'MyStruct'
 // @count - '//*[h3="impl<T> MyTrait for T"]' 1
 pub trait MyTrait {}
 

--- a/src/test/rustdoc/issue-61592.rs
+++ b/src/test/rustdoc/issue-61592.rs
@@ -5,11 +5,11 @@ extern crate foo;
 // @has issue_61592/index.html
 // @has - '//a[@href="#reexports"]' 'Re-exports'
 // @has - '//code' 'pub use foo::FooTrait as _;'
-// @!has - '//a[@href="trait._.html"]'
+// @!hasraw - '//a[@href="trait._.html"]'
 pub use foo::FooTrait as _;
 
 // @has issue_61592/index.html
 // @has - '//a[@href="#reexports"]' 'Re-exports'
 // @has - '//code' 'pub use foo::FooStruct as _;'
-// @!has - '//a[@href="struct._.html"]'
+// @!hasraw - '//a[@href="struct._.html"]'
 pub use foo::FooStruct as _;

--- a/src/test/rustdoc/issue-61592.rs
+++ b/src/test/rustdoc/issue-61592.rs
@@ -5,11 +5,11 @@ extern crate foo;
 // @has issue_61592/index.html
 // @has - '//a[@href="#reexports"]' 'Re-exports'
 // @has - '//code' 'pub use foo::FooTrait as _;'
-// @!hasraw - '//a[@href="trait._.html"]'
+// @!has - '//a[@href="trait._.html"]' ''
 pub use foo::FooTrait as _;
 
 // @has issue_61592/index.html
 // @has - '//a[@href="#reexports"]' 'Re-exports'
 // @has - '//code' 'pub use foo::FooStruct as _;'
-// @!hasraw - '//a[@href="struct._.html"]'
+// @!has - '//a[@href="struct._.html"]' ''
 pub use foo::FooStruct as _;

--- a/src/test/rustdoc/issue-89852.rs
+++ b/src/test/rustdoc/issue-89852.rs
@@ -3,7 +3,7 @@
 #![no_core]
 #![feature(no_core)]
 
-// @matches 'issue_89852/sidebar-items.js' '"repro"'
+// @matchestext 'issue_89852/sidebar-items.js' '"repro"'
 // @!matches 'issue_89852/sidebar-items.js' '"repro".*"repro"'
 
 #[macro_export]

--- a/src/test/rustdoc/issue-89852.rs
+++ b/src/test/rustdoc/issue-89852.rs
@@ -4,7 +4,7 @@
 #![feature(no_core)]
 
 // @matchesraw 'issue_89852/sidebar-items.js' '"repro"'
-// @!matches 'issue_89852/sidebar-items.js' '"repro".*"repro"'
+// @!matchesraw 'issue_89852/sidebar-items.js' '"repro".*"repro"'
 
 #[macro_export]
 macro_rules! repro {

--- a/src/test/rustdoc/issue-89852.rs
+++ b/src/test/rustdoc/issue-89852.rs
@@ -3,7 +3,7 @@
 #![no_core]
 #![feature(no_core)]
 
-// @matchestext 'issue_89852/sidebar-items.js' '"repro"'
+// @matchesraw 'issue_89852/sidebar-items.js' '"repro"'
 // @!matches 'issue_89852/sidebar-items.js' '"repro".*"repro"'
 
 #[macro_export]

--- a/src/test/rustdoc/link-title-escape.rs
+++ b/src/test/rustdoc/link-title-escape.rs
@@ -6,4 +6,4 @@
 //!
 //! [foo]: url 'title & <stuff> & "things"'
 
-// @has 'foo/index.html' 'title &amp; &lt;stuff&gt; &amp; &quot;things&quot;'
+// @hastext 'foo/index.html' 'title &amp; &lt;stuff&gt; &amp; &quot;things&quot;'

--- a/src/test/rustdoc/link-title-escape.rs
+++ b/src/test/rustdoc/link-title-escape.rs
@@ -6,4 +6,4 @@
 //!
 //! [foo]: url 'title & <stuff> & "things"'
 
-// @hastext 'foo/index.html' 'title &amp; &lt;stuff&gt; &amp; &quot;things&quot;'
+// @hasraw 'foo/index.html' 'title &amp; &lt;stuff&gt; &amp; &quot;things&quot;'

--- a/src/test/rustdoc/macro-document-private-duplicate.rs
+++ b/src/test/rustdoc/macro-document-private-duplicate.rs
@@ -18,7 +18,7 @@ macro_rules! a_macro {
 }
 
 // @hasraw macro_document_private_duplicate/index.html 'Doc 2.'
-// @!has macro_document_private_duplicate/macro.a_macro.html 'Doc 2.'
+// @!hasraw macro_document_private_duplicate/macro.a_macro.html 'Doc 2.'
 /// Doc 2.
 macro_rules! a_macro {
     () => ()

--- a/src/test/rustdoc/macro-document-private-duplicate.rs
+++ b/src/test/rustdoc/macro-document-private-duplicate.rs
@@ -10,14 +10,14 @@
 //
 // compile-flags: --document-private-items
 
-// @hastext macro_document_private_duplicate/index.html 'Doc 1.'
-// @hastext macro_document_private_duplicate/macro.a_macro.html 'Doc 1.'
+// @hasraw macro_document_private_duplicate/index.html 'Doc 1.'
+// @hasraw macro_document_private_duplicate/macro.a_macro.html 'Doc 1.'
 /// Doc 1.
 macro_rules! a_macro {
     () => ()
 }
 
-// @hastext macro_document_private_duplicate/index.html 'Doc 2.'
+// @hasraw macro_document_private_duplicate/index.html 'Doc 2.'
 // @!has macro_document_private_duplicate/macro.a_macro.html 'Doc 2.'
 /// Doc 2.
 macro_rules! a_macro {

--- a/src/test/rustdoc/macro-document-private-duplicate.rs
+++ b/src/test/rustdoc/macro-document-private-duplicate.rs
@@ -10,14 +10,14 @@
 //
 // compile-flags: --document-private-items
 
-// @has macro_document_private_duplicate/index.html 'Doc 1.'
-// @has macro_document_private_duplicate/macro.a_macro.html 'Doc 1.'
+// @hastext macro_document_private_duplicate/index.html 'Doc 1.'
+// @hastext macro_document_private_duplicate/macro.a_macro.html 'Doc 1.'
 /// Doc 1.
 macro_rules! a_macro {
     () => ()
 }
 
-// @has macro_document_private_duplicate/index.html 'Doc 2.'
+// @hastext macro_document_private_duplicate/index.html 'Doc 2.'
 // @!has macro_document_private_duplicate/macro.a_macro.html 'Doc 2.'
 /// Doc 2.
 macro_rules! a_macro {

--- a/src/test/rustdoc/macro-private-not-documented.rs
+++ b/src/test/rustdoc/macro-private-not-documented.rs
@@ -6,13 +6,13 @@
 // This is a regression text for issue #88453.
 #![feature(decl_macro)]
 
-// @!has macro_private_not_documented/index.html 'a_macro'
+// @!hasraw macro_private_not_documented/index.html 'a_macro'
 // @!has macro_private_not_documented/macro.a_macro.html
 macro_rules! a_macro {
     () => ()
 }
 
-// @!has macro_private_not_documented/index.html 'another_macro'
+// @!hasraw macro_private_not_documented/index.html 'another_macro'
 // @!has macro_private_not_documented/macro.another_macro.html
 macro another_macro {
     () => ()

--- a/src/test/rustdoc/macro_rules-matchers.rs
+++ b/src/test/rustdoc/macro_rules-matchers.rs
@@ -7,27 +7,27 @@
 // @has - '//span[@class="macro"]' 'macro_rules!'
 // @has - '//span[@class="ident"]' 'todo'
 
-// @hastext - '{ () =&gt; { ... }; ($('
+// @hasraw - '{ () =&gt; { ... }; ($('
 // @has - '//span[@class="macro-nonterminal"]' '$'
 // @has - '//span[@class="macro-nonterminal"]' 'arg'
-// @hastext - ':'
+// @hasraw - ':'
 // @has - '//span[@class="ident"]' 'tt'
-// @hastext - ')+'
-// @hastext - ') =&gt; { ... }; }'
+// @hasraw - ')+'
+// @hasraw - ') =&gt; { ... }; }'
 pub use std::todo;
 
 mod mod1 {
     // @has 'foo/macro.macro1.html'
-    // @hastext - 'macro_rules!'
-    // @hastext - 'macro1'
-    // @hastext - '{ () =&gt; { ... }; ($('
+    // @hasraw - 'macro_rules!'
+    // @hasraw - 'macro1'
+    // @hasraw - '{ () =&gt; { ... }; ($('
     // @has - '//span[@class="macro-nonterminal"]' '$'
     // @has - '//span[@class="macro-nonterminal"]' 'arg'
-    // @hastext - ':'
-    // @hastext - 'expr'
-    // @hastext - '),'
-    // @hastext - '+'
-    // @hastext - ') =&gt; { ... }; }'
+    // @hasraw - ':'
+    // @hasraw - 'expr'
+    // @hasraw - '),'
+    // @hasraw - '+'
+    // @hasraw - ') =&gt; { ... }; }'
     #[macro_export]
     macro_rules! macro1 {
         () => {};

--- a/src/test/rustdoc/macro_rules-matchers.rs
+++ b/src/test/rustdoc/macro_rules-matchers.rs
@@ -7,27 +7,27 @@
 // @has - '//span[@class="macro"]' 'macro_rules!'
 // @has - '//span[@class="ident"]' 'todo'
 
-// @has - '{ () =&gt; { ... }; ($('
+// @hastext - '{ () =&gt; { ... }; ($('
 // @has - '//span[@class="macro-nonterminal"]' '$'
 // @has - '//span[@class="macro-nonterminal"]' 'arg'
-// @has - ':'
+// @hastext - ':'
 // @has - '//span[@class="ident"]' 'tt'
-// @has - ')+'
-// @has - ') =&gt; { ... }; }'
+// @hastext - ')+'
+// @hastext - ') =&gt; { ... }; }'
 pub use std::todo;
 
 mod mod1 {
     // @has 'foo/macro.macro1.html'
-    // @has - 'macro_rules!'
-    // @has - 'macro1'
-    // @has - '{ () =&gt; { ... }; ($('
+    // @hastext - 'macro_rules!'
+    // @hastext - 'macro1'
+    // @hastext - '{ () =&gt; { ... }; ($('
     // @has - '//span[@class="macro-nonterminal"]' '$'
     // @has - '//span[@class="macro-nonterminal"]' 'arg'
-    // @has - ':'
-    // @has - 'expr'
-    // @has - '),'
-    // @has - '+'
-    // @has - ') =&gt; { ... }; }'
+    // @hastext - ':'
+    // @hastext - 'expr'
+    // @hastext - '),'
+    // @hastext - '+'
+    // @hastext - ') =&gt; { ... }; }'
     #[macro_export]
     macro_rules! macro1 {
         () => {};

--- a/src/test/rustdoc/markdown-summaries.rs
+++ b/src/test/rustdoc/markdown-summaries.rs
@@ -7,7 +7,7 @@
 //!
 //! [link]: https://example.com
 
-// @hastext search-index.js 'This <em>summary</em> has a link and <code>code</code>.'
+// @hasraw search-index.js 'This <em>summary</em> has a link and <code>code</code>.'
 // @!has - 'second paragraph'
 
 /// This `code` will be rendered in a code tag.
@@ -15,8 +15,8 @@
 /// This text should not be rendered.
 pub struct Sidebar;
 
-// @hastext search-index.js 'This <code>code</code> will be rendered in a code tag.'
-// @hastext summaries/sidebar-items.js 'This `code` will be rendered in a code tag.'
+// @hasraw search-index.js 'This <code>code</code> will be rendered in a code tag.'
+// @hasraw summaries/sidebar-items.js 'This `code` will be rendered in a code tag.'
 // @!has - 'text should not be rendered'
 
 /// ```text

--- a/src/test/rustdoc/markdown-summaries.rs
+++ b/src/test/rustdoc/markdown-summaries.rs
@@ -7,7 +7,7 @@
 //!
 //! [link]: https://example.com
 
-// @has search-index.js 'This <em>summary</em> has a link and <code>code</code>.'
+// @hastext search-index.js 'This <em>summary</em> has a link and <code>code</code>.'
 // @!has - 'second paragraph'
 
 /// This `code` will be rendered in a code tag.
@@ -15,8 +15,8 @@
 /// This text should not be rendered.
 pub struct Sidebar;
 
-// @has search-index.js 'This <code>code</code> will be rendered in a code tag.'
-// @has summaries/sidebar-items.js 'This `code` will be rendered in a code tag.'
+// @hastext search-index.js 'This <code>code</code> will be rendered in a code tag.'
+// @hastext summaries/sidebar-items.js 'This `code` will be rendered in a code tag.'
 // @!has - 'text should not be rendered'
 
 /// ```text

--- a/src/test/rustdoc/markdown-summaries.rs
+++ b/src/test/rustdoc/markdown-summaries.rs
@@ -8,7 +8,7 @@
 //! [link]: https://example.com
 
 // @hasraw search-index.js 'This <em>summary</em> has a link and <code>code</code>.'
-// @!has - 'second paragraph'
+// @!hasraw - 'second paragraph'
 
 /// This `code` will be rendered in a code tag.
 ///
@@ -17,11 +17,11 @@ pub struct Sidebar;
 
 // @hasraw search-index.js 'This <code>code</code> will be rendered in a code tag.'
 // @hasraw summaries/sidebar-items.js 'This `code` will be rendered in a code tag.'
-// @!has - 'text should not be rendered'
+// @!hasraw - 'text should not be rendered'
 
 /// ```text
 /// this block should not be rendered
 /// ```
 pub struct Sidebar2;
 
-// @!has summaries/sidebar-items.js 'block should not be rendered'
+// @!hasraw summaries/sidebar-items.js 'block should not be rendered'

--- a/src/test/rustdoc/masked.rs
+++ b/src/test/rustdoc/masked.rs
@@ -7,24 +7,24 @@
 #[doc(masked)]
 extern crate masked;
 
-// @!has 'search-index.js' 'masked_method'
+// @!hasraw 'search-index.js' 'masked_method'
 
-// @!has 'foo/struct.String.html' 'MaskedTrait'
-// @!has 'foo/struct.String.html' 'masked_method'
+// @!hasraw 'foo/struct.String.html' 'MaskedTrait'
+// @!hasraw 'foo/struct.String.html' 'masked_method'
 pub use std::string::String;
 
-// @!has 'foo/trait.Clone.html' 'MaskedStruct'
+// @!hasraw 'foo/trait.Clone.html' 'MaskedStruct'
 pub use std::clone::Clone;
 
-// @!has 'foo/struct.MyStruct.html' 'MaskedTrait'
-// @!has 'foo/struct.MyStruct.html' 'masked_method'
+// @!hasraw 'foo/struct.MyStruct.html' 'MaskedTrait'
+// @!hasraw 'foo/struct.MyStruct.html' 'masked_method'
 pub struct MyStruct;
 
 impl masked::MaskedTrait for MyStruct {
     fn masked_method() {}
 }
 
-// @!has 'foo/trait.MyTrait.html' 'MaskedStruct'
+// @!hasraw 'foo/trait.MyTrait.html' 'MaskedStruct'
 pub trait MyTrait {}
 
 impl MyTrait for masked::MaskedStruct {}

--- a/src/test/rustdoc/module-impls.rs
+++ b/src/test/rustdoc/module-impls.rs
@@ -2,4 +2,4 @@
 
 pub use std::marker::Send;
 
-// @!has foo/index.html 'Implementations'
+// @!hasraw foo/index.html 'Implementations'

--- a/src/test/rustdoc/nested-modules.rs
+++ b/src/test/rustdoc/nested-modules.rs
@@ -15,14 +15,14 @@ mod a_module {
         pub use a_nested_module::a_nested_public_function as another_nested_public_function;
     }
 
-    // @!has aCrate/a_nested_module/index.html 'yet_another_nested_public_function'
+    // @!hasraw aCrate/a_nested_module/index.html 'yet_another_nested_public_function'
     pub use a_nested_module::a_nested_public_function as yet_another_nested_public_function;
 
-    // @!has aCrate/a_nested_module/index.html 'one_last_nested_public_function'
+    // @!hasraw aCrate/a_nested_module/index.html 'one_last_nested_public_function'
     pub use a_nested_module::another_nested_public_function as one_last_nested_public_function;
 }
 
-// @!has aCrate/index.html 'a_module'
+// @!hasraw aCrate/index.html 'a_module'
 // @has aCrate/index.html '//a[@href="a_nested_module/index.html"]' 'a_nested_module'
 pub use a_module::a_nested_module;
 
@@ -36,7 +36,7 @@ pub use a_module::{
 };
 
 // @has aCrate/index.html '//a[@href="fn.private_function.html"]' 'private_function'
-// @!has aCrate/fn.private_function.html 'a_module'
+// @!hasraw aCrate/fn.private_function.html 'a_module'
 // @has aCrate/index.html '//a[@href="fn.other_private_function.html"]' 'other_private_function'
-// @!has aCrate/fn.other_private_function.html 'a_module'
+// @!hasraw aCrate/fn.other_private_function.html 'a_module'
 pub use a_module::{other_private_function, private_function};

--- a/src/test/rustdoc/nested-modules.rs
+++ b/src/test/rustdoc/nested-modules.rs
@@ -7,11 +7,11 @@ mod a_module {
 
     pub mod a_nested_module {
         // @has aCrate/a_nested_module/index.html '//a[@href="fn.a_nested_public_function.html"]' 'a_nested_public_function'
-        // @has aCrate/a_nested_module/fn.a_nested_public_function.html 'pub fn a_nested_public_function()'
+        // @hastext aCrate/a_nested_module/fn.a_nested_public_function.html 'pub fn a_nested_public_function()'
         pub fn a_nested_public_function() {}
 
         // @has aCrate/a_nested_module/index.html '//a[@href="fn.another_nested_public_function.html"]' 'another_nested_public_function'
-        // @has aCrate/a_nested_module/fn.another_nested_public_function.html 'pub fn another_nested_public_function()'
+        // @hastext aCrate/a_nested_module/fn.another_nested_public_function.html 'pub fn another_nested_public_function()'
         pub use a_nested_module::a_nested_public_function as another_nested_public_function;
     }
 

--- a/src/test/rustdoc/nested-modules.rs
+++ b/src/test/rustdoc/nested-modules.rs
@@ -7,11 +7,11 @@ mod a_module {
 
     pub mod a_nested_module {
         // @has aCrate/a_nested_module/index.html '//a[@href="fn.a_nested_public_function.html"]' 'a_nested_public_function'
-        // @hastext aCrate/a_nested_module/fn.a_nested_public_function.html 'pub fn a_nested_public_function()'
+        // @hasraw aCrate/a_nested_module/fn.a_nested_public_function.html 'pub fn a_nested_public_function()'
         pub fn a_nested_public_function() {}
 
         // @has aCrate/a_nested_module/index.html '//a[@href="fn.another_nested_public_function.html"]' 'another_nested_public_function'
-        // @hastext aCrate/a_nested_module/fn.another_nested_public_function.html 'pub fn another_nested_public_function()'
+        // @hasraw aCrate/a_nested_module/fn.another_nested_public_function.html 'pub fn another_nested_public_function()'
         pub use a_nested_module::a_nested_public_function as another_nested_public_function;
     }
 

--- a/src/test/rustdoc/no-crate-filter.rs
+++ b/src/test/rustdoc/no-crate-filter.rs
@@ -2,5 +2,5 @@
 
 // compile-flags: -Z unstable-options --disable-per-crate-search
 
-// @!has 'foo/struct.Foo.html' '//*[id="crate-search"]'
+// @!hasraw 'foo/struct.Foo.html' '//*[id="crate-search"]'
 pub struct Foo;

--- a/src/test/rustdoc/no-crate-filter.rs
+++ b/src/test/rustdoc/no-crate-filter.rs
@@ -2,5 +2,5 @@
 
 // compile-flags: -Z unstable-options --disable-per-crate-search
 
-// @!hasraw 'foo/struct.Foo.html' '//*[id="crate-search"]'
+// @!has 'foo/struct.Foo.html' '//*[id="crate-search"]' ''
 pub struct Foo;

--- a/src/test/rustdoc/recursive-deref.rs
+++ b/src/test/rustdoc/recursive-deref.rs
@@ -51,7 +51,7 @@ impl G {
 
 // @has recursive_deref/struct.D.html '//h3[@class="code-header in-band"]' 'impl Deref for D'
 // We also check that `G::g` method isn't rendered because there is no `self` argument.
-// @!hasraw '-' '//*[@id="deref-methods-G"]'
+// @!has '-' '//*[@id="deref-methods-G"]' ''
 impl Deref for D {
     type Target = E;
 
@@ -62,7 +62,7 @@ impl Deref for D {
 
 // @has recursive_deref/struct.E.html '//h3[@class="code-header in-band"]' 'impl Deref for E'
 // We also check that `G::g` method isn't rendered because there is no `self` argument.
-// @!hasraw '-' '//*[@id="deref-methods-G"]'
+// @!has '-' '//*[@id="deref-methods-G"]' ''
 impl Deref for E {
     type Target = F;
 
@@ -73,7 +73,7 @@ impl Deref for E {
 
 // @has recursive_deref/struct.F.html '//h3[@class="code-header in-band"]' 'impl Deref for F'
 // We also check that `G::g` method isn't rendered because there is no `self` argument.
-// @!hasraw '-' '//*[@id="deref-methods-G"]'
+// @!has '-' '//*[@id="deref-methods-G"]' ''
 impl Deref for F {
     type Target = G;
 
@@ -101,7 +101,7 @@ impl I {
 }
 
 // @has recursive_deref/struct.H.html '//h3[@class="code-header in-band"]' 'impl Deref for H'
-// @!hasraw '-' '//*[@id="deref-methods-I"]'
+// @!has '-' '//*[@id="deref-methods-I"]' ''
 impl Deref for H {
     type Target = I;
 

--- a/src/test/rustdoc/recursive-deref.rs
+++ b/src/test/rustdoc/recursive-deref.rs
@@ -51,7 +51,7 @@ impl G {
 
 // @has recursive_deref/struct.D.html '//h3[@class="code-header in-band"]' 'impl Deref for D'
 // We also check that `G::g` method isn't rendered because there is no `self` argument.
-// @!has '-' '//*[@id="deref-methods-G"]'
+// @!hasraw '-' '//*[@id="deref-methods-G"]'
 impl Deref for D {
     type Target = E;
 
@@ -62,7 +62,7 @@ impl Deref for D {
 
 // @has recursive_deref/struct.E.html '//h3[@class="code-header in-band"]' 'impl Deref for E'
 // We also check that `G::g` method isn't rendered because there is no `self` argument.
-// @!has '-' '//*[@id="deref-methods-G"]'
+// @!hasraw '-' '//*[@id="deref-methods-G"]'
 impl Deref for E {
     type Target = F;
 
@@ -73,7 +73,7 @@ impl Deref for E {
 
 // @has recursive_deref/struct.F.html '//h3[@class="code-header in-band"]' 'impl Deref for F'
 // We also check that `G::g` method isn't rendered because there is no `self` argument.
-// @!has '-' '//*[@id="deref-methods-G"]'
+// @!hasraw '-' '//*[@id="deref-methods-G"]'
 impl Deref for F {
     type Target = G;
 
@@ -101,7 +101,7 @@ impl I {
 }
 
 // @has recursive_deref/struct.H.html '//h3[@class="code-header in-band"]' 'impl Deref for H'
-// @!has '-' '//*[@id="deref-methods-I"]'
+// @!hasraw '-' '//*[@id="deref-methods-I"]'
 impl Deref for H {
     type Target = I;
 

--- a/src/test/rustdoc/remove-url-from-headings.rs
+++ b/src/test/rustdoc/remove-url-from-headings.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
 // @has foo/fn.foo.html
-// @!hasraw - '//a[@href="http://a.a"]'
+// @!has - '//a[@href="http://a.a"]' ''
 // @has - '//a[@href="#implementing-stuff-somewhere"]' 'Implementing stuff somewhere'
 // @has - '//a[@href="#another-one-urg"]' 'Another one urg'
 

--- a/src/test/rustdoc/remove-url-from-headings.rs
+++ b/src/test/rustdoc/remove-url-from-headings.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
 // @has foo/fn.foo.html
-// @!has - '//a[@href="http://a.a"]'
+// @!hasraw - '//a[@href="http://a.a"]'
 // @has - '//a[@href="#implementing-stuff-somewhere"]' 'Implementing stuff somewhere'
 // @has - '//a[@href="#another-one-urg"]' 'Another one urg'
 

--- a/src/test/rustdoc/search-index-summaries.rs
+++ b/src/test/rustdoc/search-index-summaries.rs
@@ -1,6 +1,6 @@
 #![crate_name = "foo"]
 
-// @hastext 'search-index.js' 'Foo short link.'
+// @hasraw 'search-index.js' 'Foo short link.'
 // @!has - 'www.example.com'
 // @!has - 'More Foo.'
 

--- a/src/test/rustdoc/search-index-summaries.rs
+++ b/src/test/rustdoc/search-index-summaries.rs
@@ -1,8 +1,8 @@
 #![crate_name = "foo"]
 
 // @hasraw 'search-index.js' 'Foo short link.'
-// @!has - 'www.example.com'
-// @!has - 'More Foo.'
+// @!hasraw - 'www.example.com'
+// @!hasraw - 'More Foo.'
 
 /// Foo short [link](https://www.example.com/).
 ///

--- a/src/test/rustdoc/search-index-summaries.rs
+++ b/src/test/rustdoc/search-index-summaries.rs
@@ -1,6 +1,6 @@
 #![crate_name = "foo"]
 
-// @has 'search-index.js' 'Foo short link.'
+// @hastext 'search-index.js' 'Foo short link.'
 // @!has - 'www.example.com'
 // @!has - 'More Foo.'
 

--- a/src/test/rustdoc/search-index.rs
+++ b/src/test/rustdoc/search-index.rs
@@ -2,13 +2,13 @@
 
 use std::ops::Deref;
 
-// @has search-index.js Foo
+// @hastext search-index.js Foo
 pub use private::Foo;
 
 mod private {
     pub struct Foo;
     impl Foo {
-        pub fn test_method() {} // @has - test_method
+        pub fn test_method() {} // @hastext - test_method
         fn priv_method() {} // @!has - priv_method
     }
 

--- a/src/test/rustdoc/search-index.rs
+++ b/src/test/rustdoc/search-index.rs
@@ -9,18 +9,18 @@ mod private {
     pub struct Foo;
     impl Foo {
         pub fn test_method() {} // @hasraw - test_method
-        fn priv_method() {} // @!has - priv_method
+        fn priv_method() {} // @!hasraw - priv_method
     }
 
     pub trait PrivateTrait {
-        fn trait_method(&self) {} // @!has - priv_method
+        fn trait_method(&self) {} // @!hasraw - priv_method
     }
 }
 
 pub struct Bar;
 
 impl Deref for Bar {
-    // @!has search-index.js Target
+    // @!hasraw search-index.js Target
     type Target = Bar;
     fn deref(&self) -> &Bar { self }
 }

--- a/src/test/rustdoc/search-index.rs
+++ b/src/test/rustdoc/search-index.rs
@@ -2,13 +2,13 @@
 
 use std::ops::Deref;
 
-// @hastext search-index.js Foo
+// @hasraw search-index.js Foo
 pub use private::Foo;
 
 mod private {
     pub struct Foo;
     impl Foo {
-        pub fn test_method() {} // @hastext - test_method
+        pub fn test_method() {} // @hasraw - test_method
         fn priv_method() {} // @!has - priv_method
     }
 

--- a/src/test/rustdoc/show-const-contents.rs
+++ b/src/test/rustdoc/show-const-contents.rs
@@ -1,34 +1,34 @@
 // Test that the contents of constants are displayed as part of the
 // documentation.
 
-// @has show_const_contents/constant.CONST_S.html 'show this'
+// @hastext show_const_contents/constant.CONST_S.html 'show this'
 // @!has show_const_contents/constant.CONST_S.html '; //'
 pub const CONST_S: &'static str = "show this";
 
-// @has show_const_contents/constant.CONST_I32.html '= 42;'
+// @hastext show_const_contents/constant.CONST_I32.html '= 42;'
 // @!has show_const_contents/constant.CONST_I32.html '; //'
 pub const CONST_I32: i32 = 42;
 
-// @has show_const_contents/constant.CONST_I32_HEX.html '= 0x42;'
+// @hastext show_const_contents/constant.CONST_I32_HEX.html '= 0x42;'
 // @!has show_const_contents/constant.CONST_I32_HEX.html '; //'
 pub const CONST_I32_HEX: i32 = 0x42;
 
-// @has show_const_contents/constant.CONST_NEG_I32.html '= -42;'
+// @hastext show_const_contents/constant.CONST_NEG_I32.html '= -42;'
 // @!has show_const_contents/constant.CONST_NEG_I32.html '; //'
 pub const CONST_NEG_I32: i32 = -42;
 
-// @has show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '= 42i32;'
+// @hastext show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '= 42i32;'
 // @!has show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '// 42i32'
 pub const CONST_EQ_TO_VALUE_I32: i32 = 42i32;
 
-// @has show_const_contents/constant.CONST_CALC_I32.html '= _; // 43i32'
+// @hastext show_const_contents/constant.CONST_CALC_I32.html '= _; // 43i32'
 pub const CONST_CALC_I32: i32 = 42 + 1;
 
 // @!has show_const_contents/constant.CONST_REF_I32.html '= &42;'
 // @!has show_const_contents/constant.CONST_REF_I32.html '; //'
 pub const CONST_REF_I32: &'static i32 = &42;
 
-// @has show_const_contents/constant.CONST_I32_MAX.html '= i32::MAX; // 2_147_483_647i32'
+// @hastext show_const_contents/constant.CONST_I32_MAX.html '= i32::MAX; // 2_147_483_647i32'
 pub const CONST_I32_MAX: i32 = i32::MAX;
 
 // @!has show_const_contents/constant.UNIT.html '= ();'
@@ -47,11 +47,11 @@ pub struct MyTypeWithStr(&'static str);
 // @!has show_const_contents/constant.MY_TYPE_WITH_STR.html '; //'
 pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 
-// @has show_const_contents/constant.PI.html '= 3.14159265358979323846264338327950288f32;'
-// @has show_const_contents/constant.PI.html '; // 3.14159274f32'
+// @hastext show_const_contents/constant.PI.html '= 3.14159265358979323846264338327950288f32;'
+// @hastext show_const_contents/constant.PI.html '; // 3.14159274f32'
 pub use std::f32::consts::PI;
 
-// @has show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
+// @hastext show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
 #[allow(deprecated, deprecated_in_future)]
 pub use std::i32::MAX;
 
@@ -61,7 +61,7 @@ macro_rules! int_module {
     )
 }
 
-// @has show_const_contents/constant.MIN.html '= i16::MIN; // -32_768i16'
+// @hastext show_const_contents/constant.MIN.html '= i16::MIN; // -32_768i16'
 int_module!(i16);
 
 // @has show_const_contents/constant.ESCAPE.html //pre '= r#"<script>alert("ESCAPE");</script>"#;'

--- a/src/test/rustdoc/show-const-contents.rs
+++ b/src/test/rustdoc/show-const-contents.rs
@@ -2,49 +2,49 @@
 // documentation.
 
 // @hasraw show_const_contents/constant.CONST_S.html 'show this'
-// @!has show_const_contents/constant.CONST_S.html '; //'
+// @!hasraw show_const_contents/constant.CONST_S.html '; //'
 pub const CONST_S: &'static str = "show this";
 
 // @hasraw show_const_contents/constant.CONST_I32.html '= 42;'
-// @!has show_const_contents/constant.CONST_I32.html '; //'
+// @!hasraw show_const_contents/constant.CONST_I32.html '; //'
 pub const CONST_I32: i32 = 42;
 
 // @hasraw show_const_contents/constant.CONST_I32_HEX.html '= 0x42;'
-// @!has show_const_contents/constant.CONST_I32_HEX.html '; //'
+// @!hasraw show_const_contents/constant.CONST_I32_HEX.html '; //'
 pub const CONST_I32_HEX: i32 = 0x42;
 
 // @hasraw show_const_contents/constant.CONST_NEG_I32.html '= -42;'
-// @!has show_const_contents/constant.CONST_NEG_I32.html '; //'
+// @!hasraw show_const_contents/constant.CONST_NEG_I32.html '; //'
 pub const CONST_NEG_I32: i32 = -42;
 
 // @hasraw show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '= 42i32;'
-// @!has show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '// 42i32'
+// @!hasraw show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '// 42i32'
 pub const CONST_EQ_TO_VALUE_I32: i32 = 42i32;
 
 // @hasraw show_const_contents/constant.CONST_CALC_I32.html '= _; // 43i32'
 pub const CONST_CALC_I32: i32 = 42 + 1;
 
-// @!has show_const_contents/constant.CONST_REF_I32.html '= &42;'
-// @!has show_const_contents/constant.CONST_REF_I32.html '; //'
+// @!hasraw show_const_contents/constant.CONST_REF_I32.html '= &42;'
+// @!hasraw show_const_contents/constant.CONST_REF_I32.html '; //'
 pub const CONST_REF_I32: &'static i32 = &42;
 
 // @hasraw show_const_contents/constant.CONST_I32_MAX.html '= i32::MAX; // 2_147_483_647i32'
 pub const CONST_I32_MAX: i32 = i32::MAX;
 
-// @!has show_const_contents/constant.UNIT.html '= ();'
-// @!has show_const_contents/constant.UNIT.html '; //'
+// @!hasraw show_const_contents/constant.UNIT.html '= ();'
+// @!hasraw show_const_contents/constant.UNIT.html '; //'
 pub const UNIT: () = ();
 
 pub struct MyType(i32);
 
-// @!has show_const_contents/constant.MY_TYPE.html '= MyType(42);'
-// @!has show_const_contents/constant.MY_TYPE.html '; //'
+// @!hasraw show_const_contents/constant.MY_TYPE.html '= MyType(42);'
+// @!hasraw show_const_contents/constant.MY_TYPE.html '; //'
 pub const MY_TYPE: MyType = MyType(42);
 
 pub struct MyTypeWithStr(&'static str);
 
-// @!has show_const_contents/constant.MY_TYPE_WITH_STR.html '= MyTypeWithStr("show this");'
-// @!has show_const_contents/constant.MY_TYPE_WITH_STR.html '; //'
+// @!hasraw show_const_contents/constant.MY_TYPE_WITH_STR.html '= MyTypeWithStr("show this");'
+// @!hasraw show_const_contents/constant.MY_TYPE_WITH_STR.html '; //'
 pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 
 // @hasraw show_const_contents/constant.PI.html '= 3.14159265358979323846264338327950288f32;'

--- a/src/test/rustdoc/show-const-contents.rs
+++ b/src/test/rustdoc/show-const-contents.rs
@@ -1,34 +1,34 @@
 // Test that the contents of constants are displayed as part of the
 // documentation.
 
-// @hastext show_const_contents/constant.CONST_S.html 'show this'
+// @hasraw show_const_contents/constant.CONST_S.html 'show this'
 // @!has show_const_contents/constant.CONST_S.html '; //'
 pub const CONST_S: &'static str = "show this";
 
-// @hastext show_const_contents/constant.CONST_I32.html '= 42;'
+// @hasraw show_const_contents/constant.CONST_I32.html '= 42;'
 // @!has show_const_contents/constant.CONST_I32.html '; //'
 pub const CONST_I32: i32 = 42;
 
-// @hastext show_const_contents/constant.CONST_I32_HEX.html '= 0x42;'
+// @hasraw show_const_contents/constant.CONST_I32_HEX.html '= 0x42;'
 // @!has show_const_contents/constant.CONST_I32_HEX.html '; //'
 pub const CONST_I32_HEX: i32 = 0x42;
 
-// @hastext show_const_contents/constant.CONST_NEG_I32.html '= -42;'
+// @hasraw show_const_contents/constant.CONST_NEG_I32.html '= -42;'
 // @!has show_const_contents/constant.CONST_NEG_I32.html '; //'
 pub const CONST_NEG_I32: i32 = -42;
 
-// @hastext show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '= 42i32;'
+// @hasraw show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '= 42i32;'
 // @!has show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '// 42i32'
 pub const CONST_EQ_TO_VALUE_I32: i32 = 42i32;
 
-// @hastext show_const_contents/constant.CONST_CALC_I32.html '= _; // 43i32'
+// @hasraw show_const_contents/constant.CONST_CALC_I32.html '= _; // 43i32'
 pub const CONST_CALC_I32: i32 = 42 + 1;
 
 // @!has show_const_contents/constant.CONST_REF_I32.html '= &42;'
 // @!has show_const_contents/constant.CONST_REF_I32.html '; //'
 pub const CONST_REF_I32: &'static i32 = &42;
 
-// @hastext show_const_contents/constant.CONST_I32_MAX.html '= i32::MAX; // 2_147_483_647i32'
+// @hasraw show_const_contents/constant.CONST_I32_MAX.html '= i32::MAX; // 2_147_483_647i32'
 pub const CONST_I32_MAX: i32 = i32::MAX;
 
 // @!has show_const_contents/constant.UNIT.html '= ();'
@@ -47,11 +47,11 @@ pub struct MyTypeWithStr(&'static str);
 // @!has show_const_contents/constant.MY_TYPE_WITH_STR.html '; //'
 pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 
-// @hastext show_const_contents/constant.PI.html '= 3.14159265358979323846264338327950288f32;'
-// @hastext show_const_contents/constant.PI.html '; // 3.14159274f32'
+// @hasraw show_const_contents/constant.PI.html '= 3.14159265358979323846264338327950288f32;'
+// @hasraw show_const_contents/constant.PI.html '; // 3.14159274f32'
 pub use std::f32::consts::PI;
 
-// @hastext show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
+// @hasraw show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
 #[allow(deprecated, deprecated_in_future)]
 pub use std::i32::MAX;
 
@@ -61,7 +61,7 @@ macro_rules! int_module {
     )
 }
 
-// @hastext show_const_contents/constant.MIN.html '= i16::MIN; // -32_768i16'
+// @hasraw show_const_contents/constant.MIN.html '= i16::MIN; // -32_768i16'
 int_module!(i16);
 
 // @has show_const_contents/constant.ESCAPE.html //pre '= r#"<script>alert("ESCAPE");</script>"#;'

--- a/src/test/rustdoc/sized_trait.rs
+++ b/src/test/rustdoc/sized_trait.rs
@@ -1,13 +1,13 @@
 #![crate_name = "foo"]
 
 // @has foo/struct.Bar.html
-// @!hasraw - '//*[@id="impl-Sized"]'
+// @!has - '//*[@id="impl-Sized"]' ''
 pub struct Bar {
     a: u16,
 }
 
 // @has foo/struct.Foo.html
-// @!hasraw - '//*[@id="impl-Sized"]'
+// @!has - '//*[@id="impl-Sized"]' ''
 pub struct Foo<T: ?Sized>(T);
 
 // @has foo/struct.Unsized.html

--- a/src/test/rustdoc/sized_trait.rs
+++ b/src/test/rustdoc/sized_trait.rs
@@ -1,13 +1,13 @@
 #![crate_name = "foo"]
 
 // @has foo/struct.Bar.html
-// @!has - '//*[@id="impl-Sized"]'
+// @!hasraw - '//*[@id="impl-Sized"]'
 pub struct Bar {
     a: u16,
 }
 
 // @has foo/struct.Foo.html
-// @!has - '//*[@id="impl-Sized"]'
+// @!hasraw - '//*[@id="impl-Sized"]'
 pub struct Foo<T: ?Sized>(T);
 
 // @has foo/struct.Unsized.html

--- a/src/test/rustdoc/sort-modules-by-appearance.rs
+++ b/src/test/rustdoc/sort-modules-by-appearance.rs
@@ -9,5 +9,5 @@ pub mod module_c {}
 
 pub mod module_a {}
 
-// @matches 'sort_modules_by_appearance/index.html' '(?s)module_b.*module_c.*module_a'
-// @matches 'sort_modules_by_appearance/sidebar-items.js' '"module_b".*"module_c".*"module_a"'
+// @matchestext 'sort_modules_by_appearance/index.html' '(?s)module_b.*module_c.*module_a'
+// @matchestext 'sort_modules_by_appearance/sidebar-items.js' '"module_b".*"module_c".*"module_a"'

--- a/src/test/rustdoc/sort-modules-by-appearance.rs
+++ b/src/test/rustdoc/sort-modules-by-appearance.rs
@@ -9,5 +9,5 @@ pub mod module_c {}
 
 pub mod module_a {}
 
-// @matchestext 'sort_modules_by_appearance/index.html' '(?s)module_b.*module_c.*module_a'
-// @matchestext 'sort_modules_by_appearance/sidebar-items.js' '"module_b".*"module_c".*"module_a"'
+// @matchesraw 'sort_modules_by_appearance/index.html' '(?s)module_b.*module_c.*module_a'
+// @matchesraw 'sort_modules_by_appearance/sidebar-items.js' '"module_b".*"module_c".*"module_a"'

--- a/src/test/rustdoc/source-file.rs
+++ b/src/test/rustdoc/source-file.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
 
-// @has source-files.js source-file.rs
+// @hastext source-files.js source-file.rs
 
 pub struct Foo;

--- a/src/test/rustdoc/source-file.rs
+++ b/src/test/rustdoc/source-file.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
 
-// @hastext source-files.js source-file.rs
+// @hasraw source-files.js source-file.rs
 
 pub struct Foo;

--- a/src/test/rustdoc/static-root-path.rs
+++ b/src/test/rustdoc/static-root-path.rs
@@ -1,18 +1,18 @@
 // compile-flags:-Z unstable-options --static-root-path /cache/
 
 // @has static_root_path/struct.SomeStruct.html
-// @matchestext - '"/cache/main\.js"'
+// @matchesraw - '"/cache/main\.js"'
 // @!matches - '"\.\./main\.js"'
-// @matchestext - 'data-root-path="\.\./"'
+// @matchesraw - 'data-root-path="\.\./"'
 // @!matches - '"/cache/search-index\.js"'
 pub struct SomeStruct;
 
 // @has src/static_root_path/static-root-path.rs.html
-// @matchestext - '"/cache/source-script\.js"'
+// @matchesraw - '"/cache/source-script\.js"'
 // @!matches - '"\.\./\.\./source-script\.js"'
-// @matchestext - '"\.\./\.\./source-files.js"'
+// @matchesraw - '"\.\./\.\./source-files.js"'
 // @!matches - '"/cache/source-files\.js"'
 
 // @has settings.html
-// @matchestext - '/cache/settings\.js'
+// @matchesraw - '/cache/settings\.js'
 // @!matches - '\./settings\.js'

--- a/src/test/rustdoc/static-root-path.rs
+++ b/src/test/rustdoc/static-root-path.rs
@@ -1,18 +1,18 @@
 // compile-flags:-Z unstable-options --static-root-path /cache/
 
 // @has static_root_path/struct.SomeStruct.html
-// @matches - '"/cache/main\.js"'
+// @matchestext - '"/cache/main\.js"'
 // @!matches - '"\.\./main\.js"'
-// @matches - 'data-root-path="\.\./"'
+// @matchestext - 'data-root-path="\.\./"'
 // @!matches - '"/cache/search-index\.js"'
 pub struct SomeStruct;
 
 // @has src/static_root_path/static-root-path.rs.html
-// @matches - '"/cache/source-script\.js"'
+// @matchestext - '"/cache/source-script\.js"'
 // @!matches - '"\.\./\.\./source-script\.js"'
-// @matches - '"\.\./\.\./source-files.js"'
+// @matchestext - '"\.\./\.\./source-files.js"'
 // @!matches - '"/cache/source-files\.js"'
 
 // @has settings.html
-// @matches - '/cache/settings\.js'
+// @matchestext - '/cache/settings\.js'
 // @!matches - '\./settings\.js'

--- a/src/test/rustdoc/static-root-path.rs
+++ b/src/test/rustdoc/static-root-path.rs
@@ -2,17 +2,17 @@
 
 // @has static_root_path/struct.SomeStruct.html
 // @matchesraw - '"/cache/main\.js"'
-// @!matches - '"\.\./main\.js"'
+// @!matchesraw - '"\.\./main\.js"'
 // @matchesraw - 'data-root-path="\.\./"'
-// @!matches - '"/cache/search-index\.js"'
+// @!matchesraw - '"/cache/search-index\.js"'
 pub struct SomeStruct;
 
 // @has src/static_root_path/static-root-path.rs.html
 // @matchesraw - '"/cache/source-script\.js"'
-// @!matches - '"\.\./\.\./source-script\.js"'
+// @!matchesraw - '"\.\./\.\./source-script\.js"'
 // @matchesraw - '"\.\./\.\./source-files.js"'
-// @!matches - '"/cache/source-files\.js"'
+// @!matchesraw - '"/cache/source-files\.js"'
 
 // @has settings.html
 // @matchesraw - '/cache/settings\.js'
-// @!matches - '\./settings\.js'
+// @!matchesraw - '\./settings\.js'

--- a/src/test/rustdoc/table-in-docblock.rs
+++ b/src/test/rustdoc/table-in-docblock.rs
@@ -2,7 +2,7 @@
 
 // @has foo/struct.Foo.html
 // @count - '//*[@class="docblock"]/div/table' 2
-// @!has - '//*[@class="docblock"]/table'
+// @!hasraw - '//*[@class="docblock"]/table'
 /// | hello | hello2 |
 /// | ----- | ------ |
 /// | data  | data2  |

--- a/src/test/rustdoc/table-in-docblock.rs
+++ b/src/test/rustdoc/table-in-docblock.rs
@@ -2,7 +2,7 @@
 
 // @has foo/struct.Foo.html
 // @count - '//*[@class="docblock"]/div/table' 2
-// @!hasraw - '//*[@class="docblock"]/table'
+// @!has - '//*[@class="docblock"]/table' ''
 /// | hello | hello2 |
 /// | ----- | ------ |
 /// | data  | data2  |

--- a/src/test/rustdoc/toggle-item-contents.rs
+++ b/src/test/rustdoc/toggle-item-contents.rs
@@ -62,7 +62,7 @@ pub struct PrivStruct {
 }
 
 // @has 'toggle_item_contents/enum.Enum.html'
-// @!hasraw - '//details[@class="rustdoc-toggle type-contents-toggle"]'
+// @!has - '//details[@class="rustdoc-toggle type-contents-toggle"]' ''
 pub enum Enum {
     A, B, C,
     D {
@@ -72,7 +72,7 @@ pub enum Enum {
 }
 
 // @has 'toggle_item_contents/enum.EnumStructVariant.html'
-// @!hasraw - '//details[@class="rustdoc-toggle type-contents-toggle"]'
+// @!has - '//details[@class="rustdoc-toggle type-contents-toggle"]' ''
 pub enum EnumStructVariant {
     A, B, C,
     D {

--- a/src/test/rustdoc/toggle-item-contents.rs
+++ b/src/test/rustdoc/toggle-item-contents.rs
@@ -62,7 +62,7 @@ pub struct PrivStruct {
 }
 
 // @has 'toggle_item_contents/enum.Enum.html'
-// @!has - '//details[@class="rustdoc-toggle type-contents-toggle"]'
+// @!hasraw - '//details[@class="rustdoc-toggle type-contents-toggle"]'
 pub enum Enum {
     A, B, C,
     D {
@@ -72,7 +72,7 @@ pub enum Enum {
 }
 
 // @has 'toggle_item_contents/enum.EnumStructVariant.html'
-// @!has - '//details[@class="rustdoc-toggle type-contents-toggle"]'
+// @!hasraw - '//details[@class="rustdoc-toggle type-contents-toggle"]'
 pub enum EnumStructVariant {
     A, B, C,
     D {

--- a/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
+++ b/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
@@ -59,7 +59,7 @@ pub struct MyStruct;
 
 // We check that associated items with default values aren't generated in the implementors list.
 impl MyTrait for (u8, u8) {
-    // @!hasraw trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-4"]'
+    // @!has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-4"]' ''
     type Assoc = bool;
     fn trait_function(&self) {}
 }

--- a/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
+++ b/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
@@ -59,7 +59,7 @@ pub struct MyStruct;
 
 // We check that associated items with default values aren't generated in the implementors list.
 impl MyTrait for (u8, u8) {
-    // @!has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-4"]'
+    // @!hasraw trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-4"]'
     type Assoc = bool;
     fn trait_function(&self) {}
 }

--- a/src/test/rustdoc/trait-impl.rs
+++ b/src/test/rustdoc/trait-impl.rs
@@ -40,7 +40,7 @@ impl Trait for Struct {
     fn c() {}
 
     // @has - '//*[@id="method.d"]/../../div[@class="docblock"]/p' 'Escaped formatting a*b*c* works'
-    // @!has - '//*[@id="method.d"]/../../div[@class="docblock"]/p/em'
+    // @!hasraw - '//*[@id="method.d"]/../../div[@class="docblock"]/p/em'
     fn d() {}
 
     // @has - '//*[@id="impl-Trait-for-Struct"]/h3//a/@href' 'trait.Trait.html'

--- a/src/test/rustdoc/trait-impl.rs
+++ b/src/test/rustdoc/trait-impl.rs
@@ -40,7 +40,7 @@ impl Trait for Struct {
     fn c() {}
 
     // @has - '//*[@id="method.d"]/../../div[@class="docblock"]/p' 'Escaped formatting a*b*c* works'
-    // @!hasraw - '//*[@id="method.d"]/../../div[@class="docblock"]/p/em'
+    // @!has - '//*[@id="method.d"]/../../div[@class="docblock"]/p/em' ''
     fn d() {}
 
     // @has - '//*[@id="impl-Trait-for-Struct"]/h3//a/@href' 'trait.Trait.html'

--- a/src/test/rustdoc/tuple-struct-fields-doc.rs
+++ b/src/test/rustdoc/tuple-struct-fields-doc.rs
@@ -5,7 +5,7 @@
 // @has - '//h3[@class="sidebar-title"]/a[@href="#fields"]' 'Tuple Fields'
 // @has - '//*[@id="structfield.0"]' '0: u32'
 // @has - '//*[@id="main-content"]/div[@class="docblock"]' 'hello'
-// @!hasraw - '//*[@id="structfield.1"]'
+// @!has - '//*[@id="structfield.1"]' ''
 // @has - '//*[@id="structfield.2"]' '2: char'
 // @has - '//*[@id="structfield.3"]' '3: i8'
 // @has - '//*[@id="main-content"]/div[@class="docblock"]' 'not hello'

--- a/src/test/rustdoc/tuple-struct-fields-doc.rs
+++ b/src/test/rustdoc/tuple-struct-fields-doc.rs
@@ -5,7 +5,7 @@
 // @has - '//h3[@class="sidebar-title"]/a[@href="#fields"]' 'Tuple Fields'
 // @has - '//*[@id="structfield.0"]' '0: u32'
 // @has - '//*[@id="main-content"]/div[@class="docblock"]' 'hello'
-// @!has - '//*[@id="structfield.1"]'
+// @!hasraw - '//*[@id="structfield.1"]'
 // @has - '//*[@id="structfield.2"]' '2: char'
 // @has - '//*[@id="structfield.3"]' '3: i8'
 // @has - '//*[@id="main-content"]/div[@class="docblock"]' 'not hello'

--- a/src/test/rustdoc/type-layout-flag-required.rs
+++ b/src/test/rustdoc/type-layout-flag-required.rs
@@ -1,4 +1,4 @@
 // Tests that `--show-type-layout` is required in order to show layout info.
 
-// @!has type_layout_flag_required/struct.Foo.html 'Size: '
+// @!hasraw type_layout_flag_required/struct.Foo.html 'Size: '
 pub struct Foo(usize);

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -29,7 +29,7 @@ pub struct X(usize);
 
 // @hasraw type_layout/struct.Y.html 'Size: '
 // @hasraw - '1 byte'
-// @!has - ' bytes'
+// @!hasraw - ' bytes'
 pub struct Y(u8);
 
 // @hasraw type_layout/struct.Z.html 'Size: '
@@ -38,7 +38,7 @@ pub struct Z;
 
 // We can't compute layout for generic types.
 // @hasraw type_layout/struct.Generic.html 'Unable to compute type layout, possibly due to this type having generic parameters'
-// @!has - 'Size: '
+// @!hasraw - 'Size: '
 pub struct Generic<T>(T);
 
 // We *can*, however, compute layout for types that are only generic over lifetimes,
@@ -63,7 +63,7 @@ pub type GenericTypeAlias = (Generic<(u32, ())>, Generic<u32>);
 // @hasraw type_layout/type.Edges.html 'Encountered an error during type layout; the type failed to be normalized.'
 pub type Edges<'a, E> = std::borrow::Cow<'a, [E]>;
 
-// @!has type_layout/trait.MyTrait.html 'Size: '
+// @!hasraw type_layout/trait.MyTrait.html 'Size: '
 pub trait MyTrait {}
 
 // @hasraw type_layout/enum.Variants.html 'Size: '

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -1,84 +1,84 @@
 // compile-flags: --show-type-layout -Z unstable-options
 
-// @has type_layout/struct.Foo.html 'Size: '
-// @has - ' bytes'
+// @hastext type_layout/struct.Foo.html 'Size: '
+// @hastext - ' bytes'
 // @has - '//*[@id="layout"]/a[@href="#layout"]' ''
 pub struct Foo {
     pub a: usize,
     b: Vec<String>,
 }
 
-// @has type_layout/enum.Bar.html 'Size: '
-// @has - ' bytes'
+// @hastext type_layout/enum.Bar.html 'Size: '
+// @hastext - ' bytes'
 pub enum Bar<'a> {
     A(String),
     B(&'a str, (std::collections::HashMap<String, usize>, Foo)),
 }
 
-// @has type_layout/union.Baz.html 'Size: '
-// @has - ' bytes'
+// @hastext type_layout/union.Baz.html 'Size: '
+// @hastext - ' bytes'
 pub union Baz {
     a: &'static str,
     b: usize,
     c: &'static [u8],
 }
 
-// @has type_layout/struct.X.html 'Size: '
-// @has - ' bytes'
+// @hastext type_layout/struct.X.html 'Size: '
+// @hastext - ' bytes'
 pub struct X(usize);
 
-// @has type_layout/struct.Y.html 'Size: '
-// @has - '1 byte'
+// @hastext type_layout/struct.Y.html 'Size: '
+// @hastext - '1 byte'
 // @!has - ' bytes'
 pub struct Y(u8);
 
-// @has type_layout/struct.Z.html 'Size: '
-// @has - '0 bytes'
+// @hastext type_layout/struct.Z.html 'Size: '
+// @hastext - '0 bytes'
 pub struct Z;
 
 // We can't compute layout for generic types.
-// @has type_layout/struct.Generic.html 'Unable to compute type layout, possibly due to this type having generic parameters'
+// @hastext type_layout/struct.Generic.html 'Unable to compute type layout, possibly due to this type having generic parameters'
 // @!has - 'Size: '
 pub struct Generic<T>(T);
 
 // We *can*, however, compute layout for types that are only generic over lifetimes,
 // because lifetimes are a type-system construct.
-// @has type_layout/struct.GenericLifetimes.html 'Size: '
-// @has - ' bytes'
+// @hastext type_layout/struct.GenericLifetimes.html 'Size: '
+// @hastext - ' bytes'
 pub struct GenericLifetimes<'a>(&'a str);
 
-// @has type_layout/struct.Unsized.html 'Size: '
-// @has - '(unsized)'
+// @hastext type_layout/struct.Unsized.html 'Size: '
+// @hastext - '(unsized)'
 pub struct Unsized([u8]);
 
-// @has type_layout/type.TypeAlias.html 'Size: '
-// @has - ' bytes'
+// @hastext type_layout/type.TypeAlias.html 'Size: '
+// @hastext - ' bytes'
 pub type TypeAlias = X;
 
-// @has type_layout/type.GenericTypeAlias.html 'Size: '
-// @has - '8 bytes'
+// @hastext type_layout/type.GenericTypeAlias.html 'Size: '
+// @hastext - '8 bytes'
 pub type GenericTypeAlias = (Generic<(u32, ())>, Generic<u32>);
 
 // Regression test for the rustdoc equivalent of #85103.
-// @has type_layout/type.Edges.html 'Encountered an error during type layout; the type failed to be normalized.'
+// @hastext type_layout/type.Edges.html 'Encountered an error during type layout; the type failed to be normalized.'
 pub type Edges<'a, E> = std::borrow::Cow<'a, [E]>;
 
 // @!has type_layout/trait.MyTrait.html 'Size: '
 pub trait MyTrait {}
 
-// @has type_layout/enum.Variants.html 'Size: '
-// @has - '2 bytes'
-// @has - '<code>A</code>: 0 bytes'
-// @has - '<code>B</code>: 1 byte'
+// @hastext type_layout/enum.Variants.html 'Size: '
+// @hastext - '2 bytes'
+// @hastext - '<code>A</code>: 0 bytes'
+// @hastext - '<code>B</code>: 1 byte'
 pub enum Variants {
     A,
     B(u8),
 }
 
-// @has type_layout/enum.WithNiche.html 'Size: '
+// @hastext type_layout/enum.WithNiche.html 'Size: '
 // @has - //p '4 bytes'
-// @has - '<code>None</code>: 0 bytes'
-// @has - '<code>Some</code>: 4 bytes'
+// @hastext - '<code>None</code>: 0 bytes'
+// @hastext - '<code>Some</code>: 4 bytes'
 pub enum WithNiche {
     None,
     Some(std::num::NonZeroU32),

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -1,84 +1,84 @@
 // compile-flags: --show-type-layout -Z unstable-options
 
-// @hastext type_layout/struct.Foo.html 'Size: '
-// @hastext - ' bytes'
+// @hasraw type_layout/struct.Foo.html 'Size: '
+// @hasraw - ' bytes'
 // @has - '//*[@id="layout"]/a[@href="#layout"]' ''
 pub struct Foo {
     pub a: usize,
     b: Vec<String>,
 }
 
-// @hastext type_layout/enum.Bar.html 'Size: '
-// @hastext - ' bytes'
+// @hasraw type_layout/enum.Bar.html 'Size: '
+// @hasraw - ' bytes'
 pub enum Bar<'a> {
     A(String),
     B(&'a str, (std::collections::HashMap<String, usize>, Foo)),
 }
 
-// @hastext type_layout/union.Baz.html 'Size: '
-// @hastext - ' bytes'
+// @hasraw type_layout/union.Baz.html 'Size: '
+// @hasraw - ' bytes'
 pub union Baz {
     a: &'static str,
     b: usize,
     c: &'static [u8],
 }
 
-// @hastext type_layout/struct.X.html 'Size: '
-// @hastext - ' bytes'
+// @hasraw type_layout/struct.X.html 'Size: '
+// @hasraw - ' bytes'
 pub struct X(usize);
 
-// @hastext type_layout/struct.Y.html 'Size: '
-// @hastext - '1 byte'
+// @hasraw type_layout/struct.Y.html 'Size: '
+// @hasraw - '1 byte'
 // @!has - ' bytes'
 pub struct Y(u8);
 
-// @hastext type_layout/struct.Z.html 'Size: '
-// @hastext - '0 bytes'
+// @hasraw type_layout/struct.Z.html 'Size: '
+// @hasraw - '0 bytes'
 pub struct Z;
 
 // We can't compute layout for generic types.
-// @hastext type_layout/struct.Generic.html 'Unable to compute type layout, possibly due to this type having generic parameters'
+// @hasraw type_layout/struct.Generic.html 'Unable to compute type layout, possibly due to this type having generic parameters'
 // @!has - 'Size: '
 pub struct Generic<T>(T);
 
 // We *can*, however, compute layout for types that are only generic over lifetimes,
 // because lifetimes are a type-system construct.
-// @hastext type_layout/struct.GenericLifetimes.html 'Size: '
-// @hastext - ' bytes'
+// @hasraw type_layout/struct.GenericLifetimes.html 'Size: '
+// @hasraw - ' bytes'
 pub struct GenericLifetimes<'a>(&'a str);
 
-// @hastext type_layout/struct.Unsized.html 'Size: '
-// @hastext - '(unsized)'
+// @hasraw type_layout/struct.Unsized.html 'Size: '
+// @hasraw - '(unsized)'
 pub struct Unsized([u8]);
 
-// @hastext type_layout/type.TypeAlias.html 'Size: '
-// @hastext - ' bytes'
+// @hasraw type_layout/type.TypeAlias.html 'Size: '
+// @hasraw - ' bytes'
 pub type TypeAlias = X;
 
-// @hastext type_layout/type.GenericTypeAlias.html 'Size: '
-// @hastext - '8 bytes'
+// @hasraw type_layout/type.GenericTypeAlias.html 'Size: '
+// @hasraw - '8 bytes'
 pub type GenericTypeAlias = (Generic<(u32, ())>, Generic<u32>);
 
 // Regression test for the rustdoc equivalent of #85103.
-// @hastext type_layout/type.Edges.html 'Encountered an error during type layout; the type failed to be normalized.'
+// @hasraw type_layout/type.Edges.html 'Encountered an error during type layout; the type failed to be normalized.'
 pub type Edges<'a, E> = std::borrow::Cow<'a, [E]>;
 
 // @!has type_layout/trait.MyTrait.html 'Size: '
 pub trait MyTrait {}
 
-// @hastext type_layout/enum.Variants.html 'Size: '
-// @hastext - '2 bytes'
-// @hastext - '<code>A</code>: 0 bytes'
-// @hastext - '<code>B</code>: 1 byte'
+// @hasraw type_layout/enum.Variants.html 'Size: '
+// @hasraw - '2 bytes'
+// @hasraw - '<code>A</code>: 0 bytes'
+// @hasraw - '<code>B</code>: 1 byte'
 pub enum Variants {
     A,
     B(u8),
 }
 
-// @hastext type_layout/enum.WithNiche.html 'Size: '
+// @hasraw type_layout/enum.WithNiche.html 'Size: '
 // @has - //p '4 bytes'
-// @hastext - '<code>None</code>: 0 bytes'
-// @hastext - '<code>Some</code>: 4 bytes'
+// @hasraw - '<code>None</code>: 0 bytes'
+// @hasraw - '<code>Some</code>: 4 bytes'
 pub enum WithNiche {
     None,
     Some(std::num::NonZeroU32),

--- a/src/test/rustdoc/typedef.rs
+++ b/src/test/rustdoc/typedef.rs
@@ -11,7 +11,7 @@ impl MyStruct {
 // @has typedef/type.MyAlias.html
 // @has - '//*[@class="impl has-srclink"]//h3[@class="code-header in-band"]' 'impl MyAlias'
 // @has - '//*[@class="impl has-srclink"]//h3[@class="code-header in-band"]' 'impl MyTrait for MyAlias'
-// @hastext - 'Alias docstring'
+// @hasraw - 'Alias docstring'
 // @has - '//*[@class="sidebar"]//*[@class="location"]' 'MyAlias'
 // @has - '//*[@class="sidebar"]//a[@href="#implementations"]' 'Methods'
 // @has - '//*[@class="sidebar"]//a[@href="#trait-implementations"]' 'Trait Implementations'

--- a/src/test/rustdoc/typedef.rs
+++ b/src/test/rustdoc/typedef.rs
@@ -11,7 +11,7 @@ impl MyStruct {
 // @has typedef/type.MyAlias.html
 // @has - '//*[@class="impl has-srclink"]//h3[@class="code-header in-band"]' 'impl MyAlias'
 // @has - '//*[@class="impl has-srclink"]//h3[@class="code-header in-band"]' 'impl MyTrait for MyAlias'
-// @has - 'Alias docstring'
+// @hastext - 'Alias docstring'
 // @has - '//*[@class="sidebar"]//*[@class="location"]' 'MyAlias'
 // @has - '//*[@class="sidebar"]//a[@href="#implementations"]' 'Methods'
 // @has - '//*[@class="sidebar"]//a[@href="#trait-implementations"]' 'Trait Implementations'

--- a/src/test/rustdoc/universal-impl-trait.rs
+++ b/src/test/rustdoc/universal-impl-trait.rs
@@ -5,15 +5,15 @@ use std::borrow::Borrow;
 
 // @has foo/fn.foo.html
 // @has - //pre 'foo('
-// @matchestext - '_x: impl <a class="trait" href="[^"]+/trait\.Clone\.html"'
-// @matchestext - '_z: .+impl.+trait\.Copy\.html.+, impl.+trait\.Clone\.html'
+// @matchesraw - '_x: impl <a class="trait" href="[^"]+/trait\.Clone\.html"'
+// @matchesraw - '_z: .+impl.+trait\.Copy\.html.+, impl.+trait\.Clone\.html'
 pub fn foo(_x: impl Clone, _y: i32, _z: (impl Copy, impl Clone)) {
 }
 
 pub trait Trait {
     // @has foo/trait.Trait.html
-    // @hastext - 'method</a>('
-    // @matchestext - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
+    // @hasraw - 'method</a>('
+    // @matchesraw - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
     fn method(&self, _x: impl std::fmt::Debug) {
     }
 }
@@ -22,30 +22,30 @@ pub struct S<T>(T);
 
 impl<T> S<T> {
     // @has foo/struct.S.html
-    // @hastext - 'bar</a>('
-    // @matchestext - '_bar: impl <a class="trait" href="[^"]+/trait\.Copy\.html"'
+    // @hasraw - 'bar</a>('
+    // @matchesraw - '_bar: impl <a class="trait" href="[^"]+/trait\.Copy\.html"'
     pub fn bar(_bar: impl Copy) {
     }
 
-    // @hastext - 'baz</a>('
-    // @matchestext - '_baz:.+struct\.S\.html.+impl .+trait\.Clone\.html'
+    // @hasraw - 'baz</a>('
+    // @matchesraw - '_baz:.+struct\.S\.html.+impl .+trait\.Clone\.html'
     pub fn baz(_baz: S<impl Clone>) {
     }
 
-    // @hastext - 'qux</a>('
-    // @matchestext - 'trait\.Read\.html'
+    // @hasraw - 'qux</a>('
+    // @matchesraw - 'trait\.Read\.html'
     pub fn qux(_qux: impl IntoIterator<Item = S<impl Read>>) {
     }
 }
 
-// @hastext - 'method</a>('
-// @matchestext - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
+// @hasraw - 'method</a>('
+// @matchesraw - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
 impl<T> Trait for S<T> {}
 
 // @has foo/fn.much_universe.html
-// @matchestext - 'T:.+Borrow.+impl .+trait\.Trait\.html'
-// @matchestext - 'U:.+IntoIterator.+= impl.+Iterator\.html.+= impl.+Clone\.html'
-// @matchestext - '_: impl .+trait\.Read\.html.+ \+ .+trait\.Clone\.html'
+// @matchesraw - 'T:.+Borrow.+impl .+trait\.Trait\.html'
+// @matchesraw - 'U:.+IntoIterator.+= impl.+Iterator\.html.+= impl.+Clone\.html'
+// @matchesraw - '_: impl .+trait\.Read\.html.+ \+ .+trait\.Clone\.html'
 pub fn much_universe<
     T: Borrow<impl Trait>,
     U: IntoIterator<Item = impl Iterator<Item = impl Clone>>,

--- a/src/test/rustdoc/universal-impl-trait.rs
+++ b/src/test/rustdoc/universal-impl-trait.rs
@@ -5,15 +5,15 @@ use std::borrow::Borrow;
 
 // @has foo/fn.foo.html
 // @has - //pre 'foo('
-// @matches - '_x: impl <a class="trait" href="[^"]+/trait\.Clone\.html"'
-// @matches - '_z: .+impl.+trait\.Copy\.html.+, impl.+trait\.Clone\.html'
+// @matchestext - '_x: impl <a class="trait" href="[^"]+/trait\.Clone\.html"'
+// @matchestext - '_z: .+impl.+trait\.Copy\.html.+, impl.+trait\.Clone\.html'
 pub fn foo(_x: impl Clone, _y: i32, _z: (impl Copy, impl Clone)) {
 }
 
 pub trait Trait {
     // @has foo/trait.Trait.html
-    // @has - 'method</a>('
-    // @matches - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
+    // @hastext - 'method</a>('
+    // @matchestext - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
     fn method(&self, _x: impl std::fmt::Debug) {
     }
 }
@@ -22,30 +22,30 @@ pub struct S<T>(T);
 
 impl<T> S<T> {
     // @has foo/struct.S.html
-    // @has - 'bar</a>('
-    // @matches - '_bar: impl <a class="trait" href="[^"]+/trait\.Copy\.html"'
+    // @hastext - 'bar</a>('
+    // @matchestext - '_bar: impl <a class="trait" href="[^"]+/trait\.Copy\.html"'
     pub fn bar(_bar: impl Copy) {
     }
 
-    // @has - 'baz</a>('
-    // @matches - '_baz:.+struct\.S\.html.+impl .+trait\.Clone\.html'
+    // @hastext - 'baz</a>('
+    // @matchestext - '_baz:.+struct\.S\.html.+impl .+trait\.Clone\.html'
     pub fn baz(_baz: S<impl Clone>) {
     }
 
-    // @has - 'qux</a>('
-    // @matches - 'trait\.Read\.html'
+    // @hastext - 'qux</a>('
+    // @matchestext - 'trait\.Read\.html'
     pub fn qux(_qux: impl IntoIterator<Item = S<impl Read>>) {
     }
 }
 
-// @has - 'method</a>('
-// @matches - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
+// @hastext - 'method</a>('
+// @matchestext - '_x: impl <a class="trait" href="[^"]+/trait\.Debug\.html"'
 impl<T> Trait for S<T> {}
 
 // @has foo/fn.much_universe.html
-// @matches - 'T:.+Borrow.+impl .+trait\.Trait\.html'
-// @matches - 'U:.+IntoIterator.+= impl.+Iterator\.html.+= impl.+Clone\.html'
-// @matches - '_: impl .+trait\.Read\.html.+ \+ .+trait\.Clone\.html'
+// @matchestext - 'T:.+Borrow.+impl .+trait\.Trait\.html'
+// @matchestext - 'U:.+IntoIterator.+= impl.+Iterator\.html.+= impl.+Clone\.html'
+// @matchestext - '_: impl .+trait\.Read\.html.+ \+ .+trait\.Clone\.html'
 pub fn much_universe<
     T: Borrow<impl Trait>,
     U: IntoIterator<Item = impl Iterator<Item = impl Clone>>,


### PR DESCRIPTION
Fixes #100354.
