### PR TITLE
adapt test for msan message change

### DIFF
--- a/src/test/ui/sanitize/memory.rs
+++ b/src/test/ui/sanitize/memory.rs
@@ -6,7 +6,7 @@
 // run-fail
 // error-pattern: MemorySanitizer: use-of-uninitialized-value
 // error-pattern: Uninitialized value was created by an allocation
-// error-pattern: in the stack frame of function 'main'
+// error-pattern: in the stack frame
 //
 // This test case intentionally limits the usage of the std,
 // since it will be linked with an uninstrumented version of it.


### PR DESCRIPTION
LLVM commit https://github.com/llvm/llvm-project/commit/057cabd997aeaef136e1e14f2ee645bd5bb197dd removed the function from the msan error message. This adapts our test accordingly.

Found via our experimental rust + llvm @ HEAD bot:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/12634#018289fe-b0bc-4bab-89b3-fb1d4e38f6db