### PR TITLE
Propagate `ExactSizeIterator` up from `Chain`'s iterators

### DIFF
--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -285,11 +285,8 @@ where
 impl<A, B> ExactSizeIterator for Chain<A, B>
 where
     A: ExactSizeIterator,
-    B: ExactSizeIterator,
+    B: ExactSizeIterator<Item = A::Item>,
 {
-    fn len(&self) -> usize {
-        maybe!(self.a.len()).unwrap_or(0) + maybe!(self.b.len()).unwrap_or(0)
-    }
 }
 
 #[inline]

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -1,4 +1,4 @@
-use crate::iter::{DoubleEndedIterator, FusedIterator, Iterator, TrustedLen};
+use crate::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator, TrustedLen};
 use crate::ops::Try;
 
 /// An iterator that links two iterators together, in a chain.
@@ -280,6 +280,16 @@ where
     A: TrustedLen,
     B: TrustedLen<Item = A::Item>,
 {
+}
+
+impl<A, B> ExactSizeIterator for Chain<A, B>
+where
+    A: ExactSizeIterator,
+    B: ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        maybe!(self.a.len()).unwrap_or(0) + maybe!(self.b.len()).unwrap_or(0)
+    }
 }
 
 #[inline]

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -285,7 +285,7 @@ where
 impl<A, B> ExactSizeIterator for Chain<A, B>
 where
     A: ExactSizeIterator,
-    B: ExactSizeIterator<Item = A::Item>,
+    B: ExactSizeIterator,
 {
 }
 


### PR DESCRIPTION
Wasn't entirely sure if this was intentional but noticed that `Chain` does not implement `ExactSizeIterator` if their internal iterators do.

I leave the implementation up to the existing `size_hint`.