### PR TITLE
Under Miri, disable debug asserts for things Miri always checks

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2227,6 +2227,7 @@ pub(crate) use assert_unsafe_precondition;
 
 /// Checks whether `ptr` is properly aligned with respect to
 /// `align_of::<T>()`.
+#[cfg(not(miri))]
 pub(crate) fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
     !ptr.is_null() && ptr.is_aligned()
 }
@@ -2243,6 +2244,7 @@ pub(crate) fn is_valid_allocation_size<T>(len: usize) -> bool {
 
 /// Checks whether the regions of memory starting at `src` and `dst` of size
 /// `count * size_of::<T>()` do *not* overlap.
+#[cfg(not(miri))]
 pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -> bool {
     let src_usize = src.addr();
     let dst_usize = dst.addr();
@@ -2352,6 +2354,7 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
     // SAFETY: the safety contract for `copy_nonoverlapping` must be
     // upheld by the caller.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null \
             and the specified memory ranges do not overlap",
@@ -2441,6 +2444,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
 
     // SAFETY: the safety contract for `copy` must be upheld by the caller.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "ptr::copy requires that both pointer arguments are aligned aligned and non-null",
             [T](src: *const T, dst: *mut T) =>
@@ -2513,6 +2517,7 @@ pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
 
     // SAFETY: the safety contract for `write_bytes` must be upheld by the caller.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "ptr::write_bytes requires that the destination pointer is aligned and non-null",
             [T](dst: *mut T) => is_aligned_and_not_null(dst)

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -56,6 +56,7 @@ macro_rules! nonzero_integers {
                 pub const unsafe fn new_unchecked(n: $Int) -> Self {
                     // SAFETY: this is guaranteed to be safe by the caller.
                     unsafe {
+                        #[cfg(not(miri))] // This precondition is already always checked by Miri
                         core::intrinsics::assert_unsafe_precondition!(
                             concat!(stringify!($Ty), "::new_unchecked requires a non-zero argument"),
                             (n: $Int) => n != 0

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
-use crate::intrinsics;
+use crate::intrinsics::{self, assert_unsafe_precondition};
 use crate::mem;
 use crate::slice::{self, SliceIndex};
 
@@ -761,6 +761,7 @@ impl<T: ?Sized> *const T {
         // SAFETY: The comparison has no side-effects, and the intrinsic
         // does this check internally in the CTFE implementation.
         unsafe {
+            #[cfg(not(miri))]
             assert_unsafe_precondition!(
                 "ptr::sub_ptr requires `this >= origin`",
                 [T](this: *const T, origin: *const T) => this >= origin

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -371,9 +371,9 @@
 use crate::cmp::Ordering;
 use crate::fmt;
 use crate::hash;
-use crate::intrinsics::{
-    self, assert_unsafe_precondition, is_aligned_and_not_null, is_nonoverlapping,
-};
+use crate::intrinsics;
+#[cfg(not(miri))]
+use crate::intrinsics::{assert_unsafe_precondition, is_aligned_and_not_null, is_nonoverlapping};
 
 use crate::mem::{self, MaybeUninit};
 
@@ -895,6 +895,7 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
         };
     }
 
+    #[cfg(not(miri))] // This precondition is already always checked by Miri
     // SAFETY: the caller must guarantee that `x` and `y` are
     // valid for writes and properly aligned.
     unsafe {
@@ -998,6 +999,7 @@ pub const unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
     // and cannot overlap `src` since `dst` must point to a distinct
     // allocated object.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "ptr::replace requires that the pointer argument is aligned and non-null",
             [T](dst: *mut T) => is_aligned_and_not_null(dst)
@@ -1496,6 +1498,7 @@ pub const unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 pub unsafe fn read_volatile<T>(src: *const T) -> T {
     // SAFETY: the caller must uphold the safety contract for `volatile_load`.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "ptr::read_volatile requires that the pointer argument is aligned and non-null",
             [T](src: *const T) => is_aligned_and_not_null(src)
@@ -1570,6 +1573,7 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
     // SAFETY: the caller must uphold the safety contract for `volatile_store`.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "ptr::write_volatile requires that the pointer argument is aligned and non-null",
             [T](dst: *mut T) => is_aligned_and_not_null(dst)

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -1,6 +1,7 @@
 //! Free functions to create `&[T]` and `&mut [T]`.
 
 use crate::array;
+#[cfg(not(miri))]
 use crate::intrinsics::{
     assert_unsafe_precondition, is_aligned_and_not_null, is_valid_allocation_size,
 };
@@ -92,6 +93,7 @@ use crate::ptr;
 pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`",
             [T](data: *const T, len: usize) => is_aligned_and_not_null(data)
@@ -137,6 +139,7 @@ pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T]
 pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts_mut`.
     unsafe {
+        #[cfg(not(miri))] // This precondition is already always checked by Miri
         assert_unsafe_precondition!(
             "slice::from_raw_parts_mut requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`",
             [T](data: *mut T, len: usize) => is_aligned_and_not_null(data)


### PR DESCRIPTION
Context: https://github.com/rust-lang/miri/issues/2497, Miri currently disables debug assertions in the standard library out of concern for how much slower code runs under Miri. A significant contributor there are these checks, which are entirely redundant and occur before Miri's, resulting in a much worse user experience if they are actually hit. So there is no reason to have them enabled under Miri.

However, this leaves some checks still enabled. Most notably, the bounds check(s) on `slice::get_unchecked` is staying put. This precondition originates in the requirements of Stacked Borrows, which can be disabled, and also has nothing to say about ZSTs, where the library API forbids out-of-bounds indexing, even for ZSTs.