### PR TITLE
Migrate ast lowering to session diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3575,6 +3575,7 @@ dependencies = [
  "rustc_errors",
  "rustc_hir",
  "rustc_index",
+ "rustc_macros",
  "rustc_middle",
  "rustc_query_system",
  "rustc_session",

--- a/compiler/rustc_ast_lowering/Cargo.toml
+++ b/compiler/rustc_ast_lowering/Cargo.toml
@@ -15,6 +15,7 @@ rustc_target = { path = "../rustc_target" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_index = { path = "../rustc_index" }
 rustc_middle = { path = "../rustc_middle" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_query_system = { path = "../rustc_query_system" }
 rustc_span = { path = "../rustc_span" }
 rustc_errors = { path = "../rustc_errors" }

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -1,11 +1,17 @@
 use crate::{ImplTraitContext, ImplTraitPosition, ParamMode, ResolverAstLoweringExt};
 
+use super::errors::{
+    AbiSpecifiedMultipleTimes, AttSyntaxOnlyX86, ClobberAbiNotSupported,
+    InlineAsmUnsupportedTarget, InvalidAbiClobberAbi, InvalidAsmTemplateModifierConst,
+    InvalidAsmTemplateModifierRegClass, InvalidAsmTemplateModifierRegClassSub,
+    InvalidAsmTemplateModifierSym, InvalidRegister, InvalidRegisterClass, RegisterClassOnlyClobber,
+    RegisterConflict,
+};
 use super::LoweringContext;
 
 use rustc_ast::ptr::P;
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::definitions::DefPathData;
@@ -26,13 +32,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let asm_arch =
             if self.tcx.sess.opts.actually_rustdoc { None } else { self.tcx.sess.asm_arch };
         if asm_arch.is_none() && !self.tcx.sess.opts.actually_rustdoc {
-            struct_span_err!(
-                self.tcx.sess,
-                sp,
-                E0472,
-                "inline assembly is unsupported on this target"
-            )
-            .emit();
+            self.tcx.sess.emit_err(InlineAsmUnsupportedTarget { span: sp });
         }
         if let Some(asm_arch) = asm_arch {
             // Inline assembly is currently only stable for these architectures.
@@ -59,10 +59,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             && !matches!(asm_arch, Some(asm::InlineAsmArch::X86 | asm::InlineAsmArch::X86_64))
             && !self.tcx.sess.opts.actually_rustdoc
         {
-            self.tcx
-                .sess
-                .struct_span_err(sp, "the `att_syntax` option is only supported on x86")
-                .emit();
+            self.tcx.sess.emit_err(AttSyntaxOnlyX86 { span: sp });
         }
         if asm.options.contains(InlineAsmOptions::MAY_UNWIND) && !self.tcx.features().asm_unwind {
             feature_err(
@@ -82,51 +79,37 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         // If the abi was already in the list, emit an error
                         match clobber_abis.get(&abi) {
                             Some((prev_name, prev_sp)) => {
-                                let mut err = self.tcx.sess.struct_span_err(
-                                    *abi_span,
-                                    &format!("`{}` ABI specified multiple times", prev_name),
-                                );
-                                err.span_label(*prev_sp, "previously specified here");
-
                                 // Multiple different abi names may actually be the same ABI
                                 // If the specified ABIs are not the same name, alert the user that they resolve to the same ABI
                                 let source_map = self.tcx.sess.source_map();
-                                if source_map.span_to_snippet(*prev_sp)
-                                    != source_map.span_to_snippet(*abi_span)
-                                {
-                                    err.note("these ABIs are equivalent on the current target");
-                                }
+                                let equivalent = (source_map.span_to_snippet(*prev_sp)
+                                    != source_map.span_to_snippet(*abi_span))
+                                .then_some(());
 
-                                err.emit();
+                                self.tcx.sess.emit_err(AbiSpecifiedMultipleTimes {
+                                    abi_span: *abi_span,
+                                    prev_name: *prev_name,
+                                    prev_span: *prev_sp,
+                                    equivalent,
+                                });
                             }
                             None => {
-                                clobber_abis.insert(abi, (abi_name, *abi_span));
+                                clobber_abis.insert(abi, (*abi_name, *abi_span));
                             }
                         }
                     }
                     Err(&[]) => {
-                        self.tcx
-                            .sess
-                            .struct_span_err(
-                                *abi_span,
-                                "`clobber_abi` is not supported on this target",
-                            )
-                            .emit();
+                        self.tcx.sess.emit_err(ClobberAbiNotSupported { abi_span: *abi_span });
                     }
                     Err(supported_abis) => {
-                        let mut err = self
-                            .tcx
-                            .sess
-                            .struct_span_err(*abi_span, "invalid ABI for `clobber_abi`");
                         let mut abis = format!("`{}`", supported_abis[0]);
                         for m in &supported_abis[1..] {
                             let _ = write!(abis, ", `{}`", m);
                         }
-                        err.note(&format!(
-                            "the following ABIs are supported on this target: {}",
-                            abis
-                        ));
-                        err.emit();
+                        self.tcx.sess.emit_err(InvalidAbiClobberAbi {
+                            abi_span: *abi_span,
+                            supported_abis: abis,
+                        });
                     }
                 }
             }
@@ -144,8 +127,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     InlineAsmRegOrRegClass::Reg(s) => {
                         asm::InlineAsmRegOrRegClass::Reg(if let Some(asm_arch) = asm_arch {
                             asm::InlineAsmReg::parse(asm_arch, s).unwrap_or_else(|e| {
-                                let msg = format!("invalid register `{}`: {}", s, e);
-                                sess.struct_span_err(*op_sp, &msg).emit();
+                                sess.emit_err(InvalidRegister { op_span: *op_sp, s, e });
                                 asm::InlineAsmReg::Err
                             })
                         } else {
@@ -155,8 +137,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     InlineAsmRegOrRegClass::RegClass(s) => {
                         asm::InlineAsmRegOrRegClass::RegClass(if let Some(asm_arch) = asm_arch {
                             asm::InlineAsmRegClass::parse(asm_arch, s).unwrap_or_else(|e| {
-                                let msg = format!("invalid register class `{}`: {}", s, e);
-                                sess.struct_span_err(*op_sp, &msg).emit();
+                                sess.emit_err(InvalidRegisterClass { op_span: *op_sp, s, e });
                                 asm::InlineAsmRegClass::Err
                             })
                         } else {
@@ -282,50 +263,39 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         }
                         let valid_modifiers = class.valid_modifiers(asm_arch.unwrap());
                         if !valid_modifiers.contains(&modifier) {
-                            let mut err = sess.struct_span_err(
-                                placeholder_span,
-                                "invalid asm template modifier for this register class",
-                            );
-                            err.span_label(placeholder_span, "template modifier");
-                            err.span_label(op_sp, "argument");
-                            if !valid_modifiers.is_empty() {
+                            let sub = if !valid_modifiers.is_empty() {
                                 let mut mods = format!("`{}`", valid_modifiers[0]);
                                 for m in &valid_modifiers[1..] {
                                     let _ = write!(mods, ", `{}`", m);
                                 }
-                                err.note(&format!(
-                                    "the `{}` register class supports \
-                                     the following template modifiers: {}",
-                                    class.name(),
-                                    mods
-                                ));
+                                InvalidAsmTemplateModifierRegClassSub::SupportModifier {
+                                    class_name: class.name(),
+                                    modifiers: mods,
+                                }
                             } else {
-                                err.note(&format!(
-                                    "the `{}` register class does not support template modifiers",
-                                    class.name()
-                                ));
-                            }
-                            err.emit();
+                                InvalidAsmTemplateModifierRegClassSub::DoesNotSupportModifier {
+                                    class_name: class.name(),
+                                }
+                            };
+                            sess.emit_err(InvalidAsmTemplateModifierRegClass {
+                                placeholder_span,
+                                op_span: op_sp,
+                                sub,
+                            });
                         }
                     }
                     hir::InlineAsmOperand::Const { .. } => {
-                        let mut err = sess.struct_span_err(
+                        sess.emit_err(InvalidAsmTemplateModifierConst {
                             placeholder_span,
-                            "asm template modifiers are not allowed for `const` arguments",
-                        );
-                        err.span_label(placeholder_span, "template modifier");
-                        err.span_label(op_sp, "argument");
-                        err.emit();
+                            op_span: op_sp,
+                        });
                     }
                     hir::InlineAsmOperand::SymFn { .. }
                     | hir::InlineAsmOperand::SymStatic { .. } => {
-                        let mut err = sess.struct_span_err(
+                        sess.emit_err(InvalidAsmTemplateModifierSym {
                             placeholder_span,
-                            "asm template modifiers are not allowed for `sym` arguments",
-                        );
-                        err.span_label(placeholder_span, "template modifier");
-                        err.span_label(op_sp, "argument");
-                        err.emit();
+                            op_span: op_sp,
+                        });
                     }
                 }
             }
@@ -346,12 +316,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 // require that the operand name an explicit register, not a
                 // register class.
                 if reg_class.is_clobber_only(asm_arch.unwrap()) && !op.is_clobber() {
-                    let msg = format!(
-                        "register class `{}` can only be used as a clobber, \
-                             not as an input or output",
-                        reg_class.name()
-                    );
-                    sess.struct_span_err(op_sp, &msg).emit();
+                    sess.emit_err(RegisterClassOnlyClobber {
+                        op_span: op_sp,
+                        reg_class_name: reg_class.name(),
+                    });
                     continue;
                 }
 
@@ -391,16 +359,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                         unreachable!();
                                     };
 
-                                    let msg = format!(
-                                        "register `{}` conflicts with register `{}`",
-                                        reg.name(),
-                                        reg2.name()
-                                    );
-                                    let mut err = sess.struct_span_err(op_sp, &msg);
-                                    err.span_label(op_sp, &format!("register `{}`", reg.name()));
-                                    err.span_label(op_sp2, &format!("register `{}`", reg2.name()));
-
-                                    match (op, op2) {
+                                    let in_out = match (op, op2) {
                                         (
                                             hir::InlineAsmOperand::In { .. },
                                             hir::InlineAsmOperand::Out { late, .. },
@@ -411,14 +370,18 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                         ) => {
                                             assert!(!*late);
                                             let out_op_sp = if input { op_sp2 } else { op_sp };
-                                            let msg = "use `lateout` instead of \
-                                                       `out` to avoid conflict";
-                                            err.span_help(out_op_sp, msg);
-                                        }
-                                        _ => {}
-                                    }
+                                            Some(out_op_sp)
+                                        },
+                                        _ => None,
+                                    };
 
-                                    err.emit();
+                                    sess.emit_err(RegisterConflict {
+                                        op_span1: op_sp,
+                                        op_span2: op_sp2,
+                                        reg1_name: reg.name(),
+                                        reg2_name: reg2.name(),
+                                        in_out
+                                    });
                                 }
                                 Entry::Vacant(v) => {
                                     if r == reg {

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -124,22 +124,28 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             .iter()
             .map(|(op, op_sp)| {
                 let lower_reg = |reg| match reg {
-                    InlineAsmRegOrRegClass::Reg(s) => {
+                    InlineAsmRegOrRegClass::Reg(reg) => {
                         asm::InlineAsmRegOrRegClass::Reg(if let Some(asm_arch) = asm_arch {
-                            asm::InlineAsmReg::parse(asm_arch, s).unwrap_or_else(|e| {
-                                sess.emit_err(InvalidRegister { op_span: *op_sp, s, e });
+                            asm::InlineAsmReg::parse(asm_arch, reg).unwrap_or_else(|error| {
+                                sess.emit_err(InvalidRegister { op_span: *op_sp, reg, error });
                                 asm::InlineAsmReg::Err
                             })
                         } else {
                             asm::InlineAsmReg::Err
                         })
                     }
-                    InlineAsmRegOrRegClass::RegClass(s) => {
+                    InlineAsmRegOrRegClass::RegClass(reg_class) => {
                         asm::InlineAsmRegOrRegClass::RegClass(if let Some(asm_arch) = asm_arch {
-                            asm::InlineAsmRegClass::parse(asm_arch, s).unwrap_or_else(|e| {
-                                sess.emit_err(InvalidRegisterClass { op_span: *op_sp, s, e });
-                                asm::InlineAsmRegClass::Err
-                            })
+                            asm::InlineAsmRegClass::parse(asm_arch, reg_class).unwrap_or_else(
+                                |error| {
+                                    sess.emit_err(InvalidRegisterClass {
+                                        op_span: *op_sp,
+                                        reg_class,
+                                        error,
+                                    });
+                                    asm::InlineAsmRegClass::Err
+                                },
+                            )
                         } else {
                             asm::InlineAsmRegClass::Err
                         })

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -150,21 +150,21 @@ pub struct AsyncGeneratorsNotSupported {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::inline_asm_unsupported_target, code = "E0472")]
+#[diag(ast_lowering::inline_asm_unsupported_target, code = "E0472")]
 pub struct InlineAsmUnsupportedTarget {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::att_syntax_only_x86)]
+#[diag(ast_lowering::att_syntax_only_x86)]
 pub struct AttSyntaxOnlyX86 {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::abi_specified_multiple_times)]
+#[diag(ast_lowering::abi_specified_multiple_times)]
 pub struct AbiSpecifiedMultipleTimes {
     #[primary_span]
     pub abi_span: Span,
@@ -176,7 +176,7 @@ pub struct AbiSpecifiedMultipleTimes {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::clobber_abi_not_supported)]
+#[diag(ast_lowering::clobber_abi_not_supported)]
 pub struct ClobberAbiNotSupported {
     #[primary_span]
     pub abi_span: Span,
@@ -184,7 +184,7 @@ pub struct ClobberAbiNotSupported {
 
 #[derive(SessionDiagnostic)]
 #[note]
-#[error(ast_lowering::invalid_abi_clobber_abi)]
+#[diag(ast_lowering::invalid_abi_clobber_abi)]
 pub struct InvalidAbiClobberAbi {
     #[primary_span]
     pub abi_span: Span,
@@ -192,7 +192,7 @@ pub struct InvalidAbiClobberAbi {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::invalid_register)]
+#[diag(ast_lowering::invalid_register)]
 pub struct InvalidRegister<'a> {
     #[primary_span]
     pub op_span: Span,
@@ -201,7 +201,7 @@ pub struct InvalidRegister<'a> {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::invalid_register_class)]
+#[diag(ast_lowering::invalid_register_class)]
 pub struct InvalidRegisterClass<'a> {
     #[primary_span]
     pub op_span: Span,
@@ -210,7 +210,7 @@ pub struct InvalidRegisterClass<'a> {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_lowering::invalid_asm_template_modifier_reg_class)]
+#[diag(ast_lowering::invalid_asm_template_modifier_reg_class)]
 pub struct InvalidAsmTemplateModifierRegClass {
     #[primary_span]
     #[label(ast_lowering::template_modifier)]
@@ -230,7 +230,7 @@ pub enum InvalidAsmTemplateModifierRegClassSub {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::invalid_asm_template_modifier_const)]
+#[diag(ast_lowering::invalid_asm_template_modifier_const)]
 pub struct InvalidAsmTemplateModifierConst {
     #[primary_span]
     #[label(ast_lowering::template_modifier)]
@@ -240,7 +240,7 @@ pub struct InvalidAsmTemplateModifierConst {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::invalid_asm_template_modifier_sym)]
+#[diag(ast_lowering::invalid_asm_template_modifier_sym)]
 pub struct InvalidAsmTemplateModifierSym {
     #[primary_span]
     #[label(ast_lowering::template_modifier)]
@@ -250,7 +250,7 @@ pub struct InvalidAsmTemplateModifierSym {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::register_class_only_clobber)]
+#[diag(ast_lowering::register_class_only_clobber)]
 pub struct RegisterClassOnlyClobber {
     #[primary_span]
     pub op_span: Span,
@@ -258,7 +258,7 @@ pub struct RegisterClassOnlyClobber {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::register_conflict)]
+#[diag(ast_lowering::register_conflict)]
 pub struct RegisterConflict<'a> {
     #[primary_span]
     #[label(ast_lowering::register1)]
@@ -273,7 +273,7 @@ pub struct RegisterConflict<'a> {
 
 #[derive(SessionDiagnostic, Clone, Copy)]
 #[help]
-#[error(ast_lowering::sub_tuple_binding)]
+#[diag(ast_lowering::sub_tuple_binding)]
 pub struct SubTupleBinding<'a> {
     #[primary_span]
     #[label]
@@ -289,7 +289,7 @@ pub struct SubTupleBinding<'a> {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::extra_double_dot)]
+#[diag(ast_lowering::extra_double_dot)]
 pub struct ExtraDoubleDot<'a> {
     #[primary_span]
     #[label]
@@ -301,28 +301,28 @@ pub struct ExtraDoubleDot<'a> {
 
 #[derive(SessionDiagnostic, Clone, Copy)]
 #[note]
-#[error(ast_lowering::misplaced_double_dot)]
+#[diag(ast_lowering::misplaced_double_dot)]
 pub struct MisplacedDoubleDot {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::misplaced_relax_trait_bound)]
+#[diag(ast_lowering::misplaced_relax_trait_bound)]
 pub struct MisplacedRelaxTraitBound {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::not_supported_for_lifetime_binder_async_closure)]
+#[diag(ast_lowering::not_supported_for_lifetime_binder_async_closure)]
 pub struct NotSupportedForLifetimeBinderAsyncClosure {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::arbitrary_expression_in_pattern)]
+#[diag(ast_lowering::arbitrary_expression_in_pattern)]
 pub struct ArbitraryExpressionInPattern {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -3,7 +3,7 @@ use rustc_macros::SessionDiagnostic;
 use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::generic_type_with_parentheses, code = "E0214")]
+#[diag(ast_lowering::generic_type_with_parentheses, code = "E0214")]
 pub struct GenericTypeWithParentheses {
     #[primary_span]
     #[label]
@@ -30,7 +30,7 @@ impl AddSubdiagnostic for UseAngleBrackets {
 
 #[derive(SessionDiagnostic)]
 #[help]
-#[error(ast_lowering::invalid_abi, code = "E0703")]
+#[diag(ast_lowering::invalid_abi, code = "E0703")]
 pub struct InvalidAbi {
     #[primary_span]
     #[label]
@@ -40,7 +40,7 @@ pub struct InvalidAbi {
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
-#[error(ast_lowering::assoc_ty_parentheses)]
+#[diag(ast_lowering::assoc_ty_parentheses)]
 pub struct AssocTyParentheses {
     #[primary_span]
     pub span: Span,
@@ -72,9 +72,79 @@ impl AddSubdiagnostic for AssocTyParenthesesSub {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(ast_lowering::misplaced_impl_trait, code = "E0562")]
+#[diag(ast_lowering::misplaced_impl_trait, code = "E0562")]
 pub struct MisplacedImplTrait {
     #[primary_span]
     pub span: Span,
     pub position: String,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::rustc_box_attribute_error)]
+pub struct RustcBoxAttributeError {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::underscore_expr_lhs_assign)]
+pub struct UnderscoreExprLhsAssign {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::base_expression_double_dot)]
+pub struct BaseExpressionDoubleDot {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::await_only_in_async_fn_and_blocks, code = "E0728")]
+pub struct AwaitOnlyInAsyncFnAndBlocks {
+    #[primary_span]
+    #[label]
+    pub dot_await_span: Span,
+    #[label(ast_lowering::this_not_async)]
+    pub item_span: Option<Span>,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::generator_too_many_parameters, code = "E0628")]
+pub struct GeneratorTooManyParameters {
+    #[primary_span]
+    pub fn_decl_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::closure_cannot_be_static, code = "E0697")]
+pub struct ClosureCannotBeStatic {
+    #[primary_span]
+    pub fn_decl_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[help]
+#[diag(ast_lowering::async_non_move_closure_not_supported, code = "E0708")]
+pub struct AsyncNonMoveClosureNotSupported {
+    #[primary_span]
+    pub fn_decl_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::functional_record_update_destructuring_assignment)]
+pub struct FunctionalRecordUpdateDestructuringAssignemnt {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[diag(ast_lowering::async_generators_not_supported, code = "E0727")]
+pub struct AsyncGeneratorsNotSupported {
+    #[primary_span]
+    pub span: Span,
 }

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,4 +1,4 @@
-use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
+use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic, DiagnosticArgFromDisplay};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::{symbol::Ident, Span, Symbol};
 
@@ -73,10 +73,10 @@ impl AddSubdiagnostic for AssocTyParenthesesSub {
 
 #[derive(SessionDiagnostic)]
 #[diag(ast_lowering::misplaced_impl_trait, code = "E0562")]
-pub struct MisplacedImplTrait {
+pub struct MisplacedImplTrait<'a> {
     #[primary_span]
     pub span: Span,
-    pub position: String,
+    pub position: DiagnosticArgFromDisplay<'a>,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
@@ -196,8 +196,8 @@ pub struct InvalidAbiClobberAbi {
 pub struct InvalidRegister<'a> {
     #[primary_span]
     pub op_span: Span,
-    pub s: Symbol,
-    pub e: &'a str,
+    pub reg: Symbol,
+    pub error: &'a str,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
@@ -205,8 +205,8 @@ pub struct InvalidRegister<'a> {
 pub struct InvalidRegisterClass<'a> {
     #[primary_span]
     pub op_span: Span,
-    pub s: Symbol,
-    pub e: &'a str,
+    pub reg_class: Symbol,
+    pub error: &'a str,
 }
 
 #[derive(SessionDiagnostic)]

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,6 +1,6 @@
 use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
-use rustc_span::{Span, Symbol};
+use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(SessionDiagnostic, Clone, Copy)]
 #[diag(ast_lowering::generic_type_with_parentheses, code = "E0214")]
@@ -269,4 +269,40 @@ pub struct RegisterConflict<'a> {
     pub reg2_name: &'a str,
     #[help]
     pub in_out: Option<Span>,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[help]
+#[error(ast_lowering::sub_tuple_binding)]
+pub struct SubTupleBinding<'a> {
+    #[primary_span]
+    #[label]
+    #[suggestion_verbose(
+        ast_lowering::sub_tuple_binding_suggestion,
+        code = "..",
+        applicability = "maybe-incorrect"
+    )]
+    pub span: Span,
+    pub ident: Ident,
+    pub ident_name: Symbol,
+    pub ctx: &'a str,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::extra_double_dot)]
+pub struct ExtraDoubleDot<'a> {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[label(ast_lowering::previously_used_here)]
+    pub prev_span: Span,
+    pub ctx: &'a str,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[note]
+#[error(ast_lowering::misplaced_double_dot)]
+pub struct MisplacedDoubleDot {
+    #[primary_span]
+    pub span: Span,
 }

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,5 +1,5 @@
 use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
-use rustc_macros::SessionDiagnostic;
+use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic, Clone, Copy)]
@@ -147,4 +147,126 @@ pub struct FunctionalRecordUpdateDestructuringAssignemnt {
 pub struct AsyncGeneratorsNotSupported {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::inline_asm_unsupported_target, code = "E0472")]
+pub struct InlineAsmUnsupportedTarget {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::att_syntax_only_x86)]
+pub struct AttSyntaxOnlyX86 {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::abi_specified_multiple_times)]
+pub struct AbiSpecifiedMultipleTimes {
+    #[primary_span]
+    pub abi_span: Span,
+    pub prev_name: Symbol,
+    #[label]
+    pub prev_span: Span,
+    #[note]
+    pub equivalent: Option<()>,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::clobber_abi_not_supported)]
+pub struct ClobberAbiNotSupported {
+    #[primary_span]
+    pub abi_span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[note]
+#[error(ast_lowering::invalid_abi_clobber_abi)]
+pub struct InvalidAbiClobberAbi {
+    #[primary_span]
+    pub abi_span: Span,
+    pub supported_abis: String,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_register)]
+pub struct InvalidRegister<'a> {
+    #[primary_span]
+    pub op_span: Span,
+    pub s: Symbol,
+    pub e: &'a str,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_register_class)]
+pub struct InvalidRegisterClass<'a> {
+    #[primary_span]
+    pub op_span: Span,
+    pub s: Symbol,
+    pub e: &'a str,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_lowering::invalid_asm_template_modifier_reg_class)]
+pub struct InvalidAsmTemplateModifierRegClass {
+    #[primary_span]
+    #[label(ast_lowering::template_modifier)]
+    pub placeholder_span: Span,
+    #[label(ast_lowering::argument)]
+    pub op_span: Span,
+    #[subdiagnostic]
+    pub sub: InvalidAsmTemplateModifierRegClassSub,
+}
+
+#[derive(SessionSubdiagnostic)]
+pub enum InvalidAsmTemplateModifierRegClassSub {
+    #[note(ast_lowering::support_modifiers)]
+    SupportModifier { class_name: Symbol, modifiers: String },
+    #[note(ast_lowering::does_not_support_modifiers)]
+    DoesNotSupportModifier { class_name: Symbol },
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_asm_template_modifier_const)]
+pub struct InvalidAsmTemplateModifierConst {
+    #[primary_span]
+    #[label(ast_lowering::template_modifier)]
+    pub placeholder_span: Span,
+    #[label(ast_lowering::argument)]
+    pub op_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_asm_template_modifier_sym)]
+pub struct InvalidAsmTemplateModifierSym {
+    #[primary_span]
+    #[label(ast_lowering::template_modifier)]
+    pub placeholder_span: Span,
+    #[label(ast_lowering::argument)]
+    pub op_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::register_class_only_clobber)]
+pub struct RegisterClassOnlyClobber {
+    #[primary_span]
+    pub op_span: Span,
+    pub reg_class_name: Symbol,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::register_conflict)]
+pub struct RegisterConflict<'a> {
+    #[primary_span]
+    #[label(ast_lowering::register1)]
+    pub op_span1: Span,
+    #[label(ast_lowering::register2)]
+    pub op_span2: Span,
+    pub reg1_name: &'a str,
+    pub reg2_name: &'a str,
+    #[help]
+    pub in_out: Option<Span>,
 }

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,0 +1,29 @@
+use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
+use rustc_macros::SessionDiagnostic;
+use rustc_span::Span;
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::generic_type_with_parentheses, code = "E0214")]
+pub struct GenericTypeWithParentheses {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: Option<UseAngleBrackets>,
+}
+
+#[derive(Clone, Copy)]
+pub struct UseAngleBrackets {
+    pub open_param: Span,
+    pub close_param: Span,
+}
+
+impl AddSubdiagnostic for UseAngleBrackets {
+    fn add_to_diagnostic(self, diag: &mut Diagnostic) {
+        diag.multipart_suggestion(
+            fluent::ast_lowering::use_angle_brackets,
+            vec![(self.open_param, String::from("<")), (self.close_param, String::from(">"))],
+            Applicability::MaybeIncorrect,
+        );
+    }
+}

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -306,3 +306,24 @@ pub struct MisplacedDoubleDot {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::misplaced_relax_trait_bound)]
+pub struct MisplacedRelaxTraitBound {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::not_supported_for_lifetime_binder_async_closure)]
+pub struct NotSupportedForLifetimeBinderAsyncClosure {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::arbitrary_expression_in_pattern)]
+pub struct ArbitraryExpressionInPattern {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,6 +1,6 @@
 use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
 use rustc_macros::SessionDiagnostic;
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic, Clone, Copy)]
 #[error(ast_lowering::generic_type_with_parentheses, code = "E0214")]
