### PR TITLE
Migrate rustc_ast_passes diagnostics to `SessionDiagnostic` and translatable messages (first part)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,6 +3595,7 @@ dependencies = [
  "rustc_data_structures",
  "rustc_errors",
  "rustc_feature",
+ "rustc_macros",
  "rustc_parse",
  "rustc_session",
  "rustc_span",

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -11,6 +11,7 @@ rustc_attr = { path = "../rustc_attr" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_feature = { path = "../rustc_feature" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_parse = { path = "../rustc_parse" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -287,16 +287,7 @@ impl<'a> AstValidator<'a> {
 
     fn check_trait_fn_not_async(&self, fn_span: Span, asyncness: Async) {
         if let Async::Yes { span, .. } = asyncness {
-            struct_span_err!(
-                self.session,
-                fn_span,
-                E0706,
-                "functions in traits cannot be declared `async`"
-            )
-            .span_label(span, "`async` because of this")
-            .note("`async` trait functions are not currently supported")
-            .note("consider using the `async-trait` crate: https://crates.io/crates/async-trait")
-            .emit();
+            self.session.emit_err(TraitFnAsync { fn_span, span });
         }
     }
 

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -372,19 +372,9 @@ impl<'a> AstValidator<'a> {
             })
             .for_each(|attr| {
                 if attr.is_doc_comment() {
-                    self.err_handler()
-                        .struct_span_err(
-                            attr.span,
-                            "documentation comments cannot be applied to function parameters",
-                        )
-                        .span_label(attr.span, "doc comments are not allowed here")
-                        .emit();
+                    self.session.emit_err(DocCommentOnFnParam { span: attr.span });
                 } else {
-                    self.err_handler().span_err(
-                        attr.span,
-                        "allow, cfg, cfg_attr, deny, expect, \
-                forbid, and warn are the only allowed built-in attributes in function parameters",
-                    );
+                    self.session.emit_err(ForbiddenAttrOnFnParam { span: attr.span });
                 }
             });
     }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -331,7 +331,7 @@ impl<'a> AstValidator<'a> {
         let max_num_args: usize = u16::MAX.into();
         if fn_decl.inputs.len() > max_num_args {
             let Param { span, .. } = fn_decl.inputs[0];
-            self.session.emit_err(FnParamTooMany { span, max_num_args });
+            self.session.emit_fatal(FnParamTooMany { span, max_num_args });
         }
     }
 

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -339,7 +339,7 @@ impl<'a> AstValidator<'a> {
         match &*fn_decl.inputs {
             [Param { ty, span, .. }] => {
                 if let TyKind::CVarArgs = ty.kind {
-                    self.session.emit_err(CVarArgsWithoutNamedArg { span: *span });
+                    self.session.emit_err(CVarArgsIsSoleParam { span: *span });
                 }
             }
             [ps @ .., _] => {

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -106,38 +106,47 @@ pub struct ForbiddenNonLifetimeParam {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::too_many_params)]
-pub struct TooManyParams {
+#[error(ast_passes::fn_param_too_many)]
+pub struct FnParamTooMany {
     #[primary_span]
     pub span: Span,
     pub max_num_args: usize,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::c_var_args_is_sole_param)]
-pub struct CVarArgsIsSoleParam {
+#[error(ast_passes::fn_param_c_var_args_only)]
+pub struct FnParamCVarArgsOnly {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::c_var_args_not_last)]
-pub struct CVarArgsNotLast {
+#[error(ast_passes::fn_param_c_var_args_not_last)]
+pub struct FnParamCVarArgsNotLast {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::doc_comment_on_fn_param)]
-pub struct DocCommentOnFnParam {
+#[error(ast_passes::fn_param_doc_comment)]
+pub struct FnParamDocComment {
     #[primary_span]
     #[label]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::forbidden_attr_on_fn_param)]
-pub struct ForbiddenAttrOnFnParam {
+#[error(ast_passes::fn_param_forbidden_attr)]
+pub struct FnParamForbiddenAttr {
     #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::fn_param_forbidden_self)]
+#[note]
+pub struct FnParamForbiddenSelf {
+    #[primary_span]
+    #[label]
     pub span: Span,
 }

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -26,7 +26,7 @@ impl AddSubdiagnostic for ForbiddenLetReason {
             }
             Self::NotSupportedParentheses(span) => {
                 diag.span_note(span, fluent::ast_passes::not_supported_parentheses);
-            },
+            }
         }
     }
 }

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -71,3 +71,14 @@ pub enum InvalidVisibilityNote {
     #[note(ast_passes::individual_foreign_items)]
     IndividualForeignItems,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::trait_fn_async, code = "E0706")]
+#[note]
+#[note(ast_passes::note2)]
+pub struct TraitFnAsync {
+    #[primary_span]
+    pub fn_span: Span,
+    #[label]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -90,3 +90,39 @@ pub struct TraitFnConst {
     #[label]
     pub span: Span,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::forbidden_lifetime_bound)]
+pub struct ForbiddenLifetimeBound {
+    #[primary_span]
+    pub spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::forbidden_non_lifetime_param)]
+pub struct ForbiddenNonLifetimeParam {
+    #[primary_span]
+    pub spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::too_many_params)]
+pub struct TooManyParams {
+    #[primary_span]
+    pub span: Span,
+    pub max_num_args: usize,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::c_var_args_without_named_arg)]
+pub struct CVarArgsWithoutNamedArg {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::c_var_args_not_last)]
+pub struct CVarArgsNotLast {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -2,8 +2,8 @@
 
 use rustc_errors::fluent;
 use rustc_errors::{AddSubdiagnostic, Diagnostic};
-use rustc_macros::SessionDiagnostic;
-use rustc_span::Span;
+use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
+use rustc_span::{Span, Symbol};
 
 use crate::ast_validation::ForbiddenLetReason;
 
@@ -29,4 +29,45 @@ impl AddSubdiagnostic for ForbiddenLetReason {
             },
         }
     }
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::forbidden_assoc_constraint)]
+pub struct ForbiddenAssocConstraint {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::keyword_lifetime)]
+pub struct KeywordLifetime {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::invalid_label)]
+pub struct InvalidLabel {
+    #[primary_span]
+    pub span: Span,
+    pub name: Symbol,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::invalid_visibility, code = "E0449")]
+pub struct InvalidVisibility {
+    #[primary_span]
+    pub span: Span,
+    #[label(ast_passes::implied)]
+    pub implied: Option<Span>,
+    #[subdiagnostic]
+    pub note: Option<InvalidVisibilityNote>,
+}
+
+#[derive(SessionSubdiagnostic)]
+pub enum InvalidVisibilityNote {
+    #[note(ast_passes::individual_impl_items)]
+    IndividualImplItems,
+    #[note(ast_passes::individual_foreign_items)]
+    IndividualForeignItems,
 }

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -106,7 +106,7 @@ pub struct ForbiddenNonLifetimeParam {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::fn_param_too_many)]
+#[fatal(ast_passes::fn_param_too_many)]
 pub struct FnParamTooMany {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -114,8 +114,8 @@ pub struct TooManyParams {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::c_var_args_without_named_arg)]
