### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3575,6 +3575,7 @@ dependencies = [
  "rustc_errors",
  "rustc_hir",
  "rustc_index",
+ "rustc_macros",
  "rustc_middle",
  "rustc_query_system",
  "rustc_session",

--- a/compiler/rustc_apfloat/src/lib.rs
+++ b/compiler/rustc_apfloat/src/lib.rs
@@ -33,6 +33,8 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![no_std]
 #![forbid(unsafe_code)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate alloc;

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -19,6 +19,8 @@
 #![feature(rustc_attrs)]
 #![cfg_attr(test, feature(test))]
 #![feature(strict_provenance)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 use smallvec::SmallVec;
 

--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -19,6 +19,8 @@
 #![feature(slice_internals)]
 #![feature(stmt_expr_attributes)]
 #![recursion_limit = "256"]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -436,6 +436,26 @@ impl Token {
             || self == &OpenDelim(Delimiter::Parenthesis)
     }
 
+    /// Returns `true` if the token can appear at the start of a item
+    pub fn can_begin_item(&self) -> bool {
+        self.is_keyword(kw::Use)
+            || self.is_keyword(kw::Fn)
+            || self.is_keyword(kw::Extern)
+            || self.is_keyword(kw::Crate)
+            || self.is_keyword(kw::Mod)
+            || self.is_keyword(kw::Const)
+            || self.is_keyword(kw::Static)
+            || self.is_keyword(kw::Trait)
+            || self.is_keyword(kw::Impl)
+            || self.is_keyword(kw::Mod)
+            || self.is_keyword(kw::Type)
+            || self.is_keyword(kw::Enum)
+            || self.is_keyword(kw::Struct)
+            || self.is_keyword(kw::Union)
+            || self.is_keyword(kw::Macro)
+            || self == &OpenDelim(Delimiter::Parenthesis)
+    }
+
     /// Returns `true` if the token is any literal.
     pub fn is_lit(&self) -> bool {
         matches!(self.kind, Literal(..))

--- a/compiler/rustc_ast_lowering/Cargo.toml
+++ b/compiler/rustc_ast_lowering/Cargo.toml
@@ -15,6 +15,7 @@ rustc_target = { path = "../rustc_target" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_index = { path = "../rustc_index" }
 rustc_middle = { path = "../rustc_middle" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_query_system = { path = "../rustc_query_system" }
 rustc_span = { path = "../rustc_span" }
 rustc_errors = { path = "../rustc_errors" }

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -1,11 +1,17 @@
 use crate::{ImplTraitContext, ImplTraitPosition, ParamMode, ResolverAstLoweringExt};
 
+use super::errors::{
+    AbiSpecifiedMultipleTimes, AttSyntaxOnlyX86, ClobberAbiNotSupported,
+    InlineAsmUnsupportedTarget, InvalidAbiClobberAbi, InvalidAsmTemplateModifierConst,
+    InvalidAsmTemplateModifierRegClass, InvalidAsmTemplateModifierRegClassSub,
+    InvalidAsmTemplateModifierSym, InvalidRegister, InvalidRegisterClass, RegisterClassOnlyClobber,
+    RegisterConflict,
+};
 use super::LoweringContext;
 
 use rustc_ast::ptr::P;
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::definitions::DefPathData;
@@ -26,13 +32,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let asm_arch =
             if self.tcx.sess.opts.actually_rustdoc { None } else { self.tcx.sess.asm_arch };
         if asm_arch.is_none() && !self.tcx.sess.opts.actually_rustdoc {
-            struct_span_err!(
-                self.tcx.sess,
-                sp,
-                E0472,
-                "inline assembly is unsupported on this target"
-            )
-            .emit();
+            self.tcx.sess.emit_err(InlineAsmUnsupportedTarget { span: sp });
         }
         if let Some(asm_arch) = asm_arch {
             // Inline assembly is currently only stable for these architectures.
@@ -59,10 +59,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             && !matches!(asm_arch, Some(asm::InlineAsmArch::X86 | asm::InlineAsmArch::X86_64))
             && !self.tcx.sess.opts.actually_rustdoc
         {
-            self.tcx
-                .sess
-                .struct_span_err(sp, "the `att_syntax` option is only supported on x86")
-                .emit();
+            self.tcx.sess.emit_err(AttSyntaxOnlyX86 { span: sp });
         }
         if asm.options.contains(InlineAsmOptions::MAY_UNWIND) && !self.tcx.features().asm_unwind {
             feature_err(
@@ -82,51 +79,37 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         // If the abi was already in the list, emit an error
                         match clobber_abis.get(&abi) {
                             Some((prev_name, prev_sp)) => {
-                                let mut err = self.tcx.sess.struct_span_err(
-                                    *abi_span,
-                                    &format!("`{}` ABI specified multiple times", prev_name),
-                                );
-                                err.span_label(*prev_sp, "previously specified here");
-
                                 // Multiple different abi names may actually be the same ABI
                                 // If the specified ABIs are not the same name, alert the user that they resolve to the same ABI
                                 let source_map = self.tcx.sess.source_map();
-                                if source_map.span_to_snippet(*prev_sp)
-                                    != source_map.span_to_snippet(*abi_span)
-                                {
-                                    err.note("these ABIs are equivalent on the current target");
-                                }
+                                let equivalent = (source_map.span_to_snippet(*prev_sp)
+                                    != source_map.span_to_snippet(*abi_span))
+                                .then_some(());
 
-                                err.emit();
+                                self.tcx.sess.emit_err(AbiSpecifiedMultipleTimes {
+                                    abi_span: *abi_span,
+                                    prev_name: *prev_name,
+                                    prev_span: *prev_sp,
+                                    equivalent,
+                                });
                             }
                             None => {
-                                clobber_abis.insert(abi, (abi_name, *abi_span));
+                                clobber_abis.insert(abi, (*abi_name, *abi_span));
                             }
                         }
                     }
                     Err(&[]) => {
-                        self.tcx
-                            .sess
-                            .struct_span_err(
-                                *abi_span,
-                                "`clobber_abi` is not supported on this target",
-                            )
-                            .emit();
+                        self.tcx.sess.emit_err(ClobberAbiNotSupported { abi_span: *abi_span });
                     }
                     Err(supported_abis) => {
-                        let mut err = self
-                            .tcx
-                            .sess
-                            .struct_span_err(*abi_span, "invalid ABI for `clobber_abi`");
                         let mut abis = format!("`{}`", supported_abis[0]);
                         for m in &supported_abis[1..] {
                             let _ = write!(abis, ", `{}`", m);
                         }
-                        err.note(&format!(
-                            "the following ABIs are supported on this target: {}",
-                            abis
-                        ));
-                        err.emit();
+                        self.tcx.sess.emit_err(InvalidAbiClobberAbi {
+                            abi_span: *abi_span,
+                            supported_abis: abis,
+                        });
                     }
                 }
             }
@@ -144,8 +127,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     InlineAsmRegOrRegClass::Reg(s) => {
                         asm::InlineAsmRegOrRegClass::Reg(if let Some(asm_arch) = asm_arch {
                             asm::InlineAsmReg::parse(asm_arch, s).unwrap_or_else(|e| {
-                                let msg = format!("invalid register `{}`: {}", s, e);
-                                sess.struct_span_err(*op_sp, &msg).emit();
+                                sess.emit_err(InvalidRegister { op_span: *op_sp, s, e });
                                 asm::InlineAsmReg::Err
                             })
                         } else {
@@ -155,8 +137,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     InlineAsmRegOrRegClass::RegClass(s) => {
                         asm::InlineAsmRegOrRegClass::RegClass(if let Some(asm_arch) = asm_arch {
                             asm::InlineAsmRegClass::parse(asm_arch, s).unwrap_or_else(|e| {
-                                let msg = format!("invalid register class `{}`: {}", s, e);
-                                sess.struct_span_err(*op_sp, &msg).emit();
+                                sess.emit_err(InvalidRegisterClass { op_span: *op_sp, s, e });
                                 asm::InlineAsmRegClass::Err
                             })
                         } else {
@@ -282,50 +263,39 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         }
                         let valid_modifiers = class.valid_modifiers(asm_arch.unwrap());
                         if !valid_modifiers.contains(&modifier) {
-                            let mut err = sess.struct_span_err(
-                                placeholder_span,
-                                "invalid asm template modifier for this register class",
-                            );
-                            err.span_label(placeholder_span, "template modifier");
-                            err.span_label(op_sp, "argument");
-                            if !valid_modifiers.is_empty() {
+                            let sub = if !valid_modifiers.is_empty() {
                                 let mut mods = format!("`{}`", valid_modifiers[0]);
                                 for m in &valid_modifiers[1..] {
                                     let _ = write!(mods, ", `{}`", m);
                                 }
-                                err.note(&format!(
-                                    "the `{}` register class supports \
-                                     the following template modifiers: {}",
-                                    class.name(),
-                                    mods
-                                ));
+                                InvalidAsmTemplateModifierRegClassSub::SupportModifier {
+                                    class_name: class.name(),
+                                    modifiers: mods,
+                                }
                             } else {
-                                err.note(&format!(
-                                    "the `{}` register class does not support template modifiers",
-                                    class.name()
-                                ));
-                            }
-                            err.emit();
+                                InvalidAsmTemplateModifierRegClassSub::DoesNotSupportModifier {
+                                    class_name: class.name(),
+                                }
+                            };
+                            sess.emit_err(InvalidAsmTemplateModifierRegClass {
+                                placeholder_span,
+                                op_span: op_sp,
+                                sub,
+                            });
                         }
                     }
                     hir::InlineAsmOperand::Const { .. } => {
-                        let mut err = sess.struct_span_err(
+                        sess.emit_err(InvalidAsmTemplateModifierConst {
                             placeholder_span,
-                            "asm template modifiers are not allowed for `const` arguments",
-                        );
-                        err.span_label(placeholder_span, "template modifier");
-                        err.span_label(op_sp, "argument");
-                        err.emit();
+                            op_span: op_sp,
+                        });
                     }
                     hir::InlineAsmOperand::SymFn { .. }
                     | hir::InlineAsmOperand::SymStatic { .. } => {
-                        let mut err = sess.struct_span_err(
+                        sess.emit_err(InvalidAsmTemplateModifierSym {
                             placeholder_span,
-                            "asm template modifiers are not allowed for `sym` arguments",
-                        );
-                        err.span_label(placeholder_span, "template modifier");
-                        err.span_label(op_sp, "argument");
-                        err.emit();
+                            op_span: op_sp,
+                        });
                     }
                 }
             }
@@ -346,12 +316,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 // require that the operand name an explicit register, not a
                 // register class.
                 if reg_class.is_clobber_only(asm_arch.unwrap()) && !op.is_clobber() {
-                    let msg = format!(
-                        "register class `{}` can only be used as a clobber, \
-                             not as an input or output",
-                        reg_class.name()
-                    );
-                    sess.struct_span_err(op_sp, &msg).emit();
+                    sess.emit_err(RegisterClassOnlyClobber {
+                        op_span: op_sp,
+                        reg_class_name: reg_class.name(),
+                    });
                     continue;
                 }
 
@@ -391,16 +359,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                         unreachable!();
                                     };
 
-                                    let msg = format!(
-                                        "register `{}` conflicts with register `{}`",
-                                        reg.name(),
-                                        reg2.name()
-                                    );
-                                    let mut err = sess.struct_span_err(op_sp, &msg);
-                                    err.span_label(op_sp, &format!("register `{}`", reg.name()));
-                                    err.span_label(op_sp2, &format!("register `{}`", reg2.name()));
-
-                                    match (op, op2) {
+                                    let in_out = match (op, op2) {
                                         (
                                             hir::InlineAsmOperand::In { .. },
                                             hir::InlineAsmOperand::Out { late, .. },
@@ -411,14 +370,18 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                         ) => {
                                             assert!(!*late);
                                             let out_op_sp = if input { op_sp2 } else { op_sp };
-                                            let msg = "use `lateout` instead of \
-                                                       `out` to avoid conflict";
-                                            err.span_help(out_op_sp, msg);
-                                        }
-                                        _ => {}
-                                    }
+                                            Some(out_op_sp)
+                                        },
+                                        _ => None,
+                                    };
 
-                                    err.emit();
+                                    sess.emit_err(RegisterConflict {
+                                        op_span1: op_sp,
+                                        op_span2: op_sp2,
+                                        reg1_name: reg.name(),
+                                        reg2_name: reg2.name(),
+                                        in_out
+                                    });
                                 }
                                 Entry::Vacant(v) => {
                                     if r == reg {

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -124,22 +124,28 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             .iter()
             .map(|(op, op_sp)| {
                 let lower_reg = |reg| match reg {
-                    InlineAsmRegOrRegClass::Reg(s) => {
+                    InlineAsmRegOrRegClass::Reg(reg) => {
                         asm::InlineAsmRegOrRegClass::Reg(if let Some(asm_arch) = asm_arch {
-                            asm::InlineAsmReg::parse(asm_arch, s).unwrap_or_else(|e| {
-                                sess.emit_err(InvalidRegister { op_span: *op_sp, s, e });
+                            asm::InlineAsmReg::parse(asm_arch, reg).unwrap_or_else(|error| {
+                                sess.emit_err(InvalidRegister { op_span: *op_sp, reg, error });
                                 asm::InlineAsmReg::Err
                             })
                         } else {
                             asm::InlineAsmReg::Err
                         })
                     }
-                    InlineAsmRegOrRegClass::RegClass(s) => {
+                    InlineAsmRegOrRegClass::RegClass(reg_class) => {
                         asm::InlineAsmRegOrRegClass::RegClass(if let Some(asm_arch) = asm_arch {
-                            asm::InlineAsmRegClass::parse(asm_arch, s).unwrap_or_else(|e| {
-                                sess.emit_err(InvalidRegisterClass { op_span: *op_sp, s, e });
-                                asm::InlineAsmRegClass::Err
-                            })
+                            asm::InlineAsmRegClass::parse(asm_arch, reg_class).unwrap_or_else(
+                                |error| {
+                                    sess.emit_err(InvalidRegisterClass {
+                                        op_span: *op_sp,
+                                        reg_class,
+                                        error,
+                                    });
+                                    asm::InlineAsmRegClass::Err
+                                },
+                            )
                         } else {
                             asm::InlineAsmRegClass::Err
                         })

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,4 +1,4 @@
-use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
+use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic, DiagnosticArgFromDisplay};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::{symbol::Ident, Span, Symbol};
 
@@ -73,10 +73,10 @@ impl AddSubdiagnostic for AssocTyParenthesesSub {
 
 #[derive(SessionDiagnostic)]
 #[error(ast_lowering::misplaced_impl_trait, code = "E0562")]
-pub struct MisplacedImplTrait {
+pub struct MisplacedImplTrait<'a> {
     #[primary_span]
     pub span: Span,
-    pub position: String,
+    pub position: DiagnosticArgFromDisplay<'a>,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
@@ -196,8 +196,8 @@ pub struct InvalidAbiClobberAbi {
 pub struct InvalidRegister<'a> {
     #[primary_span]
     pub op_span: Span,
-    pub s: Symbol,
-    pub e: &'a str,
+    pub reg: Symbol,
+    pub error: &'a str,
 }
 
 #[derive(SessionDiagnostic, Clone, Copy)]
@@ -205,8 +205,8 @@ pub struct InvalidRegister<'a> {
 pub struct InvalidRegisterClass<'a> {
     #[primary_span]
     pub op_span: Span,
-    pub s: Symbol,
-    pub e: &'a str,
+    pub reg_class: Symbol,
+    pub error: &'a str,
 }
 
 #[derive(SessionDiagnostic)]

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,5 +1,5 @@
 use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
-use rustc_macros::SessionDiagnostic;
+use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic, Clone, Copy)]
@@ -147,4 +147,126 @@ pub struct FunctionalRecordUpdateDestructuringAssignemnt {
 pub struct AsyncGeneratorsNotSupported {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::inline_asm_unsupported_target, code = "E0472")]
+pub struct InlineAsmUnsupportedTarget {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::att_syntax_only_x86)]
+pub struct AttSyntaxOnlyX86 {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::abi_specified_multiple_times)]
+pub struct AbiSpecifiedMultipleTimes {
+    #[primary_span]
+    pub abi_span: Span,
+    pub prev_name: Symbol,
+    #[label]
+    pub prev_span: Span,
+    #[note]
+    pub equivalent: Option<()>,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::clobber_abi_not_supported)]
+pub struct ClobberAbiNotSupported {
+    #[primary_span]
+    pub abi_span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[note]
+#[error(ast_lowering::invalid_abi_clobber_abi)]
+pub struct InvalidAbiClobberAbi {
+    #[primary_span]
+    pub abi_span: Span,
+    pub supported_abis: String,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_register)]
+pub struct InvalidRegister<'a> {
+    #[primary_span]
+    pub op_span: Span,
+    pub s: Symbol,
+    pub e: &'a str,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_register_class)]
+pub struct InvalidRegisterClass<'a> {
+    #[primary_span]
+    pub op_span: Span,
+    pub s: Symbol,
+    pub e: &'a str,
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_lowering::invalid_asm_template_modifier_reg_class)]
+pub struct InvalidAsmTemplateModifierRegClass {
+    #[primary_span]
+    #[label(ast_lowering::template_modifier)]
+    pub placeholder_span: Span,
+    #[label(ast_lowering::argument)]
+    pub op_span: Span,
+    #[subdiagnostic]
+    pub sub: InvalidAsmTemplateModifierRegClassSub,
+}
+
+#[derive(SessionSubdiagnostic)]
+pub enum InvalidAsmTemplateModifierRegClassSub {
+    #[note(ast_lowering::support_modifiers)]
+    SupportModifier { class_name: Symbol, modifiers: String },
+    #[note(ast_lowering::does_not_support_modifiers)]
+    DoesNotSupportModifier { class_name: Symbol },
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_asm_template_modifier_const)]
+pub struct InvalidAsmTemplateModifierConst {
+    #[primary_span]
+    #[label(ast_lowering::template_modifier)]
+    pub placeholder_span: Span,
+    #[label(ast_lowering::argument)]
+    pub op_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::invalid_asm_template_modifier_sym)]
+pub struct InvalidAsmTemplateModifierSym {
+    #[primary_span]
+    #[label(ast_lowering::template_modifier)]
+    pub placeholder_span: Span,
+    #[label(ast_lowering::argument)]
+    pub op_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::register_class_only_clobber)]
+pub struct RegisterClassOnlyClobber {
+    #[primary_span]
+    pub op_span: Span,
+    pub reg_class_name: Symbol,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::register_conflict)]
+pub struct RegisterConflict<'a> {
+    #[primary_span]
+    #[label(ast_lowering::register1)]
+    pub op_span1: Span,
+    #[label(ast_lowering::register2)]
+    pub op_span2: Span,
+    pub reg1_name: &'a str,
+    pub reg2_name: &'a str,
+    #[help]
+    pub in_out: Option<Span>,
 }

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -78,3 +78,73 @@ pub struct MisplacedImplTrait {
     pub span: Span,
     pub position: String,
 }
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::rustc_box_attribute_error)]
+pub struct RustcBoxAttributeError {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::underscore_expr_lhs_assign)]
+pub struct UnderscoreExprLhsAssign {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::base_expression_double_dot)]
+pub struct BaseExpressionDoubleDot {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::await_only_in_async_fn_and_blocks, code = "E0728")]
+pub struct AwaitOnlyInAsyncFnAndBlocks {
+    #[primary_span]
+    #[label]
+    pub dot_await_span: Span,
+    #[label(ast_lowering::this_not_async)]
+    pub item_span: Option<Span>,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::generator_too_many_parameters, code = "E0628")]
+pub struct GeneratorTooManyParameters {
+    #[primary_span]
+    pub fn_decl_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::closure_cannot_be_static, code = "E0697")]
+pub struct ClosureCannotBeStatic {
+    #[primary_span]
+    pub fn_decl_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[help]
+#[error(ast_lowering::async_non_move_closure_not_supported, code = "E0708")]
+pub struct AsyncNonMoveClosureNotSupported {
+    #[primary_span]
+    pub fn_decl_span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::functional_record_update_destructuring_assignment)]
+pub struct FunctionalRecordUpdateDestructuringAssignemnt {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::async_generators_not_supported, code = "E0727")]
+pub struct AsyncGeneratorsNotSupported {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,0 +1,29 @@
+use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
+use rustc_macros::SessionDiagnostic;
+use rustc_span::Span;
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::generic_type_with_parentheses, code = "E0214")]
+pub struct GenericTypeWithParentheses {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: Option<UseAngleBrackets>,
+}
+
+#[derive(Clone, Copy)]
+pub struct UseAngleBrackets {
+    pub open_param: Span,
+    pub close_param: Span,
+}
+
+impl AddSubdiagnostic for UseAngleBrackets {
+    fn add_to_diagnostic(self, diag: &mut Diagnostic) {
+        diag.multipart_suggestion(
+            fluent::ast_lowering::use_angle_brackets,
+            vec![(self.open_param, String::from("<")), (self.close_param, String::from(">"))],
+            Applicability::MaybeIncorrect,
+        );
+    }
+}

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -306,3 +306,24 @@ pub struct MisplacedDoubleDot {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::misplaced_relax_trait_bound)]
+pub struct MisplacedRelaxTraitBound {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::not_supported_for_lifetime_binder_async_closure)]
+pub struct NotSupportedForLifetimeBinderAsyncClosure {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::arbitrary_expression_in_pattern)]
+pub struct ArbitraryExpressionInPattern {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,6 +1,6 @@
 use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
 use rustc_macros::SessionDiagnostic;
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic, Clone, Copy)]
 #[error(ast_lowering::generic_type_with_parentheses, code = "E0214")]
