### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1124,6 +1124,16 @@ impl<'a> Parser<'a> {
                     Applicability::MaybeIncorrect,
                 )
                 .emit();
+        } else if self.eat_keyword(kw::Let) {
+            let span = self.prev_token.span;
+            self.struct_span_err(const_span.to(span), "`const` and `let` are mutually exclusive")
+                .span_suggestion(
+                    const_span.to(span),
+                    "remove `let`",
+                    "const",
+                    Applicability::MaybeIncorrect,
+                )
+                .emit();
         }
     }
 

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -247,6 +247,22 @@ impl<'a> Parser<'a> {
     /// Parses a local variable declaration.
     fn parse_local(&mut self, attrs: AttrVec) -> PResult<'a, P<Local>> {
         let lo = self.prev_token.span;
+
+        if self.token.is_keyword(kw::Const) && self.look_ahead(1, |t| t.is_ident()) {
+            self.struct_span_err(
+                lo.to(self.token.span),
+                "`const` and `let` are mutually exclusive",
+            )
+            .span_suggestion(
+                lo.to(self.token.span),
+                "remove `let`",
+                "const",
+                Applicability::MaybeIncorrect,
+            )
+            .emit();
+            self.bump();
+        }
+
         let (pat, colon) = self.parse_pat_before_ty(None, RecoverComma::Yes, "`let` bindings")?;
 
         let (err, ty) = if colon {

--- a/compiler/rustc_target/src/spec/crt_objects.rs
+++ b/compiler/rustc_target/src/spec/crt_objects.rs
@@ -63,7 +63,7 @@ pub(super) fn all(obj: &'static str) -> CrtObjects {
     ])
 }
 
