### PR TITLE
Adjust span of fn argument declaration

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2289,7 +2289,7 @@ impl<'a> Parser<'a> {
                 }
             };
 
-            let span = lo.until(this.token.span);
+            let span = lo.to(this.prev_token.span);
 
             Ok((
                 Param {

--- a/src/test/ui/argument-suggestions/complex.stderr
+++ b/src/test/ui/argument-suggestions/complex.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/complex.rs:11:4
    |
 LL | fn complex(_i: u32, _s: &str, _e: E, _f: F, _g: G, _x: X, _y: Y, _z: Z ) {}
-   |    ^^^^^^^ -------  --------  -----  -----  -----  -----  -----  ------
+   |    ^^^^^^^ -------  --------  -----  -----  -----  -----  -----  -----
 help: did you mean
    |
 LL |   complex(/* u32 */, &"", /* E */, F::X2, G{}, X {}, Y {}, Z {});

--- a/src/test/ui/c-variadic/issue-86053-1.stderr
+++ b/src/test/ui/c-variadic/issue-86053-1.stderr
@@ -44,19 +44,19 @@ error: `...` must be the last argument of a C-variadic function
   --> $DIR/issue-86053-1.rs:11:12
    |
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
-   |            ^^^^
+   |            ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
   --> $DIR/issue-86053-1.rs:11:12
    |
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
-   |            ^^^^
+   |            ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
   --> $DIR/issue-86053-1.rs:11:36
    |
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
-   |                                    ^^^^
+   |                                    ^^^
 
 error[E0412]: cannot find type `F` in this scope
   --> $DIR/issue-86053-1.rs:11:48

--- a/src/test/ui/suggestions/suggest-ref-macro.stderr
+++ b/src/test/ui/suggestions/suggest-ref-macro.stderr
@@ -10,14 +10,8 @@ LL | #[hello]
 note: function defined here
   --> $DIR/suggest-ref-macro.rs:8:1
    |
-LL |   #[hello]
-   |  _-^^^^^^^
-LL | | fn abc() {}
-LL | |
-LL | | fn x(_: &mut i32) {}
-LL | |
-LL | | macro_rules! bla {
-   | |_____________-
+LL | #[hello]
+   | ^^^^^^^^
    = note: this error originates in the attribute macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/src/test/ui/type/type-check/issue-88577-check-fn-with-more-than-65535-arguments.stderr
+++ b/src/test/ui/type/type-check/issue-88577-check-fn-with-more-than-65535-arguments.stderr
@@ -1,13 +1,13 @@
 error: function can not have more than 65535 arguments
-  --> $DIR/issue-88577-check-fn-with-more-than-65535-arguments.rs:6:24
+  --> $DIR/issue-88577-check-fn-with-more-than-65535-arguments.rs:6:22
    |
-LL |           fn _f($($t: ()),*) {}
-   |  ________________________^
-LL | |     }
-LL | | }
-LL | |
-LL | | many_args!{[_]########## ######}
-   | |____________^
+LL |         fn _f($($t: ()),*) {}
+   |                      ^
+...
+LL | many_args!{[_]########## ######}
+   | -------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `many_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Span of a fn argument declaration goes from:

```
fn foo(i : i32 , ...)
       ^^^^^^^^
```

to:

```
fn foo(i : i32 , ...)
       ^^^^^^^
```

That is, we don't include the extra spacing up to the trailing comma, which I think is more correct. 

cc https://github.com/rust-lang/rust/pull/99646#discussion_r944568074
r? @estebank

---

The two tests that had dramatic changes in their rendering I think actually are improved, though they are kinda poor spans both before and after the changes. :shrug: Thoughts?