### PR TITLE
Partially implement thread scheduling attributes API proposal

### DIFF
--- a/library/std/src/os/horizon/mod.rs
+++ b/library/std/src/os/horizon/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod fs;
 pub(crate) mod raw;
+pub mod thread;

--- a/library/std/src/os/horizon/thread.rs
+++ b/library/std/src/os/horizon/thread.rs
@@ -1,7 +1,15 @@
+//! Horizon-specific extensions for working with the [`std::thread`] module.
+//!
+//! [`std::thread`]: crate::thread
+
 #![unstable(feature = "thread_scheduling", issue = "none")]
 
 use crate::fmt;
 
+/// The relative priority of the thread. See the `libctru` docs for the `prio`
+/// parameter of [`threadCreate`] for details on valid values.
+///
+/// [`threadCreate`]: https://libctru.devkitpro.org/thread_8h.html#a38c873d8cb02de7f5eca848fe68183ee
 pub struct Priority(pub(crate) libc::c_int);
 
 impl TryFrom<i32> for Priority {
@@ -21,6 +29,10 @@ impl crate::fmt::Debug for Priority {
     }
 }
 
+/// The CPU(s) on which to spawn the thread. See the `libctru` docs for the
+/// `core_id` parameter of [`threadCreate`] for details on valid values.
+///
+/// [`threadCreate`]: https://libctru.devkitpro.org/thread_8h.html#a38c873d8cb02de7f5eca848fe68183ee
 pub struct Affinity(pub(crate) libc::c_int);
 
 impl Default for Affinity {

--- a/library/std/src/os/horizon/thread.rs
+++ b/library/std/src/os/horizon/thread.rs
@@ -1,0 +1,47 @@
+#![unstable(feature = "thread_scheduling", issue = "none")]
+
+use crate::fmt;
+
+pub struct Priority(pub(crate) libc::c_int);
+
+impl TryFrom<i32> for Priority {
+    type Error = ();
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0x18..=0x3F => Ok(Self(value)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl crate::fmt::Debug for Priority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Priority").finish_non_exhaustive()
+    }
+}
+
+pub struct Affinity(pub(crate) libc::c_int);
+
+impl Default for Affinity {
+    fn default() -> Self {
+        Self(-2)
+    }
+}
+
+impl TryFrom<i32> for Affinity {
+    type Error = ();
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            -2..=4 => Ok(Self(value)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl crate::fmt::Debug for Affinity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Affinity").finish_non_exhaustive()
+    }
+}

--- a/library/std/src/os/linux/mod.rs
+++ b/library/std/src/os/linux/mod.rs
@@ -7,3 +7,4 @@ pub mod fs;
 pub mod net;
 pub mod process;
 pub mod raw;
+pub mod thread;

--- a/library/std/src/os/linux/thread.rs
+++ b/library/std/src/os/linux/thread.rs
@@ -1,11 +1,22 @@
+//! Linux-specific extensions for working with the [`std::thread`] module.
+//!
+//! [`std::thread`]: crate::thread
+
 #![unstable(feature = "thread_scheduling", issue = "none")]
 
 use crate::fmt;
 
+/// The relative scheduling priority of a thread, corresponding to the
+/// `sched_priority` scheduling parameter.
+///
+/// Refer to the man page for [`pthread_attr_setschedparam(3)`] for more details.
+///
+/// [`pthread_attr_setschedparam(3)`]: https://man7.org/linux/man-pages/man3/pthread_attr_setschedparam.3.html
 pub struct Priority(pub(crate) libc::c_int);
 
 impl Priority {
-    fn new(priority: i32) -> Self {
+    /// Create an integer priority.
+    pub fn new(priority: i32) -> Self {
         Self(priority)
     }
 }
@@ -16,9 +27,19 @@ impl crate::fmt::Debug for Priority {
     }
 }
 
+/// The CPU affinity mask of a thread, which determines what CPUs a thread is
+/// eligible to run on.
+///
+/// Refer to the man page for [`pthread_attr_setaffinity_np(3)`] for more details.
+///
+/// [`pthread_attr_setaffinity_np(3)`]: https://man7.org/linux/man-pages/man3/pthread_attr_setaffinity_np.3.html
 pub struct Affinity(pub(crate) libc::cpu_set_t);
 
 impl Affinity {
+    /// Create an affinity mask with no CPUs in it.
+    /// See the man page entry for [`CPU_ZERO`] for more details.
+    ///
+    /// [`CPU_ZERO`]: https://man7.org/linux/man-pages/man3/CPU_SET.3.html
     pub fn new() -> Self {
         unsafe {
             let mut set = crate::mem::zeroed();
@@ -27,6 +48,10 @@ impl Affinity {
         }
     }
 
+    /// Add a CPU to the affinity mask.
+    /// See the man page entry for [`CPU_SET`] for more details.
+    ///
+    /// [`CPU_SET`]: https://man7.org/linux/man-pages/man3/CPU_SET.3.html
     pub fn set(&mut self, cpu: usize) {
         unsafe {
             libc::CPU_SET(cpu, &mut self.0);

--- a/library/std/src/os/linux/thread.rs
+++ b/library/std/src/os/linux/thread.rs
@@ -1,0 +1,41 @@
+#![unstable(feature = "thread_scheduling", issue = "none")]
+
+use crate::fmt;
+
+pub struct Priority(pub(crate) libc::c_int);
+
+impl Priority {
+    fn new(priority: i32) -> Self {
+        Self(priority)
+    }
+}
+
+impl crate::fmt::Debug for Priority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Priority").finish_non_exhaustive()
+    }
+}
+
+pub struct Affinity(pub(crate) libc::cpu_set_t);
+
+impl Affinity {
+    pub fn new() -> Self {
+        unsafe {
+            let mut set = crate::mem::zeroed();
+            libc::CPU_ZERO(&mut set);
+            Self(set)
+        }
+    }
+
+    pub fn set(&mut self, cpu: usize) {
+        unsafe {
+            libc::CPU_SET(cpu, &mut self.0);
+        }
+    }
+}
+
+impl crate::fmt::Debug for Affinity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Affinity").finish_non_exhaustive()
+    }
+}

--- a/library/std/src/sys/hermit/thread.rs
+++ b/library/std/src/sys/hermit/thread.rs
@@ -7,6 +7,7 @@ use crate::mem;
 use crate::num::NonZeroUsize;
 use crate::sys::hermit::abi;
 use crate::sys::hermit::thread_local_dtor::run_dtors;
+use crate::thread::NativeOptions;
 use crate::time::Duration;
 
 pub type Tid = abi::Tid;
@@ -55,7 +56,11 @@ impl Thread {
         }
     }
 
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: NativeOptions,
+    ) -> io::Result<Thread> {
         Thread::new_with_coreid(stack, p, -1 /* = no specific core */)
     }
 
