### PR TITLE
improve lifetime annotation diagnostics

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -56,6 +56,8 @@ impl<'tcx> UniverseInfo<'tcx> {
     ) {
         match self.0 {
             UniverseInfoInner::RelateTys { expected, found } => {
+                let (expected, found) =
+                    mbcx.regioncx.name_regions(mbcx.infcx.tcx, (expected, found));
                 let err = mbcx.infcx.report_mismatched_types(
                     &cause,
                     expected,

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -21,7 +21,7 @@ use crate::{
     WriteKind,
 };
 
-use super::{find_use, RegionName, UseSpans};
+use super::{find_use, region_errors, RegionName, UseSpans};
 
 #[derive(Debug)]
 pub(crate) enum BorrowExplanation<'tcx> {
@@ -268,6 +268,10 @@ impl<'tcx> BorrowExplanation<'tcx> {
                     );
                 };
 
+                if let ConstraintCategory::TypeAnnotation = category {
+                    err.span_help(span, "you can remove unnecessary lifetime annotations here");
+                    region_errors::suggest_relax_self(tcx, err, body.source.def_id(), span);
+                }
                 self.add_lifetime_bound_suggestion_to_diagnostic(err, &category, span, region_name);
             }
             _ => {}

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -208,9 +208,10 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 }
 
                 RegionErrorKind::UnexpectedHiddenRegion { span, hidden_ty, key, member_region } => {
-                    let named_ty = self.regioncx.name_regions(self.infcx.tcx, hidden_ty);
-                    let named_key = self.regioncx.name_regions(self.infcx.tcx, key);
-                    let named_region = self.regioncx.name_regions(self.infcx.tcx, member_region);
+                    let named_ty = self.regioncx.name_regions_opaque(self.infcx.tcx, hidden_ty);
+                    let named_key = self.regioncx.name_regions_opaque(self.infcx.tcx, key);
+                    let named_region =
+                        self.regioncx.name_regions_opaque(self.infcx.tcx, member_region);
                     self.buffer_error(unexpected_hidden_region_diagnostic(
                         self.infcx.tcx,
                         span,

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -867,7 +867,8 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         };
 
         let tcx = self.infcx.tcx;
-        let body_parent_did = tcx.opt_parent(self.mir_def_id().to_def_id())?;
+        let typeck_root_did = tcx.typeck_root_def_id(self.mir_def_id().to_def_id());
+        let body_parent_did = tcx.opt_parent(typeck_root_did)?;
         if tcx.parent(region.def_id) != body_parent_did
             || tcx.def_kind(body_parent_did) != DefKind::Impl
         {

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -153,7 +153,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// that the regions produced are in fact equal to the named region they are
     /// replaced with. This is fine because this function is only to improve the
     /// region names in error messages.
-    pub(crate) fn name_regions<T>(&self, tcx: TyCtxt<'tcx>, ty: T) -> T
+    pub(crate) fn name_regions_opaque<T>(&self, tcx: TyCtxt<'tcx>, ty: T) -> T
     where
         T: TypeFoldable<'tcx>,
     {

--- a/compiler/rustc_borrowck/src/type_check/input_output.rs
+++ b/compiler/rustc_borrowck/src/type_check/input_output.rs
@@ -101,9 +101,12 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 // argument N is stored in local N+2.
                 let local = Local::new(argument_index + 2);
                 let mir_input_ty = body.local_decls[local].ty;
+                // FIXME span should point to the type annotation, not the argument.
                 let mir_input_span = body.local_decls[local].source_info.span;
 
                 // If the user explicitly annotated the input types, enforce those.
+                let user_provided_input_ty =
+                    self.extract_annotations(user_provided_input_ty, mir_input_span);
                 let user_provided_input_ty =
                     self.normalize(user_provided_input_ty, Locations::All(mir_input_span));
 

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -494,7 +494,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
                     ty::Variance::Invariant,
                     user_ty,
                     Locations::All(*span),
-                    ConstraintCategory::TypeAnnotation,
+                    ConstraintCategory::Boring,
                 ) {
                     span_mirbug!(
                         self,
@@ -1076,6 +1076,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             let CanonicalUserTypeAnnotation { span, ref user_ty, inferred_ty } = *user_annotation;
             let inferred_ty = self.normalize(inferred_ty, Locations::All(span));
             let annotation = self.instantiate_canonical_with_fresh_inference_vars(span, user_ty);
+            let annotation = self.extract_annotations(annotation, span);
             match annotation {
                 UserType::Ty(mut ty) => {
                     ty = self.normalize(ty, Locations::All(span));

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -242,6 +242,13 @@ impl<'hir> PathSegment<'hir> {
             DUMMY
         }
     }
+
+    pub fn span(&self) -> Span {
+        match self.args {
+            Some(ref args) => self.ident.span.to(args.span_ext),
+            None => self.ident.span,
+        }
+    }
 }
 
 #[derive(Encodable, Debug, HashStable_Generic)]

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -132,6 +132,8 @@ pub struct Adt<'tcx> {
     /// Optional user-given substs: for something like `let x =
     /// Bar::<T> { ... }`.
     pub user_ty: Option<Canonical<'tcx, UserType<'tcx>>>,
+    /// Constructor span, e.g. `Foo::<u8>` in `Foo::<u8>(1)`.
+    pub ctor_span: Span,
 
     pub fields: Box<[FieldExpr]>,
     /// The base, e.g. `Foo {x: 1, .. base}`.

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -115,6 +115,7 @@ pub fn walk_expr<'a, 'tcx: 'a, V: Visitor<'a, 'tcx>>(visitor: &mut V, expr: &Exp
             variant_index: _,
             substs: _,
             user_ty: _,
+            ctor_span: _,
         }) => {
             for field in &**fields {
                 visitor.visit_expr(&visitor.thir()[field.expr]);

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -319,6 +319,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 variant_index,
                 substs,
                 user_ty,
+                ctor_span,
                 ref fields,
                 ref base,
             }) => {
@@ -380,7 +381,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let inferred_ty = expr.ty;
                 let user_ty = user_ty.map(|ty| {
                     this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
-                        span: source_info.span,
+                        span: ctor_span,
                         user_ty: ty,
                         inferred_ty,
                     })

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -395,6 +395,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 variant_index: _,
                 substs: _,
                 user_ty: _,
+                ctor_span: _,
                 fields: _,
                 base: _,
             }) => match self.tcx.layout_scalar_valid_range(adt_def.did()) {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -263,7 +263,7 @@ impl<'tcx> Cx<'tcx> {
             // Here comes the interesting stuff:
             hir::ExprKind::MethodCall(segment, ref args, fn_span) => {
                 // Rewrite a.b(c) into UFCS form like Trait::b(a, c)
-                let expr = self.method_callee(expr, segment.ident.span, None);
+                let expr = self.method_callee(expr, segment.span(), None);
                 // When we apply adjustments to the receiver, use the span of
                 // the overall method call for better diagnostics. args[0]
                 // is guaranteed to exist, since a method call always has a receiver.
@@ -347,6 +347,7 @@ impl<'tcx> Cx<'tcx> {
                             variant_index: index,
                             fields: field_refs,
                             user_ty,
+                            ctor_span: fun.span,
                             base: None,
                         }))
                     } else {
@@ -471,6 +472,7 @@ impl<'tcx> Cx<'tcx> {
                             variant_index: VariantIdx::new(0),
                             substs,
                             user_ty,
+                            ctor_span: qpath.span(),
                             fields: self.field_refs(fields),
                             base: base.as_ref().map(|base| FruInfo {
                                 base: self.mirror_expr(base),
@@ -497,6 +499,7 @@ impl<'tcx> Cx<'tcx> {
                                     variant_index: index,
                                     substs,
                                     user_ty,
+                                    ctor_span: qpath.span(),
                                     fields: self.field_refs(fields),
                                     base: None,
                                 }))
@@ -862,6 +865,7 @@ impl<'tcx> Cx<'tcx> {
                         variant_index: adt_def.variant_index_with_ctor_id(def_id),
                         substs,
                         user_ty: user_provided_type,
+                        ctor_span: expr.span,
                         fields: Box::new([]),
                         base: None,
                     })),

--- a/src/test/ui/associated-types/associated-types-subtyping-1.stderr
+++ b/src/test/ui/associated-types/associated-types-subtyping-1.stderr
@@ -8,6 +8,9 @@ LL | fn method2<'a,'b,T>(x: &'a T, y: &'b T)
 ...
 LL |     let a: <T as Trait<'a>>::Type = make_any();
    |            ^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
+...
+LL |     let _c: <T as Trait<'b>>::Type = a;
+   |                                      - because of assignment here
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/borrowck/borrowck-loan-of-static-data-issue-27616.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-of-static-data-issue-27616.stderr
@@ -2,12 +2,13 @@ error[E0506]: cannot assign to `*s` because it is borrowed
   --> $DIR/borrowck-loan-of-static-data-issue-27616.rs:16:5
    |
 LL |     let alias: &'static mut String = s;
-   |                -------------------   - borrow of `*s` occurs here
-   |                |
-   |                type annotation requires that `*s` is borrowed for `'static`
+   |                                      - borrow of `*s` occurs here
 ...
 LL |     *s = String::new();
    |     ^^ assignment to borrowed `*s` occurs here
+...
+LL |     println!("{}", inner);
+   |                    ----- borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -8,7 +8,7 @@ LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
    |                                                 ^
    |                                                 |
    |                                                 has type `fn(&'1 u32)`
-   |                                                 requires that `'1` must outlive `'x`
+   |                                                 type annotation requires that `'1` must outlive `'x`
 
 error: lifetime may not live long enough
   --> $DIR/expect-fn-supply-fn.rs:16:49
@@ -17,7 +17,7 @@ LL | fn expect_free_supply_free_from_fn<'x>(x: &'x u32) {
    |                                    -- lifetime `'x` defined here
 ...
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
-   |                                                 ^ requires that `'x` must outlive `'static`
+   |                                                 ^ type annotation requires that `'x` must outlive `'static`
 
 error[E0308]: mismatched types
   --> $DIR/expect-fn-supply-fn.rs:32:49

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -34,7 +34,7 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
    |                                                  ^ one type is more general than the other
    |
-   = note: expected fn pointer `fn(&'x u32)`
+   = note: expected fn pointer `fn(&u32)`
               found fn pointer `for<'r> fn(&'r u32)`
 
 error[E0308]: mismatched types

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -34,7 +34,7 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
    |                                                  ^ one type is more general than the other
    |
-   = note: expected fn pointer `fn(&u32)`
+   = note: expected fn pointer `fn(&'x u32)`
               found fn pointer `for<'r> fn(&'r u32)`
 
 error[E0308]: mismatched types

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.stderr
@@ -7,7 +7,7 @@ LL | fn expect_bound_supply_named<'x>() {
 LL |     closure_expecting_bound(|x: &'x u32| {
    |                              ^  - let's call the lifetime of this reference `'1`
    |                              |
-   |                              requires that `'1` must outlive `'x`
+   |                              type annotation requires that `'1` must outlive `'x`
 
 error: lifetime may not live long enough
   --> $DIR/expect-region-supply-region-2.rs:14:30
@@ -16,7 +16,7 @@ LL | fn expect_bound_supply_named<'x>() {
    |                              -- lifetime `'x` defined here
 ...
 LL |     closure_expecting_bound(|x: &'x u32| {
-   |                              ^ requires that `'x` must outlive `'static`
+   |                              ^ type annotation requires that `'x` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/invariant.stderr
+++ b/src/test/ui/const-generics/invariant.stderr
@@ -18,8 +18,8 @@ error[E0308]: mismatched types
 LL |     v
    |     ^ one type is more general than the other
    |
-   = note: expected reference `&Foo<fn(&())>`
-              found reference `&Foo<for<'a> fn(&'a ())>`
+   = note: expected reference `&'static Foo<fn(&'static ())>`
+              found reference `&'static Foo<for<'a> fn(&'a ())>`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/const-eval-intrinsic-promotion.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-intrinsic-promotion.stderr
@@ -7,6 +7,12 @@ LL |         &std::intrinsics::size_of::<i32>();
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-eval-intrinsic-promotion.rs:4:12
+   |
+LL |     let x: &'static usize =
+   |            ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn.stderr
@@ -15,6 +15,12 @@ LL |     let _: &'static u32 = &foo();
    |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dont_promote_unstable_const_fn.rs:17:12
+   |
+LL |     let _: &'static u32 = &foo();
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn.rs:21:28
@@ -26,6 +32,12 @@ LL |     let _: &'static u32 = &meh();
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dont_promote_unstable_const_fn.rs:21:12
+   |
+LL |     let _: &'static u32 = &meh();
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn.rs:22:26
@@ -37,6 +49,12 @@ LL |     let x: &'static _ = &std::time::Duration::from_millis(42).subsec_millis
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dont_promote_unstable_const_fn.rs:22:12
+   |
+LL |     let x: &'static _ = &std::time::Duration::from_millis(42).subsec_millis();
+   |            ^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn_cross_crate.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn_cross_crate.stderr
@@ -8,6 +8,12 @@ LL |     let _: &'static u32 = &foo();
 LL |     let _x: &'static u32 = &foo();
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dont_promote_unstable_const_fn_cross_crate.rs:8:12
+   |
+LL |     let _: &'static u32 = &foo();
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn_cross_crate.rs:9:29
@@ -18,6 +24,12 @@ LL |     let _x: &'static u32 = &foo();
    |             type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dont_promote_unstable_const_fn_cross_crate.rs:9:13
+   |
+LL |     let _x: &'static u32 = &foo();
+   |             ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/promoted_const_fn_fail.stderr
+++ b/src/test/ui/consts/const-eval/promoted_const_fn_fail.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static u8 = &(bar() + 1);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted_const_fn_fail.rs:19:12
+   |
+LL |     let x: &'static u8 = &(bar() + 1);
+   |            ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/promoted_const_fn_fail_deny_const_err.stderr
+++ b/src/test/ui/consts/const-eval/promoted_const_fn_fail_deny_const_err.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static u8 = &(bar() + 1);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted_const_fn_fail_deny_const_err.rs:20:12
+   |
+LL |     let x: &'static u8 = &(bar() + 1);
+   |            ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/promoted_raw_ptr_ops.stderr
+++ b/src/test/ui/consts/const-eval/promoted_raw_ptr_ops.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static bool = &(42 as *const i32 == 43 as *const i32);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted_raw_ptr_ops.rs:2:12
+   |
+LL |     let x: &'static bool = &(42 as *const i32 == 43 as *const i32);
+   |            ^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:4:30
@@ -19,6 +25,12 @@ LL |     let y: &'static usize = &(&1 as *const i32 as usize + 1);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted_raw_ptr_ops.rs:4:12
+   |
+LL |     let y: &'static usize = &(&1 as *const i32 as usize + 1);
+   |            ^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:6:28
@@ -30,6 +42,12 @@ LL |     let z: &'static i32 = &(unsafe { *(42 as *const i32) });
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted_raw_ptr_ops.rs:6:12
+   |
+LL |     let z: &'static i32 = &(unsafe { *(42 as *const i32) });
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:8:29
@@ -41,6 +59,12 @@ LL |     let a: &'static bool = &(main as fn() == main as fn());
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted_raw_ptr_ops.rs:8:12
+   |
+LL |     let a: &'static bool = &(main as fn() == main as fn());
+   |            ^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/transmute-const-promotion.stderr
+++ b/src/test/ui/consts/const-eval/transmute-const-promotion.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static u32 = unsafe { &mem::transmute(3.0f32) };
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/transmute-const-promotion.rs:4:12
+   |
+LL |     let x: &'static u32 = unsafe { &mem::transmute(3.0f32) };
+   |            ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/union_promotion.stderr
+++ b/src/test/ui/consts/const-eval/union_promotion.stderr
@@ -10,6 +10,12 @@ LL | |     };
    | |_____^ creates a temporary which is freed while still in use
 LL |   }
    |   - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/union_promotion.rs:10:12
+   |
+LL |     let x: &'static bool = &unsafe {
+   |            ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-int-conversion.stderr
+++ b/src/test/ui/consts/const-int-conversion.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static i32 = &(5_i32.reverse_bits());
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-conversion.rs:2:12
+   |
+LL |     let x: &'static i32 = &(5_i32.reverse_bits());
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:4:28
@@ -19,6 +25,12 @@ LL |     let y: &'static i32 = &(i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-conversion.rs:4:12
+   |
+LL |     let y: &'static i32 = &(i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:6:28
@@ -30,6 +42,12 @@ LL |     let z: &'static i32 = &(i32::from_le_bytes([0x12, 0x34, 0x56, 0x78]));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-conversion.rs:6:12
+   |
+LL |     let z: &'static i32 = &(i32::from_le_bytes([0x12, 0x34, 0x56, 0x78]));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:8:28
@@ -41,6 +59,12 @@ LL |     let a: &'static i32 = &(i32::from_be(i32::from_ne_bytes([0x80, 0, 0, 0]
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-conversion.rs:8:12
+   |
+LL |     let a: &'static i32 = &(i32::from_be(i32::from_ne_bytes([0x80, 0, 0, 0])));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:10:29
@@ -52,6 +76,12 @@ LL |     let b: &'static [u8] = &(0x12_34_56_78_i32.to_be_bytes());
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-conversion.rs:10:12
+   |
+LL |     let b: &'static [u8] = &(0x12_34_56_78_i32.to_be_bytes());
+   |            ^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:12:29
@@ -63,6 +93,12 @@ LL |     let c: &'static [u8] = &(0x12_34_56_78_i32.to_le_bytes());
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-conversion.rs:12:12
+   |
+LL |     let c: &'static [u8] = &(0x12_34_56_78_i32.to_le_bytes());
+   |            ^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:14:29
@@ -74,6 +110,12 @@ LL |     let d: &'static [u8] = &(i32::MIN.to_be().to_ne_bytes());
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-conversion.rs:14:12
+   |
+LL |     let d: &'static [u8] = &(i32::MIN.to_be().to_ne_bytes());
+   |            ^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/consts/const-int-overflowing.stderr
+++ b/src/test/ui/consts/const-int-overflowing.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static (i32, bool) = &(5_i32.overflowing_add(3));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-overflowing.rs:2:12
+   |
+LL |     let x: &'static (i32, bool) = &(5_i32.overflowing_add(3));
+   |            ^^^^^^^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-overflowing.rs:4:36
@@ -19,6 +25,12 @@ LL |     let y: &'static (i32, bool) = &(5_i32.overflowing_sub(3));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-overflowing.rs:4:12
+   |
+LL |     let y: &'static (i32, bool) = &(5_i32.overflowing_sub(3));
+   |            ^^^^^^^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-overflowing.rs:6:36
@@ -30,6 +42,12 @@ LL |     let z: &'static (i32, bool) = &(5_i32.overflowing_mul(3));
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-overflowing.rs:6:12
+   |
+LL |     let z: &'static (i32, bool) = &(5_i32.overflowing_mul(3));
+   |            ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-int-rotate.stderr
+++ b/src/test/ui/consts/const-int-rotate.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static i32 = &(5_i32.rotate_left(3));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-rotate.rs:2:12
+   |
+LL |     let x: &'static i32 = &(5_i32.rotate_left(3));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-rotate.rs:4:28
@@ -19,6 +25,12 @@ LL |     let y: &'static i32 = &(5_i32.rotate_right(3));
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-rotate.rs:4:12
+   |
+LL |     let y: &'static i32 = &(5_i32.rotate_right(3));
+   |            ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-int-sign.stderr
+++ b/src/test/ui/consts/const-int-sign.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static bool = &(5_i32.is_negative());
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-sign.rs:2:12
+   |
+LL |     let x: &'static bool = &(5_i32.is_negative());
+   |            ^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-sign.rs:4:29
@@ -19,6 +25,12 @@ LL |     let y: &'static bool = &(5_i32.is_positive());
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-sign.rs:4:12
+   |
+LL |     let y: &'static bool = &(5_i32.is_positive());
+   |            ^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-int-wrapping.stderr
+++ b/src/test/ui/consts/const-int-wrapping.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static i32 = &(5_i32.wrapping_add(3));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-wrapping.rs:2:12
+   |
+LL |     let x: &'static i32 = &(5_i32.wrapping_add(3));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:4:28
@@ -19,6 +25,12 @@ LL |     let y: &'static i32 = &(5_i32.wrapping_sub(3));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-wrapping.rs:4:12
+   |
+LL |     let y: &'static i32 = &(5_i32.wrapping_sub(3));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:6:28
@@ -30,6 +42,12 @@ LL |     let z: &'static i32 = &(5_i32.wrapping_mul(3));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-wrapping.rs:6:12
+   |
+LL |     let z: &'static i32 = &(5_i32.wrapping_mul(3));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:8:28
@@ -41,6 +59,12 @@ LL |     let a: &'static i32 = &(5_i32.wrapping_shl(3));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-wrapping.rs:8:12
+   |
+LL |     let a: &'static i32 = &(5_i32.wrapping_shl(3));
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:10:28
@@ -52,6 +76,12 @@ LL |     let b: &'static i32 = &(5_i32.wrapping_shr(3));
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-int-wrapping.rs:10:12
+   |
+LL |     let b: &'static i32 = &(5_i32.wrapping_shr(3));
+   |            ^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-ptr-nonnull.stderr
+++ b/src/test/ui/consts/const-ptr-nonnull.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static NonNull<u32> = &(NonNull::dangling());
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-ptr-nonnull.rs:4:12
+   |
+LL |     let x: &'static NonNull<u32> = &(NonNull::dangling());
+   |            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-ptr-nonnull.rs:9:37
@@ -19,6 +25,12 @@ LL |     let x: &'static NonNull<u32> = &(non_null.cast());
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-ptr-nonnull.rs:9:12
+   |
+LL |     let x: &'static NonNull<u32> = &(non_null.cast());
+   |            ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-ptr-unique.stderr
+++ b/src/test/ui/consts/const-ptr-unique.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static *mut u32 = &(unique.as_ptr());
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-ptr-unique.rs:8:12
+   |
+LL |     let x: &'static *mut u32 = &(unique.as_ptr());
+   |            ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/control-flow/interior-mutability.stderr
+++ b/src/test/ui/consts/control-flow/interior-mutability.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static _ = &X;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/interior-mutability.rs:40:12
+   |
+LL |     let x: &'static _ = &X;
+   |            ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/interior-mutability.rs:41:26
@@ -19,6 +25,12 @@ LL |     let y: &'static _ = &Y;
 LL |     let z: &'static _ = &Z;
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/interior-mutability.rs:41:12
+   |
+LL |     let y: &'static _ = &Y;
+   |            ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/interior-mutability.rs:42:26
@@ -29,6 +41,12 @@ LL |     let z: &'static _ = &Z;
    |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/interior-mutability.rs:42:12
+   |
+LL |     let z: &'static _ = &Z;
+   |            ^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/min_const_fn/promotion.stderr
+++ b/src/test/ui/consts/min_const_fn/promotion.stderr
@@ -8,6 +8,12 @@ LL |     let x: &'static () = &foo1();
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promotion.rs:11:12
+   |
+LL |     let x: &'static () = &foo1();
+   |            ^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:12:28
@@ -19,6 +25,12 @@ LL |     let y: &'static i32 = &foo2(42);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promotion.rs:12:12
+   |
+LL |     let y: &'static i32 = &foo2(42);
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:13:28
@@ -30,6 +42,12 @@ LL |     let z: &'static i32 = &foo3();
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promotion.rs:13:12
+   |
+LL |     let z: &'static i32 = &foo3();
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:14:34
@@ -41,6 +59,12 @@ LL |     let a: &'static Cell<i32> = &foo4();
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promotion.rs:14:12
+   |
+LL |     let a: &'static Cell<i32> = &foo4();
+   |            ^^^^^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:15:42
@@ -52,6 +76,12 @@ LL |     let a: &'static Option<Cell<i32>> = &foo5();
 LL |     let a: &'static Option<Cell<i32>> = &foo6();
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promotion.rs:15:12
+   |
+LL |     let a: &'static Option<Cell<i32>> = &foo5();
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:16:42
@@ -62,6 +92,12 @@ LL |     let a: &'static Option<Cell<i32>> = &foo6();
    |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promotion.rs:16:12
+   |
+LL |     let a: &'static Option<Cell<i32>> = &foo6();
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/consts/promote-not.stderr
+++ b/src/test/ui/consts/promote-not.stderr
@@ -27,6 +27,12 @@ LL |         let _x: &'static () = &foo();
    |                 type annotation requires that borrow lasts for `'static`
 LL |     }
    |     - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:20:17
+   |
+LL |         let _x: &'static () = &foo();
+   |                 ^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:28:29
@@ -37,6 +43,12 @@ LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
    |             type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:28:13
+   |
+LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
+   |             ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:33:29
@@ -47,6 +59,12 @@ LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
    |             type annotation requires that borrow lasts for `'static`
 LL | };
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:33:13
+   |
+LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
+   |             ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:39:29
@@ -57,6 +75,12 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
    |               type annotation requires that borrow lasts for `'static`
 LL | };
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:39:15
+   |
+LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:46:29
@@ -68,6 +92,12 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).0;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:46:15
+   |
+LL |     let _val: &'static _ = &(Cell::new(1), 2).0;
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:47:29
@@ -79,6 +109,12 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:47:15
+   |
+LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:50:29
@@ -90,6 +126,12 @@ LL |     let _val: &'static _ = &(1/0);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:50:15
+   |
+LL |     let _val: &'static _ = &(1/0);
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:51:29
@@ -101,6 +143,12 @@ LL |     let _val: &'static _ = &(1/(1-1));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:51:15
+   |
+LL |     let _val: &'static _ = &(1/(1-1));
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:52:29
@@ -112,6 +160,12 @@ LL |     let _val: &'static _ = &(1%0);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:52:15
+   |
+LL |     let _val: &'static _ = &(1%0);
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:53:29
@@ -123,6 +177,12 @@ LL |     let _val: &'static _ = &(1%(1-1));
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:53:15
+   |
+LL |     let _val: &'static _ = &(1%(1-1));
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:54:29
@@ -134,6 +194,12 @@ LL |     let _val: &'static _ = &([1,2,3][4]+1);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:54:15
+   |
+LL |     let _val: &'static _ = &([1,2,3][4]+1);
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:57:29
@@ -145,6 +211,12 @@ LL |     let _val: &'static _ = &TEST_DROP;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:57:15
+   |
+LL |     let _val: &'static _ = &TEST_DROP;
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:59:29
@@ -156,6 +228,12 @@ LL |     let _val: &'static _ = &&TEST_DROP;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:59:15
+   |
+LL |     let _val: &'static _ = &&TEST_DROP;
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:59:30
@@ -167,6 +245,12 @@ LL |     let _val: &'static _ = &&TEST_DROP;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:59:15
+   |
+LL |     let _val: &'static _ = &&TEST_DROP;
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:62:29
@@ -178,6 +262,12 @@ LL |     let _val: &'static _ = &(&TEST_DROP,);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:62:15
+   |
+LL |     let _val: &'static _ = &(&TEST_DROP,);
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:62:31
@@ -189,6 +279,12 @@ LL |     let _val: &'static _ = &(&TEST_DROP,);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:62:15
+   |
+LL |     let _val: &'static _ = &(&TEST_DROP,);
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:65:29
@@ -200,6 +296,12 @@ LL |     let _val: &'static _ = &[&TEST_DROP; 1];
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:65:15
+   |
+LL |     let _val: &'static _ = &[&TEST_DROP; 1];
+   |               ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:65:31
@@ -209,6 +311,12 @@ LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               |               |
    |               |               creates a temporary which is freed while still in use
    |               type annotation requires that borrow lasts for `'static`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote-not.rs:65:15
+   |
+LL |     let _val: &'static _ = &[&TEST_DROP; 1];
+   |               ^^^^^^^^^^
 
 error: aborting due to 20 previous errors
 

--- a/src/test/ui/consts/promote_const_let.stderr
+++ b/src/test/ui/consts/promote_const_let.stderr
@@ -8,6 +8,12 @@ LL |         &y
    |         ^^ borrowed value does not live long enough
 LL |     };
    |     - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote_const_let.rs:2:12
