### PR TITLE
Add `rustc --print rustc-path`

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -725,6 +725,10 @@ fn print_crate_info(
             | TargetFeatures => {
                 codegen_backend.print(*req, sess);
             }
+            RustcPath => match env::current_exe() {
+                Ok(exe) => println!("{}", exe.display()),
+                Err(_) => early_error(ErrorOutputType::default(), "failed to get rustc path"),
+            },
             // Any output here interferes with Cargo's parsing of other printed output
             NativeStaticLibs => {}
             LinkArgs => {}

--- a/src/test/run-make/print-rustc-path/Makefile
+++ b/src/test/run-make/print-rustc-path/Makefile
@@ -1,0 +1,9 @@
+-include ../../run-make-fulldeps/tools.mk
+
+ifdef IS_WINDOWS
+all:
+	$(RUSTC) -Zunstable-options --print rustc-path | $(CGREP) bin\rustc
+else
+all:
+	$(RUSTC) -Zunstable-options --print rustc-path | $(CGREP) bin/rustc
+endif


### PR DESCRIPTION
Related:

- https://github.com/rust-lang/cargo/issues/10986
- https://github.com/rust-lang/rustup/issues/3035

Goal:

Like the original https://github.com/rust-lang/rustup/pull/2958, the goal is to enable `cargo` to call `rustc` directly, rather than through the `rustup` shim.

Solution:

`cargo` asks `rustc` to tell it what executable to run. Sometime early in compilation, `cargo` will run `$(RUSTC_WRAPPER) $(RUSTC ?: rustc) --print rustc-path`[^1]. Further calls to `rustc` to do execution will use the resolved printed executable path rather than continuing to call the "input `rustc` path," which will allow it to bypass the `rustup` shim.

The cargo side is https://github.com/rust-lang/cargo/pull/10998.

[^1]: This can potentially be combined with other `--print`s, as well!

This is a tiny patch, so I've implemented it as insta-stable; this will need signoff probably from both the compiler and cargo teams. I'm working on the cargo side of the patch currently, but wanted to get this up ASAP.

cc @davidlattimore @bjorn3 @rust-lang/cargo @rust-lang/compiler (sorry for the big ping list 😅)