### PR TITLE
Add a missing test case for impl generic mismatch

### DIFF
--- a/src/test/ui/impl-trait/impl-generic-mismatch.rs
+++ b/src/test/ui/impl-trait/impl-generic-mismatch.rs
@@ -18,6 +18,15 @@ impl Bar for () {
     //~^ Error method `bar` has incompatible signature for trait
 }
 
+trait Baz {
+    fn baz<U: Debug, T: Debug>(&self, _: &U, _: &T);
+}
+
+impl Baz for () {
+    fn baz<T: Debug>(&self, _: &impl Debug, _: &T) { }
+    //~^ Error method `baz` has incompatible signature for trait
+}
+
 // With non-local trait (#49841):
 
 use std::hash::{Hash, Hasher};

--- a/src/test/ui/impl-trait/impl-generic-mismatch.stderr
+++ b/src/test/ui/impl-trait/impl-generic-mismatch.stderr
@@ -27,8 +27,22 @@ help: try changing the `impl Trait` argument to a generic parameter
 LL |     fn bar<U: Debug>(&self, _: &U) { }
    |           ++++++++++            ~
 
+error[E0643]: method `baz` has incompatible signature for trait
+  --> $DIR/impl-generic-mismatch.rs:26:33
+   |
+LL |     fn baz<U: Debug, T: Debug>(&self, _: &U, _: &T);
+   |                      - declaration in trait here
+...
+LL |     fn baz<T: Debug>(&self, _: &impl Debug, _: &T) { }
+   |                                 ^^^^^^^^^^ expected generic parameter, found `impl Trait`
+   |
+help: try changing the `impl Trait` argument to a generic parameter
+   |
+LL |     fn baz<U: Debug, T: Debug>(&self, _: &T, _: &T) { }
+   |           ~~~~~~~~~~~~~~~~~~~~            ~
+
 error[E0643]: method `hash` has incompatible signature for trait
-  --> $DIR/impl-generic-mismatch.rs:28:33
+  --> $DIR/impl-generic-mismatch.rs:37:33
    |
 LL |     fn hash(&self, hasher: &mut impl Hasher) {}
    |                                 ^^^^^^^^^^^ expected generic parameter, found `impl Trait`
@@ -38,6 +52,6 @@ LL |     fn hash(&self, hasher: &mut impl Hasher) {}
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
    |             - declaration in trait here
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0643`.


### PR DESCRIPTION
This suggestion use different span depending on whether the method has generics or not, so I added a test case about the method with some generics.