### PR TITLE
Migrate `rustc_passes` diagnostics

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -265,3 +265,12 @@ passes_rustc_lint_opt_deny_field_access = `#[rustc_lint_opt_deny_field_access]` 
 
 passes_link_ordinal = attribute should be applied to a foreign function or static
     .label = not a foreign function or static
+
+passes_missing_panic_handler = `#[panic_handler]` function required, but not found
+
+passes_missing_alloc_error_handler = `#[alloc_error_handler]` function required, but not found
+    .note = use `#![feature(default_alloc_error_handler)]` for a default error handler
+
+passes_missing_lang_item = language item required, but not found: `{$name}`
+    .note = this can occur when a binary crate with `#![no_std]` is compiled for a target where `{$name}` is defined in the standard library
+    .help = you may be able to compile for a target that doesn't need `{$name}`, specify a target with `--target` or in `.cargo/config`

--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -274,3 +274,11 @@ passes_missing_alloc_error_handler = `#[alloc_error_handler]` function required,
 passes_missing_lang_item = language item required, but not found: `{$name}`
     .note = this can occur when a binary crate with `#![no_std]` is compiled for a target where `{$name}` is defined in the standard library
     .help = you may be able to compile for a target that doesn't need `{$name}`, specify a target with `--target` or in `.cargo/config`
+
+passes_lang_item_on_incorrect_target = `{$name}` language item must be applied to a {$expected_target}
+    .label = attribute should be applied to a {$expected_target}, not a {$actual_target}
+
+passes_unknown_lang_item = definition of an unknown language item: `{$name}`
+    .label = definition of unknown language item `{$name}`
+
+passes_local_duplicate_lang_item = found duplicate lang item `{$name}`

--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -284,3 +284,6 @@ passes_unknown_lang_item = definition of an unknown language item: `{$name}`
     .label = definition of unknown language item `{$name}`
 
 passes_local_duplicate_lang_item = found duplicate lang item `{$name}`
+
+passes_invalid_attr_at_crate_level = `{$name}` attribute cannot be used at crate level
+    .suggestion = perhaps you meant to use an outer attribute

--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -217,6 +217,8 @@ passes_debug_visualizer_invalid = invalid argument
     .note_2 = OR
     .note_3 = expected: `gdb_script_file = "..."`
 
+passes_debug_visualizer_unreadable = couldn't read {$file}: {$error}
+
 passes_rustc_allow_const_fn_unstable = attribute should be applied to `const fn`
     .label = not a `const fn`
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1846,7 +1846,7 @@ impl CheckAttrVisitor<'_> {
                     span: meta_item.span,
                     file: &file,
                     error: err,
-                } );
+                });
                 false
             }
         }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -4,7 +4,7 @@
 //! conflicts between multiple such attributes attached to the same
 //! item.
 