-pub(super) fn pre_musl_fallback() -> CrtObjects {
+pub(super) fn pre_musl_self_contained() -> CrtObjects {
     new(&[
         (LinkOutputKind::DynamicNoPicExe, &["crt1.o", "crti.o", "crtbegin.o"]),
         (LinkOutputKind::DynamicPicExe, &["Scrt1.o", "crti.o", "crtbeginS.o"]),
@@ -74,7 +74,7 @@ pub(super) fn pre_musl_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn post_musl_fallback() -> CrtObjects {
+pub(super) fn post_musl_self_contained() -> CrtObjects {
     new(&[
         (LinkOutputKind::DynamicNoPicExe, &["crtend.o", "crtn.o"]),
         (LinkOutputKind::DynamicPicExe, &["crtendS.o", "crtn.o"]),
@@ -85,7 +85,7 @@ pub(super) fn post_musl_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn pre_mingw_fallback() -> CrtObjects {
+pub(super) fn pre_mingw_self_contained() -> CrtObjects {
     new(&[
         (LinkOutputKind::DynamicNoPicExe, &["crt2.o", "rsbegin.o"]),
         (LinkOutputKind::DynamicPicExe, &["crt2.o", "rsbegin.o"]),
@@ -96,7 +96,7 @@ pub(super) fn pre_mingw_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn post_mingw_fallback() -> CrtObjects {
+pub(super) fn post_mingw_self_contained() -> CrtObjects {
     all("rsend.o")
 }
 
@@ -108,7 +108,7 @@ pub(super) fn post_mingw() -> CrtObjects {
     all("rsend.o")
 }
 
-pub(super) fn pre_wasi_fallback() -> CrtObjects {
+pub(super) fn pre_wasi_self_contained() -> CrtObjects {
     // Use crt1-command.o instead of crt1.o to enable support for new-style
     // commands. See https://reviews.llvm.org/D81689 for more info.
     new(&[
@@ -120,37 +120,41 @@ pub(super) fn pre_wasi_fallback() -> CrtObjects {
     ])
 }
 
-pub(super) fn post_wasi_fallback() -> CrtObjects {
+pub(super) fn post_wasi_self_contained() -> CrtObjects {
     new(&[])
 }
 
-/// Which logic to use to determine whether to fall back to the "self-contained" mode or not.
+/// Which logic to use to determine whether to use self-contained linking mode
+/// if `-Clink-self-contained` is not specified explicitly.
 #[derive(Clone, Copy, PartialEq, Hash, Debug)]
-pub enum CrtObjectsFallback {
+pub enum LinkSelfContainedDefault {
+    False,
+    True,
     Musl,
     Mingw,
-    Wasm,
 }
 
-impl FromStr for CrtObjectsFallback {
+impl FromStr for LinkSelfContainedDefault {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<CrtObjectsFallback, ()> {
+    fn from_str(s: &str) -> Result<LinkSelfContainedDefault, ()> {
         Ok(match s {
-            "musl" => CrtObjectsFallback::Musl,
-            "mingw" => CrtObjectsFallback::Mingw,
-            "wasm" => CrtObjectsFallback::Wasm,
+            "false" => LinkSelfContainedDefault::False,
+            "true" | "wasm" => LinkSelfContainedDefault::True,
+            "musl" => LinkSelfContainedDefault::Musl,
+            "mingw" => LinkSelfContainedDefault::Mingw,
             _ => return Err(()),
         })
     }
 }
 
-impl ToJson for CrtObjectsFallback {
+impl ToJson for LinkSelfContainedDefault {
     fn to_json(&self) -> Json {
         match *self {
-            CrtObjectsFallback::Musl => "musl",
-            CrtObjectsFallback::Mingw => "mingw",
-            CrtObjectsFallback::Wasm => "wasm",
+            LinkSelfContainedDefault::False => "false",
+            LinkSelfContainedDefault::True => "true",
+            LinkSelfContainedDefault::Musl => "musl",
+            LinkSelfContainedDefault::Mingw => "mingw",
         }
         .to_json()
     }

--- a/compiler/rustc_target/src/spec/linux_musl_base.rs
+++ b/compiler/rustc_target/src/spec/linux_musl_base.rs
@@ -1,13 +1,13 @@
-use crate::spec::crt_objects::{self, CrtObjectsFallback};
+use crate::spec::crt_objects::{self, LinkSelfContainedDefault};
 use crate::spec::TargetOptions;
 
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();
 
     base.env = "musl".into();
-    base.pre_link_objects_fallback = crt_objects::pre_musl_fallback();
-    base.post_link_objects_fallback = crt_objects::post_musl_fallback();
-    base.crt_objects_fallback = Some(CrtObjectsFallback::Musl);
+    base.pre_link_objects_self_contained = crt_objects::pre_musl_self_contained();
+    base.post_link_objects_self_contained = crt_objects::post_musl_self_contained();
+    base.link_self_contained = LinkSelfContainedDefault::Musl;
 
     // These targets statically link libc by default
     base.crt_static_default = true;

--- a/compiler/rustc_target/src/spec/tests/tests_impl.rs
+++ b/compiler/rustc_target/src/spec/tests/tests_impl.rs
@@ -110,9 +110,9 @@ impl Target {
         }
 
         assert!(
-            (self.pre_link_objects_fallback.is_empty()
-                && self.post_link_objects_fallback.is_empty())
-                || self.crt_objects_fallback.is_some()
+            (self.pre_link_objects_self_contained.is_empty()
+                && self.post_link_objects_self_contained.is_empty())
+                || self.link_self_contained != LinkSelfContainedDefault::False
         );
 
         // If your target really needs to deviate from the rules below,

--- a/compiler/rustc_target/src/spec/wasm32_wasi.rs
+++ b/compiler/rustc_target/src/spec/wasm32_wasi.rs
@@ -82,8 +82,8 @@ pub fn target() -> Target {
     options.linker_flavor = LinkerFlavor::Lld(LldFlavor::Wasm);
     options.add_pre_link_args(LinkerFlavor::Gcc, &["--target=wasm32-wasi"]);
 
-    options.pre_link_objects_fallback = crt_objects::pre_wasi_fallback();
-    options.post_link_objects_fallback = crt_objects::post_wasi_fallback();
+    options.pre_link_objects_self_contained = crt_objects::pre_wasi_self_contained();
+    options.post_link_objects_self_contained = crt_objects::post_wasi_self_contained();
 
     // Right now this is a bit of a workaround but we're currently saying that
     // the target by default has a static crt which we're taking as a signal

--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -1,4 +1,4 @@
-use super::crt_objects::CrtObjectsFallback;
+use super::crt_objects::LinkSelfContainedDefault;
 use super::{cvs, LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, TargetOptions, TlsModel};
 
 pub fn options() -> TargetOptions {
@@ -96,7 +96,8 @@ pub fn options() -> TargetOptions {
 
         pre_link_args,
 
-        crt_objects_fallback: Some(CrtObjectsFallback::Wasm),
+        // FIXME: Figure out cases in which WASM needs to link with a native toolchain.
+        link_self_contained: LinkSelfContainedDefault::True,
 
         // This has no effect in LLVM 8 or prior, but in LLVM 9 and later when
         // PIC code is implemented this has quite a drastic effect if it stays

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -1,4 +1,4 @@
-use crate::spec::crt_objects::{self, CrtObjectsFallback};
+use crate::spec::crt_objects::{self, LinkSelfContainedDefault};
 use crate::spec::{cvs, LinkerFlavor, TargetOptions};
 
 pub fn opts() -> TargetOptions {
@@ -76,9 +76,9 @@ pub fn opts() -> TargetOptions {
         pre_link_args,
         pre_link_objects: crt_objects::pre_mingw(),
         post_link_objects: crt_objects::post_mingw(),
-        pre_link_objects_fallback: crt_objects::pre_mingw_fallback(),
-        post_link_objects_fallback: crt_objects::post_mingw_fallback(),
-        crt_objects_fallback: Some(CrtObjectsFallback::Mingw),
+        pre_link_objects_self_contained: crt_objects::pre_mingw_self_contained(),
+        post_link_objects_self_contained: crt_objects::post_mingw_self_contained(),
+        link_self_contained: LinkSelfContainedDefault::Mingw,
         late_link_args,
         late_link_args_dynamic,
         late_link_args_static,

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -746,17 +746,22 @@ impl<'tcx> TypeVisitor<'tcx> for OrphanChecker<'tcx> {
         result
     }
 
+    /// All possible values for a constant parameter already exist
+    /// in the crate defining the trait, so they are always non-local[^1].
+    ///
+    /// Because there's no way to have an impl where the first local
+    /// generic argument is a constant, we also don't have to fail
+    /// the orphan check when encountering a parameter or a generic constant.
+    ///
+    /// This means that we can completely ignore constants during the orphan check.
+    ///
+    /// See `src/test/ui/coherence/const-generics-orphan-check-ok.rs` for examples.
+    ///
+    /// [^1]: This might not hold for function pointers or trait objects in the future.
+    /// As these should be quite rare as const arguments and especially rare as impl
+    /// parameters, allowing uncovered const parameters in impls seems more useful
+    /// than allowing `impl<T> Trait<local_fn_ptr, T> for i32` to compile.
     fn visit_const(&mut self, _c: ty::Const<'tcx>) -> ControlFlow<Self::BreakTy> {
-        // All possible values for a constant parameter already exist
-        // in the crate defining the trait, so they are always non-local.
-        //
-        // Because there's no way to have an impl where the first local
-        // generic argument is a constant, we also don't have to fail
-        // the orphan check when encountering a parameter or a generic constant.
-        //
-        // This means that we can completely ignore constants during the orphan check.
-        //
-        // See `src/test/ui/coherence/const-generics-orphan-check-ok.rs` for examples.
         ControlFlow::CONTINUE
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -746,8 +746,17 @@ impl<'tcx> TypeVisitor<'tcx> for OrphanChecker<'tcx> {
         result
     }
 
-    // FIXME: Constants should participate in orphan checking.
     fn visit_const(&mut self, _c: ty::Const<'tcx>) -> ControlFlow<Self::BreakTy> {
+        // All possible values for a constant parameter already exist
+        // in the crate defining the trait, so they are always non-local.
+        //
+        // Because there's no way to have an impl where the first local
+        // generic argument is a constant, we also don't have to fail
+        // the orphan check when encountering a parameter or a generic constant.
+        //
+        // This means that we can completely ignore constants during the orphan check.
+        //
+        // See `src/test/ui/coherence/const-generics-orphan-check-ok.rs` for examples.
         ControlFlow::CONTINUE
     }
 }

--- a/compiler/rustc_typeck/src/check/intrinsic.rs
+++ b/compiler/rustc_typeck/src/check/intrinsic.rs
@@ -69,6 +69,9 @@ pub fn intrinsic_operation_unsafety(intrinsic: Symbol) -> hir::Unsafety {
         // to note that it's safe to call, since
         // safe extern fns are otherwise unprecedented.
         sym::abort
+        | sym::assert_inhabited
+        | sym::assert_zero_valid
+        | sym::assert_uninit_valid
         | sym::size_of
         | sym::min_align_of
         | sym::needs_drop

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -293,6 +293,17 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
         intravisit::walk_expr(self, e);
     }
 
+    fn visit_generic_param(&mut self, p: &'tcx hir::GenericParam<'tcx>) {
+        match &p.kind {
+            hir::GenericParamKind::Lifetime { .. } => {
+                // Nothing to write back here
+            }
+            hir::GenericParamKind::Type { .. } | hir::GenericParamKind::Const { .. } => {
+                self.tcx().sess.delay_span_bug(p.span, format!("unexpected generic param: {p:?}"));
+            }
+        }
+    }
+
     fn visit_block(&mut self, b: &'tcx hir::Block<'tcx>) {
         self.visit_node_id(b.span, b.hir_id);
         intravisit::walk_block(self, b);

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -84,6 +84,16 @@ impl<T, const N: usize> IntoIter<T, N> {
         IntoIterator::into_iter(array)
     }
 
+    /// Creates a new iterator from a partially initalized array.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that all and only the `alive` elements of
+    /// `data` are initialized.
+    pub(crate) unsafe fn with_partial(data: [MaybeUninit<T>; N], alive: Range<usize>) -> Self {
+        Self { data, alive }
+    }
+
     /// Creates an iterator over the elements in a partially-initialized buffer.
     ///
     /// If you have a fully-initialized array, then use [`IntoIterator`].

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -84,16 +84,6 @@ impl<T, const N: usize> IntoIter<T, N> {
         IntoIterator::into_iter(array)
     }
 
-    /// Creates a new iterator from a partially initalized array.
-    ///
-    /// # Safety
-    ///
-    /// The caller must guarantee that all and only the `alive` elements of
-    /// `data` are initialized.
-    pub(crate) unsafe fn with_partial(data: [MaybeUninit<T>; N], alive: Range<usize>) -> Self {
-        Self { data, alive }
-    }
-
     /// Creates an iterator over the elements in a partially-initialized buffer.
     ///
     /// If you have a fully-initialized array, then use [`IntoIterator`].

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -11,7 +11,7 @@ use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 /// method on [`Iterator`]. See its documentation for more.
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 pub struct ArrayChunks<I: Iterator, const N: usize> {
     iter: I,
     remainder: Option<array::IntoIter<I::Item, N>>,
@@ -30,14 +30,14 @@ where
     /// Returns an iterator over the remaining elements of the original iterator
     /// that are not going to be returned by this iterator. The returned
     /// iterator will yield at most `N-1` elements.
-    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
     #[inline]
     pub fn into_remainder(self) -> Option<array::IntoIter<I::Item, N>> {
         self.remainder
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> Iterator for ArrayChunks<I, N>
 where
     I: Iterator,
@@ -91,7 +91,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> DoubleEndedIterator for ArrayChunks<I, N>
 where
     I: DoubleEndedIterator + ExactSizeIterator,
@@ -162,10 +162,10 @@ where
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> FusedIterator for ArrayChunks<I, N> where I: FusedIterator {}
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 impl<I, const N: usize> ExactSizeIterator for ArrayChunks<I, N>
 where
     I: ExactSizeIterator,

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -24,6 +24,7 @@ impl<I, const N: usize> ArrayChunks<I, N>
 where
     I: Iterator,
 {
+    #[track_caller]
     pub(in crate::iter) fn new(iter: I) -> Self {
         assert!(N != 0, "chunk size must be non-zero");
         Self { iter: iter.fuse(), remainder: None }

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -312,6 +312,6 @@ where
 
     #[inline]
     fn is_empty(&self) -> bool {
-        self.iter.len() / N == 0
+        self.iter.len() < N
     }
 }

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -1,5 +1,5 @@
 use crate::array;
-use crate::iter::{Fuse, FusedIterator, Iterator, TrustedLen};
+use crate::iter::{Fuse, FusedIterator, Iterator};
 use crate::mem;
 use crate::mem::MaybeUninit;
 use crate::ops::{ControlFlow, Try};
@@ -54,11 +54,7 @@ where
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper) = self.iter.size_hint();
-        // Keep infinite iterator size hint lower bound as `usize::MAX`. This
-        // is required to implement `TrustedLen`.
-        if lower == usize::MAX {
-            return (lower, upper);
-        }
+
         (lower / N, upper.map(|n| n / N))
     }
 
@@ -318,6 +314,3 @@ where
         self.iter.len() / N == 0
     }
 }
-
-#[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<I, const N: usize> TrustedLen for ArrayChunks<I, N> where I: TrustedLen {}

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -1,5 +1,5 @@
 use crate::array;
-use crate::iter::{Fuse, FusedIterator, Iterator};
+use crate::iter::{FusedIterator, Iterator};
 use crate::mem;
 use crate::mem::MaybeUninit;
 use crate::ops::{ControlFlow, Try};
@@ -16,7 +16,7 @@ use crate::ptr;
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
 pub struct ArrayChunks<I: Iterator, const N: usize> {
-    iter: Fuse<I>,
+    iter: I,
     remainder: Option<array::IntoIter<I::Item, N>>,
 }
 
@@ -27,7 +27,7 @@ where
     #[track_caller]
     pub(in crate::iter) fn new(iter: I) -> Self {
         assert!(N != 0, "chunk size must be non-zero");
-        Self { iter: iter.fuse(), remainder: None }
+        Self { iter, remainder: None }
     }
 
     /// Returns an iterator over the remaining elements of the original iterator

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -64,7 +64,7 @@ where
                         mem::forget(guard);
                         self.remainder = {
                             // SAFETY: `array` was initialized with `init` elements.
-                            Some(unsafe { array::IntoIter::with_partial(array, 0..init) })
+                            Some(unsafe { array::IntoIter::new_unchecked(array, 0..init) })
                         };
                     }
                     return None;
@@ -124,7 +124,8 @@ where
                     let init = guard.init;
                     mem::forget(guard);
                     // SAFETY: `array` was initialized with `init` elements.
-                    self.remainder = Some(unsafe { array::IntoIter::with_partial(array, 0..init) });
+                    self.remainder =
+                        Some(unsafe { array::IntoIter::new_unchecked(array, 0..init) });
                 }
                 R::from_output(o)
             }
@@ -305,7 +306,7 @@ where
         // SAFETY: `array` was initialized with exactly `init` elements.
         self.remainder = unsafe {
             array.get_unchecked_mut(..init).reverse();
-            Some(array::IntoIter::with_partial(array, 0..init))
+            Some(array::IntoIter::new_unchecked(array, 0..init))
         };
         Some(())
     }

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -1,0 +1,427 @@
+use crate::iter::{Fuse, FusedIterator, Iterator, TrustedLen};
+use crate::mem;
+use crate::mem::MaybeUninit;
+use crate::ops::{ControlFlow, Try};
+use crate::ptr;
+
+#[derive(Debug)]
+struct Remainder<T, const N: usize> {
+    array: [MaybeUninit<T>; N],
+    init: usize,
+}
+
+impl<T, const N: usize> Remainder<T, N> {
+    fn new() -> Self {
+        Self { array: MaybeUninit::uninit_array(), init: 0 }
+    }
+
+    unsafe fn with_init(array: [MaybeUninit<T>; N], init: usize) -> Self {
+        Self { array, init }
+    }
+
+    fn as_slice(&self) -> &[T] {
+        debug_assert!(self.init <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let slice = self.array.get_unchecked(..self.init);
+            MaybeUninit::slice_assume_init_ref(slice)
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        debug_assert!(self.init <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let slice = self.array.get_unchecked_mut(..self.init);
+            MaybeUninit::slice_assume_init_mut(slice)
+        }
+    }
+}
+
+impl<T, const N: usize> Clone for Remainder<T, N>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        let mut new = Self::new();
+        // SAFETY: The new array is the same size and `init` is always less than
+        // or equal to `N`.
+        let this = unsafe { new.array.get_unchecked_mut(..self.init) };
+        MaybeUninit::write_slice_cloned(this, self.as_slice());
+        new.init = self.init;
+        new
+    }
+}
+
+impl<T, const N: usize> Drop for Remainder<T, N> {
+    fn drop(&mut self) {
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe { ptr::drop_in_place(self.as_mut_slice()) }
+    }
+}
+
+/// An iterator over `N` elements of the iterator at a time.
+///
+/// The chunks do not overlap. If `N` does not divide the length of the
+/// iterator, then the last up to `N-1` elements will be omitted.
+///
+/// This `struct` is created by the [`array_chunks`][Iterator::array_chunks]
+/// method on [`Iterator`]. See its documentation for more.
+#[derive(Debug, Clone)]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+pub struct ArrayChunks<I: Iterator, const N: usize> {
+    iter: Fuse<I>,
+    remainder: Remainder<I::Item, N>,
+}
+
+impl<I, const N: usize> ArrayChunks<I, N>
+where
+    I: Iterator,
+{
+    pub(in crate::iter) fn new(iter: I) -> Self {
+        assert!(N != 0, "chunk size must be non-zero");
+        Self { iter: iter.fuse(), remainder: Remainder::new() }
+    }
+
+    /// Returns a reference to the remaining elements of the original iterator
+    /// that are not going to be returned by this iterator. The returned slice
+    /// has at most `N-1` elements.
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[inline]
+    pub fn remainder(&self) -> &[I::Item] {
+        self.remainder.as_slice()
+    }
+
+    /// Returns a mutable reference to the remaining elements of the original
+    /// iterator that are not going to be returned by this iterator. The
+    /// returned slice has at most `N-1` elements.
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[inline]
+    pub fn remainder_mut(&mut self) -> &mut [I::Item] {
+        self.remainder.as_mut_slice()
+    }
+}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> Iterator for ArrayChunks<I, N>
+where
+    I: Iterator,
+{
+    type Item = [I::Item; N];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        for slot in array.iter_mut() {
+            match self.iter.next() {
+                Some(item) => {
+                    slot.write(item);
+                    guard.init += 1;
+                }
+                None => {
+                    if guard.init > 0 {
+                        let init = guard.init;
+                        mem::forget(guard);
+                        // SAFETY: `array` was initialized with `init` elements.
+                        self.remainder = unsafe { Remainder::with_init(array, init) };
+                    }
+                    return None;
+                }
+            }
+        }
+
+        mem::forget(guard);
+        // SAFETY: All elements of the array were populated in the loop above.
+        Some(unsafe { MaybeUninit::array_assume_init(array) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.iter.size_hint();
+        // Keep infinite iterator size hint lower bound as `usize::MAX`. This
+        // is required to implement `TrustedLen`.
+        if lower == usize::MAX {
+            return (lower, upper);
+        }
+        (lower / N, upper.map(|n| n / N))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.iter.count() / N
+    }
+
+    fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        let result = self.iter.try_fold(init, |mut acc, item| {
+            // SAFETY: `init` starts at 0, increases by one each iteration and
+            // is reset to 0 once it reaches N.
+            unsafe { array.get_unchecked_mut(guard.init) }.write(item);
+            guard.init += 1;
+            if guard.init == N {
+                guard.init = 0;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item)?;
+            }
+            R::from_output(acc)
+        });
+        match result.branch() {
+            ControlFlow::Continue(o) => {
+                if guard.init > 0 {
+                    let init = guard.init;
+                    mem::forget(guard);
+                    // SAFETY: `array` was initialized with `init` elements.
+                    self.remainder = unsafe { Remainder::with_init(array, init) };
+                }
+                R::from_output(o)
+            }
+            ControlFlow::Break(r) => R::from_residual(r),
+        }
+    }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        self.iter.fold(init, |mut acc, item| {
+            // SAFETY: `init` starts at 0, increases by one each iteration and
+            // is reset to 0 once it reaches N.
+            unsafe { array.get_unchecked_mut(guard.init) }.write(item);
+            guard.init += 1;
+            if guard.init == N {
+                guard.init = 0;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item);
+            }
+            acc
+        })
+    }
+}
+
+/// A guard for an array where elements are filled from the left.
+struct FrontGuard<T, const N: usize> {
+    /// A pointer to the array that is being filled. We need to use a raw
+    /// pointer here because of the lifetime issues in the fold implementations.
+    ptr: *mut T,
+    /// The number of *initialized* elements.
+    init: usize,
+}
+
+impl<T, const N: usize> FrontGuard<T, N> {
+    unsafe fn new(array: &mut [MaybeUninit<T>; N]) -> Self {
+        Self { ptr: MaybeUninit::slice_as_mut_ptr(array), init: 0 }
+    }
+}
+
+impl<T, const N: usize> Drop for FrontGuard<T, N> {
+    fn drop(&mut self) {
+        debug_assert!(self.init <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let slice = ptr::slice_from_raw_parts_mut(self.ptr, self.init);
+            ptr::drop_in_place(slice);
+        }
+    }
+}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> DoubleEndedIterator for ArrayChunks<I, N>
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // We are iterating from the back we need to first handle the remainder.
+        self.next_back_remainder()?;
+
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { BackGuard::new(&mut array) };
+
+        for slot in array.iter_mut().rev() {
+            slot.write(self.iter.next_back()?);
+            guard.uninit -= 1;
+        }
+
+        mem::forget(guard);
+        // SAFETY: All elements of the array were populated in the loop above.
+        Some(unsafe { MaybeUninit::array_assume_init(array) })
+    }
+
+    fn try_rfold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        // We are iterating from the back we need to first handle the remainder.
+        if self.next_back_remainder().is_none() {
+            return R::from_output(init);
+        }
+
+        let mut array = MaybeUninit::uninit_array();
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { BackGuard::new(&mut array) };
+
+        self.iter.try_rfold(init, |mut acc, item| {
+            guard.uninit -= 1;
+            // SAFETY: `uninit` starts at N, decreases by one each iteration and
+            // is reset to N once it reaches 0.
+            unsafe { array.get_unchecked_mut(guard.uninit) }.write(item);
+            if guard.uninit == 0 {
+                guard.uninit = N;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item)?;
+            }
+            R::from_output(acc)
+        })
+    }
+
+    fn rfold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // We are iterating from the back we need to first handle the remainder.
+        if self.next_back_remainder().is_none() {
+            return init;
+        }
+
+        let mut array = MaybeUninit::uninit_array();
+
+        // SAFETY: `array` will still be valid if `guard` is dropped.
+        let mut guard = unsafe { BackGuard::new(&mut array) };
+
+        self.iter.rfold(init, |mut acc, item| {
+            guard.uninit -= 1;
+            // SAFETY: `uninit` starts at N, decreases by one each iteration and
+            // is reset to N once it reaches 0.
+            unsafe { array.get_unchecked_mut(guard.uninit) }.write(item);
+            if guard.uninit == 0 {
+                guard.uninit = N;
+                let array = mem::replace(&mut array, MaybeUninit::uninit_array());
+                // SAFETY: the condition above asserts that all elements are
+                // initialized.
+                let item = unsafe { MaybeUninit::array_assume_init(array) };
+                acc = f(acc, item);
+            }
+            acc
+        })
+    }
+}
+
+impl<I, const N: usize> ArrayChunks<I, N>
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+{
+    #[inline]
+    fn next_back_remainder(&mut self) -> Option<()> {
+        // We use the `ExactSizeIterator` implementation of the underlying
+        // iterator to know how many remaining elements there are.
+        let rem = self.iter.len() % N;
+        if rem == 0 {
+            return Some(());
+        }
+
+        let mut array = MaybeUninit::uninit_array();
+
+        // SAFETY: The array will still be valid if `guard` is dropped and
+        // it is forgotten otherwise.
+        let mut guard = unsafe { FrontGuard::new(&mut array) };
+
+        // SAFETY: `rem` is in the range 1..N based on how it is calculated.
+        for slot in unsafe { array.get_unchecked_mut(..rem) }.iter_mut() {
+            slot.write(self.iter.next_back()?);
+            guard.init += 1;
+        }
+
+        let init = guard.init;
+        mem::forget(guard);
+        // SAFETY: `array` was initialized with exactly `init` elements.
+        self.remainder = unsafe {
+            array.get_unchecked_mut(..init).reverse();
+            Remainder::with_init(array, init)
+        };
+        Some(())
+    }
+}
+
+/// A guard for an array where elements are filled from the right.
+struct BackGuard<T, const N: usize> {
+    /// A pointer to the array that is being filled. We need to use a raw
+    /// pointer here because of the lifetime issues in the rfold implementations.
+    ptr: *mut T,
+    /// The number of *uninitialized* elements.
+    uninit: usize,
+}
+
+impl<T, const N: usize> BackGuard<T, N> {
+    unsafe fn new(array: &mut [MaybeUninit<T>; N]) -> Self {
+        Self { ptr: MaybeUninit::slice_as_mut_ptr(array), uninit: N }
+    }
+}
+
+impl<T, const N: usize> Drop for BackGuard<T, N> {
+    fn drop(&mut self) {
+        debug_assert!(self.uninit <= N);
+        // SAFETY: This raw slice will only contain the initialized objects
+        // within the buffer.
+        unsafe {
+            let ptr = self.ptr.offset(self.uninit as isize);
+            let slice = ptr::slice_from_raw_parts_mut(ptr, N - self.uninit);
+            ptr::drop_in_place(slice);
+        }
+    }
+}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> FusedIterator for ArrayChunks<I, N> where I: FusedIterator {}
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+impl<I, const N: usize> ExactSizeIterator for ArrayChunks<I, N>
+where
+    I: ExactSizeIterator,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len() / N
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.iter.len() / N == 0
+    }
+}
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<I, const N: usize> TrustedLen for ArrayChunks<I, N> where I: TrustedLen {}

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1,6 +1,7 @@
 use crate::iter::{InPlaceIterable, Iterator};
 use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, NeverShortCircuit, Residual, Try};
 
+mod array_chunks;
 mod by_ref_sized;
 mod chain;
 mod cloned;
@@ -31,6 +32,9 @@ pub use self::{
     flatten::FlatMap, fuse::Fuse, inspect::Inspect, map::Map, peekable::Peekable, rev::Rev,
     scan::Scan, skip::Skip, skip_while::SkipWhile, take::Take, take_while::TakeWhile, zip::Zip,
 };
+
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+pub use self::array_chunks::ArrayChunks;
 
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::by_ref_sized::ByRefSized;

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     scan::Scan, skip::Skip, skip_while::SkipWhile, take::Take, take_while::TakeWhile, zip::Zip,
 };
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 pub use self::array_chunks::ArrayChunks;
 
 #[unstable(feature = "std_internals", issue = "none")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -398,6 +398,8 @@ pub use self::traits::{
 
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::adapters::zip;
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+pub use self::adapters::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::adapters::ByRefSized;
 #[stable(feature = "iter_cloned", since = "1.1.0")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -398,7 +398,7 @@ pub use self::traits::{
 
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::adapters::zip;
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
 pub use self::adapters::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::adapters::ByRefSized;

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3350,6 +3350,7 @@ pub trait Iterator {
     ///     assert_eq!(x + y + z, 4);
     /// }
     /// ```
+    #[track_caller]
     #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
     fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
     where

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -5,7 +5,7 @@ use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 use super::super::try_process;
 use super::super::ByRefSized;
 use super::super::TrustedRandomAccessNoCoerce;
-use super::super::{Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
+use super::super::{ArrayChunks, Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
 use super::super::{FlatMap, Flatten};
 use super::super::{FromIterator, Intersperse, IntersperseWith, Product, Sum, Zip};
 use super::super::{
@@ -3314,6 +3314,46 @@ pub trait Iterator {
         Self: Sized + Clone,
     {
         Cycle::new(self)
+    }
+
+    /// Returns an iterator over `N` elements of the iterator at a time.
+    ///
+    /// The chunks do not overlap. If `N` does not divide the length of the
+    /// iterator, then the last up to `N-1` elements will be omitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `N` is 0.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(iter_array_chunks)]
+    ///
+    /// let mut iter = "lorem".chars().array_chunks();
+    /// assert_eq!(iter.next(), Some(['l', 'o']));
+    /// assert_eq!(iter.next(), Some(['r', 'e']));
+    /// assert_eq!(iter.next(), None);
+    /// assert_eq!(iter.remainder(), &['m']);
+    /// ```
+    ///
+    /// ```
+    /// #![feature(iter_array_chunks)]
+    ///
+    /// let data = [1, 1, 2, -2, 6, 0, 3, 1];
+    /// //          ^-----^  ^------^
+    /// for [x, y, z] in data.iter().array_chunks() {
+    ///     assert_eq!(x + y + z, 4);
+    /// }
+    /// ```
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
+    where
+        Self: Sized,
+    {
+        ArrayChunks::new(self)
     }
 
     /// Sums the elements of an iterator.

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3351,7 +3351,7 @@ pub trait Iterator {
     /// }
     /// ```
     #[track_caller]
-    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "none")]
+    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
     fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
     where
         Self: Sized,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3319,7 +3319,9 @@ pub trait Iterator {
     /// Returns an iterator over `N` elements of the iterator at a time.
     ///
     /// The chunks do not overlap. If `N` does not divide the length of the
-    /// iterator, then the last up to `N-1` elements will be omitted.
+    /// iterator, then the last up to `N-1` elements will be omitted and can be
+    /// retrieved from the [`.into_remainder()`][ArrayChunks::into_remainder]
+    /// function of the iterator.
     ///
     /// # Panics
     ///
@@ -3336,7 +3338,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), Some(['l', 'o']));
     /// assert_eq!(iter.next(), Some(['r', 'e']));
     /// assert_eq!(iter.next(), None);
-    /// assert_eq!(iter.remainder(), &['m']);
+    /// assert_eq!(iter.into_remainder().unwrap().as_slice(), &['m']);
     /// ```
     ///
     /// ```

--- a/library/core/tests/iter/adapters/array_chunks.rs
+++ b/library/core/tests/iter/adapters/array_chunks.rs
@@ -1,0 +1,198 @@
+use core::cell::Cell;
+use core::iter::{self, Iterator};
+
+use super::*;
+
+#[test]
+fn test_iterator_array_chunks_infer() {
+    let xs = [1, 1, 2, -2, 6, 0, 3, 1];
+    for [a, b, c] in xs.iter().copied().array_chunks() {
+        assert_eq!(a + b + c, 4);
+    }
+}
+
+#[test]
+fn test_iterator_array_chunks_clone_and_drop() {
+    let count = Cell::new(0);
+    let mut it = (0..5).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+
+    assert_eq!(it.by_ref().count(), 1);
+    assert_eq!(count.get(), 3);
+    assert_eq!(it.remainder().len(), 2);
+
+    let mut it2 = it.clone();
+    assert_eq!(count.get(), 3);
+    assert_eq!(it2.remainder().len(), 2);
+
+    drop(it);
+    assert_eq!(count.get(), 5);
+    assert_eq!(it2.remainder().len(), 2);
+    assert!(it2.next().is_none());
+
+    drop(it2);
+    assert_eq!(count.get(), 7);
+}
+
+#[test]
+fn test_iterator_array_chunks_remainder() {
+    let mut it = (0..11).array_chunks::<4>();
+    assert_eq!(it.remainder(), &[]);
+    assert_eq!(it.remainder_mut(), &[]);
+    assert_eq!(it.next(), Some([0, 1, 2, 3]));
+    assert_eq!(it.remainder(), &[]);
+    assert_eq!(it.remainder_mut(), &[]);
+    assert_eq!(it.next(), Some([4, 5, 6, 7]));
+    assert_eq!(it.remainder(), &[]);
+    assert_eq!(it.remainder_mut(), &[]);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.remainder(), &[8, 9, 10]);
+    assert_eq!(it.remainder_mut(), &[8, 9, 10]);
+}
+
+#[test]
+fn test_iterator_array_chunks_size_hint() {
+    let it = (0..6).array_chunks::<1>();
+    assert_eq!(it.size_hint(), (6, Some(6)));
+
+    let it = (0..6).array_chunks::<3>();
+    assert_eq!(it.size_hint(), (2, Some(2)));
+
+    let it = (0..6).array_chunks::<5>();
+    assert_eq!(it.size_hint(), (1, Some(1)));
+
+    let it = (0..6).array_chunks::<7>();
+    assert_eq!(it.size_hint(), (0, Some(0)));
+
+    let it = (1..).array_chunks::<2>();
+    assert_eq!(it.size_hint(), (usize::MAX, None));
+
+    let it = (1..).filter(|x| x % 2 != 0).array_chunks::<2>();
+    assert_eq!(it.size_hint(), (0, None));
+}
+
+#[test]
+fn test_iterator_array_chunks_count() {
+    let it = (0..6).array_chunks::<1>();
+    assert_eq!(it.count(), 6);
+
+    let it = (0..6).array_chunks::<3>();
+    assert_eq!(it.count(), 2);
+
+    let it = (0..6).array_chunks::<5>();
+    assert_eq!(it.count(), 1);
+
+    let it = (0..6).array_chunks::<7>();
+    assert_eq!(it.count(), 0);
+
+    let it = (0..6).filter(|x| x % 2 == 0).array_chunks::<2>();
+    assert_eq!(it.count(), 1);
+
+    let it = iter::empty::<i32>().array_chunks::<2>();
+    assert_eq!(it.count(), 0);
+
+    let it = [(); usize::MAX].iter().array_chunks::<2>();
+    assert_eq!(it.count(), usize::MAX / 2);
+}
+
+#[test]
+fn test_iterator_array_chunks_next_and_next_back() {
+    let mut it = (0..11).array_chunks::<3>();
+    assert_eq!(it.next(), Some([0, 1, 2]));
+    assert_eq!(it.next_back(), Some([6, 7, 8]));
+    assert_eq!(it.next(), Some([3, 4, 5]));
+    assert_eq!(it.next_back(), None);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.next_back(), None);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.remainder(), &[9, 10]);
+    assert_eq!(it.remainder_mut(), &[9, 10]);
+}
+
+#[test]
+fn test_iterator_array_chunks_rev_remainder() {
+    let mut it = (0..11).array_chunks::<4>();
+    {
+        let mut it = it.by_ref().rev();
+        assert_eq!(it.next(), Some([4, 5, 6, 7]));
+        assert_eq!(it.next(), Some([0, 1, 2, 3]));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next(), None);
+    }
+    assert_eq!(it.remainder(), &[8, 9, 10]);
+}
+
+#[test]
+fn test_iterator_array_chunks_try_fold() {
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result: Result<_, ()> = it.by_ref().try_fold(0, |acc, _item| Ok(acc + 1));
+    assert_eq!(result, Ok(3));
+    assert_eq!(it.remainder().len(), 1);
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 10);
+
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result = it.by_ref().try_fold(0, |acc, _item| if acc < 2 { Ok(acc + 1) } else { Err(acc) });
+    assert_eq!(result, Err(2));
+    assert_eq!(it.remainder().len(), 0);
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 9);
+}
+
+#[test]
+fn test_iterator_array_chunks_fold() {
+    let result = (1..11).array_chunks::<3>().fold(0, |acc, [a, b, c]| {
+        assert_eq!(acc + 1, a);
+        assert_eq!(acc + 2, b);
+        assert_eq!(acc + 3, c);
+        acc + 3
+    });
+    assert_eq!(result, 9);
+
+    let count = Cell::new(0);
+    let result =
+        (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>().fold(0, |acc, _item| acc + 1);
+    assert_eq!(result, 3);
+    assert_eq!(count.get(), 10);
+}
+
+#[test]
+fn test_iterator_array_chunks_try_rfold() {
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result: Result<_, ()> = it.try_rfold(0, |acc, _item| Ok(acc + 1));
+    assert_eq!(result, Ok(3));
+    assert_eq!(it.remainder().len(), 1);
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 10);
+
+    let count = Cell::new(0);
+    let mut it = (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>();
+    let result = it.try_rfold(0, |acc, _item| if acc < 2 { Ok(acc + 1) } else { Err(acc) });
+    assert_eq!(result, Err(2));
+    assert_eq!(count.get(), 9);
+    drop(it);
+    assert_eq!(count.get(), 10);
+}
+
+#[test]
+fn test_iterator_array_chunks_rfold() {
+    let result = (1..11).array_chunks::<3>().rfold(0, |acc, [a, b, c]| {
+        assert_eq!(10 - (acc + 1), c);
+        assert_eq!(10 - (acc + 2), b);
+        assert_eq!(10 - (acc + 3), a);
+        acc + 3
+    });
+    assert_eq!(result, 9);
+
+    let count = Cell::new(0);
+    let result =
+        (0..10).map(|_| CountDrop::new(&count)).array_chunks::<3>().rfold(0, |acc, _item| acc + 1);
+    assert_eq!(result, 3);
+    assert_eq!(count.get(), 10);
+}

--- a/library/core/tests/iter/adapters/array_chunks.rs
+++ b/library/core/tests/iter/adapters/array_chunks.rs
@@ -50,7 +50,7 @@ fn test_iterator_array_chunks_size_hint() {
     assert_eq!(it.size_hint(), (0, Some(0)));
 
     let it = (1..).array_chunks::<2>();
-    assert_eq!(it.size_hint(), (usize::MAX, None));
+    assert_eq!(it.size_hint(), (usize::MAX / 2, None));
 
     let it = (1..).filter(|x| x % 2 != 0).array_chunks::<2>();
     assert_eq!(it.size_hint(), (0, None));

--- a/library/core/tests/iter/adapters/mod.rs
+++ b/library/core/tests/iter/adapters/mod.rs
@@ -1,3 +1,4 @@
+mod array_chunks;
 mod chain;
 mod cloned;
 mod copied;
@@ -181,5 +182,27 @@ impl Clone for CountClone {
         let n = self.0.get();
         self.0.set(n + 1);
         ret
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CountDrop<'a> {
+    dropped: bool,
+    count: &'a Cell<usize>,
+}
+
+impl<'a> CountDrop<'a> {
+    pub fn new(count: &'a Cell<usize>) -> Self {
+        Self { dropped: false, count }
+    }
+}
+
+impl Drop for CountDrop<'_> {
+    fn drop(&mut self) {
+        if self.dropped {
+            panic!("double drop");
+        }
+        self.dropped = true;
+        self.count.set(self.count.get() + 1);
     }
 }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -61,6 +61,7 @@
 #![feature(slice_partition_dedup)]
 #![feature(int_log)]
 #![feature(iter_advance_by)]
+#![feature(iter_array_chunks)]
 #![feature(iter_collect_into)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_intersperse)]

--- a/src/test/ui/closures/binder/disallow-const.rs
+++ b/src/test/ui/closures/binder/disallow-const.rs
@@ -1,0 +1,6 @@
+#![feature(closure_lifetime_binder)]
+
+fn main() {
+    for<const N: i32> || -> () {};
+    //~^ ERROR only lifetime parameters can be used in this context
+}

--- a/src/test/ui/closures/binder/disallow-const.stderr
+++ b/src/test/ui/closures/binder/disallow-const.stderr
@@ -1,0 +1,8 @@
+error: only lifetime parameters can be used in this context
+  --> $DIR/disallow-const.rs:4:15
+   |
+LL |     for<const N: i32> || -> () {};
+   |               ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/closures/binder/disallow-ty.rs
+++ b/src/test/ui/closures/binder/disallow-ty.rs
@@ -1,0 +1,6 @@
+#![feature(closure_lifetime_binder)]
+
+fn main() {
+    for<T> || -> () {};
+    //~^ ERROR only lifetime parameters can be used in this context
+}

--- a/src/test/ui/closures/binder/disallow-ty.stderr
+++ b/src/test/ui/closures/binder/disallow-ty.stderr
@@ -1,0 +1,8 @@
+error: only lifetime parameters can be used in this context
+  --> $DIR/disallow-ty.rs:4:9
+   |
+LL |     for<T> || -> () {};
+   |         ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/coherence/auxiliary/trait-with-const-param.rs
+++ b/src/test/ui/coherence/auxiliary/trait-with-const-param.rs
@@ -1,0 +1,1 @@
+pub trait Trait<const N: usize, T> {}

--- a/src/test/ui/coherence/const-generics-orphan-check-ok.rs
+++ b/src/test/ui/coherence/const-generics-orphan-check-ok.rs
@@ -1,0 +1,28 @@
+// check-pass
+// aux-build:trait-with-const-param.rs
+extern crate trait_with_const_param;
+use trait_with_const_param::*;
+
+// Trivial case, const param after local type.
+struct Local1;
+impl<const N: usize, T> Trait<N, T> for Local1 {}
+
+// Concrete consts behave the same as foreign types,
+// so this also trivially works.
+impl Trait<3, Local1> for i32 {}
+
+// This case isn't as trivial as we would forbid type
+// parameters here, we do allow const parameters though.
+//
+// The reason that type parameters are forbidden for
+// `impl<T> Trait<T, LocalInA> for i32 {}` is that another
+// downstream crate can add `impl<T> Trait<LocalInB, T> for i32`.
+// As these two impls would overlap we forbid any impls which
+// have a type parameter in front of a local type.
+//
+// With const parameters this issue does not exist as there are no
+// constants local to another downstream crate.
+struct Local2;
+impl<const N: usize> Trait<N, Local2> for i32 {}
+
+fn main() {}

--- a/src/test/ui/consts/assert-type-intrinsics.rs
+++ b/src/test/ui/consts/assert-type-intrinsics.rs
@@ -13,10 +13,10 @@ fn main() {
     const _BAD1: () = unsafe {
         MaybeUninit::<!>::uninit().assume_init();
     };
-    const _BAD2: () = unsafe {
+    const _BAD2: () = {
         intrinsics::assert_uninit_valid::<bool>();
     };
-    const _BAD3: () = unsafe {
+    const _BAD3: () = {
         intrinsics::assert_zero_valid::<&'static i32>();
     };
 }

--- a/src/test/ui/consts/assert-type-intrinsics.stderr
+++ b/src/test/ui/consts/assert-type-intrinsics.stderr
@@ -13,7 +13,7 @@ LL |         MaybeUninit::<!>::uninit().assume_init();
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:17:9
    |
-LL |     const _BAD2: () = unsafe {
+LL |     const _BAD2: () = {
    |     ---------------
 LL |         intrinsics::assert_uninit_valid::<bool>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to leave type `bool` uninitialized, which is invalid
@@ -24,7 +24,7 @@ LL |         intrinsics::assert_uninit_valid::<bool>();
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:20:9
    |
-LL |     const _BAD3: () = unsafe {
+LL |     const _BAD3: () = {
    |     ---------------
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to zero-initialize type `&i32`, which is invalid
@@ -51,7 +51,7 @@ Future breakage diagnostic:
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:17:9
    |
-LL |     const _BAD2: () = unsafe {
+LL |     const _BAD2: () = {
    |     ---------------
 LL |         intrinsics::assert_uninit_valid::<bool>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to leave type `bool` uninitialized, which is invalid
@@ -64,7 +64,7 @@ Future breakage diagnostic:
 error: any use of this value will cause an error
   --> $DIR/assert-type-intrinsics.rs:20:9
    |
-LL |     const _BAD3: () = unsafe {
+LL |     const _BAD3: () = {
    |     ---------------
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to zero-initialize type `&i32`, which is invalid

--- a/src/test/ui/parser/issue-99910-const-let-mutually-exclusive.fixed
+++ b/src/test/ui/parser/issue-99910-const-let-mutually-exclusive.fixed
@@ -1,0 +1,8 @@
+// run-rustfix
+
+fn main() {
+    const _FOO: i32 = 123;
+    //~^ ERROR const` and `let` are mutually exclusive
+    const _BAR: i32 = 123;
+    //~^ ERROR `const` and `let` are mutually exclusive
+}

--- a/src/test/ui/parser/issue-99910-const-let-mutually-exclusive.rs
+++ b/src/test/ui/parser/issue-99910-const-let-mutually-exclusive.rs
@@ -1,0 +1,8 @@
+// run-rustfix
+
+fn main() {
+    const let _FOO: i32 = 123;
+    //~^ ERROR const` and `let` are mutually exclusive
+    let const _BAR: i32 = 123;
+    //~^ ERROR `const` and `let` are mutually exclusive
+}

--- a/src/test/ui/parser/issue-99910-const-let-mutually-exclusive.stderr
+++ b/src/test/ui/parser/issue-99910-const-let-mutually-exclusive.stderr
@@ -1,0 +1,14 @@
+error: `const` and `let` are mutually exclusive
+  --> $DIR/issue-99910-const-let-mutually-exclusive.rs:4:5
+   |
+LL |     const let _FOO: i32 = 123;
+   |     ^^^^^^^^^ help: remove `let`: `const`
+
+error: `const` and `let` are mutually exclusive
+  --> $DIR/issue-99910-const-let-mutually-exclusive.rs:6:5
+   |
+LL |     let const _BAR: i32 = 123;
+   |     ^^^^^^^^^ help: remove `let`: `const`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #99582 (Delay a span bug if we see ty/const generic params during writeback)
 - #99861 (orphan check: rationalize our handling of constants)
 - #100026 (Add `Iterator::array_chunks` (take N+1))
 - #100115 (Suggest removing `let` if `const let` or `let const` is used)
 - #100126 (rustc_target: Update some old naming around self contained linking)
 - #100487 (`assert_{inhabited,zero_valid,uninit_valid}` intrinsics are safe)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99582,99861,100026,100115,100126,100487)
<!-- homu-ignore:end -->