### PR TITLE
Loosen shadowing check inside macro contexts (attempt 2).

### DIFF
--- a/src/test/ui/hygiene/shadow-macro-extern-allowed.rs
+++ b/src/test/ui/hygiene/shadow-macro-extern-allowed.rs
@@ -1,0 +1,26 @@
+// build-pass
+
+// Check that a macro let binding that is unambiguous is allowed
+// to shadow externally defined constants
+
+macro_rules! h {
+    () => {
+        let x @ _ = 2;
+        let y @ _ = 3;
+    }
+}
+
+#[allow(non_upper_case_globals)]
+const x: usize = 4;
+
+#[allow(non_upper_case_globals)]
+const y: usize = 5;
+
+#[allow(non_upper_case_globals)]
+fn a<const x: usize>() {
+    h!();
+}
+
+fn main() {
+    h!();
+}

--- a/src/test/ui/hygiene/shadow-macro-generated-forbidden.rs
+++ b/src/test/ui/hygiene/shadow-macro-generated-forbidden.rs
@@ -1,0 +1,19 @@
+// Check that macro-generated statics and consts are not allowed to be shadowed
+
+macro_rules! h {
+    () => {
+        #[allow(non_upper_case_globals)]
+        static x: usize = 2;
+        #[allow(non_upper_case_globals)]
+        const y: usize = 3;
+    }
+}
+
+h!();
+
+fn main() {
+    let x @ _ = 4;
+    //~^ ERROR let bindings cannot shadow statics
+    let y @ _ = 5;
+    //~^ ERROR let bindings cannot shadow constants
+}

--- a/src/test/ui/hygiene/shadow-macro-generated-forbidden.stderr
+++ b/src/test/ui/hygiene/shadow-macro-generated-forbidden.stderr
@@ -1,0 +1,21 @@
+error[E0530]: let bindings cannot shadow statics
+  --> $DIR/shadow-macro-generated-forbidden.rs:15:9
+   |
+LL |         static x: usize = 2;
+   |         -------------------- the static `x` is defined here
+...
+LL |     let x @ _ = 4;
+   |         ^ cannot be named the same as a static
+
+error[E0530]: let bindings cannot shadow constants
+  --> $DIR/shadow-macro-generated-forbidden.rs:17:9
+   |
+LL |         const y: usize = 3;
+   |         ------------------- the constant `y` is defined here
+...
+LL |     let y @ _ = 5;
+   |         ^ cannot be named the same as a constant
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0530`.

--- a/src/test/ui/hygiene/shadow-macro-internal-forbidden.rs
+++ b/src/test/ui/hygiene/shadow-macro-internal-forbidden.rs
@@ -1,0 +1,25 @@
+// Test that shadowing of statics and constants from within the same macro is still forbidden.
+
+macro_rules! h {
+    () => {
+        #[allow(non_upper_case_globals)]
+        static x: usize = 2;
+        #[allow(non_upper_case_globals)]
+        const y: usize = 3;
+        fn a() {
+            let x @ _ = 4;
+            //~^ ERROR let bindings cannot shadow statics
+            let y @ _ = 5;
+            //~^ ERROR let bindings cannot shadow constants
+        }
+        #[allow(non_upper_case_globals)]
+        fn b<const z: usize>() {
+            let z @ _ = 21;
+            //~^ ERROR let bindings cannot shadow const parameters
+        }
+    }
+}
+
+h!();
+
+fn main() {}

--- a/src/test/ui/hygiene/shadow-macro-internal-forbidden.stderr
+++ b/src/test/ui/hygiene/shadow-macro-internal-forbidden.stderr
@@ -1,0 +1,44 @@
+error[E0530]: let bindings cannot shadow statics
+  --> $DIR/shadow-macro-internal-forbidden.rs:10:17
+   |
+LL |         static x: usize = 2;
+   |         -------------------- the static `x` is defined here
+...
+LL |             let x @ _ = 4;
+   |                 ^ cannot be named the same as a static
+...
+LL | h!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `h` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0530]: let bindings cannot shadow constants
+  --> $DIR/shadow-macro-internal-forbidden.rs:12:17
+   |
+LL |         const y: usize = 3;
+   |         ------------------- the constant `y` is defined here
+...
+LL |             let y @ _ = 5;
+   |                 ^ cannot be named the same as a constant
+...
+LL | h!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `h` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0530]: let bindings cannot shadow const parameters
+  --> $DIR/shadow-macro-internal-forbidden.rs:17:17
+   |
+LL |         fn b<const z: usize>() {
+   |                    - the const parameter `z` is defined here
+LL |             let z @ _ = 21;
+   |                 ^ cannot be named the same as a const parameter
+...
+LL | h!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `h` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0530`.


### PR DESCRIPTION
This allows macro code to use identifiers for local variables which are 
also defined as globals outside of the macro, so long as their
definition is not ambiguous. This improves predictability of code
containing macros, and reduces the leakage of macro implementation
details to their surroundings.

Concretely, constructions such as
```rust
thread_local!(static FOO: usize = 0);
static init: usize = 0;
```
no longer generate unexpected error messages on the implementation
detail that thread_local! defines a function with init as a parameter
name.

This fixes #99018

Note that this is a reworked implementation of #99191. Despite the comments of @petrochenkov I am of the opinion that this is worthwhile to merge, and does not really represent a change in the hygiene rules. However, I agree with the statement there that this will need a lang FCP.

My argument for this is that this is not a change in the hygiene rules for consts/statics/etc.., but rather represents a fix for an edge case in local variable and parameter name hygiene. As a developer, the intuition behind macro hygiene for locals is that there is effectively a separate namespace for locals defined fully within the macro. As such, when a variable definition in the macro is not ambiguous, I would expect it to not cause any noticeable side-effects outside of the macro. This patch aimed at ensuring just that.

Secondarily, the possibly confusing behavior that is at the basis of the error message generated outside of macros also is less of a concern within macros, as the macro probably was never written with the idea in mind that there might be a name collision on a variable name in the first place. (As an aside, I'm not even sure why E0530 is a hard error and not a warning, but let's leave that out of scope for now)

A nice side effect to this change is that changes of internal variable names used inside macros should no longer be potential breaking changes for the user of the macro, which should help with stability guarantees.

PS: Apologies that it took me a while to react to the comments made in the previous pull request, I had some personal circumstances that prevented me from putting significant time towards this project.

r? @petrochenkov