### PR TITLE
Migrate emoji identifier diagnostics to `SessionDiagnostic` in rustc_interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,6 +4011,7 @@ dependencies = [
  "rustc_hir",
  "rustc_incremental",
  "rustc_lint",
+ "rustc_macros",
  "rustc_metadata",
  "rustc_middle",
  "rustc_mir_build",

--- a/compiler/rustc_error_messages/locales/en-US/interface.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/interface.ftl
@@ -1,0 +1,6 @@
+interface_ferris_identifier =
+    Ferris cannot be used as an identifier
+    .suggestion = try using their name instead
+
+interface_emoji_identifier =
+    identifiers cannot contain emoji: `{$ident}`

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -34,6 +34,7 @@ fluent_messages! {
     builtin_macros => "../locales/en-US/builtin_macros.ftl",
     const_eval => "../locales/en-US/const_eval.ftl",
     expand => "../locales/en-US/expand.ftl",
+    interface => "../locales/en-US/interface.ftl",
     lint => "../locales/en-US/lint.ftl",
     parser => "../locales/en-US/parser.ftl",
     passes => "../locales/en-US/passes.ftl",

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -17,6 +17,7 @@ rustc_attr = { path = "../rustc_attr" }
 rustc_borrowck = { path = "../rustc_borrowck" }
 rustc_builtin_macros = { path = "../rustc_builtin_macros" }
 rustc_expand = { path = "../rustc_expand" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_parse = { path = "../rustc_parse" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }


### PR DESCRIPTION
* Migrate emoji identifier diagnostics to `interface_ferris_identifier` and `interface_emoji_identifier`.

This is my first PR! I'm learning how to migrate these diagnostics. Thanks in advance.

r? rust-lang/diagnostics