### PR TITLE
Point to generic or arg if it's the self type of unsatisfied projection predicate

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1660,12 +1660,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ObligationCauseCode::ImplDerivedObligation(code) => {
                         code.derived.parent_trait_pred.self_ty().skip_binder().into()
                     }
-                    _ if let ty::PredicateKind::Trait(predicate) =
-                        error.obligation.predicate.kind().skip_binder() =>
-                    {
-                        predicate.self_ty().into()
-                    }
-                    _ => continue,
+                    _ => match error.obligation.predicate.kind().skip_binder() {
+                        ty::PredicateKind::Trait(predicate) => predicate.self_ty().into(),
+                        ty::PredicateKind::Projection(predicate) => {
+                            predicate.projection_ty.self_ty().into()
+                        }
+                        _ => continue,
+                    },
                 };
             let self_ = self.resolve_vars_if_possible(self_);
             let ty_matches_self = |ty: Ty<'tcx>| ty.walk().any(|arg| arg == self_);

--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
-  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:10
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:19
    |
 LL | fn b() { blue_car(ModelT); }
-   |          ^^^^^^^^ type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
+   |          -------- ^^^^^^ type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
+   |          |
+   |          required by a bound introduced by this call
    |
 note: expected this to be `Blue`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:16:40
@@ -16,10 +18,12 @@ LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
    |                   ^^^^^^^^^^ required by this bound in `blue_car`
 
 error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
-  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:20
    |
 LL | fn c() { black_car(ModelU); }
-   |          ^^^^^^^^^ type mismatch resolving `<ModelU as Vehicle>::Color == Black`
+   |          --------- ^^^^^^ type mismatch resolving `<ModelU as Vehicle>::Color == Black`
+   |          |
+   |          required by a bound introduced by this call
    |
 note: expected this to be `Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:21:40

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -14,10 +14,12 @@ LL | fn foo2<I: Foo<A = Bar>>(x: I) {
    |               +++++++++
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
-  --> $DIR/associated-types-eq-3.rs:38:5
+  --> $DIR/associated-types-eq-3.rs:38:10
    |
 LL |     foo1(a);
-   |     ^^^^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     ---- ^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `Bar`
   --> $DIR/associated-types-eq-3.rs:12:14
@@ -34,7 +36,9 @@ error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:40:9
    |
 LL |     baz(&a);
-   |         ^^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     --- ^^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `Bar`
   --> $DIR/associated-types-eq-3.rs:12:14

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -1,8 +1,8 @@
 error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
-  --> $DIR/associated-types-eq-hr.rs:87:5
+  --> $DIR/associated-types-eq-hr.rs:87:11
    |
 LL |     foo::<UintStruct>();
-   |     ^^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
+   |           ^^^^^^^^^^ type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
    |
 note: expected this to be `&isize`
   --> $DIR/associated-types-eq-hr.rs:26:14
@@ -21,10 +21,10 @@ LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `foo`
 
 error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
-  --> $DIR/associated-types-eq-hr.rs:91:5
+  --> $DIR/associated-types-eq-hr.rs:91:11
    |
 LL |     bar::<IntStruct>();
-   |     ^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
+   |           ^^^^^^^^^ type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
    |
 note: expected this to be `&usize`
   --> $DIR/associated-types-eq-hr.rs:14:14

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -1,11 +1,13 @@
 error[E0271]: type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
-  --> $DIR/associated-types-issue-20346.rs:34:5
+  --> $DIR/associated-types-issue-20346.rs:34:36
    |
 LL | fn test_adapter<T, I: Iterator<Item=Option<T>>>(it: I) {
    |                 - this type parameter
 ...
 LL |     is_iterator_of::<Option<T>, _>(&adapter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
+   |     ------------------------------ ^^^^^^^^ type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `Option<T>`
   --> $DIR/associated-types-issue-20346.rs:23:17

--- a/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<T as Foo>::Y == i32`
-  --> $DIR/associated-types-multiple-types-one-trait.rs:13:5
+  --> $DIR/associated-types-multiple-types-one-trait.rs:13:12
    |
 LL |     want_y(t);
