### PR TITLE
Add a warning about `Option/Result::and()` being eagerly evaluated

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1189,6 +1189,12 @@ impl<T> Option<T> {
 
     /// Returns [`None`] if the option is [`None`], otherwise returns `optb`.
     ///
+    /// Arguments passed to `and` are eagerly evaluated; if you are passing the
+    /// result of a function call, it is recommended to use [`and_then`], which is
+    /// lazily evaluated.
+    ///
+    /// [`and_then`]: Option::and_then
+    ///
     /// # Examples
     ///
     /// ```

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1285,6 +1285,11 @@ impl<T, E> Result<T, E> {
 
     /// Returns `res` if the result is [`Ok`], otherwise returns the [`Err`] value of `self`.
     ///
+    /// Arguments passed to `and` are eagerly evaluated; if you are passing the
+    /// result of a function call, it is recommended to use [`and_then`], which is
+    /// lazily evaluated.
+    ///
+    /// [`and_then`]: Result::and_then
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Copied from `or()`.

Inspired by [this StackOverflow question](https://stackoverflow.com/questions/73461846/why-is-in-rust-the-expression-in-option-and-evaluated-if-option-is-none).

[The PR for `or()`](https://github.com/rust-lang/rust/pull/46548) mentions the Clippy lint `or_fun_call` which doesn't exist for `and()` (although there is `unnecessary_lazy_evaluations`). I still think this warning is also good for `and()`. Feel free to close if you disagree.