### PR TITLE
`ty::Error` does not match other types for region constraints

### DIFF
--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -174,7 +174,14 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
 
     #[instrument(skip(self), level = "debug")]
     fn tys(&mut self, pattern: Ty<'tcx>, value: Ty<'tcx>) -> RelateResult<'tcx, Ty<'tcx>> {
-        if pattern == value { Ok(pattern) } else { relate::super_relate_tys(self, pattern, value) }
+        if let ty::Error(_) = pattern.kind() {
+            // Unlike normal `TypeRelation` rules, `ty::Error` does not equal any type.
+            self.no_match()
+        } else if pattern == value {
+            Ok(pattern)
+        } else {
+            relate::super_relate_tys(self, pattern, value)
+        }
     }
 
     #[instrument(skip(self), level = "debug")]

--- a/src/test/ui/regions/outlives-with-missing.rs
+++ b/src/test/ui/regions/outlives-with-missing.rs
@@ -1,0 +1,16 @@
+trait HandlerFamily {
+    type Target;
+}
+
+struct HandlerWrapper<H: HandlerFamily>(H);
+
+impl<H: HandlerFamily> HandlerWrapper<H> {
+    pub fn set_handler(&self, handler: &H::Target)
+    where
+        T: Send + Sync + 'static,
+        //~^ ERROR cannot find type `T` in this scope
+    {
+    }
+}
+
+fn main() {}

--- a/src/test/ui/regions/outlives-with-missing.stderr
+++ b/src/test/ui/regions/outlives-with-missing.stderr
@@ -1,0 +1,12 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/outlives-with-missing.rs:10:9
+   |
+LL | impl<H: HandlerFamily> HandlerWrapper<H> {
+   |      - similarly named type parameter `H` defined here
+...
+LL |         T: Send + Sync + 'static,
+   |         ^ help: a type parameter with a similar name exists: `H`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #100684