### PR TITLE
support higher-ranked regions in opaque type inference

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1360,6 +1360,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             return self.eval_outlives(sup_region, self.universal_regions.fr_static);
         }
 
+        // Check `sup_region` contains all the placeholder regions in `sub_region`.
+        if !self.scc_values.contains_placeholders(sup_region_scc, sub_region_scc) {
+            debug!(
+                "eval_outlives: returning false because sub region contains a placeholder region not present in super"
+            );
+            return false;
+        }
+
         // Both the `sub_region` and `sup_region` consist of the union
         // of some number of universal regions (along with the union
         // of various points in the CFG; ignore those points for

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -167,7 +167,23 @@ pub(crate) struct RegionDefinition<'tcx> {
 
     /// If this is 'static or an early-bound region, then this is
     /// `Some(X)` where `X` is the name of the region.
+    ///
+    /// Use the method `Self::external_name` for more flexibility.
     pub(crate) external_name: Option<ty::Region<'tcx>>,
+}
+
+impl<'tcx> RegionDefinition<'tcx> {
+    /// Gets the name of a universal region (including placeholders).
+    /// Returns `None` if this is an existential variable.
+    pub fn external_name(&self, tcx: TyCtxt<'tcx>) -> Option<ty::Region<'tcx>> {
+        match self.origin {
+            NllRegionVariableOrigin::FreeRegion => self.external_name,
+            NllRegionVariableOrigin::Placeholder(placeholder) => {
+                Some(tcx.mk_region(ty::RePlaceholder(placeholder)))
+            }
+            NllRegionVariableOrigin::Existential { .. } => None,
+        }
+    }
 }
 
 /// N.B., the variants in `Cause` are intentionally ordered. Lower

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -303,6 +303,22 @@ impl<N: Idx> RegionValues<N> {
         }
     }
 
