### PR TITLE
Fix UB from misalignment and provenance widening in `std::sys::windows`

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -503,6 +503,8 @@ pub struct FILE_END_OF_FILE_INFO {
     pub EndOfFile: LARGE_INTEGER,
 }
 
+/// NB: Use carefully! In general using this as a reference is likely to get the
+/// provenance wrong for the `rest` field!
 #[repr(C)]
 pub struct REPARSE_DATA_BUFFER {
     pub ReparseTag: c_uint,
@@ -511,6 +513,8 @@ pub struct REPARSE_DATA_BUFFER {
     pub rest: (),
 }
 
+/// NB: Use carefully! In general using this as a reference is likely to get the
+/// provenance wrong for the `PathBuffer` field!
 #[repr(C)]
 pub struct SYMBOLIC_LINK_REPARSE_BUFFER {
     pub SubstituteNameOffset: c_ushort,
@@ -521,6 +525,8 @@ pub struct SYMBOLIC_LINK_REPARSE_BUFFER {
     pub PathBuffer: WCHAR,
 }
 
+/// NB: Use carefully! In general using this as a reference is likely to get the
+/// provenance wrong for the `PathBuffer` field!
 #[repr(C)]
 pub struct MOUNT_POINT_REPARSE_BUFFER {
     pub SubstituteNameOffset: c_ushort,

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -330,25 +330,10 @@ pub fn abort_internal() -> ! {
     crate::intrinsics::abort();
 }
 
-/// Used for some win32 buffers which are stack allocated, for example:
-/// `AlignedAs<c::REPARSE_DATA_BUFFER, [u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE]>`
-#[repr(C)]
+/// Align the inner value to 8 bytes.
+///
+/// This is enough for almost all of the buffers we're likely to work with in
+/// the Windows APIs we use.
+#[repr(C, align(8))]
 #[derive(Copy, Clone)]
-pub struct AlignedAs<Aligner, Alignee: ?Sized> {
-    /// Use `[Aligner; 0]` as a sort of `PhantomAlignNextField<Aligner>`. This
-    /// is a bit of a hack, and could break (in a way that's caught by tests) if
-    /// #81996 is fixed.
-    aligner: [Aligner; 0],
-    /// The aligned value. Public rather than exposed via accessors so that if
-    /// needed it can be used with `addr_of` and such (also, this is less code).
-    pub value: Alignee,
-}
-
-impl<Aligner, Alignee> AlignedAs<Aligner, Alignee> {
-    // This is frequently used with large stack buffers, so force-inline to
-    // try and avoid using 2x as much stack space in debug builds.
-    #[inline(always)]
-    pub const fn new(value: Alignee) -> Self {
-        Self { aligner: [], value }
-    }
-}
+pub(crate) struct Align8<T: ?Sized>(pub T);

--- a/library/std/src/sys/windows/os/tests.rs
+++ b/library/std/src/sys/windows/os/tests.rs
@@ -11,21 +11,3 @@ fn ntstatus_error() {
             .contains("FormatMessageW() returned error")
     );
 }
-
-#[test]
-fn smoketest_aligned_as() {
-    use crate::{
-        mem::{align_of, size_of},
-        ptr::addr_of,
-        sys::{c, AlignedAs},
-    };
-    type AlignedReparseBuf =
-        AlignedAs<c::REPARSE_DATA_BUFFER, [u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE]>;
-    assert!(size_of::<AlignedReparseBuf>() >= c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE);
-    assert_eq!(align_of::<AlignedReparseBuf>(), align_of::<c::REPARSE_DATA_BUFFER>());
-    let a = AlignedReparseBuf::new([0u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE]);
-    // Quick and dirty offsetof check.
-    assert_eq!(addr_of!(a).cast::<u8>(), addr_of!(a.value).cast::<u8>());
-    // Smoke check that it's actually aligned.
-    assert!(addr_of!(a.value).is_aligned_to(align_of::<c::REPARSE_DATA_BUFFER>()));
-}

--- a/library/std/src/sys/windows/os/tests.rs
+++ b/library/std/src/sys/windows/os/tests.rs
@@ -11,3 +11,21 @@ fn ntstatus_error() {
             .contains("FormatMessageW() returned error")
     );
 }
+
+#[test]
+fn smoketest_aligned_as() {
+    use crate::{
+        mem::{align_of, size_of},
+        ptr::addr_of,
+        sys::{c, AlignedAs},
+    };
+    type AlignedReparseBuf =
+        AlignedAs<c::REPARSE_DATA_BUFFER, [u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE]>;
+    assert!(size_of::<AlignedReparseBuf>() >= c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE);
+    assert_eq!(align_of::<AlignedReparseBuf>(), align_of::<c::REPARSE_DATA_BUFFER>());
+    let a = AlignedReparseBuf::new([0u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE]);
+    // Quick and dirty offsetof check.
+    assert_eq!(addr_of!(a).cast::<u8>(), addr_of!(a.value).cast::<u8>());
+    // Smoke check that it's actually aligned.
+    assert!(addr_of!(a.value).is_aligned_to(align_of::<c::REPARSE_DATA_BUFFER>()));
+}


### PR DESCRIPTION
This fixes two types of UB:

1. Reading past the end of a reference in types like `&c::REPARSE_DATA_BUFFER` (see https://github.com/rust-lang/unsafe-code-guidelines/issues/256). This is fixed by using `addr_of!`. I think there are probably a couple more cases where we do this for other structures, and will look into it in a bit.

2. Failing to ensure that a `[u8; N]` on the stack is sufficiently aligned to convert to a `REPARSE_DATA_BUFFER`. ~~This was done by introducing a new `AlignedAs` struct that allows aligning one type to the alignment of another type. I expect there are other places where we have this issue too, or I wouldn't introduce this type, but will get to them after this lands.~~

    ~~Worth noting, it *is* implemented in a way that can cause problems depending on how we fix #81996, but this would be caught by the test I added (and presumably if we decide to fix that in a way that would break this code, we'd also introduce a `#[repr(simple)]` or `#[repr(linear)]` as a replacement for this usage of `#[repr(C)]`).~~
    
    Edit: None of that is still in the code, I just went with a `Align8` since that's all we'll need for almost everything we want to call.

These are more or less "potential UB" since it's likely at the moment everything works fine, although the alignment not causing issues might just be down to luck (and x86 being forgiving).

~~NB: I've only ensured this check builds, but will run tests soon.~~ All tests pass, including stage2 compiler tests.

r? @ChrisDenton