### PR TITLE
core: add functions to flip boolean

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -41,4 +41,17 @@ impl bool {
     {
         if self { Some(f()) } else { None }
     }
+
+    /// Flips the `bool` value turning false to true and true to false
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert!(false.flip())
+    /// asssert!(!true.flip())
+    /// ```
+    #[inline]
+    pub const fn flip(&self) -> Self {
+        !self
+    }
 }

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -56,6 +56,7 @@ impl bool {
         !self
     }
 
+    /// Toggles the `bool` variable and mutates it
     #[unstable(feature = "toggle_bool", issue = "none", reason = "recently added")]
     #[inline]
     pub const fn toggle(&mut self) {

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -55,4 +55,10 @@ impl bool {
     pub const fn flip(&self) -> Self {
         !self
     }
+
+    #[unstable(feature = "toggle_bool", issue = "none", reason = "recently added")]
+    #[inline]
+    pub const fn toggle(&mut self) {
+        *self = self.flip();
+    }
 }

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -50,7 +50,7 @@ impl bool {
     /// assert!(false.flip())
     /// asssert!(!true.flip())
     /// ```
-    #[unstable(feature = "flip_bool", reason = "recently added")]
+    #[unstable(feature = "flip_bool", issue = "none", reason = "recently added")]
     #[inline]
     pub const fn flip(&self) -> Self {
         !self

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -50,6 +50,7 @@ impl bool {
     /// assert!(false.flip())
     /// asssert!(!true.flip())
     /// ```
+    #[unstable(feature = "flip_bool", reason = "recently added")]
     #[inline]
     pub const fn flip(&self) -> Self {
         !self

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -47,8 +47,10 @@ impl bool {
     /// # Examples
     ///
     /// ```
-    /// assert!(false.flip())
-    /// asssert!(!true.flip())
+    /// #![feature(flip_bool)]
+    ///
+    /// assert!(false.flip());
+    /// assert!(!true.flip());
     /// ```
     #[unstable(feature = "flip_bool", issue = "none", reason = "recently added")]
     #[inline]
@@ -57,6 +59,20 @@ impl bool {
     }
 
     /// Toggles the `bool` variable and mutates it
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(toggle_bool)]
+    ///
+    /// let mut eventually_true = false;
+    ///
+    /// assert!(!eventually_true);
+    ///
+    /// eventually_true.toggle();
+    ///
+    /// assert!(eventually_true);
+    /// ```
     #[unstable(feature = "toggle_bool", issue = "none", reason = "recently added")]
     #[inline]
     pub const fn toggle(&mut self) {

--- a/library/core/tests/bool.rs
+++ b/library/core/tests/bool.rs
@@ -108,8 +108,10 @@ fn test_bool_to_option() {
 fn test_bool_flip() {
     assert!(false.flip());
     assert!(!true.flip());
+}
 
-    // Test re-assignment
+#[test]
+fn test_bool_toggle() {
     let mut untrue = false;
 
     assert!(!untrue);
@@ -117,4 +119,15 @@ fn test_bool_flip() {
     untrue.toggle();
 
     assert!(untrue);
+}
+
+#[test]
+fn test_const_flip() {
+    const TRUE_CONST: bool = false.flip();
+    static TRUE_STATIC: bool = false.flip();
+
+    assert!(TRUE_CONST);
+
+
+    assert!(TRUE_STATIC);
 }

--- a/library/core/tests/bool.rs
+++ b/library/core/tests/bool.rs
@@ -103,3 +103,9 @@ fn test_bool_to_option() {
     assert_eq!(C, None);
     assert_eq!(D, Some(0));
 }
+
+#[test]
+fn test_bool_flip() {
+    assert!(false.flip());
+    assert!(!true.flip());
+}

--- a/library/core/tests/bool.rs
+++ b/library/core/tests/bool.rs
@@ -108,4 +108,13 @@ fn test_bool_to_option() {
 fn test_bool_flip() {
     assert!(false.flip());
     assert!(!true.flip());
+
+    // Test re-assignment
+    let mut untrue = false;
+
+    assert!(!untrue);
+
+    untrue.toggle();
+
+    assert!(untrue);
 }

--- a/library/core/tests/bool.rs
+++ b/library/core/tests/bool.rs
@@ -128,6 +128,5 @@ fn test_const_flip() {
 
     assert!(TRUE_CONST);
 
-
     assert!(TRUE_STATIC);
 }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -1,3 +1,5 @@
+#![feature(toggle_bool)]
+#![feature(flip_bool)]
 #![feature(alloc_layout_extra)]
 #![feature(array_chunks)]
 #![feature(array_methods)]


### PR DESCRIPTION
This PR adds two functions which invert a boolean value.

`.toggle` takes a mutable reference to a boolean value, and inverts it, then replaces the existing value with the inverted boolean.

`.flip` takes a reference to a boolean value, and inverts it, then returns that inverted value.

Implementation details are in `library/core/src/bool.rs` and tests are in `library/core/tests/bool.rs`.

The tests cover constant boolean flips, and both functions, and their applications.