-   |     ^^^^^^ expected `i32`, found associated type
+   |     ------ ^ expected `i32`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:         expected type `i32`
            found associated type `<T as Foo>::Y`
@@ -17,10 +19,12 @@ LL | fn have_x_want_y<T:Foo<X=u32, Y = i32>>(t: &T)
    |                             +++++++++
 
 error[E0271]: type mismatch resolving `<T as Foo>::X == u32`
-  --> $DIR/associated-types-multiple-types-one-trait.rs:18:5
+  --> $DIR/associated-types-multiple-types-one-trait.rs:18:12
    |
 LL |     want_x(t);
-   |     ^^^^^^ expected `u32`, found associated type
+   |     ------ ^ expected `u32`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:         expected type `u32`
            found associated type `<T as Foo>::X`

--- a/src/test/ui/associated-types/issue-87261.stderr
+++ b/src/test/ui/associated-types/issue-87261.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<A as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:56:5
+  --> $DIR/issue-87261.rs:56:19
    |
 LL |     accepts_trait(a);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<A as Trait>::Associated`
@@ -17,10 +19,12 @@ LL |     A: Trait<Associated = ()> + 'static,
    |             +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<B as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:59:5
+  --> $DIR/issue-87261.rs:59:19
    |
 LL |     accepts_trait(b);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<B as Trait>::Associated`
@@ -33,10 +37,12 @@ LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
    |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<C as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:62:5
+  --> $DIR/issue-87261.rs:62:19
    |
 LL |     accepts_trait(c);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<C as Trait>::Associated`
@@ -51,10 +57,12 @@ LL |     C: Trait<Associated = ()> + Foo,
    |             +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<D as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:65:5
+  --> $DIR/issue-87261.rs:65:19
    |
 LL |     accepts_trait(d);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<D as Trait>::Associated`
@@ -67,10 +75,12 @@ LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
    |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<E as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:68:5
+  --> $DIR/issue-87261.rs:68:27
    |
 LL |     accepts_generic_trait(e);
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<E as GenericTrait<()>>::Associated`
@@ -85,10 +95,12 @@ LL |     E: GenericTrait<(), Associated = ()> + 'static,
    |                       +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<F as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:71:5
+  --> $DIR/issue-87261.rs:71:27
    |
 LL |     accepts_generic_trait(f);
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<F as GenericTrait<()>>::Associated`
@@ -103,10 +115,12 @@ LL |     F: GenericTrait<(), Associated = ()> + Foo,
    |                       +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<G as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:74:5
+  --> $DIR/issue-87261.rs:74:27
    |
 LL |     accepts_generic_trait(g);
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<G as GenericTrait<()>>::Associated`
@@ -119,13 +133,15 @@ LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
    |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 
 error[E0271]: type mismatch resolving `<impl Trait as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:79:5
+  --> $DIR/issue-87261.rs:79:19
    |
 LL | fn returns_opaque() -> impl Trait + 'static {
    |                        -------------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl Trait as Trait>::Associated`
@@ -140,13 +156,15 @@ LL | fn returns_opaque() -> impl Trait<Associated = ()> + 'static {
    |                                  +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl DerivedTrait as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:82:5
+  --> $DIR/issue-87261.rs:82:19
    |
 LL | fn returns_opaque_derived() -> impl DerivedTrait + 'static {
    |                                --------------------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque_derived());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl DerivedTrait as Trait>::Associated`
@@ -161,13 +179,15 @@ LL | fn returns_opaque_derived() -> impl DerivedTrait<Associated = ()> + 'static
    |                                                 +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl Trait + Foo as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:85:5
+  --> $DIR/issue-87261.rs:85:19
    |
 LL | fn returns_opaque_foo() -> impl Trait + Foo {
    |                            ---------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque_foo());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl Trait + Foo as Trait>::Associated`
@@ -182,13 +202,15 @@ LL | fn returns_opaque_foo() -> impl Trait<Associated = ()> + Foo {
    |                                      +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl DerivedTrait + Foo as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:88:5
+  --> $DIR/issue-87261.rs:88:19
    |
 LL | fn returns_opaque_derived_foo() -> impl DerivedTrait + Foo {
    |                                    ----------------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque_derived_foo());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl DerivedTrait + Foo as Trait>::Associated`
