### PR TITLE
Remove unused build dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,6 @@ name = "error_index_generator"
 version = "0.0.0"
 dependencies = [
  "rustdoc",
- "walkdir",
 ]
 
 [[package]]

--- a/src/tools/error_index_generator/Cargo.toml
+++ b/src/tools/error_index_generator/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2021"
 [dependencies]
 rustdoc = { path = "../../librustdoc" }
 
-[build-dependencies]
-walkdir = "2"
-
 [[bin]]
 name = "error_index_generator"
 path = "main.rs"


### PR DESCRIPTION
There is no more `build.rs` so this dependency is unused.

r? @Dylan-DPC 