@@ -96,6 +101,9 @@ impl Thread {
         id
     }
 }
+
+pub type Priority = ();
+pub type Affinity = ();
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/itron/thread.rs
+++ b/library/std/src/sys/itron/thread.rs
@@ -13,6 +13,7 @@ use crate::{
     mem::ManuallyDrop,
     sync::atomic::{AtomicUsize, Ordering},
     sys::thread_local_dtor::run_dtors,
+    thread::NativeOptions,
     time::Duration,
 };
 
@@ -83,7 +84,11 @@ impl Thread {
     /// # Safety
     ///
     /// See `thread::Builder::spawn_unchecked` for safety requirements.
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: NativeOptions,
+    ) -> io::Result<Thread> {
         let inner = Box::new(ThreadInner {
             start: UnsafeCell::new(ManuallyDrop::new(p)),
             lifecycle: AtomicUsize::new(LIFECYCLE_INIT),
@@ -287,6 +292,9 @@ impl Drop for Thread {
         }
     }
 }
+
+pub type Priority = ();
+pub type Affinity = ();
 
 pub mod guard {
     pub type Guard = !;

--- a/library/std/src/sys/sgx/thread.rs
+++ b/library/std/src/sys/sgx/thread.rs
@@ -3,6 +3,7 @@ use super::unsupported;
 use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZeroUsize;
+use crate::thread::NativeOptions;
 use crate::time::Duration;
 
 use super::abi::usercalls;
@@ -104,7 +105,11 @@ pub mod wait_notify {
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: NativeOptions,
+    ) -> io::Result<Thread> {
         let mut queue_lock = task_queue::lock();
         unsafe { usercalls::launch_thread()? };
         let (task, handle) = task_queue::Task::new(p);
@@ -136,6 +141,9 @@ impl Thread {
         self.0.wait();
     }
 }
+
+pub type Priority = ();
+pub type Affinity = ();
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -104,8 +104,8 @@ impl Thread {
         #[cfg(any(target_os = "linux", target_os = "horizon"))]
         {
             if let Some(priority) = native_options.priority {
-                let sched_param = libc::sched_param { sched_priority: priority.0 };
-                // NOTE: needs to be added to libc, for now this doesn't compile
+                let _sched_param = libc::sched_param { sched_priority: priority.0 };
+                todo!("needs libc support for pthread_attr_setschedparam")
                 // assert_eq!(libc::pthread_attr_setschedparam(&mut attr, &sched_param), 0);
             }
 

--- a/library/std/src/sys/unsupported/thread.rs
+++ b/library/std/src/sys/unsupported/thread.rs
@@ -2,6 +2,7 @@ use super::unsupported;
 use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZeroUsize;
+use crate::thread::NativeOptions;
 use crate::time::Duration;
 
 pub struct Thread(!);
@@ -10,7 +11,11 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        _p: Box<dyn FnOnce()>,
+        _native_options: NativeOptions,
+    ) -> io::Result<Thread> {
         unsupported()
     }
 
@@ -30,6 +35,9 @@ impl Thread {
         self.0
     }
 }
+
+pub type Priority = ();
+pub type Affinity = ();
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -5,6 +5,7 @@ use crate::io;
 use crate::mem;
 use crate::num::NonZeroUsize;
 use crate::sys::unsupported;
+use crate::thread::NativeOptions;
 use crate::time::Duration;
 
 pub struct Thread(!);
@@ -13,7 +14,11 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        _p: Box<dyn FnOnce()>,
+        _native_options: NativeOptions,
+    ) -> io::Result<Thread> {
         unsupported()
     }
 
@@ -65,6 +70,9 @@ impl Thread {
         self.0
     }
 }
