### PR TITLE
translations(rustc_session): migrates `rustc_session` to use `SessionDiagnostic` - Pt. 1

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1892,7 +1892,7 @@ impl<B: ExtraBackendMethods> OngoingCodegen<B> {
             }
         });
 
-        sess.cgu_reuse_tracker.check_expected_reuse(sess.diagnostic());
+        sess.cgu_reuse_tracker.check_expected_reuse(sess);
 
         sess.abort_if_errors();
 

--- a/compiler/rustc_error_messages/locales/en-US/session.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/session.ftl
@@ -1,5 +1,13 @@
-incorrect_cgu_reuse_type = 
+session_incorrect_cgu_reuse_type =
     CGU-reuse for `{$cgu_user_name}` is `{$actual_reuse}` but should be `{$at_least}``${expected_reuse}`
 
-cgu_not_recorded = 
+session_cgu_not_recorded =
     CGU-reuse for `{$cgu_user_name}` is (mangled: `{$cgu_name}`) was not recorded`
+
+session_feature_gate_error = {$explain}
+
+session_feature_diagnostic_for_issue =
+    see issue #{$n} <https://github.com/rust-lang/rust/issues/{$n}> for more information
+
+session_feature_diagnostic_help =
+    add `#![feature({$feature})]` to the crate attributes to enable

--- a/compiler/rustc_error_messages/locales/en-US/session.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/session.ftl
@@ -1,5 +1,8 @@
 session_incorrect_cgu_reuse_type =
-    CGU-reuse for `{$cgu_user_name}` is `{$actual_reuse}` but should be `{$at_least}``${expected_reuse}`
+    CGU-reuse for `{$cgu_user_name}` is `{$actual_reuse}` but should be {$at_least ->
+    [one] {"at least "}
+    *[other] {""}
+    }`{$expected_reuse}`
 
 session_cgu_not_recorded =
     CGU-reuse for `{$cgu_user_name}` is (mangled: `{$cgu_name}`) was not recorded`

--- a/compiler/rustc_error_messages/locales/en-US/session.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/session.ftl
@@ -1,0 +1,5 @@
+incorrect_cgu_reuse_type = 
+    CGU-reuse for `{$cgu_user_name}` is `{$actual_reuse}` but should be `{$at_least}``${expected_reuse}`
+
+cgu_not_recorded = 
+    CGU-reuse for `{$cgu_user_name}` is (mangled: `{$cgu_name}`) was not recorded`

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -37,6 +37,7 @@ fluent_messages! {
     builtin_macros => "../locales/en-US/builtin_macros.ftl",
     const_eval => "../locales/en-US/const_eval.ftl",
     expand => "../locales/en-US/expand.ftl",
+    session => "../locales/en-US/session.ftl",
     interface => "../locales/en-US/interface.ftl",
     lint => "../locales/en-US/lint.ftl",
     parser => "../locales/en-US/parser.ftl",

--- a/compiler/rustc_session/src/cgu_reuse_tracker.rs
+++ b/compiler/rustc_session/src/cgu_reuse_tracker.rs
@@ -3,7 +3,6 @@
 //! output.
 
 use crate::errors::IncorrectCguReuseType;
-// use crate::errors::{CguNotRecorded, IncorrectCguReuseType};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{DiagnosticArgValue, IntoDiagnosticArg};
 use rustc_span::{Span, Symbol};
@@ -129,11 +128,14 @@ impl CguReuseTracker {
                         };
                     }
                 } else {
+                    //FIXME: Remove this once PR #100694 that implements `[fatal(..)]` is merged
                     let msg = format!(
                         "CGU-reuse for `{cgu_user_name}` (mangled: `{cgu_name}`) was \
                                        not recorded"
                     );
                     diag.span_fatal(error_span.0, &msg)
+
+                    //FIXME: Uncomment this once PR #100694 that implements `[fatal(..)]` is merged
                     // CguNotRecorded { cgu_user_name, cgu_name };
                 }
             }

--- a/compiler/rustc_session/src/cgu_reuse_tracker.rs
+++ b/compiler/rustc_session/src/cgu_reuse_tracker.rs
@@ -2,8 +2,13 @@
 //! compilation. This is used for incremental compilation tests and debug
 //! output.
 
+use crate::errors::IncorrectCguReuseType;
+// use crate::errors::{CguNotRecorded, IncorrectCguReuseType};
 use rustc_data_structures::fx::FxHashMap;
+use rustc_errors::{DiagnosticArgValue, IntoDiagnosticArg};
 use rustc_span::{Span, Symbol};
+use std::borrow::Cow;
+use std::fmt::{self};
 use std::sync::{Arc, Mutex};
 use tracing::debug;
 
