### PR TITLE
Fix broken docs for SGX target

### DIFF
--- a/library/std/src/ffi/docs_linked.md
+++ b/library/std/src/ffi/docs_linked.md
@@ -1,0 +1,39 @@
+## On Unix
+
+On Unix, [`OsStr`] implements the
+<code>std::os::unix::ffi::[OsStrExt][unix.OsStrExt]</code> trait, which
+augments it with two methods, [`from_bytes`] and [`as_bytes`].
+These do inexpensive conversions from and to byte slices.
+
+Additionally, on Unix [`OsString`] implements the
+<code>std::os::unix::ffi::[OsStringExt][unix.OsStringExt]</code> trait,
+which provides [`from_vec`] and [`into_vec`] methods that consume
+their arguments, and take or produce vectors of [`u8`].
+
+## On Windows
+
+An [`OsStr`] can be losslessly converted to a native Windows string. And
+a native Windows string can be losslessly converted to an [`OsString`].
+
+On Windows, [`OsStr`] implements the
+<code>std::os::windows::ffi::[OsStrExt][windows.OsStrExt]</code> trait,
+which provides an [`encode_wide`] method. This provides an
+iterator that can be [`collect`]ed into a vector of [`u16`]. After a nul
+characters is appended, this is the same as a native Windows string.
+
+Additionally, on Windows [`OsString`] implements the
+<code>std::os::windows:ffi::[OsStringExt][windows.OsStringExt]</code>
+trait, which provides a [`from_wide`] method to convert a native Windows
+string (without the terminating nul character) to an [`OsString`].
+
+[unix.OsStringExt]: crate::os::unix::ffi::OsStringExt "os::unix::ffi::OsStringExt"
+[`from_vec`]: crate::os::unix::ffi::OsStringExt::from_vec "os::unix::ffi::OsStringExt::from_vec"
+[`into_vec`]: crate::os::unix::ffi::OsStringExt::into_vec "os::unix::ffi::OsStringExt::into_vec"
+[unix.OsStrExt]: crate::os::unix::ffi::OsStrExt "os::unix::ffi::OsStrExt"
+[`from_bytes`]: crate::os::unix::ffi::OsStrExt::from_bytes "os::unix::ffi::OsStrExt::from_bytes"
+[`as_bytes`]: crate::os::unix::ffi::OsStrExt::as_bytes "os::unix::ffi::OsStrExt::as_bytes"
+[windows.OsStrExt]: crate::os::windows::ffi::OsStrExt "os::windows::ffi::OsStrExt"
+[`encode_wide`]: crate::os::windows::ffi::OsStrExt::encode_wide "os::windows::ffi::OsStrExt::encode_wide"
+[`collect`]: crate::iter::Iterator::collect "iter::Iterator::collect"
+[windows.OsStringExt]: crate::os::windows::ffi::OsStringExt "os::windows::ffi::OsStringExt"
+[`from_wide`]: crate::os::windows::ffi::OsStringExt::from_wide "os::windows::ffi::OsStringExt::from_wide"

--- a/library/std/src/ffi/docs_unlinked.md
+++ b/library/std/src/ffi/docs_unlinked.md
@@ -1,0 +1,29 @@
+## On Unix
+
+On Unix, [`OsStr`] implements the
+<code>std::os::unix::ffi::OsStrExt</code> trait, which
+augments it with two methods, `from_bytes` and `as_bytes`.
+These do inexpensive conversions from and to byte slices.
+
+Additionally, on Unix [`OsString`] implements the
+<code>std::os::unix::ffi::OsStringExt</code> trait,
+which provides `from_vec` and `into_vec` methods that consume
+their arguments, and take or produce vectors of [`u8`].
+
+## On Windows
+
+An [`OsStr`] can be losslessly converted to a native Windows string. And
+a native Windows string can be losslessly converted to an [`OsString`].
+
+On Windows, [`OsStr`] implements the
+<code>std::os::windows::ffi::OsStrExt</code> trait,
+which provides an `encode_wide` method. This provides an
+iterator that can be [`collect`]ed into a vector of [`u16`]. After a nul
+characters is appended, this is the same as a native Windows string.
+
+Additionally, on Windows [`OsString`] implements the
+<code>std::os::windows:ffi::OsStringExt</code>
+trait, which provides a `from_wide` method to convert a native Windows
+string (without the terminating nul character) to an [`OsString`].
+
+[`collect`]: crate::iter::Iterator::collect "iter::Iterator::collect"

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -99,50 +99,18 @@
 //!
 //! # Conversions
 //!
