### PR TITLE
Erase regions better in `promote_candidate`

### DIFF
--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -839,17 +839,12 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
             let mut promoted_operand = |ty, span| {
                 promoted.span = span;
                 promoted.local_decls[RETURN_PLACE] = LocalDecl::new(ty, span);
+                let substs = tcx.erase_regions(InternalSubsts::identity_for_item(tcx, def.did));
                 let _const = tcx.mk_const(ty::ConstS {
                     ty,
                     kind: ty::ConstKind::Unevaluated(ty::Unevaluated {
                         def,
-                        substs: InternalSubsts::for_item(tcx, def.did, |param, _| {
-                            if let ty::GenericParamDefKind::Lifetime = param.kind {
-                                tcx.lifetimes.re_erased.into()
-                            } else {
-                                tcx.mk_param_from_def(param)
-                            }
-                        }),
+                        substs,
                         promoted: Some(promoted_id),
                     }),
                 });

--- a/src/test/ui/const-generics/generic_const_exprs/issue-100360.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-100360.rs
@@ -1,0 +1,13 @@
+// check-pass
+// (this requires debug assertions)
+
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+fn foo<const B: &'static bool>(arg: &'static bool) -> bool {
+    B == arg
+}
+
+fn main() {
+    foo::<{ &true }>(&false);
+}

--- a/src/test/ui/const-generics/generic_const_exprs/issue-89851.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-89851.rs
@@ -1,0 +1,12 @@
+// check-pass
+// (this requires debug assertions)
+
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+pub const BAR: () = ice::<"">();
+pub const fn ice<const N: &'static str>() {
+    &10;
+}
+
+fn main() {}


### PR DESCRIPTION
Use `tcx.erase_regions` instead of manually walking through the substs.... this also makes the code slightly simpler :see_no_evil: 

Fixes #100360
Fixes #89851