@@ -26,4 +26,55 @@ impl AddSubdiagnostic for UseAngleBrackets {
             Applicability::MaybeIncorrect,
         );
     }
+}
+
+#[derive(SessionDiagnostic)]
+#[help]
+#[error(ast_lowering::invalid_abi, code = "E0703")]
+pub struct InvalidAbi {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub abi: Symbol,
+    pub valid_abis: String,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::assoc_ty_parentheses)]
+pub struct AssocTyParentheses {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: AssocTyParenthesesSub,
+}
+
+#[derive(Clone, Copy)]
+pub enum AssocTyParenthesesSub {
+    Empty { parentheses_span: Span },
+    NotEmpty { open_param: Span, close_param: Span },
+}
+
+impl AddSubdiagnostic for AssocTyParenthesesSub {
+    fn add_to_diagnostic(self, diag: &mut Diagnostic) {
+        match self {
+            Self::Empty { parentheses_span } => diag.multipart_suggestion(
+                fluent::ast_lowering::remove_parentheses,
+                vec![(parentheses_span, String::new())],
+                Applicability::MaybeIncorrect,
+            ),
+            Self::NotEmpty { open_param, close_param } => diag.multipart_suggestion(
+                fluent::ast_lowering::use_angle_brackets,
+                vec![(open_param, String::from("<")), (close_param, String::from(">"))],
+                Applicability::MaybeIncorrect,
+            ),
+        };
+    }
+}
+
+#[derive(SessionDiagnostic)]
+#[error(ast_lowering::misplaced_impl_trait, code = "E0562")]
+pub struct MisplacedImplTrait {
+    #[primary_span]
+    pub span: Span,
+    pub position: String,
 }

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,6 +1,6 @@
 use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
