### PR TITLE
rustdoc: remove unused CSS rule

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -745,10 +745,6 @@ pre, .rustdoc.source .example-wrap {
 	border: 1px solid var(--border-color);
 }
 
-.fields + table {
-	margin-bottom: 1em;
-}
-
 .content .item-list {
 	list-style-type: none;
 	padding: 0;


### PR DESCRIPTION
According to [blame], this rule was added to support enum struct variants. However, enum struct variants don't use tables in their design any more, so this rule does nothing.

[blame]: https://github.com/rust-lang/rust/blame/87991d5f5d72d6baca490141cb890211ba2f3843/src/librustdoc/html/static/css/rustdoc.css#L748