### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/generator_interior.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior.rs
@@ -584,7 +584,7 @@ fn check_must_not_suspend_ty<'tcx>(
         }
         // If drop tracking is enabled, we want to look through references, since the referrent
         // may not be considered live across the await point.
-        ty::Ref(_region, ty, _mutability) if fcx.sess().opts.debugging_opts.drop_tracking => {
+        ty::Ref(_region, ty, _mutability) if fcx.sess().opts.unstable_opts.drop_tracking => {
             let descr_pre = &format!("{}reference{} to ", data.descr_pre, plural_suffix);
             check_must_not_suspend_ty(fcx, ty, hir_id, SuspendCheckData { descr_pre, ..data })
         }

--- a/compiler/rustc_typeck/src/check/generator_interior.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior.rs
@@ -489,6 +489,8 @@ pub fn check_must_not_suspend_ty<'tcx>(
 
     let plural_suffix = pluralize!(data.plural_len);
 
+    debug!("Checking must_not_suspend for {}", ty);
+
     match *ty.kind() {
         ty::Adt(..) if ty.is_box() => {
             let boxed_ty = ty.boxed_ty();
@@ -579,6 +581,10 @@ pub fn check_must_not_suspend_ty<'tcx>(
                     ..data
                 },
             )
+        }
+        ty::Ref(_region, ty, _mutability) => {
+            let descr_pre = &format!("{}reference{} to ", data.descr_pre, plural_suffix);
+            check_must_not_suspend_ty(fcx, ty, hir_id, SuspendCheckData { descr_pre, ..data })
         }
         _ => false,
     }

--- a/compiler/rustc_typeck/src/check/generator_interior.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior.rs
@@ -457,7 +457,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
 }
 
 #[derive(Default)]
-pub struct SuspendCheckData<'a, 'tcx> {
+struct SuspendCheckData<'a, 'tcx> {
     expr: Option<&'tcx Expr<'tcx>>,
     source_span: Span,
     yield_span: Span,
@@ -472,7 +472,7 @@ pub struct SuspendCheckData<'a, 'tcx> {
 //
 // Note that this technique was chosen over things like a `Suspend` marker trait
 // as it is simpler and has precedent in the compiler
-pub fn check_must_not_suspend_ty<'tcx>(
+fn check_must_not_suspend_ty<'tcx>(
     fcx: &FnCtxt<'_, 'tcx>,
     ty: Ty<'tcx>,
     hir_id: HirId,
@@ -582,7 +582,9 @@ pub fn check_must_not_suspend_ty<'tcx>(
                 },
             )
         }
