### PR TITLE
rustdoc: remove unused CSS for `.multi-column`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -754,16 +754,6 @@ pre, .rustdoc.source .example-wrap {
 	padding: 0;
 }
 
-.content .multi-column {
-	-moz-column-count: 5;
-	-moz-column-gap: 2.5em;
-	-webkit-column-count: 5;
-	-webkit-column-gap: 2.5em;
-	column-count: 5;
-	column-gap: 2.5em;
-}
-.content .multi-column li { width: 100%; display: inline-block; }
-
 .content > .methods > .method {
 	font-size: 1rem;
 	position: relative;


### PR DESCRIPTION
As a sanity check, [this tool] can be used to run a CSS query across an HTML tree to detect if a selector ever matches (I use compiler-docs and std docs). This isn't good enough, because I also need to account for JavaScript, but this class is never mentioned in any of the JS files, either.

According to [blame], this class was added when rustdoc was first written, and, as far as I can tell, was never actually used.

[this tool]: https://gitlab.com/notriddle/html-scanner
[blame]: https://github.com/rust-lang/rust/blame/4d45b0745ab227feb9000bc15713ade4b99241ea/src/librustdoc/html/static/css/rustdoc.css#L753-L761