### PR TITLE
Add `IpDisplayBuffer` helper struct.

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -294,6 +294,8 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
+#![feature(maybe_uninit_uninit_array)]
+#![feature(const_maybe_uninit_uninit_array)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -999,7 +999,9 @@ impl fmt::Display for Ipv4Addr {
         if fmt.precision().is_none() && fmt.width().is_none() {
             write!(fmt, "{}.{}.{}.{}", octets[0], octets[1], octets[2], octets[3])
         } else {
-            let mut buf = IpDisplayBuffer::new(b"255.255.255.255");
+            const LONGEST_IPV4_ADDR: &str = "255.255.255.255";
+
+            let mut buf = IpDisplayBuffer::<{ LONGEST_IPV4_ADDR.len() }>::new();
             // Buffer is long enough for the longest possible IPv4 address, so this should never fail.
             write!(buf, "{}.{}.{}.{}", octets[0], octets[1], octets[2], octets[3]).unwrap();
 
@@ -1778,7 +1780,9 @@ impl fmt::Display for Ipv6Addr {
                 }
             }
         } else {
-            let mut buf = IpDisplayBuffer::new(b"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+            const LONGEST_IPV6_ADDR: &str = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
+
+            let mut buf = IpDisplayBuffer::<{ LONGEST_IPV6_ADDR.len() }>::new();
             // Buffer is long enough for the longest possible IPv6 address, so this should never fail.
             write!(buf, "{}", self).unwrap();
 

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -5,41 +5,11 @@ mod tests;
 use crate::cmp::Ordering;
 use crate::fmt::{self, Write};
 use crate::mem::transmute;
-use crate::str;
 use crate::sys::net::netc as c;
 use crate::sys_common::{FromInner, IntoInner};
 
-/// Used for slow path in `Display` implementations when alignment is required.
-struct IpDisplayBuffer<const SIZE: usize> {
-    buf: [u8; SIZE],
-    len: usize,
-}
-
-impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
-    #[inline(always)]
-    pub const fn new(_ip: &[u8; SIZE]) -> Self {
-        Self { buf: [0; SIZE], len: 0 }
-    }
-
-    #[inline(always)]
-    pub fn as_str(&self) -> &str {
-        // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
-        // which writes a valid UTF-8 string to `buf` and correctly sets `len`.
-        unsafe { str::from_utf8_unchecked(&self.buf[..self.len]) }
-    }
-}
-
-impl<const SIZE: usize> fmt::Write for IpDisplayBuffer<SIZE> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        if let Some(buf) = self.buf.get_mut(self.len..(self.len + s.len())) {
-            buf.copy_from_slice(s.as_bytes());
-            self.len += s.len();
-            Ok(())
-        } else {
-            Err(fmt::Error)
-        }
-    }
-}
+mod display_buffer;
+use display_buffer::IpDisplayBuffer;
 
 /// An IP address, either IPv4 or IPv6.
 ///

--- a/library/std/src/net/ip/display_buffer.rs
+++ b/library/std/src/net/ip/display_buffer.rs
@@ -1,0 +1,34 @@
+use crate::fmt;
+use crate::str;
+
+/// Used for slow path in `Display` implementations when alignment is required.
+pub struct IpDisplayBuffer<const SIZE: usize> {
+    buf: [u8; SIZE],
+    len: usize,
+}
+
+impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
+    #[inline(always)]
+    pub const fn new(_ip: &[u8; SIZE]) -> Self {
+        Self { buf: [0; SIZE], len: 0 }
+    }
+
+    #[inline(always)]
+    pub fn as_str(&self) -> &str {
+        // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
+        // which writes a valid UTF-8 string to `buf` and correctly sets `len`.
+        unsafe { str::from_utf8_unchecked(&self.buf[..self.len]) }
+    }
+}
+
+impl<const SIZE: usize> fmt::Write for IpDisplayBuffer<SIZE> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if let Some(buf) = self.buf.get_mut(self.len..(self.len + s.len())) {
+            buf.copy_from_slice(s.as_bytes());
+            self.len += s.len();
+            Ok(())
+        } else {
+            Err(fmt::Error)
+        }
+    }
+}

--- a/library/std/src/net/ip/display_buffer.rs
+++ b/library/std/src/net/ip/display_buffer.rs
@@ -9,12 +9,12 @@ pub struct IpDisplayBuffer<const SIZE: usize> {
 }
 
 impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
-    #[inline(always)]
-    pub const fn new(_ip: &[u8; SIZE]) -> Self {
-        Self { buf: MaybeUninit::uninit_array::<SIZE>(), len: 0 }
+    #[inline]
+    pub const fn new() -> Self {
+        Self { buf: MaybeUninit::uninit_array(), len: 0 }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn as_str(&self) -> &str {
         // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
         // which writes a valid UTF-8 string to `buf` and correctly sets `len`.

--- a/library/std/src/net/ip/display_buffer.rs
+++ b/library/std/src/net/ip/display_buffer.rs
@@ -1,31 +1,37 @@
 use crate::fmt;
+use crate::mem::MaybeUninit;
 use crate::str;
 
 /// Used for slow path in `Display` implementations when alignment is required.
 pub struct IpDisplayBuffer<const SIZE: usize> {
-    buf: [u8; SIZE],
+    buf: [MaybeUninit<u8>; SIZE],
     len: usize,
 }
 
 impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
     #[inline(always)]
     pub const fn new(_ip: &[u8; SIZE]) -> Self {
-        Self { buf: [0; SIZE], len: 0 }
+        Self { buf: MaybeUninit::uninit_array::<SIZE>(), len: 0 }
     }
 
     #[inline(always)]
     pub fn as_str(&self) -> &str {
         // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
         // which writes a valid UTF-8 string to `buf` and correctly sets `len`.
-        unsafe { str::from_utf8_unchecked(&self.buf[..self.len]) }
+        unsafe {
+            let s = MaybeUninit::slice_assume_init_ref(&self.buf[..self.len]);
+            str::from_utf8_unchecked(s)
+        }
     }
 }
 
 impl<const SIZE: usize> fmt::Write for IpDisplayBuffer<SIZE> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        if let Some(buf) = self.buf.get_mut(self.len..(self.len + s.len())) {
-            buf.copy_from_slice(s.as_bytes());
-            self.len += s.len();
+        let bytes = s.as_bytes();
+
+        if let Some(buf) = self.buf.get_mut(self.len..(self.len + bytes.len())) {
+            MaybeUninit::write_slice(buf, bytes);
+            self.len += bytes.len();
             Ok(())
         } else {
             Err(fmt::Error)


### PR DESCRIPTION
This removes the dependency on `std::io::Write` for implementing `Display`, allowing it to be moved to `core` as proposed in https://github.com/rust-lang/rfcs/pull/2832.