### PR TITLE
Use `merged_ty` method instead of rewriting it every time

### DIFF
--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1488,14 +1488,14 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                     // `break`, we want to call the `()` "expected"
                     // since it is implied by the syntax.
                     // (Note: not all force-units work this way.)"
-                    (expression_ty, self.final_ty.unwrap_or(self.expected_ty))
+                    (expression_ty, self.merged_ty())
                 } else {
                     // Otherwise, the "expected" type for error
                     // reporting is the current unification type,
                     // which is basically the LUB of the expressions
                     // we've seen so far (combined with the expected
                     // type)
-                    (self.final_ty.unwrap_or(self.expected_ty), expression_ty)
+                    (self.merged_ty(), expression_ty)
                 };
                 let (expected, found) = fcx.resolve_vars_if_possible((expected, found));
 


### PR DESCRIPTION
`merged_ty` [source code](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_typeck/check/coercion.rs.html#1331-1333) is quite literally the same, so instead of rewriting it, makes more sense to use the method instead.

r? @compiler-errors 