### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3216,7 +3216,7 @@ impl<'hir> OwnerNode<'hir> {
         }
     }
 
-    pub fn fn_decl(&self) -> Option<&FnDecl<'hir>> {
+    pub fn fn_decl(self) -> Option<&'hir FnDecl<'hir>> {
         match self {
             OwnerNode::TraitItem(TraitItem { kind: TraitItemKind::Fn(fn_sig, _), .. })
             | OwnerNode::ImplItem(ImplItem { kind: ImplItemKind::Fn(fn_sig, _), .. })
@@ -3400,19 +3400,20 @@ impl<'hir> Node<'hir> {
         }
     }
 
-    pub fn fn_decl(&self) -> Option<&'hir FnDecl<'hir>> {
+    pub fn fn_decl(self) -> Option<&'hir FnDecl<'hir>> {
         match self {
             Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(fn_sig, _), .. })
             | Node::ImplItem(ImplItem { kind: ImplItemKind::Fn(fn_sig, _), .. })
             | Node::Item(Item { kind: ItemKind::Fn(fn_sig, _, _), .. }) => Some(fn_sig.decl),
-            Node::ForeignItem(ForeignItem { kind: ForeignItemKind::Fn(fn_decl, _, _), .. }) => {
+            Node::Expr(Expr { kind: ExprKind::Closure(Closure { fn_decl, .. }), .. })
+            | Node::ForeignItem(ForeignItem { kind: ForeignItemKind::Fn(fn_decl, _, _), .. }) => {
                 Some(fn_decl)
             }
             _ => None,
         }
     }
 
-    pub fn fn_sig(&self) -> Option<&'hir FnSig<'hir>> {
+    pub fn fn_sig(self) -> Option<&'hir FnSig<'hir>> {
         match self {
             Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(fn_sig, _), .. })
             | Node::ImplItem(ImplItem { kind: ImplItemKind::Fn(fn_sig, _), .. })

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3068,7 +3068,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// #![cfg_attr(debug_assertions, crate_type = "lib")]
     /// ```
     ///
@@ -3088,7 +3088,7 @@ declare_lint! {
     /// rustc instead of `#![cfg_attr(..., crate_type = "...")]` and
     /// `--crate-name` instead of `#![cfg_attr(..., crate_name = "...")]`.
     pub DEPRECATED_CFG_ATTR_CRATE_TYPE_NAME,
-    Warn,
+    Deny,
     "detects usage of `#![cfg_attr(..., crate_type/crate_name = \"...\")]`",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #91632 <https://github.com/rust-lang/rust/issues/91632>",

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -17,28 +17,6 @@ use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::Span;
 use rustc_target::spec::abi::Abi;
 
-fn fn_decl<'hir>(node: Node<'hir>) -> Option<&'hir FnDecl<'hir>> {
-    match node {
-        Node::Item(Item { kind: ItemKind::Fn(sig, _, _), .. })
-        | Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(sig, _), .. })
-        | Node::ImplItem(ImplItem { kind: ImplItemKind::Fn(sig, _), .. }) => Some(&sig.decl),
-        Node::Expr(Expr { kind: ExprKind::Closure(Closure { fn_decl, .. }), .. })
-        | Node::ForeignItem(ForeignItem { kind: ForeignItemKind::Fn(fn_decl, ..), .. }) => {
-            Some(fn_decl)
-        }
-        _ => None,
-    }
-}
-
-pub fn fn_sig<'hir>(node: Node<'hir>) -> Option<&'hir FnSig<'hir>> {
-    match &node {
-        Node::Item(Item { kind: ItemKind::Fn(sig, _, _), .. })
-        | Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(sig, _), .. })
-        | Node::ImplItem(ImplItem { kind: ImplItemKind::Fn(sig, _), .. }) => Some(sig),
-        _ => None,
-    }
-}
-
 #[inline]
 pub fn associated_body<'hir>(node: Node<'hir>) -> Option<BodyId> {
     match node {
@@ -384,7 +362,7 @@ impl<'hir> Map<'hir> {
 
     pub fn fn_decl_by_hir_id(self, hir_id: HirId) -> Option<&'hir FnDecl<'hir>> {
         if let Some(node) = self.find(hir_id) {
-            fn_decl(node)
+            node.fn_decl()
         } else {
             bug!("no node for hir_id `{}`", hir_id)
         }
@@ -392,7 +370,7 @@ impl<'hir> Map<'hir> {
 
     pub fn fn_sig_by_hir_id(self, hir_id: HirId) -> Option<&'hir FnSig<'hir>> {
         if let Some(node) = self.find(hir_id) {
-            fn_sig(node)
+            node.fn_sig()
         } else {
             bug!("no node for hir_id `{}`", hir_id)
         }

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -541,7 +541,7 @@ fn fn_sig_and_body<'tcx>(
     // to HIR for it.
     let hir_node = tcx.hir().get_if_local(def_id).expect("expected DefId is local");
     let fn_body_id = hir::map::associated_body(hir_node).expect("HIR node is a function with body");
-    (hir::map::fn_sig(hir_node), tcx.hir().body(fn_body_id))
+    (hir_node.fn_sig(), tcx.hir().body(fn_body_id))
 }
 
 fn get_body_span<'tcx>(

--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -4,7 +4,6 @@ use rustc_errors::{
     MultiSpan,
 };
 use rustc_hir as hir;
-use rustc_middle::hir::map::fn_sig;
 use rustc_middle::ty::{self as ty, AssocItems, AssocKind, TyCtxt};
 use rustc_session::Session;
 use rustc_span::def_id::DefId;
@@ -368,7 +367,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         &self,
         num_params_to_take: usize,
     ) -> String {
-        let fn_sig = self.tcx.hir().get_if_local(self.def_id).and_then(fn_sig);
+        let fn_sig = self.tcx.hir().get_if_local(self.def_id).and_then(hir::Node::fn_sig);
         let is_used_in_input = |def_id| {
             fn_sig.map_or(false, |fn_sig| {
                 fn_sig.decl.inputs.iter().any(|ty| match ty.kind {

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2017,7 +2017,7 @@ extern "rust-intrinsic" {
     pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
 
     /// See documentation of `<*const T>::sub_ptr` for details.
-    #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
+    #[rustc_const_unstable(feature = "const_ptr_sub_ptr", issue = "95892")]
     pub fn ptr_offset_from_unsigned<T>(ptr: *const T, base: *const T) -> usize;
 
     /// See documentation of `<*const T>::guaranteed_eq` for details.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2013,11 +2013,11 @@ extern "rust-intrinsic" {
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
 
     /// See documentation of `<*const T>::offset_from` for details.
-    #[rustc_const_unstable(feature = "const_ptr_offset_from", issue = "92980")]
+    #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
     pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
 
     /// See documentation of `<*const T>::sub_ptr` for details.
-    #[rustc_const_unstable(feature = "const_ptr_offset_from", issue = "92980")]
+    #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
     pub fn ptr_offset_from_unsigned<T>(ptr: *const T, base: *const T) -> usize;
 
     /// See documentation of `<*const T>::guaranteed_eq` for details.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -130,7 +130,6 @@
 #![feature(const_replace)]
 #![feature(const_ptr_as_ref)]
 #![feature(const_ptr_is_null)]
-#![feature(const_ptr_offset_from)]
 #![feature(const_ptr_read)]
 #![feature(const_ptr_write)]
 #![feature(const_raw_ptr_comparison)]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -526,25 +526,6 @@ macro_rules! write {
 ///     Ok(())
 /// }
 /// ```
-///
-/// A module can import both `std::fmt::Write` and `std::io::Write` and call `write!` on objects
-/// implementing either, as objects do not typically implement both. However, the module must
-/// import the traits qualified so their names do not conflict:
-///
-/// ```
-/// use std::fmt::Write as FmtWrite;
-/// use std::io::Write as IoWrite;
-///
-/// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let mut s = String::new();
-///     let mut v = Vec::new();
-///
-///     writeln!(&mut s, "{} {}", "abc", 123)?; // uses fmt::Write::write_fmt
-///     writeln!(&mut v, "s = {:?}", s)?; // uses io::Write::write_fmt
-///     assert_eq!(v, b"s = \"abc 123\\n\"\n");
-///     Ok(())
-/// }
-/// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "writeln_macro")]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -460,8 +460,8 @@ macro_rules! r#try {
 /// import the traits qualified so their names do not conflict:
 ///
 /// ```
-/// use std::fmt::Write as FmtWrite;
-/// use std::io::Write as IoWrite;
+/// use std::fmt::Write as _;
+/// use std::io::Write as _;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let mut s = String::new();

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -474,6 +474,23 @@ macro_rules! r#try {
 /// }
 /// ```
 ///
+/// If you also need the trait names themselves, such as to implement one or both on your types,
+/// import the containing module and then name them with a prefix:
+///
+/// ```
+/// # #![allow(unused_imports)]
+/// use std::fmt::{self, Write as _};
+/// use std::io::{self, Write as _};
+///
+/// struct Example;
+///
+/// impl fmt::Write for Example {
+///     fn write_str(&mut self, _s: &str) -> core::fmt::Result {
+///          unimplemented!();
+///     }
+/// }
+/// ```
+///
 /// Note: This macro can be used in `no_std` setups as well.
 /// In a `no_std` setup you are responsible for the implementation details of the components.
 ///

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -457,7 +457,8 @@ macro_rules! r#try {
 ///
 /// A module can import both `std::fmt::Write` and `std::io::Write` and call `write!` on objects
 /// implementing either, as objects do not typically implement both. However, the module must
-/// import the traits qualified so their names do not conflict:
+/// avoid conflict between the trait names, such as by importing them as `_` or otherwise renaming
+/// them:
 ///
 /// ```
 /// use std::fmt::Write as _;

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -641,7 +641,7 @@ impl<T: ?Sized> *const T {
     /// }
     /// ```
     #[stable(feature = "ptr_offset_from", since = "1.47.0")]
-    #[rustc_const_unstable(feature = "const_ptr_offset_from", issue = "92980")]
+    #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn offset_from(self, origin: *const T) -> isize

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -824,7 +824,7 @@ impl<T: ?Sized> *mut T {
     /// }
     /// ```
     #[stable(feature = "ptr_offset_from", since = "1.47.0")]
-    #[rustc_const_unstable(feature = "const_ptr_offset_from", issue = "92980")]
+    #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn offset_from(self, origin: *const T) -> isize

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1514,7 +1514,15 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         test_args.append(&mut builder.config.cmd.test_args());
 
-        cmd.args(&test_args);
+        // On Windows, replace forward slashes in test-args by backslashes
+        // so the correct filters are passed to libtest
+        if cfg!(windows) {
+            let test_args_win: Vec<String> =
+                test_args.iter().map(|s| s.replace("/", "\\")).collect();
+            cmd.args(&test_args_win);
+        } else {
+            cmd.args(&test_args);
+        }
 
         if builder.is_verbose() {
             cmd.arg("--verbose");

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -987,7 +987,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
     // So C's HTML will have something like this:
     //
     // ```html
-    // <script type="text/javascript" src="/implementors/A/trait.Foo.js"
+    // <script src="/implementors/A/trait.Foo.js"
     //     data-ignore-extern-crates="A,B" async></script>
     // ```
     //
@@ -1013,9 +1013,11 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
         .map(|cnum| cx.shared.tcx.crate_name(cnum).to_string())
         .collect::<Vec<_>>()
         .join(",");
+    let (extern_before, extern_after) =
+        if extern_crates.is_empty() { ("", "") } else { (" data-ignore-extern-crates=\"", "\"") };
     write!(
         w,
-        "<script type=\"text/javascript\" src=\"{src}\" data-ignore-extern-crates=\"{extern_crates}\" async></script>",
+        "<script src=\"{src}\"{extern_before}{extern_crates}{extern_after} async></script>",
         src = js_src_path.finish(),
     );
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -371,16 +371,21 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                     }
                     clean::ImportKind::Glob => String::new(),
                 };
+                let stab_tags = stab_tags.unwrap_or_default();
+                let (stab_tags_before, stab_tags_after) = if stab_tags.is_empty() {
+                    ("", "")
+                } else {
+                    ("<div class=\"item-right docblock-short\">", "</div>")
+                };
                 write!(
                     w,
                     "<div class=\"item-left {stab}{add}import-item\"{id}>\
                          <code>{vis}{imp}</code>\
                      </div>\
-                     <div class=\"item-right docblock-short\">{stab_tags}</div>",
+                     {stab_tags_before}{stab_tags}{stab_tags_after}",
                     stab = stab.unwrap_or_default(),
                     vis = myitem.visibility.print_with_space(myitem.item_id, cx),
                     imp = import.print(cx),
-                    stab_tags = stab_tags.unwrap_or_default(),
                 );
                 w.write_str(ITEM_TABLE_ROW_CLOSE);
             }
@@ -412,6 +417,12 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
 
                 let doc_value = myitem.doc_value().unwrap_or_default();
                 w.write_str(ITEM_TABLE_ROW_OPEN);
+                let docs = MarkdownSummaryLine(&doc_value, &myitem.links(cx)).into_string();
+                let (docs_before, docs_after) = if docs.is_empty() {
+                    ("", "")
+                } else {
+                    ("<div class=\"item-right docblock-short\">", "</div>")
+                };
                 write!(
                     w,
                     "<div class=\"item-left {stab}{add}module-item\">\
@@ -420,11 +431,10 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                         {unsafety_flag}\
                         {stab_tags}\
                      </div>\
-                     <div class=\"item-right docblock-short\">{docs}</div>",
+                     {docs_before}{docs}{docs_after}",
                     name = myitem.name.unwrap(),
                     visibility_emoji = visibility_emoji,
                     stab_tags = extra_info_tags(myitem, item, cx.tcx()),
-                    docs = MarkdownSummaryLine(&doc_value, &myitem.links(cx)).into_string(),
                     class = myitem.type_(),
                     add = add,
                     stab = stab.unwrap_or_default(),

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -364,11 +364,6 @@ li {
 	margin-left: 0px;
 }
 
-nav.sub {
-	position: relative;
-	font-size: 1rem;
-}
-
 .sub-container {
 	display: flex;
 	flex-direction: row;
@@ -638,9 +633,6 @@ h2.location a {
 }
 .docblock-short p {
 	display: inline;
-}
-
-.docblock-short p {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	margin: 0;
@@ -820,6 +812,8 @@ pre, .rustdoc.source .example-wrap {
 }
 
 nav.sub {
+	position: relative;
+	font-size: 1rem;
 	flex-grow: 1;
 	margin-bottom: 25px;
 }
@@ -919,6 +913,7 @@ table,
 	position: relative;
 	display: flex;
 	height: 34px;
+	margin-top: 4px;
 }
 .search-container > * {
 	height: 100%;
@@ -989,9 +984,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 }
 #crate-search > option {
 	font-size: 1rem;
-}
-.search-container {
-	margin-top: 4px;
 }
 .search-input {
 	/* Override Normalize.css: it has a rule that sets
@@ -1188,16 +1180,13 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	padding-left: 12px;
 	padding-right: 2px;
 	position: initial;
+	float: right;
 }
 
 .impl-items .srclink, .impl .srclink, .methods .srclink {
 	/* Override header settings otherwise it's too bold */
 	font-weight: normal;
 	font-size: 1rem;
-}
-
-.rightside {
-	float: right;
 }
 
 td.summary-column {
@@ -1226,7 +1215,7 @@ a.test-arrow {
 .example-wrap:hover .test-arrow {
 	visibility: visible;
 }
-a.test-arrow:hover{
+a.test-arrow:hover {
 	text-decoration: none;
 }
 
@@ -1494,10 +1483,6 @@ pre.rust {
 	outline: none;
 }
 
-#copy-path {
-	height: 34px;
-	background-color: var(--main-background-color);
-}
 #settings-menu > a, #help-button > button, #copy-path {
 	padding: 5px;
 	width: 33px;
@@ -1555,7 +1540,8 @@ input:checked + .slider {
 }
 
 #copy-path {
-	background: initial;
+	height: 34px;
+	background-color: var(--main-background-color);
 	margin-left: 10px;
 	padding: 0;
 	padding-left: 2px;
@@ -1841,10 +1827,6 @@ in storage.js plus the media query with (min-width: 701px)
 		display: none;
 	}
 
-	.sidebar-elems {
-		margin-top: 1em;
-	}
-
 	.sidebar {
 		position: fixed;
 		top: 45px;
@@ -1938,6 +1920,7 @@ in storage.js plus the media query with (min-width: 701px)
 	}
 
 	.sidebar-elems {
+		margin-top: 1em;
 		background-color: var(--sidebar-background-color);
 	}
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -777,7 +777,7 @@ pre, .rustdoc.source .example-wrap {
 .content .docblock >.impl-items table td {
 	padding: 0;
 }
-.content .docblock > .impl-items .table-display, .impl-items table td {
+.content .docblock > .impl-items .table-display {
 	border: none;
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1581,12 +1581,6 @@ kbd {
 	cursor: default;
 }
 
-.hidden-by-impl-hider,
-.hidden-by-usual-hider {
-	/* important because of conflicting rule for small screens */
-	display: none !important;
-}
-
 #implementations-list > h3 > span.in-band {
 	width: 100%;
 }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -153,9 +153,6 @@ a {
 .sidebar h3 a {
 	color: white;
 }
-.search-results a {
-	color: #0096cf;
-}
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
@@ -359,7 +356,6 @@ h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type)
 .content span.constant,.content a.constant,.block a.current.constant,.content span.static,
 .content a.static, .block a.current.static {}
 .content span.keyword,.content a.keyword,.block a.current.keyword {}
-pre.rust .comment {}
 .content span.traitalias,.content a.traitalias,.block a.current.traitalias {}
 .content span.fn,.content a.fn,.block a.current.fn,.content span.method,.content a.method,
 .block a.current.method,.content span.tymethod,.content a.tymethod,.block a.current.tymethod,
@@ -367,7 +363,6 @@ pre.rust .comment {}
 pre.rust .kw {}
 pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
 .content span.foreigntype,.content a.foreigntype,.block a.current.foreigntype {}
-pre.rust .doccomment {}
 .stab.deprecated {}
 .content a.attr,.content a.derive,.content a.macro {}
 .stab.portability {}

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -528,9 +528,9 @@ function loadCss(cssFileName) {
         // We don't want to include impls from this JS file, when the HTML already has them.
         // The current crate should always be ignored. Other crates that should also be
         // ignored are included in the attribute `data-ignore-extern-crates`.
-        const ignoreExternCrates = document
-            .querySelector("script[data-ignore-extern-crates]")
-            .getAttribute("data-ignore-extern-crates");
+        const script = document
+            .querySelector("script[data-ignore-extern-crates]");
+        const ignoreExternCrates = script ? script.getAttribute("data-ignore-extern-crates") : "";
         for (const lib of libs) {
             if (lib === window.currentCrate || ignoreExternCrates.indexOf(lib) !== -1) {
                 continue;

--- a/src/test/codegen/external-no-mangle-statics.rs
+++ b/src/test/codegen/external-no-mangle-statics.rs
@@ -1,11 +1,10 @@
 // revisions: lib staticlib
 // ignore-emscripten default visibility is hidden
 // compile-flags: -O
+// [lib] compile-flags: --crate-type lib
+// [staticlib] compile-flags: --crate-type staticlib
 // `#[no_mangle]`d static variables always have external linkage, i.e., no `internal` in their
 // definitions
-
-#![cfg_attr(lib, crate_type = "lib")]
-#![cfg_attr(staticlib, crate_type = "staticlib")]
 
 // CHECK: @A = local_unnamed_addr constant
 #[no_mangle]

--- a/src/test/rustdoc-gui/docblock-table.goml
+++ b/src/test/rustdoc-gui/docblock-table.goml
@@ -1,0 +1,4 @@
+goto: file://|DOC_PATH|/test_docs/doc_block_table/struct.DocBlockTable.html#method.func
+
+compare-elements-css: (".impl-items .docblock table th", ".top-doc .docblock table th", ["border"])
+compare-elements-css: (".impl-items .docblock table td", ".top-doc .docblock table td", ["border"])

--- a/src/test/rustdoc-gui/item-summary-table.goml
+++ b/src/test/rustdoc-gui/item-summary-table.goml
@@ -3,4 +3,4 @@ goto: file://|DOC_PATH|/lib2/summary_table/index.html
 // We check that we picked the right item first.
 assert-text: (".item-table .item-left", "Foo")
 // Then we check that its summary is empty.
-assert-text: (".item-table .item-right", "")
+assert-false: ".item-table .item-right"

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -293,3 +293,29 @@ pub mod details {
     /// </details>
     pub struct Details;
 }
+
+pub mod doc_block_table {
+
+    pub trait DocBlockTableTrait {
+        fn func();
+    }
+
+    /// Struct doc.
+    ///
+    /// | header1                  | header2                  |
+    /// |--------------------------|--------------------------|
+    /// | Lorem Ipsum, Lorem Ipsum | Lorem Ipsum, Lorem Ipsum |
+    pub struct DocBlockTable {}
+
+    impl DocBlockTableTrait for DocBlockTable {
+        /// Trait impl func doc for struct.
+        ///
+        /// | header1                  | header2                  |
+        /// |--------------------------|--------------------------|
+        /// | Lorem Ipsum, Lorem Ipsum | Lorem Ipsum, Lorem Ipsum |
+        fn func() {
+            println!();
+        }
+    }
+
+}

--- a/src/test/rustdoc/short-docblock-codeblock.rs
+++ b/src/test/rustdoc/short-docblock-codeblock.rs
@@ -1,8 +1,6 @@
 #![crate_name = "foo"]
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]' ""
-// @!has foo/index.html '//*[@class="item-right docblock-short"]' "Some text."
-// @!has foo/index.html '//*[@class="item-right docblock-short"]' "let x = 12;"
+// @count foo/index.html '//*[@class="item-right docblock-short"]' 0
 
 /// ```
 /// let x = 12;

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
@@ -1,7 +1,6 @@
 // check-fail
 // compile-flags:--cfg foo
 
-#![deny(warnings)]
 #![cfg_attr(foo, crate_type="bin")]
 //~^ERROR `crate_type` within
 //~| WARN this was previously accepted

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
@@ -1,20 +1,15 @@
 error: `crate_type` within an `#![cfg_attr] attribute is deprecated`
-  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:5:18
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:4:18
    |
 LL | #![cfg_attr(foo, crate_type="bin")]
    |                  ^^^^^^^^^^^^^^^^
    |
-note: the lint level is defined here
-  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:4:9
-   |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(deprecated_cfg_attr_crate_type_name)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(deprecated_cfg_attr_crate_type_name)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
 
 error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
-  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:10:18
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:9:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
    |                  ^^^^^^^^^^^^^^^^
@@ -23,7 +18,7 @@ LL | #![cfg_attr(foo, crate_name="bar")]
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
 
 error: `crate_type` within an `#![cfg_attr] attribute is deprecated`
-  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:5:18
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:4:18
    |
 LL | #![cfg_attr(foo, crate_type="bin")]
    |                  ^^^^^^^^^^^^^^^^
@@ -32,7 +27,7 @@ LL | #![cfg_attr(foo, crate_type="bin")]
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
 
 error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
-  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:10:18
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:9:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
    |                  ^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/const-eval/issue-91827-extern-types.rs
+++ b/src/test/ui/consts/const-eval/issue-91827-extern-types.rs
@@ -3,7 +3,6 @@
 // Test that we can handle unsized types with an extern type tail part.
 // Regression test for issue #91827.
 
-#![feature(const_ptr_offset_from)]
 #![feature(extern_types)]
 
 use std::ptr::addr_of;

--- a/src/test/ui/consts/offset.rs
+++ b/src/test/ui/consts/offset.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(const_ptr_offset_from)]
 use std::ptr;
 
 #[repr(C)]

--- a/src/test/ui/consts/offset_from.rs
+++ b/src/test/ui/consts/offset_from.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![feature(const_ptr_offset_from)]
 #![feature(const_ptr_sub_ptr)]
 #![feature(ptr_sub_ptr)]
 

--- a/src/test/ui/consts/offset_from_ub.rs
+++ b/src/test/ui/consts/offset_from_ub.rs
@@ -1,4 +1,3 @@
-#![feature(const_ptr_offset_from)]
 #![feature(core_intrinsics)]
 
 use std::intrinsics::{ptr_offset_from, ptr_offset_from_unsigned};

--- a/src/test/ui/consts/offset_from_ub.rs
+++ b/src/test/ui/consts/offset_from_ub.rs
@@ -1,3 +1,4 @@
+#![feature(const_ptr_sub_ptr)]
 #![feature(core_intrinsics)]
 
 use std::intrinsics::{ptr_offset_from, ptr_offset_from_unsigned};

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -217,7 +217,7 @@ pub fn check(paths: &[&Path], bad: &mut bool) {
     println!("Checking which error codes lack tests...");
 
     for path in paths {
-        super::walk(path, &mut |path| super::filter_dirs(path), &mut |entry, contents| {
+        super::walk(path, &mut super::filter_dirs, &mut |entry, contents| {
             let file_name = entry.file_name();
             let entry_path = entry.path();
 

--- a/src/tools/unicode-table-generator/src/main.rs
+++ b/src/tools/unicode-table-generator/src/main.rs
@@ -220,7 +220,7 @@ fn main() {
     let write_location = std::env::args().nth(1).unwrap_or_else(|| {
         eprintln!("Must provide path to write unicode tables to");
         eprintln!(
-            "e.g. {} library/core/unicode/unicode_data.rs",
+            "e.g. {} library/core/src/unicode/unicode_data.rs",
             std::env::args().next().unwrap_or_default()
         );
         std::process::exit(1);


### PR DESCRIPTION
Successful merges:

 - #96240 (Stabilize `const_ptr_offset_from`.)
 - #99784 (Make forward compatibility lint deprecated_cfg_attr_crate_type_name deny by default)
 - #100811 (Fix wrong compiletest filters on Windows)
 - #100924 (Smaller improvements of tidy and the unicode generator)
 - #100953 (Update documentation for `write!` and `writeln!`)
 - #101018 (rustdoc: omit start/end tags for empty item description blocks)
 - #101044 (rustdoc: remove unused CSS for `hidden-by-*-hider`)
 - #101046 (rustdoc: remove incorrect CSS selector `.impl-items table td`)
 - #101057 (Merge implementations of HIR fn_decl and fn_sig.)
 - #101062 (rustdoc: remove empty extern_crates and type="text/javascript" on script)
 - #101063 (Merge duplicated CSS rules)

Failed merges:

 - #101055 (Use smaller span for suggestions)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96240,99784,100811,100924,100953,101018,101044,101046,101057,101062,101063)
<!-- homu-ignore:end -->