### PR TITLE
add `with_hash_task` to generate `DepNode` deterministically

### DIFF
--- a/compiler/rustc_query_system/src/cache.rs
+++ b/compiler/rustc_query_system/src/cache.rs
@@ -3,7 +3,7 @@
 use crate::dep_graph::{DepContext, DepNodeIndex};
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::sync::Lock;
+use rustc_data_structures::sync::{HashMapExt, Lock};
 
 use std::hash::Hash;
 
@@ -32,6 +32,12 @@ impl<Key: Eq + Hash, Value: Clone> Cache<Key, Value> {
 
     pub fn insert(&self, key: Key, dep_node: DepNodeIndex, value: Value) {
         self.hashmap.borrow_mut().insert(key, WithDepNode::new(dep_node, value));
+    }
+}
+
+impl<Key: Eq + Hash, Value: Clone + Eq> Cache<Key, Value> {
+    pub fn insert_same(&self, key: Key, dep_node: DepNodeIndex, value: Value) {
+        self.hashmap.borrow_mut().insert_same(key, WithDepNode::new(dep_node, value));
     }
 }
 


### PR DESCRIPTION
Fixes #50507
Updates #48685

In `evaluate_trait_predicate`, `DepGraph::with_anon_task` function is used to get `EvaluationResult` and generate `DepNodeIndex`. This is fine in the non-parallel compiler because `DepGraph::with_anon_task` will only be called once, writing the result to `EvaluationCache`.

But in the parallel compiler, it is possible that the same two `evaluate_trait_predicate` tasks start executing at the same time. There is no doubt that the two tasks will get the same `EvaluationResult`, but they may produce different `DepNodeIndex`. 

This PR specifies the way to generate hash values in `DepNode` by adding `DepGraph::with_hash_task` to ensure that the same two `evaluate_trait_predicate` tasks will get the same `DepNodeIndex`