### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4993,9 +4993,9 @@ checksum = "da73c8f77aebc0e40c300b93f0a5f1bece7a248a36eee287d4e095f35c7b7d6e"
 
 [[package]]
 name = "snapbox"
-version = "0.2.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f212b806d6f56d19838e36a0aaa7e79a0bc9ca177e873fb87651ad92f983e2"
+checksum = "44d199ccf8f606592df2d145db26f2aa45344e23c64b074cc5a4047f1d99b0f7"
 dependencies = [
  "concolor",
  "content_inspector",
@@ -5011,9 +5011,9 @@ dependencies = [
 
 [[package]]
 name = "snapbox-macros"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01dea7e04cbb27ef4c86e9922184608185f7cd95c1763bc30d727cda4a5e930"
+checksum = "8a253e6f894cfa440cba00600a249fa90869d8e0ec45ab274a456e043a0ce8f2"
 
 [[package]]
 name = "socket2"


### PR DESCRIPTION
7 commits in 9809f8ff33c2b998919fd0432c626f0f7323697a..6da726708a4406f31f996d813790818dce837161
2022-08-16 22:10:06 +0000 to 2022-08-23 21:39:56 +0000
- Update non-ASCII crate name warning message (rust-lang/cargo#11017)
- Add more tests for aggressive or precise update (rust-lang/cargo#11011)
- Ignore broken but excluded file during traversing (rust-lang/cargo#11008)
- Improve error message for wrong target names (rust-lang/cargo#10999)
- Bump snapbox to 0.3 (rust-lang/cargo#11005)
- remove missed reference to workspace inheritance in unstable.md (rust-lang/cargo#11001)
- Warning when precise or aggressive without -p flag (rust-lang/cargo#10988)