### PR TITLE
sugg: suggest the usage of boolean value when there is a typo in the keyword

### DIFF
--- a/src/test/ui/suggestions/bool_typo_err_suggest.rs
+++ b/src/test/ui/suggestions/bool_typo_err_suggest.rs
@@ -1,0 +1,12 @@
+// Suggest the boolean value instead of emit a generic error that the value
+// True is not in the scope.
+
+fn main() {
+    let x = True;
+    //~^ ERROR cannot find value `True` in this scope
+    //~| HELP you may want to use a bool value instead
+
+    let y = False;
+    //~^ ERROR cannot find value `False` in this scope
+    //~| HELP you may want to use a bool value instead
+}

--- a/src/test/ui/suggestions/bool_typo_err_suggest.stderr
+++ b/src/test/ui/suggestions/bool_typo_err_suggest.stderr
@@ -1,0 +1,25 @@
+error[E0425]: cannot find value `True` in this scope
+  --> $DIR/bool_typo_err_suggest.rs:5:13
+   |
+LL |     let x = True;
+   |             ^^^^ not found in this scope
+   |
+help: you may want to use a bool value instead
+   |
+LL |     let x = true;
+   |             ~~~~
+
+error[E0425]: cannot find value `False` in this scope
+  --> $DIR/bool_typo_err_suggest.rs:9:13
+   |
+LL |     let y = False;
+   |             ^^^^^ not found in this scope
+   |
+help: you may want to use a bool value instead
+   |
+LL |     let y = false;
+   |             ~~~~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/100686

This adds a new suggestion when there is a well-known typo

With the following program

```rust
fn main() {
    let x = True;
}
```

Now we have the following suggestion

```
error[E0425]: cannot find value `True` in this scope
 --> test.rs:2:13
  |
2 |     let x = True;
  |             ^^^^ not found in this scope
  |
help: you may want to use a bool value instead
  |
2 |     let x = true;
  |             ~~~~

error: aborting due to previous error
```


Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>