### PR TITLE
Improve performance of stable sort

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -822,90 +822,6 @@ where
     merge_sort(v, &mut is_less);
 }
 
-// Sort a small number of elements as fast as possible, without allocations.
-#[cfg(not(no_global_oom_handling))]
-fn stable_sort_small<T, F>(v: &mut [T], is_less: &mut F)
-where
-    F: FnMut(&T, &T) -> bool,
-{
-    let len = v.len();
-
-    // This implementation is really not fit for anything beyond that, and the call is probably a
-    // bug.
-    debug_assert!(len <= 40);
-
-    if len < 2 {
-        return;
-    }
-
-    // It's not clear that using custom code for specific sizes is worth it here.
-    // So we go with the simpler code.
-    let offset = if len <= 6 || !qualifies_for_branchless_sort::<T>() {
-        1
-    } else {
-        // Once a certain threshold is reached, it becomes worth it to analyze the input and do
-        // branchless swapping for the first 5 elements.
-
-        // SAFETY: We just checked that len >= 5
-        unsafe {
-            let arr_ptr = v.as_mut_ptr();
-
-            let should_swap_0_1 = is_less(&*arr_ptr.add(1), &*arr_ptr.add(0));
-            let should_swap_1_2 = is_less(&*arr_ptr.add(2), &*arr_ptr.add(1));
-            let should_swap_2_3 = is_less(&*arr_ptr.add(3), &*arr_ptr.add(2));
-            let should_swap_3_4 = is_less(&*arr_ptr.add(4), &*arr_ptr.add(3));
-
-            let swap_count = should_swap_0_1 as usize
-                + should_swap_1_2 as usize
-                + should_swap_2_3 as usize
-                + should_swap_3_4 as usize;
-
-            if swap_count == 0 {
-                // Potentially already sorted. No need to swap, we know the first 5 elements are
-                // already in the right order.
-                5
-            } else if swap_count == 4 {
-                // Potentially reversed.
-                let mut rev_i = 4;
-                while rev_i < (len - 1) {
-                    if !is_less(&*arr_ptr.add(rev_i + 1), &*arr_ptr.add(rev_i)) {
-                        break;
-                    }
-                    rev_i += 1;
-                }
-                rev_i += 1;
-                v[..rev_i].reverse();
-                insertion_sort_shift_left(v, rev_i, is_less);
-                return;
-            } else {
-                // Potentially random pattern.
-                branchless_swap(arr_ptr.add(0), arr_ptr.add(1), should_swap_0_1);
-                branchless_swap(arr_ptr.add(2), arr_ptr.add(3), should_swap_2_3);
-
-                if len >= 12 {
-                    // This aims to find a good balance between generating more code, which is bad
-                    // for cold loops and improving hot code while not increasing mean comparison
-                    // count too much.
-                    sort8_stable(&mut v[4..12], is_less);
-                    insertion_sort_shift_left(&mut v[4..], 8, is_less);
-                    insertion_sort_shift_right(v, 4, is_less);
-                    return;
-                } else {
-                    // Complete the sort network for the first 4 elements.
-                    swap_next_if_less(arr_ptr.add(1), is_less);
-                    swap_next_if_less(arr_ptr.add(2), is_less);
-                    swap_next_if_less(arr_ptr.add(0), is_less);
-                    swap_next_if_less(arr_ptr.add(1), is_less);
-
-                    4
-                }
-            }
-        }
-    };
-
-    insertion_sort_shift_left(v, offset, is_less);
-}
-
 #[cfg(not(no_global_oom_handling))]
 fn merge_sort<T, F>(v: &mut [T], is_less: &mut F)
 where
@@ -918,12 +834,7 @@ where
 
     let len = v.len();
 
-    // Slices of up to this length get sorted using insertion sort.
-    const MAX_NO_ALLOC_SIZE: usize = 20;
-
-    // Short arrays get sorted in-place via insertion sort to avoid allocations.
-    if len <= MAX_NO_ALLOC_SIZE {
-        stable_sort_small(v, is_less);
+    if len < 2 {
         return;
     }
 
@@ -963,6 +874,11 @@ where
             // return without allocating.
             return;
         } else if buf_ptr.is_null() {
+            // Short arrays get sorted in-place via insertion sort to avoid allocations.
+            if sort_small_stable(v, start, is_less) {
+                return;
+            }
+
             // Allocate a buffer to use as scratch memory. We keep the length 0 so we can keep in it
             // shallow copies of the contents of `v` without risking the dtors running on copies if
             // `is_less` panics. When merging two sorted runs, this buffer holds a copy of the
@@ -1016,11 +932,7 @@ where
                 || (n >= 3 && runs[n - 3].len <= runs[n - 2].len + runs[n - 1].len)
                 || (n >= 4 && runs[n - 4].len <= runs[n - 3].len + runs[n - 2].len))
         {
-            if n >= 3 && runs[n - 3].len < runs[n - 1].len {
-                Some(n - 3)
-            } else {
-                Some(n - 2)
-            }
+            if n >= 3 && runs[n - 3].len < runs[n - 1].len { Some(n - 3) } else { Some(n - 2) }
         } else {
             None
         }
@@ -1033,6 +945,67 @@ where
     }
 }
 
