### PR TITLE
Fix documentation of rustc_parse::parser::Parser::parse_stmt_without_recovery

### DIFF
--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -34,7 +34,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// If `force_capture` is true, forces collection of tokens regardless of whether
+    /// If `force_collect` is [`ForceCollect::Yes`], forces collection of tokens regardless of whether
     /// or not we have attributes
     pub(crate) fn parse_stmt_without_recovery(
         &mut self,


### PR DESCRIPTION
Something seems to have gotten out of sync during the creation of #81177, where both the argument and comment were introduced.