### PR TITLE
Update stdarch submodule

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -737,28 +737,7 @@ extern "rust-intrinsic" {
     /// [`atomic::compiler_fence`] by passing [`Ordering::AcqRel`]
     /// as the `order`.
     pub fn atomic_singlethreadfence_acqrel();
-}
 
-// These have been renamed.
-//
-// These are the aliases for the old names.
-// To be removed when stdarch and panic_unwind have been updated.
-mod atomics {
-    pub use super::atomic_cxchg_acqrel_acquire as atomic_cxchg_acqrel;
-    pub use super::atomic_cxchg_acqrel_relaxed as atomic_cxchg_acqrel_failrelaxed;
-    pub use super::atomic_cxchg_acquire_acquire as atomic_cxchg_acq;
-    pub use super::atomic_cxchg_acquire_relaxed as atomic_cxchg_acq_failrelaxed;
-    pub use super::atomic_cxchg_relaxed_relaxed as atomic_cxchg_relaxed;
-    pub use super::atomic_cxchg_release_relaxed as atomic_cxchg_rel;
-    pub use super::atomic_cxchg_seqcst_acquire as atomic_cxchg_failacq;
-    pub use super::atomic_cxchg_seqcst_relaxed as atomic_cxchg_failrelaxed;
-    pub use super::atomic_cxchg_seqcst_seqcst as atomic_cxchg;
-    pub use super::atomic_store_seqcst as atomic_store;
-}
-
-pub use atomics::*;
-
-extern "rust-intrinsic" {
     /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
     /// if supported; otherwise, it is a no-op.
     /// Prefetches have no effect on the behavior of the program but can change its performance

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -256,7 +256,7 @@ cfg_if::cfg_if! {
 }
 
 pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
-    use core::intrinsics::atomic_store;
+    use core::intrinsics::atomic_store_seqcst;
 
     // _CxxThrowException executes entirely on this stack frame, so there's no
     // need to otherwise transfer `data` to the heap. We just pass a stack
@@ -288,20 +288,23 @@ pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
     //
     // In any case, we basically need to do something like this until we can
     // express more operations in statics (and we may never be able to).
-    atomic_store(&mut THROW_INFO.pmfnUnwind as *mut _ as *mut u32, ptr!(exception_cleanup) as u32);
-    atomic_store(
+    atomic_store_seqcst(
+        &mut THROW_INFO.pmfnUnwind as *mut _ as *mut u32,
+        ptr!(exception_cleanup) as u32,
+    );
+    atomic_store_seqcst(
         &mut THROW_INFO.pCatchableTypeArray as *mut _ as *mut u32,
         ptr!(&CATCHABLE_TYPE_ARRAY as *const _) as u32,
     );
-    atomic_store(
+    atomic_store_seqcst(
         &mut CATCHABLE_TYPE_ARRAY.arrayOfCatchableTypes[0] as *mut _ as *mut u32,
         ptr!(&CATCHABLE_TYPE as *const _) as u32,
     );
-    atomic_store(
+    atomic_store_seqcst(
         &mut CATCHABLE_TYPE.pType as *mut _ as *mut u32,
         ptr!(&TYPE_DESCRIPTOR as *const _) as u32,
     );
-    atomic_store(
+    atomic_store_seqcst(
         &mut CATCHABLE_TYPE.copyFunction as *mut _ as *mut u32,
         ptr!(exception_copy) as u32,
     );


### PR DESCRIPTION
Changes from stdarch:

* Fix links in documentation of cmpxchg16b
* Use load intrinsic and loop for intrinsic-test programs. Add --release flag back to intrinsic-test programs.
* Properly fix vext intrinsic tests
* Replace some calls to `pointer::offset` with `add` and `sub`
* Allow internal use of stdsimd from detect_feature
* fix target name in contributing.md
* Tweak constant for ARM vext instruction tests
* Use `llvm.ppc.altivec.lvx` intrinsic for `vec_ld`
*  Adding doc links for arm neon intrinsics
* Adding doc links for arm crypto and aes intrinsics
* Remove instruction tests for `__mmask*` intrinsics
* Update ubuntu 21.10 docker containers to 22.04
* Adding documentation links for arm crc32 intrinsics
* Remove restrictions on compare-exchange memory ordering.
* Fix a typo in the document.
* Allow mapping a runtime feature to a set of target_features
* Update atomic intrinsics
* Fully qualify recursive macro calls
* Ensure the neon vector aggregates like `float32x4x4_t` are `#[repr(C)]`
* Remove useless conditional compilation
* Fix ARM vbsl* NEON intrinsics

r? @Amanieu 