### PR TITLE
Introducting f32:: and f64:: ZERO and NEG_ZERO

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -498,7 +498,7 @@ impl f32 {
     /// let min = f32::MIN_POSITIVE; // 1.17549435e-38f32
     /// let max = f32::MAX;
     /// let lower_than_min = 1.0e-40_f32;
-    /// let zero = 0.0_f32;
+    /// let zero = f32::ZERO;
     ///
     /// assert!(!min.is_subnormal());
     /// assert!(!max.is_subnormal());
@@ -525,7 +525,7 @@ impl f32 {
     /// let min = f32::MIN_POSITIVE; // 1.17549435e-38f32
     /// let max = f32::MAX;
     /// let lower_than_min = 1.0e-40_f32;
-    /// let zero = 0.0_f32;
+    /// let zero = f32::ZERO;
     ///
     /// assert!(min.is_normal());
     /// assert!(max.is_normal());

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -402,6 +402,12 @@ impl f32 {
     /// This constant isn't guaranteed to equal to any specific NaN bitpattern,
     /// and the stability of its representation over Rust versions
     /// and target platforms isn't guaranteed.
+    /// Zero (0).
+    #[stable(feature = "zero_consts", since = "1.64.0")]
+    pub const ZERO: f32 = 0.0_f32;
+    /// Negative Zero. Same value as Zero, but stores a negative sign bit. IEEE-754 specifies that both should be able to stored.
+    #[stable(feature = "zero_consts", since = "1.64.0")]
+    pub const NEG_ZERO: f32 = -0.0_f32;
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NAN: f32 = 0.0_f32 / 0.0_f32;
     /// Infinity (∞).
@@ -410,7 +416,6 @@ impl f32 {
     /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NEG_INFINITY: f32 = -1.0_f32 / 0.0_f32;
-
     /// Returns `true` if this value is NaN.
     ///
     /// ```

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -391,10 +391,15 @@ impl f32 {
     /// Maximum possible power of 10 exponent.
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const MAX_10_EXP: i32 = 38;
-
+    /// Zero (0).
+    #[stable(feature = "zero_consts", since = "1.64.0")]
+    pub const ZERO: f32 = 0.0_f32;
+    /// Negative Zero. Same value as Zero, but stores a negative sign bit. IEEE-754 specifies that both should be able to stored.
+    #[stable(feature = "zero_consts", since = "1.64.0")]
+    pub const NEG_ZERO: f32 = -0.0_f32;
     /// Not a Number (NaN).
     ///
-    /// Note that IEEE-745 doesn't define just a single NaN value;
+    /// Note that IEEE-754 doesn't define just a single NaN value;
     /// a plethora of bit patterns are considered to be NaN.
     /// Furthermore, the standard makes a difference
     /// between a "signaling" and a "quiet" NaN,
@@ -402,20 +407,14 @@ impl f32 {
     /// This constant isn't guaranteed to equal to any specific NaN bitpattern,
     /// and the stability of its representation over Rust versions
     /// and target platforms isn't guaranteed.
-    /// Zero (0).
-    #[stable(feature = "zero_consts", since = "1.64.0")]
-    pub const ZERO: f32 = 0.0_f32;
-    /// Negative Zero. Same value as Zero, but stores a negative sign bit. IEEE-754 specifies that both should be able to stored.
-    #[stable(feature = "zero_consts", since = "1.64.0")]
-    pub const NEG_ZERO: f32 = -0.0_f32;
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
-    pub const NAN: f32 = 0.0_f32 / 0.0_f32;
+    pub const NAN: f32 = f32::ZERO / f32::ZERO;
     /// Infinity (∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
-    pub const INFINITY: f32 = 1.0_f32 / 0.0_f32;
+    pub const INFINITY: f32 = 1.0_f32 / f32::ZERO;
     /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
-    pub const NEG_INFINITY: f32 = -1.0_f32 / 0.0_f32;
+    pub const NEG_INFINITY: f32 = -1.0_f32 / f32::ZERO;
     /// Returns `true` if this value is NaN.
     ///
     /// ```

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -415,6 +415,7 @@ impl f32 {
     /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NEG_INFINITY: f32 = -1.0_f32 / f32::ZERO;
+    
     /// Returns `true` if this value is NaN.
     ///
     /// ```

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -401,15 +401,20 @@ impl f64 {
     /// This constant isn't guaranteed to equal to any specific NaN bitpattern,
     /// and the stability of its representation over Rust versions
     /// and target platforms isn't guaranteed.
+    /// Zero (0).
+    #[stable(feature = "zero_consts", since = "1.64.0")]
+    pub const ZERO: f64 = 0.0_f64;
+    /// Negative Zero. Same value as Zero, but stores a negative sign bit. IEEE-754 specifies that both should be able to stored.
+    #[stable(feature = "zero_consts", since = "1.64.0")]
+    pub const NEG_ZERO: f64 = -0.0_f64;
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
-    pub const NAN: f64 = 0.0_f64 / 0.0_f64;
+    pub const NAN: f64 = f64::ZERO / f64::ZERO;
     /// Infinity (∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
-    pub const INFINITY: f64 = 1.0_f64 / 0.0_f64;
+    pub const INFINITY: f64 = 1.0_f64 / f64::ZERO;
     /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
-    pub const NEG_INFINITY: f64 = -1.0_f64 / 0.0_f64;
-
+    pub const NEG_INFINITY: f64 = -1.0_f64 / f64::ZERO;
     /// Returns `true` if this value is NaN.
     ///
     /// ```
@@ -495,7 +500,7 @@ impl f64 {
     /// let min = f64::MIN_POSITIVE; // 2.2250738585072014e-308_f64
     /// let max = f64::MAX;
     /// let lower_than_min = 1.0e-308_f64;
-    /// let zero = 0.0_f64;
+    /// let zero = f64::ZERO;
     ///
     /// assert!(!min.is_subnormal());
     /// assert!(!max.is_subnormal());
@@ -522,7 +527,7 @@ impl f64 {
     /// let min = f64::MIN_POSITIVE; // 2.2250738585072014e-308f64
     /// let max = f64::MAX;
     /// let lower_than_min = 1.0e-308_f64;
-    /// let zero = 0.0f64;
+    /// let zero = f64::ZERO;
     ///
     /// assert!(min.is_normal());
     /// assert!(max.is_normal());

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -415,6 +415,7 @@ impl f64 {
     /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NEG_INFINITY: f64 = -1.0_f64 / f64::ZERO;
+    
     /// Returns `true` if this value is NaN.
     ///
     /// ```

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -391,16 +391,6 @@ impl f64 {
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const MAX_10_EXP: i32 = 308;
 
-    /// Not a Number (NaN).
-    ///
-    /// Note that IEEE-745 doesn't define just a single NaN value;
-    /// a plethora of bit patterns are considered to be NaN.
-    /// Furthermore, the standard makes a difference
-    /// between a "signaling" and a "quiet" NaN,
-    /// and allows inspecting its "payload" (the unspecified bits in the bit pattern).
-    /// This constant isn't guaranteed to equal to any specific NaN bitpattern,
-    /// and the stability of its representation over Rust versions
-    /// and target platforms isn't guaranteed.
     /// Zero (0).
     #[stable(feature = "zero_consts", since = "1.64.0")]
     pub const ZERO: f64 = 0.0_f64;
@@ -408,6 +398,16 @@ impl f64 {
     #[stable(feature = "zero_consts", since = "1.64.0")]
     pub const NEG_ZERO: f64 = -0.0_f64;
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
+    /// Not a Number (NaN).
+    ///
+    /// Note that IEEE-754 doesn't define just a single NaN value;
+    /// a plethora of bit patterns are considered to be NaN.
+    /// Furthermore, the standard makes a difference
+    /// between a "signaling" and a "quiet" NaN,
+    /// and allows inspecting its "payload" (the unspecified bits in the bit pattern).
+    /// This constant isn't guaranteed to equal to any specific NaN bitpattern,
+    /// and the stability of its representation over Rust versions
+    /// and target platforms isn't guaranteed.
     pub const NAN: f64 = f64::ZERO / f64::ZERO;
     /// Infinity (∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -24,7 +24,7 @@ use crate::sys::cmath;
 #[allow(deprecated, deprecated_in_future)]
 pub use core::f32::{
     consts, DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP,
-    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX,
+    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, NEG_ZERO, RADIX, ZERO,
 };
 
 #[cfg(not(test))]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -24,7 +24,7 @@ use crate::sys::cmath;
 #[allow(deprecated, deprecated_in_future)]
 pub use core::f64::{
     consts, DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP,
-    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX,
+    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, NEG_ZERO, RADIX, ZERO, 
 };
 
 #[cfg(not(test))]


### PR DESCRIPTION
Change to the std library API which adds f32::ZERO, f64::ZERO, f32::NEG_ZERO, and f64::ZERO to improve consistency interfacing with IEEE-754.
Still a bit new to the system rust uses with the standard library. If there's more review to be done on this, then feel free to do so, edit my commits, or let me know if I should change anything with the code or workflow.
@rustbot label +T-libs-api -T-libs