### PR TITLE
Inline CStr::from_bytes_with_nul_unchecked::rt_impl

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -387,6 +387,7 @@ impl CStr {
     #[rustc_const_stable(feature = "const_cstr_unchecked", since = "1.59.0")]
     #[rustc_allow_const_fn_unstable(const_eval_select)]
     pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
+        #[inline]
         fn rt_impl(bytes: &[u8]) -> &CStr {
             // Chance at catching some UB at runtime with debug builds.
             debug_assert!(!bytes.is_empty() && bytes[bytes.len() - 1] == 0);


### PR DESCRIPTION
Currently `CStr::from_bytes_with_nul_unchecked::rt_impl` is not being inlined. The following function:

```rust
pub unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) {
    CStr::from_bytes_with_nul_unchecked(bytes);
}
```

Outputs the following assembly on current nightly

```asm
example::from_bytes_with_nul_unchecked:
        jmp     qword ptr [rip + _ZN4core3ffi5c_str4CStr29from_bytes_with_nul_unchecked7rt_impl17h026f29f3d6a41333E@GOTPCREL]
```

Meanwhile on beta this provides the following assembly:

```asm
example::from_bytes_with_nul_unchecked:
        ret
```

This pull request adds `#[inline]` annotation to`rt_impl` to fix a code generation regression for `CStr::from_bytes_with_nul_unchecked`.