### PR TITLE
Avoid reporting overflow in `is_impossible_method`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -571,9 +571,16 @@ fn is_impossible_method<'tcx>(
     });
 
     tcx.infer_ctxt().ignoring_regions().enter(|ref infcx| {
-        let mut fulfill_ctxt = <dyn TraitEngine<'_>>::new(tcx);
-        fulfill_ctxt.register_predicate_obligations(infcx, predicates_for_trait);
-        !fulfill_ctxt.select_all_or_error(infcx).is_empty()
+        for obligation in predicates_for_trait {
+            // Ignore overflow error, to be conservative.
+            if let Ok(result) = infcx.evaluate_obligation(&obligation)
+                && !result.may_apply()
+            {
+                return true;
+            }
+        }
+
+        false
     })
 }
 

--- a/src/test/rustdoc/issue-100620.rs
+++ b/src/test/rustdoc/issue-100620.rs
@@ -1,0 +1,19 @@
+pub trait Bar<S> {}
+
+pub trait Qux<T> {}
+
+pub trait Foo<T, S> {
+    fn bar()
+    where
+        T: Bar<S>,
+    {
+    }
+}
+
+pub struct Concrete;
+
+impl<S> Foo<(), S> for Concrete {}
+
+impl<T, S> Bar<S> for T where S: Qux<T> {}
+
+impl<T, S> Qux<T> for S where T: Bar<S> {}


### PR DESCRIPTION
Fixes #100620

We're evaluating a new predicate in a different param-env than it was checked during typeck, so be more careful about handling overflow errors. Instead of using `FulfillmentCtxt`, using `InferCtxt::evaluate_obligation` by itself will give us back the overflow error, so we can throw it away properly. 

This may give us more false-positives, but it doesn't regress the `<HashMap as Iterator>::rev` example that originally motivated adding `is_impossible_method` in the first place.