### PR TITLE
Erase late bound regions before comparing types in `suggest_dereferences`

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2720,7 +2720,10 @@ impl<'tcx> TypeRelation<'tcx> for SameTypeModuloInfer<'_, 'tcx> {
         a: ty::Region<'tcx>,
         b: ty::Region<'tcx>,
     ) -> RelateResult<'tcx, ty::Region<'tcx>> {
-        if (a.is_var() && b.is_free_or_static()) || (b.is_var() && a.is_free_or_static()) || a == b
+        if (a.is_var() && b.is_free_or_static())
+            || (b.is_var() && a.is_free_or_static())
+            || (a.is_var() && b.is_var())
+            || a == b
         {
             Ok(a)
         } else {

--- a/src/test/ui/generic-associated-types/issue-101020.rs
+++ b/src/test/ui/generic-associated-types/issue-101020.rs
@@ -1,0 +1,37 @@
+#![feature(generic_associated_types)]
+
+pub trait LendingIterator {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    fn consume<F>(self, _f: F)
+    where
+        Self: Sized,
+        for<'a> Self::Item<'a>: FuncInput<'a, Self::Item<'a>>,
+    {
+    }
+}
+
+impl<I: LendingIterator + ?Sized> LendingIterator for &mut I {
+    type Item<'a> = I::Item<'a> where Self: 'a;
+}
+struct EmptyIter;
+impl LendingIterator for EmptyIter {
+    type Item<'a> = &'a mut () where Self:'a;
+}
+pub trait FuncInput<'a, F>
+where
+    F: Foo<Self>,
+    Self: Sized,
+{
+}
+impl<'a, T, F: 'a> FuncInput<'a, F> for T where F: Foo<T> {}
+trait Foo<T> {}
+
+fn map_test() {
+    (&mut EmptyIter).consume(());
+    //~^ ERROR the trait bound `for<'a> &'a mut (): Foo<&'a mut ()>` is not satisfied
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-101020.stderr
+++ b/src/test/ui/generic-associated-types/issue-101020.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `for<'a> &'a mut (): Foo<&'a mut ()>` is not satisfied
+  --> $DIR/issue-101020.rs:33:5
+   |
+LL |     (&mut EmptyIter).consume(());
+   |     ^^^^^^^^^^^^^^^^ ------- required by a bound introduced by this call
+   |     |
+   |     the trait `for<'a> Foo<&'a mut ()>` is not implemented for `&'a mut ()`
+   |
+note: required for `&'a mut ()` to implement `for<'a> FuncInput<'a, &'a mut ()>`
+  --> $DIR/issue-101020.rs:29:20
+   |
+LL | impl<'a, T, F: 'a> FuncInput<'a, F> for T where F: Foo<T> {}
+   |                    ^^^^^^^^^^^^^^^^     ^
+note: required by a bound in `LendingIterator::consume`
+  --> $DIR/issue-101020.rs:11:33
+   |
+LL |     fn consume<F>(self, _f: F)
+   |        ------- required by a bound in this
+...
+LL |         for<'a> Self::Item<'a>: FuncInput<'a, Self::Item<'a>>,
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `LendingIterator::consume`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #101020