### PR TITLE
sugg: take into count the debug formatting

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -865,9 +865,14 @@ pub trait LintContext: Sized {
 
                     if let Some(positional_arg_to_replace) = position_sp_to_replace {
                         let name = if is_formatting_arg { named_arg_name + "$" } else { named_arg_name };
-
+                        let span_to_replace = if let Ok(positional_arg_content) =
+                            self.sess().source_map().span_to_snippet(positional_arg_to_replace) && positional_arg_content.starts_with(":") {
+                            positional_arg_to_replace.shrink_to_lo()
+                        } else {
+                            positional_arg_to_replace
+                        };
                         db.span_suggestion_verbose(
-                            positional_arg_to_replace,
+                            span_to_replace,
                             "use the named argument by name to avoid ambiguity",
                             name,
                             Applicability::MaybeIncorrect,

--- a/src/test/ui/suggestions/sugg_with_positional_args_and_debug_fmt.rs
+++ b/src/test/ui/suggestions/sugg_with_positional_args_and_debug_fmt.rs
@@ -1,0 +1,10 @@
+// When build the suggesttion take in consideration the `:?`
+// https://github.com/rust-lang/rust/issues/100648
+#![deny(warnings)]
+
+fn main () {
+    println!("hello {:?}", world = "world");
+    //~^ ERROR named argument `world` is not used by name
+    //~| HELP use the named argument by name to avoid ambiguity
+    //~| SUGGESTION world
+}

--- a/src/test/ui/suggestions/sugg_with_positional_args_and_debug_fmt.stderr
+++ b/src/test/ui/suggestions/sugg_with_positional_args_and_debug_fmt.stderr
@@ -1,0 +1,21 @@
+error: named argument `world` is not used by name
+  --> $DIR/sugg_with_positional_args_and_debug_fmt.rs:6:28
+   |
+LL |     println!("hello {:?}", world = "world");
+   |                     ----   ^^^^^ this named argument is referred to by position in formatting string
+   |                     |
+   |                     this formatting argument uses named argument `world` by position
+   |
+note: the lint level is defined here
+  --> $DIR/sugg_with_positional_args_and_debug_fmt.rs:3:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(named_arguments_used_positionally)]` implied by `#[deny(warnings)]`
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("hello {world:?}", world = "world");
+   |                      +++++
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/100648

This PR will fix a suggestion error by taking into consideration also the `:?` symbol and act in a different way

@rustbot r? @compiler-errors

N.B: I did not find a full way to test the change, any idea?