### PR TITLE
Migrate `rustc_lint` errors to `SessionDiagnostic`

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -414,3 +414,16 @@ lint_reason_must_come_last = reason in lint attribute must come last
 
 lint_unknown_tool_in_scoped_lint = unknown tool name `{$tool_name}` found in scoped lint: `{$tool_name}::{$lint_name}`
     .help = add `#![register_tool({$tool_name})]` to the crate root
+
+lint_unsupported_group = `{$lint_group}` lint group is not supported with ´--force-warn´
+
+lint_requested_level = requested on the command line with `{$level} {$lint_name}`
+
+lint_check_name_unknown = unknown lint: `{$lint_name}`
+    .help = did you mean: `{$suggestion}`
+
+lint_check_name_unknown_tool = unknown lint tool: `{$tool_name}`
+
+lint_check_name_warning = {$msg}
+
+lint_check_name_deprecated = lint name `{$lint_name}` is deprecated and does not have an effect anymore. Use: {$new_name}

--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -394,5 +394,13 @@ lint_builtin_deref_nullptr = dereferencing a null pointer
 
 lint_builtin_asm_labels = avoid using named labels in inline assembly
 
+lint_malformed_attribute = malformed lint attribute input
+
+lint_bad_attribute_argument = bad attribute argument
+
+lint_reason_must_be_string_literal = reason must be a string literal
+
+lint_reason_must_come_last = reason in lint attribute must come last
+
 lint_unknown_tool = unknown tool name `{$tool_name}` found in scoped lint: `{$tool_name}::{$lint_name}`
     .help = add `#![register_tool({$tool_name})]` to the crate root

--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -393,3 +393,6 @@ lint_builtin_deref_nullptr = dereferencing a null pointer
     .label = this code causes undefined behavior when executed
 
 lint_builtin_asm_labels = avoid using named labels in inline assembly
+
+lint_unknown_tool = unknown tool name `{$tool_name}` found in scoped lint: `{$tool_name}::{$lint_name}`
+    .help = add `#![register_tool({$tool_name})]` to the crate root

--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -394,6 +394,16 @@ lint_builtin_deref_nullptr = dereferencing a null pointer
 
 lint_builtin_asm_labels = avoid using named labels in inline assembly
 
+lint_overruled_attribute = {$lint_level}({$lint_source}) incompatible with previous forbid
+    .label = overruled by previous forbid
+
+lint_default_source = `forbid` lint level is the default for {$id}
+
+lint_node_source = `forbid` level set here
+    .note = {$reason}
+
+lint_command_line_source = `forbid` lint level was set on command line
+
 lint_malformed_attribute = malformed lint attribute input
 
 lint_bad_attribute_argument = bad attribute argument

--- a/compiler/rustc_error_messages/locales/en-US/lint.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/lint.ftl
@@ -412,5 +412,5 @@ lint_reason_must_be_string_literal = reason must be a string literal
 
 lint_reason_must_come_last = reason in lint attribute must come last
 
-lint_unknown_tool = unknown tool name `{$tool_name}` found in scoped lint: `{$tool_name}::{$lint_name}`
+lint_unknown_tool_in_scoped_lint = unknown tool name `{$tool_name}` found in scoped lint: `{$tool_name}::{$lint_name}`
     .help = add `#![register_tool({$tool_name})]` to the crate root

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1,6 +1,3 @@
-// #![deny(rustc::diagnostic_outside_of_impl)]
-// #![deny(rustc::untranslatable_diagnostic)]
-//
 //! Lints in the Rust compiler.
 //!
 //! This contains lints which can feasibly be implemented as their own

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1,3 +1,6 @@
+// #![deny(rustc::diagnostic_outside_of_impl)]
+// #![deny(rustc::untranslatable_diagnostic)]
+//
 //! Lints in the Rust compiler.
 //!
 //! This contains lints which can feasibly be implemented as their own
