### PR TITLE
fix the suggestion of format for asm_sub_register

### DIFF
--- a/compiler/rustc_typeck/src/check/intrinsicck.rs
+++ b/compiler/rustc_typeck/src/check/intrinsicck.rs
@@ -333,10 +333,10 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                         let mut err = lint.build(msg);
                         err.span_label(expr.span, "for this argument");
                         err.help(&format!(
-                            "use the `{suggested_modifier}` modifier to have the register formatted as `{suggested_result}`",
+                            "use `{{{idx}:{suggested_modifier}}}` to have the register formatted as `{suggested_result}`",
                         ));
                         err.help(&format!(
-                            "or use the `{default_modifier}` modifier to keep the default formatting of `{default_result}`",
+                            "or use `{{{idx}:{default_modifier}}}` to keep the default formatting of `{default_result}`",
                         ));
                         err.emit();
                     },

--- a/src/test/ui/asm/aarch64/type-check-3.stderr
+++ b/src/test/ui/asm/aarch64/type-check-3.stderr
@@ -5,8 +5,8 @@ LL |         asm!("{}", in(reg) 0u8);
    |               ^^           --- for this argument
    |
    = note: `#[warn(asm_sub_register)]` on by default
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:50:15
@@ -14,8 +14,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(reg) 0u16);
    |               ^^           ---- for this argument
    |
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:52:15
@@ -23,8 +23,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(reg) 0i32);
    |               ^^           ---- for this argument
    |
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:54:15
@@ -32,8 +32,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(reg) 0f32);
    |               ^^           ---- for this argument
    |
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:57:15
@@ -41,8 +41,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(vreg) 0i16);
    |               ^^            ---- for this argument
    |
-   = help: use the `h` modifier to have the register formatted as `h0`
-   = help: or use the `v` modifier to keep the default formatting of `v0`
+   = help: use `{0:h}` to have the register formatted as `h0`
+   = help: or use `{0:v}` to keep the default formatting of `v0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:59:15
@@ -50,8 +50,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(vreg) 0f32);
    |               ^^            ---- for this argument
    |
-   = help: use the `s` modifier to have the register formatted as `s0`
-   = help: or use the `v` modifier to keep the default formatting of `v0`
+   = help: use `{0:s}` to have the register formatted as `s0`
+   = help: or use `{0:v}` to keep the default formatting of `v0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:61:15
@@ -59,8 +59,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(vreg) 0f64);
    |               ^^            ---- for this argument
    |
-   = help: use the `d` modifier to have the register formatted as `d0`
-   = help: or use the `v` modifier to keep the default formatting of `v0`
+   = help: use `{0:d}` to have the register formatted as `d0`
+   = help: or use `{0:v}` to keep the default formatting of `v0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:63:15
@@ -68,8 +68,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(vreg_low16) 0f64);
    |               ^^                  ---- for this argument
    |
-   = help: use the `d` modifier to have the register formatted as `d0`
-   = help: or use the `v` modifier to keep the default formatting of `v0`
+   = help: use `{0:d}` to have the register formatted as `d0`
+   = help: or use `{0:v}` to keep the default formatting of `v0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:66:15
@@ -77,8 +77,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{0} {0}", in(reg) 0i16);
    |               ^^^ ^^^           ---- for this argument
    |
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:68:15
@@ -86,8 +86,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{0} {0:x}", in(reg) 0i16);
    |               ^^^                 ---- for this argument
    |
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 error: type `i128` cannot be used with this register class
   --> $DIR/type-check-3.rs:73:28

--- a/src/test/ui/asm/bad-template.aarch64_mirunsafeck.stderr
+++ b/src/test/ui/asm/bad-template.aarch64_mirunsafeck.stderr
@@ -190,8 +190,8 @@ LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument
    |
    = note: `#[warn(asm_sub_register)]` on by default
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 error: aborting due to 21 previous errors; 1 warning emitted
 

--- a/src/test/ui/asm/bad-template.aarch64_thirunsafeck.stderr
+++ b/src/test/ui/asm/bad-template.aarch64_thirunsafeck.stderr
@@ -190,8 +190,8 @@ LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument
    |
    = note: `#[warn(asm_sub_register)]` on by default
