### PR TITLE
Update minifier version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac96d1e7a65f206443f95afff6de8f1690c77c97d6fc9c9bb2d2cd0662e9ff9f"
+checksum = "8eb022374af2f446981254e6bf9efb6e2c9e1a53176d395fca02792fd4435729"
 
 [[package]]
 name = "minimal-lexical"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -11,7 +11,7 @@ arrayvec = { version = "0.7", default-features = false }
 askama = { version = "0.11", default-features = false, features = ["config"] }
 atty = "0.2"
 pulldown-cmark = { version = "0.9.2", default-features = false }
-minifier = "0.2.1"
+minifier = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.8.1"


### PR DESCRIPTION
Following [this PR](https://github.com/GuillaumeGomez/minifier-rs/pull/98), the CSS minification should be much faster now (thanks to @nnethercote).

r? @nnethercote 