@@ -21,6 +24,7 @@
 //! `late_lint_methods!` invocation in `lib.rs`.
 
 use crate::{
+    errors::BuiltinEllpisisInclusiveRangePatterns,
     types::{transparent_newtype_field, CItemKind},
     EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintContext,
 };
@@ -1760,18 +1764,11 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
                     None => format!("&(..={})", end),
                 };
                 if join.edition() >= Edition::Edition2021 {
-                    let mut err = cx.sess().struct_span_err_with_code(
-                        pat.span,
-                        msg,
-                        rustc_errors::error_code!(E0783),
-                    );
-                    err.span_suggestion(
-                        pat.span,
-                        suggestion,
+                    cx.sess().emit_err(BuiltinEllpisisInclusiveRangePatterns {
+                        span: pat.span,
+                        suggestion: pat.span,
                         replace,
-                        Applicability::MachineApplicable,
-                    )
-                    .emit();
+                    });
                 } else {
                     cx.struct_span_lint(ELLIPSIS_INCLUSIVE_RANGE_PATTERNS, pat.span, |lint| {
                         lint.build(msg)
@@ -1787,18 +1784,11 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
             } else {
                 let replace = "..=";
                 if join.edition() >= Edition::Edition2021 {
-                    let mut err = cx.sess().struct_span_err_with_code(
-                        pat.span,
-                        msg,
-                        rustc_errors::error_code!(E0783),
-                    );
-                    err.span_suggestion_short(
-                        join,
-                        suggestion,
-                        replace,
-                        Applicability::MachineApplicable,
-                    )
-                    .emit();
+                    cx.sess().emit_err(BuiltinEllpisisInclusiveRangePatterns {
+                        span: pat.span,
+                        suggestion: join,
+                        replace: replace.to_string(),
+                    });
                 } else {
                     cx.struct_span_lint(ELLIPSIS_INCLUSIVE_RANGE_PATTERNS, join, |lint| {
                         lint.build(msg)

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -1,3 +1,6 @@
+// #![deny(rustc::diagnostic_outside_of_impl)]
+// #![deny(rustc::untranslatable_diagnostic)]
+//
 //! Implementation of lint checking.
 //!
 //! The lint checking is mostly consolidated into one pass which runs
@@ -16,12 +19,16 @@
 
 use self::TargetLint::*;
 
+use crate::errors::{
+    CheckNameDeprecated, CheckNameUnknown, CheckNameUnknownTool, CheckNameWarning, RequestedLevel,
+    UnsupportedGroup,
+};
 use crate::levels::LintLevelsBuilder;
 use crate::passes::{EarlyLintPassObject, LateLintPassObject};
 use rustc_ast::util::unicode::TEXT_FLOW_CONTROL_CHARS;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync;
-use rustc_errors::{add_elided_lifetime_in_path_suggestion, struct_span_err};
+use rustc_errors::add_elided_lifetime_in_path_suggestion;
 use rustc_errors::{
     Applicability, DecorateLint, LintDiagnosticBuilder, MultiSpan, SuggestionStyle,
 };
@@ -39,7 +46,7 @@ use rustc_session::lint::{FutureIncompatibleInfo, Level, Lint, LintBuffer, LintI
 use rustc_session::Session;
 use rustc_span::lev_distance::find_best_match_for_name;
 use rustc_span::symbol::{sym, Ident, Symbol};
-use rustc_span::{BytePos, Span, DUMMY_SP};
+use rustc_span::{BytePos, Span};
 use rustc_target::abi;
 use tracing::debug;
 
@@ -326,68 +333,41 @@ impl LintStore {
     ) {
         let (tool_name, lint_name_only) = parse_lint_and_tool_name(lint_name);
         if lint_name_only == crate::WARNINGS.name_lower() && matches!(level, Level::ForceWarn(_)) {
-            struct_span_err!(
-                sess,
-                DUMMY_SP,
-                E0602,
-                "`{}` lint group is not supported with ´--force-warn´",
-                crate::WARNINGS.name_lower()
-            )
-            .emit();
+            sess.emit_err(UnsupportedGroup { lint_group: crate::WARNINGS.name_lower() });
             return;
         }
-        let db = match self.check_lint_name(lint_name_only, tool_name, registered_tools) {
-            CheckLintNameResult::Ok(_) => None,
-            CheckLintNameResult::Warning(ref msg, _) => Some(sess.struct_warn(msg)),
-            CheckLintNameResult::NoLint(suggestion) => {
-                let mut err =
-                    struct_span_err!(sess, DUMMY_SP, E0602, "unknown lint: `{}`", lint_name);
-
-                if let Some(suggestion) = suggestion {
-                    err.help(&format!("did you mean: `{}`", suggestion));
-                }
-
-                Some(err.forget_guarantee())
+        let lint_name = lint_name.to_string();
+        match self.check_lint_name(lint_name_only, tool_name, registered_tools) {
+            CheckLintNameResult::Warning(msg, _) => {
+                sess.emit_warning(CheckNameWarning {
+                    msg,
+                    sub: RequestedLevel { level, lint_name },
+                });
             }
-            CheckLintNameResult::Tool(result) => match result {
-                Err((Some(_), new_name)) => Some(sess.struct_warn(&format!(
-                    "lint name `{}` is deprecated \
-                     and does not have an effect anymore. \
-                     Use: {}",
-                    lint_name, new_name
-                ))),
-                _ => None,
-            },
-            CheckLintNameResult::NoTool => Some(
-                struct_span_err!(
-                    sess,
-                    DUMMY_SP,
-                    E0602,
-                    "unknown lint tool: `{}`",
-                    tool_name.unwrap()
-                )
-                .forget_guarantee(),
-            ),
+            CheckLintNameResult::NoLint(suggestion) => {
+                sess.emit_err(CheckNameUnknown {
+                    lint_name: lint_name.clone(),
+                    suggestion,
+                    sub: RequestedLevel { level, lint_name },
+                });
+            }
+            CheckLintNameResult::Tool(result) => {
+                if let Err((Some(_), new_name)) = result {
+                    sess.emit_warning(CheckNameDeprecated {
+                        lint_name: lint_name.clone(),
+                        new_name,
+                        sub: RequestedLevel { level, lint_name },
+                    });
+                }
+            }
+            CheckLintNameResult::NoTool => {
+                sess.emit_err(CheckNameUnknownTool {
+                    tool_name: tool_name.unwrap(),
+                    sub: RequestedLevel { level, lint_name },
+                });
+            }
+            _ => {}
         };
-
-        if let Some(mut db) = db {
-            let msg = format!(
-                "requested on the command line with `{} {}`",
-                match level {
-                    Level::Allow => "-A",
-                    Level::Warn => "-W",
-                    Level::ForceWarn(_) => "--force-warn",
-                    Level::Deny => "-D",
-                    Level::Forbid => "-F",
-                    Level::Expect(_) => {
-                        unreachable!("lints with the level of `expect` should not run this code");
-                    }
-                },
-                lint_name
-            );
-            db.note(&msg);
-            db.emit();
-        }
     }
 
     /// True if this symbol represents a lint group name.

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -1,6 +1,3 @@
-// #![deny(rustc::diagnostic_outside_of_impl)]
-// #![deny(rustc::untranslatable_diagnostic)]
-//
 //! Implementation of lint checking.
 //!
 //! The lint checking is mostly consolidated into one pass which runs

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -70,3 +70,13 @@ pub struct UnknownTool {
     #[help]
     pub is_nightly_build: Option<()>,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(lint::builtin_ellipsis_inclusive_range_patterns, code = "E0783")]
+pub struct BuiltinEllpisisInclusiveRangePatterns {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion_short(code = "{replace}", applicability = "machine-applicable")]
+    pub suggestion: Span,
+    pub replace: String,
+}

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -61,8 +61,8 @@ pub enum MalformedAttributeSub {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(lint::unknown_tool, code = "E0710")]
-pub struct UnknownTool {
+#[error(lint::unknown_tool_in_scoped_lint, code = "E0710")]
+pub struct UnknownToolInScopedLint {
     #[primary_span]
     pub span: Option<Span>,
     pub tool_name: Symbol,

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -25,7 +25,7 @@ pub enum MalformedAttributeSub {
 pub struct UnknownTool {
     #[primary_span]
     pub span: Option<Span>,
-    pub tool_name: String,
+    pub tool_name: Symbol,
     pub lint_name: String,
     #[help]
     pub is_nightly_build: Option<()>,

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -1,5 +1,5 @@
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic)]
 #[error(lint::malformed_attribute, code = "E0452")]

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -4,7 +4,7 @@ use rustc_session::{lint::Level, parse::ParseSess, SessionDiagnostic};
 use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic)]
-#[error(lint::overruled_attribute, code = "E0453")]
+#[diag(lint::overruled_attribute, code = "E0453")]
 pub struct OverruledAttribute {
     #[primary_span]
     pub span: Span,
@@ -43,7 +43,7 @@ impl AddSubdiagnostic for OverruledAttributeSub {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(lint::malformed_attribute, code = "E0452")]
+#[diag(lint::malformed_attribute, code = "E0452")]
 pub struct MalformedAttribute {
     #[primary_span]
     pub span: Span,
@@ -62,7 +62,7 @@ pub enum MalformedAttributeSub {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(lint::unknown_tool_in_scoped_lint, code = "E0710")]
+#[diag(lint::unknown_tool_in_scoped_lint, code = "E0710")]
 pub struct UnknownToolInScopedLint {
     #[primary_span]
     pub span: Option<Span>,
@@ -73,7 +73,7 @@ pub struct UnknownToolInScopedLint {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(lint::builtin_ellipsis_inclusive_range_patterns, code = "E0783")]
+#[diag(lint::builtin_ellipsis_inclusive_range_patterns, code = "E0783")]
 pub struct BuiltinEllpisisInclusiveRangePatterns {
     #[primary_span]
     pub span: Span,
@@ -108,7 +108,7 @@ impl AddSubdiagnostic for RequestedLevel {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(lint::unsupported_group, code = "E0602")]
+#[diag(lint::unsupported_group, code = "E0602")]
 pub struct UnsupportedGroup {
     pub lint_group: String,
 }
@@ -137,7 +137,7 @@ impl SessionDiagnostic<'_> for CheckNameUnknown {
 }
 
 #[derive(SessionDiagnostic)]
-#[error(lint::check_name_unknown_tool, code = "E0602")]
+#[diag(lint::check_name_unknown_tool, code = "E0602")]
 pub struct CheckNameUnknownTool {
     pub tool_name: Symbol,
     #[subdiagnostic]
@@ -145,7 +145,7 @@ pub struct CheckNameUnknownTool {
 }
 
 #[derive(SessionDiagnostic)]
-#[warning(lint::check_name_warning)]
+#[diag(lint::check_name_warning)]
 pub struct CheckNameWarning {
     pub msg: String,
     #[subdiagnostic]
@@ -153,7 +153,7 @@ pub struct CheckNameWarning {
 }
 
 #[derive(SessionDiagnostic)]
-#[warning(lint::check_name_deprecated)]
+#[diag(lint::check_name_deprecated)]
 pub struct CheckNameDeprecated {
     pub lint_name: String,
     pub new_name: String,

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -1,0 +1,13 @@
+use rustc_macros::SessionDiagnostic;
+use rustc_span::Span;
+
+#[derive(SessionDiagnostic)]
+#[error(lint::unknown_tool, code = "E0710")]
+pub struct UnknownTool {
+    #[primary_span]
+    pub span: Option<Span>,
+    pub tool_name: String,
+    pub lint_name: String,
+    #[help]
+    pub is_nightly_build: Option<()>,
+}

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -1,5 +1,24 @@
-use rustc_macros::SessionDiagnostic;
+use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::Span;
+
+#[derive(SessionDiagnostic)]
+#[error(lint::malformed_attribute, code = "E0452")]
+pub struct MalformedAttribute {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: MalformedAttributeSub,
+}
+
+#[derive(SessionSubdiagnostic)]
+pub enum MalformedAttributeSub {
+    #[label(lint::bad_attribute_argument)]
+    BadAttributeArgument(#[primary_span] Span),
+    #[label(lint::reason_must_be_string_literal)]
+    ReasonMustBeStringLiteral(#[primary_span] Span),
+    #[label(lint::reason_must_come_last)]
+    ReasonMustComeLast(#[primary_span] Span),
+}
 
 #[derive(SessionDiagnostic)]
 #[error(lint::unknown_tool, code = "E0710")]

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -1,6 +1,3 @@
-// #![deny(rustc::diagnostic_outside_of_impl)]
-// #![deny(rustc::untranslatable_diagnostic)]
-//
 use crate::context::{CheckLintNameResult, LintStore};
 use crate::late::unerased_lint_store;
 use rustc_ast as ast;

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -28,7 +28,7 @@ use tracing::debug;
 
 use crate::errors::{
     MalformedAttribute, MalformedAttributeSub, OverruledAttribute, OverruledAttributeSub,
-    UnknownTool,
+    UnknownToolInScopedLint,
 };
 
 fn lint_levels(tcx: TyCtxt<'_>, (): ()) -> LintLevelMap {
@@ -510,7 +510,7 @@ impl<'s> LintLevelsBuilder<'s> {
                     }
 
                     &CheckLintNameResult::NoTool => {
-                        sess.emit_err(UnknownTool {
+                        sess.emit_err(UnknownToolInScopedLint {
                             span: tool_ident.map(|ident| ident.span),
                             tool_name: tool_name.unwrap(),
                             lint_name: pprust::path_to_string(&meta_item.path),

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -271,7 +271,6 @@ impl<'s> LintLevelsBuilder<'s> {
         self.cur = self.sets.list.push(LintSet { specs: FxHashMap::default(), parent: prev });
 
         let sess = self.sess;
-        // let bad_attr = |span| struct_span_err!(sess, span, E0452, "malformed lint attribute input");
         for (attr_index, attr) in attrs.iter().enumerate() {
             if attr.has_name(sym::automatically_derived) {
                 self.current_specs_mut().insert(
@@ -500,7 +499,7 @@ impl<'s> LintLevelsBuilder<'s> {
                     &CheckLintNameResult::NoTool => {
                         sess.emit_err(UnknownTool {
                             span: tool_ident.map(|ident| ident.span),
-                            tool_name: tool_name.unwrap().to_string(),
+                            tool_name: tool_name.unwrap(),
                             lint_name: pprust::path_to_string(&meta_item.path),
                             is_nightly_build: sess.is_nightly_build().then_some(()),
                         });

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -36,6 +36,8 @@
 #![feature(let_else)]
 #![feature(never_type)]
 #![recursion_limit = "256"]
+// #![deny(rustc::diagnostic_outside_of_impl)]
+// #![deny(rustc::untranslatable_diagnostic)]
 
 #[macro_use]
 extern crate rustc_middle;
@@ -47,6 +49,7 @@ pub mod builtin;
 mod context;
 mod early;
 mod enum_intrinsics_non_enums;
+mod errors;
 mod expect;
 pub mod hidden_unicode_codepoints;
 mod internal;

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -36,8 +36,6 @@
 #![feature(let_else)]
 #![feature(never_type)]
 #![recursion_limit = "256"]
-// #![deny(rustc::diagnostic_outside_of_impl)]
-// #![deny(rustc::untranslatable_diagnostic)]
 
 #[macro_use]
 extern crate rustc_middle;


### PR DESCRIPTION
Draft PR for migrating `rustc_lint` to `SessionDiagnostic`, as part of the [recent blog post](https://blog.rust-lang.org/inside-rust/2022/08/16/diagnostic-effort.html)