+   |
+LL |     let x: &'static u32 = {
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote_const_let.rs:6:28
@@ -22,6 +28,12 @@ LL | |     };
    | |_____^ creates a temporary which is freed while still in use
 LL |   }
    |   - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promote_const_let.rs:6:12
+   |
+LL |     let x: &'static u32 = &{
+   |            ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/promoted-const-drop.stderr
+++ b/src/test/ui/consts/promoted-const-drop.stderr
@@ -8,6 +8,12 @@ LL |     let _: &'static A = &A();
 LL |     let _: &'static [A] = &[C];
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted-const-drop.rs:13:12
+   |
+LL |     let _: &'static A = &A();
+   |            ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted-const-drop.rs:14:28
@@ -18,6 +24,12 @@ LL |     let _: &'static [A] = &[C];
    |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted-const-drop.rs:14:12
+   |
+LL |     let _: &'static [A] = &[C];
+   |            ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/qualif-union.stderr
+++ b/src/test/ui/consts/qualif-union.stderr
@@ -8,6 +8,12 @@ LL |     let _: &'static _ = &C1;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/qualif-union.rs:28:12
+   |
+LL |     let _: &'static _ = &C1;
+   |            ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:29:26
@@ -19,6 +25,12 @@ LL |     let _: &'static _ = &C2;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/qualif-union.rs:29:12
+   |
+LL |     let _: &'static _ = &C2;
+   |            ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:30:26
@@ -30,6 +42,12 @@ LL |     let _: &'static _ = &C3;
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/qualif-union.rs:30:12
+   |
+LL |     let _: &'static _ = &C3;
+   |            ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:31:26
@@ -41,6 +59,12 @@ LL |     let _: &'static _ = &C4;
 LL |     let _: &'static _ = &C5;
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/qualif-union.rs:31:12
+   |
+LL |     let _: &'static _ = &C4;
+   |            ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:32:26
@@ -51,6 +75,12 @@ LL |     let _: &'static _ = &C5;
    |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/qualif-union.rs:32:12
