### PR TITLE
[EXPERIMENT] Use wider types in Layout multiplication

### DIFF
--- a/library/core/src/mem/valid_align.rs
+++ b/library/core/src/mem/valid_align.rs
@@ -53,13 +53,6 @@ impl ValidAlign {
     pub(crate) fn log2(self) -> u32 {
         self.as_nonzero().trailing_zeros()
     }
-
-    /// Returns the alignment for a type.
-    #[inline]
-    pub(crate) fn of<T>() -> Self {
-        // SAFETY: rustc ensures that type alignment is always a power of two.
-        unsafe { ValidAlign::new_unchecked(mem::align_of::<T>()) }
-    }
 }
 
 impl fmt::Debug for ValidAlign {


### PR DESCRIPTION
This lets us phrase it as just one check, rather than two, and might make it easier on LLVM to optimize.  It still passes the [codegen test](https://github.com/rust-lang/rust/blob/master/src/test/codegen/layout-size-checks.rs) from #99174 without needing the manual optimization anymore, so let's see whether perf likes it.

We've picked up https://github.com/llvm/llvm-project/issues/56563, so LLVM is now smarter about optimizing `mul nuw` with constants, which is what this is frequently emitting (because the type size often comes from a generic type parameter).

The IR/ASM looks pretty good for this approach too. For comparisons, see
- https://rust.godbolt.org/z/ssjr1Yeas (64-bit)
- https://rust.godbolt.org/z/9f8c45b7W (32-bit)

cc @CAD97 & #99117

