### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -130,64 +130,46 @@ impl PositionalNamedArgsLint {
     /// CountIsParam, which contains an index into the arguments.
     fn maybe_add_positional_named_arg(
         &mut self,
-        current_positional_arg: usize,
-        total_args_length: usize,
-        format_argument_index: usize,
+        arg: Option<&FormatArg>,
         ty: PositionalNamedArgType,
         cur_piece: usize,
         inner_span_to_replace: Option<rustc_parse_format::InnerSpan>,
-        names: &FxHashMap<Symbol, (usize, Span)>,
         has_formatting: bool,
     ) {
-        let start_of_named_args = total_args_length - names.len();
-        if current_positional_arg >= start_of_named_args {
-            self.maybe_push(
-                format_argument_index,
-                ty,
-                cur_piece,
-                inner_span_to_replace,
-                names,
-                has_formatting,
-            )
+        if let Some(arg) = arg {
+            if let Some(name) = arg.name {
+                self.push(name, ty, cur_piece, inner_span_to_replace, has_formatting)
+            }
         }
     }
 
-    /// Try constructing a PositionalNamedArg struct and pushing it into the vec of positional
-    /// named arguments. If a named arg associated with `format_argument_index` cannot be found,
-    /// a new item will not be added as the lint cannot be emitted in this case.
-    fn maybe_push(
+    /// Construct a PositionalNamedArg struct and push it into the vec of positional
+    /// named arguments.
+    fn push(
         &mut self,
-        format_argument_index: usize,
+        arg_name: Ident,
         ty: PositionalNamedArgType,
         cur_piece: usize,
         inner_span_to_replace: Option<rustc_parse_format::InnerSpan>,
-        names: &FxHashMap<Symbol, (usize, Span)>,
         has_formatting: bool,
     ) {
-        let named_arg = names
-            .iter()
-            .find(|&(_, &(index, _))| index == format_argument_index)
-            .map(|found| found.clone());
-
-        if let Some((&replacement, &(_, positional_named_arg_span))) = named_arg {
-            // In FormatSpec, `precision_span` starts at the leading `.`, which we want to keep in
-            // the lint suggestion, so increment `start` by 1 when `PositionalArgumentType` is
-            // `Precision`.
-            let inner_span_to_replace = if ty == PositionalNamedArgType::Precision {
-                inner_span_to_replace
-                    .map(|is| rustc_parse_format::InnerSpan { start: is.start + 1, end: is.end })
-            } else {
-                inner_span_to_replace
-            };
-            self.positional_named_args.push(PositionalNamedArg {
-                ty,
-                cur_piece,
-                inner_span_to_replace,
-                replacement,
-                positional_named_arg_span,
-                has_formatting,
-            });
-        }
+        // In FormatSpec, `precision_span` starts at the leading `.`, which we want to keep in
+        // the lint suggestion, so increment `start` by 1 when `PositionalArgumentType` is
+        // `Precision`.
+        let inner_span_to_replace = if ty == PositionalNamedArgType::Precision {
+            inner_span_to_replace
+                .map(|is| rustc_parse_format::InnerSpan { start: is.start + 1, end: is.end })
+        } else {
+            inner_span_to_replace
+        };
+        self.positional_named_args.push(PositionalNamedArg {
+            ty,
+            cur_piece,
+            inner_span_to_replace,
+            replacement: arg_name.name,
+            positional_named_arg_span: arg_name.span,
+            has_formatting,
+        });
     }
 }
 
@@ -211,7 +193,7 @@ struct Context<'a, 'b> {
     /// * `arg_types` (in JSON): `[[0, 1, 0], [0, 1, 1], [0, 1]]`
     /// * `arg_unique_types` (in simplified JSON): `[["o", "x"], ["o", "x"], ["o", "x"]]`
     /// * `names` (in JSON): `{"foo": 2}`
-    args: Vec<P<ast::Expr>>,
+    args: Vec<FormatArg>,
     /// The number of arguments that were added by implicit capturing.
     num_captured_args: usize,
     /// Placeholder slot numbers indexed by argument.
@@ -219,7 +201,7 @@ struct Context<'a, 'b> {
     /// Unique format specs seen for each argument.
     arg_unique_types: Vec<Vec<ArgumentType>>,
     /// Map from named arguments to their resolved indices.
-    names: FxHashMap<Symbol, (usize, Span)>,
+    names: FxHashMap<Symbol, usize>,
 
     /// The latest consecutive literal strings, or empty if there weren't any.
     literal: String,
@@ -282,7 +264,7 @@ struct Context<'a, 'b> {
 
 pub struct FormatArg {
     expr: P<ast::Expr>,
-    named: bool,
+    name: Option<Ident>,
 }
 
 /// Parses the arguments from the given list of tokens, returning the diagnostic
@@ -298,9 +280,9 @@ fn parse_args<'a>(
     ecx: &mut ExtCtxt<'a>,
     sp: Span,
     tts: TokenStream,
-) -> PResult<'a, (P<ast::Expr>, Vec<FormatArg>, FxHashMap<Symbol, (usize, Span)>)> {
+) -> PResult<'a, (P<ast::Expr>, Vec<FormatArg>, FxHashMap<Symbol, usize>)> {
     let mut args = Vec::<FormatArg>::new();
-    let mut names = FxHashMap::<Symbol, (usize, Span)>::default();
+    let mut names = FxHashMap::<Symbol, usize>::default();
 
     let mut p = ecx.new_parser_from_tts(tts);
 
@@ -365,9 +347,9 @@ fn parse_args<'a>(
                 p.bump();
                 p.expect(&token::Eq)?;
                 let e = p.parse_expr()?;
-                if let Some((prev, _)) = names.get(&ident.name) {
+                if let Some(&prev) = names.get(&ident.name) {
                     ecx.struct_span_err(e.span, &format!("duplicate argument named `{}`", ident))
-                        .span_label(args[*prev].expr.span, "previously here")
+                        .span_label(args[prev].expr.span, "previously here")
                         .span_label(e.span, "duplicate argument")
                         .emit();
                     continue;
@@ -378,8 +360,8 @@ fn parse_args<'a>(
                 // if the input is valid, we can simply append to the positional
                 // args. And remember the names.
                 let slot = args.len();
-                names.insert(ident.name, (slot, ident.span));
-                args.push(FormatArg { expr: e, named: true });
+                names.insert(ident.name, slot);
+                args.push(FormatArg { expr: e, name: Some(ident) });
             }
             _ => {
                 let e = p.parse_expr()?;
@@ -389,12 +371,12 @@ fn parse_args<'a>(
                         "positional arguments cannot follow named arguments",
                     );
                     err.span_label(e.span, "positional arguments must be before named arguments");
-                    for pos in names.values() {
-                        err.span_label(args[pos.0].expr.span, "named argument");
+                    for &pos in names.values() {
+                        err.span_label(args[pos].expr.span, "named argument");
                     }
                     err.emit();
                 }
-                args.push(FormatArg { expr: e, named: false });
+                args.push(FormatArg { expr: e, name: None });
             }
         }
     }