@@ -26,4 +26,55 @@ impl AddSubdiagnostic for UseAngleBrackets {
             Applicability::MaybeIncorrect,
         );
     }
+}
+
+#[derive(SessionDiagnostic)]
+#[help]
+#[error(ast_lowering::invalid_abi, code = "E0703")]
+pub struct InvalidAbi {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub abi: Symbol,
+    pub valid_abis: String,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::assoc_ty_parentheses)]
+pub struct AssocTyParentheses {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: AssocTyParenthesesSub,
+}
+
+#[derive(Clone, Copy)]
+pub enum AssocTyParenthesesSub {
+    Empty { parentheses_span: Span },
+    NotEmpty { open_param: Span, close_param: Span },
+}
+
+impl AddSubdiagnostic for AssocTyParenthesesSub {
+    fn add_to_diagnostic(self, diag: &mut Diagnostic) {
+        match self {
+            Self::Empty { parentheses_span } => diag.multipart_suggestion(
+                fluent::ast_lowering::remove_parentheses,
+                vec![(parentheses_span, String::new())],
+                Applicability::MaybeIncorrect,
+            ),
+            Self::NotEmpty { open_param, close_param } => diag.multipart_suggestion(
+                fluent::ast_lowering::use_angle_brackets,
+                vec![(open_param, String::from("<")), (close_param, String::from(">"))],
+                Applicability::MaybeIncorrect,
+            ),
+        };
+    }
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_lowering::misplaced_impl_trait, code = "E0562")]
+pub struct MisplacedImplTrait {
+    #[primary_span]
+    pub span: Span,
+    pub position: String,
 }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1,3 +1,8 @@
