### PR TITLE
Revert "Revert "Allow dynamic linking for iOS/tvOS targets.""

### DIFF
--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -65,7 +65,6 @@ pub fn opts(os: &'static str, arch: Arch) -> TargetOptions {
     TargetOptions {
         abi: target_abi(arch).into(),
         cpu: target_cpu(arch).into(),
-        dynamic_linking: false,
         link_env_remove: link_env_remove(arch),
         has_thread_local: false,
         ..super::apple_base::opts(os, target_arch_name(arch), target_abi(arch))


### PR DESCRIPTION
This reverts commit 16e10bf81ee73f61cf813acef3d5dbbce4f66da2 (PR #77716).

The original original PR enabled `cdylib` builds for iOS. However this caused problems because:

> This new feature in Rust 1.46 added a lot of headache for iOS builds with cdylib targets. cdylib target is near impossible to build if you are using any crate with native dependencies (ex. openssl, libsodium, zmq). You can't just find .so files for all architectures to perform correct linking. Usual workflow is the following:
> 
> 1. You build staticlib and rely that native dependencies will be linked as frameworks later
> 2. You setup right cocoapods in ObjectiveC/Swift wrapper.
> 
> As cargo doesn't support platform-dependent crate types https://github.com/rust-lang/rust/pull/4881 as a result a lot of projects now broken on Rust 1.46

However, this will be soon a thing of the past since 1.64 brings us the long awaited much anticipated `--crate-type` flag.

> I see that this got merged recently: https://github.com/rust-lang/cargo/issues/10083. The --crate-type flag will get stabilized in 1.64. In 1.64, you could still get a successful iOS staticlib with cargo build --crate-type=statclib even if the crate has cdylib targets too. If I'm not mistaken, this solves the problem too so this PR could be reverted in 1.64 with relatively little headache.
 
So summing up, I think this PR can be reverted in 1.64. 🤞