@@ -410,8 +392,7 @@ impl<'a, 'b> Context<'a, 'b> {
     fn resolve_name_inplace(&mut self, p: &mut parse::Piece<'_>) {
         // NOTE: the `unwrap_or` branch is needed in case of invalid format
         // arguments, e.g., `format_args!("{foo}")`.
-        let lookup =
-            |s: &str| self.names.get(&Symbol::intern(s)).unwrap_or(&(0, Span::default())).0;
+        let lookup = |s: &str| self.names.get(&Symbol::intern(s)).copied().unwrap_or(0);
 
         match *p {
             parse::String(_) => {}
@@ -457,13 +438,10 @@ impl<'a, 'b> Context<'a, 'b> {
                 let pos = match arg.position {
                     parse::ArgumentIs(i) => {
                         self.unused_names_lint.maybe_add_positional_named_arg(
-                            i,
-                            self.args.len(),
-                            i,
+                            self.args.get(i),
                             PositionalNamedArgType::Arg,
                             self.curpiece,
                             Some(arg.position_span),
-                            &self.names,
                             has_precision || has_width,
                         );
 
@@ -471,13 +449,10 @@ impl<'a, 'b> Context<'a, 'b> {
                     }
                     parse::ArgumentImplicitlyIs(i) => {
                         self.unused_names_lint.maybe_add_positional_named_arg(
-                            i,
-                            self.args.len(),
-                            i,
+                            self.args.get(i),
                             PositionalNamedArgType::Arg,
                             self.curpiece,
                             None,
-                            &self.names,
                             has_precision || has_width,
                         );
                         Exact(i)
@@ -563,13 +538,10 @@ impl<'a, 'b> Context<'a, 'b> {
             parse::CountImplied | parse::CountIs(..) => {}
             parse::CountIsParam(i) => {
                 self.unused_names_lint.maybe_add_positional_named_arg(
-                    i,
-                    self.args.len(),
-                    i,
+                    self.args.get(i),
                     named_arg_type,
                     self.curpiece,
                     *inner_span,
-                    &self.names,
                     true,
                 );
                 self.verify_arg_type(Exact(i), Count);
@@ -622,7 +594,7 @@ impl<'a, 'b> Context<'a, 'b> {
             );
             for arg in &self.args {
                 // Point at the arguments that will be formatted.
-                e.span_label(arg.span, "");
+                e.span_label(arg.expr.span, "");
             }
         } else {
             let (mut refs, spans): (Vec<_>, Vec<_>) = refs.unzip();
@@ -692,7 +664,7 @@ impl<'a, 'b> Context<'a, 'b> {
                         );
                         if let Some(arg) = self.args.get(pos) {
                             e.span_label(
-                                arg.span,
+                                arg.expr.span,
                                 "this parameter corresponds to the precision flag",
                             );
                         }
@@ -771,7 +743,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 match self.names.get(&name) {
                     Some(&idx) => {
                         // Treat as positional arg.
-                        self.verify_arg_type(Capture(idx.0), ty)
+                        self.verify_arg_type(Capture(idx), ty)
                     }
                     None => {
                         // For the moment capturing variables from format strings expanded from macros is
@@ -787,8 +759,11 @@ impl<'a, 'b> Context<'a, 'b> {
                                 self.fmtsp
                             };
                             self.num_captured_args += 1;
-                            self.args.push(self.ecx.expr_ident(span, Ident::new(name, span)));
-                            self.names.insert(name, (idx, span));
+                            self.args.push(FormatArg {
+                                expr: self.ecx.expr_ident(span, Ident::new(name, span)),
+                                name: Some(Ident::new(name, span)),
+                            });
+                            self.names.insert(name, idx);
                             self.verify_arg_type(Capture(idx), ty)
                         } else {
                             let msg = format!("there is no argument named `{}`", name);
@@ -1054,11 +1029,11 @@ impl<'a, 'b> Context<'a, 'b> {
         // evaluated a single time each, in the order written by the programmer,
         // and that the surrounding future/generator (if any) is Send whenever
         // possible.
-        let no_need_for_match =
-            nicely_ordered && !original_args.iter().skip(1).any(|e| may_contain_yield_point(e));
+        let no_need_for_match = nicely_ordered
+            && !original_args.iter().skip(1).any(|arg| may_contain_yield_point(&arg.expr));
 
         for (arg_index, arg_ty) in fmt_arg_index_and_ty {
-            let e = &mut original_args[arg_index];
+            let e = &mut original_args[arg_index].expr;
             let span = e.span;
             let arg = if no_need_for_match {
                 let expansion_span = e.span.with_ctxt(self.macsp.ctxt());
@@ -1087,7 +1062,9 @@ impl<'a, 'b> Context<'a, 'b> {
                 // span is otherwise unavailable in the MIR used by borrowck).
                 let heads = original_args
                     .into_iter()
-                    .map(|e| self.ecx.expr_addr_of(e.span.with_ctxt(self.macsp.ctxt()), e))
+                    .map(|arg| {
+                        self.ecx.expr_addr_of(arg.expr.span.with_ctxt(self.macsp.ctxt()), arg.expr)
+                    })
                     .collect();
 
                 let pat = self.ecx.pat_ident(self.macsp, Ident::new(sym::args, self.macsp));
@@ -1220,7 +1197,7 @@ pub fn expand_preparsed_format_args(
     sp: Span,
     efmt: P<ast::Expr>,
     args: Vec<FormatArg>,
-    names: FxHashMap<Symbol, (usize, Span)>,
+    names: FxHashMap<Symbol, usize>,
     append_newline: bool,
 ) -> P<ast::Expr> {
     // NOTE: this verbose way of initializing `Vec<Vec<ArgumentType>>` is because
@@ -1312,16 +1289,17 @@ pub fn expand_preparsed_format_args(
         if err.should_be_replaced_with_positional_argument {
             let captured_arg_span =
                 fmt_span.from_inner(InnerSpan::new(err.span.start, err.span.end));
-            let positional_args = args.iter().filter(|arg| !arg.named).collect::<Vec<_>>();
+            let n_positional_args =
+                args.iter().rposition(|arg| arg.name.is_none()).map_or(0, |i| i + 1);
             if let Ok(arg) = ecx.source_map().span_to_snippet(captured_arg_span) {
-                let span = match positional_args.last() {
+                let span = match args[..n_positional_args].last() {
                     Some(arg) => arg.expr.span,
                     None => fmt_sp,
                 };
                 e.multipart_suggestion_verbose(
                     "consider using a positional formatting argument instead",
                     vec![
-                        (captured_arg_span, positional_args.len().to_string()),
+                        (captured_arg_span, n_positional_args.to_string()),
                         (span.shrink_to_hi(), format!(", {}", arg)),
                     ],
                     Applicability::MachineApplicable,
@@ -1338,11 +1316,11 @@ pub fn expand_preparsed_format_args(
         .map(|span| fmt_span.from_inner(InnerSpan::new(span.start, span.end)))
         .collect();
 
-    let named_pos: FxHashSet<usize> = names.values().cloned().map(|(i, _)| i).collect();
+    let named_pos: FxHashSet<usize> = names.values().cloned().collect();
 
     let mut cx = Context {
         ecx,
-        args: args.into_iter().map(|arg| arg.expr).collect(),
+        args,
         num_captured_args: 0,
         arg_types,
         arg_unique_types,
@@ -1417,7 +1395,7 @@ pub fn expand_preparsed_format_args(
                 // positional argument
                 "argument never used"
             };
-            (cx.args[i].span, msg)
+            (cx.args[i].expr.span, msg)
         })
         .collect::<Vec<_>>();
 

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -1316,8 +1316,6 @@ pub fn expand_preparsed_format_args(
         .map(|span| fmt_span.from_inner(InnerSpan::new(span.start, span.end)))
         .collect();
 
-    let named_pos: FxHashSet<usize> = names.values().cloned().collect();
-
     let mut cx = Context {
         ecx,
         args,
@@ -1388,11 +1386,9 @@ pub fn expand_preparsed_format_args(
         .enumerate()
         .filter(|(i, ty)| ty.is_empty() && !cx.count_positions.contains_key(&i))
         .map(|(i, _)| {
-            let msg = if named_pos.contains(&i) {
-                // named argument
+            let msg = if cx.args[i].name.is_some() {
                 "named argument never used"
             } else {
-                // positional argument
                 "argument never used"
             };
             (cx.args[i].expr.span, msg)

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1027,6 +1027,11 @@ fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>) ->
         return false;
     }
 
+    if let DefKind::Static(_) = tcx.def_kind(def_id) {
+        // We cannot monomorphize statics from upstream crates.
+        return false;
+    }
+
     if !tcx.is_mir_available(def_id) {
         bug!("no MIR available for {:?}", def_id);
     }

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -590,7 +590,7 @@ impl<'a> Parser<'a> {
             )
         } else if expected.is_empty() {
             (
-                format!("unexpected token: {}", actual),
+                format!("unexpected token: {actual}"),
                 (self.prev_token.span, "unexpected token after this".to_string()),
             )
         } else {
@@ -1497,7 +1497,7 @@ impl<'a> Parser<'a> {
         MultiSugg {
             msg: format!("use `{}= 1` instead", kind.op.chr()),
             patches: vec![
-                (pre_span, format!("{{ let {} = ", tmp_var)),
+                (pre_span, format!("{{ let {tmp_var} = ")),
                 (post_span, format!("; {} {}= 1; {} }}", base_src, kind.op.chr(), tmp_var)),
             ],
             applicability: Applicability::HasPlaceholders,

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2260,7 +2260,7 @@ impl<'a> Parser<'a> {
                 (pat, this.parse_ty_for_param()?)
             } else {
                 debug!("parse_param_general ident_to_pat");
-                let parser_snapshot_before_ty = this.clone();
+                let parser_snapshot_before_ty = this.create_snapshot_for_diagnostic();
                 this.eat_incorrect_doc_comment_for_param_type();
                 let mut ty = this.parse_ty_for_param();
                 if ty.is_ok()
@@ -2283,7 +2283,7 @@ impl<'a> Parser<'a> {
                     // Recover from attempting to parse the argument as a type without pattern.
                     Err(err) => {
                         err.cancel();
-                        *this = parser_snapshot_before_ty;
+                        this.restore_snapshot(parser_snapshot_before_ty);
                         this.recover_arg_parse()?
                     }
                 }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1660,12 +1660,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ObligationCauseCode::ImplDerivedObligation(code) => {
                         code.derived.parent_trait_pred.self_ty().skip_binder().into()
                     }
-                    _ if let ty::PredicateKind::Trait(predicate) =
-                        error.obligation.predicate.kind().skip_binder() =>
-                    {
-                        predicate.self_ty().into()
-                    }
-                    _ => continue,
+                    _ => match error.obligation.predicate.kind().skip_binder() {
+                        ty::PredicateKind::Trait(predicate) => predicate.self_ty().into(),
+                        ty::PredicateKind::Projection(predicate) => {
+                            predicate.projection_ty.self_ty().into()
+                        }
+                        _ => continue,
+                    },
                 };
             let self_ = self.resolve_vars_if_possible(self_);
             let ty_matches_self = |ty: Ty<'tcx>| ty.walk().any(|arg| arg == self_);

--- a/src/test/run-make/issue-85401-static-mir/Makefile
+++ b/src/test/run-make/issue-85401-static-mir/Makefile
@@ -1,0 +1,16 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# Regression test for issue #85401
+# Verify that we do not ICE when trying to access MIR for statics,
+# but emit an error when linking.
+
+OUTPUT_FILE := $(TMPDIR)/build-output
+
+all:
+	$(RUSTC) --crate-type rlib --crate-name foo -Crelocation-model=pic --edition=2018 foo.rs -Zalways-encode-mir=yes --emit metadata -o $(TMPDIR)/libfoo.rmeta
+	$(RUSTC) --crate-type rlib --crate-name bar -Crelocation-model=pic --edition=2018 bar.rs -o $(TMPDIR)/libbar.rlib --extern=foo=$(TMPDIR)/libfoo.rmeta
+	$(RUSTC) --crate-type bin --crate-name baz -Crelocation-model=pic --edition=2018 baz.rs -o $(TMPDIR)/baz -L $(TMPDIR) --extern=bar=$(TMPDIR)/libbar.rlib > $(OUTPUT_FILE) 2>&1; [ $$? -eq 1 ]
+	cat  $(OUTPUT_FILE)
+	$(CGREP) 'crate `foo` required to be available in rlib format, but was not found in this form' < $(OUTPUT_FILE)
+	# -v tests are fragile, hopefully this text won't change
+	$(CGREP) -v "internal compiler error" < $(OUTPUT_FILE)

--- a/src/test/run-make/issue-85401-static-mir/bar.rs
+++ b/src/test/run-make/issue-85401-static-mir/bar.rs
@@ -1,0 +1,4 @@
+pub fn bar() {
+    println!("bar {}", foo::FOO);
+    foo::foo();
+}

--- a/src/test/run-make/issue-85401-static-mir/baz.rs
+++ b/src/test/run-make/issue-85401-static-mir/baz.rs
@@ -1,0 +1,3 @@
+fn main() {
+    bar::bar()
+}

--- a/src/test/run-make/issue-85401-static-mir/foo.rs
+++ b/src/test/run-make/issue-85401-static-mir/foo.rs
@@ -1,0 +1,5 @@
+pub static FOO: &str = "foo";
+
+pub fn foo() {
+    println!("foo");
+}

--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
-  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:10
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:19
    |
 LL | fn b() { blue_car(ModelT); }
-   |          ^^^^^^^^ type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
+   |          -------- ^^^^^^ type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
+   |          |
+   |          required by a bound introduced by this call
    |
 note: expected this to be `Blue`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:16:40
@@ -16,10 +18,12 @@ LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
    |                   ^^^^^^^^^^ required by this bound in `blue_car`
 
 error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
-  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:20
    |
 LL | fn c() { black_car(ModelU); }
-   |          ^^^^^^^^^ type mismatch resolving `<ModelU as Vehicle>::Color == Black`
+   |          --------- ^^^^^^ type mismatch resolving `<ModelU as Vehicle>::Color == Black`
+   |          |
+   |          required by a bound introduced by this call
    |
 note: expected this to be `Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:21:40

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -14,10 +14,12 @@ LL | fn foo2<I: Foo<A = Bar>>(x: I) {
    |               +++++++++
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
-  --> $DIR/associated-types-eq-3.rs:38:5
+  --> $DIR/associated-types-eq-3.rs:38:10
    |
 LL |     foo1(a);
-   |     ^^^^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     ---- ^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `Bar`
   --> $DIR/associated-types-eq-3.rs:12:14
@@ -34,7 +36,9 @@ error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:40:9
    |
 LL |     baz(&a);
-   |         ^^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     --- ^^ type mismatch resolving `<isize as Foo>::A == Bar`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `Bar`
   --> $DIR/associated-types-eq-3.rs:12:14

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -1,8 +1,8 @@
 error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
-  --> $DIR/associated-types-eq-hr.rs:87:5
+  --> $DIR/associated-types-eq-hr.rs:87:11
    |
 LL |     foo::<UintStruct>();
-   |     ^^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
+   |           ^^^^^^^^^^ type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
    |
 note: expected this to be `&isize`
   --> $DIR/associated-types-eq-hr.rs:26:14
@@ -21,10 +21,10 @@ LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `foo`
 
 error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
-  --> $DIR/associated-types-eq-hr.rs:91:5
+  --> $DIR/associated-types-eq-hr.rs:91:11
    |
 LL |     bar::<IntStruct>();
-   |     ^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
+   |           ^^^^^^^^^ type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
    |
 note: expected this to be `&usize`
   --> $DIR/associated-types-eq-hr.rs:14:14

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -1,11 +1,13 @@
 error[E0271]: type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
-  --> $DIR/associated-types-issue-20346.rs:34:5
+  --> $DIR/associated-types-issue-20346.rs:34:36
    |
 LL | fn test_adapter<T, I: Iterator<Item=Option<T>>>(it: I) {
    |                 - this type parameter
 ...
 LL |     is_iterator_of::<Option<T>, _>(&adapter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
+   |     ------------------------------ ^^^^^^^^ type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `Option<T>`
   --> $DIR/associated-types-issue-20346.rs:23:17

--- a/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<T as Foo>::Y == i32`
-  --> $DIR/associated-types-multiple-types-one-trait.rs:13:5
+  --> $DIR/associated-types-multiple-types-one-trait.rs:13:12
    |
 LL |     want_y(t);
-   |     ^^^^^^ expected `i32`, found associated type
+   |     ------ ^ expected `i32`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:         expected type `i32`
            found associated type `<T as Foo>::Y`
@@ -17,10 +19,12 @@ LL | fn have_x_want_y<T:Foo<X=u32, Y = i32>>(t: &T)
    |                             +++++++++
 
 error[E0271]: type mismatch resolving `<T as Foo>::X == u32`
-  --> $DIR/associated-types-multiple-types-one-trait.rs:18:5
+  --> $DIR/associated-types-multiple-types-one-trait.rs:18:12
    |
 LL |     want_x(t);
-   |     ^^^^^^ expected `u32`, found associated type
+   |     ------ ^ expected `u32`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:         expected type `u32`
            found associated type `<T as Foo>::X`

--- a/src/test/ui/associated-types/issue-87261.stderr
+++ b/src/test/ui/associated-types/issue-87261.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<A as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:56:5
+  --> $DIR/issue-87261.rs:56:19
    |
 LL |     accepts_trait(a);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<A as Trait>::Associated`
@@ -17,10 +19,12 @@ LL |     A: Trait<Associated = ()> + 'static,
    |             +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<B as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:59:5
+  --> $DIR/issue-87261.rs:59:19
    |
 LL |     accepts_trait(b);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<B as Trait>::Associated`
@@ -33,10 +37,12 @@ LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
    |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<C as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:62:5
+  --> $DIR/issue-87261.rs:62:19
    |
 LL |     accepts_trait(c);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<C as Trait>::Associated`
@@ -51,10 +57,12 @@ LL |     C: Trait<Associated = ()> + Foo,
    |             +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<D as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:65:5
+  --> $DIR/issue-87261.rs:65:19
    |
 LL |     accepts_trait(d);
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<D as Trait>::Associated`
@@ -67,10 +75,12 @@ LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
    |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<E as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:68:5
+  --> $DIR/issue-87261.rs:68:27
    |
 LL |     accepts_generic_trait(e);
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<E as GenericTrait<()>>::Associated`
@@ -85,10 +95,12 @@ LL |     E: GenericTrait<(), Associated = ()> + 'static,
    |                       +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<F as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:71:5
+  --> $DIR/issue-87261.rs:71:27
    |
 LL |     accepts_generic_trait(f);
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<F as GenericTrait<()>>::Associated`
@@ -103,10 +115,12 @@ LL |     F: GenericTrait<(), Associated = ()> + Foo,
    |                       +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<G as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:74:5
+  --> $DIR/issue-87261.rs:74:27
    |
 LL |     accepts_generic_trait(g);
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<G as GenericTrait<()>>::Associated`
@@ -119,13 +133,15 @@ LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
    |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 
 error[E0271]: type mismatch resolving `<impl Trait as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:79:5
+  --> $DIR/issue-87261.rs:79:19
    |
 LL | fn returns_opaque() -> impl Trait + 'static {
    |                        -------------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl Trait as Trait>::Associated`
@@ -140,13 +156,15 @@ LL | fn returns_opaque() -> impl Trait<Associated = ()> + 'static {
    |                                  +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl DerivedTrait as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:82:5
+  --> $DIR/issue-87261.rs:82:19
    |
 LL | fn returns_opaque_derived() -> impl DerivedTrait + 'static {
    |                                --------------------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque_derived());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl DerivedTrait as Trait>::Associated`
@@ -161,13 +179,15 @@ LL | fn returns_opaque_derived() -> impl DerivedTrait<Associated = ()> + 'static
    |                                                 +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl Trait + Foo as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:85:5
+  --> $DIR/issue-87261.rs:85:19
    |
 LL | fn returns_opaque_foo() -> impl Trait + Foo {
    |                            ---------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque_foo());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl Trait + Foo as Trait>::Associated`
@@ -182,13 +202,15 @@ LL | fn returns_opaque_foo() -> impl Trait<Associated = ()> + Foo {
    |                                      +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl DerivedTrait + Foo as Trait>::Associated == ()`
-  --> $DIR/issue-87261.rs:88:5
+  --> $DIR/issue-87261.rs:88:19
    |
 LL | fn returns_opaque_derived_foo() -> impl DerivedTrait + Foo {
    |                                    ----------------------- the found opaque type
 ...
 LL |     accepts_trait(returns_opaque_derived_foo());
-   |     ^^^^^^^^^^^^^ expected `()`, found associated type
+   |     ------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl DerivedTrait + Foo as Trait>::Associated`
@@ -201,13 +223,15 @@ LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
    |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<impl GenericTrait<()> as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:91:5
+  --> $DIR/issue-87261.rs:91:27
    |
 LL | fn returns_opaque_generic() -> impl GenericTrait<()> + 'static {
    |                                ------------------------------- the found opaque type
 ...
 LL |     accepts_generic_trait(returns_opaque_generic());
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()> as GenericTrait<()>>::Associated`
@@ -222,13 +246,15 @@ LL | fn returns_opaque_generic() -> impl GenericTrait<(), Associated = ()> + 'st
    |                                                    +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl GenericTrait<()> + Foo as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:94:5
+  --> $DIR/issue-87261.rs:94:27
    |
 LL | fn returns_opaque_generic_foo() -> impl GenericTrait<()> + Foo {
    |                                    --------------------------- the found opaque type
 ...
 LL |     accepts_generic_trait(returns_opaque_generic_foo());
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()> + Foo as GenericTrait<()>>::Associated`
@@ -243,13 +269,15 @@ LL | fn returns_opaque_generic_foo() -> impl GenericTrait<(), Associated = ()> +
    |                                                        +++++++++++++++++
 
 error[E0271]: type mismatch resolving `<impl GenericTrait<()> + GenericTrait<u8> as GenericTrait<()>>::Associated == ()`
-  --> $DIR/issue-87261.rs:97:5
+  --> $DIR/issue-87261.rs:97:27
    |
 LL | fn returns_opaque_generic_duplicate() -> impl GenericTrait<()> + GenericTrait<u8> {
    |                                          ---------------------------------------- the found opaque type
 ...
 LL |     accepts_generic_trait(returns_opaque_generic_duplicate());
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |     |
+   |     required by a bound introduced by this call
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()> + GenericTrait<u8> as GenericTrait<()>>::Associated`

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
-  --> $DIR/E0271.rs:10:5
+  --> $DIR/E0271.rs:10:9
    |
 LL |     foo(3_i8);
-   |     ^^^ type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
+   |     --- ^^^^ type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `u32`
   --> $DIR/E0271.rs:7:43

--- a/src/test/ui/generic-associated-types/issue-74684-2.stderr
+++ b/src/test/ui/generic-associated-types/issue-74684-2.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
-  --> $DIR/issue-74684-2.rs:23:5
+  --> $DIR/issue-74684-2.rs:23:9
    |
 LL |     bug(Box::new(x));
-   |     ^^^ type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
+   |     --- ^^^^^^^^^^^ type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `[u8]`
   --> $DIR/issue-74684-2.rs:10:18

--- a/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.rs
@@ -36,9 +36,9 @@ trait Ty<'a> {
 
 fn main() {
     let v = Unit2.m(
-        //~^ ERROR type mismatch
         L {
             //~^ ERROR to be a closure that returns `Unit3`, but it returns `Unit4`
+            //~| ERROR type mismatch
             f: |x| {
                 drop(x);
                 Unit4

--- a/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-62203-hrtb-ice.stderr
@@ -1,8 +1,16 @@
 error[E0271]: type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]> as T0<'r, (&'r u8,)>>::O == <_ as Ty<'r>>::V`
-  --> $DIR/issue-62203-hrtb-ice.rs:38:19
+  --> $DIR/issue-62203-hrtb-ice.rs:39:9
    |
-LL |     let v = Unit2.m(
-   |                   ^ type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]> as T0<'r, (&'r u8,)>>::O == <_ as Ty<'r>>::V`
+LL |       let v = Unit2.m(
+   |                     - required by a bound introduced by this call
+LL | /         L {
+LL | |
+LL | |
+LL | |             f: |x| {
+...  |
+LL | |             },
+LL | |         },
+   | |_________^ type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]> as T0<'r, (&'r u8,)>>::O == <_ as Ty<'r>>::V`
    |
 note: expected this to be `<_ as Ty<'_>>::V`
   --> $DIR/issue-62203-hrtb-ice.rs:21:14
@@ -23,16 +31,15 @@ LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |                                                   ^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
 
 error[E0271]: expected `[closure@$DIR/issue-62203-hrtb-ice.rs:42:16: 42:19]` to be a closure that returns `Unit3`, but it returns `Unit4`
-  --> $DIR/issue-62203-hrtb-ice.rs:40:9
+  --> $DIR/issue-62203-hrtb-ice.rs:39:9
    |
 LL |       let v = Unit2.m(
    |                     - required by a bound introduced by this call
-LL |
 LL | /         L {
 LL | |
+LL | |
 LL | |             f: |x| {
-LL | |                 drop(x);
-LL | |                 Unit4
+...  |
 LL | |             },
 LL | |         },
    | |_________^ expected struct `Unit3`, found struct `Unit4`

--- a/src/test/ui/intrinsics/const-eval-select-bad.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-bad.stderr
@@ -52,10 +52,12 @@ LL |     G: FnOnce<ARG, Output = RET> + ~const Destruct,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `const_eval_select`
 
 error[E0271]: expected `fn(i32) -> bool {bar}` to be a fn item that returns `i32`, but it returns `bool`
-  --> $DIR/const-eval-select-bad.rs:29:5
+  --> $DIR/const-eval-select-bad.rs:29:34
    |
 LL |     const_eval_select((1,), foo, bar);
-   |     ^^^^^^^^^^^^^^^^^ expected `i32`, found `bool`
+   |     -----------------            ^^^ expected `i32`, found `bool`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
-  --> $DIR/check-trait-object-bounds-5.rs:23:5
+  --> $DIR/check-trait-object-bounds-5.rs:23:12
    |
 LL |     is_obj(x)
-   |     ^^^^^^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     ------ ^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `i64`
   --> $DIR/check-trait-object-bounds-5.rs:9:14

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
-  --> $DIR/check-trait-object-bounds-6.rs:20:5
+  --> $DIR/check-trait-object-bounds-6.rs:20:12
    |
 LL |     is_obj(x)
-   |     ^^^^^^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     ------ ^ type mismatch resolving `<i32 as Is>::T == i64`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: expected this to be `i64`
   --> $DIR/check-trait-object-bounds-6.rs:9:14

--- a/src/test/ui/traits/object/enforce-supertrait-projection.stderr
+++ b/src/test/ui/traits/object/enforce-supertrait-projection.stderr
@@ -1,12 +1,12 @@
 error[E0271]: type mismatch resolving `<dyn Trait<B = B, A = A> as SuperTrait>::A == B`
-  --> $DIR/enforce-supertrait-projection.rs:9:5
+  --> $DIR/enforce-supertrait-projection.rs:9:17
    |
 LL | fn transmute<A, B>(x: A) -> B {
    |              -  - expected type parameter
    |              |
    |              found type parameter
 LL |     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `B`, found type parameter `A`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `B`, found type parameter `A`
    |
    = note: expected type parameter `B`
               found type parameter `A`

--- a/src/test/ui/traits/pointee-tail-is-generic-errors.stderr
+++ b/src/test/ui/traits/pointee-tail-is-generic-errors.stderr
@@ -1,8 +1,8 @@
 error[E0271]: type mismatch resolving `<T as Pointee>::Metadata == ()`
-  --> $DIR/pointee-tail-is-generic-errors.rs:13:5
+  --> $DIR/pointee-tail-is-generic-errors.rs:13:15
    |
 LL |     is_thin::<T>();
-   |     ^^^^^^^^^^^^ expected `()`, found associated type
+   |               ^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<T as Pointee>::Metadata`
@@ -15,13 +15,13 @@ LL | fn is_thin<T: std::ptr::Pointee<Metadata = ()> + ?Sized>() {}
    |                                 ^^^^^^^^^^^^^ required by this bound in `is_thin`
 
 error[E0271]: type mismatch resolving `<Opaque as Pointee>::Metadata == ()`
-  --> $DIR/pointee-tail-is-generic-errors.rs:16:5
+  --> $DIR/pointee-tail-is-generic-errors.rs:16:15
    |
 LL | type Opaque = impl std::fmt::Debug + ?Sized;
    |               ----------------------------- the found opaque type
 ...
 LL |     is_thin::<Opaque>();
-   |     ^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |               ^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<Opaque as Pointee>::Metadata`


### PR DESCRIPTION
Successful merges:

 - #100211 (Refuse to codegen an upstream static.)
 - #100277 (Simplify format_args builtin macro implementation.)
 - #100483 (Point to generic or arg if it's the self type of unsatisfied projection predicate)
 - #100506 (change `InlineAsmCtxt` to not talk about `FnCtxt`)
 - #100534 (Make code slightly more uniform)
 - #100566 (Use `create_snapshot_for_diagnostic` instead of `clone` for `Parser`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100211,100277,100483,100506,100534,100566)
<!-- homu-ignore:end -->