### PR TITLE
Remove `core` dependency of `profiler_builtins`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,8 +2723,6 @@ name = "profiler_builtins"
 version = "0.0.0"
 dependencies = [
  "cc",
- "compiler_builtins",
- "core",
 ]
 
 [[package]]

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -2,7 +2,7 @@
 
 use crate::errors::{
     ConflictingGlobalAlloc, CrateNotPanicRuntime, GlobalAllocRequired, NoMultipleGlobalAlloc,
-    NoPanicStrategy, NoTransitiveNeedsDep, NotProfilerRuntime, ProfilerBuiltinsNeedsCore,
+    NoPanicStrategy, NoTransitiveNeedsDep, NotProfilerRuntime,
 };
 use crate::locator::{CrateError, CrateLocator, CratePaths};
 use crate::rmeta::{CrateDep, CrateMetadata, CrateNumMap, CrateRoot, MetadataBlob};
@@ -759,7 +759,7 @@ impl<'a> CrateLoader<'a> {
         self.inject_dependency_if(cnum, "a panic runtime", &|data| data.needs_panic_runtime());
     }
 
-    fn inject_profiler_runtime(&mut self, krate: &ast::Crate) {
+    fn inject_profiler_runtime(&mut self) {
         if self.sess.opts.unstable_opts.no_profiler_runtime
             || !(self.sess.instrument_coverage()
                 || self.sess.opts.unstable_opts.profile
@@ -771,9 +771,6 @@ impl<'a> CrateLoader<'a> {
         info!("loading profiler");
 
         let name = Symbol::intern(&self.sess.opts.unstable_opts.profiler_runtime);
-        if name == sym::profiler_builtins && self.sess.contains_name(&krate.attrs, sym::no_core) {
-            self.sess.emit_err(ProfilerBuiltinsNeedsCore);
-        }
 
         let Some(cnum) = self.resolve_crate(name, DUMMY_SP, CrateDepKind::Implicit) else { return; };
         let data = self.cstore.get_crate_data(cnum);
@@ -927,7 +924,7 @@ impl<'a> CrateLoader<'a> {
     }
 
     pub fn postprocess(&mut self, krate: &ast::Crate) {
-        self.inject_profiler_runtime(krate);
+        self.inject_profiler_runtime();
         self.inject_allocator_crate(krate);
         self.inject_panic_runtime(krate);
 

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -8,9 +8,5 @@ test = false
 bench = false
 doc = false
 
-[dependencies]
-core = { path = "../core" }
-compiler_builtins = { version = "0.1.0", features = ['rustc-dep-of-std'] }
-
 [build-dependencies]
 cc = "1.0.69"

--- a/library/profiler_builtins/src/lib.rs
+++ b/library/profiler_builtins/src/lib.rs
@@ -1,10 +1,8 @@
-#![no_std]
-#![feature(profiler_runtime)]
+#![feature(no_core, profiler_runtime, staged_api)]
+#![no_core]
 #![profiler_runtime]
 #![unstable(
     feature = "profiler_runtime_lib",
     reason = "internal implementation detail of rustc right now",
     issue = "none"
 )]
-#![allow(unused_features)]
-#![feature(staged_api)]


### PR DESCRIPTION
This PR removes the `core` depdency of `profiler_builtins`, which is not needed.