### PR TITLE
use `PreInliningMap` to avoid `lock_mut` and `record_accesses` when collecting mono items

### DIFF
--- a/compiler/rustc_monomorphize/src/partitioning/default.rs
+++ b/compiler/rustc_monomorphize/src/partitioning/default.rs
@@ -219,10 +219,8 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
         // Build a map from every monomorphization to all the monomorphizations that
         // reference it.
         let mut accessor_map: FxHashMap<MonoItem<'tcx>, Vec<MonoItem<'tcx>>> = Default::default();
-        cx.inlining_map.iter_accesses(|accessor, accessees| {
-            for accessee in accessees {
-                accessor_map.entry(*accessee).or_default().push(accessor);
-            }
+        cx.inlining_map.iter_accesses(|accessor, access| {
+            accessor_map.entry(*access).or_default().push(accessor);
         });
 
         let mono_item_placements = &partitioning.mono_item_placements;


### PR DESCRIPTION
Currently we call `lock_mut` and `record_accesses` every time `collect_items_rec`, which may cause lock contention and cost time. It can be avoided by having `collect_items_rec` return a `PreInliningMap`. 
Here is a hacking that use `Vec<(Spanned<MonoItem<'tcx>>, bool)>` in `PreInliningMap` as we can directly move `neighbors` into.
The place that might affect performance is `collect`ing `PreInliningMap`s produced by neighbors. So we can first look at the results of perf run.