### PR TITLE
Set DebuginfoKind::Pdb in msvc_base

### DIFF
--- a/compiler/rustc_target/src/spec/msvc_base.rs
+++ b/compiler/rustc_target/src/spec/msvc_base.rs
@@ -1,4 +1,4 @@
-use crate::spec::{LinkerFlavor, LldFlavor, SplitDebuginfo, TargetOptions};
+use crate::spec::{DebuginfoKind, LinkerFlavor, LldFlavor, SplitDebuginfo, TargetOptions};
 use std::borrow::Cow;
 
 pub fn opts() -> TargetOptions {
@@ -20,6 +20,7 @@ pub fn opts() -> TargetOptions {
         // where `*.pdb` files show up next to the final artifact.
         split_debuginfo: SplitDebuginfo::Packed,
         supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Packed]),
+        debuginfo_kind: DebuginfoKind::Pdb,
 
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/windows_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/windows_msvc_base.rs
@@ -1,4 +1,4 @@
-use crate::spec::{cvs, DebuginfoKind, TargetOptions};
+use crate::spec::{cvs, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     let base = super::msvc_base::opts();
@@ -28,7 +28,6 @@ pub fn opts() -> TargetOptions {
         // not ever be possible for us to pass this flag.
         no_default_libraries: false,
         has_thread_local: true,
-        debuginfo_kind: DebuginfoKind::Pdb,
 
         ..base
     }


### PR DESCRIPTION
This PDB setting was added to `windows_msvc_base` in
https://github.com/rust-lang/rust/pull/98051. It's also needed for the
UEFI targets, and since `uefi_msvc_base` and `windows_msvc_base` are the
only things that inherit from `msvc_base`, just move the PDB setting up
to `mscv_base` to cover both.

Fixes https://github.com/rust-lang/rust/issues/101071