### PR TITLE
lint: avoid linting diag functions with diag lints

### DIFF
--- a/src/test/ui-fulldeps/internal-lints/diagnostics.rs
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.rs
@@ -1,6 +1,7 @@
 // compile-flags: -Z unstable-options
 
 #![crate_type = "lib"]
+#![feature(rustc_attrs)]
 #![feature(rustc_private)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
@@ -70,4 +71,11 @@ pub fn make_diagnostics<'a>(sess: &'a ParseSess) {
     let _diag = sess.struct_err("untranslatable diagnostic");
     //~^ ERROR diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
     //~^^ ERROR diagnostics should be created using translatable messages
+}
+
+// Check that `rustc_lint_diagnostics`-annotated functions aren't themselves linted.
+
+#[rustc_lint_diagnostics]
+pub fn skipped_because_of_annotation<'a>(sess: &'a ParseSess) {
+    let _diag = sess.struct_err("untranslatable diagnostic"); // okay!
 }

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
@@ -1,41 +1,41 @@
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:36:14
+  --> $DIR/diagnostics.rs:37:14
    |
 LL |         sess.struct_err("untranslatable diagnostic")
    |              ^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/diagnostics.rs:5:9
+  --> $DIR/diagnostics.rs:6:9
    |
 LL | #![deny(rustc::untranslatable_diagnostic)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:53:14
+  --> $DIR/diagnostics.rs:54:14
    |
 LL |         diag.note("untranslatable diagnostic");
    |              ^^^^
 
 error: diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
-  --> $DIR/diagnostics.rs:67:22
+  --> $DIR/diagnostics.rs:68:22
    |
 LL |     let _diag = sess.struct_err(fluent::parser::expect_path);
    |                      ^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/diagnostics.rs:6:9
+  --> $DIR/diagnostics.rs:7:9
    |
 LL | #![deny(rustc::diagnostic_outside_of_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
-  --> $DIR/diagnostics.rs:70:22
+  --> $DIR/diagnostics.rs:71:22
    |
 LL |     let _diag = sess.struct_err("untranslatable diagnostic");
    |                      ^^^^^^^^^^
 
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:70:22
+  --> $DIR/diagnostics.rs:71:22
    |
 LL |     let _diag = sess.struct_err("untranslatable diagnostic");
    |                      ^^^^^^^^^^


### PR DESCRIPTION
Functions annotated with `#[rustc_lint_diagnostics]` are used by the diagnostic migration lints to know when to lint, but functions that are annotated with this attribute shouldn't themselves be linted.

cc #100717 https://github.com/rust-lang/rust/pull/101041#discussion_r959303706
