### PR TITLE
`impl From<Infallible> for io::Error`

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -11,7 +11,7 @@ mod repr_unpacked;
 #[cfg(not(target_pointer_width = "64"))]
 use repr_unpacked::Repr;
 
-use crate::convert::From;
+use crate::convert::{From, Infallible};
 use crate::error;
 use crate::fmt;
 use crate::result;
@@ -462,6 +462,13 @@ impl From<ErrorKind> for Error {
     #[inline]
     fn from(kind: ErrorKind) -> Error {
         Error { repr: Repr::new_simple(kind) }
+    }
+}
+
+#[stable(feature = "io_error_from_infallible", since = "1.65.0")]
+impl From<Infallible> for Error {
+    fn from(infallible: Infallible) -> Error {
+        match infallible {}
     }
 }
 


### PR DESCRIPTION
This implements the trivial conversion from (uninhabited) `Infallible`
error type.

If I remember correctly trait impls are insta-stable, so I marked it as such. I hope this is obvious enough to pass FCP without too much hassle.

ACP: https://github.com/rust-lang/libs-team/issues/86