### PR TITLE
Implement `From<bool>` for f32, f64

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -168,6 +168,26 @@ impl_from! { u32, f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 // Float -> Float
 impl_from! { f32, f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")] }
 
+// bool -> Float
+#[stable(feature = "float_from_bool", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
+impl const From<bool> for f32 {
+    /// Converts `bool` to `f32` losslessly.
+    #[inline]
+    fn from(small: bool) -> Self {
+        small as u8 as Self
+    }
+}
+#[stable(feature = "float_from_bool", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
+impl const From<bool> for f64 {
+    /// Converts `bool` to `f64` losslessly.
+    #[inline]
+    fn from(small: bool) -> Self {
+        small as u8 as Self
+    }
+}
+
 // no possible bounds violation
 macro_rules! try_from_unbounded {
     ($source:ty, $($target:ty),*) => {$(


### PR DESCRIPTION
As is required for trait implementations, these are insta-stable. Given there is a release tomorrow and this needs FCP, I set 1.65 as the stable version.

@rustbot label +A-floating-point +C-feature-request +needs-fcp +relnotes +S-waiting-on-review +T-libs-api -T-libs