### PR TITLE
Fix search results color on hover for ayu theme

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -89,12 +89,13 @@ pre, .rustdoc.source .example-wrap {
 }
 
 .search-results a:hover {
-	background-color: #777;
+	color: #fff !important;
+	background-color: #3c3c3c;
 }
 
 .search-results a:focus {
-	color: #000 !important;
-	background-color: #c6afb3;
+	color: #fff !important;
+	background-color: #3c3c3c;
 }
 .search-results a {
 	color: #0096cf;

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -29,6 +29,23 @@ assert-css: (
     {"color": "rgb(120, 135, 151)"},
 )
 
+// Checking the `<a>` container.
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+
+// Checking color and background on hover.
+move-cursor-to: "//*[@class='desc']//*[text()='Just a normal struct.']"
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(255, 255, 255)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+
 // Dark theme
 local-storage: {
     "rustdoc-theme": "dark",
@@ -54,6 +71,23 @@ assert-css: (
     {"color": "rgb(221, 221, 221)"},
 )
 
+// Checking the `<a>` container.
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+
+// Checking color and background on hover.
+move-cursor-to: "//*[@class='desc']//*[text()='Just a normal struct.']"
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(221, 221, 221)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(119, 119, 119)"},
+)
+
 // Light theme
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 reload:
@@ -73,6 +107,23 @@ assert-css: (
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
     {"color": "rgb(0, 0, 0)"},
+)
+
+// Checking the `<a>` container.
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+
+// Checking color and background on hover.
+move-cursor-to: "//*[@class='desc']//*[text()='Just a normal struct.']"
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(0, 0, 0)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(221, 221, 221)"},
 )
 
 // Check the alias more specifically in the dark theme.


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3050060/185747851-038d2333-8b01-44a8-a104-ceb7410ac089.png)

After:

![image](https://user-images.githubusercontent.com/3050060/185747869-53b502f5-5800-470f-b897-2683f1cdb7ee.png)

You can test it [here](https://rustdoc.crud.net/imperio/search-results-color-ayu/foo/index.html?search=item).

r? @jsha