### PR TITLE
Deprecate uninit_array

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -15,7 +15,7 @@
 #![feature(extend_one)]
 #![feature(hash_raw_entry)]
 #![feature(hasher_prefixfree_extras)]
-#![feature(maybe_uninit_uninit_array)]
+#![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(type_alias_impl_trait)]

--- a/compiler/rustc_data_structures/src/sip128.rs
+++ b/compiler/rustc_data_structures/src/sip128.rs
@@ -183,7 +183,7 @@ impl SipHasher128 {
     pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher128 {
         let mut hasher = SipHasher128 {
             nbuf: 0,
-            buf: MaybeUninit::uninit_array(),
+            buf: MaybeUninit::uninit().transpose(),
             state: State {
                 v0: key0 ^ 0x736f6d6570736575,
                 // The XOR with 0xee is only done on 128-bit algorithm version.

--- a/compiler/rustc_serialize/tests/leb128.rs
+++ b/compiler/rustc_serialize/tests/leb128.rs
@@ -1,5 +1,4 @@
-#![feature(maybe_uninit_slice)]
-#![feature(maybe_uninit_uninit_array)]
+#![feature(maybe_uninit_uninit_array_transpose)]
 
 use rustc_serialize::leb128::*;
 use std::mem::MaybeUninit;
@@ -24,7 +23,7 @@ macro_rules! impl_test_unsigned_leb128 {
             let mut stream = Vec::new();
 
             for &x in &values {
-                let mut buf = MaybeUninit::uninit_array();
+                let mut buf = MaybeUninit::uninit().transpose();
                 stream.extend($write_fn_name(&mut buf, x));
             }
 
@@ -70,7 +69,7 @@ macro_rules! impl_test_signed_leb128 {
             let mut stream = Vec::new();
 
             for &x in &values {
-                let mut buf = MaybeUninit::uninit_array();
+                let mut buf = MaybeUninit::uninit().transpose();
                 stream.extend($write_fn_name(&mut buf, x));
             }
 

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -127,7 +127,7 @@
 #![feature(layout_for_ptr)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(maybe_uninit_slice)]
-#![feature(maybe_uninit_uninit_array)]
+#![feature(maybe_uninit_uninit_array_transpose)]
 #![cfg_attr(test, feature(new_uninit))]
 #![feature(nonnull_slice_from_raw_parts)]
 #![feature(pattern)]

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -210,7 +210,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
 
     #[inline]
     fn next_chunk<const N: usize>(&mut self) -> Result<[T; N], core::array::IntoIter<T, N>> {
-        let mut raw_ary = MaybeUninit::uninit_array();
+        let mut raw_ary = MaybeUninit::uninit().transpose();
 
         let len = self.len();
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -879,7 +879,7 @@ where
         }
     }
 
-    let mut array = MaybeUninit::uninit_array::<N>();
+    let mut array = MaybeUninit::uninit().transpose();
     let mut guard = Guard { array_mut: &mut array, initialized: 0 };
 
     for _ in 0..N {

--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -35,8 +35,8 @@ fn float_to_decimal_common_exact<T>(
 where
     T: flt2dec::DecodableFloat,
 {
-    let mut buf: [MaybeUninit<u8>; 1024] = MaybeUninit::uninit_array(); // enough for f32 and f64
-    let mut parts: [MaybeUninit<numfmt::Part<'_>>; 4] = MaybeUninit::uninit_array();
+    let mut buf = [MaybeUninit::<u8>::uninit(); 1024]; // enough for f32 and f64
+    let mut parts = [MaybeUninit::<numfmt::Part<'_>>::uninit(); 4];
     let formatted = flt2dec::to_exact_fixed_str(
         flt2dec::strategy::grisu::format_exact,
         *num,
@@ -61,8 +61,8 @@ where
     T: flt2dec::DecodableFloat,
 {
     // enough for f32 and f64
-    let mut buf: [MaybeUninit<u8>; flt2dec::MAX_SIG_DIGITS] = MaybeUninit::uninit_array();
-    let mut parts: [MaybeUninit<numfmt::Part<'_>>; 4] = MaybeUninit::uninit_array();
+    let mut buf = [MaybeUninit::<u8>::uninit(); flt2dec::MAX_SIG_DIGITS];
+    let mut parts = [MaybeUninit::<numfmt::Part<'_>>::uninit(); 4];
     let formatted = flt2dec::to_shortest_str(
         flt2dec::strategy::grisu::format_shortest,
         *num,
@@ -105,8 +105,8 @@ fn float_to_exponential_common_exact<T>(
 where
     T: flt2dec::DecodableFloat,
 {
-    let mut buf: [MaybeUninit<u8>; 1024] = MaybeUninit::uninit_array(); // enough for f32 and f64
-    let mut parts: [MaybeUninit<numfmt::Part<'_>>; 6] = MaybeUninit::uninit_array();
+    let mut buf = [MaybeUninit::<u8>::uninit(); 1024]; // enough for f32 and f64
+    let mut parts = [MaybeUninit::<numfmt::Part<'_>>::uninit(); 6];
     let formatted = flt2dec::to_exact_exp_str(
         flt2dec::strategy::grisu::format_exact,
         *num,
@@ -132,8 +132,8 @@ where
     T: flt2dec::DecodableFloat,
 {
     // enough for f32 and f64
-    let mut buf: [MaybeUninit<u8>; flt2dec::MAX_SIG_DIGITS] = MaybeUninit::uninit_array();
-    let mut parts: [MaybeUninit<numfmt::Part<'_>>; 6] = MaybeUninit::uninit_array();
+    let mut buf = [MaybeUninit::<u8>::uninit(); flt2dec::MAX_SIG_DIGITS];
+    let mut parts = [MaybeUninit::<numfmt::Part<'_>>::uninit(); 6];
     let formatted = flt2dec::to_shortest_exp_str(
         flt2dec::strategy::grisu::format_shortest,
         *num,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -119,7 +119,6 @@
 #![feature(const_int_unchecked_arith)]
 #![feature(const_intrinsic_forget)]
 #![feature(const_likely)]
-#![feature(const_maybe_uninit_uninit_array)]
 #![feature(const_maybe_uninit_as_mut_ptr)]
 #![feature(const_maybe_uninit_assume_init)]
 #![feature(const_nonnull_new)]
@@ -151,7 +150,6 @@
 #![feature(const_waker)]
 #![feature(core_panic)]
 #![feature(duration_consts_float)]
-#![feature(maybe_uninit_uninit_array)]
 #![feature(ptr_alignment_type)]
 #![feature(ptr_metadata)]
 #![feature(slice_ptr_get)]
@@ -217,6 +215,7 @@
 #![feature(unboxed_closures)]
 #![feature(unsized_fn_params)]
 #![feature(asm_const)]
+#![feature(const_transmute_copy)]
 //
 // Target features:
 #![feature(arm_target_feature)]

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1297,7 +1297,8 @@ impl<T, const N: usize> MaybeUninit<[T; N]> {
     /// let data: [MaybeUninit<u8>; 1000] = MaybeUninit::uninit().transpose();
     /// ```
     #[unstable(feature = "maybe_uninit_uninit_array_transpose", issue = "96097")]
-    pub fn transpose(self) -> [MaybeUninit<T>; N] {
+    #[inline(always)]
+    pub const fn transpose(self) -> [MaybeUninit<T>; N] {
         // SAFETY: T and MaybeUninit<T> have the same layout
         unsafe { super::transmute_copy(&ManuallyDrop::new(self)) }
     }
@@ -1316,7 +1317,8 @@ impl<T, const N: usize> [MaybeUninit<T>; N] {
     /// let data: MaybeUninit<[u8; 1000]> = data.transpose();
     /// ```
     #[unstable(feature = "maybe_uninit_uninit_array_transpose", issue = "96097")]
-    pub fn transpose(self) -> MaybeUninit<[T; N]> {
+    #[inline(always)]
+    pub const fn transpose(self) -> MaybeUninit<[T; N]> {
         // SAFETY: T and MaybeUninit<T> have the same layout
         unsafe { super::transmute_copy(&ManuallyDrop::new(self)) }
     }

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -138,7 +138,7 @@ use crate::slice;
 ///     unsafe { mem::transmute::<_, [Vec<u32>; 1000]>(data) }
 /// };
 ///
-/// assert_eq!(&data[0], &[42]);
+/// assert_eq!(&data[42], &[42]);
 /// ```
 ///
 /// You can also work with partially initialized arrays, which could
@@ -148,10 +148,9 @@ use crate::slice;
 /// use std::mem::MaybeUninit;
 /// use std::ptr;
 ///
-/// // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
-/// // safe because the type we are claiming to have initialized here is a
-/// // bunch of `MaybeUninit`s, which do not require initialization.
-/// let mut data: [MaybeUninit<String>; 1000] = unsafe { MaybeUninit::uninit().assume_init() };
+/// // Create an uninitialized array of `MaybeUninit`.
+/// const UNINIT_STRING: MaybeUninit<String> = MaybeUninit::uninit();
+/// let mut data = [UNINIT_STRING; 1000];
 /// // Count the number of elements we have assigned.
 /// let mut data_len: usize = 0;
 ///
@@ -348,6 +347,10 @@ impl<T> MaybeUninit<T> {
     #[rustc_const_unstable(feature = "const_maybe_uninit_uninit_array", issue = "96097")]
     #[must_use]
     #[inline(always)]
+    #[deprecated(
+        since = "nightly",
+        note = "Use const array initialization instead or the transpose methods."
+    )]
     pub const fn uninit_array<const N: usize>() -> [Self; N] {
         // SAFETY: An uninitialized `[MaybeUninit<_>; LEN]` is valid.
         unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -48,7 +48,6 @@
 #![feature(slice_take)]
 #![feature(slice_from_ptr_range)]
 #![feature(split_as_slice)]
-#![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(maybe_uninit_write_slice)]
 #![feature(min_specialization)]

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -163,7 +163,7 @@ fn assume_init_good() {
 
 #[test]
 fn uninit_array_assume_init() {
-    let mut array: [MaybeUninit<i16>; 5] = MaybeUninit::uninit_array();
+    let mut array = [MaybeUninit::<i16>::uninit(); 5];
     array[0].write(3);
     array[1].write(1);
     array[2].write(4);

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -312,8 +312,7 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
-#![feature(maybe_uninit_uninit_array)]
-#![feature(const_maybe_uninit_uninit_array)]
+#![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(const_waker)]
 //
 // Library features (alloc):

--- a/library/std/src/net/display_buffer.rs
+++ b/library/std/src/net/display_buffer.rs
@@ -11,7 +11,7 @@ pub struct DisplayBuffer<const SIZE: usize> {
 impl<const SIZE: usize> DisplayBuffer<SIZE> {
     #[inline]
     pub const fn new() -> Self {
-        Self { buf: MaybeUninit::uninit_array(), len: 0 }
+        Self { buf: MaybeUninit::uninit().transpose(), len: 0 }
     }
 
     #[inline]

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -205,7 +205,7 @@ where
     // This initial size also works around `GetFullPathNameW` returning
     // incorrect size hints for some short paths:
     // https://github.com/dylni/normpath/issues/5
-    let mut stack_buf: [MaybeUninit<u16>; 512] = MaybeUninit::uninit_array();
+    let mut stack_buf = [MaybeUninit::<u16>::uninit(); 512];
     let mut heap_buf: Vec<MaybeUninit<u16>> = Vec::new();
     unsafe {
         let mut n = stack_buf.len();


### PR DESCRIPTION
Now that #98304 has gone through, `uninit_array` should be removed since creating a const array is the One True Way of doing things.

Tracking issue: #96097

Closes #66845

Blocked on: https://github.com/rust-lang/libs-team/issues/122#issuecomment-1320960065