### PR TITLE
[WIP]: raw-dylib support for apple targets

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -49,6 +49,19 @@ impl LLVMRustCOFFShortExport {
     }
 }
 
+// Rust version of the C struct with the same name in rustc_llvm/llvm-wrapper/RustWrapper.cpp.
+#[repr(C)]
+pub struct LLVMRustTbdExport {
+    pub name: *const c_char,
+    pub symbol_flags: u8,
+}
+
+impl LLVMRustTbdExport {
+    pub fn new(name: *const c_char, symbol_flags: u8) -> LLVMRustTbdExport {
+        LLVMRustTbdExport { name, symbol_flags }
+    }
+}
+
 /// Translation of LLVM's MachineTypes enum, defined in llvm\include\llvm\BinaryFormat\COFF.h.
 ///
 /// We include only architectures supported on Windows.
@@ -2552,4 +2565,13 @@ extern "C" {
     pub fn LLVMRustGetMangledName(V: &Value, out: &RustString);
 
     pub fn LLVMRustGetElementTypeArgIndex(CallSite: &Value) -> i32;
+
+    pub fn LLVMRustWriteTbdFile(
+        ImportName: *const c_char,
+        Path: *const c_char,
+        Exports: *const LLVMRustTbdExport,
+        NumExports: usize,
+        LlvmTriples: *const *const c_char,
+        NumLlvmTriples: usize,
+    ) -> LLVMRustResult;
 }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -407,7 +407,13 @@ fn collate_raw_dylibs(
     let all_libs = crate_info.used_libraries.iter().chain(crate_info.native_libraries.values().flatten());
     for lib in all_libs {
         if lib.kind == NativeLibKind::RawDylib {
-            let ext = if matches!(lib.verbatim, Some(true)) { "" } else { ".dll" };
+            let ext = if matches!(lib.verbatim, Some(true)) {
+                ""
+            } else if sess.target.is_like_osx {
+                ".dylib"
+            } else {
+                ".dll"
+            };
             let name = format!("{}{}", lib.name.expect("unnamed raw-dylib library"), ext);
             let imports = dylib_table.entry(name.clone()).or_default();
             for import in &lib.dll_imports {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -111,12 +111,12 @@ impl<'tcx> Collector<'tcx> {
                                 NativeLibKind::Framework { as_needed: None }
                             }
                             "raw-dylib" => {
-                                if !sess.target.is_like_windows {
+                                if !sess.target.is_like_windows && !sess.target.is_like_osx {
                                     struct_span_err!(
                                         sess,
                                         span,
                                         E0455,
-                                        "link kind `raw-dylib` is only supported on Windows targets"
+                                        "link kind `raw-dylib` is only supported on Windows and Apple targets"
                                     )
                                     .emit();
                                 } else if !features.raw_dylib {


### PR DESCRIPTION
CC #58713

This PR adds macos support to raw-dylib. This works by generating a `.tbd` file for each library using LLVM's TextAPI functions, and linking against them. `.tbd` files are an official Apple format representing the exports of a dylib as YAML, whose format is documented [here](https://github.com/apple-opensource/tapi/blob/master/docs/TBD.rst). LLVM's TextAPI provides an easy-to-use API to produce (and consume) those files.

Apple targets bring several complications to the raw-dylib support:

## No runtime dylib search path

`dyld`, the mach-o loader, does not have a default search path to find the shared libraries (or dylibs). Instead, there are five ways to define a shared lib:

- Absolute path (`/usr/lib/libEndpointSecurity.dylib`): This is how system deps usually end up in a macho. You get an absolute path like 
- Relative path: Those get loaded relative to the current working directory. This is almost always wrong.
- `@loader_path/libEndpointSecurity.dylib`: These are loaded relative to the entity that caused the shared lib to load (the mach-o binary or intermediate shared lib). This can be useful when storing libs next to the binary, or plugins next to a lib.
- `@executable_path/libEndpointSecurity.dylib`: Similar to the above, but always relative to the binary.
- `@rpath/libEndpointSecurity.dylib`: RPATH is the closest thing to a search path, but is hardcoded in the mach-o. Essentially, a mach-o will have an `LC_RPATH` load command that specifies the list of paths to look into for libs. By default, the linker does *not* set an RPATH.

Currently, we just use whatever is in `link(name)`. The user may specify the full name in the `#[link(name)]`, e.g.

```rust
#[link(name = "/usr/lib/libEndpointSecurity.dylib", kind = "raw-dylib", modifiers = "+verbatim")]
extern "C" { /* ... */ }
```

An alternative solution could be to have a separate attribute for the directory, like `#[link(name = "EndpointSecurity", install_path = "/usr/lib", kind = "raw-dylib")]`.

## `ar` files

Unlike Windows `lib` files, which can contain `.dll` files containing the symbols to import along with the `.obj` files, macOS (and indeed, linux) `ar` archives do not have a way to specify external symbol dependencies (at least, not that I'm aware!). Those have to be specified separately to the final linking step.

To work around this issue, we cheat a bit. When building an `rlib`, the `tbd` is inserted *into* the `rlib`, so it can be extracted and linked against during the final linking step. This is... not exactly elegant. But it works and was the easiest solution I could think of. 

Currently, the `link(name)` attribute is used as the filename to use when storing the `ar` archive (meaning, our `ar` archive will have a file named `/usr/lib/libEndpointSecurity.dylib.tbd`. It may be worth adding a prefix to the filename or something?

## Additional attributes

Mach-O additionally encodes two pieces of information with every shared library in its LC_LOAD_DYLIB command: the `current_version`, and the `compatibility_version`. `compatibility_version` in particular is used by `dyld` to figure out if the dylib on the system is new enough to link properly with the current application.

This PR currently sets both of those to 0 - and that seems to work well enough, at least for my use-cases. But we could imagine adding new attributes for them if they're necessary.

# Status

This PR *works*, but is still kinda prototypical. I need to add some unit tests to ensure it works in a vast variety of scenarios (unfortunately, a lot of the windows tests don't work as-is for macos due to the above limitations). The goal here is mostly to get feedback on the current approach, maybe get some ideas bouncing on if there's another way to approach the issues here.

CC @joshtriplett 