-pub struct CVarArgsWithoutNamedArg {
+#[error(ast_passes::c_var_args_is_sole_param)]
+pub struct CVarArgsIsSoleParam {
     #[primary_span]
     pub span: Span,
 }

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -82,3 +82,11 @@ pub struct TraitFnAsync {
     #[label]
     pub span: Span,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::trait_fn_const, code = "E0379")]
+pub struct TraitFnConst {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_span::{Span, Symbol};
 use crate::ast_validation::ForbiddenLetReason;
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::forbidden_let)]
+#[diag(ast_passes::forbidden_let)]
 #[note]
 pub struct ForbiddenLet {
     #[primary_span]
@@ -31,21 +31,21 @@ impl AddSubdiagnostic for ForbiddenLetReason {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::forbidden_assoc_constraint)]
+#[diag(ast_passes::forbidden_assoc_constraint)]
 pub struct ForbiddenAssocConstraint {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::keyword_lifetime)]
+#[diag(ast_passes::keyword_lifetime)]
 pub struct KeywordLifetime {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::invalid_label)]
+#[diag(ast_passes::invalid_label)]
 pub struct InvalidLabel {
     #[primary_span]
     pub span: Span,
@@ -53,7 +53,7 @@ pub struct InvalidLabel {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::invalid_visibility, code = "E0449")]
+#[diag(ast_passes::invalid_visibility, code = "E0449")]
 pub struct InvalidVisibility {
     #[primary_span]
     pub span: Span,
@@ -72,7 +72,7 @@ pub enum InvalidVisibilityNote {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::trait_fn_async, code = "E0706")]
+#[diag(ast_passes::trait_fn_async, code = "E0706")]
 #[note]
 #[note(ast_passes::note2)]
 pub struct TraitFnAsync {
@@ -83,7 +83,7 @@ pub struct TraitFnAsync {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::trait_fn_const, code = "E0379")]
+#[diag(ast_passes::trait_fn_const, code = "E0379")]
 pub struct TraitFnConst {
     #[primary_span]
     #[label]
@@ -91,21 +91,21 @@ pub struct TraitFnConst {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::forbidden_lifetime_bound)]
+#[diag(ast_passes::forbidden_lifetime_bound)]
 pub struct ForbiddenLifetimeBound {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::forbidden_non_lifetime_param)]
