### PR TITLE
Speed up some `is_ascii*` methods on `char` and `u8`; add exhaustive tests for all `is_ascii*` methods

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -14,8 +14,6 @@ use super::*;
 macro_rules! handle_strip_of_each_chunk {
     ($x: ident, $starting_codepoints: expr, $strip_lengths: expr) => {{
         // 32-codepoint chunk number.
-        //
-        // SAFETY: Guaranteed by bit operations to be in `0..8`.
         let chunk_number = ($x as u8 >> 5) as usize;
 
         // `const` to type check and to ensure all element evaluations are done at
@@ -24,9 +22,6 @@ macro_rules! handle_strip_of_each_chunk {
         // Subtract the starting codepoint of this chunk from the input codepoint. This
         // will make sure that the matching codepoints in this strip are in
         // `0..length_of_strip`.
-        //
-        // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
-        // `0..8`.
         let x = $x.wrapping_sub(STARTING_CODEPOINTS[chunk_number] as u32);
 
         // `const` to type check and to ensure all element evaluations are done at
@@ -34,9 +29,6 @@ macro_rules! handle_strip_of_each_chunk {
         const STRIP_LENGTHS: [u8; 8] = $strip_lengths;
         // Check whether the adjusted value of the input codepoint is in
         // `0..length_of_strip`.
-        //
-        // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
-        // `0..8`.
         x < STRIP_LENGTHS[chunk_number] as u32
     }};
 }

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1309,12 +1309,7 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
-        // `| 0b0010_0000` loses one bit of information, giving exactly two possible
-        // inputs for every output. The exact two possible inputs for outputs `'a'`
-        // through `'z'` are the lowercase and uppercase versions of each letter, so we
-        // only need to check whether it's a lowercase letter.
-        let x = ((*self as u32) | 0b0010_0000).wrapping_sub('a' as u32);
-        x < 26
+        matches!(*self, 'A'..='Z' | 'a'..='z')
     }
 
     /// Checks if the value is an ASCII uppercase character:

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -17,7 +17,7 @@ macro_rules! handle_strip_of_each_chunk {
         let chunk_number = ($x as u8 >> 5) as usize;
 
         // `const` to type check and to ensure all element evaluations are done at
-        // compile time
+        // compile time.
         const STARTING_CODEPOINTS: [u8; 8] = $starting_codepoints;
         // Subtract the starting codepoint of this chunk from the input codepoint. This
         // will make sure that the matching codepoints in this strip are in
@@ -25,7 +25,7 @@ macro_rules! handle_strip_of_each_chunk {
         let x = $x.wrapping_sub(STARTING_CODEPOINTS[chunk_number] as u32);
 
         // `const` to type check and to ensure all element evaluations are done at
-        // compile time
+        // compile time.
         const STRIP_LENGTHS: [u8; 8] = $strip_lengths;
         // Check whether the adjusted value of the input codepoint is in
         // `0..length_of_strip`.

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -17,7 +17,7 @@ macro_rules! handle_strip_of_each_chunk {
         // 32-codepoint chunk number.
         //
         // SAFETY: Guaranteed by bit operations to be in `0..8`.
-        let chunk_number = ($x as u8 & 0b1110_0000).wrapping_shr(5) as usize;
+        let chunk_number = ($x as u8 >> 5) as usize;
 
         // `const` to type check and to ensure all element evaluations are done at
         // compile time
@@ -28,7 +28,7 @@ macro_rules! handle_strip_of_each_chunk {
         //
         // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
         // `0..8`.
-        let x = $x.wrapping_sub(*unsafe { STARTING_CODEPOINTS.get_unchecked(chunk_number) } as u32);
+        let x = $x.wrapping_sub(STARTING_CODEPOINTS[chunk_number] as u32);
 
         // `const` to type check and to ensure all element evaluations are done at
         // compile time
@@ -38,7 +38,7 @@ macro_rules! handle_strip_of_each_chunk {
         //
         // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
         // `0..8`.
-        x < *unsafe { STRIP_LENGTHS.get_unchecked(chunk_number) } as u32
+        x < STRIP_LENGTHS[chunk_number] as u32
     }};
 }
 

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -11,7 +11,6 @@ use super::*;
 // matching codepoints. The strips must all be in separate 32-codepoint chunks
 // (codepoints 0 to 31, 32 to 63, 64 to 95, 96 to 127, 128 to 159, 160 to 191,
 // 192 to 223, or 224 to 255).
-#[allow_internal_unstable(const_slice_index)]
 macro_rules! handle_strip_of_each_chunk {
     ($x: ident, $starting_codepoints: expr, $strip_lengths: expr) => {{
         // 32-codepoint chunk number.

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -689,7 +689,7 @@ impl u8 {
         // Add 6 to the codepoint so that each strip of consecutive matching codepoints
         // is in a separate 32-codepoint chunk. For more details, see the comment above
         // the `handle_strip_of_each_chunk` macro definition.
-        let x = (*self).wrapping_add(6);
+        let x = self.wrapping_add(6);
         handle_strip_of_each_chunk!(
             x,
             [0, b'!' + 6, b':' + 6, b'[' + 6, b'{' + 6, 0, 0, 0],
@@ -784,8 +784,7 @@ impl u8 {
         // codepoint of the input `u8`. The value of the bit there is 1 iff the `u8` is
         // an ASCII whitespace codepoint.
         let x = *self;
-        x <= b' '
-            && (0b1_0000_0000_0000_0000_0011_0110_0000_0000_u64.wrapping_shr(x as u32) & 1) != 0
+        x <= b' ' && ((0b1_0000_0000_0000_0000_0011_0110_0000_0000_u64 >> x) & 1) != 0
     }
 
     /// Checks if the value is an ASCII control character:

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -268,7 +268,7 @@ macro_rules! handle_strip_of_each_chunk {
         // 32-codepoint chunk number.
         //
         // SAFETY: Guaranteed by bit operations to be in `0..8`.
-        let chunk_number = ($x as u8 & 0b1110_0000).wrapping_shr(5) as usize;
+        let chunk_number = ($x >> 5) as usize;
 
         // `const` to type check and to ensure all element evaluations are done at
         // compile time
@@ -279,7 +279,7 @@ macro_rules! handle_strip_of_each_chunk {
         //
         // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
         // `0..8`.
-        let x = $x.wrapping_sub(*unsafe { STARTING_CODEPOINTS.get_unchecked(chunk_number) });
+        let x = $x.wrapping_sub(STARTING_CODEPOINTS[chunk_number]);
 
         // `const` to type check and to ensure all element evaluations are done at
         // compile time
@@ -289,7 +289,7 @@ macro_rules! handle_strip_of_each_chunk {
         //
         // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
         // `0..8`.
-        x < *unsafe { STRIP_LENGTHS.get_unchecked(chunk_number) }
+        x < STRIP_LENGTHS[chunk_number]
     }};
 }
 

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -262,7 +262,6 @@ const ASCII_CASE_MASK: u8 = 0b0010_0000;
 // matching codepoints. The strips must all be in separate 32-codepoint chunks
 // (codepoints 0 to 31, 32 to 63, 64 to 95, 96 to 127, 128 to 159, 160 to 191,
 // 192 to 223, or 224 to 255).
-#[allow_internal_unstable(const_slice_index)]
 macro_rules! handle_strip_of_each_chunk {
     ($x: ident, $starting_codepoints: expr, $strip_lengths: expr) => {{
         // 32-codepoint chunk number.

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -265,8 +265,6 @@ const ASCII_CASE_MASK: u8 = 0b0010_0000;
 macro_rules! handle_strip_of_each_chunk {
     ($x: ident, $starting_codepoints: expr, $strip_lengths: expr) => {{
         // 32-codepoint chunk number.
-        //
-        // SAFETY: Guaranteed by bit operations to be in `0..8`.
         let chunk_number = ($x >> 5) as usize;
 
         // `const` to type check and to ensure all element evaluations are done at
@@ -275,9 +273,6 @@ macro_rules! handle_strip_of_each_chunk {
         // Subtract the starting codepoint of this chunk from the input codepoint. This
         // will make sure that the matching codepoints in this strip are in
         // `0..length_of_strip`.
-        //
-        // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
-        // `0..8`.
         let x = $x.wrapping_sub(STARTING_CODEPOINTS[chunk_number]);
 
         // `const` to type check and to ensure all element evaluations are done at
@@ -285,9 +280,6 @@ macro_rules! handle_strip_of_each_chunk {
         const STRIP_LENGTHS: [u8; 8] = $strip_lengths;
         // Check whether the adjusted value of the input codepoint is in
         // `0..length_of_strip`.
-        //
-        // SAFETY: The array length is 8 and `chunk_number` is guaranteed to be in
-        // `0..8`.
         x < STRIP_LENGTHS[chunk_number]
     }};
 }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -268,7 +268,7 @@ macro_rules! handle_strip_of_each_chunk {
         let chunk_number = ($x >> 5) as usize;
 
         // `const` to type check and to ensure all element evaluations are done at
-        // compile time
+        // compile time.
         const STARTING_CODEPOINTS: [u8; 8] = $starting_codepoints;
         // Subtract the starting codepoint of this chunk from the input codepoint. This
         // will make sure that the matching codepoints in this strip are in
@@ -276,7 +276,7 @@ macro_rules! handle_strip_of_each_chunk {
         let x = $x.wrapping_sub(STARTING_CODEPOINTS[chunk_number]);
 
         // `const` to type check and to ensure all element evaluations are done at
-        // compile time
+        // compile time.
         const STRIP_LENGTHS: [u8; 8] = $strip_lengths;
         // Check whether the adjusted value of the input codepoint is in
         // `0..length_of_strip`.

--- a/library/core/tests/char.rs
+++ b/library/core/tests/char.rs
@@ -413,3 +413,58 @@ fn eu_iterator_specializations() {
     check('\u{12340}');
     check('\u{10FFFF}');
 }
+
+macro_rules! is_ascii_tests {
+    ($x: ident $(, $test_name: ident, $method_name: ident, $original_version: expr)+ $(,)?) => {
+        $(
+            #[test]
+            fn $test_name() {
+                for $x in ('\0'..='\u{d7ff}').chain('\u{e000}'..='\u{10ffff}') {
+                    // Test current version against simple Rust 1.63.0 version
+                    assert!(
+                        $x.$method_name() == ($original_version),
+                        concat!("`{:?}.", stringify!($variant), "()` is incorrect"),
+                        $x
+                    );
+                }
+            }
+        )*
+    };
+}
+
+is_ascii_tests!(
+    x,
+    test_is_ascii,
+    is_ascii,
+    x as u32 <= 0x7F,
+    test_is_ascii_alphabetic,
+    is_ascii_alphabetic,
+    matches!(x, 'A'..='Z' | 'a'..='z'),
+    test_is_ascii_alphanumeric,
+    is_ascii_alphanumeric,
+    matches!(x, '0'..='9' | 'A'..='Z' | 'a'..='z'),
+    test_is_ascii_control,
+    is_ascii_control,
+    matches!(x, '\0'..='\x1F' | '\x7F'),
+    test_is_ascii_digit,
+    is_ascii_digit,
+    matches!(x, '0'..='9'),
+    test_is_ascii_graphic,
+    is_ascii_graphic,
+    matches!(x, '!'..='~'),
+    test_is_ascii_hexdigit,
+    is_ascii_hexdigit,
+    matches!(x, '0'..='9' | 'A'..='F' | 'a'..='f'),
+    test_is_ascii_lowercase,
+    is_ascii_lowercase,
+    matches!(x, 'a'..='z'),
+    test_is_ascii_punctuation,
+    is_ascii_punctuation,
+    matches!(x, '!'..='/' | ':'..='@' | '['..='`' | '{'..='~'),
+    test_is_ascii_uppercase,
+    is_ascii_uppercase,
+    matches!(x, 'A'..='Z'),
+    test_is_ascii_whitespace,
+    is_ascii_whitespace,
+    matches!(x, '\t' | '\n' | '\x0C' | '\r' | ' '),
+);

--- a/library/core/tests/char.rs
+++ b/library/core/tests/char.rs
@@ -436,7 +436,7 @@ is_ascii_tests!(
     x,
     test_is_ascii,
     is_ascii,
-    x as u32 <= 0x7F,
+    matches!(x, '\0'..='\x7f'),
     test_is_ascii_alphabetic,
     is_ascii_alphabetic,
     matches!(x, 'A'..='Z' | 'a'..='z'),

--- a/library/core/tests/char.rs
+++ b/library/core/tests/char.rs
@@ -414,57 +414,67 @@ fn eu_iterator_specializations() {
     check('\u{10FFFF}');
 }
 
-macro_rules! is_ascii_tests {
-    ($x: ident $(, $test_name: ident, $method_name: ident, $original_version: expr)+ $(,)?) => {
-        $(
-            #[test]
-            fn $test_name() {
-                for $x in ('\0'..='\u{d7ff}').chain('\u{e000}'..='\u{10ffff}') {
-                    // Test current version against simple Rust 1.63.0 version
-                    assert!(
-                        $x.$method_name() == ($original_version),
-                        concat!("`{:?}.", stringify!($variant), "()` is incorrect"),
-                        $x
-                    );
-                }
-            }
-        )*
-    };
-}
+#[test]
+fn is_ascii_tests() {
+    for ch in '\0'..=char::MAX {
+        let ascii = matches!(ch, '\0'..='\x7f');
+        let control = matches!(ch, '\0'..='\x1f' | '\x7f');
+        let digit = matches!(ch, '0'..='9');
+        let graphic = matches!(ch, '!'..='~');
+        let hex_letter = matches!(ch, 'A'..='F' | 'a'..='f');
+        let lowercase = matches!(ch, 'a'..='z');
+        let punctuation = matches!(ch, '!'..='/' | ':'..='@' | '['..='`' | '{'..='~');
+        let uppercase = matches!(ch, 'A'..='Z');
+        let whitespace = matches!(ch, '\t' | '\n' | '\r' | '\x0c' | ' ');
 
-is_ascii_tests!(
-    x,
-    test_is_ascii,
-    is_ascii,
-    matches!(x, '\0'..='\x7f'),
-    test_is_ascii_alphabetic,
-    is_ascii_alphabetic,
-    matches!(x, 'A'..='Z' | 'a'..='z'),
-    test_is_ascii_alphanumeric,
-    is_ascii_alphanumeric,
-    matches!(x, '0'..='9' | 'A'..='Z' | 'a'..='z'),
-    test_is_ascii_control,
-    is_ascii_control,
-    matches!(x, '\0'..='\x1F' | '\x7F'),
-    test_is_ascii_digit,
-    is_ascii_digit,
-    matches!(x, '0'..='9'),
-    test_is_ascii_graphic,
-    is_ascii_graphic,
-    matches!(x, '!'..='~'),
-    test_is_ascii_hexdigit,
-    is_ascii_hexdigit,
-    matches!(x, '0'..='9' | 'A'..='F' | 'a'..='f'),
-    test_is_ascii_lowercase,
-    is_ascii_lowercase,
-    matches!(x, 'a'..='z'),
-    test_is_ascii_punctuation,
-    is_ascii_punctuation,
-    matches!(x, '!'..='/' | ':'..='@' | '['..='`' | '{'..='~'),
-    test_is_ascii_uppercase,
-    is_ascii_uppercase,
-    matches!(x, 'A'..='Z'),
-    test_is_ascii_whitespace,
-    is_ascii_whitespace,
-    matches!(x, '\t' | '\n' | '\x0C' | '\r' | ' '),
-);
+        let escaped_ch = ch.escape_default();
+
+        assert_eq!(ch.is_ascii(), ascii, "'{escaped_ch}'.is_ascii() is incorrect");
+        assert_eq!(
+            ch.is_ascii_alphabetic(),
+            uppercase | lowercase,
+            "'{escaped_ch}'.is_ascii_alphabetic() is incorrect"
+        );
+        assert_eq!(
+            ch.is_ascii_alphanumeric(),
+            uppercase | lowercase | digit,
+            "'{escaped_ch}'.is_ascii_alphanumeric() is incorrect"
+        );
+        assert_eq!(
+            ch.is_ascii_control(),
+            control,
+            "'{escaped_ch}'.is_ascii_control() is incorrect"
+        );
+        assert_eq!(ch.is_ascii_digit(), digit, "'{escaped_ch}'.is_ascii_digit() is incorrect");
+        assert_eq!(
+            ch.is_ascii_graphic(),
+            graphic,
+            "'{escaped_ch}'.is_ascii_graphic() is incorrect"
+        );
+        assert_eq!(
+            ch.is_ascii_hexdigit(),
+            digit | hex_letter,
+            "'{escaped_ch}'.is_ascii_hexdigit() is incorrect"
+        );
+        assert_eq!(
+            ch.is_ascii_lowercase(),
+            lowercase,
+            "'{escaped_ch}'.is_ascii_lowercase() is incorrect"
+        );
+        assert_eq!(
+            ch.is_ascii_punctuation(),
+            punctuation,
+            "'{escaped_ch}'.is_ascii_punctuation() is incorrect"
+        );
+        assert_eq!(
+            ch.is_ascii_uppercase(),
+            uppercase,
+            "'{escaped_ch}'.is_ascii_uppercase() is incorrect"
+        );
+        assert_eq!(
+            ch.is_ascii_whitespace(),
+            whitespace,
+            "'{escaped_ch}'.is_ascii_whitespace() is incorrect"
+        );
+    }
+}

--- a/library/core/tests/num/u8.rs
+++ b/library/core/tests/num/u8.rs
@@ -1,1 +1,59 @@
 uint_module!(u8);
+
+#[cfg(test)]
+mod u8_specific_tests {
+    macro_rules! is_ascii_tests {
+        ($x: ident $(, $test_name: ident, $method_name: ident, $original_version: expr)+ $(,)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    for $x in u8::MIN..=u8::MAX {
+                        // Test current version against simple Rust 1.63.0 version
+                        assert!(
+                            $x.$method_name() == ($original_version),
+                            concat!("`{}_u8.", stringify!($variant), "()` is incorrect"),
+                            $x
+                        );
+                    }
+                }
+            )*
+        };
+    }
+
+    is_ascii_tests!(
+        x,
+        test_is_ascii,
+        is_ascii,
+        x & 128 == 0,
+        test_is_ascii_alphabetic,
+        is_ascii_alphabetic,
+        matches!(x, b'A'..=b'Z' | b'a'..=b'z'),
+        test_is_ascii_alphanumeric,
+        is_ascii_alphanumeric,
+        matches!(x, b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z'),
+        test_is_ascii_control,
+        is_ascii_control,
+        matches!(x, b'\0'..=b'\x1F' | b'\x7F'),
+        test_is_ascii_digit,
+        is_ascii_digit,
+        matches!(x, b'0'..=b'9'),
+        test_is_ascii_graphic,
+        is_ascii_graphic,
+        matches!(x, b'!'..=b'~'),
+        test_is_ascii_hexdigit,
+        is_ascii_hexdigit,
+        matches!(x, b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f'),
+        test_is_ascii_lowercase,
+        is_ascii_lowercase,
+        matches!(x, b'a'..=b'z'),
+        test_is_ascii_punctuation,
+        is_ascii_punctuation,
+        matches!(x, b'!'..=b'/' | b':'..=b'@' | b'['..=b'`' | b'{'..=b'~'),
+        test_is_ascii_uppercase,
+        is_ascii_uppercase,
+        matches!(x, b'A'..=b'Z'),
+        test_is_ascii_whitespace,
+        is_ascii_whitespace,
+        matches!(x, b'\t' | b'\n' | b'\x0C' | b'\r' | b' '),
+    );
+}

--- a/library/core/tests/num/u8.rs
+++ b/library/core/tests/num/u8.rs
@@ -2,58 +2,68 @@ uint_module!(u8);
 
 #[cfg(test)]
 mod u8_specific_tests {
-    macro_rules! is_ascii_tests {
-        ($x: ident $(, $test_name: ident, $method_name: ident, $original_version: expr)+ $(,)?) => {
-            $(
-                #[test]
-                fn $test_name() {
-                    for $x in u8::MIN..=u8::MAX {
-                        // Test current version against simple Rust 1.63.0 version
-                        assert!(
-                            $x.$method_name() == ($original_version),
-                            concat!("`{}_u8.", stringify!($variant), "()` is incorrect"),
-                            $x
-                        );
-                    }
-                }
-            )*
-        };
-    }
+    #[test]
+    fn is_ascii_tests() {
+        for ch in u8::MIN..=u8::MAX {
+            let ascii = matches!(ch, 0..=0x7f);
+            let control = matches!(ch, 0..=31 | 0x7f);
+            let digit = matches!(ch, b'0'..=b'9');
+            let graphic = matches!(ch, b'!'..=b'~');
+            let hex_letter = matches!(ch, b'A'..=b'F' | b'a'..=b'f');
+            let lowercase = matches!(ch, b'a'..=b'z');
+            let punctuation = matches!(ch, b'!'..=b'/' | b':'..=b'@' | b'['..=b'`' | b'{'..=b'~');
+            let uppercase = matches!(ch, b'A'..=b'Z');
+            let whitespace = matches!(ch, b'\t' | b'\n' | b'\r' | b'\x0c' | b' ');
 
-    is_ascii_tests!(
-        x,
-        test_is_ascii,
-        is_ascii,
-        matches!(x, b'\0'..=b'\x7f'),
-        test_is_ascii_alphabetic,
-        is_ascii_alphabetic,
-        matches!(x, b'A'..=b'Z' | b'a'..=b'z'),
-        test_is_ascii_alphanumeric,
-        is_ascii_alphanumeric,
-        matches!(x, b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z'),
-        test_is_ascii_control,
-        is_ascii_control,
-        matches!(x, b'\0'..=b'\x1F' | b'\x7F'),
-        test_is_ascii_digit,
-        is_ascii_digit,
-        matches!(x, b'0'..=b'9'),
-        test_is_ascii_graphic,
-        is_ascii_graphic,
-        matches!(x, b'!'..=b'~'),
-        test_is_ascii_hexdigit,
-        is_ascii_hexdigit,
-        matches!(x, b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f'),
-        test_is_ascii_lowercase,
-        is_ascii_lowercase,
-        matches!(x, b'a'..=b'z'),
-        test_is_ascii_punctuation,
-        is_ascii_punctuation,
-        matches!(x, b'!'..=b'/' | b':'..=b'@' | b'['..=b'`' | b'{'..=b'~'),
-        test_is_ascii_uppercase,
-        is_ascii_uppercase,
-        matches!(x, b'A'..=b'Z'),
-        test_is_ascii_whitespace,
-        is_ascii_whitespace,
-        matches!(x, b'\t' | b'\n' | b'\x0C' | b'\r' | b' '),
-    );
+            let escaped_ch = ch.escape_ascii();
+
+            assert_eq!(ch.is_ascii(), ascii, "b'{escaped_ch}'.is_ascii() is incorrect");
+            assert_eq!(
+                ch.is_ascii_alphabetic(),
+                uppercase | lowercase,
+                "b'{escaped_ch}'.is_ascii_alphabetic() is incorrect"
+            );
+            assert_eq!(
+                ch.is_ascii_alphanumeric(),
+                uppercase | lowercase | digit,
+                "b'{escaped_ch}'.is_ascii_alphanumeric() is incorrect"
+            );
+            assert_eq!(
+                ch.is_ascii_control(),
+                control,
+                "b'{escaped_ch}'.is_ascii_control() is incorrect"
+            );
+            assert_eq!(ch.is_ascii_digit(), digit, "b'{escaped_ch}'.is_ascii_digit() is incorrect");
+            assert_eq!(
+                ch.is_ascii_graphic(),
+                graphic,
+                "b'{escaped_ch}'.is_ascii_graphic() is incorrect"
+            );
+            assert_eq!(
+                ch.is_ascii_hexdigit(),
+                digit | hex_letter,
+                "b'{escaped_ch}'.is_ascii_hexdigit() is incorrect"
+            );
+            assert_eq!(
+                ch.is_ascii_lowercase(),
+                lowercase,
+                "b'{escaped_ch}'.is_ascii_lowercase() is incorrect"
+            );
+            assert_eq!(
+                ch.is_ascii_punctuation(),
+                punctuation,
+                "b'{escaped_ch}'.is_ascii_punctuation() is incorrect"
+            );
+            assert_eq!(
+                ch.is_ascii_uppercase(),
+                uppercase,
+                "b'{escaped_ch}'.is_ascii_uppercase() is incorrect"
+            );
+            assert_eq!(
+                ch.is_ascii_whitespace(),
+                whitespace,
+                "b'{escaped_ch}'.is_ascii_whitespace() is incorrect"
+            );
+        }
+    }
 }

--- a/library/core/tests/num/u8.rs
+++ b/library/core/tests/num/u8.rs
@@ -24,7 +24,7 @@ mod u8_specific_tests {
         x,
         test_is_ascii,
         is_ascii,
-        x & 128 == 0,
+        matches!(x, b'\0'..=b'\x7f'),
         test_is_ascii_alphabetic,
         is_ascii_alphabetic,
         matches!(x, b'A'..=b'Z' | b'a'..=b'z'),


### PR DESCRIPTION
* ~~`is_ascii_alphabetic` is faster on `char`~~
* `is_ascii_alphanumeric` is faster on `char` and `u8`
* `is_ascii_hexdigit` is faster on `char` and `u8`
* `is_ascii_punctuation` is faster on `char` and `u8`
* `is_ascii_whitespace` is faster on `u8`

# Summary

I've repeatedly used an AMD EPYC-Rome CPU on a shared VPS to benchmark these new versions of these methods, and the methods that performed better were put into this pull request. `char::is_ascii_hexdigit` has a very minor slowdown compared to the current version when uniformly random valid `char`s are thrown at it, but I think the speedups of other benchmarks of that method more than make up for it.

I've also exhaustively tested that all valid `char` and `u8` inputs provide the exact same outputs as the current versions, so, except for invalid `char` values, if the current version works, so does the new version.

`cargo +nightly test` and `cargo +nightly bench` (or, for nicer output, `./benchit` if you have Ruby 3 and GHC Haskell installed) can be used on the repository [ChaiTRex/is_ascii_speedups](https://github.com/ChaiTRex/is_ascii_speedups) to check these results on other processor types.

# Benchmark results

<details><summary>Criterion.rs benchmarks</summary>

    ══════════════════════════════════════════════════════════════════════════════
    old_ascii_random_u8s                           [3.1140 ns 3.1215 ns 3.1297 ns]
    new_ascii_random_u8s                           [3.1311 ns 3.1392 ns 3.1472 ns]
    
    old_ascii_random_ascii_u8s                     [3.0711 ns 3.0788 ns 3.0871 ns]
    new_ascii_random_ascii_u8s                     [3.3702 ns 3.3767 ns 3.3830 ns]
    
    old_ascii_count_starting_u8_matches            [350.32 ns 352.60 ns 355.23 ns]
    new_ascii_count_starting_u8_matches            [341.31 ns 341.98 ns 342.69 ns]
    
    old_ascii_count_all_u8_matches                 [350.48 ns 351.58 ns 352.90 ns]
    new_ascii_count_all_u8_matches                 [350.78 ns 352.06 ns 353.73 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_ascii_random_chars                         [3.3534 ns 3.3874 ns 3.4254 ns]
    new_ascii_random_chars                         [3.2884 ns 3.3164 ns 3.3497 ns]
    
    old_ascii_random_ascii_chars                   [2.5487 ns 2.5573 ns 2.5670 ns]
    new_ascii_random_ascii_chars                   [2.5494 ns 2.5562 ns 2.5642 ns]
    
    old_ascii_count_starting_char_matches          [627.02 ns 629.51 ns 633.18 ns]
    new_ascii_count_starting_char_matches          [638.91 ns 647.31 ns 658.15 ns]
    
    old_ascii_count_all_char_matches               [703.22 ns 704.97 ns 707.08 ns]
    new_ascii_count_all_char_matches               [728.88 ns 737.85 ns 747.78 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_alphabetic_random_u8s                      [3.0860 ns 3.0939 ns 3.1016 ns]
    new_alphabetic_random_u8s                      [3.0897 ns 3.0963 ns 3.1042 ns]
    
    old_alphabetic_random_ascii_u8s                [3.1562 ns 3.1627 ns 3.1708 ns]
    new_alphabetic_random_ascii_u8s                [3.1529 ns 3.1584 ns 3.1642 ns]
    
    old_alphabetic_count_starting_u8_matches       [347.52 ns 348.77 ns 350.31 ns]
    new_alphabetic_count_starting_u8_matches       [346.26 ns 348.16 ns 350.72 ns]
    
    old_alphabetic_count_all_u8_matches            [355.76 ns 356.34 ns 357.01 ns]
    new_alphabetic_count_all_u8_matches            [355.13 ns 356.43 ns 358.37 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_alphabetic_random_chars                    [4.3227 ns 4.3311 ns 4.3413 ns]
    new_alphabetic_random_chars                    [3.5306 ns 3.5510 ns 3.5790 ns]
    
    old_alphabetic_random_ascii_chars              [3.5300 ns 3.5410 ns 3.5527 ns]
    new_alphabetic_random_ascii_chars              [2.7357 ns 2.7456 ns 2.7559 ns]
    
    old_alphabetic_count_starting_char_matches     [744.26 ns 746.79 ns 749.56 ns]
    new_alphabetic_count_starting_char_matches     [642.80 ns 646.72 ns 652.29 ns]
    
    old_alphabetic_count_all_char_matches          [742.97 ns 747.66 ns 752.82 ns]
    new_alphabetic_count_all_char_matches          [720.49 ns 724.48 ns 729.19 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_alphanumeric_random_u8s                    [3.7810 ns 3.7896 ns 3.7995 ns]
    new_alphanumeric_random_u8s                    [3.4073 ns 3.4233 ns 3.4435 ns]
    
    old_alphanumeric_random_ascii_u8s              [4.2139 ns 4.2265 ns 4.2399 ns]
    new_alphanumeric_random_ascii_u8s              [3.5032 ns 3.5163 ns 3.5308 ns]
    
    old_alphanumeric_count_starting_u8_matches     [693.93 ns 696.62 ns 699.40 ns]
    new_alphanumeric_count_starting_u8_matches     [524.68 ns 526.25 ns 528.29 ns]
    
    old_alphanumeric_count_all_u8_matches          [569.94 ns 570.41 ns 570.91 ns]
    new_alphanumeric_count_all_u8_matches          [528.03 ns 528.55 ns 529.13 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_alphanumeric_random_chars                  [5.0263 ns 5.0306 ns 5.0357 ns]
    new_alphanumeric_random_chars                  [3.7684 ns 3.7751 ns 3.7827 ns]
    
    old_alphanumeric_random_ascii_chars            [4.0788 ns 4.0930 ns 4.1095 ns]
    new_alphanumeric_random_ascii_chars            [2.9815 ns 2.9938 ns 3.0078 ns]
    
    old_alphanumeric_count_starting_char_matches   [1.0443 µs 1.0472 µs 1.0500 µs]
    new_alphanumeric_count_starting_char_matches   [922.84 ns 928.49 ns 935.10 ns]
    
    old_alphanumeric_count_all_char_matches        [1.0186 µs 1.0199 µs 1.0214 µs]
    new_alphanumeric_count_all_char_matches        [983.83 ns 985.98 ns 988.75 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_control_random_u8s                         [3.4447 ns 3.4579 ns 3.4752 ns]
    new_control_random_u8s                         [3.4311 ns 3.4402 ns 3.4501 ns]
    
    old_control_random_ascii_u8s                   [3.3964 ns 3.4031 ns 3.4101 ns]
    new_control_random_ascii_u8s                   [3.3813 ns 3.3844 ns 3.3875 ns]
    
    old_control_count_starting_u8_matches          [367.62 ns 369.51 ns 372.04 ns]
    new_control_count_starting_u8_matches          [366.18 ns 366.87 ns 367.60 ns]
    
    old_control_count_all_u8_matches               [367.81 ns 370.70 ns 373.83 ns]
    new_control_count_all_u8_matches               [369.39 ns 371.93 ns 374.97 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_control_random_chars                       [4.2964 ns 4.3080 ns 4.3204 ns]
    new_control_random_chars                       [3.7769 ns 3.7802 ns 3.7833 ns]
    
    old_control_random_ascii_chars                 [3.0211 ns 3.0373 ns 3.0580 ns]
    new_control_random_ascii_chars                 [3.0132 ns 3.0167 ns 3.0204 ns]
    
    old_control_count_starting_char_matches        [652.25 ns 653.96 ns 656.19 ns]
    new_control_count_starting_char_matches        [650.50 ns 652.92 ns 655.99 ns]
    
    old_control_count_all_char_matches             [718.52 ns 719.64 ns 721.14 ns]
    new_control_count_all_char_matches             [721.26 ns 723.17 ns 725.62 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_digit_random_u8s                           [3.0215 ns 3.0297 ns 3.0381 ns]
    new_digit_random_u8s                           [3.0338 ns 3.0469 ns 3.0634 ns]
    
    old_digit_random_ascii_u8s                     [3.0760 ns 3.0854 ns 3.0961 ns]
    new_digit_random_ascii_u8s                     [3.0691 ns 3.0784 ns 3.0888 ns]
    
    old_digit_count_starting_u8_matches            [343.49 ns 344.24 ns 345.15 ns]
    new_digit_count_starting_u8_matches            [345.27 ns 346.70 ns 348.44 ns]
    
    old_digit_count_all_u8_matches                 [356.01 ns 357.67 ns 359.45 ns]
    new_digit_count_all_u8_matches                 [354.12 ns 355.12 ns 356.28 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_digit_random_chars                         [3.4950 ns 3.5117 ns 3.5323 ns]
    new_digit_random_chars                         [3.4743 ns 3.4877 ns 3.5037 ns]
    
    old_digit_random_ascii_chars                   [2.5715 ns 2.5826 ns 2.5949 ns]
    new_digit_random_ascii_chars                   [2.5697 ns 2.5769 ns 2.5848 ns]
    
    old_digit_count_starting_char_matches          [636.04 ns 641.03 ns 649.20 ns]
    new_digit_count_starting_char_matches          [639.68 ns 643.37 ns 647.17 ns]
    
    old_digit_count_all_char_matches               [722.52 ns 725.37 ns 728.21 ns]
    new_digit_count_all_char_matches               [719.47 ns 721.32 ns 723.36 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_graphic_random_u8s                         [3.3190 ns 3.3551 ns 3.3843 ns]
    new_graphic_random_u8s                         [3.0882 ns 3.0967 ns 3.1064 ns]
    
    old_graphic_random_ascii_u8s                   [3.0913 ns 3.0986 ns 3.1060 ns]
    new_graphic_random_ascii_u8s                   [3.0989 ns 3.1081 ns 3.1182 ns]
    
    old_graphic_count_starting_u8_matches          [342.60 ns 343.88 ns 345.66 ns]
    new_graphic_count_starting_u8_matches          [344.06 ns 344.78 ns 345.55 ns]
    
    old_graphic_count_all_u8_matches               [352.57 ns 354.25 ns 356.22 ns]
    new_graphic_count_all_u8_matches               [352.27 ns 353.06 ns 353.90 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_graphic_random_chars                       [3.5164 ns 3.5263 ns 3.5368 ns]
    new_graphic_random_chars                       [3.4822 ns 3.4864 ns 3.4907 ns]
    
    old_graphic_random_ascii_chars                 [2.9254 ns 2.9489 ns 2.9681 ns]
    new_graphic_random_ascii_chars                 [2.5876 ns 2.6009 ns 2.6168 ns]
    
    old_graphic_count_starting_char_matches        [651.06 ns 655.54 ns 662.12 ns]
    new_graphic_count_starting_char_matches        [640.98 ns 643.04 ns 645.44 ns]
    
    old_graphic_count_all_char_matches             [716.85 ns 719.11 ns 721.64 ns]
    new_graphic_count_all_char_matches             [714.54 ns 717.74 ns 721.62 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_hexdigit_random_u8s                        [5.0812 ns 5.0931 ns 5.1046 ns]
    new_hexdigit_random_u8s                        [3.4170 ns 3.4220 ns 3.4272 ns]
    
    old_hexdigit_random_ascii_u8s                  [7.2666 ns 7.2940 ns 7.3299 ns]
    new_hexdigit_random_ascii_u8s                  [3.4851 ns 3.4932 ns 3.5020 ns]
    
    old_hexdigit_count_starting_u8_matches         [573.07 ns 574.54 ns 576.40 ns]
    new_hexdigit_count_starting_u8_matches         [458.77 ns 461.59 ns 465.21 ns]
    
    old_hexdigit_count_all_u8_matches              [500.18 ns 500.52 ns 500.87 ns]
    new_hexdigit_count_all_u8_matches              [460.89 ns 462.94 ns 465.58 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_hexdigit_random_chars                      [3.5330 ns 3.5394 ns 3.5484 ns]
    new_hexdigit_random_chars                      [3.7271 ns 3.7380 ns 3.7502 ns]
    
    old_hexdigit_random_ascii_chars                [7.5202 ns 7.5235 ns 7.5270 ns]
    new_hexdigit_random_ascii_chars                [3.0244 ns 3.0357 ns 3.0491 ns]
    
    old_hexdigit_count_starting_char_matches       [991.64 ns 993.33 ns 995.28 ns]
    new_hexdigit_count_starting_char_matches       [930.71 ns 940.34 ns 948.51 ns]
    
    old_hexdigit_count_all_char_matches            [1.1238 µs 1.1350 µs 1.1447 µs]
    new_hexdigit_count_all_char_matches            [977.39 ns 979.53 ns 981.78 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_lowercase_random_u8s                       [3.0953 ns 3.1076 ns 3.1221 ns]
    new_lowercase_random_u8s                       [3.0904 ns 3.0994 ns 3.1084 ns]
    
    old_lowercase_random_ascii_u8s                 [3.1805 ns 3.2273 ns 3.2713 ns]
    new_lowercase_random_ascii_u8s                 [3.4254 ns 3.4486 ns 3.4654 ns]
    
    old_lowercase_count_starting_u8_matches        [347.22 ns 348.39 ns 349.67 ns]
    new_lowercase_count_starting_u8_matches        [346.10 ns 347.15 ns 348.72 ns]
    
    old_lowercase_count_all_u8_matches             [353.56 ns 354.57 ns 355.65 ns]
    new_lowercase_count_all_u8_matches             [354.32 ns 355.28 ns 356.27 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_lowercase_random_chars                     [3.2948 ns 3.3023 ns 3.3149 ns]
    new_lowercase_random_chars                     [3.3122 ns 3.3180 ns 3.3243 ns]
    
    old_lowercase_random_ascii_chars               [2.5756 ns 2.5829 ns 2.5904 ns]
    new_lowercase_random_ascii_chars               [2.6012 ns 2.6202 ns 2.6454 ns]
    
    old_lowercase_count_starting_char_matches      [626.86 ns 628.28 ns 630.05 ns]
    new_lowercase_count_starting_char_matches      [629.31 ns 630.67 ns 632.45 ns]
    
    old_lowercase_count_all_char_matches           [709.69 ns 711.13 ns 712.78 ns]
    new_lowercase_count_all_char_matches           [718.02 ns 719.76 ns 721.67 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_punctuation_random_u8s                     [6.2722 ns 6.2938 ns 6.3217 ns]
    new_punctuation_random_u8s                     [3.5554 ns 3.5736 ns 3.5945 ns]
    
    old_punctuation_random_ascii_u8s               [8.8529 ns 8.8959 ns 8.9767 ns]
    new_punctuation_random_ascii_u8s               [3.5184 ns 3.5280 ns 3.5397 ns]
    
    old_punctuation_count_starting_u8_matches      [723.52 ns 724.33 ns 725.25 ns]
    new_punctuation_count_starting_u8_matches      [550.47 ns 551.72 ns 553.41 ns]
    
    old_punctuation_count_all_u8_matches           [833.11 ns 836.23 ns 840.69 ns]
    new_punctuation_count_all_u8_matches           [562.60 ns 563.60 ns 564.71 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_punctuation_random_chars                   [4.1392 ns 4.1492 ns 4.1622 ns]
    new_punctuation_random_chars                   [3.9876 ns 4.0049 ns 4.0292 ns]
    
    old_punctuation_random_ascii_chars             [8.9137 ns 8.9430 ns 8.9746 ns]
    new_punctuation_random_ascii_chars             [3.0477 ns 3.0581 ns 3.0748 ns]
    
    old_punctuation_count_starting_char_matches    [1.0271 µs 1.0281 µs 1.0291 µs]
    new_punctuation_count_starting_char_matches    [875.45 ns 877.98 ns 881.44 ns]
    
    old_punctuation_count_all_char_matches         [1.1153 µs 1.1203 µs 1.1285 µs]
    new_punctuation_count_all_char_matches         [1.0607 µs 1.0646 µs 1.0692 µs]
    ══════════════════════════════════════════════════════════════════════════════
    old_uppercase_random_u8s                       [3.1160 ns 3.1366 ns 3.1629 ns]
    new_uppercase_random_u8s                       [3.0872 ns 3.1018 ns 3.1196 ns]
    
    old_uppercase_random_ascii_u8s                 [3.0782 ns 3.0834 ns 3.0889 ns]
    new_uppercase_random_ascii_u8s                 [3.1231 ns 3.1319 ns 3.1419 ns]
    
    old_uppercase_count_starting_u8_matches        [342.89 ns 343.13 ns 343.39 ns]
    new_uppercase_count_starting_u8_matches        [348.50 ns 349.39 ns 350.32 ns]
    
    old_uppercase_count_all_u8_matches             [350.61 ns 351.31 ns 352.07 ns]
    new_uppercase_count_all_u8_matches             [351.66 ns 352.14 ns 352.70 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_uppercase_random_chars                     [3.3175 ns 3.3312 ns 3.3494 ns]
    new_uppercase_random_chars                     [3.3111 ns 3.3197 ns 3.3316 ns]
    
    old_uppercase_random_ascii_chars               [2.5638 ns 2.5668 ns 2.5706 ns]
    new_uppercase_random_ascii_chars               [2.5732 ns 2.5777 ns 2.5827 ns]
    
    old_uppercase_count_starting_char_matches      [638.51 ns 640.16 ns 641.94 ns]
    new_uppercase_count_starting_char_matches      [627.35 ns 629.95 ns 633.50 ns]
    
    old_uppercase_count_all_char_matches           [712.99 ns 713.73 ns 714.59 ns]
    new_uppercase_count_all_char_matches           [711.21 ns 712.15 ns 713.24 ns]
    ══════════════════════════════════════════════════════════════════════════════
    old_whitespace_random_u8s                      [4.0565 ns 4.0599 ns 4.0635 ns]
    new_whitespace_random_u8s                      [3.4310 ns 3.4386 ns 3.4466 ns]
    
    old_whitespace_random_ascii_u8s                [5.9413 ns 5.9808 ns 6.0265 ns]
    new_whitespace_random_ascii_u8s                [3.4784 ns 3.5015 ns 3.5256 ns]
    
    old_whitespace_count_starting_u8_matches       [426.02 ns 427.22 ns 428.61 ns]
    new_whitespace_count_starting_u8_matches       [429.11 ns 430.45 ns 431.95 ns]
    
    old_whitespace_count_all_u8_matches            [481.43 ns 482.48 ns 483.67 ns]
    new_whitespace_count_all_u8_matches            [436.00 ns 436.82 ns 437.84 ns]
    ──────────────────────────────────────────────────────────────────────────────
    old_whitespace_random_chars                    [2.9669 ns 2.9779 ns 2.9907 ns]
    new_whitespace_random_chars                    [4.0033 ns 4.0069 ns 4.0109 ns]
    
    old_whitespace_random_ascii_chars              [5.5163 ns 5.5587 ns 5.6128 ns]
    new_whitespace_random_ascii_chars              [3.0361 ns 3.0432 ns 3.0532 ns]
    
    old_whitespace_count_starting_char_matches     [734.84 ns 739.56 ns 746.44 ns]
    new_whitespace_count_starting_char_matches     [732.86 ns 734.84 ns 737.33 ns]
    
    old_whitespace_count_all_char_matches          [812.69 ns 813.49 ns 814.42 ns]
    new_whitespace_count_all_char_matches          [855.98 ns 871.39 ns 886.61 ns]
    ══════════════════════════════════════════════════════════════════════════════
</details>