+use super::errors::{
+    AsyncGeneratorsNotSupported, AsyncNonMoveClosureNotSupported, AwaitOnlyInAsyncFnAndBlocks,
+    BaseExpressionDoubleDot, ClosureCannotBeStatic, FunctionalRecordUpdateDestructuringAssignemnt,
+    GeneratorTooManyParameters, RustcBoxAttributeError, UnderscoreExprLhsAssign,
+};
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode, ParenthesizedGenericArgs};
 use crate::{FnDeclKind, ImplTraitPosition};
@@ -6,7 +11,6 @@ use rustc_ast::attr;
 use rustc_ast::ptr::P as AstP;
 use rustc_ast::*;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_hir::definitions::DefPathData;
@@ -45,13 +49,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             let hir_id = self.lower_node_id(e.id);
                             return hir::Expr { hir_id, kind, span: self.lower_span(e.span) };
                         } else {
-                            self.tcx.sess
-                                .struct_span_err(
-                                    e.span,
-                                    "#[rustc_box] requires precisely one argument \
-                                    and no other attributes are allowed",
-                                )
-                                .emit();
+                            self.tcx.sess.emit_err(RustcBoxAttributeError { span: e.span });
                             hir::ExprKind::Err
                         }
                     } else if let Some(legacy_args) = self.resolver.legacy_const_generic_args(f) {
@@ -211,13 +209,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     self.lower_expr_range(e.span, e1.as_deref(), e2.as_deref(), lims)
                 }
                 ExprKind::Underscore => {
-                    self.tcx
-                        .sess.struct_span_err(
-                            e.span,
-                            "in expressions, `_` can only be used on the left-hand side of an assignment",
-                        )
-                        .span_label(e.span, "`_` not allowed here")
-                        .emit();
+                    self.tcx.sess.emit_err(UnderscoreExprLhsAssign { span: e.span });
                     hir::ExprKind::Err
                 }
                 ExprKind::Path(ref qself, ref path) => {
@@ -249,11 +241,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     let rest = match &se.rest {
                         StructRest::Base(e) => Some(self.lower_expr(e)),
                         StructRest::Rest(sp) => {
-                            self.tcx
-                                .sess
-                                .struct_span_err(*sp, "base expression required after `..`")
-                                .span_label(*sp, "add a base expression here")
-                                .emit();
+                            self.tcx.sess.emit_err(BaseExpressionDoubleDot { span: *sp });
                             Some(&*self.arena.alloc(self.expr_err(*sp)))
                         }
                         StructRest::None => None,
@@ -662,17 +650,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         match self.generator_kind {
             Some(hir::GeneratorKind::Async(_)) => {}
             Some(hir::GeneratorKind::Gen) | None => {
-                let mut err = struct_span_err!(
-                    self.tcx.sess,
+                self.tcx.sess.emit_err(AwaitOnlyInAsyncFnAndBlocks {
                     dot_await_span,
-                    E0728,
-                    "`await` is only allowed inside `async` functions and blocks"
-                );
-                err.span_label(dot_await_span, "only allowed inside `async` functions and blocks");
-                if let Some(item_sp) = self.current_item {
-                    err.span_label(item_sp, "this is not `async`");
-                }
-                err.emit();
+                    item_span: self.current_item,
+                });
             }
         }
         let span = self.mark_span_with_reason(DesugaringKind::Await, dot_await_span, None);
@@ -892,13 +873,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         match generator_kind {
             Some(hir::GeneratorKind::Gen) => {
                 if decl.inputs.len() > 1 {
-                    struct_span_err!(
-                        self.tcx.sess,
-                        fn_decl_span,
-                        E0628,
-                        "too many parameters for a generator (expected 0 or 1 parameters)"
-                    )
-                    .emit();
+                    self.tcx.sess.emit_err(GeneratorTooManyParameters { fn_decl_span });
                 }
                 Some(movability)
             }
@@ -907,13 +882,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             None => {
                 if movability == Movability::Static {
-                    struct_span_err!(
-                        self.tcx.sess,
-                        fn_decl_span,
-                        E0697,
-                        "closures cannot be static"
-                    )
-                    .emit();
+                    self.tcx.sess.emit_err(ClosureCannotBeStatic { fn_decl_span });
                 }
                 None
             }
@@ -960,17 +929,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let body = self.with_new_scopes(|this| {
             // FIXME(cramertj): allow `async` non-`move` closures with arguments.
             if capture_clause == CaptureBy::Ref && !decl.inputs.is_empty() {
-                struct_span_err!(
-                    this.tcx.sess,
-                    fn_decl_span,
-                    E0708,
-                    "`async` non-`move` closures with parameters are not currently supported",
-                )
-                .help(
-                    "consider using `let` statements to manually capture \
-                    variables by reference before entering an `async move` closure",
-                )
-                .emit();
+                this.tcx.sess.emit_err(AsyncNonMoveClosureNotSupported { fn_decl_span });
             }
 
             // Transform `async |x: u8| -> X { ... }` into
@@ -1210,20 +1169,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 );
                 let fields_omitted = match &se.rest {
                     StructRest::Base(e) => {
-                        self.tcx
-                            .sess
-                            .struct_span_err(
-                                e.span,
-                                "functional record updates are not allowed in destructuring \
-                                    assignments",
-                            )
-                            .span_suggestion(
-                                e.span,
-                                "consider removing the trailing pattern",
-                                "",
-                                rustc_errors::Applicability::MachineApplicable,
-                            )
-                            .emit();
+                        self.tcx.sess.emit_err(FunctionalRecordUpdateDestructuringAssignemnt {
+                            span: e.span,
+                        });
                         true
                     }
                     StructRest::Rest(_) => true,
@@ -1420,13 +1368,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         match self.generator_kind {
             Some(hir::GeneratorKind::Gen) => {}
             Some(hir::GeneratorKind::Async(_)) => {
-                struct_span_err!(
-                    self.tcx.sess,
-                    span,
-                    E0727,
-                    "`async` generators are not yet supported"
-                )
-                .emit();
+                self.tcx.sess.emit_err(AsyncGeneratorsNotSupported { span });
             }
             None => self.generator_kind = Some(hir::GeneratorKind::Gen),
         }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1,7 +1,8 @@
 use super::errors::{
     AsyncGeneratorsNotSupported, AsyncNonMoveClosureNotSupported, AwaitOnlyInAsyncFnAndBlocks,
     BaseExpressionDoubleDot, ClosureCannotBeStatic, FunctionalRecordUpdateDestructuringAssignemnt,
-    GeneratorTooManyParameters, RustcBoxAttributeError, UnderscoreExprLhsAssign,
+    GeneratorTooManyParameters, NotSupportedForLifetimeBinderAsyncClosure, RustcBoxAttributeError,
+    UnderscoreExprLhsAssign,
 };
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode, ParenthesizedGenericArgs};
@@ -915,10 +916,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         fn_decl_span: Span,
     ) -> hir::ExprKind<'hir> {
         if let &ClosureBinder::For { span, .. } = binder {
-            self.tcx.sess.span_err(
-                span,
-                "`for<...>` binders on `async` closures are not currently supported",
-            );
+            self.tcx.sess.emit_err(NotSupportedForLifetimeBinderAsyncClosure { span });
         }
 
         let (binder_clause, generic_params) = self.lower_closure_binder(binder);

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1,4 +1,4 @@
-use super::errors::InvalidAbi;
+use super::errors::{InvalidAbi, MisplacedRelaxTraitBound};
 use super::ResolverAstLoweringExt;
 use super::{AstOwner, ImplTraitContext, ImplTraitPosition};
 use super::{FnDeclKind, LoweringContext, ParamMode};
@@ -1339,11 +1339,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 let is_param = *is_param.get_or_insert_with(compute_is_param);
                 if !is_param {
-                    self.diagnostic().span_err(
-                        bound.span(),
-                        "`?Trait` bounds are only permitted at the \
-                        point where a type parameter is declared",
-                    );
+                    self.tcx.sess.emit_err(MisplacedRelaxTraitBound { span: bound.span() });
                 }
             }
         }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1,3 +1,4 @@
+use super::errors::InvalidAbi;
 use super::ResolverAstLoweringExt;
 use super::{AstOwner, ImplTraitContext, ImplTraitPosition};
 use super::{FnDeclKind, LoweringContext, ParamMode};
@@ -7,7 +8,6 @@ use rustc_ast::visit::AssocCtxt;
 use rustc_ast::*;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sorted_map::SortedMap;
-use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{LocalDefId, CRATE_DEF_ID};
@@ -1260,10 +1260,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn error_on_invalid_abi(&self, abi: StrLit) {
-        struct_span_err!(self.tcx.sess, abi.span, E0703, "invalid ABI: found `{}`", abi.symbol)
-            .span_label(abi.span, "invalid ABI")
-            .help(&format!("valid ABIs: {}", abi::all_names().join(", ")))
-            .emit();
+        self.tcx.sess.emit_err(InvalidAbi {
+            span: abi.span,
+            abi: abi.symbol,
+            valid_abis: abi::all_names().join(", "),
+        });
     }
 
     fn lower_asyncness(&mut self, a: Async) -> hir::IsAsync {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -51,7 +51,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{Handler, StashKey};
+use rustc_errors::{DiagnosticArgFromDisplay, Handler, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, LifetimeRes, Namespace, PartialRes, PerNS, Res};
 use rustc_hir::def_id::{LocalDefId, CRATE_DEF_ID};
@@ -1334,7 +1334,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     ImplTraitContext::Disallowed(position) => {
                         self.tcx.sess.emit_err(MisplacedImplTrait {
                             span: t.span,
-                            position: position.to_string(),
+                            position: DiagnosticArgFromDisplay(&position),
                         });
                         hir::TyKind::Err
                     }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -39,6 +39,8 @@
 #[macro_use]
 extern crate tracing;
 
+use crate::errors::{AssocTyParentheses, AssocTyParenthesesSub, MisplacedImplTrait};
+
 use rustc_ast::ptr::P;
 use rustc_ast::visit;
 use rustc_ast::{self as ast, *};
@@ -49,7 +51,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{struct_span_err, Applicability, Handler, StashKey};
+use rustc_errors::{Handler, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, LifetimeRes, Namespace, PartialRes, PerNS, Res};
 use rustc_hir::def_id::{LocalDefId, CRATE_DEF_ID};
@@ -1071,19 +1073,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn emit_bad_parenthesized_trait_in_assoc_ty(&self, data: &ParenthesizedArgs) {
-        let mut err = self.tcx.sess.struct_span_err(
-            data.span,
-            "parenthesized generic arguments cannot be used in associated type constraints",
-        );
         // Suggest removing empty parentheses: "Trait()" -> "Trait"
-        if data.inputs.is_empty() {
+        let sub = if data.inputs.is_empty() {
             let parentheses_span =
                 data.inputs_span.shrink_to_lo().to(data.inputs_span.shrink_to_hi());
-            err.multipart_suggestion(
-                "remove these parentheses",
-                vec![(parentheses_span, String::new())],
-                Applicability::MaybeIncorrect,
-            );
+            AssocTyParenthesesSub::Empty { parentheses_span }
         }
         // Suggest replacing parentheses with angle brackets `Trait(params...)` to `Trait<params...>`
         else {
@@ -1097,13 +1091,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             // End of last argument to end of parameters
             let close_param =
                 data.inputs.last().unwrap().span.shrink_to_hi().to(data.inputs_span.shrink_to_hi());
-            err.multipart_suggestion(
-                &format!("use angle brackets instead",),
-                vec![(open_param, String::from("<")), (close_param, String::from(">"))],
-                Applicability::MaybeIncorrect,
-            );
-        }
-        err.emit();
+            AssocTyParenthesesSub::NotEmpty { open_param, close_param }
+        };
+        self.tcx.sess.emit_err(AssocTyParentheses { span: data.span, sub });
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -1342,14 +1332,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         path
                     }
                     ImplTraitContext::Disallowed(position) => {
-                        let mut err = struct_span_err!(
-                            self.tcx.sess,
-                            t.span,
-                            E0562,
-                            "`impl Trait` only allowed in function and inherent method return types, not in {}",
-                            position
-                        );
-                        err.emit();
+                        self.tcx.sess.emit_err(MisplacedImplTrait {
+                            span: t.span,
+                            position: position.to_string(),
+                        });
                         hir::TyKind::Err
                     }
                 }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -75,6 +75,7 @@ macro_rules! arena_vec {
 
 mod asm;
 mod block;
+mod errors;
 mod expr;
 mod index;
 mod item;

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -1,4 +1,6 @@
-use super::errors::{ExtraDoubleDot, MisplacedDoubleDot, SubTupleBinding};
+use super::errors::{
+    ArbitraryExpressionInPattern, ExtraDoubleDot, MisplacedDoubleDot, SubTupleBinding,
+};
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode};
 use crate::ImplTraitPosition;
@@ -330,8 +332,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             ExprKind::Path(..) if allow_paths => {}
             ExprKind::Unary(UnOp::Neg, ref inner) if matches!(inner.kind, ExprKind::Lit(_)) => {}
             _ => {
-                self.diagnostic()
-                    .span_err(expr.span, "arbitrary expressions aren't allowed in patterns");
+                self.tcx.sess.emit_err(ArbitraryExpressionInPattern { span: expr.span });
                 return self.arena.alloc(self.expr_err(expr.span));
             }
         }

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -1,3 +1,4 @@
+use super::errors::{ExtraDoubleDot, MisplacedDoubleDot, SubTupleBinding};
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode};
 use crate::ImplTraitPosition;
