### PR TITLE
Suggest moving redundant generic args of an assoc fn to its trait

### DIFF
--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -697,7 +697,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                         num_trait_generics_except_self
                     )
                 },
-                // TODO(hkmatsumoto): Emit similar suggestion for "x.<assoc fn>()"
+                // FIXME(hkmatsumoto): Emit similar suggestion for "x.<assoc fn>()"
                 hir::ExprKind::MethodCall(..) => return,
                 _ => return,
             }

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -2,15 +2,22 @@ error[E0107]: this associated function takes 0 generic arguments but 1 generic a
   --> $DIR/invalid-const-arg-for-type-param.rs:6:23
    |
 LL |     let _: u32 = 5i32.try_into::<32>().unwrap();
-   |                       ^^^^^^^^------ help: remove these generics
-   |                       |
-   |                       expected 0 generic arguments
+   |                       ^^^^^^^^ expected 0 generic arguments
    |
 note: associated function defined here, with 0 generic parameters
   --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    |
 LL |     fn try_into(self) -> Result<T, Self::Error>;
    |        ^^^^^^^^
+help: consider moving this generic argument to the `TryInto` trait, which takes up to 1 argument
+   |
+LL |     let _: u32 = TryInto::<32>::try_into(5i32).unwrap();
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+help: remove these generics
+   |
+LL -     let _: u32 = 5i32.try_into::<32>().unwrap();
+LL +     let _: u32 = 5i32.try_into().unwrap();
+   |
 
 error[E0599]: no method named `f` found for struct `S` in the current scope
   --> $DIR/invalid-const-arg-for-type-param.rs:9:7

--- a/src/test/ui/suggestions/issue-89064.rs
+++ b/src/test/ui/suggestions/issue-89064.rs
@@ -24,9 +24,7 @@ fn main() {
     //~| HELP remove these generics
     //~| HELP consider moving these generic arguments
 
-    // bad suggestion
     let _ = A::<S>::foo::<S>();
     //~^ ERROR
     //~| HELP remove these generics
-    //~| HELP consider moving this generic argument
 }

--- a/src/test/ui/suggestions/issue-89064.rs
+++ b/src/test/ui/suggestions/issue-89064.rs
@@ -27,4 +27,9 @@ fn main() {
     let _ = A::<S>::foo::<S>();
     //~^ ERROR
     //~| HELP remove these generics
+
+    let _ = 42.into::<Option<_>>();
+    //~^ ERROR
+    //~| HELP remove these generics
+    //~| HELP consider moving this generic argument
 }

--- a/src/test/ui/suggestions/issue-89064.rs
+++ b/src/test/ui/suggestions/issue-89064.rs
@@ -1,0 +1,32 @@
+use std::convert::TryInto;
+
+trait A<T> {
+    fn foo() {}
+}
+
+trait B<T, U> {
+    fn bar() {}
+}
+
+struct S;
+
+impl<T> A<T> for S {}
+impl<T, U> B<T, U> for S {}
+
+fn main() {
+    let _ = A::foo::<S>();
+    //~^ ERROR
+    //~| HELP remove these generics
+    //~| HELP consider moving this generic argument
+
+    let _ = B::bar::<S, S>();
+    //~^ ERROR
+    //~| HELP remove these generics
+    //~| HELP consider moving these generic arguments
+
+    // bad suggestion
+    let _ = A::<S>::foo::<S>();
+    //~^ ERROR
+    //~| HELP remove these generics
+    //~| HELP consider moving this generic argument
+}

--- a/src/test/ui/suggestions/issue-89064.stderr
+++ b/src/test/ui/suggestions/issue-89064.stderr
@@ -9,15 +9,15 @@ note: associated function defined here, with 0 generic parameters
    |
 LL |     fn foo() {}
    |        ^^^
-help: remove these generics
-   |
-LL -     let _ = A::foo::<S>();
-LL +     let _ = A::foo();
-   |
 help: consider moving this generic argument to the `A` trait, which takes up to 1 argument
    |
 LL -     let _ = A::foo::<S>();
 LL +     let _ = A::<S>::foo();
+   |
+help: remove these generics
+   |
+LL -     let _ = A::foo::<S>();
+LL +     let _ = A::foo();
    |
 
 error[E0107]: this associated function takes 0 generic arguments but 2 generic arguments were supplied
@@ -31,15 +31,15 @@ note: associated function defined here, with 0 generic parameters
    |
 LL |     fn bar() {}
    |        ^^^