-use rustc_span::{Span, Symbol};
+use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(SessionDiagnostic, Clone, Copy)]
 #[error(ast_lowering::generic_type_with_parentheses, code = "E0214")]
@@ -269,4 +269,40 @@ pub struct RegisterConflict<'a> {
     pub reg2_name: &'a str,
     #[help]
     pub in_out: Option<Span>,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[help]
+#[error(ast_lowering::sub_tuple_binding)]
+pub struct SubTupleBinding<'a> {
+    #[primary_span]
+    #[label]
+    #[suggestion_verbose(
+        ast_lowering::sub_tuple_binding_suggestion,
+        code = "..",
+        applicability = "maybe-incorrect"
+    )]
+    pub span: Span,
+    pub ident: Ident,
+    pub ident_name: Symbol,
+    pub ctx: &'a str,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[error(ast_lowering::extra_double_dot)]
+pub struct ExtraDoubleDot<'a> {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[label(ast_lowering::previously_used_here)]
+    pub prev_span: Span,
+    pub ctx: &'a str,
+}
+
+#[derive(SessionDiagnostic, Clone, Copy)]
+#[note]
+#[error(ast_lowering::misplaced_double_dot)]
+pub struct MisplacedDoubleDot {
+    #[primary_span]
+    pub span: Span,
 }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1,7 +1,8 @@
 use super::errors::{
     AsyncGeneratorsNotSupported, AsyncNonMoveClosureNotSupported, AwaitOnlyInAsyncFnAndBlocks,
     BaseExpressionDoubleDot, ClosureCannotBeStatic, FunctionalRecordUpdateDestructuringAssignemnt,
-    GeneratorTooManyParameters, RustcBoxAttributeError, UnderscoreExprLhsAssign,
+    GeneratorTooManyParameters, NotSupportedForLifetimeBinderAsyncClosure, RustcBoxAttributeError,
+    UnderscoreExprLhsAssign,
 };
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode, ParenthesizedGenericArgs};
@@ -916,10 +917,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         fn_decl_span: Span,
     ) -> hir::ExprKind<'hir> {
         if let &ClosureBinder::For { span, .. } = binder {
-            self.tcx.sess.span_err(
-                span,
-                "`for<...>` binders on `async` closures are not currently supported",
-            );
+            self.tcx.sess.emit_err(NotSupportedForLifetimeBinderAsyncClosure { span });
         }
 
         let (binder_clause, generic_params) = self.lower_closure_binder(binder);

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1,3 +1,8 @@
+use super::errors::{
+    AsyncGeneratorsNotSupported, AsyncNonMoveClosureNotSupported, AwaitOnlyInAsyncFnAndBlocks,
+    BaseExpressionDoubleDot, ClosureCannotBeStatic, FunctionalRecordUpdateDestructuringAssignemnt,
+    GeneratorTooManyParameters, RustcBoxAttributeError, UnderscoreExprLhsAssign,
+};
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode, ParenthesizedGenericArgs};
 use crate::{FnDeclKind, ImplTraitPosition};
