### PR TITLE
Remove unused .toggle-label CSS rule

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1242,12 +1242,6 @@ h3.variant {
 	margin-left: 24px;
 }
 
-.toggle-label {
-	display: inline-block;
-	margin-left: 4px;
-	margin-top: 3px;
-}
-
 :target > code, :target > .code-header {
 	opacity: 1;
 }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -242,7 +242,6 @@ a.test-arrow:hover {
 	color: #c5c5c5;
 }
 
-.toggle-label,
 .code-attribute {
 	color: #999;
 }

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -197,7 +197,6 @@ a.test-arrow:hover{
 	background-color: #4e8bca;
 }
 
-.toggle-label,
 .code-attribute {
 	color: #999;
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -182,7 +182,6 @@ a.test-arrow:hover{
 	background-color: #4e8bca;
 }
 
-.toggle-label,
 .code-attribute {
 	color: #999;
 }


### PR DESCRIPTION
It was added in https://github.com/rust-lang/rust/pull/44192 but since we moved to `<details>`, we don't use this rule any more.

r? @notriddle 