### PR TITLE
`assert_{inhabited,zero_valid,uninit_valid}` intrinsics are safe

### DIFF
--- a/compiler/rustc_typeck/src/check/intrinsic.rs
+++ b/compiler/rustc_typeck/src/check/intrinsic.rs
@@ -69,6 +69,9 @@ pub fn intrinsic_operation_unsafety(intrinsic: Symbol) -> hir::Unsafety {
         // to note that it's safe to call, since
         // safe extern fns are otherwise unprecedented.
         sym::abort
+        | sym::assert_inhabited
+        | sym::assert_zero_valid
+        | sym::assert_uninit_valid
         | sym::size_of
         | sym::min_align_of
         | sym::needs_drop

--- a/src/test/ui/consts/assert-type-intrinsics.rs
+++ b/src/test/ui/consts/assert-type-intrinsics.rs
@@ -13,10 +13,10 @@ fn main() {
     const _BAD1: () = unsafe {
         MaybeUninit::<!>::uninit().assume_init();
     };
-    const _BAD2: () = unsafe {
+    const _BAD2: () = {
         intrinsics::assert_uninit_valid::<bool>();
     };
-    const _BAD3: () = unsafe {
+    const _BAD3: () = {
         intrinsics::assert_zero_valid::<&'static i32>();
     };
 }

--- a/src/test/ui/consts/assert-type-intrinsics.stderr
+++ b/src/test/ui/consts/assert-type-intrinsics.stderr
@@ -13,7 +13,7 @@ LL |         MaybeUninit::<!>::uninit().assume_init();
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:17:9
    |
-LL |     const _BAD2: () = unsafe {
+LL |     const _BAD2: () = {
    |     ---------------
 LL |         intrinsics::assert_uninit_valid::<bool>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to leave type `bool` uninitialized, which is invalid
@@ -24,7 +24,7 @@ LL |         intrinsics::assert_uninit_valid::<bool>();
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:20:9
    |
-LL |     const _BAD3: () = unsafe {
+LL |     const _BAD3: () = {
    |     ---------------
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to zero-initialize type `&i32`, which is invalid
@@ -51,7 +51,7 @@ Future breakage diagnostic:
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:17:9
    |
-LL |     const _BAD2: () = unsafe {
+LL |     const _BAD2: () = {
    |     ---------------
 LL |         intrinsics::assert_uninit_valid::<bool>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to leave type `bool` uninitialized, which is invalid
@@ -64,7 +64,7 @@ Future breakage diagnostic:
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:20:9
    |
-LL |     const _BAD3: () = unsafe {
+LL |     const _BAD3: () = {
    |     ---------------
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to zero-initialize type `&i32`, which is invalid


### PR DESCRIPTION
Those intrinsics either panic or do nothing. They are safe.