### PR TITLE
Pass +atomics-32 feature for {arm,thumb}v4t-none-eabi

### DIFF
--- a/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
@@ -38,7 +38,9 @@ pub fn target() -> Target {
             linker_flavor: LinkerFlavor::Ld,
             linker: Some("arm-none-eabi-ld".into()),
             asm_args: cvs!["-mthumb-interwork", "-march=armv4t", "-mlittle-endian",],
-            features: "+soft-float,+strict-align".into(),
+            // Force-enable 32-bit atomics, which allows the use of atomic load/store only.
+            // The resulting atomics are ABI incompatible with atomics backed by libatomic.
+            features: "+soft-float,+strict-align,+atomics-32".into(),
             main_needs_argc_argv: false,
             atomic_cas: false,
             has_thumb_interworking: true,

--- a/compiler/rustc_target/src/spec/thumbv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/thumbv4t_none_eabi.rs
@@ -47,7 +47,9 @@ pub fn target() -> Target {
             asm_args: cvs!["-mthumb-interwork", "-march=armv4t", "-mlittle-endian",],
 
             // minimum extra features, these cannot be disabled via -C
-            features: "+soft-float,+strict-align".into(),
+            // Also force-enable 32-bit atomics, which allows the use of atomic load/store only.
+            // The resulting atomics are ABI incompatible with atomics backed by libatomic.
+            features: "+soft-float,+strict-align,+atomics-32".into(),
 
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rust/commit/89582e8193e0da64a54c4ffae7f9fa64ed9fe2af, but for ARMv4t.
Pre-v6 ARM target does not have atomic CAS, except for Linux and Android where atomic CAS is provided by compiler-builtins. So, there is a similar issue as thumbv6m.

I have confirmed that enabling the `atomics-32` target feature fixes the problem in the project affected by this issue. (https://github.com/taiki-e/portable-atomic/pull/28#discussion_r946604136)

Closes #100619

r? @nikic 
cc @Lokathor