@@ -7,7 +12,6 @@ use rustc_ast::ptr::P as AstP;
 use rustc_ast::*;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::thin_vec::ThinVec;
-use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_hir::definitions::DefPathData;
@@ -46,13 +50,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             let hir_id = self.lower_node_id(e.id);
                             return hir::Expr { hir_id, kind, span: self.lower_span(e.span) };
                         } else {
-                            self.tcx.sess
-                                .struct_span_err(
-                                    e.span,
-                                    "#[rustc_box] requires precisely one argument \
-                                    and no other attributes are allowed",
-                                )
-                                .emit();
+                            self.tcx.sess.emit_err(RustcBoxAttributeError { span: e.span });
                             hir::ExprKind::Err
                         }
                     } else if let Some(legacy_args) = self.resolver.legacy_const_generic_args(f) {
@@ -212,13 +210,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     self.lower_expr_range(e.span, e1.as_deref(), e2.as_deref(), lims)
                 }
                 ExprKind::Underscore => {
-                    self.tcx
-                        .sess.struct_span_err(
-                            e.span,
-                            "in expressions, `_` can only be used on the left-hand side of an assignment",
-                        )
-                        .span_label(e.span, "`_` not allowed here")
-                        .emit();
+                    self.tcx.sess.emit_err(UnderscoreExprLhsAssign { span: e.span });
                     hir::ExprKind::Err
                 }
                 ExprKind::Path(ref qself, ref path) => {
@@ -250,11 +242,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     let rest = match &se.rest {
                         StructRest::Base(e) => Some(self.lower_expr(e)),
                         StructRest::Rest(sp) => {
-                            self.tcx
-                                .sess
-                                .struct_span_err(*sp, "base expression required after `..`")
-                                .span_label(*sp, "add a base expression here")
-                                .emit();
+                            self.tcx.sess.emit_err(BaseExpressionDoubleDot { span: *sp });
                             Some(&*self.arena.alloc(self.expr_err(*sp)))
                         }
                         StructRest::None => None,
@@ -663,17 +651,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         match self.generator_kind {
             Some(hir::GeneratorKind::Async(_)) => {}
             Some(hir::GeneratorKind::Gen) | None => {
-                let mut err = struct_span_err!(
-                    self.tcx.sess,
+                self.tcx.sess.emit_err(AwaitOnlyInAsyncFnAndBlocks {
                     dot_await_span,
-                    E0728,
-                    "`await` is only allowed inside `async` functions and blocks"
-                );
-                err.span_label(dot_await_span, "only allowed inside `async` functions and blocks");
-                if let Some(item_sp) = self.current_item {
-                    err.span_label(item_sp, "this is not `async`");
-                }
-                err.emit();
+                    item_span: self.current_item,
+                });
             }
         }
         let span = self.mark_span_with_reason(DesugaringKind::Await, dot_await_span, None);
@@ -893,13 +874,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         match generator_kind {
             Some(hir::GeneratorKind::Gen) => {
                 if decl.inputs.len() > 1 {
-                    struct_span_err!(
-                        self.tcx.sess,
-                        fn_decl_span,
-                        E0628,
-                        "too many parameters for a generator (expected 0 or 1 parameters)"
-                    )
-                    .emit();
+                    self.tcx.sess.emit_err(GeneratorTooManyParameters { fn_decl_span });
                 }
                 Some(movability)
             }
@@ -908,13 +883,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             None => {
                 if movability == Movability::Static {
-                    struct_span_err!(
-                        self.tcx.sess,
-                        fn_decl_span,
-                        E0697,
-                        "closures cannot be static"
-                    )
-                    .emit();
+                    self.tcx.sess.emit_err(ClosureCannotBeStatic { fn_decl_span });
                 }
                 None
             }
@@ -961,17 +930,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let body = self.with_new_scopes(|this| {
             // FIXME(cramertj): allow `async` non-`move` closures with arguments.
             if capture_clause == CaptureBy::Ref && !decl.inputs.is_empty() {
-                struct_span_err!(
-                    this.tcx.sess,
-                    fn_decl_span,
-                    E0708,
-                    "`async` non-`move` closures with parameters are not currently supported",
-                )
-                .help(
-                    "consider using `let` statements to manually capture \
-                    variables by reference before entering an `async move` closure",
-                )
-                .emit();
+                this.tcx.sess.emit_err(AsyncNonMoveClosureNotSupported { fn_decl_span });
             }
 
             // Transform `async |x: u8| -> X { ... }` into
@@ -1211,20 +1170,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 );
                 let fields_omitted = match &se.rest {
                     StructRest::Base(e) => {
-                        self.tcx
-                            .sess
-                            .struct_span_err(
-                                e.span,
-                                "functional record updates are not allowed in destructuring \
-                                    assignments",
-                            )
-                            .span_suggestion(
-                                e.span,
-                                "consider removing the trailing pattern",
-                                "",
-                                rustc_errors::Applicability::MachineApplicable,
-                            )
-                            .emit();
+                        self.tcx.sess.emit_err(FunctionalRecordUpdateDestructuringAssignemnt {
+                            span: e.span,
+                        });
                         true
                     }
                     StructRest::Rest(_) => true,
@@ -1421,13 +1369,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         match self.generator_kind {
             Some(hir::GeneratorKind::Gen) => {}
             Some(hir::GeneratorKind::Async(_)) => {
-                struct_span_err!(
-                    self.tcx.sess,
-                    span,
-                    E0727,
-                    "`async` generators are not yet supported"
-                )
-                .emit();
+                self.tcx.sess.emit_err(AsyncGeneratorsNotSupported { span });
             }
             None => self.generator_kind = Some(hir::GeneratorKind::Gen),
         }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1,4 +1,4 @@
-use super::errors::InvalidAbi;
+use super::errors::{InvalidAbi, MisplacedRelaxTraitBound};
 use super::ResolverAstLoweringExt;
 use super::{AstOwner, ImplTraitContext, ImplTraitPosition};
 use super::{FnDeclKind, LoweringContext, ParamMode};
@@ -1339,11 +1339,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 let is_param = *is_param.get_or_insert_with(compute_is_param);
                 if !is_param {
-                    self.diagnostic().span_err(
-                        bound.span(),
-                        "`?Trait` bounds are only permitted at the \
-                        point where a type parameter is declared",
-                    );
+                    self.tcx.sess.emit_err(MisplacedRelaxTraitBound { span: bound.span() });
                 }
             }
         }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1,3 +1,4 @@
+use super::errors::InvalidAbi;
 use super::ResolverAstLoweringExt;
 use super::{AstOwner, ImplTraitContext, ImplTraitPosition};
 use super::{FnDeclKind, LoweringContext, ParamMode};
@@ -7,7 +8,6 @@ use rustc_ast::visit::AssocCtxt;
 use rustc_ast::*;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sorted_map::SortedMap;
-use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{LocalDefId, CRATE_DEF_ID};
@@ -1260,10 +1260,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn error_on_invalid_abi(&self, abi: StrLit) {
-        struct_span_err!(self.tcx.sess, abi.span, E0703, "invalid ABI: found `{}`", abi.symbol)
-            .span_label(abi.span, "invalid ABI")
-            .help(&format!("valid ABIs: {}", abi::all_names().join(", ")))
-            .emit();
+        self.tcx.sess.emit_err(InvalidAbi {
+            span: abi.span,
+            abi: abi.symbol,
+            valid_abis: abi::all_names().join(", "),
+        });
     }
 
     fn lower_asyncness(&mut self, a: Async) -> hir::IsAsync {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -51,7 +51,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{Handler, StashKey};
+use rustc_errors::{DiagnosticArgFromDisplay, Handler, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, LifetimeRes, Namespace, PartialRes, PerNS, Res};
 use rustc_hir::def_id::{LocalDefId, CRATE_DEF_ID};
@@ -1334,7 +1334,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     ImplTraitContext::Disallowed(position) => {
                         self.tcx.sess.emit_err(MisplacedImplTrait {
                             span: t.span,
-                            position: position.to_string(),
+                            position: DiagnosticArgFromDisplay(&position),
                         });
                         hir::TyKind::Err
                     }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -39,6 +39,8 @@
 #[macro_use]
 extern crate tracing;
 
+use crate::errors::{AssocTyParentheses, AssocTyParenthesesSub, MisplacedImplTrait};
+
 use rustc_ast::ptr::P;
 use rustc_ast::visit;
 use rustc_ast::{self as ast, *};
@@ -49,7 +51,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{struct_span_err, Applicability, Handler, StashKey};
+use rustc_errors::{Handler, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, LifetimeRes, Namespace, PartialRes, PerNS, Res};
 use rustc_hir::def_id::{LocalDefId, CRATE_DEF_ID};
@@ -1071,19 +1073,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn emit_bad_parenthesized_trait_in_assoc_ty(&self, data: &ParenthesizedArgs) {
-        let mut err = self.tcx.sess.struct_span_err(
-            data.span,
-            "parenthesized generic arguments cannot be used in associated type constraints",
-        );
         // Suggest removing empty parentheses: "Trait()" -> "Trait"
-        if data.inputs.is_empty() {
+        let sub = if data.inputs.is_empty() {
             let parentheses_span =
                 data.inputs_span.shrink_to_lo().to(data.inputs_span.shrink_to_hi());
-            err.multipart_suggestion(
-                "remove these parentheses",
-                vec![(parentheses_span, String::new())],
-                Applicability::MaybeIncorrect,
-            );
+            AssocTyParenthesesSub::Empty { parentheses_span }
         }
         // Suggest replacing parentheses with angle brackets `Trait(params...)` to `Trait<params...>`
         else {
@@ -1097,13 +1091,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             // End of last argument to end of parameters
             let close_param =
                 data.inputs.last().unwrap().span.shrink_to_hi().to(data.inputs_span.shrink_to_hi());
-            err.multipart_suggestion(
-                &format!("use angle brackets instead",),
-                vec![(open_param, String::from("<")), (close_param, String::from(">"))],
-                Applicability::MaybeIncorrect,
-            );
-        }
-        err.emit();
+            AssocTyParenthesesSub::NotEmpty { open_param, close_param }
+        };
+        self.tcx.sess.emit_err(AssocTyParentheses { span: data.span, sub });
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -1342,14 +1332,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         path
                     }
                     ImplTraitContext::Disallowed(position) => {
-                        let mut err = struct_span_err!(
-                            self.tcx.sess,
-                            t.span,
-                            E0562,
-                            "`impl Trait` only allowed in function and inherent method return types, not in {}",
-                            position
-                        );
-                        err.emit();
+                        self.tcx.sess.emit_err(MisplacedImplTrait {
+                            span: t.span,
+                            position: position.to_string(),
+                        });
                         hir::TyKind::Err
                     }
                 }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -75,6 +75,7 @@ macro_rules! arena_vec {
 
 mod asm;
 mod block;
+mod errors;
 mod expr;
 mod index;
 mod item;

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -1,4 +1,6 @@
-use super::errors::{ExtraDoubleDot, MisplacedDoubleDot, SubTupleBinding};
+use super::errors::{
+    ArbitraryExpressionInPattern, ExtraDoubleDot, MisplacedDoubleDot, SubTupleBinding,
+};
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode};
 use crate::ImplTraitPosition;
@@ -330,8 +332,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             ExprKind::Path(..) if allow_paths => {}
             ExprKind::Unary(UnOp::Neg, ref inner) if matches!(inner.kind, ExprKind::Lit(_)) => {}
             _ => {
-                self.diagnostic()
-                    .span_err(expr.span, "arbitrary expressions aren't allowed in patterns");
+                self.tcx.sess.emit_err(ArbitraryExpressionInPattern { span: expr.span });
                 return self.arena.alloc(self.expr_err(expr.span));
             }
         }

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -1,3 +1,4 @@
+use super::errors::{ExtraDoubleDot, MisplacedDoubleDot, SubTupleBinding};
 use super::ResolverAstLoweringExt;
 use super::{ImplTraitContext, LoweringContext, ParamMode};
 use crate::ImplTraitPosition;
@@ -5,7 +6,6 @@ use crate::ImplTraitPosition;
 use rustc_ast::ptr::P;
 use rustc_ast::*;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_span::symbol::Ident;
@@ -134,20 +134,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 // This is not allowed as a sub-tuple pattern
                 PatKind::Ident(ref _bm, ident, Some(ref sub)) if sub.is_rest() => {
                     let sp = pat.span;
-                    self.diagnostic()
-                        .struct_span_err(
-                            sp,
-                            &format!("`{} @` is not allowed in a {}", ident.name, ctx),
-                        )
-                        .span_label(sp, "this is only allowed in slice patterns")
-                        .help("remove this and bind each tuple field independently")
-                        .span_suggestion_verbose(
-                            sp,
-                            &format!("if you don't need to use the contents of {}, discard the tuple's remaining fields", ident),
-                            "..",
-                            Applicability::MaybeIncorrect,
-                        )
-                        .emit();
+                    self.tcx.sess.emit_err(SubTupleBinding {
+                        span: sp,
+                        ident_name: ident.name,
+                        ident,
+                        ctx,
+                    });
                 }
                 _ => {}
             }
@@ -296,19 +288,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
     /// Emit a friendly error for extra `..` patterns in a tuple/tuple struct/slice pattern.
     pub(crate) fn ban_extra_rest_pat(&self, sp: Span, prev_sp: Span, ctx: &str) {
-        self.diagnostic()
-            .struct_span_err(sp, &format!("`..` can only be used once per {} pattern", ctx))
-            .span_label(sp, &format!("can only be used once per {} pattern", ctx))
-            .span_label(prev_sp, "previously used here")
-            .emit();
+        self.tcx.sess.emit_err(ExtraDoubleDot { span: sp, prev_span: prev_sp, ctx });
     }
 
     /// Used to ban the `..` pattern in places it shouldn't be semantically.
     fn ban_illegal_rest_pat(&self, sp: Span) -> hir::PatKind<'hir> {
-        self.diagnostic()
-            .struct_span_err(sp, "`..` patterns are not allowed here")
-            .note("only allowed in tuple, tuple struct, and slice patterns")
-            .emit();
+        self.tcx.sess.emit_err(MisplacedDoubleDot { span: sp });
 
         // We're not in a list context so `..` can be reasonably treated
         // as `_` because it should always be valid and roughly matches the

--- a/compiler/rustc_ast_pretty/src/lib.rs
+++ b/compiler/rustc_ast_pretty/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 #![feature(associated_type_bounds)]
 #![feature(box_patterns)]
 #![feature(with_negative_coherence)]

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -1,6 +1,7 @@
 //! Concrete error types for all operations which may be invalid in a certain const context.
 
 use hir::def_id::LocalDefId;
+use hir::ConstContext;
 use rustc_errors::{
     error_code, struct_span_err, Applicability, DiagnosticBuilder, ErrorGuaranteed,
 };
@@ -330,6 +331,10 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
              tuple structs and tuple variants",
             ccx.const_kind(),
         ));
