### PR TITLE
CI: automatically approve a PR if has `auto-approve` label

### DIFF
--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -770,3 +770,19 @@ jobs:
     needs: [auto]
     if: "!success() && github.event_name == 'push' && github.ref == 'refs/heads/auto' && github.repository == 'rust-lang-ci/rust'"
     <<: *base-failure-job
+  ci-auto-approve:
+    runs-on: ubuntu-latest
+    name: "automatically approve if configured"
+    needs: [pr]
+    if: ${{ always() && !cancelled() && needs.build.result == 'success' && github.event.pull_request.labels.contains('auto-approve') }}
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@bors r=' + context.event.pull_request.assignee.login
+            })


### PR DESCRIPTION
I have no idea if this would work. But given that a lot of people (including me) would like to have this feature, I took a stab.

The current design is placing a dedicated label on PRs such that, when CI has successfully ran, GitHub Actions will tell bors to r= the current assignee of the PR.