### PR TITLE
Remove `Sync` requirement from lint pass objects

### DIFF
--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -243,6 +243,5 @@ macro_rules! declare_combined_early_lint_pass {
 }
 
 /// A lint pass boxed up as a trait object.
-pub type EarlyLintPassObject = Box<dyn EarlyLintPass + sync::Send + sync::Sync + 'static>;
-pub type LateLintPassObject =
-    Box<dyn for<'tcx> LateLintPass<'tcx> + sync::Send + sync::Sync + 'static>;
+pub type EarlyLintPassObject = Box<dyn EarlyLintPass + sync::Send + 'static>;
+pub type LateLintPassObject = Box<dyn for<'tcx> LateLintPass<'tcx> + sync::Send + 'static>;


### PR DESCRIPTION
This is blocking the clippy sync (#101140). One of the lint passes contains a `Cell` in order to make lifetimes work. It could be worked around, but this is the easier change to make if there are no objections.

Rational for removing the requirement
* All lint pass methods take `&mut self` arguments.
* Many passes depend on running is visitor order.
* Lint passes are created on demand so they're only ever stored in a local.
* `Send` is enough to lint different passes in parallel.

`LintStore` remains `Sync` with this. The constructor functions it contains still maintain their `Sync` requirement.

r? rust-lang/compiler