### PR TITLE
Improve error messages when running rustdoc GUI tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -924,6 +924,11 @@ fn compare_browser_ui_test_version(installed_version: &str, src: &Path) {
                      one used in the CI (`{}`)",
                     installed_version, v
                 );
+                eprintln!(
+                    "You can install this version using `npm update browser-ui-test` or by using \
+                     `npm install browser-ui-test@{}`",
+                    v,
+                );
             }
         }
         Err(e) => eprintln!("Couldn't find the CI browser-ui-test version: {:?}", e),

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -201,6 +201,19 @@ async function main(argv) {
         process.setMaxListeners(opts["jobs"] + 1);
     }
 
+    // We catch this "event" to display a nicer message in case of unexpected exit (because of a
+    // missing `--no-sandbox`).
+    const exitHandling = (code) => {
+        if (!opts["no_sandbox"]) {
+            console.log("");
+            console.log(
+                "`browser-ui-test` crashed unexpectedly. Please try again with adding `--test-args \
+--no-sandbox` at the end. For example: `x.py test src/test/rustdoc-gui --test-args --no-sandbox`");
+            console.log("");
+        }
+    };
+    process.on('exit', exitHandling);
+
     const tests_queue = [];
     let results = {
         successful: [],
@@ -246,6 +259,9 @@ async function main(argv) {
         await Promise.all(tests_queue);
     }
     status_bar.finish();
+
+    // We don't need this listener anymore.
+    process.removeListener("exit", exitHandling);
 
     if (debug) {
         results.successful.sort(by_filename);


### PR DESCRIPTION
There was already a message on how to install `browser-ui-test`, so nothing to be done there. However, we didn't show how to update its version, so the first commit adds it.

Another pain point was how to fix the unexpected crash in `browser-ui-test` (because of a missing `--no-sandbox`, still no idea why it became mandatory a few months ago on some linux distributions...). It now looks like this:

```console
Running 1 rustdoc-gui (8 concurrently) ...
ERROR: puppeteer failed when trying to create a new page. Please try again with `--no-sandbox`

`browser-ui-test` crashed unexpectedly. Please try again with adding `--test-args --no-sandbox` at the end. For example: `x.py test src/test/rustdoc-gui --test-args --no-sandbox`

Build completed unsuccessfully in 0:00:03
```

Thanks to @jsha for suggesting these improvements!

r? @jsha