-        ty::Ref(_region, ty, _mutability) => {
+        // If drop tracking is enabled, we want to look through references, since the referrent
+        // may not be considered live across the await point.
+        ty::Ref(_region, ty, _mutability) if fcx.sess().opts.debugging_opts.drop_tracking => {
             let descr_pre = &format!("{}reference{} to ", data.descr_pre, plural_suffix);
             check_must_not_suspend_ty(fcx, ty, hir_id, SuspendCheckData { descr_pre, ..data })
         }

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -394,7 +394,7 @@ impl f32 {
 
     /// Not a Number (NaN).
     ///
-    /// Note that IEEE-745 doesn't define just a single NaN value;
+    /// Note that IEEE-754 doesn't define just a single NaN value;
     /// a plethora of bit patterns are considered to be NaN.
     /// Furthermore, the standard makes a difference
     /// between a "signaling" and a "quiet" NaN,
@@ -632,7 +632,7 @@ impl f32 {
     }
 
     /// Returns `true` if `self` has a positive sign, including `+0.0`, NaNs with
-    /// positive sign bit and positive infinity. Note that IEEE-745 doesn't assign any
+    /// positive sign bit and positive infinity. Note that IEEE-754 doesn't assign any
     /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
     /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
     /// `is_sign_positive` on a NaN might produce an unexpected result in some cases.
@@ -654,7 +654,7 @@ impl f32 {
     }
 
     /// Returns `true` if `self` has a negative sign, including `-0.0`, NaNs with
-    /// negative sign bit and negative infinity. Note that IEEE-745 doesn't assign any
+    /// negative sign bit and negative infinity. Note that IEEE-754 doesn't assign any
     /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
     /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
     /// `is_sign_negative` on a NaN might produce an unexpected result in some cases.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -393,7 +393,7 @@ impl f64 {
 
     /// Not a Number (NaN).
     ///
-    /// Note that IEEE-745 doesn't define just a single NaN value;
+    /// Note that IEEE-754 doesn't define just a single NaN value;
     /// a plethora of bit patterns are considered to be NaN.
     /// Furthermore, the standard makes a difference
     /// between a "signaling" and a "quiet" NaN,
@@ -624,7 +624,7 @@ impl f64 {
     }
 
     /// Returns `true` if `self` has a positive sign, including `+0.0`, NaNs with
-    /// positive sign bit and positive infinity. Note that IEEE-745 doesn't assign any
+    /// positive sign bit and positive infinity. Note that IEEE-754 doesn't assign any
     /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
     /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
     /// `is_sign_positive` on a NaN might produce an unexpected result in some cases.
@@ -655,7 +655,7 @@ impl f64 {
     }
 
     /// Returns `true` if `self` has a negative sign, including `-0.0`, NaNs with
-    /// negative sign bit and negative infinity. Note that IEEE-745 doesn't assign any
+    /// negative sign bit and negative infinity. Note that IEEE-754 doesn't assign any
     /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
     /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
     /// `is_sign_negative` on a NaN might produce an unexpected result in some cases.

--- a/library/unwind/build.rs
+++ b/library/unwind/build.rs
@@ -2,8 +2,14 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    let target = env::var("TARGET").expect("TARGET was not set");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_MIRI");
 
+    if env::var_os("CARGO_CFG_MIRI").is_some() {
+        // Miri doesn't need the linker flags or a libunwind build.
+        return;
+    }
+
+    let target = env::var("TARGET").expect("TARGET was not set");
     if target.contains("android") {
         let build = cc::Build::new();
 

--- a/src/test/ui/lint/must_not_suspend/ref-drop-tracking.rs
+++ b/src/test/ui/lint/must_not_suspend/ref-drop-tracking.rs
@@ -1,0 +1,30 @@
+// edition:2018
+// compile-flags: -Zdrop-tracking
+#![feature(must_not_suspend)]
+#![deny(must_not_suspend)]
+
+#[must_not_suspend = "You gotta use Umm's, ya know?"]
+struct Umm {
+    i: i64
+}
+
+struct Bar {
+    u: Umm,
+}
+
+async fn other() {}
+
+impl Bar {
+    async fn uhoh(&mut self) {
+        let guard = &mut self.u; //~ ERROR `Umm` held across
+
+        other().await;
+
+        *guard = Umm {
+            i: 2
+        }
+    }
+}
+
+fn main() {
+}

--- a/src/test/ui/lint/must_not_suspend/ref-drop-tracking.stderr
+++ b/src/test/ui/lint/must_not_suspend/ref-drop-tracking.stderr
@@ -1,27 +1,27 @@
-error: `Umm` held across a suspend point, but should not be
-  --> $DIR/ref.rs:18:26
+error: reference to `Umm` held across a suspend point, but should not be
+  --> $DIR/ref-drop-tracking.rs:19:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
-LL |
+   |             ^^^^^
+LL | 
 LL |         other().await;
    |                ------ the value is held across this suspend point
    |
 note: the lint level is defined here
-  --> $DIR/ref.rs:3:9
+  --> $DIR/ref-drop-tracking.rs:4:9
    |
 LL | #![deny(must_not_suspend)]
    |         ^^^^^^^^^^^^^^^^
 note: You gotta use Umm's, ya know?
-  --> $DIR/ref.rs:18:26
+  --> $DIR/ref-drop-tracking.rs:19:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
+   |             ^^^^^
 help: consider using a block (`{ ... }`) to shrink the value's scope, ending before the suspend point
-  --> $DIR/ref.rs:18:26
+  --> $DIR/ref-drop-tracking.rs:19:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
+   |             ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/must_not_suspend/ref-drop-tracking.stderr
+++ b/src/test/ui/lint/must_not_suspend/ref-drop-tracking.stderr
@@ -3,7 +3,7 @@ error: reference to `Umm` held across a suspend point, but should not be
    |
 LL |         let guard = &mut self.u;
    |             ^^^^^
-LL | 
+LL |
 LL |         other().await;
    |                ------ the value is held across this suspend point
    |

--- a/src/test/ui/lint/must_not_suspend/ref.stderr
+++ b/src/test/ui/lint/must_not_suspend/ref.stderr
@@ -1,5 +1,5 @@
-error: `Umm` held across a suspend point, but should not be
-  --> $DIR/ref.rs:18:26
+error: reference to `Umm` held across a suspend point, but should not be
+  --> $DIR/ref.rs:18:13
    |
 LL |         let guard = &mut self.u;
    |                          ^^^^^^
@@ -13,15 +13,15 @@ note: the lint level is defined here
 LL | #![deny(must_not_suspend)]
    |         ^^^^^^^^^^^^^^^^
 note: You gotta use Umm's, ya know?
-  --> $DIR/ref.rs:18:26
+  --> $DIR/ref.rs:18:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
+   |             ^^^^^
 help: consider using a block (`{ ... }`) to shrink the value's scope, ending before the suspend point
-  --> $DIR/ref.rs:18:26
+  --> $DIR/ref.rs:18:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
+   |             ^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #97962 (Make must_not_suspend lint see through references when drop tracking is enabled)
 - #100532 (unwind: don't build dependency when building for Miri)
 - #100660 (Fixed a few documentation errors)
 - #100661 (Fixed a few documentation errors)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97962,100532,100660,100661)
<!-- homu-ignore:end -->