### PR TITLE
Leverage `fmt::Arguments::as_str` in the `write!` macro

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -189,7 +189,7 @@ pub trait Write {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn write_fmt(mut self: &mut Self, args: Arguments<'_>) -> Result {
-        write(&mut self, args)
+        if let Some(s) = args.as_str() { self.write_str(s) } else { write(&mut self, args) }
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1649,6 +1649,10 @@ pub trait Write {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
+        if let Some(s) = fmt.as_str() {
+            return self.write_all(s.as_bytes());
+        }
+
         // Create a shim which translates a Write to a fmt::Write and saves
         // off I/O errors. instead of discarding them
         struct Adapter<'a, T: ?Sized + 'a> {


### PR DESCRIPTION
As noted by @CAD97 [here](https://github.com/rust-lang/rust/issues/10761#issuecomment-1211781733), we could use `fmt::Argument::as_str()` to slightly optimize the performance of `write!(wr, "constant")` by using `as_str()`. It's a small band-aid to the problem of lackluster `write!` performance, but it could be worth it.

I did some experiments with `as_str` in `io` and `fmt`'s `write_fmt` implementation, and it seems that for this specific use-case it's enough to include it in `fmt` (benchmarks are located in `library/core/benches/fmt.rs`):
<details>
<summary>Original code</summary>

```
test fmt::write_str_macro1                                         ... bench:      13,047 ns/iter (+/- 1,114)
test fmt::write_str_macro2                                         ... bench:      14,810 ns/iter (+/- 602)
test fmt::write_str_macro_debug                                    ... bench:     338,593 ns/iter (+/- 26,282)
test fmt::write_str_macro_debug_ascii                              ... bench:     134,188 ns/iter (+/- 12,341)
test fmt::write_str_ref                                            ... bench:       5,739 ns/iter (+/- 502)
test fmt::write_str_value                                          ... bench:       5,684 ns/iter (+/- 362)
```
</details>

<details>
<summary>as_str in io</summary>

```
test fmt::write_str_macro1                                         ... bench:      12,602 ns/iter (+/- 497)
test fmt::write_str_macro2                                         ... bench:      14,743 ns/iter (+/- 315)
test fmt::write_str_macro_debug                                    ... bench:     333,080 ns/iter (+/- 13,721)
test fmt::write_str_macro_debug_ascii                              ... bench:     132,502 ns/iter (+/- 5,207)
test fmt::write_str_ref                                            ... bench:       5,276 ns/iter (+/- 169)
test fmt::write_str_value                                          ... bench:       5,120 ns/iter (+/- 113)
```
</details>

<details>
<summary>as_str in fmt</summary>

```
test fmt::write_str_macro1                                         ... bench:       6,898 ns/iter (+/- 298)
test fmt::write_str_macro2                                         ... bench:      15,166 ns/iter (+/- 284)
test fmt::write_str_macro_debug                                    ... bench:     366,461 ns/iter (+/- 9,659)
test fmt::write_str_macro_debug_ascii                              ... bench:     130,946 ns/iter (+/- 6,068)
test fmt::write_str_ref                                            ... bench:       5,262 ns/iter (+/- 204)
test fmt::write_str_value                                          ... bench:       5,267 ns/iter (+/- 161)
```
</details>

<details>
<summary>as_str in io + fmt</summary>

```
test fmt::write_str_macro1                                         ... bench:       6,644 ns/iter (+/- 151)
test fmt::write_str_macro2                                         ... bench:      14,595 ns/iter (+/- 309)
test fmt::write_str_macro_debug                                    ... bench:     371,741 ns/iter (+/- 11,651)
test fmt::write_str_macro_debug_ascii                              ... bench:     130,821 ns/iter (+/- 3,440)
test fmt::write_str_ref                                            ... bench:       5,062 ns/iter (+/- 209)
test fmt::write_str_value                                          ... bench:       5,058 ns/iter (+/- 151)
```
</details>

I included more benchmark results here, but the interesting one is `fmt::write_str_macro1`, which becomes ~twice as fast with this change. I benchmarked the code with disabled hyper-threading, ASLR and turbo-boost and enabled performance mode, but it's still quite noisy. Results are from (laptop) Zen 3.

Related issue: https://github.com/rust-lang/rust/issues/10761

r? @m-ou-se