### PR TITLE
Don't drop parent substs when we have no generic parameters in `create_substs_for_ast_path`

### DIFF
--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -591,7 +591,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
     pub(crate) fn create_substs_for_associated_item(
         &self,
-        tcx: TyCtxt<'tcx>,
         span: Span,
         item_def_id: DefId,
         item_segment: &hir::PathSegment<'_>,
@@ -601,22 +600,16 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             "create_substs_for_associated_item(span: {:?}, item_def_id: {:?}, item_segment: {:?}",
             span, item_def_id, item_segment
         );
-        if tcx.generics_of(item_def_id).params.is_empty() {
-            self.prohibit_generics(slice::from_ref(item_segment).iter(), |_| {});
-
-            parent_substs
-        } else {
-            self.create_substs_for_ast_path(
-                span,
-                item_def_id,
-                parent_substs,
-                item_segment,
-                item_segment.args(),
-                item_segment.infer_args,
-                None,
-            )
-            .0
-        }
+        self.create_substs_for_ast_path(
+            span,
+            item_def_id,
+            parent_substs,
+            item_segment,
+            item_segment.args(),
+            item_segment.infer_args,
+            None,
+        )
+        .0
     }
 
     /// Instantiates the path for the given trait reference, assuming that it's
@@ -1129,7 +1122,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             };
 
             let substs_trait_ref_and_assoc_item = self.create_substs_for_associated_item(
-                tcx,
                 path_span,
                 assoc_item.def_id,
                 &item_segment,
@@ -2105,7 +2097,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             self.ast_path_to_mono_trait_ref(span, trait_def_id, self_ty, trait_segment, false);
 
         let item_substs = self.create_substs_for_associated_item(
-            tcx,
             span,
             item_def_id,
             item_segment,

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -365,7 +365,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         // here and so associated type bindings will be handled regardless of whether there are any
         // non-`Self` generic parameters.
         if generics.params.is_empty() {
-            return (tcx.intern_substs(&[]), arg_count);
+            return (tcx.intern_substs(parent_substs), arg_count);
         }
 
         struct SubstsForAstPathCtxt<'a, 'tcx> {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/mod.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/mod.rs
@@ -279,7 +279,6 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
 
         let item_substs = <dyn AstConv<'tcx>>::create_substs_for_associated_item(
             self,
-            self.tcx,
             span,
             item_def_id,
             item_segment,

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -430,7 +430,6 @@ impl<'tcx> AstConv<'tcx> for ItemCtxt<'tcx> {
         if let Some(trait_ref) = poly_trait_ref.no_bound_vars() {
             let item_substs = <dyn AstConv<'tcx>>::create_substs_for_associated_item(
                 self,
-                self.tcx,
                 span,
                 item_def_id,
                 item_segment,

--- a/src/test/ui/structs/struct-path-associated-type.rs
+++ b/src/test/ui/structs/struct-path-associated-type.rs
@@ -13,7 +13,7 @@ fn f<T: Tr>() {
     //~^ ERROR expected struct, variant or union type, found associated type
     let z = T::A::<u8> {};
     //~^ ERROR expected struct, variant or union type, found associated type
-    //~| ERROR type arguments are not allowed on this type
+    //~| ERROR this associated type takes 0 generic arguments but 1 generic argument was supplied
     match S {
         T::A {} => {}
         //~^ ERROR expected struct, variant or union type, found associated type
@@ -22,7 +22,7 @@ fn f<T: Tr>() {
 
 fn g<T: Tr<A = S>>() {
     let s = T::A {}; // OK
-    let z = T::A::<u8> {}; //~ ERROR type arguments are not allowed on this type
+    let z = T::A::<u8> {}; //~ ERROR this associated type takes 0 generic arguments but 1 generic argument was supplied
     match S {
         T::A {} => {} // OK
     }

--- a/src/test/ui/structs/struct-path-associated-type.stderr
+++ b/src/test/ui/structs/struct-path-associated-type.stderr
@@ -4,13 +4,19 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |     let s = T::A {};
    |             ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed on this type
-  --> $DIR/struct-path-associated-type.rs:14:20
+error[E0107]: this associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/struct-path-associated-type.rs:14:16
    |
 LL |     let z = T::A::<u8> {};
-   |                -   ^^ type argument not allowed
+   |                ^------ help: remove these generics
    |                |
-   |                not allowed on this type
+   |                expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/struct-path-associated-type.rs:4:10
+   |
+LL |     type A;
+   |          ^
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
@@ -24,13 +30,19 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |         T::A {} => {}
    |         ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed on this type
-  --> $DIR/struct-path-associated-type.rs:25:20
+error[E0107]: this associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/struct-path-associated-type.rs:25:16
    |
 LL |     let z = T::A::<u8> {};
-   |                -   ^^ type argument not allowed
+   |                ^------ help: remove these generics
    |                |
-   |                not allowed on this type
+   |                expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/struct-path-associated-type.rs:4:10
+   |
+LL |     type A;
+   |          ^
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:32:13
@@ -52,5 +64,5 @@ LL |         S::A {} => {}
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0071, E0109, E0223.
+Some errors have detailed explanations: E0071, E0107, E0223.
 For more information about an error, try `rustc --explain E0071`.


### PR DESCRIPTION
This bug is being shadowed by an explicit check for `generics.params.is_empty()` in the only parent caller that could trigger it (`create_substs_for_associated_item`). I triggered it on another branch where I'm messing around with astconv stuff.

Also, the second commit simplifies `create_substs_for_associated_item`. Removing that explicit check I mentioned above^ and also the special case call to `Astconv::prohibit_generics` causes the UI test `src/test/ui/structs/struct-path-associated-type.stderr` to change, but I think that it's clearer now. The suggestion to remove the generics is actually useful.