@@ -201,13 +223,15 @@ LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
    |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<impl GenericTrait<()> as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:91:5
+  --> $DIR/issue-87261.rs:91:27
    |
 LL | fn returns_opaque_generic() -> impl GenericTrait<()> + 'static {
    |                                ------------------------------- the found opaque type
 ...
 LL |     accepts_generic_trait(returns_opaque_generic());
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()> as GenericTrait<()>>::Associated`
@@ -222,13 +246,15 @@ LL | fn returns_opaque_generic() -> impl GenericTrait<(), Associated = ()> + 'st
    |                                                    +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl GenericTrait<()> + Foo as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:94:5
+  --> $DIR/issue-87261.rs:94:27
    |
 LL | fn returns_opaque_generic_foo() -> impl GenericTrait<()> + Foo {
    |                                    --------------------------- the found opaque type
 ...
 LL |     accepts_generic_trait(returns_opaque_generic_foo());
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()> + Foo as GenericTrait<()>>::Associated`
@@ -243,13 +269,15 @@ LL | fn returns_opaque_generic_foo() -> impl GenericTrait<(), Associated = ()> +
    |                                                        +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl GenericTrait<()> + GenericTrait<u8> as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:97:5
+  --> $DIR/issue-87261.rs:97:27
    |
 LL | fn returns_opaque_generic_duplicate() -> impl GenericTrait<()> + GenericTrait<u8> {
    |                                          ---------------------------------------- the found opaque type
 ...
 LL |     accepts_generic_trait(returns_opaque_generic_duplicate());
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()> + GenericTrait<u8> as GenericTrait<()>>::Associated`

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
-  --> $DIR/E0271.rs:10:5
+  --> $DIR/E0271.rs:10:9
    |
 LL |     foo(3_i8);
-   |     ^^^ type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
+   |     --- ^^^^ type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `u32`
   --> $DIR/E0271.rs:7:43

--- a/src/test/ui/generic-associated-types/issue-74684-2.stderr
+++ b/src/test/ui/generic-associated-types/issue-74684-2.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
-  --> $DIR/issue-74684-2.rs:23:5
+  --> $DIR/issue-74684-2.rs:23:9
    |
 LL |     bug(Box::new(x));
-   |     ^^^ type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
+   |     --- ^^^^^^^^^^^ type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `[u8]`
   --> $DIR/issue-74684-2.rs:10:18

--- a/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.rs
@@ -36,9 +36,9 @@ trait Ty<'a> {
 
 fn main() {
     let v = Unit2.m(
-        //~^ ERROR type mismatch
         L {
             //~^ ERROR to be a closure that returns `Unit3`, but it returns `Unit4`
+            //~| ERROR type mismatch
             f: |x| {
                 drop(x);
                 Unit4

--- a/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
@@ -1,8 +1,16 @@
 error[E0271]: type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]> as T0<'r, (&'r u8,)>>::O == <_ as Ty<'r>>::V`
-  --> $DIR/issue-62203-hrtb-ice.rs:38:19
+  --> $DIR/issue-62203-hrtb-ice.rs:39:9
    |
-LL |     let v = Unit2.m(
-   |                   ^ type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]> as T0<'r, (&'r u8,)>>::O == <_ as Ty<'r>>::V`
+LL |       let v = Unit2.m(
+   |                     - required by a bound introduced by this call
+LL | /         L {
+LL | |
+LL | |
+LL | |             f: |x| {
+...  |
+LL | |             },
+LL | |         },
+   | |_________^ type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]> as T0<'r, (&'r u8,)>>::O == <_ as Ty<'r>>::V`
    |
 note: expected this to be `<_ as Ty<'_>>::V`
   --> $DIR/issue-62203-hrtb-ice.rs:21:14
@@ -23,16 +31,15 @@ LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |                                                   ^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
 
 error[E0271]: expected `[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]` to be a closure that returns `Unit3`, but it returns `Unit4`
