### PR TITLE
Handle `Err` in `ast::LitKind::to_token_lit`.

### DIFF
--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -199,7 +199,9 @@ impl LitKind {
                 let symbol = if value { kw::True } else { kw::False };
                 (token::Bool, symbol, None)
             }
-            LitKind::Err => unreachable!(),
+            // This only shows up in places like `-Zunpretty=hir` output, so we
+            // don't bother to produce something useful.
+            LitKind::Err => (token::Err, Symbol::intern("<bad-literal>"), None),
         };
 
         token::Lit::new(kind, symbol, suffix)

--- a/src/test/ui/unpretty/bad-literal.rs
+++ b/src/test/ui/unpretty/bad-literal.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Zunpretty=hir
+// check-fail
+
+// In #100948 this caused an ICE with -Zunpretty=hir.
+fn main() {
+    1u;
+    //~^ ERROR invalid suffix `u` for number literal
+}

--- a/src/test/ui/unpretty/bad-literal.stderr
+++ b/src/test/ui/unpretty/bad-literal.stderr
@@ -1,0 +1,10 @@
+error: invalid suffix `u` for number literal
+  --> $DIR/bad-literal.rs:6:5
+   |
+LL |     1u;
+   |     ^^ invalid suffix `u`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: aborting due to previous error
+

--- a/src/test/ui/unpretty/bad-literal.stdout
+++ b/src/test/ui/unpretty/bad-literal.stdout
@@ -1,0 +1,11 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// compile-flags: -Zunpretty=hir
+// check-fail
+
+// In #100948 this caused an ICE with -Zunpretty=hir.
+fn main() {
+        <bad-literal>;
+    }


### PR DESCRIPTION
Fixes #100948.

r? @petrochenkov 