### PR TITLE
Clarify `array::from_fn` documentation

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -31,6 +31,10 @@ pub use iter::IntoIter;
 /// # Example
 ///
 /// ```rust
+/// // type inference is helping us here, the way `from_fn` knows how many
+/// // elements to produce is the length of array down there: only arrays of
+/// // equal lengths can be compared, so the const generic parameter `N` is
+/// // inferred to be 5, thus creating array of 5 elements.
 /// let array = core::array::from_fn(|i| i);
 /// assert_eq!(array, [0, 1, 2, 3, 4]);
 /// ```


### PR DESCRIPTION
I've seen quite a few of people on social media confused of where the length of array is coming from in the newly stabilized `array::from_fn` example.

This PR tries to clarify the documentation on this.