### PR TITLE
Fix -Zmeta-stats ICE by giving `FileEncoder` file read permissions

### DIFF
--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -193,6 +193,8 @@ impl FileEncoder {
         // shaves an instruction off those code paths (on x86 at least).
         assert!(capacity <= usize::MAX - max_leb128_len());
 
+        // Create the file for reading and writing, because some encoders do both
+        // (e.g. the metadata encoder when -Zmeta-stats is enabled)
         let file = File::options().read(true).write(true).create(true).truncate(true).open(path)?;
 
         Ok(FileEncoder {

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -193,7 +193,7 @@ impl FileEncoder {
         // shaves an instruction off those code paths (on x86 at least).
         assert!(capacity <= usize::MAX - max_leb128_len());
 
-        let file = File::create(path)?;
+        let file = File::options().read(true).write(true).create(true).truncate(true).open(path)?;
 
         Ok(FileEncoder {
             buf: Box::new_uninit_slice(capacity),


### PR DESCRIPTION
Fixes #101001

As far as I can tell, #101001 is caused because the file is being created with write-only permissions here: https://github.com/rust-lang/rust/blob/master/compiler/rustc_serialize/src/opaque.rs#L196

but it is trying to be read here: https://github.com/rust-lang/rust/blob/master/compiler/rustc_metadata/src/rmeta/encoder.rs#L780

This PR attempts to fix this by creating/opening the file with the same permissions as `File::create()` with the addition of read.