@@ -5,7 +6,6 @@ use crate::ImplTraitPosition;
 use rustc_ast::ptr::P;
 use rustc_ast::*;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_span::symbol::Ident;
@@ -134,20 +134,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 // This is not allowed as a sub-tuple pattern
                 PatKind::Ident(ref _bm, ident, Some(ref sub)) if sub.is_rest() => {
                     let sp = pat.span;
-                    self.diagnostic()
-                        .struct_span_err(
-                            sp,
-                            &format!("`{} @` is not allowed in a {}", ident.name, ctx),
-                        )
-                        .span_label(sp, "this is only allowed in slice patterns")
-                        .help("remove this and bind each tuple field independently")
-                        .span_suggestion_verbose(
-                            sp,
-                            &format!("if you don't need to use the contents of {}, discard the tuple's remaining fields", ident),
-                            "..",
-                            Applicability::MaybeIncorrect,
-                        )
-                        .emit();
+                    self.tcx.sess.emit_err(SubTupleBinding {
+                        span: sp,
+                        ident_name: ident.name,
+                        ident,
+                        ctx,
+                    });
                 }
                 _ => {}
             }
@@ -296,19 +288,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
     /// Emit a friendly error for extra `..` patterns in a tuple/tuple struct/slice pattern.
     pub(crate) fn ban_extra_rest_pat(&self, sp: Span, prev_sp: Span, ctx: &str) {
-        self.diagnostic()
-            .struct_span_err(sp, &format!("`..` can only be used once per {} pattern", ctx))
-            .span_label(sp, &format!("can only be used once per {} pattern", ctx))
-            .span_label(prev_sp, "previously used here")
-            .emit();
+        self.tcx.sess.emit_err(ExtraDoubleDot { span: sp, prev_span: prev_sp, ctx });
     }
 
     /// Used to ban the `..` pattern in places it shouldn't be semantically.
     fn ban_illegal_rest_pat(&self, sp: Span) -> hir::PatKind<'hir> {
