### PR TITLE
Simplify wording on `*::as_ptr` docs.

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1145,9 +1145,9 @@ impl<T, A: Allocator> Vec<T, A> {
     /// Modifying the vector may cause its buffer to be reallocated,
     /// which would also make any pointers to it invalid.
     ///
-    /// The caller must also ensure that the memory the pointer (non-transitively) points to
-    /// is never written to (except inside an `UnsafeCell`) using this pointer or any pointer
-    /// derived from it. If you need to mutate the contents of the slice, use [`as_mut_ptr`].
+    /// Writing to memory that this pointer points to is undefined behavior, unless that
+    /// write goes through interior mutability of its own. If you need to mutate the
+    /// contents of the slice, use [`as_mut_ptr`].
     ///
     /// # Examples
     ///

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -498,7 +498,8 @@ impl<T> MaybeUninit<T> {
     /// Gets a pointer to the contained value. Reading from this pointer or turning it
     /// into a reference is undefined behavior unless the `MaybeUninit<T>` is initialized.
     /// Writing to memory that this pointer points to is undefined behavior, unless that
-    /// write goes through interior mutability of its own.
+    /// write goes through interior mutability of its own. If you need to mutate this
+    /// MaybeUninit, use [`as_mut_ptr`].
     ///
     /// # Examples
     ///
@@ -526,6 +527,8 @@ impl<T> MaybeUninit<T> {
     ///
     /// (Notice that the rules around references to uninitialized data are not finalized yet, but
     /// until they are, it is advisable to avoid them.)
+    ///
+    /// [`as_mut_ptr`]: MaybeUninit::as_mut_ptr
     #[stable(feature = "maybe_uninit", since = "1.36.0")]
     #[rustc_const_stable(feature = "const_maybe_uninit_as_ptr", since = "1.59.0")]
     #[inline(always)]

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -497,8 +497,8 @@ impl<T> MaybeUninit<T> {
 
     /// Gets a pointer to the contained value. Reading from this pointer or turning it
     /// into a reference is undefined behavior unless the `MaybeUninit<T>` is initialized.
-    /// Writing to memory that this pointer (non-transitively) points to is undefined behavior
-    /// (except inside an `UnsafeCell<T>`).
+    /// Writing to memory that this pointer points to is undefined behavior, unless that
+    /// write goes through interior mutability of its own.
     ///
     /// # Examples
     ///

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -448,9 +448,9 @@ impl<T> [T] {
     /// The caller must ensure that the slice outlives the pointer this
     /// function returns, or else it will end up pointing to garbage.
     ///
-    /// The caller must also ensure that the memory the pointer (non-transitively) points to
-    /// is never written to (except inside an `UnsafeCell`) using this pointer or any pointer
-    /// derived from it. If you need to mutate the contents of the slice, use [`as_mut_ptr`].
+    /// Writing to memory that this pointer points to is undefined behavior, unless that
+    /// write goes through interior mutability of its own. If you need to mutate the
+    /// contents of the slice, use [`as_mut_ptr`].
     ///
     /// Modifying the container referenced by this slice may cause its buffer
     /// to be reallocated, which would also make any pointers to it invalid.


### PR DESCRIPTION
This removes usage of "non-transitively" in several pieces of documentation.

I believe this wording is not clear enough (especially for nonnative speakers) and I hope this is better. I'm open to suggestions :)