+
+        if let ConstContext::Static(_) = ccx.const_kind() {
+            err.note("consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell");
+        }
 
         err
     }

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -28,6 +28,8 @@
 #![feature(vec_into_raw_parts)]
 #![allow(rustc::default_hash_types)]
 #![allow(rustc::potential_query_instability)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -725,6 +725,10 @@ fn print_crate_info(
             | TargetFeatures => {
                 codegen_backend.print(*req, sess);
             }
+            RustcPath => match env::current_exe() {
+                Ok(exe) => println!("{}", exe.display()),
+                Err(_) => early_error(ErrorOutputType::default(), "failed to get rustc path"),
+            },
             // Any output here interferes with Cargo's parsing of other printed output
             NativeStaticLibs => {}
             LinkArgs => {}

--- a/compiler/rustc_error_codes/src/lib.rs
+++ b/compiler/rustc_error_codes/src/lib.rs
@@ -1,4 +1,6 @@
 #![deny(rustdoc::invalid_codeblock_attributes)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 //! This library is used to gather all error codes into one place,
 //! the goal being to make their maintenance easier.
 

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -69,10 +69,10 @@ ast_lowering_invalid_abi_clobber_abi =
     .note = the following ABIs are supported on this target: {$supported_abis}
 
 ast_lowering_invalid_register =