@@ -12,6 +17,22 @@ pub enum CguReuse {
     No,
     PreLto,
     PostLto,
+}
+
+impl fmt::Display for CguReuse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            CguReuse::No => write!(f, "No"),
+            CguReuse::PreLto => write!(f, "PreLto "),
+            CguReuse::PostLto => write!(f, "PostLto "),
+        }
+    }
+}
+
+impl IntoDiagnosticArg for CguReuse {
+    fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
+        DiagnosticArgValue::Str(Cow::Owned(self.to_string()))
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -99,11 +120,13 @@ impl CguReuseTracker {
 
                     if error {
                         let at_least = if at_least { "at least " } else { "" };
-                        let msg = format!(
-                            "CGU-reuse for `{cgu_user_name}` is `{actual_reuse:?}` but \
-                                           should be {at_least}`{expected_reuse:?}`"
-                        );
-                        diag.span_err(error_span.0, &msg);
+                        IncorrectCguReuseType {
+                            span: error_span.0,
+                            cgu_user_name: &cgu_user_name,
+                            actual_reuse,
+                            expected_reuse,
+                            at_least,
+                        };
                     }
                 } else {
                     let msg = format!(
@@ -111,6 +134,7 @@ impl CguReuseTracker {
                                        not recorded"
                     );
                     diag.span_fatal(error_span.0, &msg)
+                    // CguNotRecorded { cgu_user_name, cgu_name };
                 }
             }
         }

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -1,0 +1,22 @@
+use crate as rustc_session;
+use crate::cgu_reuse_tracker::CguReuse;
+use rustc_macros::SessionDiagnostic;
+use rustc_span::Span;
+
+#[derive(SessionDiagnostic)]
+#[error(session::incorrect_cgu_reuse_type)]
+pub struct IncorrectCguReuseType<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub cgu_user_name: &'a str,
+    pub actual_reuse: CguReuse,
+    pub expected_reuse: CguReuse,
+    pub at_least: &'a str,
+}
+
+// #[derive(SessionDiagnostic)]
+// #[fatal(session::cgu_not_recorded)]
+// pub struct CguNotRecorded<'a> {
+//     pub cgu_user_name: &'a str,
+//     pub cgu_name: &'a str,
+// }

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -14,16 +14,15 @@ pub struct IncorrectCguReuseType<'a> {
     pub cgu_user_name: &'a str,
     pub actual_reuse: CguReuse,
     pub expected_reuse: CguReuse,
-    pub at_least: &'a str,
+    pub at_least: u8,
 }
 
-//FIXME: Uncomment this once PR #100694 that implements `[fatal(..)]` is merged
-// #[derive(SessionDiagnostic)]
-// #[fatal(session::cgu_not_recorded)]
-// pub struct CguNotRecorded<'a> {
-//     pub cgu_user_name: &'a str,
-//     pub cgu_name: &'a str,
-// }
+#[derive(SessionDiagnostic)]
+#[diag(session::cgu_not_recorded)]
+pub struct CguNotRecorded<'a> {
+    pub cgu_user_name: &'a str,
+    pub cgu_name: &'a str,
+}
 
 #[derive(SessionDiagnostic)]
 #[diag(session::feature_gate_error, code = "E0658")]

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -1,10 +1,13 @@
+use std::num::NonZeroU32;
+
 use crate as rustc_session;
 use crate::cgu_reuse_tracker::CguReuse;
+use rustc_errors::MultiSpan;
 use rustc_macros::SessionDiagnostic;
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic)]
-#[error(session::incorrect_cgu_reuse_type)]
+#[diag(session::incorrect_cgu_reuse_type)]
 pub struct IncorrectCguReuseType<'a> {
     #[primary_span]
     pub span: Span,
@@ -14,9 +17,30 @@ pub struct IncorrectCguReuseType<'a> {
     pub at_least: &'a str,
 }
 
+//FIXME: Uncomment this once PR #100694 that implements `[fatal(..)]` is merged
 // #[derive(SessionDiagnostic)]
 // #[fatal(session::cgu_not_recorded)]
 // pub struct CguNotRecorded<'a> {
 //     pub cgu_user_name: &'a str,
 //     pub cgu_name: &'a str,
 // }
+
+#[derive(SessionDiagnostic)]
+#[diag(session::feature_gate_error, code = "E0658")]
+pub struct FeatureGateError<'a> {
+    #[primary_span]
+    pub span: MultiSpan,
+    pub explain: &'a str,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[note(session::feature_diagnostic_for_issue)]
+pub struct FeatureDiagnosticForIssue {
+    pub n: NonZeroU32,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[help(session::feature_diagnostic_help)]
+pub struct FeatureDiagnosticHelp {
+    pub feature: Symbol,
+}

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -8,8 +8,6 @@
 #![feature(map_many_mut)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
-#![deny(rustc::untranslatable_diagnostic)]
-#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -8,9 +8,12 @@
 #![feature(map_many_mut)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;
+pub mod errors;
 
 pub mod cgu_reuse_tracker;
 pub mod utils;


### PR DESCRIPTION
## Description

This is the first PR for the migration of the module `rustc_session`. You can follow my progress [here](https://github.com/rust-lang/rust/issues/100717#issuecomment-1220279883).

The PR migrates the files `cgu_reuse_tracker` and `parse.rs` to use `SessionDiagnostic `.  





