### PR TITLE
Use `FILE_ATTRIBUTE_TAG_INFO` to get reparse tag

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -455,6 +455,12 @@ pub enum FILE_INFO_BY_HANDLE_CLASS {
 }
 
 #[repr(C)]
+pub struct FILE_ATTRIBUTE_TAG_INFO {
+    pub FileAttributes: DWORD,
+    pub ReparseTag: DWORD,
+}
+
+#[repr(C)]
 pub struct FILE_DISPOSITION_INFO {
     pub DeleteFile: BOOLEAN,
 }


### PR DESCRIPTION
I've been looking at this code recently and it just occurred to me we don't actually use the full reparse data at this point, only the tag. [`GetFileInformationByHandleEx`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getfileinformationbyhandleex) can do exactly that by filling a [`FILE_ATTRIBUTE_TAG_INFO`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_attribute_tag_info) struct.

r? @thomcc since you've made changes here recently (which is why I have this code on my mind atm)