+   |
+LL |     let _: &'static _ = &C5;
+   |            ^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/dst/dst-bad-coerce3.stderr
+++ b/src/test/ui/dst/dst-bad-coerce3.stderr
@@ -11,6 +11,12 @@ LL |     let f3: &'a Fat<[isize]> = f2;
 ...
 LL | }
    | - `f1` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dst-bad-coerce3.rs:17:13
+   |
+LL |     let f3: &'a Fat<[isize]> = f2;
+   |             ^^^^^^^^^^^^^^^^
 
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:21:25
@@ -25,6 +31,12 @@ LL |     let f3: &'a Fat<dyn Bar> = f2;
 ...
 LL | }
    | - `f1` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dst-bad-coerce3.rs:22:13
+   |
+LL |     let f3: &'a Fat<dyn Bar> = f2;
+   |             ^^^^^^^^^^^^^^^^
 
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:26:30
@@ -39,6 +51,12 @@ LL |     let f3: &'a ([isize],) = f2;
 ...
 LL | }
    | - `f1` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dst-bad-coerce3.rs:27:13
+   |
+LL |     let f3: &'a ([isize],) = f2;
+   |             ^^^^^^^^^^^^^^
 
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:31:23
@@ -52,6 +70,12 @@ LL |     let f3: &'a (dyn Bar,) = f2;
    |             -------------- type annotation requires that `f1` is borrowed for `'a`
 LL | }
    | - `f1` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/dst-bad-coerce3.rs:32:13