+#[diag(ast_passes::forbidden_non_lifetime_param)]
 pub struct ForbiddenNonLifetimeParam {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(SessionDiagnostic)]
-#[fatal(ast_passes::fn_param_too_many)]
+#[diag(ast_passes::fn_param_too_many)]
 pub struct FnParamTooMany {
     #[primary_span]
     pub span: Span,
@@ -113,21 +113,21 @@ pub struct FnParamTooMany {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::fn_param_c_var_args_only)]
+#[diag(ast_passes::fn_param_c_var_args_only)]
 pub struct FnParamCVarArgsOnly {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::fn_param_c_var_args_not_last)]
+#[diag(ast_passes::fn_param_c_var_args_not_last)]
 pub struct FnParamCVarArgsNotLast {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::fn_param_doc_comment)]
+#[diag(ast_passes::fn_param_doc_comment)]
 pub struct FnParamDocComment {
     #[primary_span]
     #[label]
@@ -135,14 +135,14 @@ pub struct FnParamDocComment {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::fn_param_forbidden_attr)]
+#[diag(ast_passes::fn_param_forbidden_attr)]
 pub struct FnParamForbiddenAttr {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::fn_param_forbidden_self)]
+#[diag(ast_passes::fn_param_forbidden_self)]
 #[note]
 pub struct FnParamForbiddenSelf {
     #[primary_span]
@@ -151,7 +151,7 @@ pub struct FnParamForbiddenSelf {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::forbidden_default)]
+#[diag(ast_passes::forbidden_default)]
 pub struct ForbiddenDefault {
     #[primary_span]
     pub span: Span,
@@ -160,7 +160,7 @@ pub struct ForbiddenDefault {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::assoc_const_without_body)]
+#[diag(ast_passes::assoc_const_without_body)]
 pub struct AssocConstWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -169,7 +169,7 @@ pub struct AssocConstWithoutBody {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::assoc_fn_without_body)]
+#[diag(ast_passes::assoc_fn_without_body)]
 pub struct AssocFnWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -178,7 +178,7 @@ pub struct AssocFnWithoutBody {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::assoc_type_without_body)]
+#[diag(ast_passes::assoc_type_without_body)]
 pub struct AssocTypeWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -187,7 +187,7 @@ pub struct AssocTypeWithoutBody {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::const_without_body)]
+#[diag(ast_passes::const_without_body)]
 pub struct ConstWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -196,7 +196,7 @@ pub struct ConstWithoutBody {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::static_without_body)]
+#[diag(ast_passes::static_without_body)]
 pub struct StaticWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -205,7 +205,7 @@ pub struct StaticWithoutBody {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::ty_alias_without_body)]
+#[diag(ast_passes::ty_alias_without_body)]
 pub struct TyAliasWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -214,7 +214,7 @@ pub struct TyAliasWithoutBody {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_passes::fn_without_body)]
