### PR TITLE
Move most of `TyCtxtAt::$name` into a generic `evaluate_query` function

### DIFF
--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -102,12 +102,6 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 }
 
-/// Helper to ensure that queries only return `Copy` types.
-#[inline(always)]
-fn copy<T: Copy>(x: &T) -> T {
-    *x
-}
-
 fn evaluate_query<'tcx, Cache>(
     tcx: TyCtxt<'tcx>,
     execute_query: fn(
@@ -126,11 +120,9 @@ where
     Cache::Stored: Copy,
     Cache: QueryCache,
 {
-    let cached = try_get_cached(tcx, query_cache, &key, copy);
-
-    match cached {
-        Ok(value) => return value,
-        Err(()) => (),
+    match try_get_cached(tcx, query_cache, &key, mode) {
+        Ok(value) => value,
+        Err(()) => execute_query(tcx.queries, tcx, span, key, mode),
     }
 }
 


### PR DESCRIPTION
Helps with https://github.com/rust-lang/rust/issues/96524. This is based on https://github.com/rust-lang/rust/pull/100943, so it looks larger than it is.

- Move `Queries::new` out of the `define_callbacks` macro. This is a very small cleanup, happy to move it to its own PR.
- Move most of `TyCtxtAt::$name` into a generic function. There were a couple different approaches I could have taken here, see https://rust-lang.zulipchat.com/#narrow/stream/241847-t-compiler.2Fwg-incr-comp/topic/making.20.60TyCtxtAt.3A.3A.24query.60.20generic.20.2396524. I chose to use a `QueryCache` generic type argument and pass in `tcx.query_caches.$name` instead of doing a much larger refactor to define `queries::$name` in rustc_middle instead of rustc_query_impl.
- Remove `OnHit` generic parameter to `try_get_cached`. It was always used with `copy` after my refactor.

r? @cjgillot