### PR TITLE
Migrate `rustc_plugin_impl` to `SessionDiagnostic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4321,6 +4321,7 @@ dependencies = [
  "rustc_ast",
  "rustc_errors",
  "rustc_lint",
+ "rustc_macros",
  "rustc_metadata",
  "rustc_session",
  "rustc_span",

--- a/compiler/rustc_error_messages/locales/en-US/plugin_impl.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/plugin_impl.ftl
@@ -1,0 +1,4 @@
+plugin_impl_load_plugin_error = {$msg}
+
+plugin_impl_malformed_plugin_attribute = malformed `plugin` attribute
+    .label = malformed attribute

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -41,6 +41,7 @@ fluent_messages! {
     lint => "../locales/en-US/lint.ftl",
     parser => "../locales/en-US/parser.ftl",
     passes => "../locales/en-US/passes.ftl",
+    plugin_impl => "../locales/en-US/plugin_impl.ftl",
     privacy => "../locales/en-US/privacy.ftl",
     typeck => "../locales/en-US/typeck.ftl",
 }

--- a/compiler/rustc_plugin_impl/Cargo.toml
+++ b/compiler/rustc_plugin_impl/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 libloading = "0.7.1"
 rustc_errors = { path = "../rustc_errors" }
 rustc_lint = { path = "../rustc_lint" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_metadata = { path = "../rustc_metadata" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_session = { path = "../rustc_session" }

--- a/compiler/rustc_plugin_impl/src/errors.rs
+++ b/compiler/rustc_plugin_impl/src/errors.rs
@@ -1,0 +1,20 @@
+//! Errors emitted by plugin_impl
+
+use rustc_macros::SessionDiagnostic;
+use rustc_span::Span;
+
+#[derive(SessionDiagnostic)]
+#[diag(plugin_impl::load_plugin_error)]
+pub struct LoadPluginError {
+    #[primary_span]
+    pub span: Span,
+    pub msg: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(plugin_impl::malformed_plugin_attribute, code = "E0498")]
+pub struct MalformedPluginAttribute {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}

--- a/compiler/rustc_plugin_impl/src/lib.rs
+++ b/compiler/rustc_plugin_impl/src/lib.rs
@@ -8,9 +8,12 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![recursion_limit = "256"]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 use rustc_lint::LintStore;
 
+mod errors;
 pub mod load;
 
 /// Structure used to register plugins.


### PR DESCRIPTION
Migration of the `rustc_plugin_impl` crate.
~Draft PR because it is blocked on #100694 for `#[fatal(...)]` support~ (this has been merged, and I've changed over to `#[diag(...)]` now too), but I would also like to know if what I did with `LoadPluginError` is okay, because all it does is display the error message from `libloading` ([See conversation on zulip](https://rust-lang.zulipchat.com/#narrow/stream/147480-t-compiler.2Fwg-diagnostics/topic/.23100717.20diagnostic.20translation/near/294327843)). This crate is apparently for a deprecated feature which is used by servo, so I don't know how much this matters anyway.