### PR TITLE
Diagnostics migr const eval

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -1,15 +1,15 @@
 // Not in interpret to make sure we do not use private implementation details
 
+use crate::errors::MaxNumNodesExceeded;
+use crate::interpret::{
+    intern_const_alloc_recursive, ConstValue, InternKind, InterpCx, InterpResult, MemPlaceMeta,
+    Scalar,
+};
 use rustc_hir::Mutability;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::{EvalToValTreeResult, GlobalId};
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{source_map::DUMMY_SP, symbol::Symbol};
-
-use crate::interpret::{
-    intern_const_alloc_recursive, ConstValue, InternKind, InterpCx, InterpResult, MemPlaceMeta,
-    Scalar,
-};
 
 mod error;
 mod eval_queries;
@@ -77,7 +77,7 @@ pub(crate) fn eval_to_valtree<'tcx>(
                 ValTreeCreationError::NodesOverflow => {
                     let msg = format!("maximum number of nodes exceeded in constant {}", &s);
                     let mut diag = match tcx.hir().span_if_local(did) {
-                        Some(span) => tcx.sess.struct_span_err(span, &msg),
+                        Some(span) => tcx.sess.create_err(MaxNumNodesExceeded { span, s }),
                         None => tcx.sess.struct_err(&msg),
                     };
                     diag.emit();

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -1,6 +1,6 @@
 // Not in interpret to make sure we do not use private implementation details
 
-use crate::errors::MaxNumNodesExceeded;
+use crate::errors::MaxNumNodesInConstErr;
 use crate::interpret::{
     intern_const_alloc_recursive, ConstValue, InternKind, InterpCx, InterpResult, MemPlaceMeta,
     Scalar,
@@ -77,7 +77,7 @@ pub(crate) fn eval_to_valtree<'tcx>(
                 ValTreeCreationError::NodesOverflow => {
                     let msg = format!("maximum number of nodes exceeded in constant {}", &s);
                     let mut diag = match tcx.hir().span_if_local(did) {
-                        Some(span) => tcx.sess.create_err(MaxNumNodesExceeded { span, s }),
+                        Some(span) => tcx.sess.create_err(MaxNumNodesInConstErr { span, s }),
                         None => tcx.sess.struct_err(&msg),
                     };
                     diag.emit();

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -75,9 +75,14 @@ pub(crate) fn eval_to_valtree<'tcx>(
             let global_const_id = cid.display(tcx);
             match err {
                 ValTreeCreationError::NodesOverflow => {
-                    let msg = format!("maximum number of nodes exceeded in constant {}", &global_const_id);
+                    let msg = format!(
+                        "maximum number of nodes exceeded in constant {}",
+                        &global_const_id
+                    );
                     let mut diag = match tcx.hir().span_if_local(did) {
-                        Some(span) => tcx.sess.create_err(MaxNumNodesInConstErr { span, global_const_id }),
+                        Some(span) => {
+                            tcx.sess.create_err(MaxNumNodesInConstErr { span, global_const_id })
+                        }
                         None => tcx.sess.struct_err(&msg),
                     };
                     diag.emit();

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -72,12 +72,12 @@ pub(crate) fn eval_to_valtree<'tcx>(
         Ok(valtree) => Ok(Some(valtree)),
         Err(err) => {
             let did = cid.instance.def_id();
-            let s = cid.display(tcx);
+            let global_const_id = cid.display(tcx);
             match err {
                 ValTreeCreationError::NodesOverflow => {
-                    let msg = format!("maximum number of nodes exceeded in constant {}", &s);
+                    let msg = format!("maximum number of nodes exceeded in constant {}", &global_const_id);
                     let mut diag = match tcx.hir().span_if_local(did) {
-                        Some(span) => tcx.sess.create_err(MaxNumNodesInConstErr { span, s }),
+                        Some(span) => tcx.sess.create_err(MaxNumNodesInConstErr { span, global_const_id }),
                         None => tcx.sess.struct_err(&msg),
                     };
                     diag.emit();

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -103,3 +103,11 @@ pub(crate) struct UnallowedFnPointerCall {
     pub span: Span,
     pub kind: ConstContext,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::unstable_const_fn)]
+pub(crate) struct UnstableConstFn {
+    #[primary_span]
+    pub span: Span,
+    pub def_id: String,
+}

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -89,8 +89,8 @@ pub(crate) struct TransientMutBorrowErrRaw {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::const_evaL_max_num_nodes_exceeded)]
-pub(crate) struct MaxNumNodesExceeded {
+#[error(const_eval::const_evaL_max_num_nodes_in_const_err)]
+pub(crate) struct MaxNumNodesInConstErr {
     #[primary_span]
     pub span: Span,
     pub s: String,
@@ -109,7 +109,7 @@ pub(crate) struct UnallowedFnPointerCall {
 pub(crate) struct UnstableConstFn {
     #[primary_span]
     pub span: Span,
-    pub def_id: String,
+    pub def_path: String,
 }
 
 #[derive(SessionDiagnostic)]
@@ -160,6 +160,7 @@ pub(crate) struct UnallowedOpInConstContext {
 #[error(const_eval::unallowed_heap_allocations, code = "E0010")]
 pub(crate) struct UnallowedHeapAllocations {
     #[primary_span]
+    #[label]
     pub span: Span,
     pub kind: ConstContext,
     #[note(const_eval::teach_note)]
@@ -178,6 +179,7 @@ pub(crate) struct UnallowedInlineAsm {
 #[error(const_eval::interior_mutable_data_refer, code = "E0492")]
 pub(crate) struct InteriorMutableDataRefer {
     #[primary_span]
+    #[label]
     pub span: Span,
     #[help]
     pub opt_help: Option<()>,

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -93,7 +93,7 @@ pub(crate) struct TransientMutBorrowErrRaw {
 pub(crate) struct MaxNumNodesInConstErr {
     #[primary_span]
     pub span: Span,
-    pub s: String,
+    pub global_const_id: String,
 }
 
 #[derive(SessionDiagnostic)]

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -95,3 +95,11 @@ pub(crate) struct MaxNumNodesExceeded {
     pub span: Span,
     pub s: String,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::unallowed_fn_pointer_call)]
+pub(crate) struct UnallowedFnPointerCall {
+    #[primary_span]
+    pub span: Span,
+    pub kind: ConstContext,
+}

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -89,7 +89,7 @@ pub(crate) struct TransientMutBorrowErrRaw {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::max_num_nodes_in_const)]
+#[diag(const_eval::max_num_nodes_in_const)]
 pub(crate) struct MaxNumNodesInConstErr {
     #[primary_span]
     pub span: Span,
@@ -97,7 +97,7 @@ pub(crate) struct MaxNumNodesInConstErr {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::unallowed_fn_pointer_call)]
+#[diag(const_eval::unallowed_fn_pointer_call)]
 pub(crate) struct UnallowedFnPointerCall {
     #[primary_span]
     pub span: Span,
@@ -105,7 +105,7 @@ pub(crate) struct UnallowedFnPointerCall {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::unstable_const_fn)]
+#[diag(const_eval::unstable_const_fn)]
 pub(crate) struct UnstableConstFn {
     #[primary_span]
     pub span: Span,
@@ -113,7 +113,7 @@ pub(crate) struct UnstableConstFn {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::unallowed_mutable_refs, code = "E0764")]
+#[diag(const_eval::unallowed_mutable_refs, code = "E0764")]
 pub(crate) struct UnallowedMutableRefs {
     #[primary_span]
     pub span: Span,
@@ -123,7 +123,7 @@ pub(crate) struct UnallowedMutableRefs {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::unallowed_mutable_refs_raw, code = "E0764")]
+#[diag(const_eval::unallowed_mutable_refs_raw, code = "E0764")]
 pub(crate) struct UnallowedMutableRefsRaw {
     #[primary_span]
     pub span: Span,
@@ -132,7 +132,7 @@ pub(crate) struct UnallowedMutableRefsRaw {
     pub teach: Option<()>,
 }
 #[derive(SessionDiagnostic)]
-#[error(const_eval::non_const_fmt_macro_call, code = "E0015")]
+#[diag(const_eval::non_const_fmt_macro_call, code = "E0015")]
 pub(crate) struct NonConstFmtMacroCall {
     #[primary_span]
     pub span: Span,
@@ -140,7 +140,7 @@ pub(crate) struct NonConstFmtMacroCall {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::non_const_fn_call, code = "E0015")]
+#[diag(const_eval::non_const_fn_call, code = "E0015")]
 pub(crate) struct NonConstFnCall {
     #[primary_span]
     pub span: Span,
@@ -149,7 +149,7 @@ pub(crate) struct NonConstFnCall {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::unallowed_op_in_const_context)]
+#[diag(const_eval::unallowed_op_in_const_context)]
 pub(crate) struct UnallowedOpInConstContext {
     #[primary_span]
     pub span: Span,
@@ -157,7 +157,7 @@ pub(crate) struct UnallowedOpInConstContext {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::unallowed_heap_allocations, code = "E0010")]
+#[diag(const_eval::unallowed_heap_allocations, code = "E0010")]
 pub(crate) struct UnallowedHeapAllocations {
     #[primary_span]
     #[label]
@@ -168,7 +168,7 @@ pub(crate) struct UnallowedHeapAllocations {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::unallowed_inline_asm, code = "E0015")]
+#[diag(const_eval::unallowed_inline_asm, code = "E0015")]
 pub(crate) struct UnallowedInlineAsm {
     #[primary_span]
     pub span: Span,
@@ -176,7 +176,7 @@ pub(crate) struct UnallowedInlineAsm {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::interior_mutable_data_refer, code = "E0492")]
+#[diag(const_eval::interior_mutable_data_refer, code = "E0492")]
 pub(crate) struct InteriorMutableDataRefer {
     #[primary_span]
     #[label]
@@ -189,7 +189,7 @@ pub(crate) struct InteriorMutableDataRefer {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::interior_mutability_borrow)]
+#[diag(const_eval::interior_mutability_borrow)]
 pub(crate) struct InteriorMutabilityBorrow {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -111,3 +111,84 @@ pub(crate) struct UnstableConstFn {
     pub span: Span,
     pub def_id: String,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::unallowed_mutable_refs, code = "E0764")]
+pub(crate) struct UnallowedMutableRefs {
+    #[primary_span]
+    pub span: Span,
+    pub kind: ConstContext,
+    #[note(const_eval::teach_note)]
+    pub teach: Option<()>,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::unallowed_mutable_refs_raw, code = "E0764")]
+pub(crate) struct UnallowedMutableRefsRaw {
+    #[primary_span]
+    pub span: Span,
+    pub kind: ConstContext,
+    #[note(const_eval::teach_note)]
+    pub teach: Option<()>,
+}
+#[derive(SessionDiagnostic)]
+#[error(const_eval::non_const_fmt_macro_call, code = "E0015")]
+pub(crate) struct NonConstFmtMacroCall {
+    #[primary_span]
+    pub span: Span,
+    pub kind: ConstContext,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::non_const_fn_call, code = "E0015")]
+pub(crate) struct NonConstFnCall {
+    #[primary_span]
+    pub span: Span,
+    pub def_path_str: String,
+    pub kind: ConstContext,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::unallowed_op_in_const_context)]
+pub(crate) struct UnallowedOpInConstContext {
+    #[primary_span]
+    pub span: Span,
+    pub msg: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::unallowed_heap_allocations, code = "E0010")]
+pub(crate) struct UnallowedHeapAllocations {
+    #[primary_span]
+    pub span: Span,
+    pub kind: ConstContext,
+    #[note(const_eval::teach_note)]
+    pub teach: Option<()>,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::unallowed_inline_asm, code = "E0015")]
+pub(crate) struct UnallowedInlineAsm {
+    #[primary_span]
+    pub span: Span,
+    pub kind: ConstContext,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::interior_mutable_data_refer, code = "E0492")]
+pub(crate) struct InteriorMutableDataRefer {
+    #[primary_span]
+    pub span: Span,
+    #[help]
+    pub opt_help: Option<()>,
+    pub kind: ConstContext,
+    #[note(const_eval::teach_note)]
+    pub teach: Option<()>,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::interior_mutability_borrow)]
+pub(crate) struct InteriorMutabilityBorrow {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -89,7 +89,7 @@ pub(crate) struct TransientMutBorrowErrRaw {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(const_eval::const_evaL_max_num_nodes_in_const_err)]
+#[error(const_eval::max_num_nodes_in_const)]
 pub(crate) struct MaxNumNodesInConstErr {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -87,3 +87,11 @@ pub(crate) struct TransientMutBorrowErrRaw {
     pub span: Span,
     pub kind: ConstContext,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(const_eval::const_evaL_max_num_nodes_exceeded)]
+pub(crate) struct MaxNumNodesExceeded {
+    #[primary_span]
+    pub span: Span,
+    pub s: String,
+}

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -345,8 +345,10 @@ impl<'tcx> NonConstOp<'tcx> for FnCallUnstable {
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
         let FnCallUnstable(def_id, feature) = *self;
 
-        let mut err =
-            ccx.tcx.sess.create_err(UnstableConstFn { span, def_id: ccx.tcx.def_path_str(def_id) });
+        let mut err = ccx
+            .tcx
+            .sess
+            .create_err(UnstableConstFn { span, def_path: ccx.tcx.def_path_str(def_id) });
 
         if ccx.is_const_stable_const_fn() {
             err.help("const-stable functions can only call other const-stable functions");
@@ -517,17 +519,6 @@ impl<'tcx> NonConstOp<'tcx> for MutBorrow {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        // let raw = match self.0 {
-        //     hir::BorrowKind::Raw => "raw ",
-        //     hir::BorrowKind::Ref => "",
-        // };
-
-        // ccx.tcx.sess.create_err(UnallowedMutableRefs {
-        //     span,
-        //     raw,
-        //     kind: ccx.const_kind(),
-        //     teach: ccx.tcx.sess.teach(&error_code!(E0764)).then_some(()),
-        // })
         match self.0 {
             hir::BorrowKind::Raw => ccx.tcx.sess.create_err(UnallowedMutableRefsRaw {
                 span,

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -25,7 +25,7 @@ use rustc_trait_selection::traits::SelectionContext;
 use super::ConstCx;
 use crate::errors::{
     MutDerefErr, NonConstOpErr, PanicNonStrErr, RawPtrToIntErr, StaticAccessErr,
-    TransientMutBorrowErr, TransientMutBorrowErrRaw, UnallowedFnPointerCall,
+    TransientMutBorrowErr, TransientMutBorrowErrRaw, UnallowedFnPointerCall, UnstableConstFn,
 };
 use crate::util::{call_kind, CallDesugaringKind, CallKind};
 
@@ -351,10 +351,8 @@ impl<'tcx> NonConstOp<'tcx> for FnCallUnstable {
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
         let FnCallUnstable(def_id, feature) = *self;
 
-        let mut err = ccx.tcx.sess.struct_span_err(
-            span,
-            &format!("`{}` is not yet stable as a const fn", ccx.tcx.def_path_str(def_id)),
-        );
+        let mut err =
+            ccx.tcx.sess.create_err(UnstableConstFn { span, def_id: ccx.tcx.def_path_str(def_id) });
 
         if ccx.is_const_stable_const_fn() {
             err.help("const-stable functions can only call other const-stable functions");

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -24,8 +24,11 @@ use rustc_trait_selection::traits::SelectionContext;
 
 use super::ConstCx;
 use crate::errors::{
-    MutDerefErr, NonConstOpErr, PanicNonStrErr, RawPtrToIntErr, StaticAccessErr,
-    TransientMutBorrowErr, TransientMutBorrowErrRaw, UnallowedFnPointerCall, UnstableConstFn,
+    InteriorMutabilityBorrow, InteriorMutableDataRefer, MutDerefErr, NonConstFmtMacroCall,
+    NonConstFnCall, NonConstOpErr, PanicNonStrErr, RawPtrToIntErr, StaticAccessErr,
+    TransientMutBorrowErr, TransientMutBorrowErrRaw, UnallowedFnPointerCall,
+    UnallowedHeapAllocations, UnallowedInlineAsm, UnallowedMutableRefs, UnallowedMutableRefsRaw,
+    UnallowedOpInConstContext, UnstableConstFn,
 };
 use crate::util::{call_kind, CallDesugaringKind, CallKind};
 
@@ -305,22 +308,13 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                 err
             }
             _ if tcx.opt_parent(callee) == tcx.get_diagnostic_item(sym::ArgumentV1Methods) => {
-                struct_span_err!(
-                    ccx.tcx.sess,
-                    span,
-                    E0015,
-                    "cannot call non-const formatting macro in {}s",
-                    ccx.const_kind(),
-                )
+                ccx.tcx.sess.create_err(NonConstFmtMacroCall { span, kind: ccx.const_kind() })
             }
-            _ => struct_span_err!(
-                ccx.tcx.sess,
+            _ => ccx.tcx.sess.create_err(NonConstFnCall {
                 span,
-                E0015,
-                "cannot call non-const fn `{}` in {}s",
-                ccx.tcx.def_path_str_with_substs(callee, substs),
-                ccx.const_kind(),
-            ),
+                def_path_str: ccx.tcx.def_path_str_with_substs(callee, substs),
+                kind: ccx.const_kind(),
+            }),
         };
 
         err.note(&format!(
@@ -387,9 +381,12 @@ impl<'tcx> NonConstOp<'tcx> for Generator {
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
         let msg = format!("{}s are not allowed in {}s", self.0, ccx.const_kind());
         if let hir::GeneratorKind::Async(hir::AsyncGeneratorKind::Block) = self.0 {
-            feature_err(&ccx.tcx.sess.parse_sess, sym::const_async_blocks, span, &msg)
+            ccx.tcx.sess.create_feature_err(
+                UnallowedOpInConstContext { span, msg },
+                sym::const_async_blocks,
+            )
         } else {
-            ccx.tcx.sess.struct_span_err(span, &msg)
+            ccx.tcx.sess.create_err(UnallowedOpInConstContext { span, msg })
         }
     }
 }
@@ -402,23 +399,11 @@ impl<'tcx> NonConstOp<'tcx> for HeapAllocation {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        let mut err = struct_span_err!(
-            ccx.tcx.sess,
+        ccx.tcx.sess.create_err(UnallowedHeapAllocations {
             span,
-            E0010,
-            "allocations are not allowed in {}s",
-            ccx.const_kind()
-        );
-        err.span_label(span, format!("allocation not allowed in {}s", ccx.const_kind()));
-        if ccx.tcx.sess.teach(&err.get_code().unwrap()) {
-            err.note(
-                "The value of statics and constants must be known at compile time, \
-                 and they live for the entire lifetime of a program. Creating a boxed \
-                 value allocates memory on the heap at runtime, and therefore cannot \
-                 be done at compile time.",
-            );
-        }
-        err
+            kind: ccx.const_kind(),
+            teach: ccx.tcx.sess.teach(&error_code!(E0010)).then_some(()),
+        })
     }
 }
 
@@ -430,13 +415,7 @@ impl<'tcx> NonConstOp<'tcx> for InlineAsm {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        struct_span_err!(
-            ccx.tcx.sess,
-            span,
-            E0015,
-            "inline assembly is not allowed in {}s",
-            ccx.const_kind()
-        )
+        ccx.tcx.sess.create_err(UnallowedInlineAsm { span, kind: ccx.const_kind() })
     }
 }
 
@@ -482,12 +461,7 @@ impl<'tcx> NonConstOp<'tcx> for TransientCellBorrow {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        feature_err(
-            &ccx.tcx.sess.parse_sess,
-            sym::const_refs_to_cell,
-            span,
-            "cannot borrow here, since the borrowed element may contain interior mutability",
-        )
+        ccx.tcx.sess.create_feature_err(InteriorMutabilityBorrow { span }, sym::const_refs_to_cell)
     }
 }
 
@@ -502,32 +476,22 @@ impl<'tcx> NonConstOp<'tcx> for CellBorrow {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        let mut err = struct_span_err!(
-            ccx.tcx.sess,
-            span,
-            E0492,
-            "{}s cannot refer to interior mutable data",
-            ccx.const_kind(),
-        );
-        err.span_label(
-            span,
-            "this borrow of an interior mutable value may end up in the final value",
-        );
+        // FIXME: Maybe a more elegant solution to this if else case
         if let hir::ConstContext::Static(_) = ccx.const_kind() {
-            err.help(
-                "to fix this, the value can be extracted to a separate \
-                `static` item and then referenced",
-            );
+            ccx.tcx.sess.create_err(InteriorMutableDataRefer {
+                span,
+                opt_help: Some(()),
+                kind: ccx.const_kind(),
+                teach: ccx.tcx.sess.teach(&error_code!(E0492)).then_some(()),
+            })
+        } else {
+            ccx.tcx.sess.create_err(InteriorMutableDataRefer {
+                span,
+                opt_help: None,
+                kind: ccx.const_kind(),
+                teach: ccx.tcx.sess.teach(&error_code!(E0492)).then_some(()),
+            })
         }
-        if ccx.tcx.sess.teach(&err.get_code().unwrap()) {
-            err.note(
-                "A constant containing interior mutable data behind a reference can allow you
-                 to modify that data. This would make multiple uses of a constant to be able to
-                 see different values and allow circumventing the `Send` and `Sync` requirements
-                 for shared mutable data, which is unsound.",
-            );
-        }
-        err
     }
 }
 
@@ -553,33 +517,29 @@ impl<'tcx> NonConstOp<'tcx> for MutBorrow {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        let raw = match self.0 {
-            hir::BorrowKind::Raw => "raw ",
-            hir::BorrowKind::Ref => "",
-        };
+        // let raw = match self.0 {
+        //     hir::BorrowKind::Raw => "raw ",
+        //     hir::BorrowKind::Ref => "",
+        // };
 
-        let mut err = struct_span_err!(
-            ccx.tcx.sess,
-            span,
-            E0764,
-            "{}mutable references are not allowed in the final value of {}s",
-            raw,
-            ccx.const_kind(),
-        );
-
-        if ccx.tcx.sess.teach(&err.get_code().unwrap()) {
-            err.note(
-                "References in statics and constants may only refer \
-                      to immutable values.\n\n\
-                      Statics are shared everywhere, and if they refer to \
-                      mutable data one might violate memory safety since \
-                      holding multiple mutable references to shared data \
-                      is not allowed.\n\n\
-                      If you really want global mutable state, try using \
-                      static mut or a global UnsafeCell.",
-            );
+        // ccx.tcx.sess.create_err(UnallowedMutableRefs {
+        //     span,
+        //     raw,
+        //     kind: ccx.const_kind(),
+        //     teach: ccx.tcx.sess.teach(&error_code!(E0764)).then_some(()),
+        // })
+        match self.0 {
+            hir::BorrowKind::Raw => ccx.tcx.sess.create_err(UnallowedMutableRefsRaw {
+                span,
+                kind: ccx.const_kind(),
+                teach: ccx.tcx.sess.teach(&error_code!(E0764)).then_some(()),
+            }),
+            hir::BorrowKind::Ref => ccx.tcx.sess.create_err(UnallowedMutableRefs {
+                span,
+                kind: ccx.const_kind(),
+                teach: ccx.tcx.sess.teach(&error_code!(E0764)).then_some(()),
+            }),
         }
-        err
     }
 }
 

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -25,7 +25,7 @@ use rustc_trait_selection::traits::SelectionContext;
 use super::ConstCx;
 use crate::errors::{
     MutDerefErr, NonConstOpErr, PanicNonStrErr, RawPtrToIntErr, StaticAccessErr,
-    TransientMutBorrowErr, TransientMutBorrowErrRaw,
+    TransientMutBorrowErr, TransientMutBorrowErrRaw, UnallowedFnPointerCall,
 };
 use crate::util::{call_kind, CallDesugaringKind, CallKind};
 
@@ -97,10 +97,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallIndirect {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        ccx.tcx.sess.struct_span_err(
-            span,
-            &format!("function pointer calls are not allowed in {}s", ccx.const_kind()),
-        )
+        ccx.tcx.sess.create_err(UnallowedFnPointerCall { span, kind: ccx.const_kind() })
     }
 }
 

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -32,4 +32,6 @@ const_eval_transient_mut_borrow_raw = raw mutable references are not allowed in 
 
 const_evaL_max_num_nodes_exceeded = maximum number of nodes exceeded in constant {$s}
 
-const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in {$const_kind}s
+const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in {$kind}s
+
+const_eval_unstable_const_fn = `{$def_id}` is not yet stable as a const fn

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -31,3 +31,5 @@ const_eval_transient_mut_borrow = mutable references are not allowed in {$kind}s
 const_eval_transient_mut_borrow_raw = raw mutable references are not allowed in {$kind}s
 
 const_evaL_max_num_nodes_exceeded = maximum number of nodes exceeded in constant {$s}
+
+const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in {$const_kind}s

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -30,7 +30,7 @@ const_eval_transient_mut_borrow = mutable references are not allowed in {$kind}s
 
 const_eval_transient_mut_borrow_raw = raw mutable references are not allowed in {$kind}s
 
-const_eval_max_num_nodes_in_const = maximum number of nodes exceeded in constant {$s}
+const_eval_max_num_nodes_in_const = maximum number of nodes exceeded in constant {$global_const_id}
 
 const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in {$kind}s
 

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -35,3 +35,51 @@ const_evaL_max_num_nodes_exceeded = maximum number of nodes exceeded in constant
 const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in {$kind}s
 
 const_eval_unstable_const_fn = `{$def_id}` is not yet stable as a const fn
+
+const_eval_unallowed_mutable_refs =
+    mutable references are not allowed in the final value of {$kind}s
+    .teach_note = 
+        References in statics and constants may only refer to immutable values.\n\n
+        Statics are shared everywhere, and if they refer to mutable data one might violate memory 
+        safety since holding multiple mutable references to shared data is not allowed.\n\n
+        If you really want global mutable state, try using static mut or a global UnsafeCell.
+
+const_eval_unallowed_mutable_refs_raw =
+    raw mutable references are not allowed in the final value of {$kind}s
+    .teach_note = 
+        References in statics and constants may only refer to immutable values.\n\n
+        Statics are shared everywhere, and if they refer to mutable data one might violate memory 
+        safety since holding multiple mutable references to shared data is not allowed.\n\n
+        If you really want global mutable state, try using static mut or a global UnsafeCell.
+
+const_eval_non_const_fmt_macro_call = 
+    cannot call non-const formatting macro in {$kind}s
+
+const_eval_non_const_fn_call = 
+    cannot call non-const fn `{$def_path_str}` in {$kind}s
+
+const_eval_unallowed_op_in_const_context = 
+    {$msg}
+
+const_eval_unallowed_heap_allocations =
+    allocations are not allowed in {$kind}s
+    .label = allocation not allowed in {$kind}s
+    .teach_note = 
+        The value of statics and constants must be known at compile time, and they live for the entire 
+        lifetime of a program. Creating a boxed value allocates memory on the heap at runtime, and 
+        therefore cannot be done at compile time.
+
+const_eval_unallowed_inline_asm =
+    inline assembly is not allowed in {$kind}s
+
+const_eval_interior_mutable_data_refer =
+    {$kind}s cannot refer to interior mutable data
+    .label = this borrow of an interior mutable value may end up in the final value
+    .help = to fix this, the value can be extracted to a separate `static` item and then referenced
+    .teach_note = 
+        A constant containing interior mutable data behind a reference can allow you to modify that data. 
+        This would make multiple uses of a constant to be able to see different values and allow circumventing 
+        the `Send` and `Sync` requirements for shared mutable data, which is unsound.
+
+const_eval_interior_mutability_borrow = 
+    cannot borrow here, since the borrowed element may contain interior mutability

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -38,33 +38,33 @@ const_eval_unstable_const_fn = `{$def_path}` is not yet stable as a const fn
 
 const_eval_unallowed_mutable_refs =
     mutable references are not allowed in the final value of {$kind}s
-    .teach_note = 
+    .teach_note =
         References in statics and constants may only refer to immutable values.\n\n
-        Statics are shared everywhere, and if they refer to mutable data one might violate memory 
+        Statics are shared everywhere, and if they refer to mutable data one might violate memory
         safety since holding multiple mutable references to shared data is not allowed.\n\n
         If you really want global mutable state, try using static mut or a global UnsafeCell.
 
 const_eval_unallowed_mutable_refs_raw =
     raw mutable references are not allowed in the final value of {$kind}s
-    .teach_note = 
+    .teach_note =
         References in statics and constants may only refer to immutable values.\n\n
-        Statics are shared everywhere, and if they refer to mutable data one might violate memory 
+        Statics are shared everywhere, and if they refer to mutable data one might violate memory
         safety since holding multiple mutable references to shared data is not allowed.\n\n
         If you really want global mutable state, try using static mut or a global UnsafeCell.
 
-const_eval_non_const_fmt_macro_call = 
+const_eval_non_const_fmt_macro_call =
     cannot call non-const formatting macro in {$kind}s
 
-const_eval_non_const_fn_call = 
+const_eval_non_const_fn_call =
     cannot call non-const fn `{$def_path_str}` in {$kind}s
 
-const_eval_unallowed_op_in_const_context = 
+const_eval_unallowed_op_in_const_context =
     {$msg}
 
 const_eval_unallowed_heap_allocations =
     allocations are not allowed in {$kind}s
     .label = allocation not allowed in {$kind}s
-    .teach_note = 
+    .teach_note =
         The value of statics and constants must be known at compile time, and they live for the entire lifetime of a program. Creating a boxed value allocates memory on the heap at runtime, and therefore cannot be done at compile time.
 
 const_eval_unallowed_inline_asm =
@@ -74,10 +74,10 @@ const_eval_interior_mutable_data_refer =
     {$kind}s cannot refer to interior mutable data
     .label = this borrow of an interior mutable value may end up in the final value
     .help = to fix this, the value can be extracted to a separate `static` item and then referenced
-    .teach_note = 
-        A constant containing interior mutable data behind a reference can allow you to modify that data. 
-        This would make multiple uses of a constant to be able to see different values and allow circumventing 
+    .teach_note =
+        A constant containing interior mutable data behind a reference can allow you to modify that data.
+        This would make multiple uses of a constant to be able to see different values and allow circumventing
         the `Send` and `Sync` requirements for shared mutable data, which is unsound.
 
-const_eval_interior_mutability_borrow = 
+const_eval_interior_mutability_borrow =
     cannot borrow here, since the borrowed element may contain interior mutability

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -30,7 +30,7 @@ const_eval_transient_mut_borrow = mutable references are not allowed in {$kind}s
 
 const_eval_transient_mut_borrow_raw = raw mutable references are not allowed in {$kind}s
 
-const_evaL_max_num_nodes_in_const_err = maximum number of nodes exceeded in constant {$s}
+const_eval_max_num_nodes_in_const = maximum number of nodes exceeded in constant {$s}
 
 const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in {$kind}s
 

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -29,3 +29,5 @@ const_eval_mut_deref =
 const_eval_transient_mut_borrow = mutable references are not allowed in {$kind}s
 
 const_eval_transient_mut_borrow_raw = raw mutable references are not allowed in {$kind}s
+
+const_evaL_max_num_nodes_exceeded = maximum number of nodes exceeded in constant {$s}

--- a/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/const_eval.ftl
@@ -30,11 +30,11 @@ const_eval_transient_mut_borrow = mutable references are not allowed in {$kind}s
 
 const_eval_transient_mut_borrow_raw = raw mutable references are not allowed in {$kind}s
 
-const_evaL_max_num_nodes_exceeded = maximum number of nodes exceeded in constant {$s}
+const_evaL_max_num_nodes_in_const_err = maximum number of nodes exceeded in constant {$s}
 
 const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in {$kind}s
 
-const_eval_unstable_const_fn = `{$def_id}` is not yet stable as a const fn
+const_eval_unstable_const_fn = `{$def_path}` is not yet stable as a const fn
 
 const_eval_unallowed_mutable_refs =
     mutable references are not allowed in the final value of {$kind}s
@@ -65,9 +65,7 @@ const_eval_unallowed_heap_allocations =
     allocations are not allowed in {$kind}s
     .label = allocation not allowed in {$kind}s
     .teach_note = 
-        The value of statics and constants must be known at compile time, and they live for the entire 
-        lifetime of a program. Creating a boxed value allocates memory on the heap at runtime, and 
-        therefore cannot be done at compile time.
+        The value of statics and constants must be known at compile time, and they live for the entire lifetime of a program. Creating a boxed value allocates memory on the heap at runtime, and therefore cannot be done at compile time.
 
 const_eval_unallowed_inline_asm =
     inline assembly is not allowed in {$kind}s

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -467,7 +467,9 @@ impl Session {
         feature: Symbol,
     ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut err = self.parse_sess.create_err(err);
-        err.code = std::option::Option::Some(error_code!(E0658));
+        if err.code.is_none() {
+            err.code = std::option::Option::Some(error_code!(E0658));
+        }
         add_feature_diagnostics(&mut err, &self.parse_sess, feature);
         err
     }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -20,8 +20,8 @@ use rustc_errors::emitter::{Emitter, EmitterWriter, HumanReadableErrorType};
 use rustc_errors::json::JsonEmitter;
 use rustc_errors::registry::Registry;
 use rustc_errors::{
-    fallback_fluent_bundle, DiagnosticBuilder, DiagnosticId, DiagnosticMessage, EmissionGuarantee,
-    ErrorGuaranteed, FluentBundle, LazyFallbackBundle, MultiSpan,
+    error_code, fallback_fluent_bundle, DiagnosticBuilder, DiagnosticId, DiagnosticMessage,
+    EmissionGuarantee, ErrorGuaranteed, FluentBundle, LazyFallbackBundle, MultiSpan,
 };
 use rustc_macros::HashStable_Generic;
 pub use rustc_span::def_id::StableCrateId;
@@ -467,6 +467,7 @@ impl Session {
         feature: Symbol,
     ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut err = self.parse_sess.create_err(err);
+        err.code = std::option::Option::Some(error_code!(E0658));
         add_feature_diagnostics(&mut err, &self.parse_sess, feature);
         err
     }


### PR DESCRIPTION
This PR should eventually contain all diagnostic migrations for the `rustc_const_eval` crate.

r? @davidtwco
@rustbot label +A-translation