-help: remove these generics
-   |
-LL -     let _ = B::bar::<S, S>();
-LL +     let _ = B::bar();
-   |
 help: consider moving these generic arguments to the `B` trait, which takes up to 2 arguments
    |
 LL -     let _ = B::bar::<S, S>();
 LL +     let _ = B::<S, S>::bar();
+   |
+help: remove these generics
+   |
+LL -     let _ = B::bar::<S, S>();
+LL +     let _ = B::bar();
    |
 
 error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
@@ -56,6 +56,27 @@ note: associated function defined here, with 0 generic parameters
 LL |     fn foo() {}
    |        ^^^
 
-error: aborting due to 3 previous errors
+error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-89064.rs:31:16
+   |
+LL |     let _ = 42.into::<Option<_>>();
+   |                ^^^^ expected 0 generic arguments
+   |
+note: associated function defined here, with 0 generic parameters
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn into(self) -> T;
+   |        ^^^^
+help: consider moving this generic argument to the `Into` trait, which takes up to 1 argument
+   |
+LL |     let _ = Into::<Option<_>>::into(42);
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+help: remove these generics
+   |
+LL -     let _ = 42.into::<Option<_>>();
+LL +     let _ = 42.into();
+   |
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/suggestions/issue-89064.stderr
+++ b/src/test/ui/suggestions/issue-89064.stderr
@@ -43,26 +43,18 @@ LL +     let _ = B::<S, S>::bar();
    |
 
 error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/issue-89064.rs:28:21
+  --> $DIR/issue-89064.rs:27:21
    |
 LL |     let _ = A::<S>::foo::<S>();
-   |                     ^^^ expected 0 generic arguments
+   |                     ^^^----- help: remove these generics
+   |                     |
+   |                     expected 0 generic arguments
    |
 note: associated function defined here, with 0 generic parameters
   --> $DIR/issue-89064.rs:4:8
    |
 LL |     fn foo() {}
    |        ^^^
-help: remove these generics
-   |
-LL -     let _ = A::<S>::foo::<S>();
-LL +     let _ = A::<S>::foo();
-   |
-help: consider moving this generic argument to the `A` trait, which takes up to 1 argument
-   |
-LL -     let _ = A::<S>::foo::<S>();
-LL +     let _ = A::<S>::<S>::foo();
-   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/issue-89064.stderr
+++ b/src/test/ui/suggestions/issue-89064.stderr
@@ -1,0 +1,69 @@
+error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-89064.rs:17:16
+   |
+LL |     let _ = A::foo::<S>();
+   |                ^^^ expected 0 generic arguments
+   |
+note: associated function defined here, with 0 generic parameters
+  --> $DIR/issue-89064.rs:4:8
+   |
+LL |     fn foo() {}
+   |        ^^^
+help: remove these generics
+   |
+LL -     let _ = A::foo::<S>();
+LL +     let _ = A::foo();
+   |
+help: consider moving this generic argument to the `A` trait, which takes up to 1 argument
+   |
+LL -     let _ = A::foo::<S>();
+LL +     let _ = A::<S>::foo();
+   |
+
+error[E0107]: this associated function takes 0 generic arguments but 2 generic arguments were supplied
+  --> $DIR/issue-89064.rs:22:16
+   |
+LL |     let _ = B::bar::<S, S>();
+   |                ^^^ expected 0 generic arguments
+   |
+note: associated function defined here, with 0 generic parameters
+  --> $DIR/issue-89064.rs:8:8
+   |
+LL |     fn bar() {}
+   |        ^^^
+help: remove these generics
+   |
+LL -     let _ = B::bar::<S, S>();
+LL +     let _ = B::bar();
+   |
+help: consider moving these generic arguments to the `B` trait, which takes up to 2 arguments
+   |
+LL -     let _ = B::bar::<S, S>();
+LL +     let _ = B::<S, S>::bar();
+   |
+
+error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-89064.rs:28:21
+   |
+LL |     let _ = A::<S>::foo::<S>();
+   |                     ^^^ expected 0 generic arguments
+   |
+note: associated function defined here, with 0 generic parameters
+  --> $DIR/issue-89064.rs:4:8
+   |
+LL |     fn foo() {}
+   |        ^^^
+help: remove these generics
+   |
+LL -     let _ = A::<S>::foo::<S>();
+LL +     let _ = A::<S>::foo();
+   |
+help: consider moving this generic argument to the `A` trait, which takes up to 1 argument
+   |
+LL -     let _ = A::<S>::foo::<S>();
+LL +     let _ = A::<S>::<S>::foo();
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Closes #89064