### PR TITLE
Avoid using `Token::uninterpolate`

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -471,11 +471,13 @@ impl Token {
     /// In other words, would this token be a valid start of `parse_literal_maybe_minus`?
     ///
     /// Keep this in sync with and `Lit::from_token`, excluding unary negation.
+    #[inline]
     pub fn can_begin_literal_maybe_minus(&self) -> bool {
-        match self.uninterpolate().kind {
+        match self.kind {
             Literal(..) | BinOp(Minus) => true,
             Ident(name, false) if name.is_bool_lit() => true,
             Interpolated(ref nt) => match &**nt {
+                NtIdent(ident, false) if ident.name.is_bool_lit() => true,
                 NtLiteral(_) => true,
                 NtExpr(e) => match &e.kind {
                     ast::ExprKind::Lit(_) => true,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2026,6 +2026,7 @@ impl Symbol {
     }
 
     /// Returns `true` if the symbol is `true` or `false`.
+    #[inline]
     pub fn is_bool_lit(self) -> bool {
         self == kw::True || self == kw::False
     }


### PR DESCRIPTION
r? @ghost