+   |
+LL |     let f3: &'a (dyn Bar,) = f2;
+   |             ^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/fn/implied-bounds-unnorm-associated-type-2.stderr
+++ b/src/test/ui/fn/implied-bounds-unnorm-associated-type-2.stderr
@@ -6,12 +6,9 @@ LL | fn g<'a, 'b>() {
    |      |
    |      lifetime `'a` defined here
 LL |     f::<'a, 'b>(());
-   |     ^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a function pointer to `f`
-   = note: the function `f` is invariant over the parameter `'a`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: aborting due to previous error
 

--- a/src/test/ui/higher-rank-trait-bounds/hrtb-cache-issue-54302.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/hrtb-cache-issue-54302.stderr
@@ -4,7 +4,7 @@ error: implementation of `Deserialize` is not general enough
 LL |     assert_deserialize_owned::<&'static str>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Deserialize` is not general enough
    |
-   = note: `&'static str` must implement `Deserialize<'0>`, for any lifetime `'0`...
+   = note: `&str` must implement `Deserialize<'0>`, for any lifetime `'0`...
    = note: ...but `&str` actually implements `Deserialize<'1>`, for some specific lifetime `'1`
 
 error: aborting due to previous error

--- a/src/test/ui/higher-rank-trait-bounds/hrtb-just-for-static.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/hrtb-just-for-static.stderr
@@ -13,7 +13,7 @@ error: lifetime may not live long enough
 LL | fn give_some<'a>() {
    |              -- lifetime `'a` defined here
 LL |     want_hrtb::<&'a u32>()
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: implementation of `Foo` is not general enough
   --> $DIR/hrtb-just-for-static.rs:30:5

--- a/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
@@ -6,36 +6,30 @@ LL |           fn subtype<'x, 'y: 'x, 'z: 'y>() {
    |                      |
    |                      lifetime `'x` defined here
 LL |               gimme::<$t2>(None::<$t1>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
+   |               ^^^^^^^^^^^^ type annotation requires that `'x` must outlive `'y`
 ...
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
    |
    = help: consider adding the following bound: `'x: 'y`
-   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: lifetime may not live long enough
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
    |                        --  -- lifetime `'y` defined here
    |                        |
    |                        lifetime `'x` defined here
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
+   |                            ^^^^^^^^^^^ type annotation requires that `'x` must outlive `'y`
 ...
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
    |
    = help: consider adding the following bound: `'x: 'y`
-   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.stderr
@@ -1,12 +1,12 @@
 error: lifetime may not live long enough
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
    |                        --  -- lifetime `'y` defined here
    |                        |
    |                        lifetime `'x` defined here
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
+   |                            ^^^^^^^^^^^ type annotation requires that `'x` must outlive `'y`
 ...
 LL | / check! { free_x_vs_free_y: (fn(&'x u32),
 LL | | fn(&'y u32)) }

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
@@ -6,6 +6,9 @@ LL | fn foo<'a, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
    |        |
    |        lifetime `'a` defined here
 ...
+LL |     let u = v;
+   |             - because of assignment here
+...
 LL |         let _: &'b i32 = *u.0;
    |                ^^^^^^^ type annotation requires that `'a` must outlive `'b`
    |

--- a/src/test/ui/inline-const/const-expr-lifetime-err.stderr
+++ b/src/test/ui/inline-const/const-expr-lifetime-err.stderr
@@ -11,6 +11,12 @@ LL |     equate(InvariantRef::new(&y), const { InvariantRef::<'a>::NEW });
 LL |
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/const-expr-lifetime-err.rs:23:43
+   |
+LL |     equate(InvariantRef::new(&y), const { InvariantRef::<'a>::NEW });
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/inline-const/const-expr-lifetime-err.stderr
+++ b/src/test/ui/inline-const/const-expr-lifetime-err.stderr
@@ -5,10 +5,9 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let y = ();
 LL |     equate(InvariantRef::new(&y), const { InvariantRef::<'a>::NEW });
-   |            ------------------^^-
-   |            |                 |
-   |            |                 borrowed value does not live long enough
-   |            argument requires that `y` is borrowed for `'a`
+   |                              ^^           ----------------------- type annotation requires that `y` is borrowed for `'a`
+   |                              |
+   |                              borrowed value does not live long enough
 LL |
 LL | }
    | - `y` dropped here while still borrowed

--- a/src/test/ui/issues/issue-26217.stderr
+++ b/src/test/ui/issues/issue-26217.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL | fn bar<'a>() {
    |        -- lifetime `'a` defined here
 LL |     foo::<&'a i32>();
-   |     ^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47184.stderr
+++ b/src/test/ui/issues/issue-47184.stderr
@@ -6,6 +6,12 @@ LL |     let _vec: Vec<&'static String> = vec![&String::new()];
    |               |                            |
    |               |                            creates a temporary which is freed while still in use
    |               type annotation requires that borrow lasts for `'static`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/issue-47184.rs:2:15
+   |
+LL |     let _vec: Vec<&'static String> = vec![&String::new()];
+   |               ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-54302.stderr
+++ b/src/test/ui/issues/issue-54302.stderr
@@ -4,7 +4,7 @@ error: implementation of `Deserialize` is not general enough
 LL |     assert_deserialize_owned::<&'static str>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Deserialize` is not general enough
    |
-   = note: `&'static str` must implement `Deserialize<'0>`, for any lifetime `'0`...
+   = note: `&str` must implement `Deserialize<'0>`, for any lifetime `'0`...
    = note: ...but `&str` actually implements `Deserialize<'1>`, for some specific lifetime `'1`
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-54943.stderr
+++ b/src/test/ui/issues/issue-54943.stderr
@@ -5,7 +5,7 @@ LL | fn boo<'a>() {
    |        -- lifetime `'a` defined here
 ...
 LL |     let x = foo::<&'a u32>();
-   |             ^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |             ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lub-glb/empty-binders-err.rs
+++ b/src/test/ui/lub-glb/empty-binders-err.rs
@@ -33,8 +33,8 @@ where
 {
 
     let _: fn(&'lower ()) = match v {
-        //~^ ERROR lifetime may not live long enough
         true => lt_in_fn::<'a>(),
+        //~^ ERROR lifetime may not live long enough
         false => lt_in_fn::<'b>(),
     };
 }
@@ -46,8 +46,8 @@ where
 
 {
     let _: Contra<'lower> = match v {
-        //~^ ERROR lifetime may not live long enough
         true => lt_in_contra::<'a>(),
+        //~^ ERROR lifetime may not live long enough
         false => lt_in_contra::<'b>(),
     };
 }

--- a/src/test/ui/lub-glb/empty-binders-err.stderr
+++ b/src/test/ui/lub-glb/empty-binders-err.stderr
@@ -30,28 +30,28 @@ help: the following changes may resolve your lifetime errors
    = help: add bound `'b: 'upper`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:35:12
+  --> $DIR/empty-binders-err.rs:36:17
    |
 LL | fn contra_fn<'a, 'b, 'lower>(v: bool)
    |              --      ------ lifetime `'lower` defined here
    |              |
    |              lifetime `'a` defined here
 ...
-LL |     let _: fn(&'lower ()) = match v {
-   |            ^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
+LL |         true => lt_in_fn::<'a>(),
+   |                 ^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
    |
    = help: consider adding the following bound: `'lower: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:48:12
+  --> $DIR/empty-binders-err.rs:49:17
    |
 LL | fn contra_struct<'a, 'b, 'lower>(v: bool)
    |                  --      ------ lifetime `'lower` defined here
    |                  |
    |                  lifetime `'a` defined here
 ...
-LL |     let _: Contra<'lower> = match v {
-   |            ^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
+LL |         true => lt_in_contra::<'a>(),
+   |                 ^^^^^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
    |
    = help: consider adding the following bound: `'lower: 'a`
 

--- a/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.rs
@@ -9,10 +9,10 @@ pub fn dangle() -> &'static [i32] {
     let other_local_arr = [0, 2, 4];
     let local_arr = other_local_arr;
     let mut out: &mut &'static [i32] = &mut (&[1] as _);
-    once(|mut z: &[i32], mut out_val: &mut &[i32]| {
+    once(|mut z: &[i32], mut out_val: &mut &[i32]| { //~ ERROR
         // We unfortunately point to the first use in the closure in the error
         // message
-        z = &local_arr; //~ ERROR
+        z = &local_arr;
         *out_val = &local_arr;
     }, &[] as &[_], &mut *out);
     *out

--- a/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -1,17 +1,22 @@
-error[E0597]: `local_arr` does not live long enough
-  --> $DIR/propagate-multiple-requirements.rs:15:14
+error[E0373]: closure may outlive the current function, but it borrows `local_arr`, which is owned by the current function
+  --> $DIR/propagate-multiple-requirements.rs:12:10
    |
-LL |     let mut out: &mut &'static [i32] = &mut (&[1] as _);
-   |                  ------------------- type annotation requires that `local_arr` is borrowed for `'static`
 LL |     once(|mut z: &[i32], mut out_val: &mut &[i32]| {
-   |          ----------------------------------------- value captured here
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may outlive borrowed value `local_arr`
 ...
 LL |         z = &local_arr;
-   |              ^^^^^^^^^ borrowed value does not live long enough
-...
-LL | }
-   | - `local_arr` dropped here while still borrowed
+   |              --------- `local_arr` is borrowed here
+   |
+note: closure is returned here
+  --> $DIR/propagate-multiple-requirements.rs:18:5
+   |
+LL |     *out
+   |     ^^^^
+help: to force the closure to take ownership of `local_arr` (and any other referenced variables), use the `move` keyword
+   |
+LL |     once(move |mut z: &[i32], mut out_val: &mut &[i32]| {
+   |          ++++
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/nll/issue-31567.stderr
+++ b/src/test/ui/nll/issue-31567.stderr
@@ -10,6 +10,12 @@ LL |     let s_inner: &'a S = &*v.0;
 LL |     &s_inner.0
 LL | }
    | - here, drop of `v` needs exclusive access to `*v.0`, because the type `VecWrapper<'_>` implements the `Drop` trait
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/issue-31567.rs:10:18
+   |
+LL |     let s_inner: &'a S = &*v.0;
+   |                  ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-55511.stderr
+++ b/src/test/ui/nll/issue-55511.stderr
@@ -9,6 +9,12 @@ LL |         <() as Foo<'static>>::C => { }
 ...
 LL | }
    | - `a` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/issue-55511.rs:16:9
+   |
+LL |         <() as Foo<'static>>::C => { }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-58299.stderr
+++ b/src/test/ui/nll/issue-58299.stderr
@@ -5,7 +5,7 @@ LL | fn foo<'a>(x: i32) {
    |        -- lifetime `'a` defined here
 ...
 LL |         A::<'a>::X..=A::<'static>::X => (),
-   |         ^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |         ^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-58299.rs:22:27
@@ -14,7 +14,7 @@ LL | fn bar<'a>(x: i32) {
    |        -- lifetime `'a` defined here
 ...
 LL |         A::<'static>::X..=A::<'a>::X => (),
-   |                           ^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |                           ^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/issue-68550.stderr
+++ b/src/test/ui/nll/issue-68550.stderr
@@ -10,6 +10,12 @@ LL |     let _: &'a A = &x;
    |            type annotation requires that `x` is borrowed for `'a`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/issue-68550.rs:12:12
+   |
+LL |     let _: &'a A = &x;
+   |            ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-98170.stderr
+++ b/src/test/ui/nll/issue-98170.stderr
@@ -9,14 +9,25 @@ LL |         Self { field }
    |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
-  --> $DIR/issue-98170.rs:7:16
+  --> $DIR/issue-98170.rs:7:9
    |
 LL | impl MyStruct<'_> {
    |               -- lifetime `'1` appears in the `impl`'s self type
 LL |     pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
    |                -- lifetime `'a` defined here
 LL |         Self { field }
-   |                ^^^^^ this usage requires that `'a` must outlive `'1`
+   |         ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-98170.rs:19:9
+   |
+LL | impl<'a> Trait<'a> for MyStruct<'_> {
+   |      --                         -- lifetime `'1` appears in the `impl`'s self type
+   |      |
+   |      lifetime `'a` defined here
+LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
+LL |         Self { field }
+   |         ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'1`
 
 error: lifetime may not live long enough
   --> $DIR/issue-98170.rs:19:9
@@ -28,17 +39,6 @@ LL | impl<'a> Trait<'a> for MyStruct<'_> {
 LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
 LL |         Self { field }
    |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
-
-error: lifetime may not live long enough
-  --> $DIR/issue-98170.rs:19:16
-   |
-LL | impl<'a> Trait<'a> for MyStruct<'_> {
-   |      --                         -- lifetime `'1` appears in the `impl`'s self type
-   |      |
-   |      lifetime `'a` defined here
-LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
-LL |         Self { field }
-   |                ^^^^^ this usage requires that `'a` must outlive `'1`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/nll/issue-98170.stderr
+++ b/src/test/ui/nll/issue-98170.stderr
@@ -7,6 +7,8 @@ LL |     pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
    |                -- lifetime `'a` defined here
 LL |         Self { field }
    |         ^^^^ type annotation requires that `'a` must outlive `'1`
+   |
+   = help: consider replacing `Self` with `MyStruct`
 
 error: lifetime may not live long enough
   --> $DIR/issue-98170.rs:7:9
@@ -28,6 +30,8 @@ LL | impl<'a> Trait<'a> for MyStruct<'_> {
 LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
 LL |         Self { field }
    |         ^^^^ type annotation requires that `'a` must outlive `'1`
+   |
+   = help: consider replacing `Self` with `MyStruct`
 
 error: lifetime may not live long enough
   --> $DIR/issue-98170.rs:19:9

--- a/src/test/ui/nll/issue-98170.stderr
+++ b/src/test/ui/nll/issue-98170.stderr
@@ -6,7 +6,7 @@ LL | impl MyStruct<'_> {
 LL |     pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
    |                -- lifetime `'a` defined here
 LL |         Self { field }
-   |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   |         ^^^^ type annotation requires that `'a` must outlive `'1`
 
 error: lifetime may not live long enough
   --> $DIR/issue-98170.rs:7:9
@@ -16,7 +16,7 @@ LL | impl MyStruct<'_> {
 LL |     pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
    |                -- lifetime `'a` defined here
 LL |         Self { field }
-   |         ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'1`
+   |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/issue-98170.rs:19:9
@@ -27,7 +27,7 @@ LL | impl<'a> Trait<'a> for MyStruct<'_> {
    |      lifetime `'a` defined here
 LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
 LL |         Self { field }
-   |         ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'1`
+   |         ^^^^ type annotation requires that `'a` must outlive `'1`
 
 error: lifetime may not live long enough
   --> $DIR/issue-98170.rs:19:9

--- a/src/test/ui/nll/issue-98589-closures-relate-named-regions.stderr
+++ b/src/test/ui/nll/issue-98589-closures-relate-named-regions.stderr
@@ -1,12 +1,12 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-98589-closures-relate-named-regions.rs:10:5
+  --> $DIR/issue-98589-closures-relate-named-regions.rs:10:10
    |
 LL | fn test_early_early<'a: 'a, 'b: 'b>() {
    |                     --      -- lifetime `'b` defined here
    |                     |
    |                     lifetime `'a` defined here
 LL |     || { None::<&'a &'b ()>; };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |          ^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 
@@ -18,7 +18,7 @@ LL | fn test_early_late<'a: 'a, 'b>() {
    |                    |
    |                    lifetime `'a` defined here
 LL |     || { None::<&'a &'b ()>; };
-   |          ^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |          ^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 
@@ -30,7 +30,7 @@ LL | fn test_late_late<'a, 'b>() {
    |                   |
    |                   lifetime `'a` defined here
 LL |     || { None::<&'a &'b ()>; };
-   |          ^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |          ^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/nll/relate_tys/fn-subtype.stderr
+++ b/src/test/ui/nll/relate_tys/fn-subtype.stderr
@@ -5,7 +5,7 @@ LL |     let y: for<'a> fn(&'a ()) = x;
    |                                 ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'a> fn(&'a ())`
-              found fn pointer `fn(&())`
+              found fn pointer `fn(&'static ())`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/relate_tys/universe-violation.stderr
+++ b/src/test/ui/nll/relate_tys/universe-violation.stderr
@@ -5,7 +5,7 @@ LL |     let b: fn(&u32) -> &u32 = a;
    |                               ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r> fn(&'r u32) -> &'r u32`
-              found fn pointer `fn(&u32) -> &u32`
+              found fn pointer `fn(&'static u32) -> &'static u32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/relate_tys/var-appears-twice.stderr
+++ b/src/test/ui/nll/relate_tys/var-appears-twice.stderr
@@ -2,9 +2,10 @@ error[E0597]: `b` does not live long enough
   --> $DIR/var-appears-twice.rs:20:38
    |
 LL |     let x: DoubleCell<_> = make_cell(&b);
-   |            -------------             ^^ borrowed value does not live long enough
-   |            |
-   |            type annotation requires that `b` is borrowed for `'static`
+   |                            ----------^^-
+   |                            |         |
+   |                            |         borrowed value does not live long enough
+   |                            argument requires that `b` is borrowed for `'static`
 ...
 LL | }
    | - `b` dropped here while still borrowed

--- a/src/test/ui/nll/type-test-universe.stderr
+++ b/src/test/ui/nll/type-test-universe.stderr
@@ -10,7 +10,7 @@ error: lifetime may not live long enough
 LL | fn test2<'a>() {
    |          -- lifetime `'a` defined here
 LL |     outlives_forall::<Value<'a>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -2,10 +2,10 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:25:48
    |
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
-   |                                                ^^
-   |                                                |
-   |                                                borrowed value does not live long enough
-   |                                                this usage requires that `c` is borrowed for `'static`
+   |     -------------------------------------------^^--
+   |     |                                          |
+   |     |                                          borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -16,10 +16,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
-   |                                           ^^
-   |                                           |
-   |                                           borrowed value does not live long enough
-   |                                           this usage requires that `c` is borrowed for `'a`
+   |     --------------------------------------^^--
+   |     |                                     |
+   |     |                                     borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -30,10 +30,10 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
-   |                                               ^^
-   |                                               |
-   |                                               borrowed value does not live long enough
-   |                                               this usage requires that `c` is borrowed for `'a`
+   |         --------------------------------------^^--
+   |         |                                     |
+   |         |                                     borrowed value does not live long enough
+   |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -7,6 +7,12 @@ LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-brace-enums.rs:25:5
+   |
+LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:30:43
@@ -20,6 +26,12 @@ LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-brace-enums.rs:30:5
+   |
+LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:40:47
@@ -33,6 +45,12 @@ LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-brace-enums.rs:40:9
+   |
+LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -2,9 +2,8 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:25:48
    |
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
-   |     -------------------------------------------^^--
-   |     |                                          |
-   |     |                                          borrowed value does not live long enough
+   |     -------------------------------------      ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
@@ -16,9 +15,8 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
-   |     --------------------------------------^^--
-   |     |                                     |
-   |     |                                     borrowed value does not live long enough
+   |     --------------------------------      ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
@@ -30,9 +28,8 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
-   |         --------------------------------------^^--
-   |         |                                     |
-   |         |                                     borrowed value does not live long enough
+   |         --------------------------------      ^^ borrowed value does not live long enough
+   |         |
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
@@ -7,6 +7,12 @@ LL |     SomeStruct::<&'static u32> { t: &c };
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-brace-structs.rs:23:5
+   |
+LL |     SomeStruct::<&'static u32> { t: &c };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:28:32
@@ -20,6 +26,12 @@ LL |     SomeStruct::<&'a u32> { t: &c };
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-brace-structs.rs:28:5
+   |
+LL |     SomeStruct::<&'a u32> { t: &c };
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:38:36
@@ -33,6 +45,12 @@ LL |         SomeStruct::<&'a u32> { t: &c };
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-brace-structs.rs:38:9
+   |
+LL |         SomeStruct::<&'a u32> { t: &c };
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
@@ -2,9 +2,8 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:23:37
    |
 LL |     SomeStruct::<&'static u32> { t: &c };
-   |     --------------------------------^^--
-   |     |                               |
-   |     |                               borrowed value does not live long enough
+   |     --------------------------      ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
@@ -16,9 +15,8 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeStruct::<&'a u32> { t: &c };
-   |     ---------------------------^^--
-   |     |                          |
-   |     |                          borrowed value does not live long enough
+   |     ---------------------      ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
@@ -30,9 +28,8 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeStruct::<&'a u32> { t: &c };
-   |         ---------------------------^^--
-   |         |                          |
-   |         |                          borrowed value does not live long enough
+   |         ---------------------      ^^ borrowed value does not live long enough
+   |         |
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
@@ -2,10 +2,10 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:23:37
    |
 LL |     SomeStruct::<&'static u32> { t: &c };
-   |                                     ^^
-   |                                     |
-   |                                     borrowed value does not live long enough
-   |                                     this usage requires that `c` is borrowed for `'static`
+   |     --------------------------------^^--
+   |     |                               |
+   |     |                               borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -16,10 +16,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeStruct::<&'a u32> { t: &c };
-   |                                ^^
-   |                                |
-   |                                borrowed value does not live long enough
-   |                                this usage requires that `c` is borrowed for `'a`
+   |     ---------------------------^^--
+   |     |                          |
+   |     |                          borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -30,10 +30,10 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeStruct::<&'a u32> { t: &c };
-   |                                    ^^
-   |                                    |
-   |                                    borrowed value does not live long enough
-   |                                    this usage requires that `c` is borrowed for `'a`
+   |         ---------------------------^^--
+   |         |                          |
+   |         |                          borrowed value does not live long enough
+   |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
@@ -1,14 +1,13 @@
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:33:41
    |
-LL | /     combine(
-LL | |         SomeEnum::SomeVariant(Cell::new(&c)),
-   | |                                         ^^ borrowed value does not live long enough
-LL | |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
-LL | |     );
-   | |_____- argument requires that `c` is borrowed for `'static`
-LL |   }
-   |   - `c` dropped here while still borrowed
+LL |         SomeEnum::SomeVariant(Cell::new(&c)),
+   |                                         ^^ borrowed value does not live long enough
+LL |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
+   |         ------------------------------------------------ type annotation requires that `c` is borrowed for `'static`
+LL |     );
+LL | }
+   | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:41:41
@@ -17,11 +16,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 ...
 LL |         SomeEnum::SomeVariant(Cell::new(&c)),
-   |                               ----------^^-
-   |                               |         |
-   |                               |         borrowed value does not live long enough
-   |                               argument requires that `c` is borrowed for `'a`
-...
+   |                                         ^^ borrowed value does not live long enough
+LL |         SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
+   |         ------------------------------------------- type annotation requires that `c` is borrowed for `'a`
+LL |     );
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -34,10 +32,9 @@ LL |     let _closure = || {
    |                     - `c` dropped here while still borrowed
 ...
 LL |             SomeEnum::SomeVariant(Cell::new(&c)),
-   |                                   ----------^^-
-   |                                   |         |
-   |                                   |         borrowed value does not live long enough
-   |                                   argument requires that `c` is borrowed for `'a`
+   |                                             ^^ borrowed value does not live long enough
+LL |             SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
+   |             ------------------------------------------- type annotation requires that `c` is borrowed for `'a`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
@@ -8,6 +8,12 @@ LL |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
 LL |     );
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-nullary-enums.rs:34:9
+   |
+LL |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:41:41
@@ -22,6 +28,12 @@ LL |         SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
 LL |     );
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-nullary-enums.rs:42:9
+   |
+LL |         SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:54:45
@@ -35,6 +47,12 @@ LL |             SomeEnum::SomeVariant(Cell::new(&c)),
    |                                             ^^ borrowed value does not live long enough
 LL |             SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
    |             ------------------------------------------- type annotation requires that `c` is borrowed for `'a`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-nullary-enums.rs:55:13
+   |
+LL |             SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
@@ -7,6 +7,12 @@ LL |     SomeEnum::SomeVariant::<&'static u32>(&c);
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-enums.rs:28:5
+   |
+LL |     SomeEnum::SomeVariant::<&'static u32>(&c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:33:38
@@ -20,6 +26,12 @@ LL |     SomeEnum::SomeVariant::<&'a u32>(&c);
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-enums.rs:33:5
+   |
+LL |     SomeEnum::SomeVariant::<&'a u32>(&c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:43:42
@@ -33,6 +45,12 @@ LL |         SomeEnum::SomeVariant::<&'a u32>(&c);
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-enums.rs:43:9
+   |
+LL |         SomeEnum::SomeVariant::<&'a u32>(&c);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
@@ -2,9 +2,8 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:28:43
    |
 LL |     SomeEnum::SomeVariant::<&'static u32>(&c);
-   |     --------------------------------------^^-
-   |     |                                     |
-   |     |                                     borrowed value does not live long enough
+   |     ------------------------------------- ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
@@ -16,9 +15,8 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeEnum::SomeVariant::<&'a u32>(&c);
-   |     ---------------------------------^^-
-   |     |                                |
-   |     |                                borrowed value does not live long enough
+   |     -------------------------------- ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
@@ -30,9 +28,8 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeEnum::SomeVariant::<&'a u32>(&c);
-   |         ---------------------------------^^-
-   |         |                                |
-   |         |                                borrowed value does not live long enough
+   |         -------------------------------- ^^ borrowed value does not live long enough
+   |         |
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
@@ -2,10 +2,10 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:28:43
    |
 LL |     SomeEnum::SomeVariant::<&'static u32>(&c);
-   |                                           ^^
-   |                                           |
-   |                                           borrowed value does not live long enough
-   |                                           this usage requires that `c` is borrowed for `'static`
+   |     --------------------------------------^^-
+   |     |                                     |
+   |     |                                     borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -16,10 +16,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeEnum::SomeVariant::<&'a u32>(&c);
-   |                                      ^^
-   |                                      |
-   |                                      borrowed value does not live long enough
-   |                                      this usage requires that `c` is borrowed for `'a`
+   |     ---------------------------------^^-
+   |     |                                |
+   |     |                                borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -30,10 +30,10 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeEnum::SomeVariant::<&'a u32>(&c);
-   |                                          ^^
-   |                                          |
-   |                                          borrowed value does not live long enough
-   |                                          this usage requires that `c` is borrowed for `'a`
+   |         ---------------------------------^^-
+   |         |                                |
+   |         |                                borrowed value does not live long enough
+   |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
@@ -1,11 +1,10 @@
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:27:7
    |
+LL |     let f = SomeStruct::<&'static u32>;
+   |             -------------------------- type annotation requires that `c` is borrowed for `'static`
 LL |     f(&c);
-   |     --^^-
-   |     | |
-   |     | borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'static`
+   |       ^^ borrowed value does not live long enough
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -14,12 +13,11 @@ error[E0597]: `c` does not live long enough
    |
 LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
-...
+LL |     let c = 66;
+LL |     let f = SomeStruct::<&'a u32>;
+   |             --------------------- type annotation requires that `c` is borrowed for `'a`
 LL |     f(&c);
-   |     --^^-
-   |     | |
-   |     | borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |       ^^ borrowed value does not live long enough
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -30,12 +28,11 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 LL |     let _closure = || {
    |                     - `c` dropped here while still borrowed
-...
+LL |         let c = 66;
+LL |         let f = SomeStruct::<&'a u32>;
+   |                 --------------------- type annotation requires that `c` is borrowed for `'a`
 LL |         f(&c);
-   |         --^^-
-   |         | |
-   |         | borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'a`
+   |           ^^ borrowed value does not live long enough
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:53:11

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
@@ -7,6 +7,12 @@ LL |     f(&c);
    |       ^^ borrowed value does not live long enough
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-struct-calls.rs:26:13
+   |
+LL |     let f = SomeStruct::<&'static u32>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:33:7
@@ -20,6 +26,12 @@ LL |     f(&c);
    |       ^^ borrowed value does not live long enough
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-struct-calls.rs:32:13
+   |
+LL |     let f = SomeStruct::<&'a u32>;
+   |             ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:45:11
@@ -33,6 +45,12 @@ LL |         let f = SomeStruct::<&'a u32>;
    |                 --------------------- type annotation requires that `c` is borrowed for `'a`
 LL |         f(&c);
    |           ^^ borrowed value does not live long enough
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-struct-calls.rs:44:17
+   |
+LL |         let f = SomeStruct::<&'a u32>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:53:11

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
@@ -2,9 +2,8 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:23:32
    |
 LL |     SomeStruct::<&'static u32>(&c);
-   |     ---------------------------^^-
-   |     |                          |
-   |     |                          borrowed value does not live long enough
+   |     -------------------------- ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
@@ -16,9 +15,8 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeStruct::<&'a u32>(&c);
-   |     ----------------------^^-
-   |     |                     |
-   |     |                     borrowed value does not live long enough
+   |     --------------------- ^^ borrowed value does not live long enough
+   |     |
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
@@ -30,9 +28,8 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeStruct::<&'a u32>(&c);
-   |         ----------------------^^-
-   |         |                     |
-   |         |                     borrowed value does not live long enough
+   |         --------------------- ^^ borrowed value does not live long enough
+   |         |
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
@@ -7,6 +7,12 @@ LL |     SomeStruct::<&'static u32>(&c);
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-struct.rs:23:5
+   |
+LL |     SomeStruct::<&'static u32>(&c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:28:27
@@ -20,6 +26,12 @@ LL |     SomeStruct::<&'a u32>(&c);
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-struct.rs:28:5
+   |
+LL |     SomeStruct::<&'a u32>(&c);
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:38:31
@@ -33,6 +45,12 @@ LL |         SomeStruct::<&'a u32>(&c);
    |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/adt-tuple-struct.rs:38:9
+   |
+LL |         SomeStruct::<&'a u32>(&c);
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
@@ -2,10 +2,10 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:23:32
    |
 LL |     SomeStruct::<&'static u32>(&c);
-   |                                ^^
-   |                                |
-   |                                borrowed value does not live long enough
-   |                                this usage requires that `c` is borrowed for `'static`
+   |     ---------------------------^^-
+   |     |                          |
+   |     |                          borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -16,10 +16,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     SomeStruct::<&'a u32>(&c);
-   |                           ^^
-   |                           |
-   |                           borrowed value does not live long enough
-   |                           this usage requires that `c` is borrowed for `'a`
+   |     ----------------------^^-
+   |     |                     |
+   |     |                     borrowed value does not live long enough
+   |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -30,10 +30,10 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
 LL |         SomeStruct::<&'a u32>(&c);
-   |                               ^^
-   |                               |
-   |                               borrowed value does not live long enough
-   |                               this usage requires that `c` is borrowed for `'a`
+   |         ----------------------^^-
+   |         |                     |
+   |         |                     borrowed value does not live long enough
+   |         type annotation requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/user-annotations/cast_static_lifetime.stderr
+++ b/src/test/ui/nll/user-annotations/cast_static_lifetime.stderr
@@ -8,6 +8,12 @@ LL |     let y: &u32 = (&x) as &'static u32;
    |                   type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/cast_static_lifetime.rs:5:19
+   |
+LL |     let y: &u32 = (&x) as &'static u32;
+   |                   ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/closure-substs.rs
+++ b/src/test/ui/nll/user-annotations/closure-substs.rs
@@ -17,14 +17,16 @@ fn foo1() {
 fn bar<'a>() {
     // Here `x` is free in the closure sig:
     |x: &'a i32, b: fn(&'static i32)| {
-        b(x); //~ ERROR lifetime may not live long enough
+        //~^ ERROR lifetime may not live long enough
+        b(x);
     };
 }
 
 fn bar1() {
     // Here `x` is bound in the closure sig:
     |x: &i32, b: fn(&'static i32)| {
-        b(x); //~ ERROR borrowed data escapes outside of closure
+        //~^ ERROR lifetime may not live long enough
+        b(x);
     };
 }
 

--- a/src/test/ui/nll/user-annotations/closure-substs.stderr
+++ b/src/test/ui/nll/user-annotations/closure-substs.stderr
@@ -31,6 +31,9 @@ LL |     |x: &i32, b: fn(&'static i32)| {
    |         -     ^ type annotation requires that `'1` must outlive `'static`
    |         |
    |         let's call the lifetime of this reference `'1`
+LL |
+LL |         b(x);
+   |         ---- because of argument here
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/nll/user-annotations/closure-substs.stderr
+++ b/src/test/ui/nll/user-annotations/closure-substs.stderr
@@ -16,27 +16,21 @@ LL |         return x;
    |                ^ returning this value requires that `'1` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/closure-substs.rs:20:9
+  --> $DIR/closure-substs.rs:19:18
    |
 LL | fn bar<'a>() {
    |        -- lifetime `'a` defined here
-...
-LL |         b(x);
-   |         ^^^^ argument requires that `'a` must outlive `'static`
+LL |     // Here `x` is free in the closure sig:
+LL |     |x: &'a i32, b: fn(&'static i32)| {
+   |                  ^ type annotation requires that `'a` must outlive `'static`
 
-error[E0521]: borrowed data escapes outside of closure
-  --> $DIR/closure-substs.rs:27:9
+error: lifetime may not live long enough
+  --> $DIR/closure-substs.rs:27:15
    |
 LL |     |x: &i32, b: fn(&'static i32)| {
-   |      -  - let's call the lifetime of this reference `'1`
-   |      |
-   |      `x` is a reference that is only valid in the closure body
-LL |         b(x);
-   |         ^^^^
+   |         -     ^ type annotation requires that `'1` must outlive `'static`
    |         |
-   |         `x` escapes the closure body here
-   |         argument requires that `'1` must outlive `'static`
+   |         let's call the lifetime of this reference `'1`
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/nll/user-annotations/fns.stderr
+++ b/src/test/ui/nll/user-annotations/fns.stderr
@@ -7,6 +7,12 @@ LL |     some_fn::<&'static u32>(&c);
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/fns.rs:23:5
+   |
+LL |     some_fn::<&'static u32>(&c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:28:24
@@ -20,6 +26,12 @@ LL |     some_fn::<&'a u32>(&c);
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/fns.rs:28:5
+   |
+LL |     some_fn::<&'a u32>(&c);
+   |     ^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:38:28
@@ -33,6 +45,12 @@ LL |         some_fn::<&'a u32>(&c);
    |         ------------------ ^^ borrowed value does not live long enough
    |         |
    |         type annotation requires that `c` is borrowed for `'a`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/fns.rs:38:9
+   |
+LL |         some_fn::<&'a u32>(&c);
+   |         ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/fns.stderr
+++ b/src/test/ui/nll/user-annotations/fns.stderr
@@ -2,10 +2,9 @@ error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:23:29
    |
 LL |     some_fn::<&'static u32>(&c);
-   |     ------------------------^^-
-   |     |                       |
-   |     |                       borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'static`
+   |     ----------------------- ^^ borrowed value does not live long enough
+   |     |
+   |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -16,10 +15,9 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
 LL |     some_fn::<&'a u32>(&c);
-   |     -------------------^^-
-   |     |                  |
-   |     |                  borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |     ------------------ ^^ borrowed value does not live long enough
+   |     |
+   |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -32,10 +30,9 @@ LL |     let _closure = || {
    |                     - `c` dropped here while still borrowed
 LL |         let c = 66;
 LL |         some_fn::<&'a u32>(&c);
-   |         -------------------^^-
-   |         |                  |
-   |         |                  borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'a`
+   |         ------------------ ^^ borrowed value does not live long enough
+   |         |
+   |         type annotation requires that `c` is borrowed for `'a`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
+++ b/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL | fn non_wf_associated_const<'a>(x: i32) {
    |                            -- lifetime `'a` defined here
 LL |     A::<'a>::IC;
-   |     ^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/issue-54124.stderr
+++ b/src/test/ui/nll/user-annotations/issue-54124.stderr
@@ -6,7 +6,7 @@ LL | fn test<'a>() {
 LL |     let _:fn(&()) = |_:&'a ()| {};
    |                      ^ - let's call the lifetime of this reference `'1`
    |                      |
-   |                      requires that `'1` must outlive `'a`
+   |                      type annotation requires that `'1` must outlive `'a`
 
 error: lifetime may not live long enough
   --> $DIR/issue-54124.rs:2:22
@@ -14,7 +14,7 @@ error: lifetime may not live long enough
 LL | fn test<'a>() {
    |         -- lifetime `'a` defined here
 LL |     let _:fn(&()) = |_:&'a ()| {};
-   |                      ^ requires that `'a` must outlive `'static`
+   |                      ^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-call.stderr
+++ b/src/test/ui/nll/user-annotations/method-call.stderr
@@ -2,10 +2,9 @@ error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:36:34
    |
 LL |     a.method::<&'static u32>(b,  &c);
-   |     -----------------------------^^-
-   |     |                            |
-   |     |                            borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'static`
+   |       ------                     ^^ borrowed value does not live long enough
+   |       |
+   |       type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -16,10 +15,9 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 ...
 LL |     a.method::<&'a u32>(b,  &c);
-   |     ------------------------^^-
-   |     |                       |
-   |     |                       borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |       ------                ^^ borrowed value does not live long enough
+   |       |
+   |       type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -33,10 +31,9 @@ LL |     let _closure = || {
    |                     - `c` dropped here while still borrowed
 LL |         let c = 66;
 LL |         a.method::<&'a u32>(b,  &c);
-   |         ------------------------^^-
-   |         |                       |
-   |         |                       borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'a`
+   |           ------                ^^ borrowed value does not live long enough
+   |           |
+   |           type annotation requires that `c` is borrowed for `'a`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-call.stderr
+++ b/src/test/ui/nll/user-annotations/method-call.stderr
@@ -2,7 +2,7 @@ error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:36:34
    |
 LL |     a.method::<&'static u32>(b,  &c);
-   |       ------                     ^^ borrowed value does not live long enough
+   |       ----------------------     ^^ borrowed value does not live long enough
    |       |
    |       type annotation requires that `c` is borrowed for `'static`
 LL | }
@@ -15,7 +15,7 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 ...
 LL |     a.method::<&'a u32>(b,  &c);
-   |       ------                ^^ borrowed value does not live long enough
+   |       -----------------     ^^ borrowed value does not live long enough
    |       |
    |       type annotation requires that `c` is borrowed for `'a`
 LL | }
@@ -31,7 +31,7 @@ LL |     let _closure = || {
    |                     - `c` dropped here while still borrowed
 LL |         let c = 66;
 LL |         a.method::<&'a u32>(b,  &c);
-   |           ------                ^^ borrowed value does not live long enough
+   |           -----------------     ^^ borrowed value does not live long enough
    |           |
    |           type annotation requires that `c` is borrowed for `'a`
 

--- a/src/test/ui/nll/user-annotations/method-call.stderr
+++ b/src/test/ui/nll/user-annotations/method-call.stderr
@@ -7,6 +7,12 @@ LL |     a.method::<&'static u32>(b,  &c);
    |       type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-call.rs:36:7
+   |
+LL |     a.method::<&'static u32>(b,  &c);
+   |       ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:43:29
@@ -20,6 +26,12 @@ LL |     a.method::<&'a u32>(b,  &c);
    |       type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-call.rs:43:7
+   |
+LL |     a.method::<&'a u32>(b,  &c);
+   |       ^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:57:33
@@ -34,6 +46,12 @@ LL |         a.method::<&'a u32>(b,  &c);
    |           -----------------     ^^ borrowed value does not live long enough
    |           |
    |           type annotation requires that `c` is borrowed for `'a`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-call.rs:57:11
+   |
+LL |         a.method::<&'a u32>(b,  &c);
+   |           ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-1.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-1.stderr
@@ -1,11 +1,10 @@
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:30:7
    |
+LL |     let x = <&'static u32 as Bazoom<_>>::method;
+   |             ----------------------------------- type annotation requires that `a` is borrowed for `'static`
 LL |     x(&a, b, c);
-   |     --^^-------
-   |     | |
-   |     | borrowed value does not live long enough
-   |     argument requires that `a` is borrowed for `'static`
+   |       ^^ borrowed value does not live long enough
 LL | }
    | - `a` dropped here while still borrowed
 
@@ -16,10 +15,9 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 ...
 LL |     <&'a u32 as Bazoom<_>>::method(&a, b, c);
-   |     -------------------------------^^-------
-   |     |                              |
-   |     |                              borrowed value does not live long enough
-   |     argument requires that `a` is borrowed for `'a`
+   |     ------------------------------ ^^ borrowed value does not live long enough
+   |     |
+   |     type annotation requires that `a` is borrowed for `'a`
 LL | }
    | - `a` dropped here while still borrowed
 
@@ -33,10 +31,9 @@ LL |     let _closure = || {
    |                    -- value captured here
 LL |         let c = 66;
 LL |         <&'a u32 as Bazoom<_>>::method(&a, b, c);
-   |         --------------------------------^-------
-   |         |                               |
-   |         |                               borrowed value does not live long enough
-   |         argument requires that `a` is borrowed for `'a`
+   |         ------------------------------  ^ borrowed value does not live long enough
+   |         |
+   |         type annotation requires that `a` is borrowed for `'a`
 LL |     };
 LL | }
    | - `a` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/method-ufcs-1.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-1.stderr
@@ -7,6 +7,12 @@ LL |     x(&a, b, c);
    |       ^^ borrowed value does not live long enough
 LL | }
    | - `a` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-1.rs:29:13
+   |
+LL |     let x = <&'static u32 as Bazoom<_>>::method;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:37:36
@@ -20,6 +26,12 @@ LL |     <&'a u32 as Bazoom<_>>::method(&a, b, c);
    |     type annotation requires that `a` is borrowed for `'a`
 LL | }
    | - `a` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-1.rs:37:5
+   |
+LL |     <&'a u32 as Bazoom<_>>::method(&a, b, c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:51:41
@@ -37,6 +49,12 @@ LL |         <&'a u32 as Bazoom<_>>::method(&a, b, c);
 LL |     };
 LL | }
    | - `a` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-1.rs:51:9
+   |
+LL |         <&'a u32 as Bazoom<_>>::method(&a, b, c);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-2.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-2.stderr
@@ -1,11 +1,10 @@
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-2.rs:30:7
    |
+LL |     let x = <&'static u32 as Bazoom<_>>::method;
+   |             ----------------------------------- type annotation requires that `a` is borrowed for `'static`
 LL |     x(&a, b, c);
-   |     --^^-------
-   |     | |
-   |     | borrowed value does not live long enough
-   |     argument requires that `a` is borrowed for `'static`
+   |       ^^ borrowed value does not live long enough
 LL | }
    | - `a` dropped here while still borrowed
 
@@ -16,10 +15,9 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 ...
 LL |     <_ as Bazoom<&'a u32>>::method(a, &b, c);
-   |     ----------------------------------^^----
-   |     |                                 |
-   |     |                                 borrowed value does not live long enough
-   |     argument requires that `b` is borrowed for `'a`
+   |     ------------------------------    ^^ borrowed value does not live long enough
+   |     |
+   |     type annotation requires that `b` is borrowed for `'a`
 LL | }
    | - `b` dropped here while still borrowed
 
@@ -33,10 +31,9 @@ LL |     let _closure = || {
    |                    -- value captured here
 LL |         let c = 66;
 LL |         <_ as Bazoom<&'a u32>>::method(a, &b, c);
-   |         -----------------------------------^----
-   |         |                                  |
-   |         |                                  borrowed value does not live long enough
-   |         argument requires that `b` is borrowed for `'a`
+   |         ------------------------------     ^ borrowed value does not live long enough
+   |         |
+   |         type annotation requires that `b` is borrowed for `'a`
 LL |     };
 LL | }
    | - `b` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/method-ufcs-2.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-2.stderr
@@ -7,6 +7,12 @@ LL |     x(&a, b, c);
    |       ^^ borrowed value does not live long enough
 LL | }
    | - `a` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-2.rs:29:13
+   |
+LL |     let x = <&'static u32 as Bazoom<_>>::method;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `b` does not live long enough
   --> $DIR/method-ufcs-2.rs:37:39
@@ -20,6 +26,12 @@ LL |     <_ as Bazoom<&'a u32>>::method(a, &b, c);
    |     type annotation requires that `b` is borrowed for `'a`
 LL | }
    | - `b` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-2.rs:37:5
+   |
+LL |     <_ as Bazoom<&'a u32>>::method(a, &b, c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `b` does not live long enough
   --> $DIR/method-ufcs-2.rs:51:44
@@ -37,6 +49,12 @@ LL |         <_ as Bazoom<&'a u32>>::method(a, &b, c);
 LL |     };
 LL | }
    | - `b` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-2.rs:51:9
