### PR TITLE
improved diagnostic for function defined with `def`, `fun`, `func`, or `function` instead of `fn`

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -611,6 +611,15 @@ impl<'a> Parser<'a> {
                     appl,
                 );
             }
+
+            if ["def", "fun", "func", "function"].contains(&symbol.as_str()) {
+                err.span_suggestion_short(
+                    self.prev_token.span,
+                    &format!("write `fn` instead of `{symbol}` to declare a function"),
+                    "fn",
+                    appl,
+                );
+            }
         }
 
         // Add suggestion for a missing closing angle bracket if '>' is included in expected_tokens

--- a/src/test/ui/parser/fn-defined-using-def.rs
+++ b/src/test/ui/parser/fn-defined-using-def.rs
@@ -1,0 +1,10 @@
+// Check what happens when `def` is used to define a function, instead of `fn`
+// edition:2021
+
+#![allow(dead_code)]
+
+def foo() {}
+//~^ ERROR expected one of `!` or `::`, found `foo`
+//~^^ HELP write `fn` instead of `def` to declare a function
+
+fn main() {}

--- a/src/test/ui/parser/fn-defined-using-def.stderr
+++ b/src/test/ui/parser/fn-defined-using-def.stderr
@@ -1,0 +1,10 @@
+error: expected one of `!` or `::`, found `foo`
+  --> $DIR/fn-defined-using-def.rs:6:5
+   |
+LL | def foo() {}
+   | --- ^^^ expected one of `!` or `::`
+   | |
+   | help: write `fn` instead of `def` to declare a function
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/fn-defined-using-fun.rs
+++ b/src/test/ui/parser/fn-defined-using-fun.rs
@@ -1,0 +1,10 @@
+// Check what happens when `fun` is used to define a function, instead of `fn`
+// edition:2021
+
+#![allow(dead_code)]
+
+fun foo() {}
+//~^ ERROR expected one of `!` or `::`, found `foo`
+//~^^ HELP write `fn` instead of `fun` to declare a function
+
+fn main() {}

--- a/src/test/ui/parser/fn-defined-using-fun.stderr
+++ b/src/test/ui/parser/fn-defined-using-fun.stderr
@@ -1,0 +1,10 @@
+error: expected one of `!` or `::`, found `foo`
+  --> $DIR/fn-defined-using-fun.rs:6:5
+   |
+LL | fun foo() {}
+   | --- ^^^ expected one of `!` or `::`
+   | |
+   | help: write `fn` instead of `fun` to declare a function
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/fn-defined-using-func.rs
+++ b/src/test/ui/parser/fn-defined-using-func.rs
@@ -1,0 +1,10 @@
+// Check what happens when `func` is used to define a function, instead of `fn`
+// edition:2021
+
+#![allow(dead_code)]
+
+func foo() {}
+//~^ ERROR expected one of `!` or `::`, found `foo`
+//~^^ HELP write `fn` instead of `func` to declare a function
+
+fn main() {}

--- a/src/test/ui/parser/fn-defined-using-func.stderr
+++ b/src/test/ui/parser/fn-defined-using-func.stderr
@@ -1,0 +1,10 @@
+error: expected one of `!` or `::`, found `foo`
+  --> $DIR/fn-defined-using-func.rs:6:6
+   |
+LL | func foo() {}
+   | ---- ^^^ expected one of `!` or `::`
+   | |
+   | help: write `fn` instead of `func` to declare a function
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/fn-defined-using-function.rs
+++ b/src/test/ui/parser/fn-defined-using-function.rs
@@ -1,0 +1,10 @@
+// Check what happens when `function` is used to define a function, instead of `fn`
+// edition:2021
+
+#![allow(dead_code)]
+
+function foo() {}
+//~^ ERROR expected one of `!` or `::`, found `foo`
+//~^^ HELP write `fn` instead of `function` to declare a function
+
+fn main() {}

--- a/src/test/ui/parser/fn-defined-using-function.stderr
+++ b/src/test/ui/parser/fn-defined-using-function.stderr
@@ -1,0 +1,10 @@
+error: expected one of `!` or `::`, found `foo`
+  --> $DIR/fn-defined-using-function.rs:6:10
+   |
+LL | function foo() {}
+   | -------- ^^^ expected one of `!` or `::`
+   | |
+   | help: write `fn` instead of `function` to declare a function
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #99751