-        self.diagnostic()
-            .struct_span_err(sp, "`..` patterns are not allowed here")
-            .note("only allowed in tuple, tuple struct, and slice patterns")
-            .emit();
+        self.tcx.sess.emit_err(MisplacedDoubleDot { span: sp });
 
         // We're not in a list context so `..` can be reasonably treated
         // as `_` because it should always be valid and roughly matches the

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -69,10 +69,10 @@ ast_lowering_invalid_abi_clobber_abi =
     .note = the following ABIs are supported on this target: {$supported_abis}
 
 ast_lowering_invalid_register =
-    invalid register `{$s}`: {$e}
+    invalid register `{$reg}`: {$error}
 
 ast_lowering_invalid_register_class =
-    invalid register class `{$s}`: {$e}
+    invalid register class `{$reg_class}`: {$error}
 
 ast_lowering_invalid_asm_template_modifier_reg_class =
     invalid asm template modifier for this register class

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -49,3 +49,57 @@ ast_lowering_functional_record_update_destructuring_assignment =
 
 ast_lowering_async_generators_not_supported =
     `async` generators are not yet supported
+
+ast_lowering_inline_asm_unsupported_target =
+    inline assembly is unsupported on this target
+
+ast_lowering_att_syntax_only_x86 =
+    the `att_syntax` option is only supported on x86
+
+ast_lowering_abi_specified_multiple_times =
+    `{$prev_name}` ABI specified multiple times
+    .label = previously specified here
+    .note = these ABIs are equivalent on the current target
+
+ast_lowering_clobber_abi_not_supported =
+    `clobber_abi` is not supported on this target
+
+ast_lowering_invalid_abi_clobber_abi =
+    invalid ABI for `clobber_abi`
+    .note = the following ABIs are supported on this target: {$supported_abis}
+
+ast_lowering_invalid_register =
+    invalid register `{$s}`: {$e}
+
+ast_lowering_invalid_register_class =
+    invalid register class `{$s}`: {$e}
+
+ast_lowering_invalid_asm_template_modifier_reg_class =
+    invalid asm template modifier for this register class
+
+ast_lowering_argument = argument
+
+ast_lowering_template_modifier = template modifier
+
+ast_lowering_support_modifiers =
+    the `{$class_name}` register class supports the following template modifiers: {$modifiers}
+
+ast_lowering_does_not_support_modifiers =
+    the `{$class_name}` register class does not support template modifiers
+
+ast_lowering_invalid_asm_template_modifier_const =
+    asm template modifiers are not allowed for `const` arguments
+
+ast_lowering_invalid_asm_template_modifier_sym =
+    asm template modifiers are not allowed for `sym` arguments
+
+ast_lowering_register_class_only_clobber =
+    register class `{$reg_class_name}` can only be used as a clobber, not as an input or output
+
+ast_lowering_register_conflict =
+    register `{$reg1_name}` conflicts with register `{$reg2_name}`
+    .help = use `lateout` instead of `out` to avoid conflict
+
+ast_lowering_register1 = register `{$reg1_name}`
+
+ast_lowering_register2 = register `{$reg2_name}`

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -103,3 +103,20 @@ ast_lowering_register_conflict =
 ast_lowering_register1 = register `{$reg1_name}`
 
 ast_lowering_register2 = register `{$reg2_name}`