-   = help: use the `w` modifier to have the register formatted as `w0`
-   = help: or use the `x` modifier to keep the default formatting of `x0`
+   = help: use `{0:w}` to have the register formatted as `w0`
+   = help: or use `{0:x}` to keep the default formatting of `x0`
 
 error: aborting due to 21 previous errors; 1 warning emitted
 

--- a/src/test/ui/asm/bad-template.x86_64_mirunsafeck.stderr
+++ b/src/test/ui/asm/bad-template.x86_64_mirunsafeck.stderr
@@ -190,8 +190,8 @@ LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument
    |
    = note: `#[warn(asm_sub_register)]` on by default
-   = help: use the `e` modifier to have the register formatted as `eax`
-   = help: or use the `r` modifier to keep the default formatting of `rax`
+   = help: use `{0:e}` to have the register formatted as `eax`
+   = help: or use `{0:r}` to keep the default formatting of `rax`
 
 error: aborting due to 21 previous errors; 1 warning emitted
 

--- a/src/test/ui/asm/bad-template.x86_64_thirunsafeck.stderr
+++ b/src/test/ui/asm/bad-template.x86_64_thirunsafeck.stderr
@@ -190,8 +190,8 @@ LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument
    |
    = note: `#[warn(asm_sub_register)]` on by default
-   = help: use the `e` modifier to have the register formatted as `eax`
-   = help: or use the `r` modifier to keep the default formatting of `rax`
+   = help: use `{0:e}` to have the register formatted as `eax`
+   = help: or use `{0:r}` to keep the default formatting of `rax`
 
 error: aborting due to 21 previous errors; 1 warning emitted
 

--- a/src/test/ui/asm/x86_64/type-check-3.stderr
+++ b/src/test/ui/asm/x86_64/type-check-3.stderr
@@ -45,8 +45,8 @@ LL |         asm!("{0} {0}", in(reg) 0i16);
    |               ^^^ ^^^           ---- for this argument
    |
    = note: `#[warn(asm_sub_register)]` on by default
-   = help: use the `x` modifier to have the register formatted as `ax`
-   = help: or use the `r` modifier to keep the default formatting of `rax`
+   = help: use `{0:x}` to have the register formatted as `ax`
+   = help: or use `{0:r}` to keep the default formatting of `rax`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:36:15
@@ -54,8 +54,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{0} {0:x}", in(reg) 0i16);
    |               ^^^                 ---- for this argument
    |
-   = help: use the `x` modifier to have the register formatted as `ax`
-   = help: or use the `r` modifier to keep the default formatting of `rax`
+   = help: use `{0:x}` to have the register formatted as `ax`
+   = help: or use `{0:r}` to keep the default formatting of `rax`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:38:15
@@ -63,8 +63,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(reg) 0i32);
    |               ^^           ---- for this argument
    |
-   = help: use the `e` modifier to have the register formatted as `eax`
-   = help: or use the `r` modifier to keep the default formatting of `rax`
+   = help: use `{0:e}` to have the register formatted as `eax`
+   = help: or use `{0:r}` to keep the default formatting of `rax`
 
 warning: formatting may not be suitable for sub-register argument
   --> $DIR/type-check-3.rs:41:15
@@ -72,8 +72,8 @@ warning: formatting may not be suitable for sub-register argument
 LL |         asm!("{}", in(ymm_reg) 0i64);
    |               ^^               ---- for this argument
    |
-   = help: use the `x` modifier to have the register formatted as `xmm0`
-   = help: or use the `y` modifier to keep the default formatting of `ymm0`
+   = help: use `{0:x}` to have the register formatted as `xmm0`
+   = help: or use `{0:y}` to keep the default formatting of `ymm0`
 
 error: type `i8` cannot be used with this register class
   --> $DIR/type-check-3.rs:52:28


### PR DESCRIPTION
	modified:   compiler/rustc_typeck/src/check/intrinsicck.rs
	modified:   src/test/ui/asm/bad-template.aarch64_mirunsafeck.stderr
	modified:   src/test/ui/asm/bad-template.aarch64_thirunsafeck.stderr
	modified:   src/test/ui/asm/bad-template.x86_64_mirunsafeck.stderr
	modified:   src/test/ui/asm/bad-template.x86_64_thirunsafeck.stderr
	modified:   src/test/ui/asm/type-check-1.rs
	modified:   src/test/ui/asm/type-check-1.stderr
	modified:   src/test/ui/asm/x86_64/type-check-3.stderr