### PR TITLE
Make the GATS self outlives error take into GATs in the inputs

### DIFF
--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -383,7 +383,7 @@ fn check_gat_where_clauses(tcx: TyCtxt<'_>, associated_items: &[hir::TraitItemRe
                             tcx,
                             param_env,
                             item_hir_id,
-                            sig.output(),
+                            sig.inputs_and_output,
                             // We also assume that all of the function signature's parameter types
                             // are well formed.
                             &sig.inputs().iter().copied().collect(),

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -210,4 +210,17 @@ trait StaticReturnAndTakes<'a> {
     fn bar<'b>(&self, arg: Self::Y<'b>);
 }
 
+// We require bounds when the GAT appears in the inputs
+trait Input {
+    type Item<'a>;
+    //~^ missing required
+    fn takes_item<'a>(&'a self, item: Self::Item<'a>);
+}
+
+// We don't require bounds when the GAT appears in the where clauses
+trait WhereClause {
+    type Item<'a>;
+    fn takes_item<'a>(&'a self) where Self::Item<'a>: ;
+}
+
 fn main() {}

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -163,5 +163,16 @@ LL |     type Fut<'out>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 15 previous errors
+error: missing required bound on `Item`
+  --> $DIR/self-outlives-lint.rs:215:5
+   |
+LL |     type Item<'a>;
+   |     ^^^^^^^^^^^^^-
+   |                  |
+   |                  help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Before, the reasoning was that outlives should factor in to the outlives error, because that value is produced and inputs aren't. However, this is potentially confusing, and we can just require this for now and relax it later if we need. GATs in where clauses still don't count for the self outlives error, and I've added a test for that.

This now errors:
```rust
trait Input {
    type Item<'a>;
    //~^ missing required
    fn takes_item<'a>(&'a self, item: Self::Item<'a>);
}
```

I've also added a test that this does not:
```rust
trait WhereClause {
    type Item<'a>;
    fn takes_item<'a>(&'a self) where Self::Item<'a>: ;
}
```

r? @compiler-errors 