+   |
+LL |         <_ as Bazoom<&'a u32>>::method(a, &b, c);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
@@ -7,6 +7,12 @@ LL |     <_ as Bazoom<_>>::method::<&'static u32>(&a, b, &c);
    |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-3.rs:36:5
+   |
+LL |     <_ as Bazoom<_>>::method::<&'static u32>(&a, b, &c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:43:48
@@ -20,6 +26,12 @@ LL |     <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
    |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-3.rs:43:5
+   |
+LL |     <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:57:52
@@ -34,6 +46,12 @@ LL |         <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
    |         -----------------------------------        ^^ borrowed value does not live long enough
    |         |
    |         type annotation requires that `c` is borrowed for `'a`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-3.rs:57:9
+   |
+LL |         <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
@@ -2,10 +2,9 @@ error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:36:53
    |
 LL |     <_ as Bazoom<_>>::method::<&'static u32>(&a, b, &c);
-   |     ------------------------------------------------^^-
-   |     |                                               |
-   |     |                                               borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'static`
+   |     ----------------------------------------        ^^ borrowed value does not live long enough
+   |     |
+   |     type annotation requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -16,10 +15,9 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 ...
 LL |     <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
-   |     -------------------------------------------^^-
-   |     |                                          |
-   |     |                                          borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |     -----------------------------------        ^^ borrowed value does not live long enough
+   |     |
+   |     type annotation requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -33,10 +31,9 @@ LL |     let _closure = || {
    |                     - `c` dropped here while still borrowed
 LL |         let c = 66;
 LL |         <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
-   |         -------------------------------------------^^-
-   |         |                                          |
-   |         |                                          borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'a`
+   |         -----------------------------------        ^^ borrowed value does not live long enough
+   |         |
+   |         type annotation requires that `c` is borrowed for `'a`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
@@ -5,10 +5,9 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let v = 22;
 LL |     let x = A::<'a>::new(&v, 22);
-   |             -------------^^-----
-   |             |            |
-   |             |            borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |             ------------ ^^ borrowed value does not live long enough
+   |             |
+   |             type annotation requires that `v` is borrowed for `'a`
 LL |
 LL | }
    | - `v` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
