### PR TITLE
Use internal iteration in `Iterator` comparison methods

### DIFF
--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -364,6 +364,13 @@ fn bench_partial_cmp(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_chain_partial_cmp(b: &mut Bencher) {
+    b.iter(|| {
+        (0..50000).chain(50000..100000).map(black_box).partial_cmp((0..100000).map(black_box))
+    })
+}
+
+#[bench]
 fn bench_lt(b: &mut Bencher) {
     b.iter(|| (0..100000).map(black_box).lt((0..100000).map(black_box)))
 }


### PR DESCRIPTION
Updates the `Iterator` methods `cmp_by`, `partial_cmp_by`, and `eq_by` to use internal iteration on `self`. I've also extracted their shared logic into a private helper function `iter_compare`, which will either short-circuit once the comparison result is known or return the comparison of the lengths of the iterators.

This change also indirectly benefits calls to `cmp`, `partial_cmp`, `eq`, `lt`, `le`, `gt`, and `ge`.

Unsurprising benchmark results: iterators that benefit from internal iteration (like `Chain`) see a speedup, while other iterators are unaffected.
```
 name                           before ns/iter  after ns/iter  diff ns/iter   diff %  speedup 
 iter::bench_chain_partial_cmp  208,301         54,978             -153,323  -73.61%   x 3.79 
 iter::bench_partial_cmp        55,527          55,702                  175    0.32%   x 1.00 
 iter::bench_lt                 55,502          55,322                 -180   -0.32%   x 1.00 
```