### PR TITLE
Make `[rust] use-lld=true` work on windows

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -658,7 +658,12 @@ impl Step for Rustc {
 
         // With LLD, we can use ICF (identical code folding) to reduce the executable size
         // of librustc_driver/rustc and to improve i-cache utilization.
-        if builder.config.use_lld {
+        //
+        // -Wl,[link options] doesn't work on MSVC. However, /OPT:ICF (technically /OPT:REF,ICF)
+        // is already on by default in MSVC optimized builds, which is interpreted as --icf=all:
+        // https://github.com/llvm/llvm-project/blob/3329cec2f79185bafd678f310fafadba2a8c76d2/lld/COFF/Driver.cpp#L1746
+        // https://github.com/rust-lang/rust/blob/f22819bcce4abaff7d1246a56eec493418f9f4ee/compiler/rustc_codegen_ssa/src/back/linker.rs#L827
+        if builder.config.use_lld && !compiler.host.contains("msvc") {
             cargo.rustflag("-Clink-args=-Wl,--icf=all");
         }
 


### PR DESCRIPTION
Before, it would fail with "error: ignoring unknown argument '-Wl,--icf=all'"

This option was introduced in https://github.com/rust-lang/rust/pull/99062 (well, technically https://github.com/rust-lang/rust/pull/99680)

See zulip thread: https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/rust-lld.3A.20error.3A.20ignoring.20unknown.20argument.20'-Wl.2C--icf.3Dall'