### PR TITLE
Handle projections as uncovered types during coherence check

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -641,18 +641,7 @@ impl<'tcx> OrphanChecker<'tcx> {
     #[instrument(skip(self), level = "debug")]
     fn found_uncovered_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<OrphanCheckEarlyExit<'tcx>> {
         if self.search_first_local_ty {
-            return ControlFlow::CONTINUE;
-        };
-
-        // Fully concrete projections are OK, so check
-        // and only exit if there's generics
-        if let ty::Projection(proj) = *t.kind() {
-            if proj.has_type_flags(TypeFlags::HAS_TY_PARAM) {
-                debug!("found_uncovered_ty: type parameter found in projection, exit orphan check");
-                ControlFlow::Break(OrphanCheckEarlyExit::ParamTy(t))
-            } else {
-                ControlFlow::CONTINUE
-            }
+            ControlFlow::CONTINUE
         } else {
             ControlFlow::Break(OrphanCheckEarlyExit::ParamTy(t))
         }
@@ -693,7 +682,15 @@ impl<'tcx> TypeVisitor<'tcx> for OrphanChecker<'tcx> {
             | ty::Never
             | ty::Tuple(..) => self.found_non_local_ty(ty),
 
-            ty::Param(..) | ty::Projection(..) => self.found_uncovered_ty(ty),
+            ty::Param(..) => self.found_uncovered_ty(ty),
+
+            ty::Projection(proj) => {
+                if proj.has_type_flags(TypeFlags::HAS_TY_PARAM) {
+                    self.found_uncovered_ty(ty)
+                } else {
+                    ControlFlow::CONTINUE
+                }
+            }
 
             ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) => match self.in_crate {
                 InCrate::Local => self.found_non_local_ty(ty),

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -674,12 +674,7 @@ impl<'tcx> TypeVisitor<'tcx> for OrphanChecker<'tcx> {
             | ty::Never
             | ty::Tuple(..) => self.found_non_local_ty(ty),
 
-            ty::Param(..) => self.found_uncovered_ty(ty),
-
-            ty::Projection(..) => {
-                self.found_non_local_ty(ty);
-                self.found_uncovered_ty(ty)
-            }
+            ty::Param(..) | ty::Projection(..) => self.found_uncovered_ty(ty),
 
             ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) => match self.in_crate {
                 InCrate::Local => self.found_non_local_ty(ty),

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -631,7 +631,7 @@ impl<'tcx> OrphanChecker<'tcx> {
         ControlFlow::CONTINUE
     }
 
-    fn found_param_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<OrphanCheckEarlyExit<'tcx>> {
+    fn found_uncovered_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<OrphanCheckEarlyExit<'tcx>> {
         if self.search_first_local_ty {
             ControlFlow::CONTINUE
         } else {
@@ -672,10 +672,14 @@ impl<'tcx> TypeVisitor<'tcx> for OrphanChecker<'tcx> {
             | ty::Slice(..)
             | ty::RawPtr(..)
             | ty::Never
-            | ty::Tuple(..)
-            | ty::Projection(..) => self.found_non_local_ty(ty),
+            | ty::Tuple(..) => self.found_non_local_ty(ty),
 
-            ty::Param(..) => self.found_param_ty(ty),
+            ty::Param(..) => self.found_uncovered_ty(ty),
+
+            ty::Projection(..) => {
+                self.found_non_local_ty(ty);
+                self.found_uncovered_ty(ty)
+            }
 
             ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) => match self.in_crate {
                 InCrate::Local => self.found_non_local_ty(ty),

--- a/compiler/rustc_typeck/src/coherence/orphan.rs
+++ b/compiler/rustc_typeck/src/coherence/orphan.rs
@@ -299,7 +299,7 @@ fn emit_orphan_check_error<'tcx>(
                                 tcx.sess,
                                 sp,
                                 E0210,
-                                "type projection `{}` must be covered by another type \
+                                "associated type `{}` must be covered by another type \
                                 when it appears before the first local type (`{}`)",
                                 param_ty,
                                 local_type
@@ -307,7 +307,7 @@ fn emit_orphan_check_error<'tcx>(
                             err.span_label(
                                 sp,
                                 format!(
-                                    "type projection `{}` must be covered by another type \
+                                    "associated type `{}` must be covered by another type \
                                     when it appears before the first local type (`{}`)",
                                     param_ty, local_type
                                 ),
@@ -339,8 +339,8 @@ fn emit_orphan_check_error<'tcx>(
                     err.note(
                         "implementing a foreign trait is only possible if at \
                         least one of the types for which it is implemented is local, \
-                        and no uncovered type parameters or projections appear before that first \
-                        local type",
+                        and no uncovered type parameters or associated types appear \
+                        before that first local type",
                     )
                     .note(
                         "in this case, 'before' refers to the following order: \

--- a/src/test/ui/coherence/auxiliary/coherence_projection_assoc.rs
+++ b/src/test/ui/coherence/auxiliary/coherence_projection_assoc.rs
@@ -1,0 +1,3 @@
+pub trait Foreign<T, U> {
+    type Assoc;
+}

--- a/src/test/ui/coherence/coherence-all-remote.stderr
+++ b/src/test/ui/coherence/coherence-all-remote.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-all-remote.rs:6:6
+  --> $DIR/coherence-all-remote.rs:6:17
    |
 LL | impl<T> Remote1<T> for isize { }
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                 ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/coherence-bigint-param.stderr
+++ b/src/test/ui/coherence/coherence-bigint-param.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<BigInt> for T { }
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-bigint-param.stderr
+++ b/src/test/ui/coherence/coherence-bigint-param.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<BigInt> for T { }
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-bigint-param.stderr
+++ b/src/test/ui/coherence/coherence-bigint-param.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
-  --> $DIR/coherence-bigint-param.rs:8:6
+  --> $DIR/coherence-bigint-param.rs:8:29
    |
 LL | impl<T> Remote1<BigInt> for T { }
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
+   |                             ^ type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last

--- a/src/test/ui/coherence/coherence-cross-crate-conflict.stderr
+++ b/src/test/ui/coherence/coherence-cross-crate-conflict.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `A` must be used as the type parameter for some local type (e.g., `MyStruct<A>`)
-  --> $DIR/coherence-cross-crate-conflict.rs:9:6
+  --> $DIR/coherence-cross-crate-conflict.rs:9:17
    |
 LL | impl<A> Foo for A {
-   |      ^ type parameter `A` must be used as the type parameter for some local type
+   |                 ^ type parameter `A` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/coherence-lone-type-parameter.stderr
+++ b/src/test/ui/coherence/coherence-lone-type-parameter.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-lone-type-parameter.rs:6:6
+  --> $DIR/coherence-lone-type-parameter.rs:6:20
    |
 LL | impl<T> Remote for T { }
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                    ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty-2.rs
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty-2.rs
@@ -1,0 +1,24 @@
+// Here we expect that orphan rule is violated
+// because T is an uncovered parameter appearing
+// before the first local (Issue #99554)
+
+// aux-build:coherence_projection_assoc.rs
+
+extern crate coherence_projection_assoc as lib;
+use lib::Foreign;
+
+trait Id {
+    type Assoc;
+}
+
+impl<T> Id for T {
+    type Assoc = T;
+}
+
+pub struct B;
+impl<T> Foreign<B, T> for <Vec<Vec<T>> as Id>::Assoc {
+    //~^ ERROR E0210
+    type Assoc = usize;
+}
+
+fn main() {}

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty-2.stderr
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty-2.stderr
@@ -1,0 +1,12 @@
+error[E0210]: associated type `<Vec<Vec<T>> as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
+  --> $DIR/coherence-projection-uncovered-ty-2.rs:19:27
+   |
+LL | impl<T> Foreign<B, T> for <Vec<Vec<T>> as Id>::Assoc {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ associated type `<Vec<Vec<T>> as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0210`.

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty-3.rs
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty-3.rs
@@ -1,0 +1,20 @@
+// aux-build:coherence_projection_assoc.rs
+
+extern crate coherence_projection_assoc as lib;
+use lib::Foreign;
+
+trait Id {
+    type Assoc;
+}
+
+impl<T> Id for T {
+    type Assoc = T;
+}
+
+pub struct Local<T>(T);
+impl<T> Foreign<<T as Id>::Assoc, Local<T>> for () {
+    //~^ ERROR E0210
+    type Assoc = usize;
+}
+
+fn main() {}

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty-3.stderr
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty-3.stderr
@@ -1,0 +1,12 @@
+error[E0210]: associated type `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`Local<T>`)
+  --> $DIR/coherence-projection-uncovered-ty-3.rs:15:17
+   |
+LL | impl<T> Foreign<<T as Id>::Assoc, Local<T>> for () {
+   |                 ^^^^^^^^^^^^^^^^ associated type `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`Local<T>`)
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0210`.

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty-4.rs
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty-4.rs
@@ -1,0 +1,19 @@
+// aux-build:coherence_projection_assoc.rs
+
+extern crate coherence_projection_assoc as lib;
+use lib::Foreign;
+
+trait Id {
+    type Assoc;
+}
+
+impl<T> Id for T {
+    type Assoc = T;
+}
+
+impl<T> Foreign<(), Vec<T>> for <T as Id>::Assoc {
+//~^ ERROR E0210
+    type Assoc = usize;
+}
+
+fn main() {}

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty-4.stderr
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty-4.stderr
@@ -1,0 +1,12 @@
+error[E0210]: associated type `<T as Id>::Assoc` must be used as the type parameter for some local type (e.g., `MyStruct<<T as Id>::Assoc>`)
+  --> $DIR/coherence-projection-uncovered-ty-4.rs:14:33
+   |
+LL | impl<T> Foreign<(), Vec<T>> for <T as Id>::Assoc {
+   |                                 ^^^^^^^^^^^^^^^^ associated type `<T as Id>::Assoc` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0210`.

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty.rs
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty.rs
@@ -1,0 +1,24 @@
+// Here we expect that orphan rule is violated
+// because T is an uncovered parameter appearing
+// before the first local (Issue #99554)
+
+// aux-build:coherence_projection_assoc.rs
+
+extern crate coherence_projection_assoc as lib;
+use lib::Foreign;
+
+trait Id {
+    type Assoc;
+}
+
+impl<T> Id for T {
+    type Assoc = T;
+}
+
+pub struct B;
+impl<T> Foreign<B, T> for <T as Id>::Assoc {
+//~^ ERROR E0210
+    type Assoc = usize;
+}
+
+fn main() {}

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty.stderr
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty.stderr
@@ -1,10 +1,10 @@
-error[E0210]: type projection `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
+error[E0210]: associated type `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
   --> $DIR/coherence-projection-uncovered-ty.rs:19:27
    |
 LL | impl<T> Foreign<B, T> for <T as Id>::Assoc {
-   |                           ^^^^^^^^^^^^^^^^ type projection `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
+   |                           ^^^^^^^^^^^^^^^^ associated type `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-projection-uncovered-ty.stderr
+++ b/src/test/ui/coherence/coherence-projection-uncovered-ty.stderr
@@ -1,0 +1,12 @@
+error[E0210]: type projection `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
+  --> $DIR/coherence-projection-uncovered-ty.rs:19:27
+   |
+LL | impl<T> Foreign<B, T> for <T as Id>::Assoc {
+   |                           ^^^^^^^^^^^^^^^^ type projection `<T as Id>::Assoc` must be covered by another type when it appears before the first local type (`B`)
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0210`.

--- a/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].rs
+++ b/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for
+    //~^ ERROR type parameter `T` as argument to a fundamental type must be used as the type parameter for
     // | some local type (e.g., `MyStruct<T>`)
 }
 

--- a/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign-for-fundamental[t].rs:10:6
+error[E0210]: type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/impl[t]-foreign-for-fundamental[t].rs:10:20
    |
 LL | impl<T> Remote for Box<T> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                    ^^^^^^ type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].rs
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].rs
@@ -8,11 +8,13 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<u32> for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` as argument to a fundamental type
+    // | must be used as the type parameter for some local type
 }
 
 impl<'a, T> Remote1<u32> for &'a T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` as argument to a fundamental type
+    // | must be used as the type parameter for some local type
 }
 
 fn main() {}

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:10:6
+error[E0210]: type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:10:26
    |
 LL | impl<T> Remote1<u32> for Box<T> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                          ^^^^^^ type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:14:10
+error[E0210]: type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:15:30
    |
 LL | impl<'a, T> Remote1<u32> for &'a T {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |                              ^^^^^ type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[foreign]-for-t.rs:10:6
+  --> $DIR/impl[t]-foreign[foreign]-for-t.rs:10:26
    |
 LL | impl<T> Remote1<u32> for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
@@ -1,17 +1,17 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:10:6
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:10:17
    |
 LL | impl<T> Remote1<Box<T>> for u32 {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                 ^^^^^^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:14:10
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:14:21
    |
 LL | impl<'a, T> Remote1<&'a T> for u32 {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |                     ^^^^^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs
@@ -8,10 +8,12 @@ use std::rc::Rc;
 struct Local;
 
 impl<'a, T> Remote1<Box<T>> for &'a T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` as argument to a fundamental type
+    // | must be used as the type parameter for some local type
 }
 impl<'a, T> Remote1<&'a T> for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` as argument to a fundamental type
+    // | must be used as the type parameter for some local type
 }
 
 fn main() {}

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:10:10
+error[E0210]: type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:10:33
    |
 LL | impl<'a, T> Remote1<Box<T>> for &'a T {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |                                 ^^^^^ type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:13:10
+error[E0210]: type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:14:32
    |
 LL | impl<'a, T> Remote1<&'a T> for Box<T> {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |                                ^^^^^^ type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
@@ -1,17 +1,17 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:10:6
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:10:29
    |
 LL | impl<T> Remote1<Box<T>> for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                             ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:13:10
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:13:32
    |
 LL | impl<'a, T> Remote1<&'a T> for T {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |                                ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote2<Box<T>, Local> for u32 {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<'a, T> Remote2<&'a T, Local> for u32 {
    |          ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
@@ -1,17 +1,17 @@
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
-  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:10:6
+  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:10:17
    |
 LL | impl<T> Remote2<Box<T>, Local> for u32 {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |                 ^^^^^^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
-  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:14:10
+  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:14:21
    |
 LL | impl<'a, T> Remote2<&'a T, Local> for u32 {
-   |          ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |                     ^^^^^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote2<Box<T>, Local> for u32 {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<'a, T> Remote2<&'a T, Local> for u32 {
    |          ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].rs
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].rs
@@ -8,11 +8,13 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<Local> for Box<T> {
-    //~^ ERROR type parameter `T` must be covered by another type
+    //~^ ERROR type parameter `T` as argument to a fundamental type
+    // | must be covered by another type when it appears before the first local type (`Local`)
 }
 
 impl<T> Remote1<Local> for &T {
-    //~^ ERROR type parameter `T` must be covered by another type
+    //~^ ERROR type parameter `T` as argument to a fundamental type
+    // | must be covered by another type when it appears before the first local type (`Local`)
 }
 
 fn main() {}

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for Box<T> {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for &T {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for Box<T> {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for &T {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
-  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:10:6
+error[E0210]: type parameter `T` as argument to a fundamental type must be covered by another type when it appears before the first local type (`Local`)
+  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:10:28
    |
 LL | impl<T> Remote1<Local> for Box<T> {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |                            ^^^^^^ type parameter `T` as argument to a fundamental type must be covered by another type when it appears before the first local type (`Local`)
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
-error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
-  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:14:6
+error[E0210]: type parameter `T` as argument to a fundamental type must be covered by another type when it appears before the first local type (`Local`)
+  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:15:28
    |
 LL | impl<T> Remote1<Local> for &T {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |                            ^^ type parameter `T` as argument to a fundamental type must be covered by another type when it appears before the first local type (`Local`)
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
-  --> $DIR/impl[t]-foreign[local]-for-t.rs:10:6
+  --> $DIR/impl[t]-foreign[local]-for-t.rs:10:28
    |
 LL | impl<T> Remote1<Local> for T {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |                            ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for T {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or associated types appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for T {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters or projections appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[t]-for-foreign.rs:10:6
+  --> $DIR/impl[t]-foreign[t]-for-foreign.rs:10:17
    |
 LL | impl<T> Remote1<T> for u32 {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                 ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.rs
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.rs
@@ -8,11 +8,13 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<T> for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` as argument to a fundamental type
+    // | must be used as the type parameter for some local type
 }
 
 impl<'a, A, B> Remote1<A> for &'a B {
-    //~^ ERROR type parameter `B` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `B` as argument to a fundamental type
+    // | must be used as the type parameter for some local type
 }
 
 fn main() {}

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:10:6
+error[E0210]: type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:10:24
    |
 LL | impl<T> Remote1<T> for Box<T> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                        ^^^^^^ type parameter `T` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `B` must be used as the type parameter for some local type (e.g., `MyStruct<B>`)
-  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:14:13
+error[E0210]: type parameter `B` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<B>`)
+  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:15:31
    |
 LL | impl<'a, A, B> Remote1<A> for &'a B {
-   |             ^ type parameter `B` must be used as the type parameter for some local type
+   |                               ^^^^^ type parameter `B` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[t]-for-t.rs:10:6
+  --> $DIR/impl[t]-foreign[t]-for-t.rs:10:24
    |
 LL | impl<T> Remote1<T> for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                        ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/coherence/issue-100191.stderr
+++ b/src/test/ui/coherence/issue-100191.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/issue-100191.rs:18:6
+  --> $DIR/issue-100191.rs:18:38
    |
 LL | impl<T> From<<A<T> as Z>::Assoc> for T {}
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                                      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/error-codes/e0119/issue-28981.stderr
+++ b/src/test/ui/error-codes/e0119/issue-28981.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `Foo` must be used as the type parameter for some local type (e.g., `MyStruct<Foo>`)
-  --> $DIR/issue-28981.rs:5:6
+  --> $DIR/issue-28981.rs:5:21
    |
 LL | impl<Foo> Deref for Foo { }
-   |      ^^^ type parameter `Foo` must be used as the type parameter for some local type
+   |                     ^^^ type parameter `Foo` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/issues/issue-41974.stderr
+++ b/src/test/ui/issues/issue-41974.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/issue-41974.rs:7:6
+  --> $DIR/issue-41974.rs:7:18
    |
 LL | impl<T> Drop for T where T: A {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                  ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/orphan-check-diagnostics.stderr
+++ b/src/test/ui/orphan-check-diagnostics.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/orphan-check-diagnostics.rs:11:6
+  --> $DIR/orphan-check-diagnostics.rs:11:25
    |
 LL | impl<T> RemoteTrait for T where T: LocalTrait {}
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                         ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/specialization/issue-43037.stderr
+++ b/src/test/ui/specialization/issue-43037.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/issue-43037.rs:17:6
+  --> $DIR/issue-43037.rs:17:38
    |
 LL | impl<T> From<<A<T> as Z>::Assoc> for T {}
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |                                      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/src/test/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.rs
+++ b/src/test/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.rs
@@ -8,7 +8,9 @@ trait MyTrait {}
 impl MyTrait for () {}
 
 impl<F> FnOnce<()> for &F {
-    //~^ ERROR type parameter `F` must be used
+    //~^ ERROR type parameter `F` as argument to a fundamental type
+    // | must be used as the type parameter for some local type
+    // | (e.g., `MyStruct<F>`)
     type Output = impl MyTrait;
     extern "rust-call" fn call_once(self, _: ()) -> Self::Output {}
 }

--- a/src/test/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.stderr
+++ b/src/test/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `F` must be used as the type parameter for some local type (e.g., `MyStruct<F>`)
-  --> $DIR/incoherent-assoc-imp-trait.rs:10:6
+error[E0210]: type parameter `F` as argument to a fundamental type must be used as the type parameter for some local type (e.g., `MyStruct<F>`)
+  --> $DIR/incoherent-assoc-imp-trait.rs:10:24
    |
 LL | impl<F> FnOnce<()> for &F {
-   |      ^ type parameter `F` must be used as the type parameter for some local type
+   |                        ^^ type parameter `F` as argument to a fundamental type must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter


### PR DESCRIPTION
Fixes #99554. Update code to handle projections as uncovered types during coherence check/orphan check & update error messages accordingly.