+
+pub type Priority = ();
+pub type Affinity = ();
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/wasm/atomics/thread.rs
+++ b/library/std/src/sys/wasm/atomics/thread.rs
@@ -2,6 +2,7 @@ use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZeroUsize;
 use crate::sys::unsupported;
+use crate::thread::NativeOptions;
 use crate::time::Duration;
 
 pub struct Thread(!);
@@ -10,7 +11,11 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        _p: Box<dyn FnOnce()>,
+        _native_options: NativeOptions,
+    ) -> io::Result<Thread> {
         unsupported()
     }
 
@@ -39,6 +44,9 @@ impl Thread {
 
     pub fn join(self) {}
 }
+
+pub type Priority = ();
+pub type Affinity = ();
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/windows/thread.rs
+++ b/library/std/src/sys/windows/thread.rs
@@ -7,6 +7,7 @@ use crate::sys::c;
 use crate::sys::handle::Handle;
 use crate::sys::stack_overflow;
 use crate::sys_common::FromInner;
+use crate::thread::NativeOptions;
 use crate::time::Duration;
 
 use libc::c_void;
@@ -15,13 +16,20 @@ use super::to_u16s;
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
 
+pub type Priority = ();
+pub type Affinity = ();
+
 pub struct Thread {
     handle: Handle,
 }
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: NativeOptions,
+    ) -> io::Result<Thread> {
         let p = Box::into_raw(box p);
 
         // FIXME On UNIX, we guard against stack sizes that are too small but
@@ -97,6 +105,9 @@ impl Thread {
         self.handle
     }
 }
