### PR TITLE
Check discriminant types before span_mirbug

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1270,14 +1270,17 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 if let Err(terr) =
                     self.sub_types(rv_ty, place_ty, location.to_locations(), category)
                 {
-                    span_mirbug!(
-                        self,
-                        stmt,
-                        "bad assignment ({:?} = {:?}): {:?}",
-                        place_ty,
-                        rv_ty,
-                        terr
-                    );
+                    // HACK(ouz-a): Bypasses ICE for #91633 
+                    if rv_ty.discriminant_ty(self.tcx()) != place_ty.discriminant_ty(self.tcx()) {
+                        span_mirbug!(
+                            self,
+                            stmt,
+                            "bad assignment ({:?} = {:?}): {:?}",
+                            place_ty,
+                            rv_ty,
+                            terr
+                        );
+                    }
                 }
 
                 if let Some(annotation_index) = self.rvalue_user_ty(rv) {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1270,17 +1270,14 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 if let Err(terr) =
                     self.sub_types(rv_ty, place_ty, location.to_locations(), category)
                 {
-                    // HACK(ouz-a): Bypasses ICE for #91633
-                    if rv_ty.discriminant_ty(self.tcx()) != place_ty.discriminant_ty(self.tcx()) {
-                        span_mirbug!(
-                            self,
-                            stmt,
-                            "bad assignment ({:?} = {:?}): {:?}",
-                            place_ty,
-                            rv_ty,
-                            terr
-                        );
-                    }
+                    span_mirbug!(
+                        self,
+                        stmt,
+                        "bad assignment ({:?} = {:?}): {:?}",
+                        place_ty,
+                        rv_ty,
+                        terr
+                    );
                 }
 
                 if let Some(annotation_index) = self.rvalue_user_ty(rv) {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1270,7 +1270,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 if let Err(terr) =
                     self.sub_types(rv_ty, place_ty, location.to_locations(), category)
                 {
-                    // HACK(ouz-a): Bypasses ICE for #91633 
+                    // HACK(ouz-a): Bypasses ICE for #91633
                     if rv_ty.discriminant_ty(self.tcx()) != place_ty.discriminant_ty(self.tcx()) {
                         span_mirbug!(
                             self,

--- a/src/test/ui/typeck/issue-91633.rs
+++ b/src/test/ui/typeck/issue-91633.rs
@@ -1,0 +1,8 @@
+// check-pass
+fn f<T> (it: &[T])
+where
+    [T] : std::ops::Index<usize>,
+{
+    let _ = &it[0];
+}
+fn main(){}


### PR DESCRIPTION
~The compiler is unable to relate types when a user tries to write a bound for `std::ops::Index<usize>`, and gives out an error, we bypass that by proving LHS and RHS are discriminantly the same types.~

We now check if the `expr` is `LangItem::Index` while inside `fix_index_builtin_expr` if so we don't execute the function.

Mentored by @compiler-errors 

The problem regarding the issue is explained greatly [here](https://rust-lang.zulipchat.com/#narrow/stream/245100-t-compiler.2Fwg-prioritization.2Falerts/topic/.2391633.20ICE.20for.20broken.20MIR.20in.201.2E57.2E0.2C.20beta.20and.20nightly/near/266301881) by @danielhenrymantilla 

Fixes #91633