### PR TITLE
rustdoc: ayu code color selector more specific

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -47,7 +47,7 @@ h4 {
 .docblock pre > code, pre > code {
 	color: #e6e1cf;
 }
-span code {
+.item-info code {
 	color: #e6e1cf;
 }
 .docblock a > code {


### PR DESCRIPTION
According to https://github.com/rust-lang/rust/pull/100960#issuecomment-1225970579, this selector is only really intended to apply to item info. However, it's so broad that it's hard to tell when it deliberately applies vs where it accidentally applies.