### PR TITLE
Fix doc_auto_cfg for impl blocks in different modules with different `cfg`

### DIFF
--- a/src/test/rustdoc/doc_auto_cfg_nested_impl.rs
+++ b/src/test/rustdoc/doc_auto_cfg_nested_impl.rs
@@ -1,0 +1,24 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/101129>.
+
+#![feature(doc_auto_cfg)]
+#![crate_type = "lib"]
+#![crate_name = "foo"]
+
+pub struct S;
+pub trait MyTrait1 {}
+pub trait MyTrait2 {}
+
+// @has foo/struct.S.html
+// @has - '//*[@id="impl-MyTrait1-for-S"]//*[@class="stab portability"]' \
+//        'Available on non-crate feature coolstuff only.'
+#[cfg(not(feature = "coolstuff"))]
+impl MyTrait1 for S {}
+
+#[cfg(not(feature = "coolstuff"))]
+mod submod {
+    use crate::{S, MyTrait2};
+    // This impl should also have the `not(feature = "coolstuff")`.
+    // @has - '//*[@id="impl-MyTrait2-for-S"]//*[@class="stab portability"]' \
+    //        'Available on non-crate feature coolstuff only.'
+    impl MyTrait2 for S {}
+}


### PR DESCRIPTION
Fixes #101129.

Just like reexports, impl blocks don't necessarily share the same "space" as the item they implement so we need to merge attributes from its parents as well.

r? @notriddle 