+    /// Returns `true` if `sup_region` contains all the placeholder elements that
+    /// `sub_region` contains.
+    pub(crate) fn contains_placeholders(&self, sup_region: N, sub_region: N) -> bool {
+        if let Some(sub_row) = self.placeholders.row(sub_region) {
+            if let Some(sup_row) = self.placeholders.row(sup_region) {
+                sup_row.superset(sub_row)
+            } else {
+                // sup row is empty, so sub row must be empty
+                sub_row.is_empty()
+            }
+        } else {
+            // sub row is empty, always true
+            true
+        }
+    }
+
     /// Returns the locations contained within a given region `r`.
     pub(crate) fn locations_outlived_by<'a>(&'a self, r: N) -> impl Iterator<Item = Location> + 'a {
         self.points.row(r).into_iter().flat_map(move |set| {

--- a/src/test/ui/impl-trait/higher-ranked-regions-diag.rs
+++ b/src/test/ui/impl-trait/higher-ranked-regions-diag.rs
@@ -1,0 +1,25 @@
+// Regression test for #97099.
+// This was an ICE because `impl Sized` captures the lifetime 'a.
+
+// check-fail
+
+trait Trait<E> {
+    type Assoc;
+}
+
+struct Foo;
+
+impl<'a> Trait<&'a ()> for Foo {
+    type Assoc = ();
+}
+
+fn foo() -> impl for<'a> Trait<&'a ()> {
+    Foo
+}
+
+fn bar() -> impl for<'a> Trait<&'a (), Assoc = impl Sized> {
+    foo()
+    //~^ ERROR hidden type for `impl Sized` captures lifetime that does not appear in bounds
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/higher-ranked-regions-diag.stderr
+++ b/src/test/ui/impl-trait/higher-ranked-regions-diag.stderr
@@ -1,0 +1,11 @@
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-diag.rs:21:5
+   |
+LL | fn bar() -> impl for<'a> Trait<&'a (), Assoc = impl Sized> {
+   |                      -- hidden type `<impl for<'a> Trait<&'a ()> as Trait<&'a ()>>::Assoc` captures the lifetime `'a` as defined here
+LL |     foo()
+   |     ^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0700`.

--- a/src/test/ui/type-alias-impl-trait/higher-ranked-regions-basic.rs
+++ b/src/test/ui/type-alias-impl-trait/higher-ranked-regions-basic.rs
@@ -1,0 +1,77 @@
+// Basic tests for opaque type inference under for<_> binders.
+
+// check-fail
+
+#![feature(type_alias_impl_trait)]
+
+trait Trait<'a> {
+    type Ty;
+}
+impl<'a, T> Trait<'a> for T {
+    type Ty = &'a ();
+}
+
+mod basic_pass {
+    use super::*;
+    type Opq<'a> = impl Sized + 'a;
+    fn test() -> impl for<'a> Trait<'a, Ty = Opq<'a>> {}
+}
+
+mod capture_rpit {
+    use super::*;
+    fn test() -> impl for<'a> Trait<'a, Ty = impl Sized> {}
+    //~^ ERROR hidden type for `impl Sized` captures lifetime that does not appear in bounds
+}
+
+mod capture_tait {
+    use super::*;
+    type Opq0 = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0>;
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+    //~^ ERROR hidden type for `capture_tait::Opq0` captures lifetime that does not appear in bounds
+}
+
+mod capture_tait_complex_pass {
+    use super::*;
+    type Opq0<'a> = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+}
+
+// Same as the above, but make sure that different placeholder regions are not equal.
+mod capture_tait_complex_fail {
+    use super::*;
+    type Opq0<'a> = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a>>; // <- Note 'a
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+    //~^ ERROR hidden type for `capture_tait_complex_fail::Opq0<'a>` captures lifetime that does not appear in bounds
+}
+
+// non-defining use because 'static is used.
+mod constrain_fail0 {
+    use super::*;
+    type Opq0<'a, 'b> = impl Sized;
+    fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
+    //~^ ERROR non-defining opaque type use in defining scope
+}
+
+// non-defining use because generic lifetime is used multiple times.
+mod constrain_fail {
+    use super::*;
+    type Opq0<'a, 'b> = impl Sized;
+    fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
+    //~^ ERROR non-defining opaque type use in defining scope
+}
+
+mod constrain_pass {
+    use super::*;
+    type Opq0<'a, 'b> = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/higher-ranked-regions-basic.stderr
+++ b/src/test/ui/type-alias-impl-trait/higher-ranked-regions-basic.stderr
@@ -1,0 +1,49 @@
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-basic.rs:22:58
+   |
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = impl Sized> {}
+   |                           --                             ^^
+   |                           |
+   |                           hidden type `&'a ()` captures the lifetime `'a` as defined here
+
+error[E0700]: hidden type for `capture_tait::Opq0` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-basic.rs:31:23
+   |
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0>;
+   |                              -- hidden type `&'b ()` captures the lifetime `'b` as defined here
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+LL |     fn test() -> Opq2 {}
+   |                       ^^
+
+error[E0700]: hidden type for `capture_tait_complex_fail::Opq0<'a>` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-basic.rs:49:23
+   |
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a>>; // <- Note 'a
+   |                              -- hidden type `&'b ()` captures the lifetime `'b` as defined here
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+LL |     fn test() -> Opq2 {}
+   |                       ^^
+
+error: non-defining opaque type use in defining scope
+  --> $DIR/higher-ranked-regions-basic.rs:57:65
+   |
+LL |     type Opq0<'a, 'b> = impl Sized;
+   |                   -- cannot use static lifetime; use a bound lifetime instead or remove the lifetime parameter from the opaque type
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
+   |                                                                 ^^
+
+error: non-defining opaque type use in defining scope
+  --> $DIR/higher-ranked-regions-basic.rs:65:60
+   |
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
+   |                                                            ^^
+   |
+note: lifetime used multiple times
+  --> $DIR/higher-ranked-regions-basic.rs:64:15
+   |
+LL |     type Opq0<'a, 'b> = impl Sized;
+   |               ^^  ^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0700`.

--- a/src/test/ui/type-alias-impl-trait/higher-ranked-regions-gat.rs
+++ b/src/test/ui/type-alias-impl-trait/higher-ranked-regions-gat.rs
@@ -1,0 +1,22 @@
+// Regression test for #97098.
+
+// check-pass
+
+#![feature(generic_associated_types)]
+#![feature(type_alias_impl_trait)]
+
+pub trait Trait {
+    type Assoc<'a>;
+}
+
+pub type Foo = impl for<'a> Trait<Assoc<'a> = FooAssoc<'a>>;
+pub type FooAssoc<'a> = impl Sized;
+
+struct Struct;
+impl Trait for Struct {
+    type Assoc<'a> = &'a u32;
+}
+
+const FOO: Foo = Struct;
+
+fn main() {}


### PR DESCRIPTION

Best reviewed commit by commit.

Cc @WaffleLapkin  this may help #93582.

Fixes #96146.
Fixes #97098.
Fixes #97099.

~Builds on #100375.~