### PR TITLE
Implement `Ready::into_inner()`

### DIFF
--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -24,6 +24,30 @@ impl<T> Future for Ready<T> {
     }
 }
 
+impl<T> Ready<T> {
+    /// Consumes the `Ready`, returning the wrapped value.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if this [`Ready`] was already polled to completion.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ready_into_inner)]
+    /// use std::future;
+    ///
+    /// let a = future::ready(1);
+    /// assert_eq!(a.into_inner(), 1);
+    /// ```
+    #[unstable(feature = "ready_into_inner", issue = "101196")]
+    #[must_use]
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.0.expect("Called `into_inner()` on `Ready` after completion")
+    }
+}
+
 /// Creates a future that is immediately ready with a value.
 ///
 /// Futures created through this function are functionally similar to those


### PR DESCRIPTION
Tracking issue: #101196.

This implements a method to unwrap the value inside a `Ready` outside an async context.
See https://docs.rs/futures/0.3.24/futures/future/struct.Ready.html#method.into_inner for previous work.

This was discussed in [Zulip beforehand](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/.60Ready.3A.3Ainto_inner.28.29.60):
> An example I'm hitting right now:
I have a cross-platform library that provides a functions that returns a `Future`. The only reason why it returns a `Future` is because the WASM platform requires it, but the native doesn't, to make a cross-platform API that is equal for all I just return a `Ready` on the native targets.
>
> Now I would like to expose native-only functions that aren't async, that users can use to avoid having to deal with async when they are targeting native. With `into_inner` that's easily solvable now.
>
> I want to point out that some internal restructuring could be used to solve that problem too, but in this case it's not that simple, the library uses internal traits that return the `Future` already and playing around with that would introduce unnecessary `cfg` in a lot more places. So it is really only a quality-of-life feature.