### PR TITLE
Do not call object_lifetime_default on lifetime params.

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1162,10 +1162,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             if should_encode_type(tcx, local_id, def_kind) {
                 record!(self.tables.type_of[def_id] <- self.tcx.type_of(def_id));
             }
-            if let DefKind::TyParam | DefKind::ConstParam = def_kind {
-                if let Some(default) = self.tcx.object_lifetime_default(def_id) {
-                    record!(self.tables.object_lifetime_default[def_id] <- default);
-                }
+            if let DefKind::TyParam = def_kind {
+                let default = self.tcx.object_lifetime_default(def_id);
+                record!(self.tables.object_lifetime_default[def_id] <- default);
             }
             if let DefKind::Trait | DefKind::TraitAlias = def_kind {
                 record!(self.tables.super_predicates_of[def_id] <- self.tcx.super_predicates_of(def_id));

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1593,12 +1593,13 @@ rustc_queries! {
     query is_late_bound_map(_: LocalDefId) -> Option<&'tcx FxIndexSet<LocalDefId>> {
         desc { "testing if a region is late bound" }
     }
-    /// For a given item (like a struct), gets the default lifetimes to be used
+    /// For a given item's generic parameter, gets the default lifetimes to be used
     /// for each parameter if a trait object were to be passed for that parameter.
-    /// For example, for `struct Foo<'a, T, U>`, this would be `['static, 'static]`.
-    /// For `struct Foo<'a, T: 'a, U>`, this would instead be `['a, 'static]`.
-    query object_lifetime_default(key: DefId) -> Option<ObjectLifetimeDefault> {
-        desc { "looking up lifetime defaults for generic parameter `{:?}`", key }
+    /// For example, for `T` in `struct Foo<'a, T>`, this would be `'static`.
+    /// For `T` in `struct Foo<'a, T: 'a>`, this would instead be `'a`.
+    /// This query will panic if passed something that is not a type parameter.
+    query object_lifetime_default(key: DefId) -> ObjectLifetimeDefault {
+        desc { "looking up lifetime defaults for generic parameter `{}`", tcx.def_path_str(key) }
         separate_provide_extern
     }
     query late_bound_vars_map(_: LocalDefId)

--- a/src/test/ui/object-lifetime/object-lifetime-default.rs
+++ b/src/test/ui/object-lifetime/object-lifetime-default.rs
@@ -1,24 +1,50 @@
 #![feature(rustc_attrs)]
 
 #[rustc_object_lifetime_default]
-struct A<T>(T); //~ ERROR BaseDefault
+struct A<
+    T, //~ ERROR BaseDefault
+>(T);
 
 #[rustc_object_lifetime_default]
-struct B<'a,T>(&'a (), T); //~ ERROR BaseDefault
+struct B<
+    'a,
+    T, //~ ERROR BaseDefault
+>(&'a (), T);
 
 #[rustc_object_lifetime_default]
-struct C<'a,T:'a>(&'a T); //~ ERROR 'a
+struct C<
+    'a,
+    T: 'a, //~ ERROR 'a
+>(&'a T);
 
 #[rustc_object_lifetime_default]
-struct D<'a,'b,T:'a+'b>(&'a T, &'b T); //~ ERROR Ambiguous
+struct D<
+    'a,
+    'b,
+    T: 'a + 'b, //~ ERROR Ambiguous
+>(&'a T, &'b T);
 
 #[rustc_object_lifetime_default]
-struct E<'a,'b:'a,T:'b>(&'a T, &'b T); //~ ERROR 'b
+struct E<
+    'a,
+    'b: 'a,
+    T: 'b, //~ ERROR 'b
+>(&'a T, &'b T);
 
 #[rustc_object_lifetime_default]
-struct F<'a,'b,T:'a,U:'b>(&'a T, &'b U); //~ ERROR 'a,'b
+struct F<
+    'a,
+    'b,
+    T: 'a, //~ ERROR 'a
+    U: 'b, //~ ERROR 'b
+>(&'a T, &'b U);
 
 #[rustc_object_lifetime_default]
-struct G<'a,'b,T:'a,U:'a+'b>(&'a T, &'b U); //~ ERROR 'a,Ambiguous
+struct G<
+    'a,
+    'b,
+    T: 'a,      //~ ERROR 'a
+    U: 'a + 'b, //~ ERROR Ambiguous
+>(&'a T, &'b U);
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/object-lifetime/object-lifetime-default.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default.stderr
@@ -1,44 +1,56 @@
 error: BaseDefault
-  --> $DIR/object-lifetime-default.rs:4:1
+  --> $DIR/object-lifetime-default.rs:5:5
    |
-LL | struct A<T>(T);
-   | ^^^^^^^^^^^^^^^
+LL |     T,
+   |     ^
 
 error: BaseDefault
-  --> $DIR/object-lifetime-default.rs:7:1
+  --> $DIR/object-lifetime-default.rs:11:5
    |
-LL | struct B<'a,T>(&'a (), T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     T,
+   |     ^
 
 error: 'a
-  --> $DIR/object-lifetime-default.rs:10:1
+  --> $DIR/object-lifetime-default.rs:17:5
    |
-LL | struct C<'a,T:'a>(&'a T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     T: 'a,
+   |     ^
 
 error: Ambiguous
-  --> $DIR/object-lifetime-default.rs:13:1
+  --> $DIR/object-lifetime-default.rs:24:5
    |
-LL | struct D<'a,'b,T:'a+'b>(&'a T, &'b T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     T: 'a + 'b,
+   |     ^
 
 error: 'b
-  --> $DIR/object-lifetime-default.rs:16:1
+  --> $DIR/object-lifetime-default.rs:31:5
    |
-LL | struct E<'a,'b:'a,T:'b>(&'a T, &'b T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     T: 'b,
+   |     ^
 
-error: 'a,'b
-  --> $DIR/object-lifetime-default.rs:19:1
+error: 'a
+  --> $DIR/object-lifetime-default.rs:38:5
    |
-LL | struct F<'a,'b,T:'a,U:'b>(&'a T, &'b U);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     T: 'a,
+   |     ^
 
-error: 'a,Ambiguous
-  --> $DIR/object-lifetime-default.rs:22:1
+error: 'b
+  --> $DIR/object-lifetime-default.rs:39:5
    |
-LL | struct G<'a,'b,T:'a,U:'a+'b>(&'a T, &'b U);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     U: 'b,
+   |     ^
 
-error: aborting due to 7 previous errors
+error: 'a
+  --> $DIR/object-lifetime-default.rs:46:5
+   |
+LL |     T: 'a,
+   |     ^
+
+error: Ambiguous
+  --> $DIR/object-lifetime-default.rs:47:5
+   |
+LL |     U: 'a + 'b,
+   |     ^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Small cleanup to avoid unnecessary query invocations in trivial cases.