### PR TITLE
give some suggestion for returning anonymous enum

### DIFF
--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -30,6 +30,7 @@ pub const MACRO_ARGUMENTS: Option<&str> = Some("macro arguments");
 pub mod parser;
 use parser::{emit_unclosed_delims, make_unclosed_delims_error, Parser};
 pub mod lexer;
+mod utils;
 pub mod validate_attr;
 
 // A bunch of utility functions of the form `parse_<thing>_from_<source>`

--- a/compiler/rustc_parse/src/utils.rs
+++ b/compiler/rustc_parse/src/utils.rs
@@ -1,0 +1,60 @@
+/// copied from rustc_lint
+
+/// Some unicode characters *have* case, are considered upper case or lower case, but they *can't*
+/// be upper cased or lower cased. For the purposes of the lint suggestion, we care about being able
+/// to change the char's case.
+fn char_has_case(c: char) -> bool {
+    let mut l = c.to_lowercase();
+    let mut u = c.to_uppercase();
+    while let Some(l) = l.next() {
+        match u.next() {
+            Some(u) if l != u => return true,
+            _ => {}
+        }
+    }
+    u.next().is_some()
+}
+
+pub fn to_camel_case(s: &str) -> String {
+    s.trim_matches('_')
+        .split('_')
+        .filter(|component| !component.is_empty())
+        .map(|component| {
+            let mut camel_cased_component = String::new();
+
+            let mut new_word = true;
+            let mut prev_is_lower_case = true;
+
+            for c in component.chars() {
+                // Preserve the case if an uppercase letter follows a lowercase letter, so that
+                // `camelCase` is converted to `CamelCase`.
+                if prev_is_lower_case && c.is_uppercase() {
+                    new_word = true;
+                }
+
+                if new_word {
+                    camel_cased_component.extend(c.to_uppercase());
+                } else {
+                    camel_cased_component.extend(c.to_lowercase());
+                }
+
+                prev_is_lower_case = c.is_lowercase();
+                new_word = false;
+            }
+
+            camel_cased_component
+        })
+        .fold((String::new(), None), |(acc, prev): (String, Option<String>), next| {
+            // separate two components with an underscore if their boundary cannot
+            // be distinguished using an uppercase/lowercase case distinction
+            let join = if let Some(prev) = prev {
+                let l = prev.chars().last().unwrap();
+                let f = next.chars().next().unwrap();
+                !char_has_case(l) && !char_has_case(f)
+            } else {
+                false
+            };
+            (acc + if join { "_" } else { "" } + &next, Some(next))
+        })
+        .0
+}

--- a/src/test/ui/return/issue-100741-return-anonymous-enum.rs
+++ b/src/test/ui/return/issue-100741-return-anonymous-enum.rs
@@ -1,0 +1,7 @@
+struct Foo {}
+
+fn foo<'a>() -> i32 | Vec<i32> | &str | &'a String | Foo {
+    //~^ ERROR: anonymous enums are not supported
+}
+
+fn main() {}

--- a/src/test/ui/return/issue-100741-return-anonymous-enum.stderr
+++ b/src/test/ui/return/issue-100741-return-anonymous-enum.stderr
@@ -1,0 +1,17 @@
+error: anonymous enums are not supported
+  --> $DIR/issue-100741-return-anonymous-enum.rs:3:17
+   |
+LL | fn foo<'a>() -> i32 | Vec<i32> | &str | &'a String | Foo {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using enum as return type: `SomeEnum`
+   |
+   = note: enum SomeEnum<'lifetime,'a>{
+               I32(i32)
+               Vec(Vec<...>)
+               StrRef(&'lifetime str)
+               StringRef(&'a String)
+               Foo(Foo)
+           }
+           
+
+error: aborting due to previous error
+


### PR DESCRIPTION
give some suggestion for returning anonymous enum
```
fn foo<'a>() -> i32 | Vec<i32> | &str | &'a String | Foo {
                         ^ help: consider using enum as return type: `SomeEnum`
   = note: enum SomeEnum<'lifetime,'a>{
               I32(i32)
               Vec(Vec<...>)
               StrRef(&'lifetime str)
               StringRef(&'a String)
               Foo(Foo)
           }
```
fix https://github.com/rust-lang/rust/issues/100741
r? @estebank 