### PR TITLE
Extend pointer cast to be able to return thin (including extern) types

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -43,8 +43,9 @@ impl<T: ?Sized> *const T {
     #[stable(feature = "ptr_cast", since = "1.38.0")]
     #[rustc_const_stable(feature = "const_ptr_cast", since = "1.38.0")]
     #[inline]
-    pub const fn cast<U>(self) -> *const U {
-        self as _
+    pub const fn cast<U: ?Sized + Thin>(self) -> *const U {
+        // TODO: Just use `self as _` when the compiler understands `Thin`
+        from_raw_parts(self as *const (), ())
     }
 
     /// Use the pointer value in a new pointer of another type.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -41,9 +41,10 @@ impl<T: ?Sized> *mut T {
     /// Casts to a pointer of another type.
     #[stable(feature = "ptr_cast", since = "1.38.0")]
     #[rustc_const_stable(feature = "const_ptr_cast", since = "1.38.0")]
-    #[inline(always)]
-    pub const fn cast<U>(self) -> *mut U {
-        self as _
+    #[inline]
+    pub const fn cast<U: ?Sized + Thin>(self) -> *mut U {
+        // TODO: Just use `self as _` when the compiler understands `Thin`
+        from_raw_parts_mut(self as *mut (), ())
     }
 
     /// Use the pointer value in a new pointer of another type.

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -6,7 +6,7 @@ use crate::marker::Unsize;
 use crate::mem::{self, MaybeUninit};
 use crate::num::NonZeroUsize;
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
-use crate::ptr::Unique;
+use crate::ptr::{Thin, Unique};
 use crate::slice::{self, SliceIndex};
 
 /// `*mut T` but non-zero and [covariant].
@@ -450,9 +450,9 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[inline]
-    pub const fn cast<U>(self) -> NonNull<U> {
+    pub const fn cast<U: ?Sized + Thin>(self) -> NonNull<U> {
         // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null
-        unsafe { NonNull::new_unchecked(self.as_ptr() as *mut U) }
+        unsafe { NonNull::new_unchecked(self.as_ptr().cast()) }
     }
 }
 


### PR DESCRIPTION
Motivation: To make migrating to `extern type` easier.

While this type of casting is achievable today using a normal `as` cast, it requires that the type is known since the compiler doesn't know that it can handle a `Thin` bound specially. While that would also be nice to fix, this PR is at least a first step.

Unsure of how to proceed with this, as the implementation now uses `from_raw_parts` and `from_raw_parts_mut` which are unstable in `const` contexts.

Relatedly, see https://github.com/rust-lang/rust/issues/93959.