### PR TITLE
Don't --bless in pre-push hook

### DIFF
--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -10,7 +10,7 @@ set -Eeuo pipefail
 # https://github.com/rust-lang/rust/issues/77620#issuecomment-705144570
 unset GIT_DIR
 ROOT_DIR="$(git rev-parse --show-toplevel)"
-COMMAND="$ROOT_DIR/x.py test tidy --bless"
+COMMAND="$ROOT_DIR/x.py test tidy"
 
 if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
   COMMAND="python $COMMAND"


### PR DESCRIPTION
Running with --bless causes the push to succeed if there are fixable
formatting changes, but the changes don't make it into the push.

We should have the user rerun with --bless (or x.py fmt) and commit the
changes themselves (they might want to amend a particular commit, for
instance).