### PR TITLE
rustdoc: remove unused CSS for `hidden-by-*-hider`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1581,12 +1581,6 @@ kbd {
 	cursor: default;
 }
 
-.hidden-by-impl-hider,
-.hidden-by-usual-hider {
-	/* important because of conflicting rule for small screens */
-	display: none !important;
-}
-
 #implementations-list > h3 > span.in-band {
 	width: 100%;
 }


### PR DESCRIPTION
This CSS seems to have become obsolete with the move to `<details>` tags,
and its corresponding JavaScript was removed in aee054d05d8b795d35c0b448a4b731b6507aa459