@@ -11,6 +11,12 @@ LL |     let x = A::<'a>::new(&v, 22);
 LL |
 LL | }
    | - `v` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-inherent-1.rs:14:13
+   |
+LL |     let x = A::<'a>::new(&v, 22);
+   |             ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
@@ -5,10 +5,9 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let v = 22;
 LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
-   |             ------------------------^^-----
-   |             |                       |
-   |             |                       borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |             ----------------------- ^^ borrowed value does not live long enough
+   |             |
+   |             type annotation requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
@@ -20,10 +19,9 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let v = 22;
 LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
-   |             ----------------------------^^-
-   |             |                           |
-   |             |                           borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |             -----------------------     ^^ borrowed value does not live long enough
+   |             |
+   |             type annotation requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
@@ -11,6 +11,12 @@ LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
 ...
 LL | }
    | - `v` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-inherent-2.rs:14:13
+   |
+LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-2.rs:14:41
@@ -25,6 +31,12 @@ LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
 ...
 LL | }
    | - `v` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-inherent-2.rs:14:13
+   |
+LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
@@ -5,10 +5,9 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let v = 22;
 LL |     let x = <A<'a>>::new(&v, 22);
-   |             -------------^^-----
-   |             |            |
-   |             |            borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |             ------------ ^^ borrowed value does not live long enough
+   |             |
+   |             type annotation requires that `v` is borrowed for `'a`
 LL |
 LL | }
    | - `v` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
@@ -11,6 +11,12 @@ LL |     let x = <A<'a>>::new(&v, 22);
 LL |
 LL | }
    | - `v` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-inherent-3.rs:14:13
+   |
+LL |     let x = <A<'a>>::new(&v, 22);
+   |             ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
@@ -5,10 +5,9 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let v = 22;
 LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
-   |             ------------------------^^-----
-   |             |                       |
-   |             |                       borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |             ----------------------- ^^ borrowed value does not live long enough
+   |             |
+   |             type annotation requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
@@ -20,10 +19,9 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let v = 22;
 LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
-   |             ----------------------------^^-
-   |             |                           |
-   |             |                           borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |             -----------------------     ^^ borrowed value does not live long enough
+   |             |
+   |             type annotation requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
@@ -11,6 +11,12 @@ LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
 ...
 LL | }
    | - `v` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-inherent-4.rs:15:13
+   |
+LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-4.rs:15:41
@@ -25,6 +31,12 @@ LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
 ...
 LL | }
    | - `v` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/method-ufcs-inherent-4.rs:15:13
+   |
+LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/normalization.stderr
+++ b/src/test/ui/nll/user-annotations/normalization.stderr
@@ -7,6 +7,12 @@ LL |     let b: <() as Foo>::Out = &a;
    |            type annotation requires that `a` is borrowed for `'static`
 LL | }
    | - `a` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/normalization.rs:9:12
+   |
+LL |     let b: <() as Foo>::Out = &a;
+   |            ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
@@ -8,6 +8,12 @@ LL |     let Foo::Bar::<'static> { field: _z } = foo;
    |         --------------------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:9:9
+   |
+LL |     let Foo::Bar::<'static> { field: _z } = foo;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_brace_enum_variant.rs:14:33
@@ -20,6 +26,12 @@ LL |         Foo::Bar::<'static> { field: _z } => {
 ...
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:17:9
+   |
+LL |         Foo::Bar::<'static> { field: _z } => {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_struct.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_struct.stderr
@@ -8,6 +8,12 @@ LL |     let Foo::<'static> { field: _z } = foo;
    |         ---------------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_brace_struct.rs:7:9