-use crate::errors;
+use crate::errors::{self, DebugVisualizerUnreadable};
 use rustc_ast::{ast, AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{fluent, struct_span_err, Applicability, MultiSpan};
@@ -1842,13 +1842,11 @@ impl CheckAttrVisitor<'_> {
         match std::fs::File::open(&file) {
             Ok(_) => true,
             Err(err) => {
-                self.tcx
-                    .sess
-                    .struct_span_err(
-                        meta_item.span,
-                        &format!("couldn't read {}: {}", file.display(), err),
-                    )
-                    .emit();
+                self.tcx.sess.emit_err(DebugVisualizerUnreadable {
+                    span: meta_item.span,
+                    file: &file,
+                    error: err,
+                } );
                 false
             }
         }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -4,7 +4,7 @@
 //! conflicts between multiple such attributes attached to the same
 //! item.
 
-use crate::errors::{self, DebugVisualizerUnreadable};
+use crate::errors::{self, DebugVisualizerUnreadable, InvalidAttrAtCrateLevel};
 use rustc_ast::{ast, AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{fluent, struct_span_err, Applicability, MultiSpan};
@@ -2156,25 +2156,10 @@ fn check_invalid_crate_level_attr(tcx: TyCtxt<'_>, attrs: &[Attribute]) {
         if attr.style == AttrStyle::Inner {
             for attr_to_check in ATTRS_TO_CHECK {
                 if attr.has_name(*attr_to_check) {
-                    let mut err = tcx.sess.struct_span_err(
-                        attr.span,
-                        &format!(
-                            "`{}` attribute cannot be used at crate level",
-                            attr_to_check.to_ident_string()
-                        ),
-                    );
-                    // Only emit an error with a suggestion if we can create a
-                    // string out of the attribute span
-                    if let Ok(src) = tcx.sess.source_map().span_to_snippet(attr.span) {
-                        let replacement = src.replace("#!", "#");
-                        err.span_suggestion_verbose(
-                            attr.span,
-                            "perhaps you meant to use an outer attribute",
-                            replacement,
-                            rustc_errors::Applicability::MachineApplicable,
-                        );
-                    }
-                    err.emit();
+                    tcx.sess.emit_err(InvalidAttrAtCrateLevel {
+                        span: attr.span,
+                        name: *attr_to_check,
+                    });
                 }
             }
         }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1,3 +1,5 @@
+use std::{io::Error, path::Path};
+
 use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::Target;
 use rustc_macros::{LintDiagnostic, SessionDiagnostic, SessionSubdiagnostic};
@@ -525,6 +527,15 @@ pub struct DebugVisualizerPlacement {
 pub struct DebugVisualizerInvalid {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(passes::debug_visualizer_unreadable)]
+pub struct DebugVisualizerUnreadable<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub file: &'a Path,
+    pub error: Error,
 }
 
 #[derive(SessionDiagnostic)]

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1,4 +1,5 @@
 use rustc_errors::{Applicability, MultiSpan};
+use rustc_hir::Target;
 use rustc_macros::{LintDiagnostic, SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::{Span, Symbol};
 
@@ -664,5 +665,25 @@ pub struct MissingAllocErrorHandler;
 #[note]
 #[help]
 pub struct MissingLangItem {
+    pub name: Symbol,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(passes::lang_item_on_incorrect_target, code = "E0718")]
+pub struct LangItemOnIncorrectTarget {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub name: Symbol,
+    pub expected_target: Target,
+    pub actual_target: Target,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(passes::unknown_lang_item, code = "E0522")]
+pub struct UnknownLangItem {
+    #[primary_span]
+    #[label]
+    pub span: Span,
     pub name: Symbol,
 }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1,6 +1,6 @@
 use std::{io::Error, path::Path};
 
-use rustc_errors::{Applicability, MultiSpan, ErrorGuaranteed};
+use rustc_errors::{Applicability, ErrorGuaranteed, MultiSpan};
 use rustc_hir::Target;
 use rustc_macros::{LintDiagnostic, SessionDiagnostic, SessionSubdiagnostic};
 use rustc_session::SessionDiagnostic;
@@ -706,7 +706,10 @@ pub struct InvalidAttrAtCrateLevel {
 }
 
 impl SessionDiagnostic<'_> for InvalidAttrAtCrateLevel {
-    fn into_diagnostic(self, sess: &'_ rustc_session::parse::ParseSess) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
+    fn into_diagnostic(
+        self,
+        sess: &'_ rustc_session::parse::ParseSess,
+    ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
         let mut diag = sess.struct_err(rustc_errors::fluent::passes::invalid_attr_at_crate_level);
         diag.set_span(self.span);
         diag.set_arg("name", self.name);

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -649,3 +649,20 @@ pub struct RustcLintOptDenyFieldAccess {
     #[label]
     pub span: Span,
 }
+
+#[derive(SessionDiagnostic)]
+#[diag(passes::missing_panic_handler)]
+pub struct MissingPanicHandler;
+
+#[derive(SessionDiagnostic)]
+#[diag(passes::missing_alloc_error_handler)]
+#[note]
+pub struct MissingAllocErrorHandler;
+
+#[derive(SessionDiagnostic)]
+#[diag(passes::missing_lang_item)]
+#[note]
+#[help]
+pub struct MissingLangItem {
+    pub name: Symbol,
+}

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -7,6 +7,7 @@
 //! * Traits that represent operators; e.g., `Add`, `Sub`, `Index`.
 //! * Functions called by the compiler itself.
 
+use crate::errors::{LangItemOnIncorrectTarget, UnknownLangItem};
 use crate::check_attr::target_from_impl_item;
 use crate::weak_lang_items;
 
@@ -42,34 +43,19 @@ impl<'tcx> LanguageItemCollector<'tcx> {
                 }
                 // Known lang item with attribute on incorrect target.
                 Some((_, expected_target)) => {
-                    struct_span_err!(
-                        self.tcx.sess,
+                    self.tcx.sess.emit_err(LangItemOnIncorrectTarget {
                         span,
-                        E0718,
-                        "`{}` language item must be applied to a {}",
-                        value,
+                        name: value,
                         expected_target,
-                    )
-                    .span_label(
-                        span,
-                        format!(
-                            "attribute should be applied to a {}, not a {}",
-                            expected_target, actual_target,
-                        ),
-                    )
-                    .emit();
+                        actual_target,
+                    });
                 }
                 // Unknown lang item.
                 _ => {
-                    struct_span_err!(
-                        self.tcx.sess,
+                    self.tcx.sess.emit_err(UnknownLangItem {
                         span,
-                        E0522,
-                        "definition of an unknown language item: `{}`",
-                        value
-                    )
-                    .span_label(span, format!("definition of unknown language item `{}`", value))
-                    .emit();
+                        name: value,
+                    });
                 }
             }
         }

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -7,8 +7,8 @@
 //! * Traits that represent operators; e.g., `Add`, `Sub`, `Index`.
 //! * Functions called by the compiler itself.
 
-use crate::errors::{LangItemOnIncorrectTarget, UnknownLangItem};
 use crate::check_attr::target_from_impl_item;
+use crate::errors::{LangItemOnIncorrectTarget, UnknownLangItem};
 use crate::weak_lang_items;
 
 use rustc_errors::{pluralize, struct_span_err};
@@ -52,10 +52,7 @@ impl<'tcx> LanguageItemCollector<'tcx> {
                 }
                 // Unknown lang item.
                 _ => {
-                    self.tcx.sess.emit_err(UnknownLangItem {
-                        span,
-                        name: value,
-                    });
+                    self.tcx.sess.emit_err(UnknownLangItem { span, name: value });
                 }
             }
         }

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -5,6 +5,8 @@
 //! This API is completely unstable and subject to change.
 
 #![allow(rustc::potential_query_instability)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]


### PR DESCRIPTION
This PR migrates `rustc_passes` diagnostics to use the new translatable system

@rustbot label +A-translation
r? rust-lang/diagnostics
cc #100717