### PR TITLE
rustdoc: remove unused CSS for `.variants_table`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1210,14 +1210,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	float: right;
 }
 
-.variants_table {
-	width: 100%;
-}
-
-.variants_table tbody tr td:first-child {
-	width: 1%; /* make the variant name as small as possible */
-}
-
 td.summary-column {
 	width: 100%;
 }


### PR DESCRIPTION
Continuation of #100938 and #101010. This rule was added to support the old, table-based style for displaying enum variants, which are now displayed using headers and paragraphs.