-    invalid register `{$s}`: {$e}
+    invalid register `{$reg}`: {$error}
 
 ast_lowering_invalid_register_class =
-    invalid register class `{$s}`: {$e}
+    invalid register class `{$reg_class}`: {$error}
 
 ast_lowering_invalid_asm_template_modifier_reg_class =
     invalid asm template modifier for this register class

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -49,3 +49,57 @@ ast_lowering_functional_record_update_destructuring_assignment =
 
 ast_lowering_async_generators_not_supported =
     `async` generators are not yet supported
+
+ast_lowering_inline_asm_unsupported_target =
+    inline assembly is unsupported on this target
+
+ast_lowering_att_syntax_only_x86 =
+    the `att_syntax` option is only supported on x86
+
+ast_lowering_abi_specified_multiple_times =
+    `{$prev_name}` ABI specified multiple times
+    .label = previously specified here
+    .note = these ABIs are equivalent on the current target
+
+ast_lowering_clobber_abi_not_supported =
+    `clobber_abi` is not supported on this target
+
+ast_lowering_invalid_abi_clobber_abi =
+    invalid ABI for `clobber_abi`
+    .note = the following ABIs are supported on this target: {$supported_abis}
+
+ast_lowering_invalid_register =
+    invalid register `{$s}`: {$e}
+
+ast_lowering_invalid_register_class =
+    invalid register class `{$s}`: {$e}
+
+ast_lowering_invalid_asm_template_modifier_reg_class =
+    invalid asm template modifier for this register class
+
+ast_lowering_argument = argument
+
+ast_lowering_template_modifier = template modifier
+
+ast_lowering_support_modifiers =
+    the `{$class_name}` register class supports the following template modifiers: {$modifiers}
+
+ast_lowering_does_not_support_modifiers =
+    the `{$class_name}` register class does not support template modifiers
+
+ast_lowering_invalid_asm_template_modifier_const =
+    asm template modifiers are not allowed for `const` arguments
+
+ast_lowering_invalid_asm_template_modifier_sym =
+    asm template modifiers are not allowed for `sym` arguments
+
+ast_lowering_register_class_only_clobber =
+    register class `{$reg_class_name}` can only be used as a clobber, not as an input or output
+
+ast_lowering_register_conflict =
+    register `{$reg1_name}` conflicts with register `{$reg2_name}`
+    .help = use `lateout` instead of `out` to avoid conflict
+
+ast_lowering_register1 = register `{$reg1_name}`
+
+ast_lowering_register2 = register `{$reg2_name}`

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -103,3 +103,20 @@ ast_lowering_register_conflict =
 ast_lowering_register1 = register `{$reg1_name}`
 
 ast_lowering_register2 = register `{$reg2_name}`
+
+ast_lowering_sub_tuple_binding =
+    `{$ident_name} @` is not allowed in a {$ctx}
+    .label = this is only allowed in slice patterns
+    .help = remove this and bind each tuple field independently
+
+ast_lowering_sub_tuple_binding_suggestion = if you don't need to use the contents of {$ident}, discard the tuple's remaining fields
+
+ast_lowering_extra_double_dot =
+    `..` can only be used once per {$ctx} pattern
+    .label = can only be used once per {$ctx} pattern
+
+ast_lowering_previously_used_here = previously used here
+
+ast_lowering_misplaced_double_dot =
+    `..` patterns are not allowed here
+    .note = only allowed in tuple, tuple struct, and slice patterns

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -16,3 +16,36 @@ ast_lowering_remove_parentheses = remove these parentheses
 
 ast_lowering_misplaced_impl_trait =
     `impl Trait` only allowed in function and inherent method return types, not in {$position}
+
+ast_lowering_rustc_box_attribute_error =
+    #[rustc_box] requires precisely one argument and no other attributes are allowed
+
+ast_lowering_underscore_expr_lhs_assign =
+    in expressions, `_` can only be used on the left-hand side of an assignment
+    .label = `_` not allowed here
+
+ast_lowering_base_expression_double_dot =
+    base expression required after `..`
+    .label = add a base expression here
+
+ast_lowering_await_only_in_async_fn_and_blocks =
+    `await` is only allowed inside `async` functions and blocks
+    .label = only allowed inside `async` functions and blocks
+
+ast_lowering_this_not_async = this is not `async`
+
+ast_lowering_generator_too_many_parameters =
+    too many parameters for a generator (expected 0 or 1 parameters)
+
+ast_lowering_closure_cannot_be_static = closures cannot be static
+
+ast_lowering_async_non_move_closure_not_supported =
+    `async` non-`move` closures with parameters are not currently supported
+    .help = consider using `let` statements to manually capture variables by reference before entering an `async move` closure
+
+ast_lowering_functional_record_update_destructuring_assignment =
+    functional record updates are not allowed in destructuring assignments
+    .suggestion = consider removing the trailing pattern
+
+ast_lowering_async_generators_not_supported =
+    `async` generators are not yet supported

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -3,3 +3,16 @@ ast_lowering_generic_type_with_parentheses =
     .label = only `Fn` traits may use parentheses
 
 ast_lowering_use_angle_brackets = use angle brackets instead
+
+ast_lowering_invalid_abi =
+    invalid ABI: found `{$abi}`
+    .label = invalid ABI
+    .help = valid ABIs: {$valid_abis}
+
+ast_lowering_assoc_ty_parentheses =
+    parenthesized generic arguments cannot be used in associated type constraints
+
+ast_lowering_remove_parentheses = remove these parentheses
+
+ast_lowering_misplaced_impl_trait =
+    `impl Trait` only allowed in function and inherent method return types, not in {$position}

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -1,0 +1,5 @@
+ast_lowering_generic_type_with_parentheses =
+    parenthesized type parameters may only be used with a `Fn` trait
+    .label = only `Fn` traits may use parentheses
+
+ast_lowering_use_angle_brackets = use angle brackets instead

--- a/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/ast_lowering.ftl
@@ -120,3 +120,12 @@ ast_lowering_previously_used_here = previously used here
 ast_lowering_misplaced_double_dot =
     `..` patterns are not allowed here
     .note = only allowed in tuple, tuple struct, and slice patterns
+
+ast_lowering_misplaced_relax_trait_bound =
+    `?Trait` bounds are only permitted at the point where a type parameter is declared
+
+ast_lowering_not_supported_for_lifetime_binder_async_closure =
+    `for<...>` binders on `async` closures are not currently supported
+
+ast_lowering_arbitrary_expression_in_pattern =
+    arbitrary expressions aren't allowed in patterns

--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -32,3 +32,12 @@ parser_incorrect_use_of_await =
 parser_in_in_typo =
     expected iterable, found keyword `in`
     .suggestion = remove the duplicated `in`
+
+parser_invalid_variable_declaration =
+    invalid variable declaration
+
+parser_switch_mut_let_order =
+    switch the order of `mut` and `let`
+parser_missing_let_before_mut = missing keyword
+parser_use_let_not_auto = write `let` instead of `auto` to introduce a new variable
+parser_use_let_not_var = write `let` instead of `var` to introduce a new variable

--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -131,3 +131,5 @@ typeck_unused_extern_crate =
 typeck_extern_crate_not_idiomatic =
     `extern crate` is not idiomatic in the new edition
     .suggestion = convert it to a `{$msg_code}`
