### PR TITLE
Enum variant ctor inherits the stability of the enum variant

### DIFF
--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -460,7 +460,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         AnnotationKind::Required,
                         InheritDeprecation::Yes,
                         InheritConstStability::No,
-                        InheritStability::No,
+                        InheritStability::Yes,
                         |_| {},
                     );
                 }

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -600,6 +600,9 @@ impl<'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'tcx> {
 
     fn visit_variant(&mut self, var: &'tcx Variant<'tcx>) {
         self.check_missing_stability(self.tcx.hir().local_def_id(var.id), var.span);
+        if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
+            self.check_missing_stability(self.tcx.hir().local_def_id(ctor_hir_id), var.span);
+        }
         intravisit::walk_variant(self, var);
     }
 

--- a/src/test/ui/stability-attribute/auxiliary/ctor-stability.rs
+++ b/src/test/ui/stability-attribute/auxiliary/ctor-stability.rs
@@ -1,0 +1,8 @@
+#![crate_type = "lib"]
+#![feature(staged_api)]
+#![stable(feature = "none", since = "1.0")]
+
+#[stable(feature = "none", since = "1.0")]
+pub enum Foo {
+    A,
+}

--- a/src/test/ui/stability-attribute/ctor-stability.rs
+++ b/src/test/ui/stability-attribute/ctor-stability.rs
@@ -1,0 +1,8 @@
+// aux-build:ctor-stability.rs
+// check-pass
+
+extern crate ctor_stability;
+
+fn main() {
+    let _ = ctor_stability::Foo::A;
+}


### PR DESCRIPTION
Fixes #100399
Fixes #100420

Context #71481 for why enum variants don't need stability