### PR TITLE
Support 128-bit atomics on all aarch64 targets

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_pc_windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/aarch64_pc_windows_gnullvm.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_gnullvm_base::opts();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.features = "+neon,+fp-armv8".into();
     base.linker = Some("aarch64-w64-mingw32-clang".into());
 

--- a/compiler/rustc_target/src/spec/aarch64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/aarch64_pc_windows_msvc.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.features = "+neon,+fp-armv8".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/aarch64_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_uefi.rs
@@ -7,7 +7,7 @@ use crate::spec::{LinkerFlavor, Target};
 pub fn target() -> Target {
     let mut base = uefi_msvc_base::opts();
 
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Msvc, &["/machine:arm64"]);
 
     Target {

--- a/compiler/rustc_target/src/spec/aarch64_uwp_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/aarch64_uwp_windows_msvc.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_uwp_msvc_base::opts();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
 
     Target {
         llvm_target: "aarch64-pc-windows-msvc".into(),

--- a/compiler/rustc_target/src/spec/arm64_32_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/arm64_32_apple_watchos.rs
@@ -10,7 +10,7 @@ pub fn target() -> Target {
         arch: "aarch64".into(),
         options: TargetOptions {
             features: "+neon,+fp-armv8,+apple-a7".into(),
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             forces_embed_bitcode: true,
             // These arguments are not actually invoked - they just have
             // to look right to pass App Store validation.


### PR DESCRIPTION
Some aarch64 targets currently set `max_atomic_width` to 64, but aarch64 always supports 128-bit atomics.

r? @Amanieu 