### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -162,6 +162,7 @@ macro_rules! separate_provide_extern_default {
     };
 }
 
+#[macro_export]
 macro_rules! opt_remap_env_constness {
     ([][$name:ident]) => {};
     ([(remap_env_constness) $($rest:tt)*][$name:ident]) => {

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -162,7 +162,6 @@ macro_rules! separate_provide_extern_default {
     };
 }
 
-#[macro_export]
 macro_rules! opt_remap_env_constness {
     ([][$name:ident]) => {};
     ([(remap_env_constness) $($rest:tt)*][$name:ident]) => {

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -237,7 +237,6 @@ macro_rules! define_queries {
     (<$tcx:tt>
      $($(#[$attr:meta])*
         [$($modifiers:tt)*] fn $name:ident($($K:tt)*) -> $V:ty,)*) => {
-        use rustc_middle::opt_remap_env_constness;
         define_queries_struct! {
             tcx: $tcx,
             input: ($(([$($modifiers)*] [$($attr)*] [$name]))*)
@@ -249,7 +248,6 @@ macro_rules! define_queries {
             // Create an eponymous constructor for each query.
             $(#[allow(nonstandard_style)] $(#[$attr])*
             pub fn $name<$tcx>(tcx: QueryCtxt<$tcx>, key: query_keys::$name<$tcx>) -> QueryStackFrame {
-                opt_remap_env_constness!([$($modifiers)*][key]);
                 let kind = dep_graph::DepKind::$name;
                 let name = stringify!($name);
                 // Disable visible paths printing for performance reasons.
@@ -539,7 +537,6 @@ macro_rules! define_queries_struct {
                 key: query_keys::$name<$tcx>,
                 mode: QueryMode,
             ) -> Option<query_stored::$name<$tcx>> {
-                opt_remap_env_constness!([$($modifiers)*][key]);
                 let qcx = QueryCtxt { tcx, queries: self };
                 get_query::<queries::$name<$tcx>, _>(qcx, span, key, mode)
             })*

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -233,21 +233,11 @@ macro_rules! get_provider {
     };
 }
 
-macro_rules! opt_remap_env_constness {
-    ([][$name:ident]) => {};
-    ([(remap_env_constness) $($rest:tt)*][$name:ident]) => {
-        let $name = $name.without_const();
-    };
-    ([$other:tt $($modifiers:tt)*][$name:ident]) => {
-        opt_remap_env_constness!([$($modifiers)*][$name])
-    };
-}
-
 macro_rules! define_queries {
     (<$tcx:tt>
      $($(#[$attr:meta])*
         [$($modifiers:tt)*] fn $name:ident($($K:tt)*) -> $V:ty,)*) => {
-
+        use rustc_middle::opt_remap_env_constness;
         define_queries_struct! {
             tcx: $tcx,
             input: ($(([$($modifiers)*] [$($attr)*] [$name]))*)

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1488,14 +1488,14 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                     // `break`, we want to call the `()` "expected"
                     // since it is implied by the syntax.
                     // (Note: not all force-units work this way.)"
-                    (expression_ty, self.final_ty.unwrap_or(self.expected_ty))
+                    (expression_ty, self.merged_ty())
                 } else {
                     // Otherwise, the "expected" type for error
                     // reporting is the current unification type,
                     // which is basically the LUB of the expressions
                     // we've seen so far (combined with the expected
                     // type)
-                    (self.final_ty.unwrap_or(self.expected_ty), expression_ty)
+                    (self.merged_ty(), expression_ty)
                 };
                 let (expected, found) = fcx.resolve_vars_if_possible((expected, found));
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -294,6 +294,8 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
+#![feature(maybe_uninit_uninit_array)]
+#![feature(const_maybe_uninit_uninit_array)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -999,7 +999,9 @@ impl fmt::Display for Ipv4Addr {
         if fmt.precision().is_none() && fmt.width().is_none() {
             write!(fmt, "{}.{}.{}.{}", octets[0], octets[1], octets[2], octets[3])
         } else {
-            let mut buf = IpDisplayBuffer::new(b"255.255.255.255");
+            const LONGEST_IPV4_ADDR: &str = "255.255.255.255";
+
+            let mut buf = IpDisplayBuffer::<{ LONGEST_IPV4_ADDR.len() }>::new();
             // Buffer is long enough for the longest possible IPv4 address, so this should never fail.
             write!(buf, "{}.{}.{}.{}", octets[0], octets[1], octets[2], octets[3]).unwrap();
 
@@ -1778,7 +1780,9 @@ impl fmt::Display for Ipv6Addr {
                 }
             }
         } else {
-            let mut buf = IpDisplayBuffer::new(b"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+            const LONGEST_IPV6_ADDR: &str = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
+
+            let mut buf = IpDisplayBuffer::<{ LONGEST_IPV6_ADDR.len() }>::new();
             // Buffer is long enough for the longest possible IPv6 address, so this should never fail.
             write!(buf, "{}", self).unwrap();
 

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -5,41 +5,11 @@ mod tests;
 use crate::cmp::Ordering;
 use crate::fmt::{self, Write};
 use crate::mem::transmute;
-use crate::str;
 use crate::sys::net::netc as c;
 use crate::sys_common::{FromInner, IntoInner};
 
-/// Used for slow path in `Display` implementations when alignment is required.
-struct IpDisplayBuffer<const SIZE: usize> {
-    buf: [u8; SIZE],
-    len: usize,
-}
-
-impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
-    #[inline(always)]
-    pub const fn new(_ip: &[u8; SIZE]) -> Self {
-        Self { buf: [0; SIZE], len: 0 }
-    }
-
-    #[inline(always)]
-    pub fn as_str(&self) -> &str {
-        // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
-        // which writes a valid UTF-8 string to `buf` and correctly sets `len`.
-        unsafe { str::from_utf8_unchecked(&self.buf[..self.len]) }
-    }
-}
-
-impl<const SIZE: usize> fmt::Write for IpDisplayBuffer<SIZE> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        if let Some(buf) = self.buf.get_mut(self.len..(self.len + s.len())) {
-            buf.copy_from_slice(s.as_bytes());
-            self.len += s.len();
-            Ok(())
-        } else {
-            Err(fmt::Error)
-        }
-    }
-}
+mod display_buffer;
+use display_buffer::IpDisplayBuffer;
 
 /// An IP address, either IPv4 or IPv6.
 ///

--- a/library/std/src/net/ip/display_buffer.rs
+++ b/library/std/src/net/ip/display_buffer.rs
@@ -1,0 +1,34 @@
+use crate::fmt;
+use crate::str;
+
+/// Used for slow path in `Display` implementations when alignment is required.
+pub struct IpDisplayBuffer<const SIZE: usize> {
+    buf: [u8; SIZE],
+    len: usize,
+}
+
+impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
+    #[inline(always)]
+    pub const fn new(_ip: &[u8; SIZE]) -> Self {
+        Self { buf: [0; SIZE], len: 0 }
+    }
+
+    #[inline(always)]
+    pub fn as_str(&self) -> &str {
+        // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
+        // which writes a valid UTF-8 string to `buf` and correctly sets `len`.
+        unsafe { str::from_utf8_unchecked(&self.buf[..self.len]) }
+    }
+}
+
+impl<const SIZE: usize> fmt::Write for IpDisplayBuffer<SIZE> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if let Some(buf) = self.buf.get_mut(self.len..(self.len + s.len())) {
+            buf.copy_from_slice(s.as_bytes());
+            self.len += s.len();
+            Ok(())
+        } else {
+            Err(fmt::Error)
+        }
+    }
+}

--- a/library/std/src/net/ip/display_buffer.rs
+++ b/library/std/src/net/ip/display_buffer.rs
@@ -9,12 +9,12 @@ pub struct IpDisplayBuffer<const SIZE: usize> {
 }
 
 impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
-    #[inline(always)]
-    pub const fn new(_ip: &[u8; SIZE]) -> Self {
-        Self { buf: MaybeUninit::uninit_array::<SIZE>(), len: 0 }
+    #[inline]
+    pub const fn new() -> Self {
+        Self { buf: MaybeUninit::uninit_array(), len: 0 }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn as_str(&self) -> &str {
         // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
         // which writes a valid UTF-8 string to `buf` and correctly sets `len`.

--- a/library/std/src/net/ip/display_buffer.rs
+++ b/library/std/src/net/ip/display_buffer.rs
@@ -1,31 +1,37 @@
 use crate::fmt;
+use crate::mem::MaybeUninit;
 use crate::str;
 
 /// Used for slow path in `Display` implementations when alignment is required.
 pub struct IpDisplayBuffer<const SIZE: usize> {
-    buf: [u8; SIZE],
+    buf: [MaybeUninit<u8>; SIZE],
     len: usize,
 }
 
 impl<const SIZE: usize> IpDisplayBuffer<SIZE> {
     #[inline(always)]
     pub const fn new(_ip: &[u8; SIZE]) -> Self {
-        Self { buf: [0; SIZE], len: 0 }
+        Self { buf: MaybeUninit::uninit_array::<SIZE>(), len: 0 }
     }
 
     #[inline(always)]
     pub fn as_str(&self) -> &str {
         // SAFETY: `buf` is only written to by the `fmt::Write::write_str` implementation
         // which writes a valid UTF-8 string to `buf` and correctly sets `len`.
-        unsafe { str::from_utf8_unchecked(&self.buf[..self.len]) }
+        unsafe {
+            let s = MaybeUninit::slice_assume_init_ref(&self.buf[..self.len]);
+            str::from_utf8_unchecked(s)
+        }
     }
 }
 
 impl<const SIZE: usize> fmt::Write for IpDisplayBuffer<SIZE> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        if let Some(buf) = self.buf.get_mut(self.len..(self.len + s.len())) {
-            buf.copy_from_slice(s.as_bytes());
-            self.len += s.len();
+        let bytes = s.as_bytes();
+
+        if let Some(buf) = self.buf.get_mut(self.len..(self.len + bytes.len())) {
+            MaybeUninit::write_slice(buf, bytes);
+            self.len += bytes.len();
             Ok(())
         } else {
             Err(fmt::Error)

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -209,11 +209,11 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                 }
 
                 types::ItemEnum::Method(_)
+                | types::ItemEnum::Module(_)
                 | types::ItemEnum::AssocConst { .. }
                 | types::ItemEnum::AssocType { .. }
                 | types::ItemEnum::PrimitiveType(_) => true,
-                types::ItemEnum::Module(_)
-                | types::ItemEnum::ExternCrate { .. }
+                types::ItemEnum::ExternCrate { .. }
                 | types::ItemEnum::Import(_)
                 | types::ItemEnum::StructField(_)
                 | types::ItemEnum::Variant(_)

--- a/src/test/rustdoc-json/reexport/export_extern_crate_as_self.rs
+++ b/src/test/rustdoc-json/reexport/export_extern_crate_as_self.rs
@@ -1,0 +1,11 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/100531>
+
+#![feature(no_core)]
+#![no_core]
+
+#![crate_name = "export_extern_crate_as_self"]
+
+// ignore-tidy-linelength
+
+// @is export_extern_crate_as_self.json "$.index[*][?(@.kind=='module')].name" \"export_extern_crate_as_self\"
+pub extern crate self as export_extern_crate_as_self; // Must be the same name as the crate already has


### PR DESCRIPTION
Successful merges:

 - #100243 (Remove opt_remap_env_constness from rustc_query_impl)
 - #100625 (Add `IpDisplayBuffer` helper struct.)
 - #100629 (Use `merged_ty` method instead of rewriting it every time)
 - #100630 (rustdoc JSON: Fix ICE with `pub extern crate self as <self_crate_name>`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100243,100625,100629,100630)
<!-- homu-ignore:end -->