### PR TITLE
Document eager evaluation of `bool::then_some` argument

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -6,6 +6,12 @@ impl bool {
     /// Returns `Some(t)` if the `bool` is [`true`](../std/keyword.true.html),
     /// or `None` otherwise.
     ///
+    /// Arguments passed to `then_some` are eagerly evaluated; if you are 
+    /// passing the result of a function call, it is recommended to use 
+    /// [`then`], which is lazily evaluated.
+    /// 
+    /// [`then`]: bool::then
+    /// 
     /// # Examples
     ///
     /// ```

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -6,12 +6,12 @@ impl bool {
     /// Returns `Some(t)` if the `bool` is [`true`](../std/keyword.true.html),
     /// or `None` otherwise.
     ///
-    /// Arguments passed to `then_some` are eagerly evaluated; if you are 
-    /// passing the result of a function call, it is recommended to use 
+    /// Arguments passed to `then_some` are eagerly evaluated; if you are
+    /// passing the result of a function call, it is recommended to use
     /// [`then`], which is lazily evaluated.
-    /// 
+    ///
     /// [`then`]: bool::then
-    /// 
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
I encountered this earlier today and thought maybe `bool::then_some` could use a little addition to the documentation.

It's pretty obvious with familiarity and from looking at the implementation, but the argument for `then_some` is eagerly evaluated, which means if you do the following (as I did), you can have a problem:

```rust
// Oops!
let _ = something
    .has_another_thing()
    .then_some(something.another_thing_or_panic());
```

A note, similar to other methods with eagerly-evaluated arguments and a lazy alternative (`Option::or`, for example), could help point this out to people who forget (like me)!