### PR TITLE
Support setting signal masks for child processes on Unix

### DIFF
--- a/library/std/src/sys/unix/process/mod.rs
+++ b/library/std/src/sys/unix/process/mod.rs
@@ -1,4 +1,4 @@
-pub use self::process_common::{Command, CommandArgs, ExitCode, Stdio, StdioPipes};
+pub use self::process_common::{Command, CommandArgs, ExitCode, SignalSet, Stdio, StdioPipes};
 pub use self::process_inner::{ExitStatus, ExitStatusError, Process};
 pub use crate::ffi::OsString as EnvKey;
 pub use crate::sys_common::process::CommandEnvs;


### PR DESCRIPTION
This commit implements basic support for setting signal masks during process spawning.
    
* With the `posix_spawn` code path, this means setting `posix_spawnattr_setsigmask`.
* With the `fork/exec` path, this means calling `pthread_sigmask` in the child before executing it.

This PR retains the default behavior (empty signal mask). I've also put up #101077 as a dependent PR to change the default behavior.

API change proposal:

* https://github.com/rust-lang/libs-team/issues/88

Unresolved questions:

* [ ] Is the possible UB with masking `SIGSEGV` etc (documented in the POSIX spec) enough reason to mark this unsafe?