### PR TITLE
[BETA] Use `node_type_opt` to skip over generics that were not expected 

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1761,13 +1761,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             .filter_map(|seg| seg.args.as_ref())
                             .flat_map(|a| a.args.iter())
                         {
-                            if let hir::GenericArg::Type(hir_ty) = &arg {
-                                let ty = self.resolve_vars_if_possible(
-                                    self.typeck_results.borrow().node_type(hir_ty.hir_id),
-                                );
-                                if ty == predicate.self_ty() {
-                                    error.obligation.cause.span = hir_ty.span;
-                                }
+                            if let hir::GenericArg::Type(hir_ty) = &arg
+                                && let Some(ty) =
+                                    self.typeck_results.borrow().node_type_opt(hir_ty.hir_id)
+                                && self.resolve_vars_if_possible(ty) == predicate.self_ty()
+                            {
+                                error.obligation.cause.span = hir_ty.span;
+                                break;
                             }
                         }
                     }

--- a/src/test/ui/argument-suggestions/issue-100154.rs
+++ b/src/test/ui/argument-suggestions/issue-100154.rs
@@ -1,0 +1,7 @@
+fn foo(i: impl std::fmt::Display) {}
+
+fn main() {
+    foo::<()>(());
+    //~^ ERROR this function takes 0 generic arguments but 1 generic argument was supplied
+    //~| ERROR `()` doesn't implement `std::fmt::Display`
+}

--- a/src/test/ui/argument-suggestions/issue-100154.stderr
+++ b/src/test/ui/argument-suggestions/issue-100154.stderr
@@ -1,0 +1,35 @@
+error[E0107]: this function takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-100154.rs:4:5
+   |
+LL |     foo::<()>(());
+   |     ^^^------ help: remove these generics
+   |     |
+   |     expected 0 generic arguments
+   |
+note: function defined here, with 0 generic parameters
+  --> $DIR/issue-100154.rs:1:4
+   |
+LL | fn foo(i: impl std::fmt::Display) {}
+   |    ^^^
+   = note: `impl Trait` cannot be explicitly specified as a generic argument
+
+error[E0277]: `()` doesn't implement `std::fmt::Display`
+  --> $DIR/issue-100154.rs:4:15
+   |
+LL |     foo::<()>(());
+   |     --------- ^^ `()` cannot be formatted with the default formatter
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `()`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `foo`
+  --> $DIR/issue-100154.rs:1:16
+   |
+LL | fn foo(i: impl std::fmt::Display) {}
+   |                ^^^^^^^^^^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0277.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/transmutability/references.stderr
+++ b/src/test/ui/transmutability/references.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
-  --> $DIR/references.rs:19:52
+  --> $DIR/references.rs:19:37
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static Unit>();
-   |                                                    ^^^^^^^^^^^^^ `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
+   |                                     ^^^^^^^^^^^^^ `&'static Unit` cannot be safely transmuted into `&'static Unit` in the defining scope of `assert::Context`.
    |
    = help: the trait `BikeshedIntrinsicFrom<&'static Unit, assert::Context, true, true, true, true>` is not implemented for `&'static Unit`
 note: required by a bound in `is_maybe_transmutable`


### PR DESCRIPTION
Backports #100155
cc #100541
r? @ghost