+
+typeck_expected_used_symbol = expected `used`, `used(compiler)` or `used(linker)`

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(once_cell)]
 #![feature(rustc_attrs)]
 #![feature(type_alias_impl_trait)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 use fluent_bundle::FluentResource;
 use fluent_syntax::parser::ParserError;

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -30,6 +30,7 @@ pub use unic_langid::{langid, LanguageIdentifier};
 
 // Generates `DEFAULT_LOCALE_RESOURCES` static and `fluent_generated` module.
 fluent_messages! {
+    ast_lowering => "../locales/en-US/ast_lowering.ftl",
     borrowck => "../locales/en-US/borrowck.ftl",
     builtin_macros => "../locales/en-US/builtin_macros.ftl",
     const_eval => "../locales/en-US/const_eval.ftl",

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -12,6 +12,8 @@
 //! symbol to the `accepted` or `removed` modules respectively.
 
 #![feature(once_cell)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 mod accepted;
 mod active;

--- a/compiler/rustc_fs_util/src/lib.rs
+++ b/compiler/rustc_fs_util/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
+
 use std::ffi::CString;
 use std::fs;
 use std::io;

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -273,6 +273,8 @@
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     test(attr(allow(unused_variables), deny(warnings)))
 )]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 use LabelText::*;
 

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -11,6 +11,8 @@
 #![feature(never_type)]
 #![feature(rustc_attrs)]
 #![recursion_limit = "256"]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 use rustc_ast as ast;
 use rustc_ast::util::parser::{self, AssocOp, Fixity};

--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 #![feature(allow_internal_unstable)]
 #![feature(bench_black_box)]
 #![feature(extend_one)]

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -18,6 +18,8 @@
 //! lexeme types.
 //!
 //! [`rustc_parse::lexer`]: ../rustc_parse/lexer/index.html
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 // We want to be able to build this crate with a stable compiler, so no
 // `#![feature]` attributes should be added.
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(min_specialization)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_llvm/src/lib.rs
+++ b/compiler/rustc_llvm/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 
 // NOTE: This crate only exists to allow linking on mingw targets.

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -38,6 +38,9 @@
 //! debugging, you can make changes inside those crates and quickly run main.rs
 //! to read the debug logs.
 
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
+
 use std::env::{self, VarError};
 use std::fmt::{self, Display};
 use std::io;

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -4,6 +4,8 @@
 #![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_span)]
 #![allow(rustc::default_hash_types)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 #![recursion_limit = "128"]
 
 use synstructure::decl_derive;

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -334,6 +334,35 @@ struct InInTypo {
     sugg_span: Span,
 }
 
