### PR TITLE
rustdoc: remove unused `.docblock .impl-items` CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -759,14 +759,6 @@ pre, .rustdoc.source .example-wrap {
 	margin-bottom: 15px;
 }
 
-.content .docblock > .impl-items {
-	margin-left: 20px;
-	margin-top: -34px;
-}
-.content .docblock >.impl-items table td {
-	padding: 0;
-}
-
 .item-info {
 	display: block;
 }


### PR DESCRIPTION
The impl-items list stopped being nested inside a docblock since c1b1d6804bfce1aee3a95b3cbff3eaeb15bad9a4