### PR TITLE
Add `AsFd` implementations for stdio types on WASI.

### DIFF
--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -4,7 +4,7 @@ use super::fd::WasiFd;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
 use crate::os::raw;
-use crate::os::wasi::io::{AsRawFd, FromRawFd};
+use crate::os::wasi::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd};
 
 pub struct Stdin;
 pub struct Stdout;
@@ -20,6 +20,13 @@ impl AsRawFd for Stdin {
     #[inline]
     fn as_raw_fd(&self) -> raw::c_int {
         0
+    }
+}
+
+impl AsFd for Stdin {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(0) }
     }
 }
 
@@ -51,6 +58,13 @@ impl AsRawFd for Stdout {
     }
 }
 
+impl AsFd for Stdout {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(1) }
+    }
+}
+
 impl io::Write for Stdout {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         self.write_vectored(&[IoSlice::new(data)])
@@ -79,6 +93,13 @@ impl AsRawFd for Stderr {
     #[inline]
     fn as_raw_fd(&self) -> raw::c_int {
         2
+    }
+}
+
+impl AsFd for Stderr {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(2) }
     }
 }
 


### PR DESCRIPTION
This mirrors the implementations on Unix platforms, and also mirrors the
existing `AsRawFd` impls.