### PR TITLE
Recover when unclosed char literal is parsed as a lifetime in some positions

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -461,6 +461,9 @@ pub enum StashKey {
     UnderscoreForArrayLengths,
     EarlySyntaxWarning,
     CallIntoMethod,
+    /// When an invalid lifetime e.g. `'2` should be reinterpreted
+    /// as a char literal in the parser
+    LifetimeIsChar,
 }
 
 fn default_track_diagnostic(_: &Diagnostic) {}

--- a/src/test/ui/parser/issues/issue-93282.rs
+++ b/src/test/ui/parser/issues/issue-93282.rs
@@ -12,4 +12,5 @@ fn foo() {
     let x = 1;
     bar('y, x);
     //~^ ERROR expected
+    //~| ERROR mismatched types
 }

--- a/src/test/ui/parser/issues/issue-93282.stderr
+++ b/src/test/ui/parser/issues/issue-93282.stderr
@@ -3,6 +3,11 @@ error: expected `while`, `for`, `loop` or `{` after a label
    |
 LL |     f<'a,>
    |         ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     f<'a',>
+   |         +
 
 error: expected one of `.`, `:`, `;`, `?`, `for`, `loop`, `while`, `}`, or an operator, found `,`
   --> $DIR/issue-93282.rs:2:9
@@ -20,6 +25,26 @@ error: expected `while`, `for`, `loop` or `{` after a label
    |
 LL |     bar('y, x);
    |           ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     bar('y', x);
+   |           +
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-93282.rs:13:9
+   |
+LL |     bar('y, x);
+   |     --- ^^ expected `usize`, found `char`
+   |     |
+   |     arguments to this function are incorrect
+   |
+note: function defined here
+  --> $DIR/issue-93282.rs:7:4
+   |
+LL | fn bar(a: usize, b: usize) -> usize {
+   |    ^^^ --------
 
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/label-is-actually-char.rs
+++ b/src/test/ui/parser/label-is-actually-char.rs
@@ -1,0 +1,16 @@
+fn main() {
+    let c = 'a;
+    //~^ ERROR expected `while`, `for`, `loop` or `{` after a label
+    //~| HELP add `'` to close the char literal
+    match c {
+        'a'..='b => {}
+        //~^ ERROR unexpected token: `'b`
+        //~| HELP add `'` to close the char literal
+        _ => {}
+    }
+    let x = ['a, 'b];
+    //~^ ERROR expected `while`, `for`, `loop` or `{` after a label
+    //~| ERROR expected `while`, `for`, `loop` or `{` after a label
+    //~| HELP add `'` to close the char literal
+    //~| HELP add `'` to close the char literal
+}

--- a/src/test/ui/parser/label-is-actually-char.stderr
+++ b/src/test/ui/parser/label-is-actually-char.stderr
@@ -1,0 +1,46 @@
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/label-is-actually-char.rs:2:15
+   |
+LL |     let c = 'a;
+   |               ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     let c = 'a';
+   |               +
+
+error: unexpected token: `'b`
+  --> $DIR/label-is-actually-char.rs:6:15
+   |
+LL |         'a'..='b => {}
+   |               ^^
+   |
+help: add `'` to close the char literal
+   |
+LL |         'a'..='b' => {}
+   |                 +
+
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/label-is-actually-char.rs:11:16
+   |
+LL |     let x = ['a, 'b];
+   |                ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     let x = ['a', 'b];
+   |                +
+
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/label-is-actually-char.rs:11:20
+   |
+LL |     let x = ['a, 'b];
+   |                    ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     let x = ['a, 'b'];
+   |                    +
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/parser/numeric-lifetime.stderr
+++ b/src/test/ui/parser/numeric-lifetime.stderr
@@ -1,3 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/numeric-lifetime.rs:6:20
+   |
+LL |     let x: usize = "";
+   |            -----   ^^ expected `usize`, found `&str`
+   |            |
+   |            expected due to this
+
 error: lifetimes cannot start with a number
   --> $DIR/numeric-lifetime.rs:1:10
    |
@@ -9,14 +17,6 @@ error: lifetimes cannot start with a number
    |
 LL | struct S<'1> { s: &'1 usize }
    |                    ^^
-
-error[E0308]: mismatched types
-  --> $DIR/numeric-lifetime.rs:6:20
-   |
-LL |     let x: usize = "";
-   |            -----   ^^ expected `usize`, found `&str`
-   |            |
-   |            expected due to this
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/require-parens-for-chained-comparison.rs
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.rs
@@ -23,11 +23,13 @@ fn main() {
     //~^ ERROR expected one of
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
     //~| ERROR expected
+    //~| HELP add `'` to close the char literal
 
     f<'_>();
     //~^ comparison operators cannot be chained
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
     //~| ERROR expected
+    //~| HELP add `'` to close the char literal
 
     let _ = f<u8>;
     //~^ ERROR comparison operators cannot be chained

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -58,6 +58,11 @@ error: expected `while`, `for`, `loop` or `{` after a label
    |
 LL |     let _ = f<'_, i8>();
    |                 ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     let _ = f<'_', i8>();
+   |                 +
 
 error: expected one of `.`, `:`, `;`, `?`, `else`, `for`, `loop`, `while`, or an operator, found `,`
   --> $DIR/require-parens-for-chained-comparison.rs:22:17
@@ -71,13 +76,18 @@ LL |     let _ = f::<'_, i8>();
    |              ++
 
 error: expected `while`, `for`, `loop` or `{` after a label
-  --> $DIR/require-parens-for-chained-comparison.rs:27:9
+  --> $DIR/require-parens-for-chained-comparison.rs:28:9
    |
 LL |     f<'_>();
    |         ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     f<'_'>();
+   |         +
 
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:27:6
+  --> $DIR/require-parens-for-chained-comparison.rs:28:6
    |
 LL |     f<'_>();
    |      ^  ^
@@ -88,7 +98,7 @@ LL |     f::<'_>();
    |      ++
 
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:32:14
+  --> $DIR/require-parens-for-chained-comparison.rs:34:14
    |
 LL |     let _ = f<u8>;
    |              ^  ^


### PR DESCRIPTION
Fixes #101278