### PR TITLE
rustdoc: omit start/end tags for empty item description blocks

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -371,16 +371,21 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                     }
                     clean::ImportKind::Glob => String::new(),
                 };
+                let stab_tags = stab_tags.unwrap_or_default();
+                let (stab_tags_before, stab_tags_after) = if stab_tags.is_empty() {
+                    ("", "")
+                } else {
+                    ("<div class=\"item-right docblock-short\">", "</div>")
+                };
                 write!(
                     w,
                     "<div class=\"item-left {stab}{add}import-item\"{id}>\
                          <code>{vis}{imp}</code>\
                      </div>\
-                     <div class=\"item-right docblock-short\">{stab_tags}</div>",
+                     {stab_tags_before}{stab_tags}{stab_tags_after}",
                     stab = stab.unwrap_or_default(),
                     vis = myitem.visibility.print_with_space(myitem.item_id, cx),
                     imp = import.print(cx),
-                    stab_tags = stab_tags.unwrap_or_default(),
                 );
                 w.write_str(ITEM_TABLE_ROW_CLOSE);
             }
@@ -412,6 +417,12 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
 
                 let doc_value = myitem.doc_value().unwrap_or_default();
                 w.write_str(ITEM_TABLE_ROW_OPEN);
+                let docs = MarkdownSummaryLine(&doc_value, &myitem.links(cx)).into_string();
+                let (docs_before, docs_after) = if docs.is_empty() {
+                    ("", "")
+                } else {
+                    ("<div class=\"item-right docblock-short\">", "</div>")
+                };
                 write!(
                     w,
                     "<div class=\"item-left {stab}{add}module-item\">\
@@ -420,11 +431,10 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                         {unsafety_flag}\
                         {stab_tags}\
                      </div>\
-                     <div class=\"item-right docblock-short\">{docs}</div>",
+                     {docs_before}{docs}{docs_after}",
                     name = myitem.name.unwrap(),
                     visibility_emoji = visibility_emoji,
                     stab_tags = extra_info_tags(myitem, item, cx.tcx()),
-                    docs = MarkdownSummaryLine(&doc_value, &myitem.links(cx)).into_string(),
                     class = myitem.type_(),
                     add = add,
                     stab = stab.unwrap_or_default(),

--- a/src/test/rustdoc-gui/item-summary-table.goml
+++ b/src/test/rustdoc-gui/item-summary-table.goml
@@ -3,4 +3,4 @@ goto: file://|DOC_PATH|/lib2/summary_table/index.html
 // We check that we picked the right item first.
 assert-text: (".item-table .item-left", "Foo")
 // Then we check that its summary is empty.
-assert-text: (".item-table .item-right", "")
+assert-false: ".item-table .item-right"

--- a/src/test/rustdoc/short-docblock-codeblock.rs
+++ b/src/test/rustdoc/short-docblock-codeblock.rs
@@ -1,8 +1,6 @@
 #![crate_name = "foo"]
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]' ""
-// @!has foo/index.html '//*[@class="item-right docblock-short"]' "Some text."
-// @!has foo/index.html '//*[@class="item-right docblock-short"]' "let x = 12;"
+// @count foo/index.html '//*[@class="item-right docblock-short"]' 0
 
 /// ```
 /// let x = 12;


### PR DESCRIPTION
Related to #100952

This is definitely not a complete solution, but it does shrink keysyms/index.html on smithay from 620K to 516K.