### PR TITLE
Ensure that feature stabilizations are for the current version

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -157,6 +157,8 @@ declare_features! (
     (accepted, extern_prelude, "1.30.0", Some(44660), None),
     /// Allows field shorthands (`x` meaning `x: x`) in struct literal expressions.
     (accepted, field_init_shorthand, "1.17.0", Some(37340), None),
+    /// Allows using `#[repr(align(...))]` on function items
+    (accepted, fn_align, "1.53.0", Some(82232), None),
     /// Allows `#[must_use]` on functions, and introduces must-use operators (RFC 1940).
     (accepted, fn_must_use, "1.27.0", Some(43302), None),
     /// Allows capturing variables in scope using format_args!

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -392,8 +392,6 @@ declare_features! (
     (active, ffi_pure, "1.45.0", Some(58329), None),
     /// Allows using `#[ffi_returns_twice]` on foreign functions.
     (active, ffi_returns_twice, "1.34.0", Some(58314), None),
-    /// Allows using `#[repr(align(...))]` on function items
-    (active, fn_align, "1.53.0", Some(82232), None),
     /// Allows defining generators.
     (active, generators, "1.21.0", Some(43122), None),
     /// Infer generic args for both consts and types.

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -79,25 +79,19 @@ pub fn collect_lib_features(base_src_path: &Path) -> Features {
     lib_features
 }
 
-pub fn check(
-    src_path: &Path,
-    compiler_path: &Path,
-    lib_path: &Path,
-    bad: &mut bool,
-    verbose: bool,
-) -> CollectedFeatures {
-    let mut features = collect_lang_features(compiler_path, bad);
+pub fn check(paths: &crate::Paths, bad: &mut bool, verbose: bool) -> CollectedFeatures {
+    let mut features = collect_lang_features(&paths.compiler, bad);
     assert!(!features.is_empty());
 
-    let lib_features = get_and_check_lib_features(lib_path, bad, &features);
+    let lib_features = get_and_check_lib_features(&paths.library, bad, &features);
     assert!(!lib_features.is_empty());
 
     super::walk_many(
         &[
-            &src_path.join("test/ui"),
-            &src_path.join("test/ui-fulldeps"),
-            &src_path.join("test/rustdoc-ui"),
-            &src_path.join("test/rustdoc"),
+            &paths.src.join("test/ui"),
+            &paths.src.join("test/ui-fulldeps"),
+            &paths.src.join("test/rustdoc-ui"),
+            &paths.src.join("test/rustdoc"),
         ],
         &mut |path| super::filter_dirs(path),
         &mut |entry, contents| {

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::Read;
 use walkdir::{DirEntry, WalkDir};
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 macro_rules! t {
     ($e:expr, $p:expr) => {
@@ -74,6 +74,24 @@ fn filter_dirs(path: &Path) -> bool {
         "target/rls",
     ];
     skip.iter().any(|p| path.ends_with(p))
+}
+
+pub struct Paths {
+    pub root: PathBuf,
+    pub src: PathBuf,
+    pub compiler: PathBuf,
+    pub library: PathBuf,
+}
+
+impl Paths {
+    pub fn from_root(root: &Path) -> Self {
+        Self {
+            root: root.to_owned(),
+            src: root.join("src"),
+            library: root.join("library"),
+            compiler: root.join("compiler"),
+        }
+    }
 }
 
 fn walk_many(


### PR DESCRIPTION
It's a common phenomenon that feature stabilizations don't make it into a particular release, but the version is still inaccurate. Often this is caught in the PR, but it can also require subsequent changes to adjust/correct the version, e.g.:

* #43315
* #89605
* #95452
* #94186
* #97337

This PR adds checking to ensure that a stabilization is always for the current release: it makes tidy determine a git "base commit" for the given change, and then compares the list to that base commit. That way, tidy knows the features that have stabilized, and can compare them to the current version.

Currently, this is implemented for lang features only, but with some engineering it can be extended to library features as well.

Note: currently the PR includes a mock stabilization meant to showcase how the PR works. I will remove it once the bot issues the expected complaint.