-//! ## On Unix
-//!
-//! On Unix, [`OsStr`] implements the
-//! <code>std::os::unix::ffi::[OsStrExt][unix.OsStrExt]</code> trait, which
-//! augments it with two methods, [`from_bytes`] and [`as_bytes`].
-//! These do inexpensive conversions from and to byte slices.
-//!
-//! Additionally, on Unix [`OsString`] implements the
-//! <code>std::os::unix::ffi::[OsStringExt][unix.OsStringExt]</code> trait,
-//! which provides [`from_vec`] and [`into_vec`] methods that consume
-//! their arguments, and take or produce vectors of [`u8`].
-//!
-//! ## On Windows
-//!
-//! An [`OsStr`] can be losslessly converted to a native Windows string. And
-//! a native Windows string can be losslessly converted to an [`OsString`].
-//!
-//! On Windows, [`OsStr`] implements the
-//! <code>std::os::windows::ffi::[OsStrExt][windows.OsStrExt]</code> trait,
-//! which provides an [`encode_wide`] method. This provides an
-//! iterator that can be [`collect`]ed into a vector of [`u16`]. After a nul
-//! characters is appended, this is the same as a native Windows string.
-//!
-//! Additionally, on Windows [`OsString`] implements the
-//! <code>std::os::windows:ffi::[OsStringExt][windows.OsStringExt]</code>
-//! trait, which provides a [`from_wide`] method to convert a native Windows
-//! string (without the terminating nul character) to an [`OsString`].
+#![cfg_attr(not(target_env = "sgx"), doc = include_str!("./docs_linked.md"))] // see note below
+#![cfg_attr(target_env = "sgx", doc = include_str!("./docs_unlinked.md"))]
 //!
 //! [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
 //! [Unicode code point]: https://www.unicode.org/glossary/#code_point
 //! [`env::set_var()`]: crate::env::set_var "env::set_var"
 //! [`env::var_os()`]: crate::env::var_os "env::var_os"
-//! [unix.OsStringExt]: crate::os::unix::ffi::OsStringExt "os::unix::ffi::OsStringExt"
-//! [`from_vec`]: crate::os::unix::ffi::OsStringExt::from_vec "os::unix::ffi::OsStringExt::from_vec"
-//! [`into_vec`]: crate::os::unix::ffi::OsStringExt::into_vec "os::unix::ffi::OsStringExt::into_vec"
-//! [unix.OsStrExt]: crate::os::unix::ffi::OsStrExt "os::unix::ffi::OsStrExt"
-//! [`from_bytes`]: crate::os::unix::ffi::OsStrExt::from_bytes "os::unix::ffi::OsStrExt::from_bytes"
-//! [`as_bytes`]: crate::os::unix::ffi::OsStrExt::as_bytes "os::unix::ffi::OsStrExt::as_bytes"
-//! [`OsStrExt`]: crate::os::unix::ffi::OsStrExt "os::unix::ffi::OsStrExt"
-//! [windows.OsStrExt]: crate::os::windows::ffi::OsStrExt "os::windows::ffi::OsStrExt"
-//! [`encode_wide`]: crate::os::windows::ffi::OsStrExt::encode_wide "os::windows::ffi::OsStrExt::encode_wide"
-//! [`collect`]: crate::iter::Iterator::collect "iter::Iterator::collect"
-//! [windows.OsStringExt]: crate::os::windows::ffi::OsStringExt "os::windows::ffi::OsStringExt"
-//! [`from_wide`]: crate::os::windows::ffi::OsStringExt::from_wide "os::windows::ffi::OsStringExt::from_wide"
+
+// NOTE: The last section of the docs contains links to unix and windows
+// specific types that are not available in the SGX target. Therefore two
+// versions of the docs are stored in files and included based on target. These
+// should be kept in sync modulo the links.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -194,9 +194,13 @@ pub struct FileTimes(fs_imp::FileTimes);
 /// This module only currently provides one bit of information,
 /// [`Permissions::readonly`], which is exposed on all currently supported
 /// platforms. Unix-specific functionality, such as mode bits, is available
-/// through the [`PermissionsExt`] trait.
+#[cfg_attr(target_env = "sgx", doc = " through the `std::os::unix::fs::PermissionsExt` trait.")]
+#[cfg_attr(not(target_env = "sgx"), doc = " through the [`PermissionsExt`] trait.")]
 ///
