### PR TITLE
update cc dependency to 1.0.73

### DIFF
--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -8,7 +8,7 @@ test = false
 
 [dependencies]
 bitflags = "1.2.1"
-cc = "1.0.69"
+cc = "1.0.73"
 itertools = "0.10.1"
 tracing = "0.1"
 libc = "0.2.50"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -11,4 +11,4 @@ emscripten = []
 libc = "0.2.73"
 
 [build-dependencies]
-cc = "1.0.69"
+cc = "1.0.73"

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -13,4 +13,4 @@ core = { path = "../core" }
 compiler_builtins = { version = "0.1.0", features = ['rustc-dep-of-std'] }
 
 [build-dependencies]
-cc = "1.0.69"
+cc = "1.0.73"

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -20,7 +20,7 @@ compiler_builtins = "0.1.0"
 cfg-if = "0.1.8"
 
 [build-dependencies]
-cc = "1.0.69"
+cc = "1.0.73"
 
 [features]
 

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -39,7 +39,7 @@ cmake = "0.1.38"
 fd-lock = "3.0.6"
 filetime = "0.2"
 getopts = "0.2.19"
-cc = "1.0.69"
+cc = "1.0.73"
 libc = "0.2"
 hex = "0.4"
 serde = { version = "1.0.8", features = ["derive"] }


### PR DESCRIPTION
update the `cc` dependency to latest 1.0.73 version.

it will help OpenBSD to build out-of-box on riscv64 architecture (and should also help FreeBSD).