### PR TITLE
Fix STD build for ESP-IDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,9 +2140,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.129"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 dependencies = [
  "rustc-std-workspace-core",
 ]


### PR DESCRIPTION
We have accidentally broken the STD build for the Tier 3 `target_os="espidf"` (only) by pushing non-buildable changes to `libc` which ended up in version 0.2.229.

`libc` [was fixed](https://github.com/rust-lang/libc/commit/d0e3ff01a808d429baf925bf0e6e5f2273de1ac0) from V0.2.230 onwards. This PR is only upgrading the `libc` dependency in `Cargo.lock` to latest (V0.2.231).

`Cargo.lock` was modified by using `cargo update -p libc`.
