### PR TITLE
Fake capture closures if typeck results are empty

### DIFF
--- a/src/test/ui/closures/issue-93242.rs
+++ b/src/test/ui/closures/issue-93242.rs
@@ -1,0 +1,11 @@
+// check-pass
+// edition:2021
+
+pub fn something(path: &[usize]) -> impl Fn() -> usize + '_ {
+    move || match path {
+        [] => 0,
+        _ => 1,
+    }
+}
+
+fn main(){}

--- a/src/tools/clippy/tests/ui/redundant_clone.fixed
+++ b/src/tools/clippy/tests/ui/redundant_clone.fixed
@@ -201,7 +201,7 @@ fn clone_then_move_cloned() {
     fn foo<F: Fn()>(_: &Alpha, _: F) {}
     let x = Alpha;
     // ok, data is moved while the clone is in use.
-    foo(&x, move || {
+    foo(&x.clone(), move || {
         let _ = x;
     });
 

--- a/src/tools/clippy/tests/ui/redundant_clone.stderr
+++ b/src/tools/clippy/tests/ui/redundant_clone.stderr
@@ -167,17 +167,5 @@ note: cloned value is neither consumed nor mutated
 LL |     let y = x.clone().join("matthias");
    |             ^^^^^^^^^
 
-error: redundant clone
-  --> $DIR/redundant_clone.rs:204:11
-   |
-LL |     foo(&x.clone(), move || {
-   |           ^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:204:10
-   |
-LL |     foo(&x.clone(), move || {
-   |          ^
-
-error: aborting due to 15 previous errors
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
This ICE happens because `closure_min_captures` is empty, the reason it's empty is with the 2021 edition `enable_precise_capture` is set to true, which makes it so that we can't fake capture any information because that result of the `unwrap` is none hence the ICE.

Other solution is editing [maybe_read_scrutinee](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_typeck/expr_use_visitor.rs.html#453-463) to this since empty slice contains no sub patterns.

Fixes #93242


```rust
PatKind::Slice(_, ref slice, _) => {
    if slice.is_none(){
    need_to_be_read = true;
    }
}
// instead of
PatKind::Or(_)
| PatKind::Box(_)
| PatKind::Slice(..)
| PatKind::Ref(..)
| PatKind::Wild => {}
```