+
+pub type Priority = ();
+pub type Affinity = ();
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     let res = unsafe {

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -193,6 +193,11 @@ pub use scoped::{scope, Scope, ScopedJoinHandle};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::local::{AccessError, LocalKey};
 
+#[unstable(feature = "thread_scheduling", issue = "none")]
+mod schedule;
+#[unstable(feature = "thread_scheduling", issue = "none")]
+pub use schedule::*;
+
 // Provide the type used by the thread_local! macro to access TLS keys. This
 // needs to be kept in sync with the macro itself (in `local.rs`).
 // There are three types: "static", "fast", "OS". The "OS" thread local key
@@ -231,6 +236,14 @@ pub use self::local::os::Key as __OsLocalKeyInner;
 #[cfg(all(target_family = "wasm", not(target_feature = "atomics")))]
 #[doc(hidden)]
 pub use self::local::statik::Key as __StaticLocalKeyInner;
+
+#[derive(Debug, Default)]
+pub(crate) struct NativeOptions {
+    /// The spawned thread's priority value
+    pub priority: Option<imp::Priority>,
+    /// The processor(s) to run the spawned thread on
+    pub affinity: Option<imp::Affinity>,
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Builder
@@ -286,6 +299,8 @@ pub struct Builder {
     name: Option<String>,
     // The size of the stack for the spawned thread in bytes
     stack_size: Option<usize>,
+    // Other OS-specific fields. These can be set with helpers found in std::os.
+    native_options: NativeOptions,
 }
 
 impl Builder {
@@ -309,7 +324,7 @@ impl Builder {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> Builder {
-        Builder { name: None, stack_size: None }
+        Builder { name: None, stack_size: None, native_options: NativeOptions::default() }
     }
 
     /// Names the thread-to-be. Currently the name is used for identification
@@ -362,6 +377,18 @@ impl Builder {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn stack_size(mut self, size: usize) -> Builder {
         self.stack_size = Some(size);
+        self
+    }
+
+    #[unstable(feature = "thread_scheduling", issue = "none")]
+    pub fn priority(mut self, priority: Priority) -> Builder {
+        self.native_options.priority = Some(priority.into());
+        self
+    }
+
+    #[unstable(feature = "thread_scheduling", issue = "none")]
+    pub fn affinity(mut self, affinity: Affinity) -> Builder {
+        self.native_options.affinity = Some(affinity.into());
         self
     }
 
@@ -489,11 +516,9 @@ impl Builder {
         T: Send + 'a,
         'scope: 'a,
     {
-        let Builder { name, stack_size } = self;
+        let stack_size = self.stack_size.unwrap_or_else(thread::min_stack);
 
-        let stack_size = stack_size.unwrap_or_else(thread::min_stack);
-
-        let my_thread = Thread::new(name.map(|name| {
+        let my_thread = Thread::new(self.name.map(|name| {
             CString::new(name).expect("thread name may not contain interior null bytes")
         }));
         let their_thread = my_thread.clone();
@@ -586,6 +611,7 @@ impl Builder {
                     mem::transmute::<Box<dyn FnOnce() + 'a>, Box<dyn FnOnce() + 'static>>(
                         Box::new(main),
                     ),
+                    self.native_options,
                 )?
             },
             thread: my_thread,

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -380,12 +380,18 @@ impl Builder {
         self
     }
 
+    /// Sets the priority of the new thread in a platform-specific way.
+    ///
+    /// See [`Priority`] for more details.
     #[unstable(feature = "thread_scheduling", issue = "none")]
     pub fn priority(mut self, priority: Priority) -> Builder {
         self.native_options.priority = Some(priority.into());
         self
     }
 
+    /// Sets the CPU affinity of the new thread in a platform-specific way.
+    ///
+    /// See [`Affinity`] for more details.
     #[unstable(feature = "thread_scheduling", issue = "none")]
     pub fn affinity(mut self, affinity: Affinity) -> Builder {
         self.native_options.affinity = Some(affinity.into());

--- a/library/std/src/thread/schedule.rs
+++ b/library/std/src/thread/schedule.rs
@@ -1,5 +1,15 @@
 use super::imp;
 
+/// The relative priority of an thread. The representation of this priority is
+/// platform-dependent and setting priority may not be supported on all platforms.
+///
+/// To set a thread's priority on supported platforms, use helpers in [`std::os`]
+/// (e.g. [`os::linux::thread::Priority`]) to create a `thread::Priority` and
+/// [`thread::Builder::priority`] to set the thread's priority.
+///
+/// [`std::os`]: crate::os
+/// [`os::linux::thread::Priority`]: crate::os::linux::thread::Priority
+/// [`thread::Builder::priority`]: crate::thread::Builder::priority
 #[derive(Debug)]
 pub struct Priority(imp::Priority);
 
@@ -15,6 +25,17 @@ impl From<Priority> for imp::Priority {
     }
 }
 
+/// The affinity of an thread, i.e. which CPU(s) a thread may run on. The
+/// meaning and representation of a thread's affinity is platform-dependent
+/// and setting affinity may not be supported on all platforms.
+///
+/// To set a thread's affinity on supported platforms, use helpers from [`std::os`]
+/// (e.g. [`os::linux::thread::Affinity`]) to create a `thread::Affinity` and
+/// [`thread::Builder::affinity`] to set the thread's affinity.
+///
+/// [`std::os`]: crate::os
+/// [`os::linux::thread::Affinity`]: crate::os::linux::thread::Affinity
+/// [`thread::Builder::affinity`]: crate::thread::Builder::affinity
 #[derive(Debug)]
 pub struct Affinity(pub(crate) imp::Affinity);
 

--- a/library/std/src/thread/schedule.rs
+++ b/library/std/src/thread/schedule.rs
@@ -1,0 +1,31 @@
+use super::imp;
+
+#[derive(Debug)]
+pub struct Priority(imp::Priority);
+
+impl From<imp::Priority> for Priority {
+    fn from(priority: imp::Priority) -> Self {
+        Self(priority)
+    }
+}
+
+impl From<Priority> for imp::Priority {
+    fn from(priority: Priority) -> Self {
+        priority.0
+    }
+}
+
+#[derive(Debug)]
+pub struct Affinity(pub(crate) imp::Affinity);
+
+impl From<imp::Affinity> for Affinity {
+    fn from(affinity: imp::Affinity) -> Self {
+        Self(affinity)
+    }
+}
+
+impl From<Affinity> for imp::Affinity {
+    fn from(affinity: Affinity) -> Self {
+        affinity.0
+    }
+}


### PR DESCRIPTION
This PR is a sketch of the standard library API proposed in https://github.com/rust-lang/libs-team/issues/71#issuecomment-1225102818

It most likely doesn't compile on all platforms, and it won't work correctly on Linux without added `libc` support for the corresponding pthread APIs, but I think this works as a proof-of-concept to create a portable-enough API that abstracts over the OS-specific details.

Many of the changes are taken from #98514 but the public API is somewhat different. See the libs-team discussion linked above for more details.

CC @AzureMarker @Meziu 