+   |
+LL |     let Foo::<'static> { field: _z } = foo;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_brace_struct.rs:12:28
@@ -20,6 +26,12 @@ LL |         Foo::<'static> { field: _z } => {
 ...
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_brace_struct.rs:15:9
+   |
+LL |         Foo::<'static> { field: _z } => {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
@@ -8,6 +8,12 @@ LL |     let Foo::Bar::<'static>(_z) = foo;
    |         ----------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:9:9
+   |
+LL |     let Foo::Bar::<'static>(_z) = foo;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_tuple_enum_variant.rs:14:24
@@ -20,6 +26,12 @@ LL |         Foo::Bar::<'static>(_z) => {
 ...
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:17:9
+   |
+LL |         Foo::Bar::<'static>(_z) => {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_struct.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_struct.stderr
@@ -8,6 +8,12 @@ LL |     let Foo::<'static>(_z) = foo;
    |         ------------------ type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_tuple_struct.rs:7:9
+   |
+LL |     let Foo::<'static>(_z) = foo;
+   |         ^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_tuple_struct.rs:12:19
@@ -20,6 +26,12 @@ LL |         Foo::<'static>(_z) => {
 ...
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/pattern_substs_on_tuple_struct.rs:15:9
+   |
+LL |         Foo::<'static>(_z) => {
+   |         ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/patterns.rs
+++ b/src/test/ui/nll/user-annotations/patterns.rs
@@ -129,8 +129,8 @@ fn static_to_a_to_static_through_struct<'a>(_x: &'a u32) -> &'static u32 {
 }
 
 fn a_to_static_then_static<'a>(x: &'a u32) -> &'static u32 {
-    let (y, _z): (&'static u32, u32) = (x, 44); //~ ERROR
-    y
+    let (y, _z): (&'static u32, u32) = (x, 44);
+    y //~ ERROR
 }
 
 fn main() { }

--- a/src/test/ui/nll/user-annotations/patterns.stderr
+++ b/src/test/ui/nll/user-annotations/patterns.stderr
@@ -42,10 +42,11 @@ LL | }
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:51:10
    |
-LL |     let Single2 { value: mut _y }: Single2<StaticU32>;
-   |                                    ------------------ type annotation requires that `x` is borrowed for `'static`
 LL |     _y = &x;
-   |          ^^ borrowed value does not live long enough
+   |     -----^^
+   |     |    |
+   |     |    borrowed value does not live long enough
+   |     assignment requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
 
