### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/expand.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/expand.ftl
@@ -10,5 +10,13 @@ expand_expr_repeat_no_syntax_vars =
 expand_must_repeat_once = 
     this must repeat at least once
 
-count_repetition_misplaced =
+expand_count_repetition_misplaced =
     `count` can not be placed inside the inner-most repetition
+
+expand_meta_var_expr_unrecognized_var =
+    variable `{$key}` is not recognized in meta-variable expression
+
+expand_var_still_repeating =
+    variable '{$ident}' is still repeating at this depth
+
+expand_meta_var_dif_seq_matchers = {$msg}

--- a/compiler/rustc_error_messages/locales/en-US/expand.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/expand.ftl
@@ -3,3 +3,6 @@ expand_explain_doc_comment_outer =
 
 expand_explain_doc_comment_inner =
     inner doc comments expand to `#![doc = "..."]`, which is what this macro attempted to match
+
+expand_expr_repeat_no_syntax_vars = 
+    attempted to repeat an expression containing no syntax variables matched as repeating at this depth

--- a/compiler/rustc_error_messages/locales/en-US/expand.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/expand.ftl
@@ -6,3 +6,9 @@ expand_explain_doc_comment_inner =
 
 expand_expr_repeat_no_syntax_vars = 
     attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+
+expand_must_repeat_once = 
+    this must repeat at least once
+
+count_repetition_misplaced =
+    `count` can not be placed inside the inner-most repetition

--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -123,3 +123,11 @@ typeck_manual_implementation =
     .help = add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 typeck_substs_on_overridden_impl = could not resolve substs on overridden impl
+
+typeck_unused_extern_crate =
+    unused extern crate
+    .suggestion = remove it
+
+typeck_extern_crate_not_idiomatic =
+    `extern crate` is not idiomatic in the new edition
+    .suggestion = convert it to a `{$msg_code}`

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -8,7 +8,7 @@ use rustc_error_messages::FluentValue;
 use rustc_hir as hir;
 use rustc_lint_defs::{Applicability, LintExpectationId};
 use rustc_span::edition::LATEST_STABLE_EDITION;
-use rustc_span::symbol::{Ident, Symbol};
+use rustc_span::symbol::{Ident, MacroRulesNormalizedIdent, Symbol};
 use rustc_span::{edition::Edition, Span, DUMMY_SP};
 use std::borrow::Cow;
 use std::fmt;
