### PR TITLE
Add function `Arc/Rc::as_weak(…)` to convert `&Arc/Rc` to `&Weak`

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -950,7 +950,7 @@ impl<T: ?Sized> Rc<T> {
     /// let weak_five: &Weak<i32> = Rc::as_weak(five);
     /// ```
     #[inline]
-    #[unstable(feature = "rc_as_weak", issue = "none")]
+    #[unstable(feature = "rc_as_weak", issue = "100472")]
     #[must_use]
     pub const fn as_weak<'a>(this: &'a Self) -> &'a Weak<T> {
         unsafe { mem::transmute::<&'a Rc<T>, &'a Weak<T>>(this) }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -306,6 +306,7 @@ struct RcBox<T: ?Sized> {
 #[cfg_attr(not(test), rustc_diagnostic_item = "Rc")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_insignificant_dtor]
+#[repr(transparent)]
 pub struct Rc<T: ?Sized> {
     ptr: NonNull<RcBox<T>>,
     phantom: PhantomData<RcBox<T>>,
@@ -2143,6 +2144,7 @@ impl<T, I: iter::TrustedLen<Item = T>> ToRcSlice<T> for I {
 ///
 /// [`upgrade`]: Weak::upgrade
 #[stable(feature = "rc_weak", since = "1.4.0")]
+#[repr(transparent)]
 pub struct Weak<T: ?Sized> {
     // This is a `NonNull` to allow optimizing the size of this type in enums,
     // but it is not necessarily a valid pointer.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -952,8 +952,9 @@ impl<T: ?Sized> Rc<T> {
     #[inline]
     #[unstable(feature = "rc_as_weak", issue = "100472")]
     #[must_use]
-    pub const fn as_weak<'a>(this: &'a Self) -> &'a Weak<T> {
-        unsafe { mem::transmute::<&'a Rc<T>, &'a Weak<T>>(this) }
+    pub const fn as_weak(this: &Self) -> &Weak<T> {
+        let weak = this as *const Self as *const Weak<T>;
+        unsafe { &*weak }
     }
 
     /// Gets the number of [`Weak`] pointers to this allocation.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -934,6 +934,28 @@ impl<T: ?Sized> Rc<T> {
         Weak { ptr: this.ptr }
     }
 
+    /// Convert a reference to an [`Rc`] into a reference to a [`Weak`] of the same type.
+    ///
+    /// This is a type-only operation; it doesn't modify the inner reference counts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(rc_as_weak)]
+    ///
+    /// use std::rc::{Rc, Weak};
+    ///
+    /// let five: &Rc<i32> = &Rc::new(5);
+    ///
+    /// let weak_five: &Weak<i32> = Rc::as_weak(five);
+    /// ```
+    #[inline]
+    #[unstable(feature = "rc_as_weak", issue = "none")]
+    #[must_use]
+    pub const fn as_weak<'a>(this: &'a Self) -> &'a Weak<T> {
+        unsafe { mem::transmute::<&'a Rc<T>, &'a Weak<T>>(this) }
+    }
+
     /// Gets the number of [`Weak`] pointers to this allocation.
     ///
     /// # Examples

