### PR TITLE
Do not report cycle error when inferring return type for suggestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,7 @@ dependencies = [
  "rustc_serialize",
  "rustc_session",
  "rustc_span",
+ "rustc_target",
  "tracing",
 ]
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -770,6 +770,7 @@ rustc_queries! {
         desc { |tcx| "computing function signature of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
+        cycle_delay_bug
     }
 
     /// Performs lint checking for the module.

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -20,6 +20,7 @@ rustc_query_system = { path = "../rustc_query_system" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
+rustc_target = { path = "../rustc_target" }
 tracing = "0.1"
 
 [features]

--- a/src/test/ui/suggestions/return-cycle-2.rs
+++ b/src/test/ui/suggestions/return-cycle-2.rs
@@ -1,0 +1,14 @@
+use std::marker::PhantomData;
+
+struct Token<T>(PhantomData<T>);
+
+impl<T> Token<T> {
+    fn as_ref(_: i32, _: i32) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+        //~| NOTE not allowed in type signatures
+        //~| HELP replace with the correct return type
+        Token(PhantomData::<&T>)
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/return-cycle-2.stderr
+++ b/src/test/ui/suggestions/return-cycle-2.stderr
@@ -1,0 +1,12 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/return-cycle-2.rs:6:34
+   |
+LL |     fn as_ref(_: i32, _: i32) -> _ {
+   |                                  ^
+   |                                  |
+   |                                  not allowed in type signatures
+   |                                  help: replace with the correct return type: `Token<&'static T>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/suggestions/return-cycle.rs
+++ b/src/test/ui/suggestions/return-cycle.rs
@@ -1,0 +1,14 @@
+use std::marker::PhantomData;
+
+struct Token<T>(PhantomData<T>);
+
+impl<T> Token<T> {
+    fn new() -> _ {
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+        //~| NOTE not allowed in type signatures
+        //~| HELP replace with the correct return type
+        Token(PhantomData::<()>)
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/return-cycle.stderr
+++ b/src/test/ui/suggestions/return-cycle.stderr
@@ -1,0 +1,12 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/return-cycle.rs:6:17
+   |
+LL |     fn new() -> _ {
+   |                 ^
+   |                 |
+   |                 not allowed in type signatures
+   |                 help: replace with the correct return type: `Token<()>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
The UI test is a good example of a case where this happens. The cycle is due to needing the value of the return type `-> _` to compute the variances of items in the crate, but then needing the variances of the items in the crate to do typechecking to infer what `-> _`'s real type is. 

Since we're already gonna emit an error in astconv, just delay the cycle bug as an error.