### PR TITLE
std::io: retry write operation on ErrorKind::WouldBlock

### DIFF
--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -174,7 +174,9 @@ impl<W: Write> BufWriter<W> {
                     ));
                 }
                 Ok(n) => guard.consume(n),
-                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(ref e)
+                    if e.kind() == io::ErrorKind::Interrupted
+                        || e.kind() == ErrorKind::WouldBlock => {}
                 Err(e) => return Err(e),
             }
         }


### PR DESCRIPTION
If writing to tty when O_NONBLOCK bit is set and the lock to
tty is held (e.g. multiple threads writing to console), the Linux kernel
returns -EAGAIN.
(https://elixir.bootlin.com/linux/v5.19/source/drivers/tty/tty_io.c#L952)

Not accounting for -EAGAIN (i.e. ErrorKind::WouldBlock), results in
a panic. Its better to retry the write as the other thread could have
release the lock by then.

Signed-off-by: Usama Arif <usama.arif@bytedance.com>