+#[derive(SessionDiagnostic)]
+#[error(parser::invalid_variable_declaration)]
+pub struct InvalidVariableDeclaration {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: InvalidVariableDeclarationSub,
+}
+
+#[derive(SessionSubdiagnostic)]
+pub enum InvalidVariableDeclarationSub {
+    #[suggestion(
+        parser::switch_mut_let_order,
+        applicability = "maybe-incorrect",
+        code = "let mut"
+    )]
+    SwitchMutLetOrder(#[primary_span] Span),
+    #[suggestion(
+        parser::missing_let_before_mut,
+        applicability = "machine-applicable",
+        code = "let mut"
+    )]
+    MissingLet(#[primary_span] Span),
+    #[suggestion(parser::use_let_not_auto, applicability = "machine-applicable", code = "let")]
+    UseLetNotAuto(#[primary_span] Span),
+    #[suggestion(parser::use_let_not_var, applicability = "machine-applicable", code = "let")]
+    UseLetNotVar(#[primary_span] Span),
+}
+
 // SnapshotParser is used to create a snapshot of the parser
 // without causing duplicate errors being emitted when the `Parser`
 // is dropped.

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -22,7 +22,7 @@ use rustc_errors::{
 use rustc_errors::{pluralize, struct_span_err, Diagnostic, EmissionGuarantee, ErrorGuaranteed};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::source_map::Spanned;
-use rustc_span::symbol::{kw, Ident};
+use rustc_span::symbol::{kw, sym, Ident};
 use rustc_span::{Span, SpanSnippetError, DUMMY_SP};
 use std::ops::{Deref, DerefMut};
 
@@ -602,15 +602,13 @@ impl<'a> Parser<'a> {
         self.last_unexpected_token_span = Some(self.token.span);
         let mut err = self.struct_span_err(self.token.span, &msg_exp);
 
-        if let TokenKind::Ident(symbol, _) = &self.prev_token.kind {
-            if symbol.as_str() == "public" {
-                err.span_suggestion_short(
-                    self.prev_token.span,
-                    "write `pub` instead of `public` to make the item public",
-                    "pub",
-                    appl,
-                );
-            }
+        if self.prev_token.is_ident_named(sym::public) && self.token.can_begin_item() {
+            err.span_suggestion_short(
+                self.prev_token.span,
+                "write `pub` instead of `public` to make the item public",
+                "pub",
+                appl,
+            );
         }
 
         // Add suggestion for a missing closing angle bracket if '>' is included in expected_tokens

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -1,5 +1,7 @@
 use super::attr::DEFAULT_INNER_ATTR_FORBIDDEN;
-use super::diagnostics::{AttemptLocalParseRecovery, Error};
+use super::diagnostics::{
+    AttemptLocalParseRecovery, Error, InvalidVariableDeclaration, InvalidVariableDeclarationSub,
+};
 use super::expr::LhsExpr;
 use super::pat::RecoverComma;
 use super::path::PathStyle;
@@ -58,28 +60,22 @@ impl<'a> Parser<'a> {
         if self.token.is_keyword(kw::Mut) && self.is_keyword_ahead(1, &[kw::Let]) {
             self.bump();
             let mut_let_span = lo.to(self.token.span);
-            self.struct_span_err(mut_let_span, "invalid variable declaration")
-                .span_suggestion(
-                    mut_let_span,
-                    "switch the order of `mut` and `let`",
-                    "let mut",
-                    Applicability::MaybeIncorrect,
-                )
-                .emit();
+            self.sess.emit_err(InvalidVariableDeclaration {
+                span: mut_let_span,
+                sub: InvalidVariableDeclarationSub::SwitchMutLetOrder(mut_let_span),
+            });
         }
 
         Ok(Some(if self.token.is_keyword(kw::Let) {
             self.parse_local_mk(lo, attrs, capture_semi, force_collect)?
         } else if self.is_kw_followed_by_ident(kw::Mut) {
-            self.recover_stmt_local(lo, attrs, "missing keyword", "let mut")?
+            self.recover_stmt_local(lo, attrs, InvalidVariableDeclarationSub::MissingLet)?
         } else if self.is_kw_followed_by_ident(kw::Auto) {
             self.bump(); // `auto`
-            let msg = "write `let` instead of `auto` to introduce a new variable";
-            self.recover_stmt_local(lo, attrs, msg, "let")?
+            self.recover_stmt_local(lo, attrs, InvalidVariableDeclarationSub::UseLetNotAuto)?
         } else if self.is_kw_followed_by_ident(sym::var) {
             self.bump(); // `var`
-            let msg = "write `let` instead of `var` to introduce a new variable";
-            self.recover_stmt_local(lo, attrs, msg, "let")?
+            self.recover_stmt_local(lo, attrs, InvalidVariableDeclarationSub::UseLetNotVar)?
         } else if self.check_path() && !self.token.is_qpath_start() && !self.is_path_start_item() {
             // We have avoided contextual keywords like `union`, items with `crate` visibility,
             // or `auto trait` items. We aim to parse an arbitrary path `a::b` but not something
@@ -217,13 +213,10 @@ impl<'a> Parser<'a> {
         &mut self,
         lo: Span,
         attrs: AttrWrapper,
-        msg: &str,
-        sugg: &str,
+        subdiagnostic: fn(Span) -> InvalidVariableDeclarationSub,
     ) -> PResult<'a, Stmt> {
         let stmt = self.recover_local_after_let(lo, attrs)?;
-        self.struct_span_err(lo, "invalid variable declaration")
-            .span_suggestion(lo, msg, sugg, Applicability::MachineApplicable)
-            .emit();
+        self.sess.emit_err(InvalidVariableDeclaration { span: lo, sub: subdiagnostic(lo) });
         Ok(stmt)
     }
 

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -9,6 +9,8 @@
     html_playground_url = "https://play.rust-lang.org/",
     test(attr(deny(warnings)))
 )]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 // We want to be able to build this crate with a stable compiler, so no
 // `#![feature]` attributes should be added.
 

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -7,6 +7,8 @@
 #![feature(rustc_attrs)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_serialize/src/lib.rs
+++ b/compiler/rustc_serialize/src/lib.rs
@@ -18,6 +18,8 @@ Core encoding and decoding interfaces.
 #![feature(new_uninit)]
 #![cfg_attr(test, feature(test))]
 #![allow(rustc::internal)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 pub use self::serialize::{Decodable, Decoder, Encodable, Encoder};
 

--- a/compiler/rustc_smir/src/lib.rs
+++ b/compiler/rustc_smir/src/lib.rs
@@ -11,6 +11,8 @@
     test(attr(allow(unused_variables), deny(warnings)))
 )]
 #![cfg_attr(not(feature = "default"), feature(rustc_private))]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 pub mod mir;
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -20,6 +20,8 @@
 #![feature(negative_impls)]
 #![feature(min_specialization)]
 #![feature(rustc_attrs)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1118,6 +1118,7 @@ symbols! {
         ptr_offset_from_unsigned,
         pub_macro_rules,
         pub_restricted,
+        public,
         pure,
         pushpop_unsafe,
         qreg,

--- a/compiler/rustc_target/src/lib.rs
+++ b/compiler/rustc_target/src/lib.rs
@@ -16,6 +16,8 @@
 #![feature(never_type)]
 #![feature(rustc_attrs)]
 #![feature(step_trait)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};

--- a/compiler/rustc_traits/src/lib.rs
+++ b/compiler/rustc_traits/src/lib.rs
@@ -1,6 +1,8 @@
 //! New recursive solver modeled on Chalk's recursive solver. Most of
 //! the guts are broken up into modules; see the comments in those modules.
 
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 #![feature(let_else)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2836,12 +2836,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
                     codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED;
                 }
                 Some(_) => {
-                    tcx.sess
-                        .struct_span_err(
-                            attr.span,
-                            "expected `used`, `used(compiler)` or `used(linker)`",
-                        )
-                        .emit();
+                    tcx.sess.emit_err(errors::ExpectedUsedSymbol { span: attr.span });
                 }
                 None => {
                     // Unfortunately, unconditionally using `llvm.used` causes

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -340,3 +340,10 @@ pub struct ExternCrateNotIdiomatic {
     pub msg_code: String,
     pub suggestion_code: String,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(typeck::expected_used_symbol)]
+pub struct ExpectedUsedSymbol {
+    #[primary_span]
+    pub span: Span,
+}

--- a/library/std/src/sys/sgx/abi/usercalls/tests.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/tests.rs
@@ -1,8 +1,8 @@
-use super::alloc::copy_to_userspace;
 use super::alloc::User;
+use super::alloc::{copy_from_userspace, copy_to_userspace};
 
 #[test]
-fn test_copy_function() {
+fn test_copy_to_userspace_function() {
     let mut src = [0u8; 100];
     let mut dst = User::<[u8]>::uninitialized(100);
 
@@ -23,6 +23,32 @@ fn test_copy_function() {
             for byte in 0..size {
                 unsafe {
                     assert_eq!(*dst.as_ptr().offset(offset + byte as isize), src[byte as usize]);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_copy_from_userspace_function() {
+    let mut dst = [0u8; 100];
+    let mut src = User::<[u8]>::uninitialized(100);
+
+    src.copy_from_enclave(&[0u8; 100]);
+
+    for size in 0..48 {
+        // For all possible alignment
+        for offset in 0..8 {
+            // overwrite complete dst
+            dst = [0u8; 100];
+
+            // Copy src[0..size] to dst + offset
+            unsafe { copy_from_userspace(src.as_ptr().offset(offset), dst.as_mut_ptr(), size) };
+
+            // Verify copy
+            for byte in 0..size {
+                unsafe {
+                    assert_eq!(dst[byte as usize], *src.as_ptr().offset(offset + byte as isize));
                 }
             }
         }

--- a/src/test/run-make/print-rustc-path/Makefile
+++ b/src/test/run-make/print-rustc-path/Makefile
@@ -1,0 +1,4 @@
+-include ../../run-make-fulldeps/tools.mk
+
+all:
+	$(RUSTC) -Zunstable-options --print rustc-path | $(CGREP) bin/rustc

--- a/src/test/ui/borrowck/issue-64453.stderr
+++ b/src/test/ui/borrowck/issue-64453.stderr
@@ -14,6 +14,7 @@ LL | static settings_dir: String = format!("");
    |                               ^^^^^^^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0507]: cannot move out of static item `settings_dir`

--- a/src/test/ui/check-static-values-constraints.stderr
+++ b/src/test/ui/check-static-values-constraints.stderr
@@ -22,6 +22,7 @@ LL |     field2: SafeEnum::Variant4("str".to_string())
    |                                      ^^^^^^^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-static-values-constraints.rs:94:5

--- a/src/test/ui/consts/issue-32829-2.stderr
+++ b/src/test/ui/consts/issue-32829-2.stderr
@@ -13,6 +13,7 @@ LL |         invalid();
    |         ^^^^^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error[E0015]: cannot call non-const fn `invalid` in statics
   --> $DIR/issue-32829-2.rs:54:9
@@ -21,6 +22,7 @@ LL |         invalid();
    |         ^^^^^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/mir_check_nonconst.stderr
+++ b/src/test/ui/consts/mir_check_nonconst.stderr
@@ -5,6 +5,7 @@ LL | static foo: Foo = bar();
    |                   ^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-16538.mir.stderr
+++ b/src/test/ui/issues/issue-16538.mir.stderr
@@ -5,6 +5,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-16538.rs:14:30

--- a/src/test/ui/issues/issue-16538.thir.stderr
+++ b/src/test/ui/issues/issue-16538.thir.stderr
@@ -21,6 +21,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-25901.stderr
+++ b/src/test/ui/issues/issue-25901.stderr
@@ -16,6 +16,7 @@ note: impl defined here, but it is not `const`
 LL | impl Deref for A {
    | ^^^^^^^^^^^^^^^^
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/public-instead-of-pub-1.fixed
+++ b/src/test/ui/parser/public-instead-of-pub-1.fixed
@@ -1,0 +1,11 @@
+// Checks what happens when `public` is used instead of the correct, `pub`
+// run-rustfix
+
+pub enum Test {
+    //~^ ERROR expected one of `!` or `::`, found keyword `enum`
+    //~^^ HELP write `pub` instead of `public` to make the item public
+    A,
+    B,
+}
+
+fn main() { }

--- a/src/test/ui/parser/public-instead-of-pub-1.rs
+++ b/src/test/ui/parser/public-instead-of-pub-1.rs
@@ -1,0 +1,11 @@
+// Checks what happens when `public` is used instead of the correct, `pub`
+// run-rustfix
+
+public enum Test {
+    //~^ ERROR expected one of `!` or `::`, found keyword `enum`
+    //~^^ HELP write `pub` instead of `public` to make the item public
+    A,
+    B,
+}
+
+fn main() { }

--- a/src/test/ui/parser/public-instead-of-pub-1.stderr
+++ b/src/test/ui/parser/public-instead-of-pub-1.stderr
@@ -1,0 +1,13 @@
+error: expected one of `!` or `::`, found keyword `enum`
+  --> $DIR/public-instead-of-pub-1.rs:4:8
+   |
+LL | public enum Test {
+   |        ^^^^ expected one of `!` or `::`
+   |
+help: write `pub` instead of `public` to make the item public
+   |
+LL | pub enum Test {
+   | ~~~
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/public-instead-of-pub-2.rs
+++ b/src/test/ui/parser/public-instead-of-pub-2.rs
@@ -1,0 +1,7 @@
+// Checks what happens when `public` is used instead of the correct, `pub`
+// Won't give help message for this case
+
+public let x = 1;
+//~^ ERROR expected one of `!` or `::`, found keyword `let`
+
+fn main() { }

--- a/src/test/ui/parser/public-instead-of-pub-2.stderr
+++ b/src/test/ui/parser/public-instead-of-pub-2.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found keyword `let`
+  --> $DIR/public-instead-of-pub-2.rs:4:8
+   |
+LL | public let x = 1;
+   |        ^^^ expected one of `!` or `::`
+
+error: aborting due to previous error
+

--- a/src/test/ui/static/static-vec-repeat-not-constant.stderr
+++ b/src/test/ui/static/static-vec-repeat-not-constant.stderr
@@ -5,6 +5,7 @@ LL | static a: [isize; 2] = [foo(); 2];
    |                         ^^^^^
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #100188 (Parser will not suggest invalid expression when use public)
 - #100383 (Mitigate stale data reads on SGX platform)
 - #100507 (suggest `once_cell::Lazy` for non-const statics)
 - #100667 (Migrate "invalid variable declaration" errors to SessionDiagnostic)
 - #100681 (Add `rustc --print rustc-path`)
 - #100709 (Migrate typeck's `used` expected symbol diagnostic to `SessionDiagnostic`)
 - #100723 (Add the diagnostic translation lints to crates that don't emit them)
 - #100724 (Migrate ast lowering to session diagnostic)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100188,100383,100507,100667,100681,100709,100723,100724)
<!-- homu-ignore:end -->