@@ -87,6 +87,7 @@ into_diagnostic_arg_using_display!(
     hir::Target,
     Edition,
     Ident,
+    MacroRulesNormalizedIdent,
 );
 
 impl IntoDiagnosticArg for bool {

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -40,7 +40,7 @@ pub(crate) struct VarStillRepeating {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(expand::var_still_repeating)]
+#[error(expand::meta_var_dif_seq_matchers)]
 pub(crate) struct MetaVarsDifSeqMatchers {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -1,6 +1,6 @@
 use rustc_macros::SessionDiagnostic;
+use rustc_span::symbol::MacroRulesNormalizedIdent;
 use rustc_span::Span;
-use rustc_span::symbol::{MacroRulesNormalizedIdent};
 
 #[derive(SessionDiagnostic)]
 #[error(expand::expr_repeat_no_syntax_vars)]
@@ -46,5 +46,3 @@ pub(crate) struct MetaVarsDifSeqMatchers {
     pub span: Span,
     pub msg: String,
 }
-
-

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -1,0 +1,50 @@
+use rustc_macros::SessionDiagnostic;
+use rustc_span::Span;
+use rustc_span::symbol::{MacroRulesNormalizedIdent};
+
+#[derive(SessionDiagnostic)]
+#[error(expand::expr_repeat_no_syntax_vars)]
+pub(crate) struct NoSyntaxVarsExprRepeat {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(expand::must_repeat_once)]
+pub(crate) struct MustRepeatOnce {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(expand::count_repetition_misplaced)]
+pub(crate) struct CountRepetitionMisplaced {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(expand::meta_var_expr_unrecognized_var)]
+pub(crate) struct MetaVarExprUnrecognizedVar {
+    #[primary_span]
+    pub span: Span,
+    pub key: MacroRulesNormalizedIdent,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(expand::var_still_repeating)]
+pub(crate) struct VarStillRepeating {
+    #[primary_span]
+    pub span: Span,
+    pub ident: MacroRulesNormalizedIdent,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(expand::var_still_repeating)]
+pub(crate) struct MetaVarsDifSeqMatchers {
+    #[primary_span]
+    pub span: Span,
+    pub msg: String,
+}
+
+

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -25,6 +25,7 @@ pub mod base;
 pub mod build;
 #[macro_use]
 pub mod config;
+pub mod errors;
 pub mod expand;
 pub mod module;
 pub mod proc_macro;

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -463,7 +463,7 @@ fn count_repetitions<'a>(
         match matched {
             MatchedTokenTree(_) | MatchedNonterminal(_) => {
                 if declared_lhs_depth == 0 {
-                    return Err(cx.create_err( CountRepetitionMisplaced { span: sp.entire()} ));
+                    return Err(cx.create_err(CountRepetitionMisplaced { span: sp.entire() }));
                 }
                 match depth_opt {
                     None => Ok(1),

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -79,7 +79,7 @@ impl<'tcx> ConstValue<'tcx> {
     }
 
     pub fn try_to_scalar_int(&self) -> Option<ScalarInt> {
-        Some(self.try_to_scalar()?.assert_int())
+        self.try_to_scalar()?.try_to_int().ok()
     }
 
     pub fn try_to_bits(&self, size: Size) -> Option<u128> {
@@ -368,6 +368,7 @@ impl<'tcx, Prov: Provenance> Scalar<Prov> {
     }
 
     #[inline(always)]
+    #[cfg_attr(debug_assertions, track_caller)] // only in debug builds due to perf (see #98980)
     pub fn assert_int(self) -> ScalarInt {
         self.try_to_int().unwrap()
     }
@@ -389,6 +390,7 @@ impl<'tcx, Prov: Provenance> Scalar<Prov> {
     }
 
     #[inline(always)]
+    #[cfg_attr(debug_assertions, track_caller)] // only in debug builds due to perf (see #98980)
     pub fn assert_bits(self, target_size: Size) -> u128 {
         self.to_bits(target_size).unwrap()
     }

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -34,7 +34,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// If `force_capture` is true, forces collection of tokens regardless of whether
+    /// If `force_collect` is [`ForceCollect::Yes`], forces collection of tokens regardless of whether
     /// or not we have attributes
     pub(crate) fn parse_stmt_without_recovery(
         &mut self,

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -1,6 +1,6 @@
 //! Errors emitted by typeck.
 use rustc_errors::{error_code, Applicability, DiagnosticBuilder, ErrorGuaranteed};
-use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
+use rustc_macros::{LintDiagnostic, SessionDiagnostic, SessionSubdiagnostic};
 use rustc_middle::ty::Ty;
 use rustc_session::{parse::ParseSess, SessionDiagnostic};
 use rustc_span::{symbol::Ident, Span, Symbol};
@@ -323,4 +323,22 @@ pub struct ManualImplementation {
 pub struct SubstsOnOverriddenImpl {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(LintDiagnostic)]
+#[lint(typeck::unused_extern_crate)]
+pub struct UnusedExternCrate {
+    #[primary_span]
+    #[suggestion(applicability = "machine-applicable", code = "")]
+    pub span: Span,
+}
+
+#[derive(LintDiagnostic)]
+#[lint(typeck::extern_crate_not_idiomatic)]
+pub struct ExternCrateNotIdiomatic {
+    #[primary_span]
+    #[suggestion(applicability = "machine-applicable", code = "{suggestion_code}")]
+    pub span: Span,
+    pub msg_code: String,
+    pub suggestion_code: String,
 }

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -337,7 +337,7 @@ pub struct UnusedExternCrate {
 #[lint(typeck::extern_crate_not_idiomatic)]
 pub struct ExternCrateNotIdiomatic {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "{suggestion_code}")]
+    #[suggestion_short(applicability = "machine-applicable", code = "{suggestion_code}")]
     pub span: Span,
     pub msg_code: String,
     pub suggestion_code: String,

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -328,7 +328,6 @@ pub struct SubstsOnOverriddenImpl {
 #[derive(LintDiagnostic)]
 #[lint(typeck::unused_extern_crate)]
 pub struct UnusedExternCrate {
-    #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
@@ -336,7 +335,6 @@ pub struct UnusedExternCrate {
 #[derive(LintDiagnostic)]
 #[lint(typeck::extern_crate_not_idiomatic)]
 pub struct ExternCrateNotIdiomatic {
-    #[primary_span]
     #[suggestion_short(applicability = "machine-applicable", code = "{suggestion_code}")]
     pub span: Span,
     pub msg_code: String,

--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -127,7 +127,10 @@ following files inside:
 
 **`package/meta/package`**
 ```json
-{"name":"hello_fuchsia","version":0}
+{
+  "name": "hello_fuchsia",
+  "version": "0"
+}
 ```
 
 The `package` file describes our package's name and version number. Every
@@ -238,10 +241,17 @@ ${SDK_PATH}/tools/${ARCH}/ffx product-bundle get workstation_eng.qemu-${ARCH}
 ${SDK_PATH}/tools/${ARCH}/ffx emu start workstation_eng.qemu-${ARCH} --headless
 ```
 
-Then, once the emulator has been started:
+Once the emulator is running, start a package repository server to serve our
+package to the emulator:
 
 ```sh
-${SDK_PATH}/tools/${ARCH}/ffx target repository register
+${SDK_PATH}/tools/${ARCH}/ffx repository server start
+```
+
+Once the repository server is up and running, register our repository:
+
+```sh
+${SDK_PATH}/tools/${ARCH}/ffx target repository register --repository hello-fuchsia
 ```
 
 And watch the logs from the emulator in a separate terminal:
@@ -258,6 +268,10 @@ ${SDK_PATH}/tools/${ARCH}/ffx component run fuchsia-pkg://hello-fuchsia/hello_fu
 
 On reruns of the component, the `--recreate` argument may also need to be
 passed.
+
+```sh
+${SDK_PATH}/tools/${ARCH}/ffx component run --recreate fuchsia-pkg://hello-fuchsia/hello_fuchsia#meta/hello_fuchsia.cm
+```
 
 ## Testing
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
@@ -2,7 +2,9 @@ error[E0423]: expected value, found type parameter `T`
   --> $DIR/issue-69654.rs:5:25
    |
 LL | impl<T> Bar<T> for [u8; T] {}
-   |                         ^ not a value
+   |      -                  ^ not a value
+   |      |
+   |      found this type pararmeter
 
 error[E0599]: the function or associated item `foo` exists for struct `Foo<_>`, but its trait bounds were not satisfied
   --> $DIR/issue-69654.rs:17:10

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -1,6 +1,8 @@
 error[E0574]: expected struct, variant or union type, found type parameter `T`
   --> $DIR/lexical-scopes.rs:3:13
    |
+LL | fn f<T>() {
+   |      - found this type pararmeter
 LL |     let t = T { i: 0 };
    |             ^ not a struct, variant or union type
 

--- a/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.rs
+++ b/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.rs
@@ -1,0 +1,21 @@
+trait Foo<T> {
+    fn foo(&self, name: T) -> usize;
+}
+
+struct Bar {
+    baz: Baz,
+}
+
+struct Baz {
+    num: usize,
+}
+
+impl<Baz> Foo<Baz> for Bar {
+    fn foo(&self, _name: Baz) -> usize {
+        match self.baz {
+            Baz { num } => num, //~ ERROR expected struct, variant or union type, found type parameter `Baz`
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
+++ b/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
@@ -1,0 +1,12 @@
+error[E0574]: expected struct, variant or union type, found type parameter `Baz`
+  --> $DIR/point-at-type-parameter-shadowing-another-type.rs:16:13
+   |
+LL | impl<Baz> Foo<Baz> for Bar {
+   |      --- found this type pararmeter
+...
+LL |             Baz { num } => num,
+   |             ^^^ not a struct, variant or union type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0574`.

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,9 +1,11 @@
 error: unused extern crate
-  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:11:1
+  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:12:1
    |
 LL | / #[cfg(blandiloquence)]
 LL | | extern crate edition_lint_paths;
-   | |________________________________^ help: remove it
+   | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   | |________________________________|
+   |                                  help: remove it
    |
 note: the lint level is defined here
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:6:9

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,11 +1,9 @@
 error: unused extern crate
-  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:12:1
+  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:11:1
    |
 LL | / #[cfg(blandiloquence)]
 LL | | extern crate edition_lint_paths;
-   | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   | |________________________________|
-   |                                  help: remove it
+   | |________________________________^ help: remove it
    |
 note: the lint level is defined here
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:6:9

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -2,7 +2,9 @@ error[E0404]: expected trait, found type parameter `Add`
   --> $DIR/issue-35987.rs:5:21
    |
 LL | impl<T: Clone, Add> Add for Foo<T> {
-   |                     ^^^ not a trait
+   |                ---  ^^^ not a trait
+   |                |
+   |                found this type pararmeter
    |
 help: consider importing this trait instead
    |

--- a/src/tools/rust-analyzer/bench_data/glorious_old_parser
+++ b/src/tools/rust-analyzer/bench_data/glorious_old_parser
@@ -1988,7 +1988,7 @@ impl<'a> Parser<'a> {
                     err.span_suggestion(
                         span,
                         "declare the type after the parameter binding",
-                        String::from("<identifier>: <type>"),
+                        "<identifier>: <type>",
                         Applicability::HasPlaceholders,
                     );
                 } else if require_name && is_trait_item {


### PR DESCRIPTION
Successful merges:

 - #99966 (avoid assertion failures in try_to_scalar_int)
 - #100637 (Improving Fuchsia rustc support documentation)
 - #100643 (Point at a type parameter shadowing another type)
 - #100651 (Migrations for rustc_expand transcribe.rs)
 - #100670 (Fix documentation of rustc_parse::parser::Parser::parse_stmt_without_recovery)
 - #100674 (Migrate lint reports in typeck::check_unused to LintDiagnostic)
 - #100682 (update Miri)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99966,100637,100643,100651,100670,100674,100682)
<!-- homu-ignore:end -->