@@ -176,12 +177,13 @@ LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/patterns.rs:132:18
+  --> $DIR/patterns.rs:133:5
    |
 LL | fn a_to_static_then_static<'a>(x: &'a u32) -> &'static u32 {
    |                            -- lifetime `'a` defined here
 LL |     let (y, _z): (&'static u32, u32) = (x, 44);
-   |                  ^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
+LL |     y
+   |     ^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to 19 previous errors
 

--- a/src/test/ui/nll/user-annotations/patterns.stderr
+++ b/src/test/ui/nll/user-annotations/patterns.stderr
@@ -7,6 +7,12 @@ LL |     y = &x;
    |         ^^ borrowed value does not live long enough
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:5:12
+   |
+LL |     let y: &'static u32;
+   |            ^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:14:9
@@ -17,6 +23,12 @@ LL |     y = &x;
    |         ^^ borrowed value does not live long enough
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:13:17
+   |
+LL |     let (y, z): (&'static u32, &'static u32);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:20:13
@@ -28,6 +40,12 @@ LL |     let ref z: &'static u32 = y;
 LL |     **z
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:21:16
+   |
+LL |     let ref z: &'static u32 = y;
+   |                ^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:39:9
@@ -38,6 +56,12 @@ LL |     y = &x;
    |         ^^ borrowed value does not live long enough
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:38:30
+   |
+LL |     let Single { value: y }: Single<&'static u32>;
+   |                              ^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:51:10
@@ -59,6 +83,12 @@ LL |     let y: &'static u32 = &x;
    |            type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:56:12
+   |
+LL |     let y: &'static u32 = &x;
+   |            ^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:61:27
@@ -70,6 +100,12 @@ LL |     let _: &'static u32 = &x;
 ...
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:61:12
+   |
+LL |     let _: &'static u32 = &x;
+   |            ^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:63:41
@@ -79,6 +115,12 @@ LL |     let _: Vec<&'static String> = vec![&String::new()];
    |            |                            |
    |            |                            creates a temporary which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:63:12
+   |
+LL |     let _: Vec<&'static String> = vec![&String::new()];
+   |            ^^^^^^^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:66:52
@@ -88,6 +130,12 @@ LL |     let (_, a): (Vec<&'static String>, _) = (vec![&String::new()], 44);
    |                 |                                  |
    |                 |                                  creates a temporary which is freed while still in use
    |                 type annotation requires that borrow lasts for `'static`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:66:17
+   |
+LL |     let (_, a): (Vec<&'static String>, _) = (vec![&String::new()], 44);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:69:53
@@ -97,6 +145,12 @@ LL |     let (_a, b): (Vec<&'static String>, _) = (vec![&String::new()], 44);
    |                  |                                  |
    |                  |                                  creates a temporary which is freed while still in use
    |                  type annotation requires that borrow lasts for `'static`
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:69:18
+   |
+LL |     let (_a, b): (Vec<&'static String>, _) = (vec![&String::new()], 44);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:75:40
@@ -107,6 +161,12 @@ LL |     let (_, _): (&'static u32, u32) = (&x, 44);
    |                 type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:75:17
+   |
+LL |     let (_, _): (&'static u32, u32) = (&x, 44);
+   |                 ^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:80:40
@@ -117,6 +177,12 @@ LL |     let (y, _): (&'static u32, u32) = (&x, 44);
    |                 type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:80:17
+   |
+LL |     let (y, _): (&'static u32, u32) = (&x, 44);
+   |                 ^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:85:69
@@ -127,6 +193,12 @@ LL |     let Single { value: y }: Single<&'static u32> = Single { value: &x };
    |                              type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:85:30
+   |
+LL |     let Single { value: y }: Single<&'static u32> = Single { value: &x };
+   |                              ^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:90:69
@@ -137,6 +209,12 @@ LL |     let Single { value: _ }: Single<&'static u32> = Single { value: &x };
    |                              type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:90:30
+   |
+LL |     let Single { value: _ }: Single<&'static u32> = Single { value: &x };
+   |                              ^^^^^^^^^^^^^^^^^^^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:98:17
@@ -148,6 +226,12 @@ LL |         value1: &x,
 ...
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/patterns.rs:97:42
+   |
+LL |     let Double { value1: _, value2: _ }: Double<&'static u32> = Double {
+   |                                          ^^^^^^^^^^^^^^^^^^^^
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:111:5

--- a/src/test/ui/nll/user-annotations/promoted-annotation.stderr
+++ b/src/test/ui/nll/user-annotations/promoted-annotation.stderr
@@ -11,6 +11,12 @@ LL |     f(&x);
 LL |
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/promoted-annotation.rs:5:14
+   |
+LL |     let f = &drop::<&'a i32>;
+   |              ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/promoted-annotation.stderr
+++ b/src/test/ui/nll/user-annotations/promoted-annotation.stderr
@@ -5,7 +5,7 @@ LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here
 LL |     let x = 0;
 LL |     let f = &drop::<&'a i32>;
-   |             ---------------- assignment requires that `x` is borrowed for `'a`
+   |              --------------- type annotation requires that `x` is borrowed for `'a`
 LL |     f(&x);
    |       ^^ borrowed value does not live long enough
 LL |

--- a/src/test/ui/nll/user-annotations/self-diagnostics.rs
+++ b/src/test/ui/nll/user-annotations/self-diagnostics.rs
@@ -1,0 +1,73 @@
+// Some subtle cases where `Self` imposes unnecessary lifetime constraints.
+// Make sure we detect these cases and suggest a proper fix.
+
+// check-fail
+
+struct S<'a>(&'a str);
+
+impl S<'_> {
+    const CLOSURE_ARGS: () = {
+        |s: &str| {
+            Self(s);
+            //~^ ERROR lifetime may not live long enough
+        };
+    };
+
+    fn closure_body() {
+        let closure = |s| {
+            Self(s);
+        };
+        closure(&String::new());
+        //~^ ERROR temporary value dropped while borrowed
+    }
+}
+
+impl<'x> S<'x> {
+    fn static_method(_: &'x str) {}
+
+    // FIXME suggesting replacing `Self` is better than the current one.
+    fn test3(s: &str) {
+        let _ = || {
+            Self::static_method(s);
+            //~^ ERROR explicit lifetime required in the type of `s`
+        };
+    }
+
+    fn test_named_lt<'y>(s: &'y str) {
+        let _ = || {
+            Self::static_method(s);
+            //~^ ERROR lifetime may not live long enough
+        };
+    }
+}
+
+impl<'x> S<'x> {
+    fn test7(s: String) {
+        s.split('/')
+            //~^ ERROR `s` does not live long enough
+            .map(|s| Self(s))
+            .collect::<Vec<_>>();
+    }
+
+    // FIXME there is no suggestion here because we don't have a
+    // correct span for closure argument annotations.
+    fn test8(s: String) {
+        s.split('/')
+            //~^ ERROR `s` does not live long enough
+            .map(|s| S(s))
+            .map(|_: Self| {})
+            .collect::<Vec<_>>();
+    }
+}
+
+impl<'x> S<'x> {
+    fn eq<T>(self, _: T) {}
+
+    // test annotations on method call.
+    fn method_call<'c>(self, s: &'c str) {
+        self.eq::<Self>(S(s)); // remove Self
+        //~^ ERROR lifetime may not live long enough
+    }
+}
+
+fn main() {}

--- a/src/test/ui/nll/user-annotations/self-diagnostics.stderr
+++ b/src/test/ui/nll/user-annotations/self-diagnostics.stderr
@@ -1,0 +1,119 @@
+error: lifetime may not live long enough
+  --> $DIR/self-diagnostics.rs:11:13
+   |
+LL | impl S<'_> {
+   |        -- lifetime `'2` appears in the `impl`'s self type
+LL |     const CLOSURE_ARGS: () = {
+LL |         |s: &str| {
+   |             - let's call the lifetime of this reference `'1`
+LL |             Self(s);
+   |             ^^^^ type annotation requires that `'1` must outlive `'2`
+   |
+   = help: consider replacing `Self` with `S`
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/self-diagnostics.rs:20:18
+   |
+LL | impl S<'_> {
+   |        -- lifetime `'1` appears in the `impl`'s self type
+...
+LL |             Self(s);
+   |             ---- type annotation requires that borrow lasts for `'1`
+LL |         };
+LL |         closure(&String::new());
+   |                  ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                  |
+   |                  creates a temporary which is freed while still in use
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/self-diagnostics.rs:18:13
+   |
+LL |             Self(s);
+   |             ^^^^
+   = help: consider replacing `Self` with `S`
+
+error[E0621]: explicit lifetime required in the type of `s`
+  --> $DIR/self-diagnostics.rs:31:13
+   |
+LL |     fn test3(s: &str) {
+   |                 ---- help: add explicit lifetime `'x` to the type of `s`: `&'x str`
+LL |         let _ = || {
+LL |             Self::static_method(s);
+   |             ^^^^^^^^^^^^^^^^^^^ lifetime `'x` required
+
+error: lifetime may not live long enough
+  --> $DIR/self-diagnostics.rs:38:13
+   |
+LL | impl<'x> S<'x> {
+   |      -- lifetime `'x` defined here
+...
+LL |     fn test_named_lt<'y>(s: &'y str) {
+   |                      -- lifetime `'y` defined here
+LL |         let _ = || {
+LL |             Self::static_method(s);
+   |             ^^^^^^^^^^^^^^^^^^^ type annotation requires that `'y` must outlive `'x`
+   |
+   = help: consider replacing `Self` with `S`
+   = help: consider adding the following bound: `'y: 'x`
+
+error[E0597]: `s` does not live long enough
+  --> $DIR/self-diagnostics.rs:46:9
+   |
+LL | impl<'x> S<'x> {
+   |      -- lifetime `'x` defined here
+LL |     fn test7(s: String) {
+LL |         s.split('/')
+   |         ^^^^^^^^^^^^ borrowed value does not live long enough
+LL |
+LL |             .map(|s| Self(s))
+   |                      ---- type annotation requires that `s` is borrowed for `'x`
+LL |             .collect::<Vec<_>>();
+LL |     }
+   |     - `s` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/self-diagnostics.rs:48:22
+   |
+LL |             .map(|s| Self(s))
+   |                      ^^^^
+   = help: consider replacing `Self` with `S`
+
+error[E0597]: `s` does not live long enough
+  --> $DIR/self-diagnostics.rs:55:9
+   |
+LL | impl<'x> S<'x> {
+   |      -- lifetime `'x` defined here
+...
+LL |         s.split('/')
+   |         ^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL |             .map(|_: Self| {})
+   |                   - type annotation requires that `s` is borrowed for `'x`
+LL |             .collect::<Vec<_>>();
+LL |     }
+   |     - `s` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/self-diagnostics.rs:58:19
+   |
+LL |             .map(|_: Self| {})
+   |                   ^
+
+error: lifetime may not live long enough
+  --> $DIR/self-diagnostics.rs:68:14
+   |
+LL | impl<'x> S<'x> {
+   |      -- lifetime `'x` defined here
+...
+LL |     fn method_call<'c>(self, s: &'c str) {
+   |                    -- lifetime `'c` defined here
+LL |         self.eq::<Self>(S(s)); // remove Self
+   |              ^^^^^^^^^^ type annotation requires that `'c` must outlive `'x`
+   |
+   = help: consider replacing `Self` with `S`
+   = help: consider adding the following bound: `'c: 'x`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0597, E0621, E0716.
+For more information about an error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/user-annotations/self-issue-100725.rs
+++ b/src/test/ui/nll/user-annotations/self-issue-100725.rs
@@ -1,0 +1,26 @@
+// Make sure we suggest replacing `Self` with `Bigger` to make it pass.
+
+// check-fail
+
+pub struct Bigger<'a> {
+    _marker: &'a (),
+}
+impl<'a> Bigger<'a> {
+    pub fn get_addr(byte_list: &'a mut Vec<u8>) -> &mut u8 {
+        byte_list.iter_mut().find_map(|item| {
+            Self::other(item); // replace with `Bigger`
+            Some(())
+        });
+
+        byte_list.push(0);
+        //~^ ERROR cannot borrow `*byte_list` as mutable more than once at a time
+        byte_list.last_mut().unwrap()
+        //~^ ERROR cannot borrow `*byte_list` as mutable more than once at a time
+    }
+
+    pub fn other<'b: 'a>(_value: &'b mut u8) {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/nll/user-annotations/self-issue-100725.stderr
+++ b/src/test/ui/nll/user-annotations/self-issue-100725.stderr
@@ -1,0 +1,45 @@
+error[E0499]: cannot borrow `*byte_list` as mutable more than once at a time
+  --> $DIR/self-issue-100725.rs:15:9
+   |
+LL | impl<'a> Bigger<'a> {
+   |      -- lifetime `'a` defined here
+LL |     pub fn get_addr(byte_list: &'a mut Vec<u8>) -> &mut u8 {
+LL |         byte_list.iter_mut().find_map(|item| {
+   |         -------------------- first mutable borrow occurs here
+LL |             Self::other(item); // replace with `Bigger`
+   |             ----------- type annotation requires that `*byte_list` is borrowed for `'a`
+...
+LL |         byte_list.push(0);
+   |         ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/self-issue-100725.rs:11:13
+   |
+LL |             Self::other(item); // replace with `Bigger`
+   |             ^^^^^^^^^^^
+   = help: consider replacing `Self` with `Bigger`
+
+error[E0499]: cannot borrow `*byte_list` as mutable more than once at a time
+  --> $DIR/self-issue-100725.rs:17:9
+   |
+LL | impl<'a> Bigger<'a> {
+   |      -- lifetime `'a` defined here
+LL |     pub fn get_addr(byte_list: &'a mut Vec<u8>) -> &mut u8 {
+LL |         byte_list.iter_mut().find_map(|item| {
+   |         -------------------- first mutable borrow occurs here
+LL |             Self::other(item); // replace with `Bigger`
+   |             ----------- type annotation requires that `*byte_list` is borrowed for `'a`
+...
+LL |         byte_list.last_mut().unwrap()
+   |         ^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/self-issue-100725.rs:11:13
+   |
+LL |             Self::other(item); // replace with `Bigger`
+   |             ^^^^^^^^^^^
+   = help: consider replacing `Self` with `Bigger`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/nll/user-annotations/type_ascription_static_lifetime.stderr
+++ b/src/test/ui/nll/user-annotations/type_ascription_static_lifetime.stderr
@@ -8,6 +8,12 @@ LL |     let y: &u32 = &x: &'static u32;
    |                   type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/type_ascription_static_lifetime.rs:6:19
+   |
+LL |     let y: &u32 = &x: &'static u32;
+   |                   ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/issue-28848.stderr
+++ b/src/test/ui/regions/issue-28848.stderr
@@ -6,7 +6,7 @@ LL | pub fn foo<'a, 'b>(u: &'b ()) -> &'a () {
    |            |
    |            lifetime `'a` defined here
 LL |     Foo::<'a, 'b>::xmute(u)
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/regions/regions-addr-of-arg.stderr
+++ b/src/test/ui/regions/regions-addr-of-arg.stderr
@@ -7,6 +7,12 @@ LL |     let _p: &'static isize = &a;
    |             type annotation requires that `a` is borrowed for `'static`
 LL | }
    |  - `a` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/regions-addr-of-arg.rs:5:13
+   |
+LL |     let _p: &'static isize = &a;
+   |             ^^^^^^^^^^^^^^
 
 error[E0515]: cannot return reference to function parameter `a`
   --> $DIR/regions-addr-of-arg.rs:13:5

--- a/src/test/ui/regions/regions-addr-of-upvar-self.stderr
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.stderr
@@ -29,6 +29,12 @@ LL |             let p: &'static mut usize = &mut self.food;
 ...
 LL |     }
    |      - `self` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/regions-addr-of-upvar-self.rs:8:20
+   |
+LL |             let p: &'static mut usize = &mut self.food;
+   |                    ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions/regions-bounded-by-trait-requiring-static.stderr
+++ b/src/test/ui/regions/regions-bounded-by-trait-requiring-static.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL | fn param_not_ok<'a>(x: &'a isize) {
    |                 -- lifetime `'a` defined here
 LL |     assert_send::<&'a isize>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:27:5
@@ -12,7 +12,7 @@ error: lifetime may not live long enough
 LL | fn param_not_ok1<'a>(_: &'a isize) {
    |                  -- lifetime `'a` defined here
 LL |     assert_send::<&'a str>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:32:5
@@ -20,7 +20,7 @@ error: lifetime may not live long enough
 LL | fn param_not_ok2<'a>(_: &'a isize) {
    |                  -- lifetime `'a` defined here
 LL |     assert_send::<&'a [isize]>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:47:5
@@ -28,7 +28,7 @@ error: lifetime may not live long enough
 LL | fn box_with_region_not_ok<'a>() {
    |                           -- lifetime `'a` defined here
 LL |     assert_send::<Box<&'a isize>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:59:5
@@ -36,7 +36,7 @@ error: lifetime may not live long enough
 LL | fn unsafe_ok2<'a>(_: &'a isize) {
    |               -- lifetime `'a` defined here
 LL |     assert_send::<*const &'a isize>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:64:5
@@ -44,7 +44,7 @@ error: lifetime may not live long enough
 LL | fn unsafe_ok3<'a>(_: &'a isize) {
    |               -- lifetime `'a` defined here
 LL |     assert_send::<*mut &'a isize>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL | fn caller<'a>(x: &isize) {
    |           -- lifetime `'a` defined here
 LL |     Foo.some_method::<&'a isize>();
-   |         ^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL | fn caller<'a>(x: &isize) {
    |           -- lifetime `'a` defined here
 LL |     Foo.some_method::<&'a isize>();
-   |         ^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |         ^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-free-region-ordering-caller1.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-caller1.stderr
@@ -11,6 +11,12 @@ LL |     let z: &'a & usize = &(&y);
 ...
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/regions-free-region-ordering-caller1.rs:9:12
+   |
+LL |     let z: &'a & usize = &(&y);
+   |            ^^^^^^^^^^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/regions-free-region-ordering-caller1.rs:9:27
@@ -25,6 +31,12 @@ LL |     let z: &'a & usize = &(&y);
 ...
 LL | }
    | - `y` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/regions-free-region-ordering-caller1.rs:9:12
+   |
+LL |     let z: &'a & usize = &(&y);
+   |            ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/regions-outlives-projection-container.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container.stderr
@@ -33,7 +33,7 @@ LL | fn call_with_assoc<'a,'b>() {
    |                    lifetime `'a` defined here
 ...
 LL |     call::<&'a WithAssoc<TheType<'b>>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 
@@ -46,7 +46,7 @@ LL | fn call_without_assoc<'a,'b>() {
    |                       lifetime `'a` defined here
 ...
 LL |     call::<&'a WithoutAssoc<TheType<'b>>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.stderr
@@ -6,10 +6,6 @@ LL | fn use_<'b>(c: Invariant<'b>) {
 ...
 LL |     let _: Invariant<'static> = c;
    |            ^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'static`
-   |
-   = note: requirement occurs because of the type `Invariant<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `Invariant<'a>` is invariant over the parameter `'a`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/lifetime-update.stderr
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/lifetime-update.stderr
@@ -9,6 +9,12 @@ LL |     let m2: Machine<'static, State1> = Machine {
 ...
 LL | }
    | - `s` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/lifetime-update.rs:38:13
+   |
+LL |     let m2: Machine<'static, State1> = Machine {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/self/issue-61882-2.stderr
+++ b/src/test/ui/self/issue-61882-2.stderr
@@ -8,6 +8,13 @@ LL |         Self(&x);
 LL |
 LL |     }
    |     - `x` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/issue-61882-2.rs:6:9
+   |
+LL |         Self(&x);
+   |         ^^^^
+   = help: consider replacing `Self` with `A<&u8>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/self/issue-61882-2.stderr
+++ b/src/test/ui/self/issue-61882-2.stderr
@@ -2,9 +2,8 @@ error[E0597]: `x` does not live long enough
   --> $DIR/issue-61882-2.rs:6:14
    |
 LL |         Self(&x);
-   |         -----^^-
-   |         |    |
-   |         |    borrowed value does not live long enough
+   |         ---- ^^ borrowed value does not live long enough
+   |         |
    |         type annotation requires that `x` is borrowed for `'static`
 LL |
 LL |     }

--- a/src/test/ui/self/issue-61882-2.stderr
+++ b/src/test/ui/self/issue-61882-2.stderr
@@ -2,10 +2,10 @@ error[E0597]: `x` does not live long enough
   --> $DIR/issue-61882-2.rs:6:14
    |
 LL |         Self(&x);
-   |              ^^
-   |              |
-   |              borrowed value does not live long enough
-   |              this usage requires that `x` is borrowed for `'static`
+   |         -----^^-
+   |         |    |
+   |         |    borrowed value does not live long enough
+   |         type annotation requires that `x` is borrowed for `'static`
 LL |
 LL |     }
    |     - `x` dropped here while still borrowed

--- a/src/test/ui/statics/issue-44373.stderr
+++ b/src/test/ui/statics/issue-44373.stderr
@@ -7,6 +7,12 @@ LL |     let _val: &'static [&'static u32] = &[&FOO];
    |               type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/issue-44373.rs:4:15
+   |
+LL |     let _val: &'static [&'static u32] = &[&FOO];
+   |               ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/object/supertrait-lifetime-bound.stderr
+++ b/src/test/ui/traits/object/supertrait-lifetime-bound.stderr
@@ -5,7 +5,7 @@ LL | fn test2<'a>() {
    |          -- lifetime `'a` defined here
 ...
 LL |     test1::<dyn Bar<&'a u32>, _>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.stderr
@@ -39,6 +39,12 @@ LL |         let g = factorial.as_ref().unwrap();
 ...
 LL | }
    | - `factorial` dropped here while still borrowed
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/unboxed-closures-failed-recursive-fn-1.rs:25:24
+   |
+LL |     let mut factorial: Option<Box<dyn Fn(u32) -> u32 + 'static>> = None;
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0506]: cannot assign to `factorial` because it is borrowed
   --> $DIR/unboxed-closures-failed-recursive-fn-1.rs:33:5
@@ -53,6 +59,12 @@ LL |         let g = factorial.as_ref().unwrap();
 ...
 LL |     factorial = Some(Box::new(f));
    |     ^^^^^^^^^ assignment to borrowed `factorial` occurs here
+   |
+help: you can remove unnecessary lifetime annotations here
+  --> $DIR/unboxed-closures-failed-recursive-fn-1.rs:25:24
+   |
+LL |     let mut factorial: Option<Box<dyn Fn(u32) -> u32 + 'static>> = None;
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/variance/variance-cell-is-invariant.stderr
+++ b/src/test/ui/variance/variance-cell-is-invariant.stderr
@@ -10,9 +10,6 @@ LL |     let _: Foo<'long> = c;
    |            ^^^^^^^^^^ type annotation requires that `'short` must outlive `'long`
    |
    = help: consider adding the following bound: `'short: 'long`
-   = note: requirement occurs because of the type `Foo<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `Foo<'a>` is invariant over the parameter `'a`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: aborting due to previous error
 

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<G,&'min i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<G,&'max i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<&'min G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<&'max G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<G,&'min i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<G,&'max i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-covariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<&'min G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<&'max G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<G,&'min i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<G,&'max i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-invariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<&'min G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>()
    |                     lifetime `'min` defined here
 ...
 LL |     impls_get::<&'max G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+   |     ^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'min` must outlive `'max`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/wf/wf-static-method.stderr
+++ b/src/test/ui/wf/wf-static-method.stderr
@@ -22,6 +22,7 @@ LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
 LL |         let me = Self::make_me();
    |                  ^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
+   = help: consider replacing `Self` with `IndirectEvil`
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough

--- a/src/test/ui/wf/wf-static-method.stderr
+++ b/src/test/ui/wf/wf-static-method.stderr
@@ -20,7 +20,7 @@ LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
    |      lifetime `'a` defined here
 ...
 LL |         let me = Self::make_me();
-   |                  ^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |                  ^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 


### PR DESCRIPTION
- register the lifetime annotations in closure signature and function calls under the category `ConstraintCategory::TypeAnnotation`.
- when searching for the "best blame constraint", make sure we report type annotation constraints only if there is no other constraint to blame. Now  whenever we get `TypeAnnotation` error, we can be sure that the lifetime annotation is unnecessarily restrictive and we can safely suggest removing it.
- handle the subtle cases of `Self` where it forces unnecessary constraints and suggest a proper fix.

TODO:

- [ ] Use of type aliases may impose additional region constraints even when neither the definition nor the use site has an explicit lifetime annotation:
```rust
type Same<X> = (X, X);
type Inv<'x> = *mut &'x ();
fn test(s1: Inv<'_>, s2: Inv<'_>) {
    let _: Same<_> = (s1, s2);
}
```

cc #100725, not closing it though.
resolves #100572
resolves #101393
resolves #69224
resolves #62185

r? @estebank