### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -911,6 +911,10 @@ impl<'a> State<'a> {
         if let Some(els) = els {
             self.nbsp();
             self.word_space("else");
+            // containing cbox, will be closed by print-block at `}`
+            self.cbox(0);
+            // head-box, will be closed by print-block after `{`
+            self.ibox(0);
             self.print_block(els);
         }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2268,7 +2268,7 @@ impl<'a> Parser<'a> {
                     attrs: attrs.into(),
                     ty,
                     pat,
-                    span: lo.to(this.token.span),
+                    span: lo.to(this.prev_token.span),
                     id: DUMMY_NODE_ID,
                     is_placeholder: false,
                 },

--- a/compiler/rustc_target/src/spec/crt_objects.rs
+++ b/compiler/rustc_target/src/spec/crt_objects.rs
@@ -63,7 +63,7 @@ pub(super) fn all(obj: &'static str) -> CrtObjects {
     ])
 }
 
-pub(super) fn pre_musl_fallback() -> CrtObjects {
+pub(super) fn pre_musl_self_contained() -> CrtObjects {
     new(&[
         (LinkOutputKind::DynamicNoPicExe, &["crt1.o", "crti.o", "crtbegin.o"]),
         (LinkOutputKind::DynamicPicExe, &["Scrt1.o", "crti.o", "crtbeginS.o"]),
@@ -74,7 +74,7 @@ pub(super) fn pre_musl_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn post_musl_fallback() -> CrtObjects {
+pub(super) fn post_musl_self_contained() -> CrtObjects {
     new(&[
         (LinkOutputKind::DynamicNoPicExe, &["crtend.o", "crtn.o"]),
         (LinkOutputKind::DynamicPicExe, &["crtendS.o", "crtn.o"]),
@@ -85,7 +85,7 @@ pub(super) fn post_musl_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn pre_mingw_fallback() -> CrtObjects {
+pub(super) fn pre_mingw_self_contained() -> CrtObjects {
     new(&[
         (LinkOutputKind::DynamicNoPicExe, &["crt2.o", "rsbegin.o"]),
         (LinkOutputKind::DynamicPicExe, &["crt2.o", "rsbegin.o"]),
@@ -96,7 +96,7 @@ pub(super) fn pre_mingw_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn post_mingw_fallback() -> CrtObjects {
+pub(super) fn post_mingw_self_contained() -> CrtObjects {
     all("rsend.o")
 }
 
@@ -108,7 +108,7 @@ pub(super) fn post_mingw() -> CrtObjects {
     all("rsend.o")
 }
 
-pub(super) fn pre_wasi_fallback() -> CrtObjects {
+pub(super) fn pre_wasi_self_contained() -> CrtObjects {
     // Use crt1-command.o instead of crt1.o to enable support for new-style
     // commands. See https://reviews.llvm.org/D81689 for more info.
     new(&[
@@ -120,37 +120,41 @@ pub(super) fn pre_wasi_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn post_wasi_fallback() -> CrtObjects {
+pub(super) fn post_wasi_self_contained() -> CrtObjects {
     new(&[])
 }
 
-/// Which logic to use to determine whether to fall back to the "self-contained" mode or not.
+/// Which logic to use to determine whether to use self-contained linking mode
+/// if `-Clink-self-contained` is not specified explicitly.
 #[derive(Clone, Copy, PartialEq, Hash, Debug)]
-pub enum CrtObjectsFallback {
+pub enum LinkSelfContainedDefault {
+    False,
+    True,
     Musl,
     Mingw,
-    Wasm,
 }
 
-impl FromStr for CrtObjectsFallback {
+impl FromStr for LinkSelfContainedDefault {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<CrtObjectsFallback, ()> {
+    fn from_str(s: &str) -> Result<LinkSelfContainedDefault, ()> {
         Ok(match s {
-            "musl" => CrtObjectsFallback::Musl,
-            "mingw" => CrtObjectsFallback::Mingw,
-            "wasm" => CrtObjectsFallback::Wasm,
+            "false" => LinkSelfContainedDefault::False,
+            "true" | "wasm" => LinkSelfContainedDefault::True,
+            "musl" => LinkSelfContainedDefault::Musl,
+            "mingw" => LinkSelfContainedDefault::Mingw,
             _ => return Err(()),
         })
     }
 }
 
-impl ToJson for CrtObjectsFallback {
+impl ToJson for LinkSelfContainedDefault {
     fn to_json(&self) -> Json {
         match *self {
-            CrtObjectsFallback::Musl => "musl",
-            CrtObjectsFallback::Mingw => "mingw",
-            CrtObjectsFallback::Wasm => "wasm",
+            LinkSelfContainedDefault::False => "false",
+            LinkSelfContainedDefault::True => "true",
+            LinkSelfContainedDefault::Musl => "musl",
+            LinkSelfContainedDefault::Mingw => "mingw",
         }
         .to_json()
     }

--- a/compiler/rustc_target/src/spec/linux_musl_base.rs
+++ b/compiler/rustc_target/src/spec/linux_musl_base.rs
@@ -1,13 +1,13 @@
-use crate::spec::crt_objects::{self, CrtObjectsFallback};
+use crate::spec::crt_objects::{self, LinkSelfContainedDefault};
 use crate::spec::TargetOptions;
 
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();
 
     base.env = "musl".into();
-    base.pre_link_objects_fallback = crt_objects::pre_musl_fallback();
-    base.post_link_objects_fallback = crt_objects::post_musl_fallback();
-    base.crt_objects_fallback = Some(CrtObjectsFallback::Musl);
+    base.pre_link_objects_self_contained = crt_objects::pre_musl_self_contained();
+    base.post_link_objects_self_contained = crt_objects::post_musl_self_contained();
+    base.link_self_contained = LinkSelfContainedDefault::Musl;
 
     // These targets statically link libc by default
     base.crt_static_default = true;

--- a/compiler/rustc_target/src/spec/tests/tests_impl.rs
+++ b/compiler/rustc_target/src/spec/tests/tests_impl.rs
@@ -110,9 +110,9 @@ impl Target {
         }
 
         assert!(
-            (self.pre_link_objects_fallback.is_empty()
-                && self.post_link_objects_fallback.is_empty())
-                || self.crt_objects_fallback.is_some()
+            (self.pre_link_objects_self_contained.is_empty()
+                && self.post_link_objects_self_contained.is_empty())
+                || self.link_self_contained != LinkSelfContainedDefault::False
         );
 
         // If your target really needs to deviate from the rules below,

--- a/compiler/rustc_target/src/spec/wasm32_wasi.rs
+++ b/compiler/rustc_target/src/spec/wasm32_wasi.rs
@@ -82,8 +82,8 @@ pub fn target() -> Target {
     options.linker_flavor = LinkerFlavor::Lld(LldFlavor::Wasm);
     options.add_pre_link_args(LinkerFlavor::Gcc, &["--target=wasm32-wasi"]);
 
-    options.pre_link_objects_fallback = crt_objects::pre_wasi_fallback();
-    options.post_link_objects_fallback = crt_objects::post_wasi_fallback();
+    options.pre_link_objects_self_contained = crt_objects::pre_wasi_self_contained();
+    options.post_link_objects_self_contained = crt_objects::post_wasi_self_contained();
 
     // Right now this is a bit of a workaround but we're currently saying that
     // the target by default has a static crt which we're taking as a signal

--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -1,4 +1,4 @@
-use super::crt_objects::CrtObjectsFallback;
+use super::crt_objects::LinkSelfContainedDefault;
 use super::{cvs, LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, TargetOptions, TlsModel};
 
 pub fn options() -> TargetOptions {
@@ -96,7 +96,8 @@ pub fn options() -> TargetOptions {
 
         pre_link_args,
 
-        crt_objects_fallback: Some(CrtObjectsFallback::Wasm),
+        // FIXME: Figure out cases in which WASM needs to link with a native toolchain.
+        link_self_contained: LinkSelfContainedDefault::True,
 
         // This has no effect in LLVM 8 or prior, but in LLVM 9 and later when
         // PIC code is implemented this has quite a drastic effect if it stays

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -1,4 +1,4 @@
-use crate::spec::crt_objects::{self, CrtObjectsFallback};
+use crate::spec::crt_objects::{self, LinkSelfContainedDefault};
 use crate::spec::{cvs, LinkerFlavor, TargetOptions};
 
 pub fn opts() -> TargetOptions {
@@ -76,9 +76,9 @@ pub fn opts() -> TargetOptions {
         pre_link_args,
         pre_link_objects: crt_objects::pre_mingw(),
         post_link_objects: crt_objects::post_mingw(),
-        pre_link_objects_fallback: crt_objects::pre_mingw_fallback(),
-        post_link_objects_fallback: crt_objects::post_mingw_fallback(),
-        crt_objects_fallback: Some(CrtObjectsFallback::Mingw),
+        pre_link_objects_self_contained: crt_objects::pre_mingw_self_contained(),
+        post_link_objects_self_contained: crt_objects::post_mingw_self_contained(),
+        link_self_contained: LinkSelfContainedDefault::Mingw,
         late_link_args,
         late_link_args_dynamic,
         late_link_args_static,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -440,7 +440,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         call_expr: &hir::Expr<'tcx>,
     ) {
         // Next, let's construct the error
-        let (error_span, full_call_span, ctor_of) = match &call_expr.kind {
+        let (error_span, full_call_span, ctor_of, is_method) = match &call_expr.kind {
             hir::ExprKind::Call(
                 hir::Expr { hir_id, span, kind: hir::ExprKind::Path(qpath), .. },
                 _,
@@ -448,12 +448,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let Res::Def(DefKind::Ctor(of, _), _) =
                     self.typeck_results.borrow().qpath_res(qpath, *hir_id)
                 {
-                    (call_span, *span, Some(of))
+                    (call_span, *span, Some(of), false)
                 } else {
-                    (call_span, *span, None)
+                    (call_span, *span, None, false)
                 }
             }
-            hir::ExprKind::Call(hir::Expr { span, .. }, _) => (call_span, *span, None),
+            hir::ExprKind::Call(hir::Expr { span, .. }, _) => (call_span, *span, None, false),
             hir::ExprKind::MethodCall(path_segment, _, span) => {
                 let ident_span = path_segment.ident.span;
                 let ident_span = if let Some(args) = path_segment.args {
@@ -461,9 +461,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else {
                     ident_span
                 };
-                (
-                    *span, ident_span, None, // methods are never ctors
-                )
+                // methods are never ctors
+                (*span, ident_span, None, true)
             }
             k => span_bug!(call_span, "checking argument types on a non-call: `{:?}`", k),
         };
@@ -659,7 +658,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             Applicability::MachineApplicable,
                         );
                     };
-                    self.label_fn_like(&mut err, fn_def_id, callee_ty);
+                    self.label_fn_like(&mut err, fn_def_id, callee_ty, Some(mismatch_idx), is_method);
                     err.emit();
                     return;
                 }
@@ -701,16 +700,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         errors.drain_filter(|error| {
-                let Error::Invalid(provided_idx, expected_idx, Compatibility::Incompatible(error)) = error else { return false };
+                let Error::Invalid(provided_idx, expected_idx, Compatibility::Incompatible(Some(e))) = error else { return false };
                 let (provided_ty, provided_span) = provided_arg_tys[*provided_idx];
                 let (expected_ty, _) = formal_and_expected_inputs[*expected_idx];
                 let cause = &self.misc(provided_span);
                 let trace = TypeTrace::types(cause, true, expected_ty, provided_ty);
-                if let Some(e) = error {
-                    if !matches!(trace.cause.as_failure_code(e), FailureCode::Error0308(_)) {
-                        self.report_and_explain_type_error(trace, e).emit();
-                        return true;
-                    }
+                if !matches!(trace.cause.as_failure_code(e), FailureCode::Error0308(_)) {
+                    self.report_and_explain_type_error(trace, e).emit();
+                    return true;
                 }
                 false
             });
@@ -749,7 +746,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 format!("arguments to this {} are incorrect", call_name),
             );
             // Call out where the function is defined
-            self.label_fn_like(&mut err, fn_def_id, callee_ty);
+            self.label_fn_like(&mut err, fn_def_id, callee_ty, Some(expected_idx.as_usize()), is_method);
             err.emit();
             return;
         }
@@ -1031,7 +1028,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         // Call out where the function is defined
-        self.label_fn_like(&mut err, fn_def_id, callee_ty);
+        self.label_fn_like(&mut err, fn_def_id, callee_ty, None, is_method);
 
         // And add a suggestion block for all of the parameters
         let suggestion_text = match suggestion_text {
@@ -1781,6 +1778,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err: &mut Diagnostic,
         callable_def_id: Option<DefId>,
         callee_ty: Option<Ty<'tcx>>,
+        // A specific argument should be labeled, instead of all of them
+        expected_idx: Option<usize>,
+        is_method: bool,
     ) {
         let Some(mut def_id) = callable_def_id else {
             return;
@@ -1881,10 +1881,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .get_if_local(def_id)
                 .and_then(|node| node.body_id())
                 .into_iter()
-                .flat_map(|id| self.tcx.hir().body(id).params);
+                .flat_map(|id| self.tcx.hir().body(id).params)
+                .skip(if is_method { 1 } else { 0 });
 
-            for param in params {
-                spans.push_span_label(param.span, "");
+            for (idx, param) in params.into_iter().enumerate() {
+                if let Some(expected_idx) = expected_idx {
+                    if idx == expected_idx {
+                        spans.push_span_label(param.span, "");
+                    }
+                } else {
+                    spans.push_span_label(param.span, "");
+                }
             }
 
             let def_kind = self.tcx.def_kind(def_id);

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1890,14 +1890,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .flat_map(|id| self.tcx.hir().body(id).params)
                 .skip(if is_method { 1 } else { 0 });
 
-            for (idx, param) in params.into_iter().enumerate() {
-                if let Some(expected_idx) = expected_idx {
-                    if idx == expected_idx {
-                        spans.push_span_label(param.span, "");
-                    }
-                } else {
-                    spans.push_span_label(param.span, "");
-                }
+            for (_, param) in params
+                .into_iter()
+                .enumerate()
+                .filter(|(idx, _)| expected_idx.map_or(true, |expected_idx| expected_idx == *idx))
+            {
+                spans.push_span_label(param.span, "");
             }
 
             let def_kind = self.tcx.def_kind(def_id);

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -84,6 +84,16 @@ impl<T, const N: usize> IntoIter<T, N> {
         IntoIterator::into_iter(array)
     }
 
+    /// Creates a new iterator from a partially initalized array.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that all and only the `alive` elements of
+    /// `data` are initialized.
+    pub(crate) unsafe fn with_partial(data: [MaybeUninit<T>; N], alive: Range<usize>) -> Self {
+        Self { data, alive }
+    }
+
     /// Creates an iterator over the elements in a partially-initialized buffer.
     ///
     /// If you have a fully-initialized array, then use [`IntoIterator`].

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -84,16 +84,6 @@ impl<T, const N: usize> IntoIter<T, N> {
         IntoIterator::into_iter(array)
     }
 
-    /// Creates a new iterator from a partially initalized array.
-    ///
-    /// # Safety
-    ///
-    /// The caller must guarantee that all and only the `alive` elements of
-    /// `data` are initialized.
-    pub(crate) unsafe fn with_partial(data: [MaybeUninit<T>; N], alive: Range<usize>) -> Self {
-        Self { data, alive }
-    }
-
     /// Creates an iterator over the elements in a partially-initialized buffer.
     ///
     /// If you have a fully-initialized array, then use [`IntoIterator`].

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -11,7 +11,7 @@ use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 /// method on [`Iterator`]. See its documentation for more.
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 pub struct ArrayChunks<I: Iterator, const N: usize> {
     iter: I,
     remainder: Option<array::IntoIter<I::Item, N>>,
@@ -30,14 +30,14 @@ where
     /// Returns an iterator over the remaining elements of the original iterator
     /// that are not going to be returned by this iterator. The returned
     /// iterator will yield at most `N-1` elements.
-    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
     #[inline]
     pub fn into_remainder(self) -> Option<array::IntoIter<I::Item, N>> {
         self.remainder
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> Iterator for ArrayChunks<I, N>
 where
     I: Iterator,
@@ -91,7 +91,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> DoubleEndedIterator for ArrayChunks<I, N>
 where
     I: DoubleEndedIterator + ExactSizeIterator,
@@ -162,10 +162,10 @@ where
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> FusedIterator for ArrayChunks<I, N> where I: FusedIterator {}
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> ExactSizeIterator for ArrayChunks<I, N>
 where
     I: ExactSizeIterator,

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -24,6 +24,7 @@ impl<I, const N: usize> ArrayChunks<I, N>
 where
     I: Iterator,
 {
+    #[track_caller]
     pub(in crate::iter) fn new(iter: I) -> Self {
         assert!(N != 0, "chunk size must be non-zero");
         Self { iter: iter.fuse(), remainder: None }

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -312,6 +312,6 @@ where
 
     #[inline]
     fn is_empty(&self) -> bool {
-        self.iter.len() / N == 0
+        self.iter.len() < N
     }
 }

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -1,5 +1,5 @@
 use crate::array;
-use crate::iter::{Fuse, FusedIterator, Iterator, TrustedLen};
+use crate::iter::{Fuse, FusedIterator, Iterator};
 use crate::mem;
 use crate::mem::MaybeUninit;
 use crate::ops::{ControlFlow, Try};
@@ -54,11 +54,7 @@ where
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper) = self.iter.size_hint();
-        // Keep infinite iterator size hint lower bound as `usize::MAX`. This
-        // is required to implement `TrustedLen`.
-        if lower == usize::MAX {
-            return (lower, upper);
-        }
+
         (lower / N, upper.map(|n| n / N))
     }
 
@@ -318,6 +314,3 @@ where
         self.iter.len() / N == 0
     }
 }
-
-#[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<I, const N: usize> TrustedLen for ArrayChunks<I, N> where I: TrustedLen {}

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -1,5 +1,5 @@
 use crate::array;
-use crate::iter::{Fuse, FusedIterator, Iterator};
+use crate::iter::{FusedIterator, Iterator};
 use crate::mem;
 use crate::mem::MaybeUninit;
 use crate::ops::{ControlFlow, Try};
@@ -16,7 +16,7 @@ use crate::ptr;
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
 pub struct ArrayChunks<I: Iterator, const N: usize> {
-    iter: Fuse<I>,
+    iter: I,
     remainder: Option<array::IntoIter<I::Item, N>>,
 }
 
@@ -27,7 +27,7 @@ where
     #[track_caller]
     pub(in crate::iter) fn new(iter: I) -> Self {
         assert!(N != 0, "chunk size must be non-zero");
-        Self { iter: iter.fuse(), remainder: None }
+        Self { iter, remainder: None }
     }
 
     /// Returns an iterator over the remaining elements of the original iterator

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -64,7 +64,7 @@ where
                         mem::forget(guard);
                         self.remainder = {
                             // SAFETY: `array` was initialized with `init` elements.
-                            Some(unsafe { array::IntoIter::with_partial(array, 0..init) })
+                            Some(unsafe { array::IntoIter::new_unchecked(array, 0..init) })
                         };
                     }
                     return None;
@@ -124,7 +124,8 @@ where
                     let init = guard.init;
                     mem::forget(guard);
                     // SAFETY: `array` was initialized with `init` elements.
-                    self.remainder = Some(unsafe { array::IntoIter::with_partial(array, 0..init) });
+                    self.remainder =
+                        Some(unsafe { array::IntoIter::new_unchecked(array, 0..init) });
                 }
                 R::from_output(o)
             }
@@ -305,7 +306,7 @@ where
         // SAFETY: `array` was initialized with exactly `init` elements.
         self.remainder = unsafe {
             array.get_unchecked_mut(..init).reverse();
-            Some(array::IntoIter::with_partial(array, 0..init))
+            Some(array::IntoIter::new_unchecked(array, 0..init))
         };
         Some(())
     }

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -1,0 +1,427 @@
+use crate::iter::{Fuse, FusedIterator, Iterator, TrustedLen};
+use crate::mem;
+use crate::mem::MaybeUninit;
+use crate::ops::{ControlFlow, Try};
+use crate::ptr;
+
+#[derive(Debug)]
+struct Remainder<T, const N: usize> {
+    array: [MaybeUninit<T>; N],
+    init: usize,
+}
+
+impl<T, const N: usize> Remainder<T, N> {
+    fn new() -> Self {
+        Self { array: MaybeUninit::uninit_array(), init: 0 }
+    }
+
+    unsafe fn with_init(array: [MaybeUninit<T>; N], init: usize) -> Self {
+        Self { array, init }
+    }
+
+    fn as_slice(&self) -> &[T] {
+        debug_assert!(self.init <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let slice = self.array.get_unchecked(..self.init);
+            MaybeUninit::slice_assume_init_ref(slice)
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        debug_assert!(self.init <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let slice = self.array.get_unchecked_mut(..self.init);
+            MaybeUninit::slice_assume_init_mut(slice)
+        }
+    }
+}
+
+impl<T, const N: usize> Clone for Remainder<T, N>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        let mut new = Self::new();
+        // SAFETY: The new array is the same size and `init` is always less than
+        // or equal to `N`.
+        let this = unsafe { new.array.get_unchecked_mut(..self.init) };
+        MaybeUninit::write_slice_cloned(this, self.as_slice());
+        new.init = self.init;
+        new
+    }
+}
+
+impl<T, const N: usize> Drop for Remainder<T, N> {
+    fn drop(&mut self) {
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe { ptr::drop_in_place(self.as_mut_slice()) }
+    }
+}
+
+/// An iterator over `N` elements of the iterator at a time.
+///
+/// The chunks do not overlap. If `N` does not divide the length of the
+/// iterator, then the last up to `N-1` elements will be omitted.
+///
+/// This `struct` is created by the [`array_chunks`][Iterator::array_chunks]
+/// method on [`Iterator`]. See its documentation for more.
+#[derive(Debug, Clone)]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+pub struct ArrayChunks<I: Iterator, const N: usize> {
+    iter: Fuse<I>,
+    remainder: Remainder<I::Item, N>,
+}
+
+impl<I, const N: usize> ArrayChunks<I, N>
+where
+    I: Iterator,
+{
+    pub(in crate::iter) fn new(iter: I) -> Self {
+        assert!(N != 0, "chunk size must be non-zero");
+        Self { iter: iter.fuse(), remainder: Remainder::new() }
+    }
+
+    /// Returns a reference to the remaining elements of the original iterator
+    /// that are not going to be returned by this iterator. The returned slice
+    /// has at most `N-1` elements.
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[inline]
+    pub fn remainder(&self) -> &[I::Item] {
+        self.remainder.as_slice()
+    }
+
+    /// Returns a mutable reference to the remaining elements of the original
+    /// iterator that are not going to be returned by this iterator. The
+    /// returned slice has at most `N-1` elements.
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[inline]
+    pub fn remainder_mut(&mut self) -> &mut [I::Item] {
+        self.remainder.as_mut_slice()
+    }
+}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> Iterator for ArrayChunks<I, N>
+where
+    I: Iterator,
+{
+    type Item = [I::Item; N];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        for slot in array.iter_mut() {
+            match self.iter.next() {
+                Some(item) => {
+                    slot.write(item);
+                    guard.init += 1;
+                }
+                None => {
+                    if guard.init > 0 {
+                        let init = guard.init;
+                        mem::forget(guard);
+                        // SAFETY: `array` was initialized with `init` elements.
+                        self.remainder = unsafe { Remainder::with_init(array, init) };
+                    }
+                    return None;
+                }
+            }
+        }
+
+        mem::forget(guard);
+        // SAFETY: All elements of the array were populated in the loop above.
+        Some(unsafe { MaybeUninit::array_assume_init(array) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.iter.size_hint();
+        // Keep infinite iterator size hint lower bound as `usize::MAX`. This
+        // is required to implement `TrustedLen`.
+        if lower == usize::MAX {
+            return (lower, upper);
+        }
+        (lower / N, upper.map(|n| n / N))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.iter.count() / N
+    }
+
+    fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        let result = self.iter.try_fold(init, |mut acc, item| {
+            // SAFETY: `init` starts at 0, increases by one each iteration and
+            // is reset to 0 once it reaches N.
+            unsafe { array.get_unchecked_mut(guard.init) }.write(item);
+            guard.init += 1;
+            if guard.init == N {
+                guard.init = 0;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item)?;
+            }
+            R::from_output(acc)
+        });
+        match result.branch() {
+            ControlFlow::Continue(o) => {
+                if guard.init > 0 {
+                    let init = guard.init;
+                    mem::forget(guard);
+                    // SAFETY: `array` was initialized with `init` elements.
+                    self.remainder = unsafe { Remainder::with_init(array, init) };
+                }
+                R::from_output(o)
+            }
+            ControlFlow::Break(r) => R::from_residual(r),
+        }
+    }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        self.iter.fold(init, |mut acc, item| {
+            // SAFETY: `init` starts at 0, increases by one each iteration and
+            // is reset to 0 once it reaches N.
+            unsafe { array.get_unchecked_mut(guard.init) }.write(item);
+            guard.init += 1;
+            if guard.init == N {
+                guard.init = 0;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item);
+            }
+            acc
+        })
+    }
+}
+
+/// A guard for an array where elements are filled from the left.
+struct FrontGuard<T, const N: usize> {
+    /// A pointer to the array that is being filled. We need to use a raw
+    /// pointer here because of the lifetime issues in the fold implementations.
+    ptr: *mut T,
+    /// The number of *initialized* elements.
+    init: usize,
+}
+
+impl<T, const N: usize> FrontGuard<T, N> {
+    unsafe fn new(array: &mut [MaybeUninit<T>; N]) -> Self {
+        Self { ptr: MaybeUninit::slice_as_mut_ptr(array), init: 0 }
+    }
+}
+
+impl<T, const N: usize> Drop for FrontGuard<T, N> {
+    fn drop(&mut self) {
+        debug_assert!(self.init <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let slice = ptr::slice_from_raw_parts_mut(self.ptr, self.init);
+            ptr::drop_in_place(slice);
+        }
+    }
+}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> DoubleEndedIterator for ArrayChunks<I, N>
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // We are iterating from the back we need to first handle the remainder.
+        self.next_back_remainder()?;
+
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { BackGuard::new(&mut array) };
+
+        for slot in array.iter_mut().rev() {
+            slot.write(self.iter.next_back()?);
+            guard.uninit -= 1;
+        }
+
+        mem::forget(guard);
+        // SAFETY: All elements of the array were populated in the loop above.
+        Some(unsafe { MaybeUninit::array_assume_init(array) })
+    }
+
+    fn try_rfold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        // We are iterating from the back we need to first handle the remainder.
+        if self.next_back_remainder().is_none() {
+            return R::from_output(init);
+        }
+
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { BackGuard::new(&mut array) };
+
+        self.iter.try_rfold(init, |mut acc, item| {
+            guard.uninit -= 1;
+            // SAFETY: `uninit` starts at N, decreases by one each iteration and
+            // is reset to N once it reaches 0.
+            unsafe { array.get_unchecked_mut(guard.uninit) }.write(item);
+            if guard.uninit == 0 {
+                guard.uninit = N;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item)?;
+            }
+            R::from_output(acc)
+        })
+    }
+
+    fn rfold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // We are iterating from the back we need to first handle the remainder.
+        if self.next_back_remainder().is_none() {
+            return init;
+        }
+
+        let mut array = MaybeUninit::uninit_array();
+
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { BackGuard::new(&mut array) };
+
+        self.iter.rfold(init, |mut acc, item| {
+            guard.uninit -= 1;
+            // SAFETY: `uninit` starts at N, decreases by one each iteration and
+            // is reset to N once it reaches 0.
+            unsafe { array.get_unchecked_mut(guard.uninit) }.write(item);
+            if guard.uninit == 0 {
+                guard.uninit = N;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item);
+            }
+            acc
+        })
+    }
+}
+
+impl<I, const N: usize> ArrayChunks<I, N>
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+{
+    #[inline]
+    fn next_back_remainder(&mut self) -> Option<()> {
+        // We use the `ExactSizeIterator` implementation of the underlying
+        // iterator to know how many remaining elements there are.
+        let rem = self.iter.len() % N;
+        if rem == 0 {
+            return Some(());
+        }
+
+        let mut array = MaybeUninit::uninit_array();
+
+        // SAFETY: The array will still be valid if `guard` is dropped and
+        // it is forgotten otherwise.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        // SAFETY: `rem` is in the range 1..N based on how it is calculated.
+        for slot in unsafe { array.get_unchecked_mut(..rem) }.iter_mut() {
+            slot.write(self.iter.next_back()?);
+            guard.init += 1;
+        }
+
+        let init = guard.init;
+        mem::forget(guard);
+        // SAFETY: `array` was initialized with exactly `init` elements.
+        self.remainder = unsafe {
+            array.get_unchecked_mut(..init).reverse();
+            Remainder::with_init(array, init)
+        };
+        Some(())
+    }
+}
+
+/// A guard for an array where elements are filled from the right.
+struct BackGuard<T, const N: usize> {
+    /// A pointer to the array that is being filled. We need to use a raw
+    /// pointer here because of the lifetime issues in the rfold implementations.
+    ptr: *mut T,
+    /// The number of *uninitialized* elements.
+    uninit: usize,
+}
+
+impl<T, const N: usize> BackGuard<T, N> {
+    unsafe fn new(array: &mut [MaybeUninit<T>; N]) -> Self {
+        Self { ptr: MaybeUninit::slice_as_mut_ptr(array), uninit: N }
+    }
+}
+
+impl<T, const N: usize> Drop for BackGuard<T, N> {
+    fn drop(&mut self) {
+        debug_assert!(self.uninit <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let ptr = self.ptr.offset(self.uninit as isize);
+            let slice = ptr::slice_from_raw_parts_mut(ptr, N - self.uninit);
+            ptr::drop_in_place(slice);
+        }
+    }
+}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> FusedIterator for ArrayChunks<I, N> where I: FusedIterator {}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> ExactSizeIterator for ArrayChunks<I, N>
+where
+    I: ExactSizeIterator,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len() / N
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.iter.len() / N == 0
+    }
+}
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<I, const N: usize> TrustedLen for ArrayChunks<I, N> where I: TrustedLen {}

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1,6 +1,7 @@
 use crate::iter::{InPlaceIterable, Iterator};
 use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, NeverShortCircuit, Residual, Try};
 
+mod array_chunks;
 mod by_ref_sized;
 mod chain;
 mod cloned;
@@ -31,6 +32,9 @@ pub use self::{
     flatten::FlatMap, fuse::Fuse, inspect::Inspect, map::Map, peekable::Peekable, rev::Rev,
     scan::Scan, skip::Skip, skip_while::SkipWhile, take::Take, take_while::TakeWhile, zip::Zip,
 };
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+pub use self::array_chunks::ArrayChunks;
 
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::by_ref_sized::ByRefSized;

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     scan::Scan, skip::Skip, skip_while::SkipWhile, take::Take, take_while::TakeWhile, zip::Zip,
 };
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 pub use self::array_chunks::ArrayChunks;
 
 #[unstable(feature = "std_internals", issue = "none")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -398,6 +398,8 @@ pub use self::traits::{
 
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::adapters::zip;
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+pub use self::adapters::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::adapters::ByRefSized;
 #[stable(feature = "iter_cloned", since = "1.1.0")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -398,7 +398,7 @@ pub use self::traits::{
 
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::adapters::zip;
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 pub use self::adapters::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::adapters::ByRefSized;

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3350,6 +3350,7 @@ pub trait Iterator {
     ///     assert_eq!(x + y + z, 4);
     /// }
     /// ```
+    #[track_caller]
     #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
     fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
     where

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -5,7 +5,7 @@ use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 use super::super::try_process;
 use super::super::ByRefSized;
 use super::super::TrustedRandomAccessNoCoerce;
-use super::super::{Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
+use super::super::{ArrayChunks, Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
 use super::super::{FlatMap, Flatten};
 use super::super::{FromIterator, Intersperse, IntersperseWith, Product, Sum, Zip};
 use super::super::{
@@ -3314,6 +3314,46 @@ pub trait Iterator {
         Self: Sized + Clone,
     {
         Cycle::new(self)
+    }
+
+    /// Returns an iterator over `N` elements of the iterator at a time.
+    ///
+    /// The chunks do not overlap. If `N` does not divide the length of the
+    /// iterator, then the last up to `N-1` elements will be omitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `N` is 0.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(iter_array_chunks)]
+    ///
+    /// let mut iter = "lorem".chars().array_chunks();
+    /// assert_eq!(iter.next(), Some(['l', 'o']));
+    /// assert_eq!(iter.next(), Some(['r', 'e']));
+    /// assert_eq!(iter.next(), None);
+    /// assert_eq!(iter.remainder(), &['m']);
+    /// ```
+    ///
+    /// ```
+    /// #![feature(iter_array_chunks)]
+    ///
+    /// let data = [1, 1, 2, -2, 6, 0, 3, 1];
+    /// //          ^-----^  ^------^
+    /// for [x, y, z] in data.iter().array_chunks() {
+    ///     assert_eq!(x + y + z, 4);
+    /// }
+    /// ```
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
+    where
+        Self: Sized,
+    {
+        ArrayChunks::new(self)
     }
 
     /// Sums the elements of an iterator.

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3351,7 +3351,7 @@ pub trait Iterator {
     /// }
     /// ```
     #[track_caller]
-    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
     fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
     where
         Self: Sized,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3319,7 +3319,9 @@ pub trait Iterator {
     /// Returns an iterator over `N` elements of the iterator at a time.
     ///
     /// The chunks do not overlap. If `N` does not divide the length of the
-    /// iterator, then the last up to `N-1` elements will be omitted.
+    /// iterator, then the last up to `N-1` elements will be omitted and can be
+    /// retrieved from the [`.into_remainder()`][ArrayChunks::into_remainder]
+    /// function of the iterator.
     ///
     /// # Panics
     ///
@@ -3336,7 +3338,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), Some(['l', 'o']));
     /// assert_eq!(iter.next(), Some(['r', 'e']));
     /// assert_eq!(iter.next(), None);
-    /// assert_eq!(iter.remainder(), &['m']);
+    /// assert_eq!(iter.into_remainder().unwrap().as_slice(), &['m']);
     /// ```
     ///
     /// ```

--- a/library/core/tests/iter/adapters/array_chunks.rs
+++ b/library/core/tests/iter/adapters/array_chunks.rs
@@ -1,0 +1,198 @@
+use core::cell::Cell;
+use core::iter::{self, Iterator};
+
+use super::*;
+
+#[test]
+fn test_iterator_array_chunks_infer() {
+    let xs = [1, 1, 2, -2, 6, 0, 3, 1];
+    for [a, b, c] in xs.iter().copied().array_chunks() {
+        assert_eq!(a + b + c, 4);
+    }
+}
+
+#[test]
+fn test_iterator_array_chunks_clone_and_drop() {
+    let count = Cell::new(0);
+    let mut it = (0..5).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+
+    assert_eq!(it.by_ref().count(), 1);
+    assert_eq!(count.get(), 3);
+    assert_eq!(it.remainder().len(), 2);
+
+    let mut it2 = it.clone();
+    assert_eq!(count.get(), 3);
+    assert_eq!(it2.remainder().len(), 2);
+
+    drop(it);
+    assert_eq!(count.get(), 5);
+    assert_eq!(it2.remainder().len(), 2);
+    assert!(it2.next().is_none());
+
+    drop(it2);
+    assert_eq!(count.get(), 7);
+}
+
+#[test]
+fn test_iterator_array_chunks_remainder() {
+    let mut it = (0..11).array_chunks::<4>();
+    assert_eq!(it.remainder(), &[]);
+    assert_eq!(it.remainder_mut(), &[]);
+    assert_eq!(it.next(), Some([0, 1, 2, 3]));
+    assert_eq!(it.remainder(), &[]);
+    assert_eq!(it.remainder_mut(), &[]);
+    assert_eq!(it.next(), Some([4, 5, 6, 7]));
+    assert_eq!(it.remainder(), &[]);
+    assert_eq!(it.remainder_mut(), &[]);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.remainder(), &[8, 9, 10]);
+    assert_eq!(it.remainder_mut(), &[8, 9, 10]);
+}
+
+#[test]
+fn test_iterator_array_chunks_size_hint() {
+    let it = (0..6).array_chunks::<1>();
+    assert_eq!(it.size_hint(), (6, Some(6)));
+
+    let it = (0..6).array_chunks::<3>();
+    assert_eq!(it.size_hint(), (2, Some(2)));
+
+    let it = (0..6).array_chunks::<5>();
+    assert_eq!(it.size_hint(), (1, Some(1)));
+
+    let it = (0..6).array_chunks::<7>();
+    assert_eq!(it.size_hint(), (0, Some(0)));
+
+    let it = (1..).array_chunks::<2>();
+    assert_eq!(it.size_hint(), (usize::MAX, None));
+
+    let it = (1..).filter(|x| x % 2 != 0).array_chunks::<2>();
+    assert_eq!(it.size_hint(), (0, None));
+}
+
+#[test]
+fn test_iterator_array_chunks_count() {
+    let it = (0..6).array_chunks::<1>();
+    assert_eq!(it.count(), 6);
+
+    let it = (0..6).array_chunks::<3>();
+    assert_eq!(it.count(), 2);
+
+    let it = (0..6).array_chunks::<5>();
+    assert_eq!(it.count(), 1);
+
+    let it = (0..6).array_chunks::<7>();
+    assert_eq!(it.count(), 0);
+
+    let it = (0..6).filter(|x| x % 2 == 0).array_chunks::<2>();
+    assert_eq!(it.count(), 1);
+
+    let it = iter::empty::<i32>().array_chunks::<2>();
+    assert_eq!(it.count(), 0);
+
+    let it = [(); usize::MAX].iter().array_chunks::<2>();
+    assert_eq!(it.count(), usize::MAX / 2);
+}
+
+#[test]
+fn test_iterator_array_chunks_next_and_next_back() {
+    let mut it = (0..11).array_chunks::<3>();
+    assert_eq!(it.next(), Some([0, 1, 2]));
+    assert_eq!(it.next_back(), Some([6, 7, 8]));
+    assert_eq!(it.next(), Some([3, 4, 5]));
+    assert_eq!(it.next_back(), None);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.next_back(), None);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.remainder(), &[9, 10]);
+    assert_eq!(it.remainder_mut(), &[9, 10]);
+}
+
+#[test]
+fn test_iterator_array_chunks_rev_remainder() {
+    let mut it = (0..11).array_chunks::<4>();
+    {
+        let mut it = it.by_ref().rev();
+        assert_eq!(it.next(), Some([4, 5, 6, 7]));
+        assert_eq!(it.next(), Some([0, 1, 2, 3]));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next(), None);
+    }
+    assert_eq!(it.remainder(), &[8, 9, 10]);
+}
+
+#[test]
+fn test_iterator_array_chunks_try_fold() {
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result: Result<_, ()> = it.by_ref().try_fold(0, |acc, _item| Ok(acc + 1));
+    assert_eq!(result, Ok(3));
+    assert_eq!(it.remainder().len(), 1);
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 10);
+
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result = it.by_ref().try_fold(0, |acc, _item| if acc < 2 { Ok(acc + 1) } else { Err(acc) });
+    assert_eq!(result, Err(2));
+    assert_eq!(it.remainder().len(), 0);
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 9);
+}
+
+#[test]
+fn test_iterator_array_chunks_fold() {
+    let result = (1..11).array_chunks::<3>().fold(0, |acc, [a, b, c]| {
+        assert_eq!(acc + 1, a);
+        assert_eq!(acc + 2, b);
+        assert_eq!(acc + 3, c);
+        acc + 3
+    });
+    assert_eq!(result, 9);
+
+    let count = Cell::new(0);
+    let result =
+        (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>().fold(0, |acc, _item| acc + 1);
+    assert_eq!(result, 3);
+    assert_eq!(count.get(), 10);
+}
+
+#[test]
+fn test_iterator_array_chunks_try_rfold() {
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result: Result<_, ()> = it.try_rfold(0, |acc, _item| Ok(acc + 1));
+    assert_eq!(result, Ok(3));
+    assert_eq!(it.remainder().len(), 1);
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 10);
+
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result = it.try_rfold(0, |acc, _item| if acc < 2 { Ok(acc + 1) } else { Err(acc) });
+    assert_eq!(result, Err(2));
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 10);
+}
+
+#[test]
+fn test_iterator_array_chunks_rfold() {
+    let result = (1..11).array_chunks::<3>().rfold(0, |acc, [a, b, c]| {
+        assert_eq!(10 - (acc + 1), c);
+        assert_eq!(10 - (acc + 2), b);
+        assert_eq!(10 - (acc + 3), a);
+        acc + 3
+    });
+    assert_eq!(result, 9);
+
+    let count = Cell::new(0);
+    let result =
+        (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>().rfold(0, |acc, _item| acc + 1);
+    assert_eq!(result, 3);
+    assert_eq!(count.get(), 10);
+}

--- a/library/core/tests/iter/adapters/array_chunks.rs
+++ b/library/core/tests/iter/adapters/array_chunks.rs
@@ -50,7 +50,7 @@ fn test_iterator_array_chunks_size_hint() {
     assert_eq!(it.size_hint(), (0, Some(0)));
 
     let it = (1..).array_chunks::<2>();
-    assert_eq!(it.size_hint(), (usize::MAX, None));
+    assert_eq!(it.size_hint(), (usize::MAX / 2, None));
 
     let it = (1..).filter(|x| x % 2 != 0).array_chunks::<2>();
     assert_eq!(it.size_hint(), (0, None));

--- a/library/core/tests/iter/adapters/mod.rs
+++ b/library/core/tests/iter/adapters/mod.rs
@@ -1,3 +1,4 @@
+mod array_chunks;
 mod chain;
 mod cloned;
 mod copied;
@@ -181,5 +182,27 @@ impl Clone for CountClone {
         let n = self.0.get();
         self.0.set(n + 1);
         ret
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CountDrop<'a> {
+    dropped: bool,
+    count: &'a Cell<usize>,
+}
+
+impl<'a> CountDrop<'a> {
+    pub fn new(count: &'a Cell<usize>) -> Self {
+        Self { dropped: false, count }
+    }
+}
+
+impl Drop for CountDrop<'_> {
+    fn drop(&mut self) {
+        if self.dropped {
+            panic!("double drop");
+        }
+        self.dropped = true;
+        self.count.set(self.count.get() + 1);
     }
 }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -61,6 +61,7 @@
 #![feature(slice_partition_dedup)]
 #![feature(int_log)]
 #![feature(iter_advance_by)]
+#![feature(iter_array_chunks)]
 #![feature(iter_collect_into)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_intersperse)]

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -428,10 +428,8 @@ impl FromWithTcx<clean::GenericBound> for GenericBound {
         use clean::GenericBound::*;
         match bound {
             TraitBound(clean::PolyTrait { trait_, generic_params }, modifier) => {
-                // FIXME: should `trait_` be a clean::Path equivalent in JSON?
-                let trait_ = clean::Type::Path { path: trait_ }.into_tcx(tcx);
                 GenericBound::TraitBound {
-                    trait_,
+                    trait_: trait_.into_tcx(tcx),
                     generic_params: generic_params.into_tcx(tcx),
                     modifier: from_trait_bound_modifier(modifier),
                 }
@@ -460,12 +458,7 @@ impl FromWithTcx<clean::Type> for Type {
         };
 
         match ty {
-            clean::Type::Path { path } => Type::ResolvedPath {
-                name: path.whole_name(),
-                id: from_item_id(path.def_id().into(), tcx),
-                args: path.segments.last().map(|args| Box::new(args.clone().args.into_tcx(tcx))),
-                param_names: Vec::new(),
-            },
+            clean::Type::Path { path } => Type::ResolvedPath(path.into_tcx(tcx)),
             clean::Type::DynTrait(bounds, lt) => Type::DynTrait(DynTrait {
                 lifetime: lt.map(convert_lifetime),
                 traits: bounds.into_tcx(tcx),
@@ -487,16 +480,22 @@ impl FromWithTcx<clean::Type> for Type {
                 mutable: mutability == ast::Mutability::Mut,
                 type_: Box::new((*type_).into_tcx(tcx)),
             },
-            QPath { assoc, self_type, trait_, .. } => {
-                // FIXME: should `trait_` be a clean::Path equivalent in JSON?
-                let trait_ = clean::Type::Path { path: trait_ }.into_tcx(tcx);
-                Type::QualifiedPath {
-                    name: assoc.name.to_string(),
-                    args: Box::new(assoc.args.clone().into_tcx(tcx)),
-                    self_type: Box::new((*self_type).into_tcx(tcx)),
-                    trait_: Box::new(trait_),
-                }
-            }
+            QPath { assoc, self_type, trait_, .. } => Type::QualifiedPath {
+                name: assoc.name.to_string(),
+                args: Box::new(assoc.args.clone().into_tcx(tcx)),
+                self_type: Box::new((*self_type).into_tcx(tcx)),
+                trait_: trait_.into_tcx(tcx),
+            },
+        }
+    }
+}
+
+impl FromWithTcx<clean::Path> for Path {
+    fn from_tcx(path: clean::Path, tcx: TyCtxt<'_>) -> Path {
+        Path {
+            name: path.whole_name(),
+            id: from_item_id(path.def_id().into(), tcx),
+            args: path.segments.last().map(|args| Box::new(args.clone().args.into_tcx(tcx))),
         }
     }
 }
@@ -565,10 +564,7 @@ impl FromWithTcx<clean::PolyTrait> for PolyTrait {
         clean::PolyTrait { trait_, generic_params }: clean::PolyTrait,
         tcx: TyCtxt<'_>,
     ) -> Self {
-        PolyTrait {
-            trait_: clean::Type::Path { path: trait_ }.into_tcx(tcx),
-            generic_params: generic_params.into_tcx(tcx),
-        }
+        PolyTrait { trait_: trait_.into_tcx(tcx), generic_params: generic_params.into_tcx(tcx) }
     }
 }
 
@@ -576,8 +572,6 @@ impl FromWithTcx<clean::Impl> for Impl {
     fn from_tcx(impl_: clean::Impl, tcx: TyCtxt<'_>) -> Self {
         let provided_trait_methods = impl_.provided_trait_methods(tcx);
         let clean::Impl { unsafety, generics, trait_, for_, items, polarity, kind } = impl_;
-        // FIXME: should `trait_` be a clean::Path equivalent in JSON?
-        let trait_ = trait_.map(|path| clean::Type::Path { path }.into_tcx(tcx));
         // FIXME: use something like ImplKind in JSON?
         let (synthetic, blanket_impl) = match kind {
             clean::ImplKind::Normal | clean::ImplKind::FakeVaradic => (false, None),
@@ -595,7 +589,7 @@ impl FromWithTcx<clean::Impl> for Impl {
                 .into_iter()
                 .map(|x| x.to_string())
                 .collect(),
-            trait_,
+            trait_: trait_.map(|path| path.into_tcx(tcx)),
             for_: for_.into_tcx(tcx),
             items: ids(items, tcx),
             negative: negative_polarity,

--- a/src/test/rustdoc-json/fns/generic_args.rs
+++ b/src/test/rustdoc-json/fns/generic_args.rs
@@ -14,7 +14,7 @@ pub trait GenericFoo<'a> {}
 // @is - "$.index[*][?(@.name=='generics')].inner.generics.params[0].name" '"F"'
 // @is - "$.index[*][?(@.name=='generics')].inner.generics.params[0].kind.type.default" 'null'
 // @count - "$.index[*][?(@.name=='generics')].inner.generics.params[0].kind.type.bounds[*]" 1
-// @is - "$.index[*][?(@.name=='generics')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" '$foo'
+// @is - "$.index[*][?(@.name=='generics')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" '$foo'
 // @count - "$.index[*][?(@.name=='generics')].inner.decl.inputs[*]" 1
 // @is - "$.index[*][?(@.name=='generics')].inner.decl.inputs[0][0]" '"f"'
 // @is - "$.index[*][?(@.name=='generics')].inner.decl.inputs[0][1].kind" '"generic"'
@@ -24,12 +24,12 @@ pub fn generics<F: Foo>(f: F) {}
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.where_predicates" "[]"
 // @count - "$.index[*][?(@.name=='impl_trait')].inner.generics.params[*]" 1
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.params[0].name" '"impl Foo"'
-// @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" $foo
+// @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $foo
 // @count - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[*]" 1
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][0]" '"f"'
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][1].kind" '"impl_trait"'
 // @count - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][1].inner[*]" 1
-// @is - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][1].inner[0].trait_bound.trait.inner.id" $foo
+// @is - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][1].inner[0].trait_bound.trait.id" $foo
 pub fn impl_trait(f: impl Foo) {}
 
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.params[*]" 3
@@ -43,11 +43,11 @@ pub fn impl_trait(f: impl Foo) {}
 
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[0].bound_predicate.type" '{"inner": "F", "kind": "generic"}'
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[0].bound_predicate.bounds[*]" 1
-// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.inner.id" $foo
+// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.id" $foo
 
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.type" '{"inner": "G", "kind": "generic"}'
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[*]" 1
-// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.trait.inner.id" $generic_foo
+// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.trait.id" $generic_foo
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[*]" 1
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].name" \"\'a\"
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
@@ -57,7 +57,7 @@ pub fn impl_trait(f: impl Foo) {}
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.type.inner.lifetime" \"\'b\"
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.type.inner.type" '{"inner": "H", "kind": "generic"}'
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.bounds[*]" 1
-// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.trait.inner.id" $foo
+// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.trait.id" $foo
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.generic_params" "[]"
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.generic_params[*]" 1
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.generic_params[0].name" \"\'b\"

--- a/src/test/rustdoc-json/fns/generic_returns.rs
+++ b/src/test/rustdoc-json/fns/generic_returns.rs
@@ -11,7 +11,7 @@ pub trait Foo {}
 // @is - "$.index[*][?(@.name=='get_foo')].inner.decl.inputs" []
 // @is - "$.index[*][?(@.name=='get_foo')].inner.decl.output.kind" '"impl_trait"'
 // @count - "$.index[*][?(@.name=='get_foo')].inner.decl.output.inner[*]" 1
-// @is - "$.index[*][?(@.name=='get_foo')].inner.decl.output.inner[0].trait_bound.trait.inner.id" $foo
+// @is - "$.index[*][?(@.name=='get_foo')].inner.decl.output.inner[0].trait_bound.trait.id" $foo
 pub fn get_foo() -> impl Foo {
     Fooer {}
 }

--- a/src/test/rustdoc-json/fns/generics.rs
+++ b/src/test/rustdoc-json/fns/generics.rs
@@ -10,7 +10,7 @@ pub trait Wham {}
 // @count - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[*]" 1
 // @is    - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[0].name" '"T"'
 // @has   - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[0].kind.type.synthetic" false
-// @has   - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" $wham_id
+// @has   - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
 // @is    - "$.index[*][?(@.name=='one_generic_param_fn')].inner.decl.inputs" '[["w", {"inner": "T", "kind": "generic"}]]'
 pub fn one_generic_param_fn<T: Wham>(w: T) {}
 
@@ -18,9 +18,9 @@ pub fn one_generic_param_fn<T: Wham>(w: T) {}
 // @count - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[*]" 1
 // @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[0].name" '"impl Wham"'
 // @has   - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[0].kind.type.synthetic" true
-// @has   - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" $wham_id
+// @has   - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
 // @count - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[*]" 1
 // @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[0][0]" '"w"'
 // @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[0][1].kind" '"impl_trait"'
-// @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[0][1].inner[0].trait_bound.trait.inner.id" $wham_id
+// @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[0][1].inner[0].trait_bound.trait.id" $wham_id
 pub fn one_synthetic_generic_param_fn(w: impl Wham) {}

--- a/src/test/rustdoc-json/traits/supertrait.rs
+++ b/src/test/rustdoc-json/traits/supertrait.rs
@@ -9,18 +9,18 @@ pub trait Loud {}
 
 // @set very_loud_id = - "$.index[*][?(@.name=='VeryLoud')].id"
 // @count - "$.index[*][?(@.name=='VeryLoud')].inner.bounds[*]" 1
-// @is -    "$.index[*][?(@.name=='VeryLoud')].inner.bounds[0].trait_bound.trait.inner.id" $loud_id
+// @is -    "$.index[*][?(@.name=='VeryLoud')].inner.bounds[0].trait_bound.trait.id" $loud_id
 pub trait VeryLoud: Loud {}
 
 // @set sounds_good_id = - "$.index[*][?(@.name=='SoundsGood')].id"
 pub trait SoundsGood {}
 
 // @count - "$.index[*][?(@.name=='MetalBand')].inner.bounds[*]" 2
-// @is -    "$.index[*][?(@.name=='MetalBand')].inner.bounds[0].trait_bound.trait.inner.id" $very_loud_id
-// @is -    "$.index[*][?(@.name=='MetalBand')].inner.bounds[1].trait_bound.trait.inner.id" $sounds_good_id
+// @is -    "$.index[*][?(@.name=='MetalBand')].inner.bounds[0].trait_bound.trait.id" $very_loud_id
+// @is -    "$.index[*][?(@.name=='MetalBand')].inner.bounds[1].trait_bound.trait.id" $sounds_good_id
 pub trait MetalBand: VeryLoud + SoundsGood {}
 
 // @count - "$.index[*][?(@.name=='DnabLatem')].inner.bounds[*]" 2
-// @is -    "$.index[*][?(@.name=='DnabLatem')].inner.bounds[1].trait_bound.trait.inner.id" $very_loud_id
-// @is -    "$.index[*][?(@.name=='DnabLatem')].inner.bounds[0].trait_bound.trait.inner.id" $sounds_good_id
+// @is -    "$.index[*][?(@.name=='DnabLatem')].inner.bounds[1].trait_bound.trait.id" $very_loud_id
+// @is -    "$.index[*][?(@.name=='DnabLatem')].inner.bounds[0].trait_bound.trait.id" $sounds_good_id
 pub trait DnabLatem: SoundsGood + VeryLoud {}

--- a/src/test/rustdoc-json/type/dyn.rs
+++ b/src/test/rustdoc-json/type/dyn.rs
@@ -21,10 +21,10 @@ use std::fmt::Debug;
 // @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[0].generic_params" []
 // @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[1].generic_params" []
 // @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[2].generic_params" []
-// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[0].trait.inner.name" '"Fn"'
-// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[1].trait.inner.name" '"Send"'
-// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[2].trait.inner.name" '"Sync"'
-// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[0].trait.inner.args" '{"parenthesized": {"inputs": [],"output": {"inner": "i32","kind": "primitive"}}}'
+// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[0].trait.name" '"Fn"'
+// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[1].trait.name" '"Send"'
+// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[2].trait.name" '"Sync"'
+// @is    - "$.index[*][?(@.name=='SyncIntGen')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[0].trait.args" '{"parenthesized": {"inputs": [],"output": {"inner": "i32","kind": "primitive"}}}'
 pub type SyncIntGen = Box<dyn Fn() -> i32 + Send + Sync + 'static>;
 
 // @is - "$.index[*][?(@.name=='RefFn')].kind" \"typedef\"
@@ -36,14 +36,13 @@ pub type SyncIntGen = Box<dyn Fn() -> i32 + Send + Sync + 'static>;
 // @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.lifetime" null
 // @count - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[*]" 1
 // @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
-// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.kind" '"resolved_path"'
-// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.inner.name" '"Fn"'
-// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.inner.args.parenthesized.inputs[0].kind" '"borrowed_ref"'
-// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.inner.args.parenthesized.inputs[0].inner.lifetime" "\"'b\""
-// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.inner.args.parenthesized.output.kind" '"borrowed_ref"'
-// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.inner.args.parenthesized.output.inner.lifetime" "\"'b\""
+// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.name" '"Fn"'
+// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.args.parenthesized.inputs[0].kind" '"borrowed_ref"'
+// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.args.parenthesized.inputs[0].inner.lifetime" "\"'b\""
+// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.args.parenthesized.output.kind" '"borrowed_ref"'
+// @is - "$.index[*][?(@.name=='RefFn')].inner.type.inner.type.inner.traits[0].trait.args.parenthesized.output.inner.lifetime" "\"'b\""
 pub type RefFn<'a> = &'a dyn for<'b> Fn(&'b i32) -> &'b i32;
 
-// @is    - "$.index[*][?(@.name=='WeirdOrder')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[0].trait.inner.name" '"Send"'
-// @is    - "$.index[*][?(@.name=='WeirdOrder')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[1].trait.inner.name" '"Debug"'
+// @is    - "$.index[*][?(@.name=='WeirdOrder')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[0].trait.name" '"Send"'
+// @is    - "$.index[*][?(@.name=='WeirdOrder')].inner.type.inner.args.angle_bracketed.args[0].type.inner.traits[1].trait.name" '"Debug"'
 pub type WeirdOrder = Box<dyn Send + Debug>;

--- a/src/test/rustdoc-json/type/hrtb.rs
+++ b/src/test/rustdoc-json/type/hrtb.rs
@@ -19,7 +19,7 @@ where
 // @is - "$.index[*][?(@.name=='dynfn')].inner.decl.inputs[0][1].inner.type.inner.lifetime" null
 // @count - "$.index[*][?(@.name=='dynfn')].inner.decl.inputs[0][1].inner.type.inner.traits[*]" 1
 // @is - "$.index[*][?(@.name=='dynfn')].inner.decl.inputs[0][1].inner.type.inner.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
-// @is - "$.index[*][?(@.name=='dynfn')].inner.decl.inputs[0][1].inner.type.inner.traits[0].trait.inner.name" '"Fn"'
+// @is - "$.index[*][?(@.name=='dynfn')].inner.decl.inputs[0][1].inner.type.inner.traits[0].trait.name" '"Fn"'
 pub fn dynfn(f: &dyn for<'a, 'b> Fn(&'a i32, &'b i32)) {
     let zero = 0;
     f(&zero, &zero);

--- a/src/test/ui/argument-suggestions/invalid_arguments.stderr
+++ b/src/test/ui/argument-suggestions/invalid_arguments.stderr
@@ -24,7 +24,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:6:4
    |
 LL | fn two_arg_same(_a: i32, _b: i32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^          -------
 
 error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:17:16
@@ -38,7 +38,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:6:4
    |
 LL | fn two_arg_same(_a: i32, _b: i32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^ -------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:18:3
@@ -66,7 +66,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:7:4
    |
 LL | fn two_arg_diff(_a: i32, _b: f32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^          -------
 
 error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:20:16
@@ -80,7 +80,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:7:4
    |
 LL | fn two_arg_diff(_a: i32, _b: f32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^ -------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:21:3
@@ -108,7 +108,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:8:4
    |
 LL | fn three_arg_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^ -------
 
 error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:25:21
@@ -122,7 +122,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:8:4
    |
 LL | fn three_arg_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^          -------
 
 error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:26:26
@@ -136,7 +136,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:8:4
    |
 LL | fn three_arg_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^                   --------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:28:3
@@ -207,7 +207,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:9:4
    |
 LL | fn three_arg_repeat(_a: i32, _b: i32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^^^ -------
 
 error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:35:23
@@ -221,7 +221,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:9:4
    |
 LL | fn three_arg_repeat(_a: i32, _b: i32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^^^          -------
 
 error[E0308]: mismatched types
   --> $DIR/invalid_arguments.rs:36:26
@@ -235,7 +235,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:9:4
    |
 LL | fn three_arg_repeat(_a: i32, _b: i32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^^^                   --------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:38:3

--- a/src/test/ui/argument-suggestions/too-long.rs
+++ b/src/test/ui/argument-suggestions/too-long.rs
@@ -1,0 +1,41 @@
+struct Qux;
+
+impl Qux {
+    fn foo(
+        &self,
+        a: i32,
+        b: i32,
+        c: i32,
+        d: i32,
+        e: i32,
+        f: i32,
+        g: i32,
+        h: i32,
+        i: i32,
+        j: i32,
+        k: i32,
+        l: i32,
+    ) {
+    }
+}
+
+fn what(
+    qux: &Qux,
+    a: i32,
+    b: i32,
+    c: i32,
+    d: i32,
+    e: i32,
+    f: &i32,
+    g: i32,
+    h: i32,
+    i: i32,
+    j: i32,
+    k: i32,
+    l: i32,
+) {
+    qux.foo(a, b, c, d, e, f, g, h, i, j, k, l);
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/argument-suggestions/too-long.stderr
+++ b/src/test/ui/argument-suggestions/too-long.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/too-long.rs:37:28
+   |
+LL |     qux.foo(a, b, c, d, e, f, g, h, i, j, k, l);
+   |         ---                ^ expected `i32`, found `&i32`
+   |         |
+   |         arguments to this function are incorrect
+   |
+note: associated function defined here
+  --> $DIR/too-long.rs:4:8
+   |
+LL |     fn foo(
+   |        ^^^
+...
+LL |         f: i32,
+   |         ------
+help: consider dereferencing the borrow
+   |
+LL |     qux.foo(a, b, c, d, e, *f, g, h, i, j, k, l);
+   |                            +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/associated-types/associated-type-projection-from-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-type-projection-from-supertrait.stderr
@@ -10,7 +10,7 @@ note: function defined here
   --> $DIR/associated-type-projection-from-supertrait.rs:25:4
    |
 LL | fn dent<C:Car>(c: C, color: C::Color) { c.chip_paint(color) }
-   |    ^^^^        ----  ---------------
+   |    ^^^^              ---------------
 
 error[E0308]: mismatched types
   --> $DIR/associated-type-projection-from-supertrait.rs:28:23
@@ -24,7 +24,7 @@ note: function defined here
   --> $DIR/associated-type-projection-from-supertrait.rs:25:4
    |
 LL | fn dent<C:Car>(c: C, color: C::Color) { c.chip_paint(color) }
-   |    ^^^^        ----  ---------------
+   |    ^^^^              ---------------
 
 error[E0308]: mismatched types
   --> $DIR/associated-type-projection-from-supertrait.rs:32:28
@@ -38,7 +38,7 @@ note: associated function defined here
   --> $DIR/associated-type-projection-from-supertrait.rs:12:8
    |
 LL |     fn chip_paint(&self, c: Self::Color) { }
-   |        ^^^^^^^^^^ -----  --------------
+   |        ^^^^^^^^^^        --------------
 
 error[E0308]: mismatched types
   --> $DIR/associated-type-projection-from-supertrait.rs:33:28
@@ -52,7 +52,7 @@ note: associated function defined here
   --> $DIR/associated-type-projection-from-supertrait.rs:12:8
    |
 LL |     fn chip_paint(&self, c: Self::Color) { }
-   |        ^^^^^^^^^^ -----  --------------
+   |        ^^^^^^^^^^        --------------
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -10,7 +10,7 @@ note: function defined here
   --> $DIR/associated-types-path-2.rs:13:8
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   |        ^^         ----  -------
+   |        ^^               -------
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     f1(2i32, 4u32);

--- a/src/test/ui/async-await/generator-desc.stderr
+++ b/src/test/ui/async-await/generator-desc.stderr
@@ -42,7 +42,7 @@ note: function defined here
   --> $DIR/generator-desc.rs:8:4
    |
 LL | fn fun<F: Future<Output = ()>>(f1: F, f2: F) {}
-   |    ^^^                         -----  -----
+   |    ^^^                                -----
 
 error[E0308]: mismatched types
   --> $DIR/generator-desc.rs:14:26
@@ -67,7 +67,7 @@ note: function defined here
   --> $DIR/generator-desc.rs:8:4
    |
 LL | fn fun<F: Future<Output = ()>>(f1: F, f2: F) {}
-   |    ^^^                         -----  -----
+   |    ^^^                                -----
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/coercion/coerce-reborrow-multi-arg-fail.stderr
+++ b/src/test/ui/coercion/coerce-reborrow-multi-arg-fail.stderr
@@ -12,7 +12,7 @@ note: function defined here
   --> $DIR/coerce-reborrow-multi-arg-fail.rs:1:4
    |
 LL | fn test<T>(_a: T, _b: T) {}
-   |    ^^^^    -----  -----
+   |    ^^^^           -----
 
 error: aborting due to previous error
 

--- a/src/test/ui/coercion/coerce-to-bang.stderr
+++ b/src/test/ui/coercion/coerce-to-bang.stderr
@@ -12,7 +12,7 @@ note: function defined here
   --> $DIR/coerce-to-bang.rs:3:4
    |
 LL | fn foo(x: usize, y: !, z: usize) { }
-   |    ^^^ --------  ----  --------
+   |    ^^^           ----
 
 error[E0308]: mismatched types
   --> $DIR/coerce-to-bang.rs:18:13
@@ -28,7 +28,7 @@ note: function defined here
   --> $DIR/coerce-to-bang.rs:3:4
    |
 LL | fn foo(x: usize, y: !, z: usize) { }
-   |    ^^^ --------  ----  --------
+   |    ^^^           ----
 
 error[E0308]: mismatched types
   --> $DIR/coerce-to-bang.rs:26:12
@@ -44,7 +44,7 @@ note: function defined here
   --> $DIR/coerce-to-bang.rs:3:4
    |
 LL | fn foo(x: usize, y: !, z: usize) { }
-   |    ^^^ --------  ----  --------
+   |    ^^^           ----
 
 error[E0308]: mismatched types
   --> $DIR/coerce-to-bang.rs:36:12
@@ -60,7 +60,7 @@ note: function defined here
   --> $DIR/coerce-to-bang.rs:3:4
    |
 LL | fn foo(x: usize, y: !, z: usize) { }
-   |    ^^^ --------  ----  --------
+   |    ^^^           ----
 
 error[E0308]: mismatched types
   --> $DIR/coerce-to-bang.rs:45:12
@@ -76,7 +76,7 @@ note: function defined here
   --> $DIR/coerce-to-bang.rs:3:4
    |
 LL | fn foo(x: usize, y: !, z: usize) { }
-   |    ^^^ --------  ----  --------
+   |    ^^^           ----
 
 error[E0308]: mismatched types
   --> $DIR/coerce-to-bang.rs:50:21

--- a/src/test/ui/fn/fn-item-type.stderr
+++ b/src/test/ui/fn/fn-item-type.stderr
@@ -15,7 +15,7 @@ note: function defined here
   --> $DIR/fn-item-type.rs:7:4
    |
 LL | fn eq<T>(x: T, y: T) { }
-   |    ^^    ----  ----
+   |    ^^          ----
 
 error[E0308]: mismatched types
   --> $DIR/fn-item-type.rs:22:19
@@ -34,7 +34,7 @@ note: function defined here
   --> $DIR/fn-item-type.rs:7:4
    |
 LL | fn eq<T>(x: T, y: T) { }
-   |    ^^    ----  ----
+   |    ^^          ----
 
 error[E0308]: mismatched types
   --> $DIR/fn-item-type.rs:29:23
@@ -53,7 +53,7 @@ note: function defined here
   --> $DIR/fn-item-type.rs:7:4
    |
 LL | fn eq<T>(x: T, y: T) { }
-   |    ^^    ----  ----
+   |    ^^          ----
 
 error[E0308]: mismatched types
   --> $DIR/fn-item-type.rs:38:26
@@ -72,7 +72,7 @@ note: function defined here
   --> $DIR/fn-item-type.rs:7:4
    |
 LL | fn eq<T>(x: T, y: T) { }
-   |    ^^    ----  ----
+   |    ^^          ----
 
 error[E0308]: mismatched types
   --> $DIR/fn-item-type.rs:45:19
@@ -90,7 +90,7 @@ note: function defined here
   --> $DIR/fn-item-type.rs:7:4
    |
 LL | fn eq<T>(x: T, y: T) { }
-   |    ^^    ----  ----
+   |    ^^          ----
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-11374.stderr
+++ b/src/test/ui/issues/issue-11374.stderr
@@ -14,7 +14,7 @@ note: associated function defined here
   --> $DIR/issue-11374.rs:13:12
    |
 LL |     pub fn read_to(&mut self, vec: &mut [u8]) {
-   |            ^^^^^^^ ---------  --------------
+   |            ^^^^^^^            --------------
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/method-call-err-msg.stderr
+++ b/src/test/ui/methods/method-call-err-msg.stderr
@@ -8,7 +8,7 @@ note: associated function defined here
   --> $DIR/method-call-err-msg.rs:5:8
    |
 LL |     fn zero(self) -> Foo { self }
-   |        ^^^^ ----
+   |        ^^^^
 help: remove the extra argument
    |
 LL |     x.zero()
@@ -24,7 +24,7 @@ note: associated function defined here
   --> $DIR/method-call-err-msg.rs:6:8
    |
 LL |     fn one(self, _: isize) -> Foo { self }
-   |        ^^^ ----  --------
+   |        ^^^       --------
 help: provide the argument
    |
 LL |      .one(/* isize */)
@@ -40,7 +40,7 @@ note: associated function defined here
   --> $DIR/method-call-err-msg.rs:7:8
    |
 LL |     fn two(self, _: isize, _: isize) -> Foo { self }
-   |        ^^^ ----  --------  --------
+   |        ^^^       --------  --------
 help: provide the argument
    |
 LL |      .two(0, /* isize */);
@@ -80,7 +80,7 @@ note: associated function defined here
   --> $DIR/method-call-err-msg.rs:8:8
    |
 LL |     fn three<T>(self, _: T, _: T, _: T) -> Foo { self }
-   |        ^^^^^    ----  ----  ----  ----
+   |        ^^^^^          ----  ----  ----
 help: provide the arguments
    |
 LL |     y.three::<usize>(/* usize */, /* usize */, /* usize */);

--- a/src/test/ui/resolve/issue-100365.rs
+++ b/src/test/ui/resolve/issue-100365.rs
@@ -1,0 +1,50 @@
+fn main() {
+    let addr = Into::<std::net::IpAddr>.into([127, 0, 0, 1]);
+    //~^ ERROR expected value, found trait `Into`
+    //~| HELP use the path separator
+
+    let _ = Into.into(());
+    //~^ ERROR expected value, found trait `Into`
+    //~| HELP use the path separator
+
+    let _ = Into::<()>.into;
+    //~^ ERROR expected value, found trait `Into`
+    //~| HELP use the path separator
+}
+
+macro_rules! Trait {
+    () => {
+        ::std::iter::Iterator
+        //~^ ERROR expected value, found trait `std::iter::Iterator`
+        //~| ERROR expected value, found trait `std::iter::Iterator`
+    };
+}
+
+macro_rules! create {
+    () => {
+        Into::<String>.into("")
+        //~^ ERROR expected value, found trait `Into`
+        //~| HELP use the path separator
+    };
+}
+
+fn interaction_with_macros() {
+    //
+    // Note that if the receiver is a macro call, we do not want to suggest to replace
+    // `.` with `::` as that would be a syntax error.
+    // Since the receiver is a trait and not a type, we cannot suggest to surround
+    // it with angle brackets. It would be interpreted as a trait object type void of
+    // `dyn` which is most likely not what the user intended to write.
+    // `<_ as Trait!()>::` is also not an option as it's equally syntactically invalid.
+    //
+
+    Trait!().map(std::convert::identity); // no `help` here!
+
+    Trait!().map; // no `help` here!
+
+    //
+    // Ensure that the suggestion is shown for expressions inside of macro definitions.
+    //
+
+    let _ = create!();
+}

--- a/src/test/ui/resolve/issue-100365.stderr
+++ b/src/test/ui/resolve/issue-100365.stderr
@@ -1,0 +1,54 @@
+error[E0423]: expected value, found trait `Into`
+  --> $DIR/issue-100365.rs:2:16
+   |
+LL |     let addr = Into::<std::net::IpAddr>.into([127, 0, 0, 1]);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+
+error[E0423]: expected value, found trait `Into`
+  --> $DIR/issue-100365.rs:6:13
+   |
+LL |     let _ = Into.into(());
+   |             ^^^^- help: use the path separator to refer to an item: `::`
+
+error[E0423]: expected value, found trait `Into`
+  --> $DIR/issue-100365.rs:10:13
+   |
+LL |     let _ = Into::<()>.into;
+   |             ^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+
+error[E0423]: expected value, found trait `std::iter::Iterator`
+  --> $DIR/issue-100365.rs:17:9
+   |
+LL |         ::std::iter::Iterator
+   |         ^^^^^^^^^^^^^^^^^^^^^ not a value
+...
+LL |     Trait!().map(std::convert::identity); // no `help` here!
+   |     -------- in this macro invocation
+   |
+   = note: this error originates in the macro `Trait` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found trait `std::iter::Iterator`
+  --> $DIR/issue-100365.rs:17:9
+   |
+LL |         ::std::iter::Iterator
+   |         ^^^^^^^^^^^^^^^^^^^^^ not a value
+...
+LL |     Trait!().map; // no `help` here!
+   |     -------- in this macro invocation
+   |
+   = note: this error originates in the macro `Trait` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found trait `Into`
+  --> $DIR/issue-100365.rs:25:9
+   |
+LL |         Into::<String>.into("")
+   |         ^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+...
+LL |     let _ = create!();
+   |             --------- in this macro invocation
+   |
+   = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/resolve/issue-22692.rs
+++ b/src/test/ui/resolve/issue-22692.rs
@@ -1,3 +1,60 @@
 fn main() {
-    let _ = String.new(); //~ ERROR expected value, found struct `String`
+    let _ = String.new();
+    //~^ ERROR expected value, found struct `String`
+    //~| HELP use the path separator
+
+    let _ = String.default;
+    //~^ ERROR expected value, found struct `String`
+    //~| HELP use the path separator
+
+    let _ = Vec::<()>.with_capacity(1);
+    //~^ ERROR expected value, found struct `Vec`
+    //~| HELP use the path separator
+}
+
+macro_rules! Type {
+    () => {
+        ::std::cell::Cell
+        //~^ ERROR expected value, found struct `std::cell::Cell`
+        //~| ERROR expected value, found struct `std::cell::Cell`
+        //~| ERROR expected value, found struct `std::cell::Cell`
+    };
+}
+
+macro_rules! create {
+    (type method) => {
+        Vec.new()
+        //~^ ERROR expected value, found struct `Vec`
+        //~| HELP use the path separator
+    };
+    (type field) => {
+        Vec.new
+        //~^ ERROR expected value, found struct `Vec`
+        //~| HELP use the path separator
+    };
+    (macro method) => {
+        Type!().new(0)
+        //~^ HELP use the path separator
+    };
+}
+
+fn interaction_with_macros() {
+    //
+    // Verify that we do not only suggest to replace `.` with `::` if the receiver is a
+    // macro call but that we also correctly suggest to surround it with angle brackets.
+    //
+
+    Type!().get();
+    //~^ HELP use the path separator
+
+    Type! {}.get;
+    //~^ HELP use the path separator
+
+    //
+    // Ensure that the suggestion is shown for expressions inside of macro definitions.
+    //
+
+    let _ = create!(type method);
+    let _ = create!(type field);
+    let _ = create!(macro method);
 }

--- a/src/test/ui/resolve/issue-22692.stderr
+++ b/src/test/ui/resolve/issue-22692.stderr
@@ -2,10 +2,87 @@ error[E0423]: expected value, found struct `String`
   --> $DIR/issue-22692.rs:2:13
    |
 LL |     let _ = String.new();
-   |             ^^^^^^----
-   |             |
-   |             help: use the path separator to refer to an item: `String::new`
+   |             ^^^^^^- help: use the path separator to refer to an item: `::`
 
-error: aborting due to previous error
+error[E0423]: expected value, found struct `String`
+  --> $DIR/issue-22692.rs:6:13
+   |
+LL |     let _ = String.default;
+   |             ^^^^^^- help: use the path separator to refer to an item: `::`
+
+error[E0423]: expected value, found struct `Vec`
+  --> $DIR/issue-22692.rs:10:13
+   |
+LL |     let _ = Vec::<()>.with_capacity(1);
+   |             ^^^^^^^^^- help: use the path separator to refer to an item: `::`
+
+error[E0423]: expected value, found struct `std::cell::Cell`
+  --> $DIR/issue-22692.rs:17:9
+   |
+LL |         ::std::cell::Cell
+   |         ^^^^^^^^^^^^^^^^^
+...
+LL |     Type!().get();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `Type` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |     <Type!()>::get();
+   |     ~~~~~~~~~~~
+
+error[E0423]: expected value, found struct `std::cell::Cell`
+  --> $DIR/issue-22692.rs:17:9
+   |
+LL |         ::std::cell::Cell
+   |         ^^^^^^^^^^^^^^^^^
+...
+LL |     Type! {}.get;
+   |     -------- in this macro invocation
+   |
+   = note: this error originates in the macro `Type` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |     <Type! {}>::get;
+   |     ~~~~~~~~~~~~
+
+error[E0423]: expected value, found struct `Vec`
+  --> $DIR/issue-22692.rs:26:9
+   |
+LL |         Vec.new()
+   |         ^^^- help: use the path separator to refer to an item: `::`
+...
+LL |     let _ = create!(type method);
+   |             -------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found struct `Vec`
+  --> $DIR/issue-22692.rs:31:9
+   |
+LL |         Vec.new
+   |         ^^^- help: use the path separator to refer to an item: `::`
+...
+LL |     let _ = create!(type field);
+   |             ------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found struct `std::cell::Cell`
+  --> $DIR/issue-22692.rs:17:9
+   |
+LL |         ::std::cell::Cell
+   |         ^^^^^^^^^^^^^^^^^
+...
+LL |     let _ = create!(macro method);
+   |             --------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `Type` which comes from the expansion of the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |         <Type!()>::new(0)
+   |         ~~~~~~~~~~~
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/resolve/suggest-path-for-tuple-struct.stderr
+++ b/src/test/ui/resolve/suggest-path-for-tuple-struct.stderr
@@ -2,17 +2,13 @@ error[E0423]: expected value, found struct `SomeTupleStruct`
   --> $DIR/suggest-path-for-tuple-struct.rs:22:13
    |
 LL |     let _ = SomeTupleStruct.new();
-   |             ^^^^^^^^^^^^^^^----
-   |             |
-   |             help: use the path separator to refer to an item: `SomeTupleStruct::new`
+   |             ^^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
 
 error[E0423]: expected value, found struct `SomeRegularStruct`
   --> $DIR/suggest-path-for-tuple-struct.rs:24:13
    |
 LL |     let _ = SomeRegularStruct.new();
-   |             ^^^^^^^^^^^^^^^^^----
-   |             |
-   |             help: use the path separator to refer to an item: `SomeRegularStruct::new`
+   |             ^^^^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.rs
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.rs
@@ -16,44 +16,96 @@ pub mod a {
 fn h1() -> i32 {
     a.I
     //~^ ERROR expected value, found module `a`
+    //~| HELP use the path separator
 }
 
 fn h2() -> i32 {
     a.g()
     //~^ ERROR expected value, found module `a`
+    //~| HELP use the path separator
 }
 
 fn h3() -> i32 {
     a.b.J
     //~^ ERROR expected value, found module `a`
+    //~| HELP use the path separator
 }
 
 fn h4() -> i32 {
     a::b.J
     //~^ ERROR expected value, found module `a::b`
+    //~| HELP a constant with a similar name exists
+    //~| HELP use the path separator
 }
 
 fn h5() {
     a.b.f();
     //~^ ERROR expected value, found module `a`
+    //~| HELP use the path separator
     let v = Vec::new();
     v.push(a::b);
     //~^ ERROR expected value, found module `a::b`
+    //~| HELP a constant with a similar name exists
 }
 
 fn h6() -> i32 {
     a::b.f()
     //~^ ERROR expected value, found module `a::b`
+    //~| HELP a constant with a similar name exists
+    //~| HELP use the path separator
 }
 
 fn h7() {
     a::b
     //~^ ERROR expected value, found module `a::b`
+    //~| HELP a constant with a similar name exists
 }
 
 fn h8() -> i32 {
     a::b()
     //~^ ERROR expected function, found module `a::b`
+    //~| HELP a constant with a similar name exists
+}
+
+macro_rules! module {
+    () => {
+        a
+        //~^ ERROR expected value, found module `a`
+        //~| ERROR expected value, found module `a`
+    };
+}
+
+macro_rules! create {
+    (method) => {
+        a.f()
+        //~^ ERROR expected value, found module `a`
+        //~| HELP use the path separator
+    };
+    (field) => {
+        a.f
+        //~^ ERROR expected value, found module `a`
+        //~| HELP use the path separator
+    };
+}
+
+fn h9() {
+    //
+    // Note that if the receiver is a macro call, we do not want to suggest to replace
+    // `.` with `::` as that would be a syntax error.
+    // Since the receiver is a module and not a type, we cannot suggest to surround
+    // it with angle brackets.
+    //
+
+    module!().g::<()>(); // no `help` here!
+
+    module!().g; // no `help` here!
+
+    //
+    // Ensure that the suggestion is shown for expressions inside of macro definitions.
+    //
+
+    let _ = create!(method);
+    let _ = create!(field);
 }
 
 fn main() {}

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -2,28 +2,22 @@ error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:17:5
    |
 LL |     a.I
-   |     ^--
-   |     |
-   |     help: use the path separator to refer to an item: `a::I`
+   |     ^- help: use the path separator to refer to an item: `::`
 
 error[E0423]: expected value, found module `a`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:22:5
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:23:5
    |
 LL |     a.g()
-   |     ^--
-   |     |
-   |     help: use the path separator to refer to an item: `a::g`
+   |     ^- help: use the path separator to refer to an item: `::`
 
 error[E0423]: expected value, found module `a`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:27:5
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:29:5
    |
 LL |     a.b.J
-   |     ^--
-   |     |
-   |     help: use the path separator to refer to an item: `a::b`
+   |     ^- help: use the path separator to refer to an item: `::`
 
 error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:32:5
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:35:5
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
@@ -34,22 +28,20 @@ LL |     a::b.J
 help: use the path separator to refer to an item
    |
 LL |     a::b::J
-   |
+   |         ~~
 help: a constant with a similar name exists
    |
 LL |     a::I.J
    |        ~
 
 error[E0423]: expected value, found module `a`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:37:5
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:42:5
    |
 LL |     a.b.f();
-   |     ^--
-   |     |
-   |     help: use the path separator to refer to an item: `a::b`
+   |     ^- help: use the path separator to refer to an item: `::`
 
 error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:40:12
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:46:12
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
@@ -60,7 +52,7 @@ LL |     v.push(a::b);
    |               help: a constant with a similar name exists: `I`
 
 error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:45:5
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:52:5
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
@@ -71,14 +63,14 @@ LL |     a::b.f()
 help: use the path separator to refer to an item
    |
 LL |     a::b::f()
-   |     ~~~~~~~
+   |         ~~
 help: a constant with a similar name exists
    |
 LL |     a::I.f()
    |        ~
 
 error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:50:5
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:59:5
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
@@ -89,7 +81,7 @@ LL |     a::b
    |        help: a constant with a similar name exists: `I`
 
 error[E0423]: expected function, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:55:5
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:65:5
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
@@ -99,6 +91,50 @@ LL |     a::b()
    |        |
    |        help: a constant with a similar name exists: `I`
 
-error: aborting due to 9 previous errors
+error[E0423]: expected value, found module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:72:9
+   |
+LL |         a
+   |         ^ not a value
+...
+LL |     module!().g::<()>(); // no `help` here!
+   |     --------- in this macro invocation
+   |
+   = note: this error originates in the macro `module` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:72:9
+   |
+LL |         a
+   |         ^ not a value
+...
+LL |     module!().g; // no `help` here!
+   |     --------- in this macro invocation
+   |
+   = note: this error originates in the macro `module` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:80:9
+   |
+LL |         a.f()
+   |         ^- help: use the path separator to refer to an item: `::`
+...
+LL |     let _ = create!(method);
+   |             --------------- in this macro invocation
+   |
+   = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected value, found module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:85:9
+   |
+LL |         a.f
+   |         ^- help: use the path separator to refer to an item: `::`
+...
+LL |     let _ = create!(field);
+   |             -------------- in this macro invocation
+   |
+   = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -78,7 +78,7 @@ note: function defined here
   --> $DIR/issue-34264.rs:3:4
    |
 LL | fn bar(x, y: usize) {}
-   |    ^^^ -  --------
+   |    ^^^    --------
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/issue-34264.rs:10:5

--- a/src/test/ui/span/missing-unit-argument.stderr
+++ b/src/test/ui/span/missing-unit-argument.stderr
@@ -72,7 +72,7 @@ note: associated function defined here
   --> $DIR/missing-unit-argument.rs:6:8
    |
 LL |     fn baz(self, (): ()) { }
-   |        ^^^ ----  ------
+   |        ^^^       ------
 help: provide the argument
    |
 LL |     S.baz(());
@@ -88,7 +88,7 @@ note: associated function defined here
   --> $DIR/missing-unit-argument.rs:7:8
    |
 LL |     fn generic<T>(self, _: T) { }
-   |        ^^^^^^^    ----  ----
+   |        ^^^^^^^          ----
 help: provide the argument
    |
 LL |     S.generic::<()>(());

--- a/src/test/ui/suggestions/assoc-const-as-field.stderr
+++ b/src/test/ui/suggestions/assoc-const-as-field.stderr
@@ -2,9 +2,7 @@ error[E0423]: expected value, found struct `Mod::Foo`
   --> $DIR/assoc-const-as-field.rs:11:9
    |
 LL |     foo(Mod::Foo.Bar);
-   |         ^^^^^^^^----
-   |         |
-   |         help: use the path separator to refer to an item: `Mod::Foo::Bar`
+   |         ^^^^^^^^- help: use the path separator to refer to an item: `::`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/multidispatch-bad.stderr
+++ b/src/test/ui/traits/multidispatch-bad.stderr
@@ -10,7 +10,7 @@ note: function defined here
   --> $DIR/multidispatch-bad.rs:13:4
    |
 LL | fn test<T,U>(_: T, _: U)
-   |    ^^^^      ----  ----
+   |    ^^^^            ----
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     test(22i32, 44u32);

--- a/src/test/ui/tuple/add-tuple-within-arguments.stderr
+++ b/src/test/ui/tuple/add-tuple-within-arguments.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/add-tuple-within-arguments.rs:1:4
    |
 LL | fn foo(s: &str, a: (i32, i32), s2: &str) {}
-   |    ^^^ -------  -------------  --------
+   |    ^^^          -------------
 help: wrap these arguments in parentheses to construct a tuple
    |
 LL |     foo("hi", (1, 2), "hi");
@@ -28,7 +28,7 @@ note: function defined here
   --> $DIR/add-tuple-within-arguments.rs:3:4
    |
 LL | fn bar(s: &str, a: (&str,), s2: &str) {}
-   |    ^^^ -------  ----------  --------
+   |    ^^^          ----------
 help: use a trailing comma to create a tuple with one element
    |
 LL |     bar("hi", ("hi",), "hi");

--- a/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
@@ -6,11 +6,11 @@ LL |     let z = f(1_usize, 2);
    |             |
    |             arguments to this function are incorrect
    |
-note: closure defined here
-  --> $DIR/unboxed-closures-type-mismatch.rs:4:17
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:4:18
    |
 LL |     let mut f = |x: isize, y: isize| -> isize { x + y };
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^
 help: change the type of the numeric literal from `usize` to `isize`
    |
 LL |     let z = f(1_isize, 2);

--- a/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
@@ -10,7 +10,7 @@ note: closure parameter defined here
   --> $DIR/unboxed-closures-type-mismatch.rs:4:18
    |
 LL |     let mut f = |x: isize, y: isize| -> isize { x + y };
-   |                  ^^^^^^^^^
+   |                  ^^^^^^^^
 help: change the type of the numeric literal from `usize` to `isize`
    |
 LL |     let z = f(1_isize, 2);

--- a/src/test/ui/unpretty/pretty-let-else.rs
+++ b/src/test/ui/unpretty/pretty-let-else.rs
@@ -1,0 +1,10 @@
+// compile-flags: -Zunpretty=hir
+// check-pass
+
+#![feature(let_else)]
+
+fn foo(x: Option<u32>) {
+    let Some(_) = x else { panic!() };
+}
+
+fn main() {}

--- a/src/test/ui/unpretty/pretty-let-else.stdout
+++ b/src/test/ui/unpretty/pretty-let-else.stdout
@@ -1,0 +1,18 @@
+// compile-flags: -Zunpretty=hir
+// check-pass
+
+#![feature(let_else)]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+
+fn foo(x:
+        Option<u32>) {
+        let Some(_) = x else
+            {
+
+            { ::std::rt::begin_panic("explicit panic") }
+        };
+    }
+fn main() { }


### PR DESCRIPTION
Successful merges:

 - #99646 (Only point out a single function parameter if we have a single arg incompatibility)
 - #100026 (Add `Iterator::array_chunks` (take N+1))
 - #100126 (rustc_target: Update some old naming around self contained linking)
 - #100335 (Rustdoc-Json: Add `Path` type for traits.)
 - #100367 (Suggest the path separator when a dot is used on a trait)
 - #100434 (Fix HIR pretty printing of let else)
 - #100447 (Remove more Clean trait implementations)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99646,100026,100126,100335,100367,100434,100447)
<!-- homu-ignore:end -->