### PR TITLE
Simplify the arguments to macros generated by the `rustc_queries` proc macro

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -400,10 +400,8 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         #[macro_export]
         macro_rules! rustc_query_append {
-            ([$($macro:tt)*][$($other:tt)*]) => {
+            ([$($macro:tt)*]) => {
                 $($macro)* {
-                    $($other)*
-
                     #query_stream
                 }
             }

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -400,15 +400,15 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         #[macro_export]
         macro_rules! rustc_query_append {
-            ([$($macro:tt)*]) => {
-                $($macro)* {
+            ($macro:ident !) => {
+                $macro! {
                     #query_stream
                 }
             }
         }
         macro_rules! rustc_dep_node_append {
-            ([$($macro:tt)*][$($other:tt)*]) => {
-                $($macro)*(
+            ($macro:ident! [$($other:tt)*]) => {
+                $macro!(
                     $($other)*
 
                     #dep_node_def_stream
@@ -417,8 +417,8 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
         }
         #[macro_export]
         macro_rules! rustc_cached_queries {
-            ($($macro:tt)*) => {
-                $($macro)*(#cached_queries);
+            ( $macro:ident! ) => {
+                $macro!(#cached_queries);
             }
         }
         #[macro_export]

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -258,13 +258,13 @@ fn add_query_description_impl(query: &Query, impls: &mut proc_macro2::TokenStrea
         let try_load_from_disk = if let Some((tcx, id, block)) = modifiers.load_cached.as_ref() {
             // Use custom code to load the query from disk
             quote! {
-                const TRY_LOAD_FROM_DISK: Option<fn(QueryCtxt<$tcx>, SerializedDepNodeIndex) -> Option<Self::Value>>
+                const TRY_LOAD_FROM_DISK: Option<fn(QueryCtxt<'tcx>, SerializedDepNodeIndex) -> Option<Self::Value>>
                     = Some(|#tcx, #id| { #block });
             }
         } else {
             // Use the default code to load the query from disk
             quote! {
-                const TRY_LOAD_FROM_DISK: Option<fn(QueryCtxt<$tcx>, SerializedDepNodeIndex) -> Option<Self::Value>>
+                const TRY_LOAD_FROM_DISK: Option<fn(QueryCtxt<'tcx>, SerializedDepNodeIndex) -> Option<Self::Value>>
                     = Some(|tcx, id| tcx.on_disk_cache().as_ref()?.try_load_query_result(*tcx, id));
             }
         };
@@ -291,7 +291,7 @@ fn add_query_description_impl(query: &Query, impls: &mut proc_macro2::TokenStrea
                 false
             }
 
-            const TRY_LOAD_FROM_DISK: Option<fn(QueryCtxt<$tcx>, SerializedDepNodeIndex) -> Option<Self::Value>> = None;
+            const TRY_LOAD_FROM_DISK: Option<fn(QueryCtxt<'tcx>, SerializedDepNodeIndex) -> Option<Self::Value>> = None;
         }
     };
 
@@ -300,7 +300,7 @@ fn add_query_description_impl(query: &Query, impls: &mut proc_macro2::TokenStrea
 
     let desc = quote! {
         #[allow(unused_variables)]
-        fn describe(tcx: QueryCtxt<$tcx>, key: Self::Key) -> String {
+        fn describe(tcx: QueryCtxt<'tcx>, key: Self::Key) -> String {
             let (#tcx, #key) = (*tcx, key);
             ::rustc_middle::ty::print::with_no_trimmed_paths!(
                 format!(#desc)
@@ -309,7 +309,7 @@ fn add_query_description_impl(query: &Query, impls: &mut proc_macro2::TokenStrea
     };
 
     impls.extend(quote! {
-        (#name<$tcx:tt>) => {
+        (#name) => {
             #desc
             #cache
         };

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -76,9 +76,9 @@ impl ProcessQueryValue<'_, Option<DeprecationEntry>> for Option<Deprecation> {
 }
 
 macro_rules! provide_one {
-    (<$lt:tt> $tcx:ident, $def_id:ident, $other:ident, $cdata:ident, $name:ident => { table }) => {
+    ($tcx:ident, $def_id:ident, $other:ident, $cdata:ident, $name:ident => { table }) => {
         provide_one! {
-            <$lt> $tcx, $def_id, $other, $cdata, $name => {
+            $tcx, $def_id, $other, $cdata, $name => {
                 $cdata
                     .root
                     .tables
@@ -89,9 +89,9 @@ macro_rules! provide_one {
             }
         }
     };
-    (<$lt:tt> $tcx:ident, $def_id:ident, $other:ident, $cdata:ident, $name:ident => { table_direct }) => {
+    ($tcx:ident, $def_id:ident, $other:ident, $cdata:ident, $name:ident => { table_direct }) => {
         provide_one! {
-            <$lt> $tcx, $def_id, $other, $cdata, $name => {
+            $tcx, $def_id, $other, $cdata, $name => {
                 // We don't decode `table_direct`, since it's not a Lazy, but an actual value
                 $cdata
                     .root
@@ -102,11 +102,11 @@ macro_rules! provide_one {
             }
         }
     };
-    (<$lt:tt> $tcx:ident, $def_id:ident, $other:ident, $cdata:ident, $name:ident => $compute:block) => {
-        fn $name<$lt>(
-            $tcx: TyCtxt<$lt>,
-            def_id_arg: ty::query::query_keys::$name<$lt>,
-        ) -> ty::query::query_values::$name<$lt> {
+    ($tcx:ident, $def_id:ident, $other:ident, $cdata:ident, $name:ident => $compute:block) => {
+        fn $name<'tcx>(
+            $tcx: TyCtxt<'tcx>,
+            def_id_arg: ty::query::query_keys::$name<'tcx>,
+        ) -> ty::query::query_values::$name<'tcx> {
             let _prof_timer =
                 $tcx.prof.generic_activity(concat!("metadata_decode_entry_", stringify!($name)));
 
@@ -130,11 +130,11 @@ macro_rules! provide_one {
 }
 
 macro_rules! provide {
-    (<$lt:tt> $tcx:ident, $def_id:ident, $other:ident, $cdata:ident,
+    ($tcx:ident, $def_id:ident, $other:ident, $cdata:ident,
       $($name:ident => { $($compute:tt)* })*) => {
         pub fn provide_extern(providers: &mut ExternProviders) {
             $(provide_one! {
-                <$lt> $tcx, $def_id, $other, $cdata, $name => { $($compute)* }
+                $tcx, $def_id, $other, $cdata, $name => { $($compute)* }
             })*
 
             *providers = ExternProviders {
@@ -187,7 +187,7 @@ impl IntoArgs for (CrateNum, SimplifiedType) {
     }
 }
 
-provide! { <'tcx> tcx, def_id, other, cdata,
+provide! { tcx, def_id, other, cdata,
     explicit_item_bounds => { table }
     explicit_predicates_of => { table }
     generics_of => { table }

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -179,7 +179,7 @@ macro_rules! define_dep_nodes {
     );
 }
 
-rustc_dep_node_append!([define_dep_nodes!][
+rustc_dep_node_append!(define_dep_nodes![
     // We use this for most things when incr. comp. is turned off.
     [] Null,
 

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -143,7 +143,7 @@ impl DepKind {
 }
 
 macro_rules! define_dep_nodes {
-    (<$tcx:tt>
+    (
     $(
         [$($attrs:tt)*]
         $variant:ident $(( $tuple_arg_ty:ty $(,)? ))*
@@ -179,7 +179,7 @@ macro_rules! define_dep_nodes {
     );
 }
 
-rustc_dep_node_append!([define_dep_nodes!][ <'tcx>
+rustc_dep_node_append!([define_dep_nodes!][
     // We use this for most things when incr. comp. is turned off.
     [] Null,
 

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -332,7 +332,7 @@ macro_rules! define_callbacks {
 // Queries marked with `fatal_cycle` do not need the latter implementation,
 // as they will raise an fatal error on query cycles instead.
 
-rustc_query_append! { [define_callbacks!] }
+rustc_query_append! { define_callbacks! }
 
 mod sealed {
     use super::{DefId, LocalDefId};

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -54,7 +54,7 @@ fn describe_as_module(def_id: LocalDefId, tcx: TyCtxt<'_>) -> String {
     }
 }
 
-rustc_query_append! { [define_queries!] }
+rustc_query_append! { define_queries! }
 
 impl<'tcx> Queries<'tcx> {
     // Force codegen in the dyn-trait transformation in this crate.

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -55,7 +55,7 @@ fn describe_as_module(def_id: LocalDefId, tcx: TyCtxt<'_>) -> String {
     }
 }
 
-rustc_query_append! { [define_queries!][<'tcx>] }
+rustc_query_append! { [define_queries!] }
 
 impl<'tcx> Queries<'tcx> {
     // Force codegen in the dyn-trait transformation in this crate.

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -15,7 +15,6 @@ extern crate rustc_macros;
 #[macro_use]
 extern crate rustc_middle;
 
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::AtomicU64;
 use rustc_middle::arena::Arena;
 use rustc_middle::dep_graph::{self, DepKindStruct, SerializedDepNodeIndex};

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -322,7 +322,7 @@ macro_rules! define_queries {
         }
 
         impl<'tcx> QueryDescription<QueryCtxt<'tcx>> for queries::$name<'tcx> {
-            rustc_query_description! { $name<'tcx> }
+            rustc_query_description! { $name }
 
             type Cache = query_storage::$name<'tcx>;
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -234,11 +234,10 @@ macro_rules! get_provider {
 }
 
 macro_rules! define_queries {
-    (<$tcx:tt>
+    (
      $($(#[$attr:meta])*
         [$($modifiers:tt)*] fn $name:ident($($K:tt)*) -> $V:ty,)*) => {
         define_queries_struct! {
-            tcx: $tcx,
             input: ($(([$($modifiers)*] [$($attr)*] [$name]))*)
         }
 
@@ -247,7 +246,7 @@ macro_rules! define_queries {
 
             // Create an eponymous constructor for each query.
             $(#[allow(nonstandard_style)] $(#[$attr])*
-            pub fn $name<$tcx>(tcx: QueryCtxt<$tcx>, key: query_keys::$name<$tcx>) -> QueryStackFrame {
+            pub fn $name<'tcx>(tcx: QueryCtxt<'tcx>, key: query_keys::$name<'tcx>) -> QueryStackFrame {
                 let kind = dep_graph::DepKind::$name;
                 let name = stringify!($name);
                 // Disable visible paths printing for performance reasons.
@@ -295,32 +294,32 @@ macro_rules! define_queries {
         mod queries {
             use std::marker::PhantomData;
 
-            $(pub struct $name<$tcx> {
-                data: PhantomData<&$tcx ()>
+            $(pub struct $name<'tcx> {
+                data: PhantomData<&'tcx ()>
             })*
         }
 
-        $(impl<$tcx> QueryConfig for queries::$name<$tcx> {
-            type Key = query_keys::$name<$tcx>;
-            type Value = query_values::$name<$tcx>;
-            type Stored = query_stored::$name<$tcx>;
+        $(impl<'tcx> QueryConfig for queries::$name<'tcx> {
+            type Key = query_keys::$name<'tcx>;
+            type Value = query_values::$name<'tcx>;
+            type Stored = query_stored::$name<'tcx>;
             const NAME: &'static str = stringify!($name);
         }
 
-        impl<$tcx> QueryDescription<QueryCtxt<$tcx>> for queries::$name<$tcx> {
-            rustc_query_description! { $name<$tcx> }
+        impl<'tcx> QueryDescription<QueryCtxt<'tcx>> for queries::$name<'tcx> {
+            rustc_query_description! { $name<'tcx> }
 
-            type Cache = query_storage::$name<$tcx>;
+            type Cache = query_storage::$name<'tcx>;
 
             #[inline(always)]
-            fn query_state<'a>(tcx: QueryCtxt<$tcx>) -> &'a QueryState<Self::Key>
-                where QueryCtxt<$tcx>: 'a
+            fn query_state<'a>(tcx: QueryCtxt<'tcx>) -> &'a QueryState<Self::Key>
+                where QueryCtxt<'tcx>: 'a
             {
                 &tcx.queries.$name
             }
 
             #[inline(always)]
-            fn query_cache<'a>(tcx: QueryCtxt<$tcx>) -> &'a Self::Cache
+            fn query_cache<'a>(tcx: QueryCtxt<'tcx>) -> &'a Self::Cache
                 where 'tcx:'a
             {
                 &tcx.query_caches.$name
@@ -328,7 +327,7 @@ macro_rules! define_queries {
 
             #[inline]
             fn make_vtable(tcx: QueryCtxt<'tcx>, key: &Self::Key) ->
-                QueryVTable<QueryCtxt<$tcx>, Self::Key, Self::Value>
+                QueryVTable<QueryCtxt<'tcx>, Self::Key, Self::Value>
             {
                 let compute = get_provider!([$($modifiers)*][tcx, $name, key]);
                 let cache_on_disk = Self::cache_on_disk(tcx.tcx, key);
@@ -465,28 +464,25 @@ macro_rules! define_queries {
     }
 }
 
-// FIXME(eddyb) this macro (and others?) use `$tcx` and `'tcx` interchangeably.
-// We should either not take `$tcx` at all and use `'tcx` everywhere, or use
-// `$tcx` everywhere (even if that isn't necessary due to lack of hygiene).
 macro_rules! define_queries_struct {
-    (tcx: $tcx:tt,
+    (
      input: ($(([$($modifiers:tt)*] [$($attr:tt)*] [$name:ident]))*)) => {
-        pub struct Queries<$tcx> {
+        pub struct Queries<'tcx> {
             local_providers: Box<Providers>,
             extern_providers: Box<ExternProviders>,
 
-            pub on_disk_cache: Option<OnDiskCache<$tcx>>,
+            pub on_disk_cache: Option<OnDiskCache<'tcx>>,
 
             jobs: AtomicU64,
 
-            $($(#[$attr])*  $name: QueryState<query_keys::$name<$tcx>>,)*
+            $($(#[$attr])*  $name: QueryState<query_keys::$name<'tcx>>,)*
         }
 
-        impl<$tcx> Queries<$tcx> {
+        impl<'tcx> Queries<'tcx> {
             pub fn new(
                 local_providers: Providers,
                 extern_providers: ExternProviders,
-                on_disk_cache: Option<OnDiskCache<$tcx>>,
+                on_disk_cache: Option<OnDiskCache<'tcx>>,
             ) -> Self {
                 Queries {
                     local_providers: Box::new(local_providers),
@@ -498,8 +494,8 @@ macro_rules! define_queries_struct {
             }
 
             pub(crate) fn try_collect_active_jobs(
-                &$tcx self,
-                tcx: TyCtxt<$tcx>,
+                &'tcx self,
+                tcx: TyCtxt<'tcx>,
             ) -> Option<QueryMap> {
                 let tcx = QueryCtxt { tcx, queries: self };
                 let mut jobs = QueryMap::default();
@@ -532,13 +528,13 @@ macro_rules! define_queries_struct {
             #[tracing::instrument(level = "trace", skip(self, tcx))]
             fn $name(
                 &'tcx self,
-                tcx: TyCtxt<$tcx>,
+                tcx: TyCtxt<'tcx>,
                 span: Span,
-                key: query_keys::$name<$tcx>,
+                key: query_keys::$name<'tcx>,
                 mode: QueryMode,
-            ) -> Option<query_stored::$name<$tcx>> {
+            ) -> Option<query_stored::$name<'tcx>> {
                 let qcx = QueryCtxt { tcx, queries: self };
-                get_query::<queries::$name<$tcx>, _>(qcx, span, key, mode)
+                get_query::<queries::$name<'tcx>, _>(qcx, span, key, mode)
             })*
         }
     };

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -320,5 +320,5 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
         }
     }
 
-    rustc_query_append! { [alloc_once!] }
+    rustc_query_append! { alloc_once! }
 }

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -306,7 +306,7 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
     let mut string_cache = QueryKeyStringCache::new();
 
     macro_rules! alloc_once {
-        (<$tcx:tt>
+        (
             $($(#[$attr:meta])* [$($modifiers:tt)*] fn $name:ident($K:ty) -> $V:ty,)*
         ) => {
             $({
@@ -320,5 +320,5 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
         }
     }
 
-    rustc_query_append! { [alloc_once!][<'tcx>] }
+    rustc_query_append! { [alloc_once!] }
 }


### PR DESCRIPTION
Very small cleanup. Based on https://github.com/rust-lang/rust/pull/100436 which modifies some of the same code.

r? @cjgillot