### PR TITLE
Add two let else regression tests

### DIFF
--- a/src/test/ui/let-else/issue-94176.rs
+++ b/src/test/ui/let-else/issue-94176.rs
@@ -1,0 +1,10 @@
+// Issue #94176: wrong span for the error message of a mismatched type error,
+// if the function uses a `let else` construct.
+#![feature(let_else)]
+
+pub fn test(a: Option<u32>) -> Option<u32> { //~ ERROR mismatched types
+    let Some(_) = a else { return None; };
+    println!("Foo");
+}
+
+fn main() {}

--- a/src/test/ui/let-else/issue-94176.stderr
+++ b/src/test/ui/let-else/issue-94176.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-94176.rs:5:32
+   |
+LL | pub fn test(a: Option<u32>) -> Option<u32> {
+   |        ----                    ^^^^^^^^^^^ expected enum `Option`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note:   expected enum `Option<u32>`
+           found unit type `()`
+help: consider returning the local binding `a`
+   |
+LL ~     println!("Foo");
+LL +     a
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/let-else/let-else-then-diverge.rs
+++ b/src/test/ui/let-else/let-else-then-diverge.rs
@@ -1,0 +1,19 @@
+//
+// popped up in in #94012, where an alternative desugaring was
+// causing unreachable code errors
+
+#![feature(let_else)]
+#![deny(unused_variables)]
+#![deny(unreachable_code)]
+
+fn let_else_diverge() -> bool {
+    let Some(_) = Some("test") else {
+        let x = 5; //~ ERROR unused variable: `x`
+        return false;
+    };
+    return true;
+}
+
+fn main() {
+    let_else_diverge();
+}

--- a/src/test/ui/let-else/let-else-then-diverge.stderr
+++ b/src/test/ui/let-else/let-else-then-diverge.stderr
@@ -1,0 +1,14 @@
+error: unused variable: `x`
+  --> $DIR/let-else-then-diverge.rs:11:13
+   |
+LL |         let x = 5;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+note: the lint level is defined here
+  --> $DIR/let-else-then-diverge.rs:6:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Adds a regression test for #94176, as it was fixed by #98574 but doesn't have a regression test. The PR also incorporates a commit from #94012 which added a test for an issue discovered in that PR.

Originally they have been part of #99291, but I've moved them out in the hopes of getting them merged more quickly, as that PR is already open since a month, and so that #99291 can focus on the drop order part of things.

Closes #94176
Closes #96961 -- dupe of #94176