--- a/library/alloc/src/rc/tests.rs
+++ b/library/alloc/src/rc/tests.rs
@@ -103,6 +103,10 @@ fn test_weak_count() {
     let w = Rc::downgrade(&a);
     assert!(Rc::strong_count(&a) == 1);
     assert!(Rc::weak_count(&a) == 1);
+    let r = Rc::as_weak(&a);
+    assert!(Rc::strong_count(&a) == 1);
+    assert!(Rc::weak_count(&a) == 1);
+    assert!(r.as_ptr() == Rc::as_ptr(&a));
     drop(w);
     assert!(Rc::strong_count(&a) == 1);
     assert!(Rc::weak_count(&a) == 0);

--- a/library/alloc/src/rc/tests.rs
+++ b/library/alloc/src/rc/tests.rs
@@ -103,7 +103,7 @@ fn test_weak_count() {
     let w = Rc::downgrade(&a);
     assert!(Rc::strong_count(&a) == 1);
     assert!(Rc::weak_count(&a) == 1);
-    let r = Rc::as_weak(&a);
+    let r: &Weak<i32> = Rc::as_weak(&a);
     assert!(Rc::strong_count(&a) == 1);
     assert!(Rc::weak_count(&a) == 1);
     assert!(r.as_ptr() == Rc::as_ptr(&a));

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -979,8 +979,9 @@ impl<T: ?Sized> Arc<T> {
     #[inline]
     #[unstable(feature = "rc_as_weak", issue = "100472")]
     #[must_use]
-    pub const fn as_weak<'a>(this: &'a Self) -> &'a Weak<T> {
-        unsafe { mem::transmute::<&'a Arc<T>, &'a Weak<T>>(this) }
+    pub const fn as_weak(this: &Self) -> &Weak<T> {
+        let weak = this as *const Self as *const Weak<T>;
+        unsafe { &*weak }
     }
 
     /// Gets the number of [`Weak`] pointers to this allocation.

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -961,6 +961,28 @@ impl<T: ?Sized> Arc<T> {
         }
     }
 
+    /// Convert a reference to an [`Arc`] into a reference to a [`Weak`] of the same type.
+    ///
+    /// This is a type-only operation; it doesn't modify the inner reference counts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(rc_as_weak)]
+    ///
+    /// use std::sync::{Arc, Weak};
+    ///
+    /// let five: &Arc<i32> = &Arc::new(5);
+    ///
+    /// let weak_five: &Weak<i32> = Arc::as_weak(five);
+    /// ```
+    #[inline]
+    #[unstable(feature = "rc_as_weak", issue = "none")]
+    #[must_use]
+    pub const fn as_weak<'a>(this: &'a Self) -> &'a Weak<T> {
+        unsafe { mem::transmute::<&'a Arc<T>, &'a Weak<T>>(this) }
+    }
+
     /// Gets the number of [`Weak`] pointers to this allocation.
     ///
     /// # Safety

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -977,7 +977,7 @@ impl<T: ?Sized> Arc<T> {
     /// let weak_five: &Weak<i32> = Arc::as_weak(five);
     /// ```
     #[inline]
-    #[unstable(feature = "rc_as_weak", issue = "none")]
+    #[unstable(feature = "rc_as_weak", issue = "100472")]
     #[must_use]
     pub const fn as_weak<'a>(this: &'a Self) -> &'a Weak<T> {
         unsafe { mem::transmute::<&'a Arc<T>, &'a Weak<T>>(this) }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -964,6 +964,9 @@ impl<T: ?Sized> Arc<T> {
     /// Convert a reference to an [`Arc`] into a reference to a [`Weak`] of the same type.
     ///
     /// This is a type-only operation; it doesn't modify the inner reference counts.
+    /// Therefore if you call [`Weak::weak_count()`] on the returned `&Weak<T>`,
+    /// it is possible to get a result of `0`, which is otherwise only possible
+    /// when there are no remaining strong references and the value has been dropped.
     ///
     /// # Examples
     ///
@@ -980,6 +983,15 @@ impl<T: ?Sized> Arc<T> {
     #[unstable(feature = "rc_as_weak", issue = "100472")]
     #[must_use]
     pub const fn as_weak(this: &Self) -> &Weak<T> {
+        // SAFETY: `Arc<T>` and `Weak<T>` are guaranteed to have the same representation
+        // because both are `#[repr(transparent)]` with their only (non-ZST) field being
+        // being a `NonNull<ArcInner<T>>`. The static guarantees carried by a `Weak<T>` (that
+        // the pointer will point to a live `ArcInner<T>` allocation _unless_ it is the sentinel
+        // value of `usize::MAX`) are strictly weaker than those carried by an `Arc<T>` (that
+        // the pointer will always point to a live `ArcInner<T>` allocation containing a live `T`).
+        // The different drop in their drop behaviour is not relevant because this function
+        // is only concerned with shared references, not owned values. Therefore no safety
+        // invariants are violated by interpreting an `&Arc<T>` as a `&Weak<T>`.
         let weak = this as *const Self as *const Weak<T>;
         unsafe { &*weak }
     }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -232,6 +232,7 @@ macro_rules! acquire {
 /// [rc_examples]: crate::rc#examples
 #[cfg_attr(not(test), rustc_diagnostic_item = "Arc")]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[repr(transparent)]
 pub struct Arc<T: ?Sized> {
     ptr: NonNull<ArcInner<T>>,
     phantom: PhantomData<ArcInner<T>>,
@@ -282,6 +283,7 @@ impl<T: ?Sized> Arc<T> {
 ///
 /// [`upgrade`]: Weak::upgrade
 #[stable(feature = "arc_weak", since = "1.4.0")]
+#[repr(transparent)]
 pub struct Weak<T: ?Sized> {
     // This is a `NonNull` to allow optimizing the size of this type in enums,
     // but it is not necessarily a valid pointer.

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -314,6 +314,10 @@ fn test_weak_count() {
     let w = Arc::downgrade(&a);
     assert!(Arc::strong_count(&a) == 1);
     assert!(Arc::weak_count(&a) == 1);
+    let r = Arc::as_weak(&a);
+    assert!(Arc::strong_count(&a) == 1);
+    assert!(Arc::weak_count(&a) == 1);
+    assert!(r.as_ptr() == Arc::as_ptr(&a));
     let x = w.clone();
     assert!(Arc::weak_count(&a) == 2);
     drop(w);

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -314,7 +314,7 @@ fn test_weak_count() {
     let w = Arc::downgrade(&a);
     assert!(Arc::strong_count(&a) == 1);
     assert!(Arc::weak_count(&a) == 1);
-    let r = Arc::as_weak(&a);
+    let r: &Weak<i32> = Arc::as_weak(&a);
     assert!(Arc::strong_count(&a) == 1);
     assert!(Arc::weak_count(&a) == 1);
     assert!(r.as_ptr() == Arc::as_ptr(&a));


### PR DESCRIPTION
I would like to propose the addition of a new `as_weak` associated function on `Arc` and `Rc`, taking a shared reference to a strong `Arc`/`Rc` and transmuting it into a shared reference to the corresponding `Weak` type.

Currently, if you have a strong `Arc`/`Rc` and you're calling a function that expects a `&Weak`, you'll need to `.downgrade()` to create a temporary `Weak`, incurring two additional writes to the backing allocation. This could be avoided if it were possible to convert an `&Arc`/`&Rc` to a `&Weak` directly, with a function like this:

```rust
impl<T: ?Sized> Arc<T> {
    pub const fn as_weak<'a>(this: &'a Self) -> &'a Weak<T> {
        unsafe { mem::transmute::<&'a Arc<T>, &'a Weak<T>>(this) }
    }
}
```

In memory, `Arc`/`Rc` and `sync::Weak`/`rc::Weak` are both represented by a `NotNull` pointer to the backing `ArcInner`/`RcBox` where the reference counts and inner value are actually stored. Whether a reference is strong or weak exists only at the type level, and the static guarantees provided by `Weak` (that the pointed-to allocation will exist, unless the pointer has the special non-aligned `Weak::new` value) are strictly weaker than those provided by `Arc`/`Rc` (that the pointed-to allocation will exist full-stop, and that the value inside that allocation will still be valid/will not have been dropped yet). The `Arc`/`Rc` do have a `PhantomData<T>` that the `Weak`s do not, but it's zero-size and shouldn't affect layout, only drop behaviour (which isn't relevant since the proposed function is for borrowed values).

This requires the addition of the `#[repr(transparent)]` attribute to `Arc`/`Rc`, and `Weak` in order to guarantee their memory layouts are identical. (`#[repr(C)]` might also work for that purpose, but I'm not sure if that would break the `NonZero` niche optimization.) According to the discussions at https://github.com/rust-lang/rust/pull/72841#pullrequestreview-429527831, adding the `#[repr]` does **not** constitute a public interface change/commitment because the internal fields are still private (and with https://github.com/rust-lang/rust/issues/90435 such `#[repr]`s may be hidden from the docs in the future). So even if the `#[repr(transparent)]` were added, this function still couldn't be implemented in an external crate as the crate wouldn't be able to soundly rely on the layout remaining the same; this function can only be implemented in the standard library.

This implementation is gated behind a new `#![feature(rc_as_weak)]`.

---

_previous discussion: [Rust Internals thread #17171](https://internals.rust-lang.org/t/marking-arc-rc-weak-as-repr-transparent/17171), [Stack Overflow question #73314967](https://stackoverflow.com/q/73314967/1114)_
