### PR TITLE
Add `/build-rust-analyzer/` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ no_llvm_build
 /llvm/
 /mingw-build/
 /build/
+/build-rust-analyzer/
 /dist/
 /unicode-downloads
 /target


### PR DESCRIPTION
To avoid rust-analyzer and rustc having to wait for each other, the [dev guide](https://rustc-dev-guide.rust-lang.org/building/suggested.html#configuring-rust-analyzer-for-rustc) mentions using another build directory for RA.

We should also put this into the .gitignore, just like the normal `build`.