### PR TITLE
tidy: remove crossbeam-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5294,7 +5294,6 @@ name = "tidy"
 version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.14.0",
- "crossbeam-utils",
  "lazy_static",
  "regex",
  "walkdir",

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -9,7 +9,6 @@ cargo_metadata = "0.14"
 regex = "1"
 lazy_static = "1"
 walkdir = "2"
-crossbeam-utils = "0.8.0"
 
 [[bin]]
 name = "rust-tidy"

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -6,7 +6,6 @@
 
 use tidy::*;
 
-use crossbeam_utils::thread::{scope, ScopedJoinHandle};
 use std::collections::VecDeque;
 use std::env;
 use std::num::NonZeroUsize;
@@ -14,6 +13,7 @@ use std::path::PathBuf;
 use std::process;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{scope, ScopedJoinHandle};
 
 fn main() {
     let root_path: PathBuf = env::args_os().nth(1).expect("need path to root of repo").into();
@@ -44,7 +44,7 @@ fn main() {
                     handles.pop_front().unwrap().join().unwrap();
                 }
 
-                let handle = s.spawn(|_| {
+                let handle = s.spawn(|| {
                     let mut flag = false;
                     $p::check($($args),* , &mut flag);
                     if (flag) {
@@ -102,8 +102,7 @@ fn main() {
             r
         };
         check!(unstable_book, &src_path, collected);
-    })
-    .unwrap();
+    });
 
     if bad.load(Ordering::Relaxed) {
         eprintln!("some tidy checks failed");


### PR DESCRIPTION
crossbeam-utils is no longer needed now that scoped threads are available in 1.63.
