### PR TITLE
Improve the help message for an invalid calling convention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,6 +4110,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "rustc_data_structures",
+ "rustc_feature",
  "rustc_index",
  "rustc_macros",
  "rustc_serialize",

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -29,14 +29,28 @@ impl AddToDiagnostic for UseAngleBrackets {
 }
 
 #[derive(Diagnostic)]
-#[help]
 #[diag(ast_lowering::invalid_abi, code = "E0703")]
+#[note]
 pub struct InvalidAbi {
     #[primary_span]
     #[label]
     pub span: Span,
     pub abi: Symbol,
-    pub valid_abis: String,
+    pub command: String,
+    #[subdiagnostic]
+    pub suggestion: Option<InvalidAbiSuggestion>,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(
+    ast_lowering::invalid_abi_suggestion,
+    code = "{suggestion}",
+    applicability = "maybe-incorrect"
+)]
+pub struct InvalidAbiSuggestion {
+    #[primary_span]
+    pub span: Span,
+    pub suggestion: String,
 }
 
 #[derive(Diagnostic, Clone, Copy)]

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -742,6 +742,11 @@ fn print_crate_info(
                     println!("{}", cfg);
                 }
             }
+            CallingConventions => {
+                let mut calling_conventions = rustc_target::spec::abi::all_names();
+                calling_conventions.sort_unstable();
+                println!("{}", calling_conventions.join("\n"));
+            }
             RelocationModels
             | CodeModels
             | TlsModels

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -7,7 +7,9 @@ ast_lowering_use_angle_brackets = use angle brackets instead
 ast_lowering_invalid_abi =
     invalid ABI: found `{$abi}`
     .label = invalid ABI
-    .help = valid ABIs: {$valid_abis}
+    .note = invoke `{$command}` for a full list of supported calling conventions.
+
+ast_lowering_invalid_abi_suggestion = did you mean
 
 ast_lowering_assoc_ty_parentheses =
     parenthesized generic arguments cannot be used in associated type constraints

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -538,6 +538,7 @@ pub enum PrintRequest {
     TargetLibdir,
     CrateName,
     Cfg,
+    CallingConventions,
     TargetList,
     TargetCPUs,
     TargetFeatures,
@@ -1354,8 +1355,8 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
             "",
             "print",
             "Compiler information to print on stdout",
-            "[crate-name|file-names|sysroot|target-libdir|cfg|target-list|\
-             target-cpus|target-features|relocation-models|code-models|\
+            "[crate-name|file-names|sysroot|target-libdir|cfg|calling-conventions|\
+             target-list|target-cpus|target-features|relocation-models|code-models|\
              tls-models|target-spec-json|native-static-libs|stack-protector-strategies|\
              link-args]",
         ),
@@ -1794,6 +1795,7 @@ fn collect_print_requests(
         "sysroot" => PrintRequest::Sysroot,
         "target-libdir" => PrintRequest::TargetLibdir,
         "cfg" => PrintRequest::Cfg,
+        "calling-conventions" => PrintRequest::CallingConventions,
         "target-list" => PrintRequest::TargetList,
         "target-cpus" => PrintRequest::TargetCPUs,
         "target-features" => PrintRequest::TargetFeatures,

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -8,7 +8,8 @@ bitflags = "1.2.1"
 tracing = "0.1"
 serde_json = "1.0.59"
 rustc_data_structures = { path = "../rustc_data_structures" }
+rustc_feature = { path = "../rustc_feature" }
+rustc_index = { path = "../rustc_index" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
-rustc_index = { path = "../rustc_index" }

--- a/src/test/run-make-fulldeps/print-calling-conventions/Makefile
+++ b/src/test/run-make-fulldeps/print-calling-conventions/Makefile
@@ -1,0 +1,4 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) --print calling-conventions

--- a/src/test/ui/abi/abi-typo-unstable.rs
+++ b/src/test/ui/abi/abi-typo-unstable.rs
@@ -1,0 +1,6 @@
+// rust-intrinsic is unstable and not enabled, so it should not be suggested as a fix
+extern "rust-intrinsec" fn rust_intrinsic() {} //~ ERROR invalid ABI
+
+fn main() {
+    rust_intrinsic();
+}

--- a/src/test/ui/abi/abi-typo-unstable.stderr
+++ b/src/test/ui/abi/abi-typo-unstable.stderr
@@ -1,8 +1,8 @@
-error[E0703]: invalid ABI: found `路濫狼á́́`
-  --> $DIR/unicode.rs:5:8
+error[E0703]: invalid ABI: found `rust-intrinsec`
+  --> $DIR/abi-typo-unstable.rs:2:8
    |
-LL | extern "路濫狼á́́" fn foo() {}
-   |        ^^^^^^^^^ invalid ABI
+LL | extern "rust-intrinsec" fn rust_intrinsic() {}
+   |        ^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
 

--- a/src/test/ui/parser/issues/issue-8537.stderr
+++ b/src/test/ui/parser/issues/issue-8537.stderr
@@ -4,7 +4,7 @@ error[E0703]: invalid ABI: found `invalid-ab_isize`
 LL |   "invalid-ab_isize"
    |   ^^^^^^^^^^^^^^^^^^ invalid ABI
    |
-   = help: valid ABIs: Rust, C, C-unwind, cdecl, cdecl-unwind, stdcall, stdcall-unwind, fastcall, fastcall-unwind, vectorcall, vectorcall-unwind, thiscall, thiscall-unwind, aapcs, aapcs-unwind, win64, win64-unwind, sysv64, sysv64-unwind, ptx-kernel, msp430-interrupt, x86-interrupt, amdgpu-kernel, efiapi, avr-interrupt, avr-non-blocking-interrupt, C-cmse-nonsecure-call, wasm, system, system-unwind, rust-intrinsic, rust-call, platform-intrinsic, unadjusted, rust-cold
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/abi-typo.fixed
+++ b/src/test/ui/suggestions/abi-typo.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+extern "cdecl" fn cdedl() {} //~ ERROR invalid ABI
+
+fn main() {
+    cdedl();
+}

--- a/src/test/ui/suggestions/abi-typo.rs
+++ b/src/test/ui/suggestions/abi-typo.rs
@@ -1,0 +1,6 @@
+// run-rustfix
+extern "cdedl" fn cdedl() {} //~ ERROR invalid ABI
+
+fn main() {
+    cdedl();
+}

--- a/src/test/ui/suggestions/abi-typo.stderr
+++ b/src/test/ui/suggestions/abi-typo.stderr
@@ -1,8 +1,11 @@
-error[E0703]: invalid ABI: found `路濫狼á́́`
-  --> $DIR/unicode.rs:5:8
+error[E0703]: invalid ABI: found `cdedl`
+  --> $DIR/abi-typo.rs:2:8
    |
-LL | extern "路濫狼á́́" fn foo() {}
-   |        ^^^^^^^^^ invalid ABI
+LL | extern "cdedl" fn cdedl() {}
+   |        ^^^^^^^
+   |        |
+   |        invalid ABI
+   |        help: did you mean: `"cdecl"`
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/93601

I mostly followed the suggestions of @nagisa in that issue, ~~however, I wasn't sure how to check stability for the suggestion of "Do not suggest CCs that cannot be used due to them being unstable and feature not being enabled", so I did not implement that point.~~

I haven't contributed to rustc much, please feel free to point out suggestions! For example, the `.map(|s| Symbol::intern(s)).collect::<Vec<_>>()` seems pretty gross performance-wise, but maybe that's OK in error reporting code.