### PR TITLE
rustdoc: remove incorrect CSS selector `.impl-items table td`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -777,7 +777,7 @@ pre, .rustdoc.source .example-wrap {
 .content .docblock >.impl-items table td {
 	padding: 0;
 }
-.content .docblock > .impl-items .table-display, .impl-items table td {
+.content .docblock > .impl-items .table-display {
 	border: none;
 }
 

--- a/src/test/rustdoc-gui/docblock-table.goml
+++ b/src/test/rustdoc-gui/docblock-table.goml
@@ -1,0 +1,4 @@
+goto: file://|DOC_PATH|/test_docs/doc_block_table/struct.DocBlockTable.html#method.func
+
+compare-elements-css: (".impl-items .docblock table th", ".top-doc .docblock table th", ["border"])
+compare-elements-css: (".impl-items .docblock table td", ".top-doc .docblock table td", ["border"])

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -293,3 +293,29 @@ pub mod details {
     /// </details>
     pub struct Details;
 }
+
+pub mod doc_block_table {
+
+    pub trait DocBlockTableTrait {
+        fn func();
+    }
+
+    /// Struct doc.
+    ///
+    /// | header1                  | header2                  |
+    /// |--------------------------|--------------------------|
+    /// | Lorem Ipsum, Lorem Ipsum | Lorem Ipsum, Lorem Ipsum |
+    pub struct DocBlockTable {}
+
+    impl DocBlockTableTrait for DocBlockTable {
+        /// Trait impl func doc for struct.
+        ///
+        /// | header1                  | header2                  |
+        /// |--------------------------|--------------------------|
+        /// | Lorem Ipsum, Lorem Ipsum | Lorem Ipsum, Lorem Ipsum |
+        fn func() {
+            println!();
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #100994

This selector was added in c7312fbae4979c6d4fdfbd1f55a71cd47d82a480. The bug can be seen at <https://doc.rust-lang.org/1.27.0/alloc/slice/trait.SliceIndex.html#foreign-impls>.

This rule was added to help with a `<table>` that was used for displaying the function signature [src] lockup. That lockup was changed in 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9 to use flexbox instead, leaving this selector unused (at least, for its original purpose).