### PR TITLE
Further simplify the macros generated by `rustc_queries`

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -383,7 +383,7 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
         if let Some(remap_env_constness) = &modifiers.remap_env_constness {
             attributes.push(quote! { (#remap_env_constness) });
         }
-        // Pass on the const modifier
+        // Pass on the cache modifier
         if modifiers.cache.is_some() {
             attributes.push(quote! { (cache) });
         }

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -344,7 +344,6 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
                 #name,
             });
         }
-        all_names.extend(quote! { #name, });
 
         let mut attributes = Vec::new();
 
@@ -394,11 +393,16 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
         // be very useful.
         let span = name.span();
         let attribute_stream = quote_spanned! {span=> #(#attributes),*};
-        let doc_comments = query.doc_comments.iter();
+        let doc_comments = &query.doc_comments;
         // Add the query to the group
         query_stream.extend(quote! {
             #(#doc_comments)*
             [#attribute_stream] fn #name(#arg) #result,
+        });
+
+        all_names.extend(quote! {
+            #(#doc_comments)*
+            #name,
         });
 
         add_query_description_impl(&query, &mut query_description_stream);

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -144,10 +144,7 @@ impl DepKind {
 
 macro_rules! define_dep_nodes {
     (
-    $(
-        [$($attrs:tt)*]
-        $variant:ident $(( $tuple_arg_ty:ty $(,)? ))*
-      ,)*
+        $( $variant:ident, )*
     ) => (
         #[macro_export]
         macro_rules! make_dep_kind_array {
@@ -179,21 +176,14 @@ macro_rules! define_dep_nodes {
     );
 }
 
-rustc_dep_node_append!(define_dep_nodes![
+rustc_query_names!(define_dep_nodes![
     // We use this for most things when incr. comp. is turned off.
-    [] Null,
-
+    Null,
     // We use this to create a forever-red node.
-    [] Red,
-
-    [anon] TraitSelect,
-
-    // WARNING: if `Symbol` is changed, make sure you update `make_compile_codegen_unit` below.
-    [] CompileCodegenUnit(Symbol),
-
-    // WARNING: if `MonoItem` is changed, make sure you update `make_compile_mono_item` below.
-    // Only used by rustc_codegen_cranelift
-    [] CompileMonoItem(MonoItem),
+    Red,
+    TraitSelect,
+    CompileCodegenUnit,
+    CompileMonoItem,
 ]);
 
 // WARNING: `construct` is generic and does not know that `CompileCodegenUnit` takes `Symbol`s as keys.

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -144,7 +144,7 @@ impl DepKind {
 
 macro_rules! define_dep_nodes {
     (
-        $( $variant:ident, )*
+        $( $( #[$attr:meta] )* $variant:ident, )+
     ) => (
         #[macro_export]
         macro_rules! make_dep_kind_array {
@@ -155,7 +155,7 @@ macro_rules! define_dep_nodes {
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Encodable, Decodable)]
         #[allow(non_camel_case_types)]
         pub enum DepKind {
-            $($variant),*
+            $( $( #[$attr] )* $variant),*
         }
 
         fn dep_kind_from_label_string(label: &str) -> Result<DepKind, ()> {
@@ -177,9 +177,9 @@ macro_rules! define_dep_nodes {
 }
 
 rustc_query_names!(define_dep_nodes![
-    // We use this for most things when incr. comp. is turned off.
+    /// We use this for most things when incr. comp. is turned off.
     Null,
-    // We use this to create a forever-red node.
+    /// We use this to create a forever-red node.
     Red,
     TraitSelect,
     CompileCodegenUnit,

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -144,8 +144,9 @@ impl DepKind {
 
 macro_rules! define_dep_nodes {
     (
-        $( $( #[$attr:meta] )* $variant:ident, )+
-    ) => (
+     $($(#[$attr:meta])*
+        [$($modifiers:tt)*] fn $variant:ident($($K:tt)*) -> $V:ty,)*) => {
+
         #[macro_export]
         macro_rules! make_dep_kind_array {
             ($mod:ident) => {[ $($mod::$variant()),* ]};
@@ -173,17 +174,17 @@ macro_rules! define_dep_nodes {
                 pub const $variant: &str = stringify!($variant);
             )*
         }
-    );
+    };
 }
 
-rustc_query_names!(define_dep_nodes![
+rustc_query_append!(define_dep_nodes![
     /// We use this for most things when incr. comp. is turned off.
-    Null,
+    [] fn Null() -> (),
     /// We use this to create a forever-red node.
-    Red,
-    TraitSelect,
-    CompileCodegenUnit,
-    CompileMonoItem,
+    [] fn Red() -> (),
+    [] fn TraitSelect() -> (),
+    [] fn CompileCodegenUnit() -> (),
+    [] fn CompileMonoItem() -> (),
 ]);
 
 // WARNING: `construct` is generic and does not know that `CompileCodegenUnit` takes `Symbol`s as keys.

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -148,19 +148,31 @@ impl<'tcx> QueryCtxt<'tcx> {
         encoder: &mut on_disk_cache::CacheEncoder<'_, 'tcx>,
         query_result_index: &mut on_disk_cache::EncodedDepNodeIndex,
     ) {
+        macro_rules! expand_if_cached {
+            ([] $encode:expr) => {};
+            ([(cache) $($rest:tt)*] $encode:expr) => {
+                $encode
+            };
+            ([$other:tt $($modifiers:tt)*] $encode:expr) => {
+                expand_if_cached!([$($modifiers)*] $encode)
+            };
+        }
+
         macro_rules! encode_queries {
-            ($($query:ident,)*) => {
+            (
+            $($(#[$attr:meta])*
+                [$($modifiers:tt)*] fn $query:ident($($K:tt)*) -> $V:ty,)*) => {
                 $(
-                    on_disk_cache::encode_query_results::<_, super::queries::$query<'_>>(
+                    expand_if_cached!([$($modifiers)*] on_disk_cache::encode_query_results::<_, super::queries::$query<'_>>(
                         self,
                         encoder,
                         query_result_index
-                    );
+                    ));
                 )*
             }
         }
 
-        rustc_cached_queries!(encode_queries!);
+        rustc_query_append!(encode_queries!);
     }
 
     pub fn try_print_query_stack(

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -307,7 +307,7 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
 
     macro_rules! alloc_once {
         (
-            $($(#[$attr:meta])* [$($modifiers:tt)*] fn $name:ident($K:ty) -> $V:ty,)*
+            $($name:ident,)*
         ) => {
             $({
                 alloc_self_profile_query_strings_for_query_cache(
@@ -320,5 +320,5 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
         }
     }
 
-    rustc_query_append! { alloc_once! }
+    rustc_query_names! { alloc_once! }
 }

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -307,18 +307,18 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
 
     macro_rules! alloc_once {
         (
-            $( $( #[$attr:meta] )* $name:ident, )+
-        ) => {
-            $({
+        $($(#[$attr:meta])*
+            [$($modifiers:tt)*] fn $name:ident($($K:tt)*) -> $V:ty,)*) => {
+            $(
                 alloc_self_profile_query_strings_for_query_cache(
                     tcx,
                     stringify!($name),
                     &tcx.query_caches.$name,
                     &mut string_cache,
                 );
-            })+
+            )+
         }
     }
 
-    rustc_query_names! { alloc_once! }
+    rustc_query_append! { alloc_once! }
 }

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -307,7 +307,7 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
 
     macro_rules! alloc_once {
         (
-            $($name:ident,)*
+            $( $( #[$attr:meta] )* $name:ident, )+
         ) => {
             $({
                 alloc_self_profile_query_strings_for_query_cache(
@@ -316,7 +316,7 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
                     &tcx.query_caches.$name,
                     &mut string_cache,
                 );
-            })*
+            })+
         }
     }
 


### PR DESCRIPTION
This doesn't actually move anything outside the macros, but it makes them simpler to read.

- Add a new `rustc_query_names` macro. This allows a much simpler syntax for the matchers in the macros passed to it as a callback.
- Convert `define_dep_nodes` and `alloc_once` to use `rustc_query_names`. This is possible because they only use the names
  (despite the quite complicated matchers in `define_dep_nodes`, none of the other arguments are used).
- Get rid of `rustc_dep_node_append`.

r? @cjgillot