+
+ast_lowering_sub_tuple_binding =
+    `{$ident_name} @` is not allowed in a {$ctx}
+    .label = this is only allowed in slice patterns
+    .help = remove this and bind each tuple field independently
+
+ast_lowering_sub_tuple_binding_suggestion = if you don't need to use the contents of {$ident}, discard the tuple's remaining fields
+
+ast_lowering_extra_double_dot =
+    `..` can only be used once per {$ctx} pattern
+    .label = can only be used once per {$ctx} pattern
+
+ast_lowering_previously_used_here = previously used here
+
+ast_lowering_misplaced_double_dot =
+    `..` patterns are not allowed here
+    .note = only allowed in tuple, tuple struct, and slice patterns

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -16,3 +16,36 @@ ast_lowering_remove_parentheses = remove these parentheses
 
 ast_lowering_misplaced_impl_trait =
     `impl Trait` only allowed in function and inherent method return types, not in {$position}
+
+ast_lowering_rustc_box_attribute_error =
+    #[rustc_box] requires precisely one argument and no other attributes are allowed
+
+ast_lowering_underscore_expr_lhs_assign =
+    in expressions, `_` can only be used on the left-hand side of an assignment
+    .label = `_` not allowed here
+
+ast_lowering_base_expression_double_dot =
+    base expression required after `..`
+    .label = add a base expression here
+
+ast_lowering_await_only_in_async_fn_and_blocks =
+    `await` is only allowed inside `async` functions and blocks
+    .label = only allowed inside `async` functions and blocks
+
+ast_lowering_this_not_async = this is not `async`
+
+ast_lowering_generator_too_many_parameters =
+    too many parameters for a generator (expected 0 or 1 parameters)
+
+ast_lowering_closure_cannot_be_static = closures cannot be static
+
+ast_lowering_async_non_move_closure_not_supported =
+    `async` non-`move` closures with parameters are not currently supported
+    .help = consider using `let` statements to manually capture variables by reference before entering an `async move` closure
+
+ast_lowering_functional_record_update_destructuring_assignment =
+    functional record updates are not allowed in destructuring assignments
+    .suggestion = consider removing the trailing pattern
+
+ast_lowering_async_generators_not_supported =
+    `async` generators are not yet supported

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -3,3 +3,16 @@ ast_lowering_generic_type_with_parentheses =
     .label = only `Fn` traits may use parentheses
 
 ast_lowering_use_angle_brackets = use angle brackets instead
