### PR TITLE
Migrate `rustc_ty_utils` to `SessionDiagnostic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,6 +4601,7 @@ dependencies = [
  "rustc_hir",
  "rustc_index",
  "rustc_infer",
+ "rustc_macros",
  "rustc_middle",
  "rustc_session",
  "rustc_span",

--- a/compiler/rustc_error_messages/locales/en-US/ty_utils.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ty_utils.ftl
@@ -1,0 +1,47 @@
+ty_utils_needs_drop_overflow = overflow while checking whether `{$query_ty}` requires drop
+
+ty_utils_generic_constant_too_complex = overly complex generic constant
+    .help = consider moving this anonymous constant into a `const` function
+    .maybe_supported = this operation may be supported in the future
+
+ty_utils_borrow_not_supported = borrowing is not supported in generic constants
+
+ty_utils_address_and_deref_not_supported = dereferencing or taking the address is not supported in generic constants
+
+ty_utils_array_not_supported = array construction is not supported in generic constants
+
+ty_utils_block_not_supported = blocks are not supported in generic constant
+
+ty_utils_never_to_any_not_supported = converting nevers to any is not supported in generic constant
+
+ty_utils_tuple_not_supported = tuple construction is not supported in generic constants
+
+ty_utils_index_not_supported = indexing is not supported in generic constant
+
+ty_utils_field_not_supported = field access is not supported in generic constant
+
+ty_utils_const_block_not_supported = const blocks are not supported in generic constant
+
+ty_utils_adt_not_supported = struct/enum construction is not supported in generic constants
+
+ty_utils_pointer_not_supported = pointer casts are not allowed in generic constants
+
+ty_utils_yield_not_supported = generator control flow is not allowed in generic constants
+
+ty_utils_loop_not_supported = loops and loop control flow are not supported in generic constants
+
+ty_utils_box_not_supported = allocations are not allowed in generic constants
+
+ty_utils_binary_not_supported = unsupported binary operation in generic constants
+
+ty_utils_logical_op_not_supported = unsupported operation in generic constants, short-circuiting operations would imply control flow
+
+ty_utils_assign_not_supported = assignment is not supported in generic constants
+
+ty_utils_closure_and_return_not_supported = closures and function keywords are not supported in generic constants
+
+ty_utils_control_flow_not_supported = control flow is not supported in generic constants
+
+ty_utils_inline_asm_not_supported = assembly is not supported in generic constants
+
+ty_utils_operation_not_supported = unsupported operation in generic constant

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -44,6 +44,7 @@ fluent_messages! {
     plugin_impl => "../locales/en-US/plugin_impl.ftl",
     privacy => "../locales/en-US/privacy.ftl",
     save_analysis => "../locales/en-US/save_analysis.ftl",
+    ty_utils => "../locales/en-US/ty_utils.ftl",
     typeck => "../locales/en-US/typeck.ftl",
 }
 

--- a/compiler/rustc_ty_utils/Cargo.toml
+++ b/compiler/rustc_ty_utils/Cargo.toml
@@ -10,6 +10,7 @@ rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_hir = { path = "../rustc_hir" }
 rustc_infer = { path = "../rustc_infer" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_span = { path = "../rustc_span" }
 rustc_session = { path = "../rustc_session" }
 rustc_target = { path = "../rustc_target" }

--- a/compiler/rustc_ty_utils/src/errors.rs
+++ b/compiler/rustc_ty_utils/src/errors.rs
@@ -1,0 +1,69 @@
+//! Errors emitted by ty_utils
+
+use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
+use rustc_middle::ty::Ty;
+use rustc_span::Span;
+
+#[derive(SessionDiagnostic)]
+#[diag(ty_utils::needs_drop_overflow)]
+pub struct NeedsDropOverflow<'tcx> {
+    pub query_ty: Ty<'tcx>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(ty_utils::generic_constant_too_complex)]
+#[help]
+pub struct GenericConstantTooComplex {
+    #[primary_span]
+    pub span: Span,
+    #[note(ty_utils::maybe_supported)]
+    pub maybe_supported: Option<()>,
+    #[subdiagnostic]
+    pub sub: GenericConstantTooComplexSub,
+}
+
+#[derive(SessionSubdiagnostic)]
+pub enum GenericConstantTooComplexSub {
+    #[label(ty_utils::borrow_not_supported)]
+    BorrowNotSupported(#[primary_span] Span),
+    #[label(ty_utils::address_and_deref_not_supported)]
+    AddressAndDerefNotSupported(#[primary_span] Span),
+    #[label(ty_utils::array_not_supported)]
+    ArrayNotSupported(#[primary_span] Span),
+    #[label(ty_utils::block_not_supported)]
+    BlockNotSupported(#[primary_span] Span),
+    #[label(ty_utils::never_to_any_not_supported)]
+    NeverToAnyNotSupported(#[primary_span] Span),
+    #[label(ty_utils::tuple_not_supported)]
+    TupleNotSupported(#[primary_span] Span),
+    #[label(ty_utils::index_not_supported)]
+    IndexNotSupported(#[primary_span] Span),
+    #[label(ty_utils::field_not_supported)]
+    FieldNotSupported(#[primary_span] Span),
+    #[label(ty_utils::const_block_not_supported)]
+    ConstBlockNotSupported(#[primary_span] Span),
+    #[label(ty_utils::adt_not_supported)]
+    AdtNotSupported(#[primary_span] Span),
+    #[label(ty_utils::pointer_not_supported)]
+    PointerNotSupported(#[primary_span] Span),
+    #[label(ty_utils::yield_not_supported)]
+    YieldNotSupported(#[primary_span] Span),
+    #[label(ty_utils::loop_not_supported)]
+    LoopNotSupported(#[primary_span] Span),
+    #[label(ty_utils::box_not_supported)]
+    BoxNotSupported(#[primary_span] Span),
+    #[label(ty_utils::binary_not_supported)]
+    BinaryNotSupported(#[primary_span] Span),
+    #[label(ty_utils::logical_op_not_supported)]
+    LogicalOpNotSupported(#[primary_span] Span),
+    #[label(ty_utils::assign_not_supported)]
+    AssignNotSupported(#[primary_span] Span),
+    #[label(ty_utils::closure_and_return_not_supported)]
+    ClosureAndReturnNotSupported(#[primary_span] Span),
+    #[label(ty_utils::control_flow_not_supported)]
+    ControlFlowNotSupported(#[primary_span] Span),
+    #[label(ty_utils::inline_asm_not_supported)]
+    InlineAsmNotSupported(#[primary_span] Span),
+    #[label(ty_utils::operation_not_supported)]
+    OperationNotSupported(#[primary_span] Span),
+}

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -10,6 +10,8 @@
 #![feature(never_type)]
 #![feature(box_patterns)]
 #![recursion_limit = "256"]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_middle;
@@ -21,6 +23,7 @@ use rustc_middle::ty::query::Providers;
 mod assoc;
 mod common_traits;
 mod consts;
+mod errors;
 mod implied_bounds;
 pub mod instance;
 mod needs_drop;

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -9,6 +9,8 @@ use rustc_middle::ty::{self, EarlyBinder, Ty, TyCtxt};
 use rustc_session::Limit;
 use rustc_span::{sym, DUMMY_SP};
 
+use crate::errors::NeedsDropOverflow;
+
 type NeedsDropResult<T> = Result<T, AlwaysRequiresDrop>;
 
 fn needs_drop_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
@@ -90,10 +92,7 @@ where
             if !self.recursion_limit.value_within_limit(level) {
                 // Not having a `Span` isn't great. But there's hopefully some other
                 // recursion limit error as well.
-                tcx.sess.span_err(
-                    DUMMY_SP,
-                    &format!("overflow while checking whether `{}` requires drop", self.query_ty),
-                );
+                tcx.sess.emit_err(NeedsDropOverflow { query_ty: self.query_ty });
                 return Some(Err(AlwaysRequiresDrop));
             }
 


### PR DESCRIPTION
I have migrated the `rustc_ty_utils` crate to use `SessionDiagnostic`, motivated by the [recent blog post about the diagnostic translation effort](https://blog.rust-lang.org/inside-rust/2022/08/16/diagnostic-effort.html).

This is my first PR to the Rust repository, so if I have missed anything, or anything needs to be changed, please let me know! 😄

@rustbot label +A-translation