### PR TITLE
Implement RefUnwindSafe for Backtrace

### DIFF
--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -92,6 +92,7 @@ use crate::backtrace_rs::{self, BytesOrWideString};
 use crate::env;
 use crate::ffi::c_void;
 use crate::fmt;
+use crate::panic::UnwindSafe;
 use crate::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use crate::sync::LazyLock;
 use crate::sys_common::backtrace::{lock, output_filename};
@@ -427,7 +428,7 @@ impl fmt::Display for Backtrace {
     }
 }
 
-type LazyResolve = impl (FnOnce() -> Capture) + Send + Sync;
+type LazyResolve = impl (FnOnce() -> Capture) + Send + Sync + UnwindSafe;
 
 fn lazy_resolve(mut capture: Capture) -> LazyResolve {
     move || {

--- a/library/std/src/backtrace/tests.rs
+++ b/library/std/src/backtrace/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::panic::{RefUnwindSafe, UnwindSafe};
 
 fn generate_fake_frames() -> Vec<BacktraceFrame> {
     vec![
@@ -90,4 +91,10 @@ fn test_frames() {
     let mut iter = frames.iter().zip(expected.iter());
 
     assert!(iter.all(|(f, e)| format!("{f:#?}") == *e));
+}
+
+#[test]
+fn backtrace_unwind_safe() {
+    fn assert_unwind_safe<T: UnwindSafe + RefUnwindSafe>() {}
+    assert_unwind_safe::<Backtrace>();
 }


### PR DESCRIPTION
Backtrace doesn't have visible mutable state.

See also https://internals.rust-lang.org/t/should-backtrace-be-refunwindsafe/17169?u=xfix