### PR TITLE
lower baseline for i686 on unixlike targets

### DIFF
--- a/compiler/rustc_target/src/spec/i686_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_freebsd.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, StackProbeType, Target};
 
 pub fn target() -> Target {
     let mut base = super::freebsd_base::opts();
-    base.cpu = "pentium4".into();
+    base.cpu = "pentiumpro".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m32", "-Wl,-znotext"]);
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved

--- a/compiler/rustc_target/src/spec/i686_unknown_haiku.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_haiku.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, StackProbeType, Target};
 
 pub fn target() -> Target {
     let mut base = super::haiku_base::opts();
-    base.cpu = "pentium4".into();
+    base.cpu = "pentiumpro".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m32"]);
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved

--- a/compiler/rustc_target/src/spec/i686_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_linux_gnu.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, StackProbeType, Target};
 
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
-    base.cpu = "pentium4".into();
+    base.cpu = "pentiumpro".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m32"]);
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved

--- a/compiler/rustc_target/src/spec/i686_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_linux_musl.rs
@@ -2,7 +2,7 @@ use crate::spec::{FramePointer, LinkerFlavor, StackProbeType, Target};
 
 pub fn target() -> Target {
     let mut base = super::linux_musl_base::opts();
-    base.cpu = "pentium4".into();
+    base.cpu = "pentiumpro".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m32", "-Wl,-melf_i386"]);
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved

--- a/compiler/rustc_target/src/spec/i686_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_netbsd.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
-    base.cpu = "pentium4".into();
+    base.cpu = "pentiumpro".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m32"]);
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved

--- a/compiler/rustc_target/src/spec/i686_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_openbsd.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, StackProbeType, Target};
 
 pub fn target() -> Target {
     let mut base = super::openbsd_base::opts();
-    base.cpu = "pentium4".into();
+    base.cpu = "pentiumpro".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m32", "-fuse-ld=lld"]);
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved


### PR DESCRIPTION
experimental, draft PR for rust-lang/compiler-team#548

this commit lowers the baseline for i686 from 'pentium4' to 'pentiumpro'
on the following targets to match their expected baseline for i686:

- i686-unknown-linux-gnu
- i686-unknown-linux-musl
- i686-unknown-freebsd
- i686-unknown-openbsd
- i686-unknown-netbsd
- i686-unknown-haiku

the pentium4 is not i686-class, and setting it as baseline results
in Rust using SSE2, which i686-class processors never had. this
change enables users of these platforms, with their expected
baseline, to use the upstream Rust host tools, and binaries built
for their platform. I fall into this category of users.

at least Debian and Gentoo have issues relating to this, and at least
Debian and FreeBSD patch Rust in order to make a similar change and
enable Rust to work correctly on their expected baseline. Users with
i686 hardware running distributions that do not distribute their own
modified toolchain are left unable to use Rust or software written
in it. as an aside, Rust is now a de-facto requirement to have a usable
GNU/Linux installation with a GUI.

Rust has an existing issue rust-lang/rust#82435, which this patch
resolves; this patch also obviates the need for the MCP i filed as
rust-lang/compiler-team#543.

NetBSD (and i believe OpenBSD) normally targets i486 where possible,
and i586 where atomics make that difficult (which includes all Rust
programs); if targeting i686, these operating systems would also
expect a lower baseline than pentium4.

Haiku normally targets i586, but would also expect a lower baseline
than pentium4 for an i686 target.

Distributions such as Fedora which do not have a 32-bit version and
only use i686 for multilib can easily alter their build system to
enable SSE2, to match their expected baseline of x86_64 processors
running in 32-bit compatibility mode (all of which have SSE2).
@cuviper has expressed willingness to make this patch in Fedora.

Targets not changed are left as-is for the following reasons:

- Rust supports no earlier than Windows 7; Windows 7 and later all
  require SSE2, and so a minimum of Pentium 4 or similar.
- UEFI was not introduced until 2004 and not common until ~2011,
  well after the Pentium 4's heyday, and does not self-host
- I am aware of no scenario under which VxWorks would be running
  on a 32-bit x86 processor with a lower featureset than pentium4,
  unless it is a Vortex86, which is i586-class. even then, these
  would not be compiling programs for themselves, and the party
  building programs for that platform would have the ability to
  set target flags that make sense for their situation.