### PR TITLE
update test for LLVM change

### DIFF
--- a/src/test/codegen/pic-relocation-model.rs
+++ b/src/test/codegen/pic-relocation-model.rs
@@ -13,4 +13,4 @@ pub fn call_foreign_fn() -> u8 {
 // CHECK: declare zeroext i8 @foreign_fn()
 extern "C" {fn foreign_fn() -> u8;}
 
-// CHECK: !{i32 7, !"PIC Level", i32 2}
+// CHECK: !{i32 {{[78]}}, !"PIC Level", i32 2}

--- a/src/test/codegen/pie-relocation-model.rs
+++ b/src/test/codegen/pie-relocation-model.rs
@@ -18,5 +18,5 @@ pub fn call_foreign_fn() -> u8 {
 // CHECK: declare zeroext i8 @foreign_fn()
 extern "C" {fn foreign_fn() -> u8;}
 
-// CHECK: !{i32 7, !"PIC Level", i32 2}
+// CHECK: !{i32 {{[78]}}, !"PIC Level", i32 2}
 // CHECK: !{i32 7, !"PIE Level", i32 2}


### PR DESCRIPTION
LLVM commit https://github.com/llvm/llvm-project/commit/c2a38887932e3a46aa3bee35f3f5568ac68282f4 updates the PIC level version selection. Updated an affected rust test to work under both the old and new behaviors.

Detected by our experimental rust + llvm @ HEAD bot:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/12829#0182b368-a405-47a2-b3da-9c79cb907bfe/701-709