### PR TITLE
Fix wrong compiletest filters on Windows

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1514,7 +1514,15 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         test_args.append(&mut builder.config.cmd.test_args());
 
-        cmd.args(&test_args);
+        // On Windows, replace forward slashes in test-args by backslashes
+        // so the correct filters are passed to libtest
+        if cfg!(windows) {
+            let test_args_win: Vec<String> =
+                test_args.iter().map(|s| s.replace("/", "\\")).collect();
+            cmd.args(&test_args_win);
+        } else {
+            cmd.args(&test_args);
+        }
 
         if builder.is_verbose() {
             cmd.arg("--verbose");


### PR DESCRIPTION
As discussed in [#79334](https://github.com/rust-lang/rust/issues/79334), when calling e.g.
```
python x.py test src/test/ui/expr/compound-assignment/eval-order.rs
```
on Windows, compiletest passes the filter `expr/compound-assignment/eval-order.rs` to libtest, which instead should be `expr\compound-assignment\eval-order.rs`, as that is the file found when collecting tests. This is what I fixed.

I'm not sure how to organize a test for this. Any suggestions?