### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
3 commits in efd4ca3dc0b89929dc8c5f5c023d25978d76cb61..9809f8ff33c2b998919fd0432c626f0f7323697a
2022-08-12 01:28:28 +0000 to 2022-08-16 22:10:06 +0000
- Improve error message for an array value in the manifest (rust-lang/cargo#10944)
- Fix file locking being not supported on Android raising an error (rust-lang/cargo#10975)
- Bump to 0.66.0, update changelog (rust-lang/cargo#10983)