### PR TITLE
Use in-page links for sanitizer docs.

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/sanitizer.md
+++ b/src/doc/unstable-book/src/compiler-flags/sanitizer.md
@@ -9,17 +9,17 @@ The tracking issues for this feature are:
 
 This feature allows for use of one of following sanitizers:
 
-* [AddressSanitizer][clang-asan] a fast memory error detector.
-* [ControlFlowIntegrity][clang-cfi] LLVM Control Flow Integrity (CFI) provides
+* [AddressSanitizer](#addresssanitizer) a fast memory error detector.
+* [ControlFlowIntegrity](#controlflowintegrity) LLVM Control Flow Integrity (CFI) provides
   forward-edge control flow protection.
-* [HWAddressSanitizer][clang-hwasan] a memory error detector similar to
+* [HWAddressSanitizer](#hwaddresssanitizer) a memory error detector similar to
   AddressSanitizer, but based on partial hardware assistance.
-* [LeakSanitizer][clang-lsan] a run-time memory leak detector.
-* [MemorySanitizer][clang-msan] a detector of uninitialized reads.
-* [MemTagSanitizer][clang-memtag] fast memory error detector based on
+* [LeakSanitizer](#leaksanitizer) a run-time memory leak detector.
+* [MemorySanitizer](#memorysanitizer) a detector of uninitialized reads.
+* [MemTagSanitizer](#memtagsanitizer) fast memory error detector based on
   Armv8.5-A Memory Tagging Extension.
-* [ShadowCallStack][clang-scs] provides backward-edge control flow protection.
-* [ThreadSanitizer][clang-tsan] a fast data race detector.
+* [ShadowCallStack](#shadowcallstack) provides backward-edge control flow protection.
+* [ThreadSanitizer](#threadsanitizer) a fast data race detector.
 
 To enable a sanitizer compile with `-Zsanitizer=address`,`-Zsanitizer=cfi`,
 `-Zsanitizer=hwaddress`, `-Zsanitizer=leak`, `-Zsanitizer=memory`,
@@ -57,6 +57,8 @@ AddressSanitizer is supported on the following targets:
 AddressSanitizer works with non-instrumented code although it will impede its
 ability to detect some bugs.  It is not expected to produce false positive
 reports.
+
+See the [Clang AddressSanitizer documentation][clang-asan] for more details.
 
 ## Examples
 
@@ -203,6 +205,8 @@ compatible type identifiers (see Type metadata in the design document in the
 tracking issue [#89653](https://github.com/rust-lang/rust/issues/89653)).
 
 LLVM CFI can be enabled with -Zsanitizer=cfi and requires LTO (i.e., -Clto).
+
+See the [Clang ControlFlowIntegrity documentation][clang-cfi] for more details.
 
 ## Example
 
@@ -430,6 +434,8 @@ HWAddressSanitizer requires `tagged-globals` target feature to instrument
 globals. To enable this target feature compile with `-C
 target-feature=+tagged-globals`
 
+See the [Clang HWAddressSanitizer documentation][clang-hwasan] for more details.
+
 ## Example
 
 Heap buffer overflow:
@@ -507,6 +513,8 @@ LeakSanitizer is supported on the following targets:
 * `x86_64-apple-darwin`
 * `x86_64-unknown-linux-gnu`
 
+See the [Clang LeakSanitizer documentation][clang-lsan] for more details.
+
 # MemorySanitizer
 
 MemorySanitizer is detector of uninitialized reads.
@@ -520,6 +528,8 @@ MemorySanitizer is supported on the following targets:
 MemorySanitizer requires all program code to be instrumented. C/C++ dependencies
 need to be recompiled using Clang with `-fsanitize=memory` option. Failing to
 achieve that will result in false positive reports.
+
+See the [Clang MemorySanitizer documentation][clang-msan] for more details.
 
 ## Example
 
@@ -569,7 +579,7 @@ MemTagSanitizer is supported on the following targets:
 MemTagSanitizer requires hardware support and the `mte` target feature.
 To enable this target feature compile with `-C target-feature="+mte"`.
 
-More information can be found in the associated [LLVM documentation](https://llvm.org/docs/MemTagSanitizer.html).
+See the [LLVM MemTagSanitizer documentation][llvm-memtag] for more details.
 
 # ShadowCallStack
 
@@ -581,7 +591,9 @@ ShadowCallStack can be enabled with `-Zsanitizer=shadow-call-stack` option and i
 
 * `aarch64-linux-android`
 
-A runtime must be provided by the application or operating system. See the [LLVM documentation][clang-scs] for further details.
+A runtime must be provided by the application or operating system.
+
+See the [Clang ShadowCallStack documentation][clang-scs] for more details.
 
 # ThreadSanitizer
 
@@ -603,6 +615,8 @@ can lead to false positive reports.
 
 ThreadSanitizer does not support atomic fences `std::sync::atomic::fence`,
 nor synchronization performed using inline assembly code.
+
+See the [Clang ThreadSanitizer documentation][clang-tsan] for more details.
 
 ## Example
 
@@ -673,6 +687,7 @@ Sanitizers produce symbolized stacktraces when llvm-symbolizer binary is in `PAT
 * [HWAddressSanitizer in Clang][clang-hwasan]
 * [LeakSanitizer in Clang][clang-lsan]
 * [MemorySanitizer in Clang][clang-msan]
+* [MemTagSanitizer in LLVM][llvm-memtag]
 * [ThreadSanitizer in Clang][clang-tsan]
 
 [clang-asan]: https://clang.llvm.org/docs/AddressSanitizer.html
@@ -682,3 +697,4 @@ Sanitizers produce symbolized stacktraces when llvm-symbolizer binary is in `PAT
 [clang-msan]: https://clang.llvm.org/docs/MemorySanitizer.html
 [clang-scs]: https://clang.llvm.org/docs/ShadowCallStack.html
 [clang-tsan]: https://clang.llvm.org/docs/ThreadSanitizer.html
+[llvm-memtag]: https://llvm.org/docs/MemTagSanitizer.html


### PR DESCRIPTION
This updates the sanitizer documentation page so that the links in the summary at the top jump to the relevant sections within the page instead of leading away to a different site. I think this makes it a little easier to navigate this page which has gotten quite long.

This also fixes the broken link for MemTagSanitizer which was not defined.  It also adds MemTagSanitizer to the external summary list at the bottom of the page.