+#[diag(ast_passes::fn_without_body)]
 pub struct FnWithoutBody {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -1,0 +1,32 @@
+//! Errors emitted by ast_passes.
+
+use rustc_errors::fluent;
+use rustc_errors::{AddSubdiagnostic, Diagnostic};
+use rustc_macros::SessionDiagnostic;
+use rustc_span::Span;
+
+use crate::ast_validation::ForbiddenLetReason;
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::forbidden_let)]
+#[note]
+pub struct ForbiddenLet {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub(crate) reason: ForbiddenLetReason,
+}
+
+impl AddSubdiagnostic for ForbiddenLetReason {
+    fn add_to_diagnostic(self, diag: &mut Diagnostic) {
+        match self {
+            Self::GenericForbidden => {}
+            Self::NotSupportedOr(span) => {
+                diag.span_note(span, fluent::ast_passes::not_supported_or);
+            }
+            Self::NotSupportedParentheses(span) => {
+                diag.span_note(span, fluent::ast_passes::not_supported_parentheses);
+            },
+        }
+    }
+}

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -126,3 +126,18 @@ pub struct CVarArgsNotLast {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::doc_comment_on_fn_param)]
+pub struct DocCommentOnFnParam {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_passes::forbidden_attr_on_fn_param)]
+pub struct ForbiddenAttrOnFnParam {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_passes/src/lib.rs
+++ b/compiler/rustc_ast_passes/src/lib.rs
@@ -12,6 +12,7 @@
 #![recursion_limit = "256"]
 
 pub mod ast_validation;
+mod errors;
 pub mod feature_gate;
 pub mod node_count;
 pub mod show_span;

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -1176,7 +1176,7 @@ fn create_lints_for_named_arguments_used_positionally(cx: &mut Context<'_, '_>) 
 
         cx.ecx.buffered_early_lint.push(BufferedEarlyLint {
             span: MultiSpan::from_span(named_arg.positional_named_arg_span),
-            msg: msg.clone().into(),
+            msg: msg.into(),
             node_id: ast::CRATE_NODE_ID,
             lint_id: LintId::of(&NAMED_ARGUMENTS_USED_POSITIONALLY),
             diagnostic: BuiltinLintDiagnostics::NamedArgumentUsedPositionally {

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -1176,7 +1176,7 @@ fn create_lints_for_named_arguments_used_positionally(cx: &mut Context<'_, '_>) 
 
         cx.ecx.buffered_early_lint.push(BufferedEarlyLint {
             span: MultiSpan::from_span(named_arg.positional_named_arg_span),
-            msg: msg.clone(),
+            msg: msg.clone().into(),
             node_id: ast::CRATE_NODE_ID,
             lint_id: LintId::of(&NAMED_ARGUMENTS_USED_POSITIONALLY),
             diagnostic: BuiltinLintDiagnostics::NamedArgumentUsedPositionally {

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -31,3 +31,18 @@ ast_passes_trait_fn_async =
 ast_passes_trait_fn_const =
     functions in traits cannot be declared const
     .label = functions in traits cannot be const
+
+ast_passes_forbidden_lifetime_bound =
+    lifetime bounds cannot be used in this context
+
+ast_passes_forbidden_non_lifetime_param =
+    only lifetime parameters can be used in this context
+
+ast_passes_too_many_params =
+    function can not have more than {$max_num_args} arguments
+
+ast_passes_c_var_args_without_named_arg =
+    C-variadic function must be declared with at least one named argument
+
+ast_passes_c_var_args_not_last =
+    `...` must be the last argument of a C-variadic function

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -3,3 +3,21 @@ ast_passes_forbidden_let =
     .note = only supported directly in conditions of `if` and `while` expressions
     .not_supported_or = `||` operators are not supported in let chain expressions
     .not_supported_parentheses = `let`s wrapped in parentheses are not supported in a context with let chains
+
+ast_passes_deprecated_where_clause_location =
+    where clause not allowed here
+
+ast_passes_forbidden_assoc_constraint =
+    associated type bounds are not allowed within structs, enums, or unions
+
+ast_passes_keyword_lifetime =
+    lifetimes cannot use keyword names
+
+ast_passes_invalid_label =
+    invalid label name `{$name}`
+
+ast_passes_invalid_visibility =
+    unnecessary visibility qualifier
+    .implied = `pub` not permitted here because it's implied
+    .individual_impl_items = place qualifiers on individual impl items instead
+    .individual_foreign_items = place qualifiers on individual foreign items instead

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -46,3 +46,10 @@ ast_passes_c_var_args_without_named_arg =
 
 ast_passes_c_var_args_not_last =
     `...` must be the last argument of a C-variadic function
+
+ast_passes_doc_comment_on_fn_param =
+    documentation comments cannot be applied to function parameters
+    .label = doc comments are not allowed here
+
+ast_passes_forbidden_attr_on_fn_param =
+    allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -21,3 +21,9 @@ ast_passes_invalid_visibility =
     .implied = `pub` not permitted here because it's implied
     .individual_impl_items = place qualifiers on individual impl items instead
     .individual_foreign_items = place qualifiers on individual foreign items instead
+
+ast_passes_trait_fn_async =
+    functions in traits cannot be declared `async`
+    .label = `async` because of this
+    .note = `async` trait functions are not currently supported
+    .note2 = consider using the `async-trait` crate: https://crates.io/crates/async-trait

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -1,0 +1,5 @@
+ast_passes_forbidden_let =
+    `let` expressions are not supported here
+    .note = only supported directly in conditions of `if` and `while` expressions
+    .not_supported_or = `||` operators are not supported in let chain expressions
+    .not_supported_parentheses = `let`s wrapped in parentheses are not supported in a context with let chains

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -41,7 +41,7 @@ ast_passes_forbidden_non_lifetime_param =
 ast_passes_too_many_params =
     function can not have more than {$max_num_args} arguments
 
-ast_passes_c_var_args_without_named_arg =
+ast_passes_c_var_args_is_sole_param =
     C-variadic function must be declared with at least one named argument
 
 ast_passes_c_var_args_not_last =

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -58,3 +58,36 @@ ast_passes_fn_param_forbidden_self =
     `self` parameter is only allowed in associated functions
     .label = not semantically valid as function parameter
     .note = associated functions are those in `impl` or `trait` definitions
+
+ast_passes_forbidden_default =
+    `default` is only allowed on items in trait impls
+    .label = `default` because of this
+
+ast_passes_assoc_const_without_body =
+    associated constant in `impl` without body
+    .suggestion = provide a definition for the constant
+
+ast_passes_assoc_fn_without_body =
+    associated function in `impl` without body
+    .suggestion = provide a definition for the function
+
+ast_passes_assoc_type_without_body =
+    associated type in `impl` without body
+    .suggestion = provide a definition for the type
+
+ast_passes_const_without_body =
+    free constant item without body
+    .suggestion = provide a definition for the constant
+
+ast_passes_static_without_body =
+    free static item without body
+    .suggestion = provide a definition for the static
+
+ast_passes_ty_alias_without_body =
+    free type alias without body
+    .suggestion = provide a definition for the type
+
+ast_passes_fn_without_body =
+    free function without a body
+    .suggestion = provide a definition for the function
+    .extern_block_suggestion = if you meant to declare an externally defined function, use an `extern` block

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -27,3 +27,7 @@ ast_passes_trait_fn_async =
     .label = `async` because of this
     .note = `async` trait functions are not currently supported
     .note2 = consider using the `async-trait` crate: https://crates.io/crates/async-trait
+
+ast_passes_trait_fn_const =
+    functions in traits cannot be declared const
+    .label = functions in traits cannot be const

--- a/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_passes.ftl
@@ -38,18 +38,23 @@ ast_passes_forbidden_lifetime_bound =
 ast_passes_forbidden_non_lifetime_param =
     only lifetime parameters can be used in this context
 
-ast_passes_too_many_params =
+ast_passes_fn_param_too_many =
     function can not have more than {$max_num_args} arguments
 
-ast_passes_c_var_args_is_sole_param =
+ast_passes_fn_param_c_var_args_only =
     C-variadic function must be declared with at least one named argument
 
-ast_passes_c_var_args_not_last =
+ast_passes_fn_param_c_var_args_not_last =
     `...` must be the last argument of a C-variadic function
 
-ast_passes_doc_comment_on_fn_param =
+ast_passes_fn_param_doc_comment =
     documentation comments cannot be applied to function parameters
     .label = doc comments are not allowed here
 
-ast_passes_forbidden_attr_on_fn_param =
+ast_passes_fn_param_forbidden_attr =
     allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+
+ast_passes_fn_param_forbidden_self =
+    `self` parameter is only allowed in associated functions
+    .label = not semantically valid as function parameter
+    .note = associated functions are those in `impl` or `trait` definitions

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -32,6 +32,7 @@ pub use unic_langid::{langid, LanguageIdentifier};
 
 // Generates `DEFAULT_LOCALE_RESOURCES` static and `fluent_generated` module.
 fluent_messages! {
+    ast_passes => "../locales/en-US/ast_passes.ftl",
     borrowck => "../locales/en-US/borrowck.ftl",
     builtin_macros => "../locales/en-US/builtin_macros.ftl",
     const_eval => "../locales/en-US/const_eval.ftl",

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -45,7 +45,7 @@ impl<'a, T: EarlyLintPass> EarlyContextAndPass<'a, T> {
                 lint_id.lint,
                 Some(span),
                 |lint| {
-                    lint.build(&msg).emit();
+                    lint.build(msg).emit();
                 },
                 diagnostic,
             );

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -9,7 +9,7 @@ pub use self::Level::*;
 use rustc_ast::node_id::{NodeId, NodeMap};
 use rustc_ast::{AttrId, Attribute};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
-use rustc_error_messages::{MultiSpan, DiagnosticMessage};
+use rustc_error_messages::{DiagnosticMessage, MultiSpan};
 use rustc_hir::HashStableContext;
 use rustc_hir::HirId;
 use rustc_span::edition::Edition;

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -9,7 +9,7 @@ pub use self::Level::*;
 use rustc_ast::node_id::{NodeId, NodeMap};
 use rustc_ast::{AttrId, Attribute};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
-use rustc_error_messages::MultiSpan;
+use rustc_error_messages::{MultiSpan, DiagnosticMessage};
 use rustc_hir::HashStableContext;
 use rustc_hir::HirId;
 use rustc_span::edition::Edition;
@@ -491,7 +491,7 @@ pub struct BufferedEarlyLint {
     pub span: MultiSpan,
 
     /// The lint message.
-    pub msg: String,
+    pub msg: DiagnosticMessage,
 
     /// The `NodeId` of the AST node that generated the lint.
     pub node_id: NodeId,
@@ -520,11 +520,11 @@ impl LintBuffer {
         lint: &'static Lint,
         node_id: NodeId,
         span: MultiSpan,
-        msg: &str,
+        msg: impl Into<DiagnosticMessage>,
         diagnostic: BuiltinLintDiagnostics,
     ) {
         let lint_id = LintId::of(lint);
-        let msg = msg.to_string();
+        let msg = msg.into();
         self.add_early_lint(BufferedEarlyLint { lint_id, node_id, span, msg, diagnostic });
     }
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -537,7 +537,7 @@ impl LintBuffer {
         lint: &'static Lint,
         id: NodeId,
         sp: impl Into<MultiSpan>,
-        msg: &str,
+        msg: impl Into<DiagnosticMessage>,
     ) {
         self.add_lint(lint, id, sp.into(), msg, BuiltinLintDiagnostics::Normal)
     }
@@ -547,7 +547,7 @@ impl LintBuffer {
         lint: &'static Lint,
         id: NodeId,
         sp: impl Into<MultiSpan>,
-        msg: &str,
+        msg: impl Into<DiagnosticMessage>,
         diagnostic: BuiltinLintDiagnostics,
     ) {
         self.add_lint(lint, id, sp.into(), msg, diagnostic)

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -360,6 +360,17 @@ impl ParseSess {
         self.create_warning(warning).emit()
     }
 
+    pub fn create_fatal<'a>(
+        &'a self,
+        fatal: impl SessionDiagnostic<'a, !>,
+    ) -> DiagnosticBuilder<'a, !> {
+        fatal.into_diagnostic(self)
+    }
+
+    pub fn emit_fatal<'a>(&'a self, fatal: impl SessionDiagnostic<'a, !>) -> ! {
+        self.create_fatal(fatal).emit()
+    }
+
     #[rustc_lint_diagnostics]
     pub fn struct_err(
         &self,
@@ -371,6 +382,11 @@ impl ParseSess {
     #[rustc_lint_diagnostics]
     pub fn struct_warn(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         self.span_diagnostic.struct_warn(msg)
+    }
+
+    #[rustc_lint_diagnostics]
+    pub fn struct_fatal(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, !> {
+        self.span_diagnostic.struct_fatal(msg)
     }
 
     #[rustc_lint_diagnostics]

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -482,6 +482,15 @@ impl Session {
     pub fn emit_warning<'a>(&'a self, warning: impl SessionDiagnostic<'a, ()>) {
         self.parse_sess.emit_warning(warning)
     }
+    pub fn create_fatal<'a>(
+        &'a self,
+        fatal: impl SessionDiagnostic<'a, !>,
+    ) -> DiagnosticBuilder<'a, !> {
+        self.parse_sess.create_fatal(fatal)
+    }
+    pub fn emit_fatal<'a>(&'a self, fatal: impl SessionDiagnostic<'a, !>) {
+        self.parse_sess.emit_fatal(fatal)
+    }
     #[inline]
     pub fn err_count(&self) -> usize {
         self.diagnostic().err_count()

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -488,7 +488,7 @@ impl Session {
     ) -> DiagnosticBuilder<'a, !> {
         self.parse_sess.create_fatal(fatal)
     }
-    pub fn emit_fatal<'a>(&'a self, fatal: impl SessionDiagnostic<'a, !>) {
+    pub fn emit_fatal<'a>(&'a self, fatal: impl SessionDiagnostic<'a, !>) -> ! {
         self.parse_sess.emit_fatal(fatal)
     }
     #[inline]


### PR DESCRIPTION
Doing a full migration of the `rustc_ast_passes` crate.
Making a draft here since there's not yet a tracking issue for the migrations going on.

@rustbot label +A-translation