### PR TITLE
Use par_body_owners for liveness

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -911,13 +911,13 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                 });
             },
             {
-                sess.time("liveness_and_intrinsic_checking", || {
-                    tcx.hir().par_for_each_module(|module| {
+                sess.time("liveness_checking", || {
+                    tcx.hir().par_body_owners(|def_id| {
                         // this must run before MIR dump, because
                         // "not all control paths return a value" is reported here.
                         //
                         // maybe move the check to a MIR pass?
-                        tcx.ensure().check_mod_liveness(module);
+                        tcx.ensure().check_liveness(def_id.to_def_id());
                     });
                 });
             }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -818,8 +818,8 @@ rustc_queries! {
         desc { |tcx| "checking privacy in {}", describe_as_module(key, tcx) }
     }
 
-    query check_mod_liveness(key: LocalDefId) -> () {
-        desc { |tcx| "checking liveness of variables in {}", describe_as_module(key, tcx) }
+    query check_liveness(key: DefId) {
+        desc { |tcx| "checking liveness of variables in {}", tcx.def_path_str(key) }
     }
 
     /// Return the live symbols in the crate for dead code check.

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/destructure-pattern-closure-within-closure.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/destructure-pattern-closure-within-closure.stderr
@@ -1,8 +1,8 @@
-warning: unused variable: `t2`
-  --> $DIR/destructure-pattern-closure-within-closure.rs:13:21
+warning: unused variable: `g2`
+  --> $DIR/destructure-pattern-closure-within-closure.rs:10:17
    |
-LL |             let (_, t2) = t;
-   |                     ^^ help: if this is intentional, prefix it with an underscore: `_t2`
+LL |         let (_, g2) = g;
+   |                 ^^ help: if this is intentional, prefix it with an underscore: `_g2`
    |
 note: the lint level is defined here
   --> $DIR/destructure-pattern-closure-within-closure.rs:3:9
@@ -11,11 +11,11 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
 
-warning: unused variable: `g2`
-  --> $DIR/destructure-pattern-closure-within-closure.rs:10:17
+warning: unused variable: `t2`
+  --> $DIR/destructure-pattern-closure-within-closure.rs:13:21
    |
-LL |         let (_, g2) = g;
-   |                 ^^ help: if this is intentional, prefix it with an underscore: `_g2`
+LL |             let (_, t2) = t;
+   |                     ^^ help: if this is intentional, prefix it with an underscore: `_t2`
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/unused/issue-54180-unused-ref-field.stderr
+++ b/src/test/ui/lint/unused/issue-54180-unused-ref-field.stderr
@@ -11,12 +11,6 @@ LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
-error: unused variable: `x`
-  --> $DIR/issue-54180-unused-ref-field.rs:29:45
-   |
-LL |     let _: i32 = points.iter().map(|Point { x, y }| y).sum();
-   |                                             ^ help: try ignoring the field: `x: _`
-
 error: unused variable: `f1`
   --> $DIR/issue-54180-unused-ref-field.rs:26:13
    |
@@ -28,6 +22,12 @@ error: unused variable: `x`
    |
 LL |         Point { y, ref mut x } => y,
    |                    ^^^^^^^^^ help: try ignoring the field: `x: _`
+
+error: unused variable: `x`
+  --> $DIR/issue-54180-unused-ref-field.rs:29:45
+   |
+LL |     let _: i32 = points.iter().map(|Point { x, y }| y).sum();
+   |                                             ^ help: try ignoring the field: `x: _`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/unused/lint-unused-variables.stderr
+++ b/src/test/ui/lint/unused/lint-unused-variables.stderr
@@ -17,30 +17,6 @@ LL |     b: i32,
    |     ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/lint-unused-variables.rs:68:9
-   |
-LL |         a: i32,
-   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
-
-error: unused variable: `b`
-  --> $DIR/lint-unused-variables.rs:74:9
-   |
-LL |         b: i32,
-   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
-
-error: unused variable: `b`
-  --> $DIR/lint-unused-variables.rs:42:9
-   |
-LL |         b: i32,
-   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
-
-error: unused variable: `b`
-  --> $DIR/lint-unused-variables.rs:47:9
-   |
-LL |         b: i32,
-   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
-
-error: unused variable: `a`
   --> $DIR/lint-unused-variables.rs:22:9
    |
 LL |         a: i32,
@@ -59,6 +35,18 @@ LL |         b: i32,
    |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `b`
+  --> $DIR/lint-unused-variables.rs:42:9
+   |
+LL |         b: i32,
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
+
+error: unused variable: `b`
+  --> $DIR/lint-unused-variables.rs:47:9
+   |
+LL |         b: i32,
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
+
+error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:55:9
    |
 LL |         b: i32,
@@ -66,6 +54,18 @@ LL |         b: i32,
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:60:9
+   |
+LL |         b: i32,
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
+
+error: unused variable: `a`
+  --> $DIR/lint-unused-variables.rs:68:9
+   |
+LL |         a: i32,
+   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
+
+error: unused variable: `b`
+  --> $DIR/lint-unused-variables.rs:74:9
    |
 LL |         b: i32,
    |         ^ help: if this is intentional, prefix it with an underscore: `_b`

--- a/src/test/ui/liveness/liveness-consts.stderr
+++ b/src/test/ui/liveness/liveness-consts.stderr
@@ -39,12 +39,6 @@ warning: unused variable: `z`
 LL | pub fn f(x: [u8; { let s = 17; 100 }]) -> [u8;  { let z = 18; 100 }] {
    |                                                       ^ help: if this is intentional, prefix it with an underscore: `_z`
 
-warning: unused variable: `z`
-  --> $DIR/liveness-consts.rs:60:13
-   |
-LL |         let z = 42;
-   |             ^ help: if this is intentional, prefix it with an underscore: `_z`
-
 warning: value assigned to `t` is never read
   --> $DIR/liveness-consts.rs:42:9
    |
@@ -58,6 +52,12 @@ warning: unused variable: `w`
    |
 LL |         let w = 10;
    |             ^ help: if this is intentional, prefix it with an underscore: `_w`
+
+warning: unused variable: `z`
+  --> $DIR/liveness-consts.rs:60:13
+   |
+LL |         let z = 42;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_z`
 
 warning: 8 warnings emitted
 

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-cfg.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-cfg.stderr
@@ -23,48 +23,6 @@ LL |     #[cfg_attr(nothing, cfg(nothing))] c: i32,
    |                                        ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `a`
-  --> $DIR/param-attrs-cfg.rs:107:27
-   |
-LL |         #[cfg(something)] a: i32,
-   |                           ^ help: if this is intentional, prefix it with an underscore: `_a`
-
-error: unused variable: `b`
-  --> $DIR/param-attrs-cfg.rs:113:27
-   |
-LL |         #[cfg(something)] b: i32,
-   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
-
-error: unused variable: `c`
-  --> $DIR/param-attrs-cfg.rs:115:44
-   |
-LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
-
-error: unused variable: `b`
-  --> $DIR/param-attrs-cfg.rs:67:27
-   |
-LL |         #[cfg(something)] b: i32,
-   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
-
-error: unused variable: `c`
-  --> $DIR/param-attrs-cfg.rs:69:44
-   |
-LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
-
-error: unused variable: `b`
-  --> $DIR/param-attrs-cfg.rs:75:27
-   |
-LL |         #[cfg(something)] b: i32,
-   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
-
-error: unused variable: `c`
-  --> $DIR/param-attrs-cfg.rs:77:44
-   |
-LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
-
-error: unused variable: `a`
   --> $DIR/param-attrs-cfg.rs:41:27
    |
 LL |         #[cfg(something)] a: i32,
@@ -95,6 +53,30 @@ LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
    |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `b`
+  --> $DIR/param-attrs-cfg.rs:67:27
+   |
+LL |         #[cfg(something)] b: i32,
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
+
+error: unused variable: `c`
+  --> $DIR/param-attrs-cfg.rs:69:44
+   |
+LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
+
+error: unused variable: `b`
+  --> $DIR/param-attrs-cfg.rs:75:27
+   |
+LL |         #[cfg(something)] b: i32,
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
+
+error: unused variable: `c`
+  --> $DIR/param-attrs-cfg.rs:77:44
+   |
+LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
+
+error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:86:27
    |
 LL |         #[cfg(something)] b: i32,
@@ -114,6 +96,24 @@ LL |         #[cfg(something)] b: i32,
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:96:44
+   |
+LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
+
+error: unused variable: `a`
+  --> $DIR/param-attrs-cfg.rs:107:27
+   |
+LL |         #[cfg(something)] a: i32,
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_a`
+
+error: unused variable: `b`
+  --> $DIR/param-attrs-cfg.rs:113:27
+   |
+LL |         #[cfg(something)] b: i32,
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
+
+error: unused variable: `c`
+  --> $DIR/param-attrs-cfg.rs:115:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
    |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`


### PR DESCRIPTION
I did this refactoring while working on something else. Liveness is about bodies, there is no reason to use par_for_each_module here.

Tests are updated because things are visited in a different order. I checked diagnostics are same, just in a different (and IMO, better) order.