### PR TITLE
Migrate lint reports in typeck::check_unused to LintDiagnostic

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -123,3 +123,11 @@ typeck_manual_implementation =
     .help = add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 typeck_substs_on_overridden_impl = could not resolve substs on overridden impl
+
+typeck_unused_extern_crate =
+    unused extern crate
+    .suggestion = remove it
+
+typeck_extern_crate_not_idiomatic =
+    `extern crate` is not idiomatic in the new edition
+    .suggestion = convert it to a `{$msg_code}`

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -1,6 +1,6 @@
 //! Errors emitted by typeck.
 use rustc_errors::{error_code, Applicability, DiagnosticBuilder, ErrorGuaranteed};
-use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
+use rustc_macros::{LintDiagnostic, SessionDiagnostic, SessionSubdiagnostic};
 use rustc_middle::ty::Ty;
 use rustc_session::{parse::ParseSess, SessionDiagnostic};
 use rustc_span::{symbol::Ident, Span, Symbol};
@@ -323,4 +323,22 @@ pub struct ManualImplementation {
 pub struct SubstsOnOverriddenImpl {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(LintDiagnostic)]
+#[lint(typeck::unused_extern_crate)]
+pub struct UnusedExternCrate {
+    #[primary_span]
+    #[suggestion(applicability = "machine-applicable", code = "")]
+    pub span: Span,
+}
+
+#[derive(LintDiagnostic)]
+#[lint(typeck::extern_crate_not_idiomatic)]
+pub struct ExternCrateNotIdiomatic {
+    #[primary_span]
+    #[suggestion(applicability = "machine-applicable", code = "{suggestion_code}")]
+    pub span: Span,
+    pub msg_code: String,
+    pub suggestion_code: String,
 }

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -337,7 +337,7 @@ pub struct UnusedExternCrate {
 #[lint(typeck::extern_crate_not_idiomatic)]
 pub struct ExternCrateNotIdiomatic {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "{suggestion_code}")]
+    #[suggestion_short(applicability = "machine-applicable", code = "{suggestion_code}")]
     pub span: Span,
     pub msg_code: String,
     pub suggestion_code: String,

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -328,7 +328,6 @@ pub struct SubstsOnOverriddenImpl {
 #[derive(LintDiagnostic)]
 #[lint(typeck::unused_extern_crate)]
 pub struct UnusedExternCrate {
-    #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
@@ -336,7 +335,6 @@ pub struct UnusedExternCrate {
 #[derive(LintDiagnostic)]
 #[lint(typeck::extern_crate_not_idiomatic)]
 pub struct ExternCrateNotIdiomatic {
-    #[primary_span]
     #[suggestion_short(applicability = "machine-applicable", code = "{suggestion_code}")]
     pub span: Span,
     pub msg_code: String,

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,9 +1,11 @@
 error: unused extern crate
-  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:11:1
+  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:12:1
    |
 LL | / #[cfg(blandiloquence)]
 LL | | extern crate edition_lint_paths;
-   | |________________________________^ help: remove it
+   | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   | |________________________________|
+   |                                  help: remove it
    |
 note: the lint level is defined here
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:6:9

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,11 +1,9 @@
 error: unused extern crate
-  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:12:1
+  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:11:1
    |
 LL | / #[cfg(blandiloquence)]
 LL | | extern crate edition_lint_paths;
-   | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   | |________________________________|
-   |                                  help: remove it
+   | |________________________________^ help: remove it
    |
 note: the lint level is defined here
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:6:9


### PR DESCRIPTION
In this PR, I migrate two lint reports in `typeck::check_unused` by `LintDiagnostic`, all of which is about extern crates.

@rustbot label +A-translation
r? rust-lang/diagnostics