-/// [`PermissionsExt`]: crate::os::unix::fs::PermissionsExt
+#[cfg_attr(
+    not(target_env = "sgx"),
+    doc = " [`PermissionsExt`]: crate::os::unix::fs::PermissionsExt"
+)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Permissions(fs_imp::FilePermissions);
@@ -1919,13 +1923,33 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Re
 ///
 /// The `link` path will be a symbolic link pointing to the `original` path.
 /// On Windows, this will be a file symlink, not a directory symlink;
-/// for this reason, the platform-specific [`std::os::unix::fs::symlink`]
-/// and [`std::os::windows::fs::symlink_file`] or [`symlink_dir`] should be
+#[cfg_attr(
+    target_env = "sgx",
+    doc = " for this reason, the platform-specific `std::os::unix::fs::symlink`"
+)]
+#[cfg_attr(
+    target_env = "sgx",
+    doc = " and `std::os::windows::fs::symlink_file` or `std::os::windows::fs::symlink_dir` should be"
+)]
+#[cfg_attr(
+    not(target_env = "sgx"),
+    doc = " for this reason, the platform-specific [`std::os::unix::fs::symlink`]"
+)]
+#[cfg_attr(
+    not(target_env = "sgx"),
+    doc = " and [`std::os::windows::fs::symlink_file`] or [`symlink_dir`] should be"
+)]
 /// used instead to make the intent explicit.
 ///
-/// [`std::os::unix::fs::symlink`]: crate::os::unix::fs::symlink
-/// [`std::os::windows::fs::symlink_file`]: crate::os::windows::fs::symlink_file
-/// [`symlink_dir`]: crate::os::windows::fs::symlink_dir
+#[cfg_attr(
+    not(target_env = "sgx"),
+    doc = " [`std::os::unix::fs::symlink`]: crate::os::unix::fs::symlink"
+)]
+#[cfg_attr(
+    not(target_env = "sgx"),
+    doc = " [`std::os::windows::fs::symlink_file`]: crate::os::windows::fs::symlink_file"
+)]
+#[cfg_attr(not(target_env = "sgx"), doc = " [`symlink_dir`]: crate::os::windows::fs::symlink_dir")]
 ///
 /// # Examples
 ///

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -5,7 +5,7 @@
 use crate::fs;
 use crate::io;
 use crate::os::raw;
-#[cfg(all(doc, not(target_arch = "wasm32")))]
+#[cfg(all(doc, not(target_arch = "wasm32"), not(target_env = "sgx")))]
 use crate::os::unix::io::AsFd;
 #[cfg(unix)]
 use crate::os::unix::io::OwnedFd;

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1514,7 +1514,11 @@ impl ExitStatus {
     /// runtime system (often, for example, 255, 254, 127 or 126).
     ///
     /// On Unix, this will return `None` if the process was terminated by a signal.
-    /// [`ExitStatusExt`](crate::os::unix::process::ExitStatusExt) is an
+    #[cfg_attr(target_env = "sgx", doc = " `std::os::unix::process::ExitStatusExt` is an")]
+    #[cfg_attr(
+        not(target_env = "sgx"),
+        doc = " [`ExitStatusExt`](crate::os::unix::process::ExitStatusExt) is an"
+    )]
     /// extension trait for extracting any such signal, and other details, from the `ExitStatus`.
     ///
     /// # Examples
@@ -1599,7 +1603,11 @@ impl ExitStatusError {
     ///
     /// On Unix, this will return `None` if the process was terminated by a signal.  If you want to
     /// handle such situations specially, consider using methods from
-    /// [`ExitStatusExt`](crate::os::unix::process::ExitStatusExt).
+    #[cfg_attr(target_env = "sgx", doc = " `std::os::unix::process::ExitStatusExt`.")]
+    #[cfg_attr(
+        not(target_env = "sgx"),
+        doc = " [`ExitStatusExt`](crate::os::unix::process::ExitStatusExt)."
+    )]
     ///
     /// If the process finished by calling `exit` with a nonzero value, this will return
     /// that exit status.


### PR DESCRIPTION
This PR fixes broken links in some doc comments that prevent generating standard library API reference for `x86_64-fortanix-unknown-sgx` target.

Due to the fact that `std::os::unix` and `std::os::windows` modules are empty when compiling with the SGX target, intra-doc links to items in those modules are broken. To fix the issue, I have changed the docs depending on target using `cfg_attr`. Please let me know if there is a better way to do this.

cc @jethrogb 