+
+ast_lowering_invalid_abi =
+    invalid ABI: found `{$abi}`
+    .label = invalid ABI
+    .help = valid ABIs: {$valid_abis}
+
+ast_lowering_assoc_ty_parentheses =
+    parenthesized generic arguments cannot be used in associated type constraints
+
+ast_lowering_remove_parentheses = remove these parentheses
+
+ast_lowering_misplaced_impl_trait =
+    `impl Trait` only allowed in function and inherent method return types, not in {$position}

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -1,0 +1,5 @@
+ast_lowering_generic_type_with_parentheses =
+    parenthesized type parameters may only be used with a `Fn` trait
+    .label = only `Fn` traits may use parentheses
+
+ast_lowering_use_angle_brackets = use angle brackets instead

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -120,3 +120,12 @@ ast_lowering_previously_used_here = previously used here
 ast_lowering_misplaced_double_dot =
     `..` patterns are not allowed here
     .note = only allowed in tuple, tuple struct, and slice patterns
+
+ast_lowering_misplaced_relax_trait_bound =
+    `?Trait` bounds are only permitted at the point where a type parameter is declared
+
+ast_lowering_not_supported_for_lifetime_binder_async_closure =
+    `for<...>` binders on `async` closures are not currently supported
+
+ast_lowering_arbitrary_expression_in_pattern =
+    arbitrary expressions aren't allowed in patterns

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -32,6 +32,7 @@ pub use unic_langid::{langid, LanguageIdentifier};
 
 // Generates `DEFAULT_LOCALE_RESOURCES` static and `fluent_generated` module.
 fluent_messages! {
+    ast_lowering => "../locales/en-US/ast_lowering.ftl",
     ast_passes => "../locales/en-US/ast_passes.ftl",
     borrowck => "../locales/en-US/borrowck.ftl",
     builtin_macros => "../locales/en-US/builtin_macros.ftl",


### PR DESCRIPTION
I migrated the whole rustc_ast_lowering crate to session diagnostic *except* the for the use of `span_fatal` at /compiler/rustc_ast_lowering/src/expr.rs#L1268 because `#[fatal(...)]` is not yet supported (see https://github.com/rust-lang/rust/pull/100694).