+/// Check whether `v` applies for small sort optimization.
+/// `v[start..]` is assumed already sorted.
+#[cfg(not(no_global_oom_handling))]
+fn sort_small_stable<T, F>(v: &mut [T], start: usize, is_less: &mut F) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    let len = v.len();
+
+    if qualifies_for_branchless_sort::<T>() {
+        // Testing showed that even though this incurs more comparisons, up to size 32 (4 * 8),
+        // avoiding the allocation and sticking with simple code is worth it. Going further eg. 40
+        // is still worth it for u64 or even types with more expensive comparisons, but risks
+        // incurring just too many comparisons than doing the regular TimSort.
+        const MAX_NO_ALLOC_SIZE: usize = 32;
+        if len <= MAX_NO_ALLOC_SIZE {
+            if len < 8 {
+                insertion_sort_shift_right(v, start, is_less);
+                return true;
+            }
+
+            let mut merge_count = 0;
+            for chunk in v.chunks_exact_mut(8) {
+                // SAFETY: chunks_exact_mut promised to give us slices of len 8.
+                unsafe {
+                    sort8_stable(chunk, is_less);
+                }
+                merge_count += 1;
+            }
+
+            let mut swap = mem::MaybeUninit::<[T; 8]>::uninit();
+            let swap_ptr = swap.as_mut_ptr() as *mut T;
+
+            let mut i = 8;
+            while merge_count > 1 {
+                // SAFETY: We know the smaller side will be of size 8 because mid is 8. And both
+                // sides are non empty because of merge_count, and the right side will always be of
+                // size 8 and the left size of 8 or greater. Thus the smaller side will always be
+                // exactly 8 long, the size of swap.
+                unsafe {
+                    merge(&mut v[0..(i + 8)], i, swap_ptr, is_less);
+                }
+                i += 8;
+                merge_count -= 1;
+            }
+
+            insertion_sort_shift_left(v, i, is_less);
+
+            return true;
+        }
+    } else {
+        const MAX_NO_ALLOC_SIZE: usize = 20;
+        if len <= MAX_NO_ALLOC_SIZE {
+            insertion_sort_shift_right(v, start, is_less);
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Takes a range as denoted by start and end, that is already sorted and extends it if necessary
 /// with sorts optimized for smaller ranges such as insertion sort.
 #[cfg(not(no_global_oom_handling))]
@@ -1042,8 +1015,7 @@ where
 {
     debug_assert!(end > start);
 
-    // Testing showed that using MAX_INSERTION here yields the best performance for many types, but
-    // incurs more total comparisons. A balance between least comparisons and best performance, as
+    // This value is a balance between least comparisons and best performance, as
     // influenced by for example cache locality.
     const MIN_INSERTION_RUN: usize = 10;
 
@@ -1115,6 +1087,7 @@ impl<T> Drop for InsertionHole<T> {
 
 /// Inserts `v[v.len() - 1]` into pre-sorted sequence `v[..v.len() - 1]` so that whole `v[..]`
 /// becomes sorted.
+#[cfg(not(no_global_oom_handling))]
 unsafe fn insert_tail<T, F>(v: &mut [T], is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
@@ -1167,11 +1140,12 @@ where
     }
 }
 
-/// Sort v assuming v[..offset] is already sorted.
+/// Sort `v` assuming `v[..offset]` is already sorted.
 ///
 /// Never inline this function to avoid code bloat. It still optimizes nicely and has practically no
 /// performance impact. Even improving performance in some cases.
 #[inline(never)]
+#[cfg(not(no_global_oom_handling))]
 fn insertion_sort_shift_left<T, F>(v: &mut [T], offset: usize, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
@@ -1195,11 +1169,12 @@ where
     }
 }
 
-/// Sort v assuming v[offset..] is already sorted.
+/// Sort `v` assuming `v[offset..]` is already sorted.
 ///
 /// Never inline this function to avoid code bloat. It still optimizes nicely and has practically no
 /// performance impact. Even improving performance in some cases.
 #[inline(never)]
+#[cfg(not(no_global_oom_handling))]
 fn insertion_sort_shift_right<T, F>(v: &mut [T], offset: usize, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
@@ -1227,6 +1202,7 @@ where
 /// Inserts `v[0]` into pre-sorted sequence `v[1..]` so that whole `v[..]` becomes sorted.
 ///
 /// This is the integral subroutine of insertion sort.
+#[cfg(not(no_global_oom_handling))]
 unsafe fn insert_head<T, F>(v: &mut [T], is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
@@ -1287,6 +1263,10 @@ where
 ///
 /// The two slices must be non-empty and `mid` must be in bounds. Buffer `buf` must be long enough
 /// to hold a copy of the shorter slice. Also, `T` must not be a zero-sized type.
+///
+/// Never inline this function to avoid code bloat. It still optimizes nicely and has practically no
+/// performance impact.
+#[inline(never)]
 #[cfg(not(no_global_oom_handling))]
 unsafe fn merge<T, F>(v: &mut [T], mid: usize, buf: *mut T, is_less: &mut F)
 where
@@ -1506,6 +1486,7 @@ where
 /// Never inline this function to avoid code bloat. It still optimizes nicely and has practically no
 /// performance impact.
 #[inline(never)]
+#[cfg(not(no_global_oom_handling))]
 unsafe fn sort8_stable<T, F>(v: &mut [T], is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
@@ -1559,6 +1540,7 @@ where
     }
 }
 
+#[cfg(not(no_global_oom_handling))]
 unsafe fn sort24_stable<T, F>(v: &mut [T], is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -1072,11 +1072,13 @@ where
 }
 
 // When dropped, copies from `src` into `dest`.
+#[cfg(not(no_global_oom_handling))]
 struct InsertionHole<T> {
     src: *const T,
     dest: *mut T,
 }
 
+#[cfg(not(no_global_oom_handling))]
 impl<T> Drop for InsertionHole<T> {
     fn drop(&mut self) {
         unsafe {
@@ -1398,6 +1400,7 @@ impl<T: IsCopyMarker> IsCopy for T {
 }
 
 #[inline]
+#[cfg(not(no_global_oom_handling))]
 fn qualifies_for_branchless_sort<T>() -> bool {
     // This is a heuristic, and as such it will guess wrong from time to time. The two parts broken
     // down:
@@ -1416,6 +1419,7 @@ fn qualifies_for_branchless_sort<T>() -> bool {
 
 /// Swap two values in array pointed to by a_ptr and b_ptr if b is less than a.
 #[inline]
+#[cfg(not(no_global_oom_handling))]
 unsafe fn branchless_swap<T>(a_ptr: *mut T, b_ptr: *mut T, should_swap: bool) {
     // This is a branchless version of swap if.
     // The equivalent code with a branch would be:
@@ -1443,6 +1447,7 @@ unsafe fn branchless_swap<T>(a_ptr: *mut T, b_ptr: *mut T, should_swap: bool) {
 
 /// Swap two values in array pointed to by a_ptr and b_ptr if b is less than a.
 #[inline]
+#[cfg(not(no_global_oom_handling))]
 unsafe fn swap_if_less<T, F>(arr_ptr: *mut T, a: usize, b: usize, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
@@ -1470,6 +1475,7 @@ where
 /// Comparing and swapping anything but adjacent elements will yield a non stable sort.
 /// So this must be fundamental building block for stable sorting networks.
 #[inline]
+#[cfg(not(no_global_oom_handling))]
 unsafe fn swap_next_if_less<T, F>(arr_ptr: *mut T, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -16,7 +16,9 @@ use core::borrow::{Borrow, BorrowMut};
 #[cfg(not(no_global_oom_handling))]
 use core::cmp::Ordering::{self, Less};
 #[cfg(not(no_global_oom_handling))]
-use core::mem::{self, SizedTypeProperties};
+use core::mem;
+#[cfg(not(no_global_oom_handling))]
+use core::mem::size_of;
 #[cfg(not(no_global_oom_handling))]
 use core::ptr;
 
@@ -203,7 +205,7 @@ impl<T> [T] {
     where
         T: Ord,
     {
-        merge_sort(self, T::lt);
+        merge_sort(self, |a, b| a.lt(b));
     }
 
     /// Sorts the slice with a comparator function.
@@ -259,7 +261,7 @@ impl<T> [T] {
     where
         F: FnMut(&T, &T) -> Ordering,
     {
-        merge_sort(self, |a, b| compare(a, b) == Less);
+        stable_sort(self, |a, b| compare(a, b) == Less);
     }
 
     /// Sorts the slice with a key extraction function.
@@ -302,7 +304,7 @@ impl<T> [T] {
         F: FnMut(&T) -> K,
         K: Ord,
     {
-        merge_sort(self, |a, b| f(a).lt(&f(b)));
+        stable_sort(self, |a, b| f(a).lt(&f(b)));
     }
 
     /// Sorts the slice with a key extraction function.
@@ -809,16 +811,333 @@ impl<T: Clone> ToOwned for [T] {
 // Sorting
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Inserts `v[0]` into pre-sorted sequence `v[1..]` so that whole `v[..]` becomes sorted.
-///
-/// This is the integral subroutine of insertion sort.
+#[inline]
 #[cfg(not(no_global_oom_handling))]
-fn insert_head<T, F>(v: &mut [T], is_less: &mut F)
+fn stable_sort<T, F>(v: &mut [T], mut is_less: F)
 where
     F: FnMut(&T, &T) -> bool,
 {
-    if v.len() >= 2 && is_less(&v[1], &v[0]) {
+    if mem::size_of::<T>() == 0 {
+        // Sorting has no meaningful behavior on zero-sized types. Do nothing.
+        return;
+    }
+
+    merge_sort(v, &mut is_less);
+}
+
+// Slices of up to this length get sorted using insertion sort.
+const MAX_INSERTION: usize = 20;
+
+// Sort a small number of elements as fast as possible, without allocations.
+#[inline]
+#[cfg(not(no_global_oom_handling))]
+fn sort_small<T, F>(v: &mut [T], is_less: &mut F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    let len = v.len();
+
+    if len < 2 {
+        return;
+    }
+
+    if T::is_copy() {
+        // SAFETY: We check the corresponding min len for sortX.
         unsafe {
+            if len == 2 {
+                sort2(v, is_less);
+            } else if len == 3 {
+                sort3(v, is_less);
+            } else if len < 8 {
+                sort4(&mut v[..4], is_less);
+                insertion_sort_remaining(v, 4, is_less);
+            } else if len < 16 {
+                sort8(&mut v[..8], is_less);
+                insertion_sort_remaining(v, 8, is_less);
+            } else {
+                sort16(&mut v[..16], is_less);
+                insertion_sort_remaining(v, 16, is_less);
+            }
+        }
+    } else {
+        for i in (0..len - 1).rev() {
+            // SAFETY: We checked above that len is at least 2.
+            unsafe {
+                insert_head(&mut v[i..], is_less);
+            }
+        }
+    }
+}
+
+#[cfg(not(no_global_oom_handling))]
+fn merge_sort<T, F>(v: &mut [T], is_less: &mut F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    // Sorting has no meaningful behavior on zero-sized types.
+    if mem::size_of::<T>() == 0 {
+        return;
+    }
+
+    let len = v.len();
+
+    // Short arrays get sorted in-place via insertion sort to avoid allocations.
+    if len <= MAX_INSERTION {
+        sort_small(v, is_less);
+        return;
+    }
+
+    // Allocate a buffer to use as scratch memory. We keep the length 0 so we can keep in it
+    // shallow copies of the contents of `v` without risking the dtors running on copies if
+    // `is_less` panics. When merging two sorted runs, this buffer holds a copy of the shorter run,
+    // which will always have length at most `len / 2`.
+    let mut buf = Vec::with_capacity(len / 2);
+
+    // In order to identify natural runs in `v`, we traverse it backwards. That might seem like a
+    // strange decision, but consider the fact that merges more often go in the opposite direction
+    // (forwards). According to benchmarks, merging forwards is slightly faster than merging
+    // backwards. To conclude, identifying runs by traversing backwards improves performance.
+    let mut runs = vec![];
+    let mut end = len;
+    while end > 0 {
+        // Find the next natural run, and reverse it if it's strictly descending.
+        let mut start = end - 1;
+        if start > 0 {
+            start -= 1;
+            unsafe {
+                if is_less(v.get_unchecked(start + 1), v.get_unchecked(start)) {
+                    while start > 0 && is_less(v.get_unchecked(start), v.get_unchecked(start - 1)) {
+                        start -= 1;
+                    }
+                    v[start..end].reverse();
+                } else {
+                    while start > 0 && !is_less(v.get_unchecked(start), v.get_unchecked(start - 1))
+                    {
+                        start -= 1;
+                    }
+                }
+            }
+        }
+
+        // SAFETY: end > start.
+        start = provide_sorted_batch(v, start, end, is_less);
+
+        // Push this run onto the stack.
+        runs.push(Run { start, len: end - start });
+        end = start;
+
+        // Merge some pairs of adjacent runs to satisfy the invariants.
+        while let Some(r) = collapse(&runs) {
+            let left = runs[r + 1];
+            let right = runs[r];
+            unsafe {
+                merge(
+                    &mut v[left.start..right.start + right.len],
+                    left.len,
+                    buf.as_mut_ptr(),
+                    is_less,
+                );
+            }
+            runs[r] = Run { start: left.start, len: left.len + right.len };
+            runs.remove(r + 1);
+        }
+    }
+
+    // Finally, exactly one run must remain in the stack.
+    debug_assert!(runs.len() == 1 && runs[0].start == 0 && runs[0].len == len);
+
+    // Examines the stack of runs and identifies the next pair of runs to merge. More specifically,
+    // if `Some(r)` is returned, that means `runs[r]` and `runs[r + 1]` must be merged next. If the
+    // algorithm should continue building a new run instead, `None` is returned.
+    //
+    // TimSort is infamous for its buggy implementations, as described here:
+    // http://envisage-project.eu/timsort-specification-and-verification/
+    //
+    // The gist of the story is: we must enforce the invariants on the top four runs on the stack.
+    // Enforcing them on just top three is not sufficient to ensure that the invariants will still
+    // hold for *all* runs in the stack.
+    //
+    // This function correctly checks invariants for the top four runs. Additionally, if the top
+    // run starts at index 0, it will always demand a merge operation until the stack is fully
+    // collapsed, in order to complete the sort.
+    #[inline]
+    fn collapse(runs: &[Run]) -> Option<usize> {
+        let n = runs.len();
+        if n >= 2
+            && (runs[n - 1].start == 0
+                || runs[n - 2].len <= runs[n - 1].len
+                || (n >= 3 && runs[n - 3].len <= runs[n - 2].len + runs[n - 1].len)
+                || (n >= 4 && runs[n - 4].len <= runs[n - 3].len + runs[n - 2].len))
+        {
+            if n >= 3 && runs[n - 3].len < runs[n - 1].len {
+                Some(n - 3)
+            } else {
+                Some(n - 2)
+            }
+        } else {
+            None
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct Run {
+        len: usize,
+        start: usize,
+    }
+}
+
+/// Takes a range as denoted by start and end, that is already sorted and extends it if necessary
+/// with sorts optimized for smaller ranges such as insertion sort.
+#[cfg(not(no_global_oom_handling))]
+fn provide_sorted_batch<T, F>(v: &mut [T], mut start: usize, end: usize, is_less: &mut F) -> usize
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    // Not doing so is a logic bug, but not a safety bug.
+    debug_assert!(end > start);
+
+    const MAX_PRE_SORT16: usize = 8;
+
+    // Testing showed that using MAX_INSERTION here yields the best performance for many types, but
+    // incurs more total comparisons. A balance between least comparisons and best performance, as
+    // influenced by for example cache locality.
+    const MIN_INSERTION_RUN: usize = 10;
+
+    // Insert some more elements into the run if it's too short. Insertion sort is faster than
+    // merge sort on short sequences, so this significantly improves performance.
+    let start_found = start;
+    let start_end_diff = end - start;
+
+    if T::is_copy() && start_end_diff < MAX_PRE_SORT16 && start_found >= 16 {
+        // SAFETY: We just checked that start_found is >= 16.
+        unsafe {
+            start = start_found.unchecked_sub(16);
+            sort16(&mut v[start..start_found], is_less);
+        }
+        insertion_sort_remaining(&mut v[start..end], 16, is_less);
+    } else if start_end_diff < MIN_INSERTION_RUN {
+        start = start.saturating_sub(MIN_INSERTION_RUN - start_end_diff);
+
+        for i in (start..start_found).rev() {
+            // SAFETY: We ensured that the slice length is always at lest 2 long.
+            // We know that start_found will be at least one less than end,
+            // and the range is exclusive. Which gives us i always <= (end - 2).
+            unsafe {
+                insert_head(&mut v[i..end], is_less);
+            }
+        }
+    }
+
+    start
+}
+
+// When dropped, copies from `src` into `dest`.
+struct InsertionHole<T> {
+    src: *const T,
+    dest: *mut T,
+}
+
+impl<T> Drop for InsertionHole<T> {
+    fn drop(&mut self) {
+        // SAFETY: caller must ensure src is valid to read and dest is valid to write. They must not
+        // alias.
+        unsafe {
+            ptr::copy_nonoverlapping(self.src, self.dest, 1);
+        }
+    }
+}
+
+/// Sort v assuming v[..offset] is already sorted.
+#[inline]
+#[cfg(not(no_global_oom_handling))]
+fn insertion_sort_remaining<T, F>(v: &mut [T], offset: usize, is_less: &mut F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    let len = v.len();
+
+    // This is a logic but not a safety bug.
+    debug_assert!(offset != 0 && offset <= len);
+
+    if len < 2 || offset == 0 {
+        return;
+    }
+
+    // Shift each element of the unsorted region v[i..] as far left as is needed to make v sorted.
+    for i in offset..len {
+        insert_tail(&mut v[..=i], is_less);
+    }
+}
+
+/// Inserts `v[v.len() - 1]` into pre-sorted sequence `v[..v.len() - 1]` so that whole `v[..]`
+/// becomes sorted.
+#[inline]
+#[cfg(not(no_global_oom_handling))]
+fn insert_tail<T, F>(v: &mut [T], is_less: &mut F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    debug_assert!(v.len() >= 2);
+
+    let arr_ptr = v.as_mut_ptr();
+    let i = v.len() - 1;
+
+    unsafe {
+        // See insert_head which talks about why this approach is beneficial.
+        let i_ptr = arr_ptr.add(i);
+
+        // It's important that we use i_ptr here. If this check is positive and we continue,
+        // We want to make sure that no other copy of the value was seen by is_less.
+        // Otherwise we would have to copy it back.
+        if !is_less(&*i_ptr, &*i_ptr.sub(1)) {
+            return;
+        }
+
+        // It's important, that we use tmp for comparison from now on. As it is the value that
+        // will be copied back. And notionally we could have created a divergence if we copy
+        // back the wrong value.
+        let tmp = mem::ManuallyDrop::new(ptr::read(i_ptr));
+        // Intermediate state of the insertion process is always tracked by `hole`, which
+        // serves two purposes:
+        // 1. Protects integrity of `v` from panics in `is_less`.
+        // 2. Fills the remaining hole in `v` in the end.
+        //
+        // Panic safety:
+        //
+        // If `is_less` panics at any point during the process, `hole` will get dropped and
+        // fill the hole in `v` with `tmp`, thus ensuring that `v` still holds every object it
+        // initially held exactly once.
+        let mut hole = InsertionHole { src: &*tmp, dest: i_ptr.sub(1) };
+        ptr::copy_nonoverlapping(hole.dest, i_ptr, 1);
+
+        // SAFETY: We know i is at least 1.
+        for j in (0..(i - 1)).rev() {
+            let j_ptr = arr_ptr.add(j);
+            if !is_less(&*tmp, &*j_ptr) {
+                break;
+            }
+
+            hole.dest = j_ptr;
+            ptr::copy_nonoverlapping(hole.dest, j_ptr.add(1), 1);
+        }
+        // `hole` gets dropped and thus copies `tmp` into the remaining hole in `v`.
+    }
+}
+
+/// Inserts `v[0]` into pre-sorted sequence `v[1..]` so that whole `v[..]` becomes sorted.
+///
+/// This is the integral subroutine of insertion sort.
+#[inline]
+#[cfg(not(no_global_oom_handling))]
+unsafe fn insert_head<T, F>(v: &mut [T], is_less: &mut F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    debug_assert!(v.len() >= 2);
+
+    // SAFETY: caller must ensure v is at least len 2.
+    unsafe {
+        if is_less(&v[1], &v[0]) {
             // There are three ways to implement insertion here:
             //
             // 1. Swap adjacent elements until the first one gets to its final destination.
@@ -861,20 +1180,6 @@ where
             // `hole` gets dropped and thus copies `tmp` into the remaining hole in `v`.
         }
     }
-
-    // When dropped, copies from `src` into `dest`.
-    struct InsertionHole<T> {
-        src: *const T,
-        dest: *mut T,
-    }
-
-    impl<T> Drop for InsertionHole<T> {
-        fn drop(&mut self) {
-            unsafe {
-                ptr::copy_nonoverlapping(self.src, self.dest, 1);
-            }
-        }
-    }
 }
 
 /// Merges non-decreasing runs `v[..mid]` and `v[mid..]` using `buf` as temporary storage, and
@@ -890,8 +1195,8 @@ where
     F: FnMut(&T, &T) -> bool,
 {
     let len = v.len();
-    let v = v.as_mut_ptr();
-    let (v_mid, v_end) = unsafe { (v.add(mid), v.add(len)) };
+    let arr_ptr = v.as_mut_ptr();
+    let (v_mid, v_end) = unsafe { (arr_ptr.add(mid), arr_ptr.add(len)) };
 
     // The merge process first copies the shorter run into `buf`. Then it traces the newly copied
     // run and the longer run forwards (or backwards), comparing their next unconsumed elements and
@@ -915,8 +1220,8 @@ where
     if mid <= len - mid {
         // The left run is shorter.
         unsafe {
-            ptr::copy_nonoverlapping(v, buf, mid);
-            hole = MergeHole { start: buf, end: buf.add(mid), dest: v };
+            ptr::copy_nonoverlapping(arr_ptr, buf, mid);
+            hole = MergeHole { start: buf, end: buf.add(mid), dest: arr_ptr };
         }
 
         // Initially, these pointers point to the beginnings of their arrays.
@@ -948,7 +1253,7 @@ where
         let right = &mut hole.end;
         let mut out = v_end;
 
-        while v < *left && buf < *right {
+        while arr_ptr < *left && buf < *right {
             // Consume the greater side.
             // If equal, prefer the right run to maintain stability.
             unsafe {
@@ -993,20 +1298,62 @@ where
     }
 }
 
-/// This merge sort borrows some (but not all) ideas from TimSort, which is described in detail
-/// [here](https://github.com/python/cpython/blob/main/Objects/listsort.txt).
-///
-/// The algorithm identifies strictly descending and non-descending subsequences, which are called
-/// natural runs. There is a stack of pending runs yet to be merged. Each newly found run is pushed
-/// onto the stack, and then some pairs of adjacent runs are merged until these two invariants are
-/// satisfied:
-///
-/// 1. for every `i` in `1..runs.len()`: `runs[i - 1].len > runs[i].len`
-/// 2. for every `i` in `2..runs.len()`: `runs[i - 2].len > runs[i - 1].len + runs[i].len`
-///
-/// The invariants ensure that the total running time is *O*(*n* \* log(*n*)) worst-case.
-#[cfg(not(no_global_oom_handling))]
-fn merge_sort<T, F>(v: &mut [T], mut is_less: F)
+trait IsCopy<T> {
+    fn is_copy() -> bool;
+}
+
+impl<T> IsCopy<T> for T {
+    fn is_copy() -> bool {
+        // FIXME, heuristic loss and uniqueness preservation bug.
+        true
+    }
+}
+
+// FIXME!
+// impl<T: Copy> IsCopy<T> for T {
+//     fn is_copy() -> bool {
+//         true
+//     }
+// }
+
+// --- Branchless sorting (less branches not zero) ---
+
+/// Swap value with next value in array pointed to by arr_ptr if should_swap is true.
+#[inline]
+unsafe fn swap_next_if<T>(arr_ptr: *mut T, should_swap: bool) {
+    // This is a branchless version of swap if.
+    // The equivalent code with a branch would be:
+    //
+    // if should_swap {
+    //     ptr::swap_nonoverlapping(arr_ptr, arr_ptr.add(1), 1)
+    // }
+    //
+    // Be mindful in your benchmarking that this only starts to outperform branching code if the
+    // benchmark doesn't execute the same branches again and again.
+    // }
+    //
+
+    // Give ourselves some scratch space to work with.
+    // We do not have to worry about drops: `MaybeUninit` does nothing when dropped.
+    let mut tmp = mem::MaybeUninit::<T>::uninit();
+
+    // Perform the conditional swap.
+    // SAFETY: the caller must guarantee that `arr_ptr` and `arr_ptr.add(1)` are
+    // valid for writes and properly aligned. `tmp` cannot be overlapping either `arr_ptr` or
+    // `arr_ptr.add(1) because `tmp` was just allocated on the stack as a separate allocated object.
+    // And `arr_ptr` and `arr_ptr.add(1)` can't overlap either.
+    // However `arr_ptr` and `arr_ptr.add(should_swap as usize)` can point to the same memory if
+    // should_swap is false.
+    unsafe {
+        ptr::copy_nonoverlapping(arr_ptr.add(!should_swap as usize), tmp.as_mut_ptr(), 1);
+        ptr::copy(arr_ptr.add(should_swap as usize), arr_ptr, 1);
+        ptr::copy_nonoverlapping(tmp.as_ptr(), arr_ptr.add(1), 1);
+    }
+}
+
+/// Swap value with next value in array pointed to by arr_ptr if should_swap is true.
+#[inline]
+unsafe fn swap_next_if_less<T, F>(arr_ptr: *mut T, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
 {
@@ -1016,7 +1363,7 @@ where
     const MIN_RUN: usize = 10;
 
     // Sorting has no meaningful behavior on zero-sized types.
-    if T::IS_ZST {
+    if size_of::<T>() == 0 {
         return;
     }
 
@@ -1124,9 +1471,22 @@ where
         }
     }
 
-    #[derive(Clone, Copy)]
-    struct Run {
-        start: usize,
-        len: usize,
+        let mut swap = mem::MaybeUninit::<[T; 16]>::uninit();
+        let swap_ptr = swap.as_mut_ptr() as *mut T;
+
+        // Merge the already sorted v[0..4] with v[4..8] into swap.
+        parity_merge8(arr_ptr, swap_ptr, is_less);
+        // Merge the already sorted v[8..12] with v[12..16] into swap.
+        parity_merge8(arr_ptr.add(8), swap_ptr.add(8), is_less);
+
+        // v is still the same as before parity_merge8
+        // swap now contains a shallow copy of v and is sorted in v[0..8] and v[8..16]
+        // Merge the two partitions.
+        // parity_merge(swap_ptr, arr_ptr, 16, is_less);
+
+        // FIXME discuss perf loss by promising original elements in case of panic.
+        ptr::copy_nonoverlapping(swap_ptr, arr_ptr, 16);
+        parity_merge(arr_ptr, swap_ptr, 16, is_less);
+        ptr::copy_nonoverlapping(swap_ptr, arr_ptr, 16);
     }
 }


### PR DESCRIPTION
This reworks the internals of slice::sort. Mainly:

- Introduce branchless swap_next_if and optimized sortX functions
- Speedup core batch extension with sort16
- Many small tweaks to reduce the amount of branches/jumps

This commit is incomplete and MUST NOT be merged as is. It is missing Copy
detection and would break uniqueness preservation of values that are being
sorted.

---

This initially started as an exploration to port [fluxsort](https://github.com/scandum/fluxsort) to Rust. Together with ideas from the recent libcxx sort improvement, namely optimal sorting networks, this PR aims to improve the performance of `slice::sort`.

Before submitting this PR, I wanted good answers for these two questions:

- How can I know that it works correctly?
- How can I know it is actually faster?

Maybe I've used it wrong, but I did not find a comprehensive set of tests for sort in the std test suite. Even simple bugs, manually added to the existing code, still passed the library/std suite. So I embarked on creating my own test and benchmark suite https://github.com/Voultapher/sort-research-rs. Having a variety of test types, pattern and sizes.

## How can I know that it works correctly?

- The new implementation is tested with a variety of tests. [Varying types, input size and test logic](https://github.com/Voultapher/sort-research-rs/blob/19db1c2a2f1b747e2d5f5d7d68ffa51355a51017/tests/main.rs)
- miri does not complain when running the tests
- Repeatedly running the tests with random inputs has not yielded failures (In its current form. While developing I had many bugs)
- Careful analysis and reasoning of the code. Augmented with comments.
- debug_asserts for invariants where doing so is reasonably cheap
- Review process via PR
- Potential nightly adoption and feedback

## How can I know it is actually faster?

Benchmarking is notoriously tricky. Along the way I've mad all kinds of mistakes, ranging from false randomness. Not being representative enough. Botching type distributions and more. In it's current form the benchmark suite tests along 4 dimensions:

- Input type
- Input pattern
- Input size
- hot/cold prediction state

### input type

I chose 5 types that are to represent some of the types users will call this generic sort implementation with:

- `i32` basic type often used to test sorting algorithms.
- `u64` common type for usize on 64-bit machines. Sorting indices is very common.
- `String` Larger type that is not Copy and does heap access.
- `1k` Very large stack value 1kb, not Copy.
- `f128` 16 byte stack value that is Copy but has a relatively expensive cmp implementation.

### Input pattern

I chose 11 input patterns. Sorting algorithms behave wildly different based on the input pattern. And most hight performance implementation try to be some kind of adaptive.

- random
- random_uniform
- random_random_size
- all_equal
- ascending
- descending
- ascending_saw_5
- ascending_saw_20
- descending_saw_5
- descending_saw_20
- pipe_organ

For more details on the input patterns, take a look at their [implementation](https://github.com/Voultapher/sort-research-rs/blob/19db1c2a2f1b747e2d5f5d7d68ffa51355a51017/src/patterns.rs).

### Input size

While in general sorting random data should be n log(n), the specifics might be quite different. So it's important to get a representative set of test sizes. I chose these:

```rust
let test_sizes = [
    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 13, 16, 17, 19, 20, 24, 36, 50, 101, 200, 500, 1_000,
    2_048, 10_000, 100_000, 1_000_000,
];
```

#### hot/cold prediction state

Modern CPUs are highly out-of-order and speculative to extract as much Instruction Level Parallelism (ILP) as possible. This is highly dependent on speculation. And while the common way to do benchmarks is good to get reliable standalone numbers, their magnitude might be misleading in programs that do more than just calling sort in a tight loop. So I run every benchmark twice once via criterion `iter_batched` (hot) and `iter_batch PerIteration` with a function in-between that attempts to flush the Branch Target Buffer (BTB) and does a syscall for good measure too. The cold benchmarks are not necessarily representative for the absolute gains in a particular application, nor are the hot results. But together they give a decent range of possible speedups.


### What makes a sort algorithm fast

Talking in depth about all kinds of sort algorithm would go too deep here, especially given, that this does not change the underlying algorithm. But merely augments it with branchless code that can extract more ILP. Broadly speaking a generic sorting algorithms runtime will depend on 3 factors:

- How cheap is your type to compare?
- How expensive is your type to move?
- How well can access to your type be predicted?

For example, a `u64` is very cheap to compare, very cheap to move and many of them fit into a cache line. And only that cache line is needed to compare them. A type like `u64` will give you pretty close to the maximum performance of the sorting algorithm. In contrast, `String` is potentially expensive to compare, relatively cheap to move and access is hard to predict. And a type like `f128` (just a name used for testing, not an official literal) is rather expensive to compare, it does two f64 divisions for each comparison, is cheap to move, and access is easily predicted. Given the vast freedom Rust users have, the sort algorithm can only do a best effort for common use cases and be reasonably good in others. If you decompress files with each comparison, that will be your bottleneck. Rust users can implement arbitrarily expensive `is_less` functions, and the key metric for such cases is how many comparisons are performed by the implementation. As I was developing the optimisations, I took great care to ensure that not only was it faster, but also not significantly slower. For example by measuring the total comparisons done for each input, type + pattern + size combination.

- [new_stable vs std_stable](https://github.com/Voultapher/sort-research-rs/blob/0003488ea89c9260e8b3a83f7d2cc737d2f0d91e/results/cf11b1e/analysis/std_stable_vs_new_stable_comparisons.txt)
- [std_unstable vs std_stable](https://github.com/Voultapher/sort-research-rs/blob/0003488ea89c9260e8b3a83f7d2cc737d2f0d91e/results/cf11b1e/analysis/std_stable_vs_std_unstable_comparisons.txt)

For non Copy types the total comparisons done are roughly equal. For Copy types and random input, it's 6% more on average. And while at first it might seem intuitive that more comparisons means higher runtime. That's not true for various reasons, mostly cache access. For example `sort_unstable` does on average for random input, and input size > 20 14% more comparisons. There are even some pathological inputs such as `pipe_organ` where the merge sort with streak analysis is vastly superior. For `u64-pipe_organ-10000` the stable sort performs 20k comparisons while unstable sort does 130k. If your type is expensive to compare, unstable sort will quickly loose its advantage.

### Benchmark results

Which the 4 input dimensions, we get 2.5k individual benchmarks. I ran them on 3 different microarchitectures. Comparing new_stable with std_stable, gives us 15k data points. That's a lot and requires some kind of analysis. The raw results are [here](https://github.com/Voultapher/sort-research-rs/tree/0003488ea89c9260e8b3a83f7d2cc737d2f0d91e/results/cf11b1e), feel free to crush the numbers yourself, I probably did some mistakes.

TLDR:

- The biggest winners are Copy types, in random order. Such scenarios see 30-100% speedup.
- Non Copy types remain largely the same, with some outliers that I guess are dependent on memory layout and alignment and other factors.
- Some scenarios see slowdowns, but they are pretty contained
- Wider and deeper microarchitectures see relatively larger wins (ie. current and future designs)

Test setup:

Compiler: rustc 1.65.0-nightly (29e4a9ee0 2022-08-10)

Machines:
- AMD 5900X (Zen3)
- Intel i7-5500U (Broadwell)
- Apple M1 Pro (Firestorm)

hot-u64 (Zen3)

<img width="610" alt="Screenshot 2022-08-21 at 22 14 38" src="https://user-images.githubusercontent.com/6864584/185809198-bf66c588-bb7f-481d-ba74-4d59d03e7d5d.png">

This plots the `hot-u64` results. Everything above 0 means the new implementation was faster and everything below means the current version was faster. Check out an [interactive version here](https://voultapher.github.io/sort-research-rs/results/cf11b1e/analysis/zen3/hot-overview), you can hover over all the values to see the relative speedup. Note, the speedup is calculated symmetrically, so it doesn't matter which 'side' you view it from.

hot-u64-random <= 20 (Firestorm)

<img width="610" alt="Screenshot 2022-08-21 at 23 10 35" src="https://user-images.githubusercontent.com/6864584/185811076-b899bf23-3de3-4f81-8903-873f1e49ba5f.png">

[Interactive version here](https://voultapher.github.io/sort-research-rs/results/cf11b1e/analysis/firestorm/hot-u64-detail) you have to scroll down a bit to get to random. But the other ones are interesting too of course.

hot-u64 (Firestorm)

<img width="610" alt="Screenshot 2022-08-21 at 22 13 40" src="https://user-images.githubusercontent.com/6864584/185809184-8050e135-1488-41d4-8525-602c21ad24eb.png">

Here you can see what I suspect is the really wide core flexing it's ILP capabilities, speeding up sorting a slice of 16 random `u64` by 2.4x.

hot-u64 (Broadwell)

<img width="610" alt="Screenshot 2022-08-21 at 22 14 38" src="https://user-images.githubusercontent.com/6864584/185809213-ef1d608b-c5aa-4ca7-a4b0-248f655807c1.png">

Even on older hardware the results look promising.

You can explore [all results here](https://voultapher.github.io/sort-research-rs/results/cf11b1e/). Note, I accidentally forgot to add 16 as test size when running the benchmarks on the Zen3 machine, the other two have this included. But from what I see the difference is not too big.

---


### Outstanding work

- Get the `is_copy` check to work within the standard library. I used specialisation in my repo, but I'm not sure what the right path forward here would be. On the surface it seems like a relatively simple property to check.
- Talk about the expected behaviour when `is_less` panics inside `sort16` during the final parity merge. With the current double copy, it retains the current behaviour of leaving `v` in a valid state *and* preserving all its original elements. A faster version is possible, by omitting the two copy calls, and directly writing the result of `parity_merge` into `arr_ptr`, however this changes the current behaviour. Should `is_less` panic, `v` will be left in a valid state *but* there might be duplicate elements, losing the original set. The question is, how many people rely on such behaviour? How big of a footgun is that? Is the price worth having everyone pay it when they don't need it? Would documentation be enough?

A note on 'uniqueness preservation'. Maybe this concept has a name, but I don't know it. I did experiments of allowing the `sort16` approach for non Copy types, however I saw slowdowns for such types, even when limiting it to relatively cheap to move types. I suspect Copy is a pretty good heuristic for types that are cheap to compare, move and access. But what makes them crucially the only ones applicable, is not panic safety as I initially thought. With the two extra copy's `sort16` which could be done only for non Copy types, that part is solved. However, what memory location is dereferenced and used to call `is_less` is the tricky part. By creating a shallow copy of type and using that address to call `is_less`, if this value is then not copied back, and used along the chain as 'unique' object along the progress of code, you could observe that for all intents and purposes, the type that is in your mutable slice, is the one you put in there. But if you self modify yourself inside `is_less` this self modification can be lost. That's exactly what `parity_merge8` and `parity_merge` do. The way they sweep along the slice overlapping between 'iterations' might compare something from src, copy it and then use src again for a comparison, but then later `dest` is copied back into `v`, which has only seen one of the comparisons. And crucially `Cell` is not Copy, which means such logical foot guns are not possible with Copy types, or not to my knowledge. I wrote a test for it [here](https://github.com/Voultapher/sort-research-rs/blob/0003488ea89c9260e8b3a83f7d2cc737d2f0d91e/tests/main.rs#L391).

I would love to see if this improvement has any noticeable effect on compile times. Coarse analysis showed some places where the compiler uses stable sort with suitable types.

### Future work

- For input_size <20 stable and unstable sort both use insertion sort, albeit slightly different implementations. The same speedups here could be applied to unstable sort.
- If I find the time I want to investigate porting the merge part of fluxsort and see if that speeds things up. My main worry is correctness. It's quite liberal in it's use of pointers and I've already discovered memory and logic bugs in the parts that I ported. For <16 elements its somewhat possible to think about in my head. But for general situations, I fear it might require formal verification, to attain the expected level of confidence.
- Use sort16 to speedup unstable sort, or in general look into improving unstable sort.

This is my first time contributing to the standard library, my apologies if I missed or got something important wrong.
