### PR TITLE
Fix  bad target name in Walkthrough

### DIFF
--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -79,7 +79,7 @@ the following commands:
 
 ```sh
 rustup target add x86_64-fuchsia
-rustup target add aarch_64-fuchsia
+rustup target add aarch64-fuchsia
 ```
 
 After installing our Fuchsia targets, we can now compile a Rust binary that targets


### PR DESCRIPTION
Walkthrough currently say:

```
rustup target add aarch_64-fuchsia
```
but should say

```
rustup target add aarch64-fuchsia
```