### PR TITLE
Migrate typeck::outlives::mod.rs to SessionDiagnostic

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -123,3 +123,5 @@ typeck_manual_implementation =
     .help = add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 typeck_substs_on_overridden_impl = could not resolve substs on overridden impl
+
+typeck_rustc_outlives = rustc_outlives

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -324,3 +324,20 @@ pub struct SubstsOnOverriddenImpl {
     #[primary_span]
     pub span: Span,
 }
+
+pub struct RustcOutlives {
+    pub span: Span,
+    pub pred: Vec<String>,
+}
+
+impl SessionDiagnostic<'_> for RustcOutlives {
+    fn into_diagnostic(self, sess: &ParseSess) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
+        let mut diag = sess
+            .span_diagnostic
+            .struct_span_err(self.span, rustc_errors::fluent::typeck::rustc_outlives);
+        for p in self.pred {
+            diag.note(p);
+        }
+        diag
+    }
+}

--- a/compiler/rustc_typeck/src/outlives/mod.rs
+++ b/compiler/rustc_typeck/src/outlives/mod.rs
@@ -7,6 +7,8 @@ use rustc_middle::ty::{self, CratePredicatesMap, ToPredicate, TyCtxt};
 use rustc_span::symbol::sym;
 use rustc_span::Span;
 
+use crate::errors::RustcOutlives;
+
 mod explicit;
 mod implicit_infer;
 pub(crate) mod outlives_bounds;
@@ -59,12 +61,7 @@ fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: DefId) -> &[(ty::Predicate
                         .collect();
                     pred.sort();
 
-                    let span = tcx.def_span(item_def_id);
-                    let mut err = tcx.sess.struct_span_err(span, "rustc_outlives");
-                    for p in &pred {
-                        err.note(p);
-                    }
-                    err.emit();
+                    tcx.sess.emit_err(RustcOutlives { span: tcx.def_span(item_def_id), pred });
                 }
 
                 debug!("inferred_outlives_of({:?}) = {:?}", item_def_id, predicates);


### PR DESCRIPTION
Migration of a part of the outlive module to Session Diagnostic. 
This is my first PR, I hope is ok

r? rust-lang/diagnostics
