### PR TITLE
Use separate infcx to solve obligations during negative coherence

### DIFF
--- a/src/test/ui/coherence/coherence-negative-outlives-lifetimes.rs
+++ b/src/test/ui/coherence/coherence-negative-outlives-lifetimes.rs
@@ -1,10 +1,15 @@
+// revisions: stock with_negative_coherence
 #![feature(negative_impls)]
+#![cfg_attr(with_negative_coherence, feature(with_negative_coherence))]
 
 // FIXME: this should compile
 
 trait MyPredicate<'a> {}
-impl<'a, T> !MyPredicate<'a> for &T where T: 'a {}
+
+impl<'a, T> !MyPredicate<'a> for &'a T where T: 'a {}
+
 trait MyTrait<'a> {}
+
 impl<'a, T: MyPredicate<'a>> MyTrait<'a> for T {}
 impl<'a, T> MyTrait<'a> for &'a T {}
 //~^ ERROR: conflicting implementations of trait `MyTrait<'_>` for type `&_`

--- a/src/test/ui/coherence/coherence-negative-outlives-lifetimes.stock.stderr
+++ b/src/test/ui/coherence/coherence-negative-outlives-lifetimes.stock.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `MyTrait<'_>` for type `&_`
-  --> $DIR/coherence-negative-outlives-lifetimes.rs:9:1
+  --> $DIR/coherence-negative-outlives-lifetimes.rs:14:1
    |
 LL | impl<'a, T: MyPredicate<'a>> MyTrait<'a> for T {}
    | ---------------------------------------------- first implementation here

--- a/src/test/ui/coherence/coherence-negative-outlives-lifetimes.with_negative_coherence.stderr
+++ b/src/test/ui/coherence/coherence-negative-outlives-lifetimes.with_negative_coherence.stderr
@@ -1,0 +1,11 @@
+error[E0119]: conflicting implementations of trait `MyTrait<'_>` for type `&_`
+  --> $DIR/coherence-negative-outlives-lifetimes.rs:14:1
+   |
+LL | impl<'a, T: MyPredicate<'a>> MyTrait<'a> for T {}
+   | ---------------------------------------------- first implementation here
+LL | impl<'a, T> MyTrait<'a> for &'a T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `&_`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
I feel like I fixed this already but I may have fixed it then forgot to push the branch...

Also fixes up some redundant param-envs being passed around (since they're already passed around in the `Obligation`)

Fixes #99662

r? @spastorino