### PR TITLE
[rustdoc] Fix handling of stripped enum variant in JSON output format

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -662,12 +662,10 @@ impl FromWithTcx<clean::Variant> for Variant {
             Tuple(fields) => Variant::Tuple(
                 fields
                     .into_iter()
-                    .map(|f| {
-                        if let clean::StructFieldItem(ty) = *f.kind {
-                            ty.into_tcx(tcx)
-                        } else {
-                            unreachable!()
-                        }
+                    .filter_map(|f| match *f.kind {
+                        clean::StructFieldItem(ty) => Some(ty.into_tcx(tcx)),
+                        clean::StrippedItem(_) => None,
+                        _ => unreachable!(),
                     })
                     .collect(),
             ),

--- a/src/test/rustdoc-json/enum_variant_hidden.rs
+++ b/src/test/rustdoc-json/enum_variant_hidden.rs
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/100529>.
+
+#![no_core]
+#![feature(no_core)]
+
+// @has enum_variant_hidden.json "$.index[*][?(@.name=='ParseError')]"
+// @has - "$.index[*][?(@.name=='UnexpectedEndTag')]"
+// @is - "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant_kind" '"tuple"'
+// @is - "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant_inner" []
+
+pub enum ParseError {
+    UnexpectedEndTag(#[doc(hidden)] u32),
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/100529.

cc @aDotInTheVoid @Enselic 
r? @notriddle 