### PR TITLE
tidy: check fluent files for style

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
@@ -13,6 +13,6 @@ borrowck_could_not_normalize =
 
 borrowck_higher_ranked_subtype_error =
     higher-ranked subtype error
-  
+
 generic_does_not_live_long_enough =
     `{$kind}` does not live long enough

--- a/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/borrowck.ftl
@@ -14,5 +14,5 @@ borrowck_could_not_normalize =
 borrowck_higher_ranked_subtype_error =
     higher-ranked subtype error
 
-generic_does_not_live_long_enough =
+borrowck_generic_does_not_live_long_enough =
     `{$kind}` does not live long enough

--- a/compiler/rustc_error_messages/locales/en-US/expand.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/expand.ftl
@@ -4,10 +4,10 @@ expand_explain_doc_comment_outer =
 expand_explain_doc_comment_inner =
     inner doc comments expand to `#![doc = "..."]`, which is what this macro attempted to match
 
-expand_expr_repeat_no_syntax_vars = 
+expand_expr_repeat_no_syntax_vars =
     attempted to repeat an expression containing no syntax variables matched as repeating at this depth
 
-expand_must_repeat_once = 
+expand_must_repeat_once =
     this must repeat at least once
 
 expand_count_repetition_misplaced =

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -125,16 +125,13 @@ fn should_ignore(line: &str) -> bool {
 
 /// Returns `true` if `line` is allowed to be longer than the normal limit.
 fn long_line_is_ok(extension: &str, is_error_code: bool, max_columns: usize, line: &str) -> bool {
-    if extension != "md" || is_error_code {
-        if line_is_url(is_error_code, max_columns, line) || should_ignore(line) {
-            return true;
-        }
-    } else if extension == "md" {
+    match extension {
+        // fluent files are allowed to be any length
+        "ftl" => true,
         // non-error code markdown is allowed to be any length
-        return true;
+        "md" if !is_error_code => true,
+        _ => line_is_url(is_error_code, max_columns, line) || should_ignore(line),
     }
-
-    false
 }
 
 enum Directive {
@@ -230,7 +227,7 @@ pub fn check(path: &Path, bad: &mut bool) {
     super::walk(path, &mut skip, &mut |entry, contents| {
         let file = entry.path();
         let filename = file.file_name().unwrap().to_string_lossy();
-        let extensions = [".rs", ".py", ".js", ".sh", ".c", ".cpp", ".h", ".md", ".css"];
+        let extensions = [".rs", ".py", ".js", ".sh", ".c", ".cpp", ".h", ".md", ".css", ".ftl"];
         if extensions.iter().all(|e| !filename.ends_with(e)) || filename.starts_with(".#") {
             return;
         }


### PR DESCRIPTION
Inspired by https://github.com/rust-lang/rust/pull/100651#discussion_r947600576

There were a lot of line length violations, so I've excepted that lint - I'm not sure if fluent files can be formatted to avoid long lines at all.