-  --> $DIR/issue-62203-hrtb-ice.rs:40:9
+  --> $DIR/issue-62203-hrtb-ice.rs:39:9
    |
 LL |       let v = Unit2.m(
    |                     - required by a bound introduced by this call
-LL |
 LL | /         L {
 LL | |
+LL | |
 LL | |             f: |x| {
-LL | |                 drop(x);
-LL | |                 Unit4
+...  |
 LL | |             },
 LL | |         },
    | |_________^ expected struct `Unit3`, found struct `Unit4`

--- a/src/test/ui/intrinsics/const-eval-select-bad.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-bad.stderr
@@ -52,10 +52,12 @@ LL |     G: FnOnce<ARG, Output = RET> + ~const Destruct,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `const_eval_select`
 
 error[E0271]: expected `fn(i32) -> bool {bar}` to be a fn item that returns `i32`, but it returns `bool`
-  --> $DIR/const-eval-select-bad.rs:29:5
+  --> $DIR/const-eval-select-bad.rs:29:34
    |
 LL |     const_eval_select((1,), foo, bar);
-   |     ^^^^^^^^^^^^^^^^^ expected `i32`, found `bool`
+   |     -----------------            ^^^ expected `i32`, found `bool`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
-  --> $DIR/check-trait-object-bounds-5.rs:23:5
+  --> $DIR/check-trait-object-bounds-5.rs:23:12
    |
 LL |     is_obj(x)
-   |     ^^^^^^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     ------ ^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `i64`
   --> $DIR/check-trait-object-bounds-5.rs:9:14

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
-  --> $DIR/check-trait-object-bounds-6.rs:20:5
+  --> $DIR/check-trait-object-bounds-6.rs:20:12
    |
 LL |     is_obj(x)
-   |     ^^^^^^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     ------ ^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `i64`
   --> $DIR/check-trait-object-bounds-6.rs:9:14

--- a/src/test/ui/traits/object/enforce-supertrait-projection.stderr
+++ b/src/test/ui/traits/object/enforce-supertrait-projection.stderr
@@ -1,12 +1,12 @@
 error[E0271]: type mismatch resolving `<dyn Trait<B = B, A = A> as SuperTrait>::A == B`
-  --> $DIR/enforce-supertrait-projection.rs:9:5
+  --> $DIR/enforce-supertrait-projection.rs:9:17
    |
 LL | fn transmute<A, B>(x: A) -> B {
    |              -  - expected type parameter
    |              |
    |              found type parameter
 LL |     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `B`, found type parameter `A`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `B`, found type parameter `A`
    |
    = note: expected type parameter `B`
               found type parameter `A`

--- a/src/test/ui/traits/pointee-tail-is-generic-errors.stderr
+++ b/src/test/ui/traits/pointee-tail-is-generic-errors.stderr
@@ -1,8 +1,8 @@
 error[E0271]: type mismatch resolving `<T as Pointee>::Metadata == ()`
-  --> $DIR/pointee-tail-is-generic-errors.rs:13:5
+  --> $DIR/pointee-tail-is-generic-errors.rs:13:15
    |
 LL |     is_thin::<T>();
-   |     ^^^^^^^^^^^^ expected `()`, found associated type
+   |               ^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<T as Pointee>::Metadata`
@@ -15,13 +15,13 @@ LL | fn is_thin<T: std::ptr::Pointee<Metadata = ()> + ?Sized>() {}
    |                                 ^^^^^^^^^^^^^ required by this bound in `is_thin`
 
 error[E0271]: type mismatch resolving `<Opaque as Pointee>::Metadata == ()`
-  --> $DIR/pointee-tail-is-generic-errors.rs:16:5
+  --> $DIR/pointee-tail-is-generic-errors.rs:16:15
    |
 LL | type Opaque = impl std::fmt::Debug + ?Sized;
    |               ----------------------------- the found opaque type
 ...
 LL |     is_thin::<Opaque>();
-   |     ^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |               ^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<Opaque as Pointee>::Metadata`


### PR DESCRIPTION
We do this for `TraitPredicate`s in `point_at_type_arg_instead_of_call_if_possible` and `point_at_arg_instead_of_call_if_possible`, so also do it for `ProjectionPredicate`.

Improves spans for a lot of unit tests.