### PR TITLE
Add armv5te-none-eabi and thumbv5te-none-eabi targets

### DIFF
--- a/compiler/rustc_target/src/spec/armv5te_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv5te_none_eabi.rs
@@ -1,6 +1,6 @@
 //! Targets the ARMv5TE, with code as `a32` code by default.
 
-use crate::spec::{cvs, LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOptions};
+use crate::spec::{cvs, FramePointer, Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -20,8 +20,6 @@ pub fn target() -> Target {
 
         options: TargetOptions {
             abi: "eabi".into(),
-            linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
-            linker: Some("rust-lld".into()),
             // extra args passed to the external assembler (assuming `arm-none-eabi-as`):
             // * activate t32/a32 interworking
             // * use arch ARMv5TE
@@ -31,18 +29,13 @@ pub fn target() -> Target {
             // Also force-enable 32-bit atomics, which allows the use of atomic load/store only.
             // The resulting atomics are ABI incompatible with atomics backed by libatomic.
             features: "+soft-float,+strict-align,+atomics-32".into(),
+            frame_pointer: FramePointer::MayOmit,
             main_needs_argc_argv: false,
             // don't have atomic compare-and-swap
             atomic_cas: false,
             has_thumb_interworking: true,
-            relocation_model: RelocModel::Static,
-            panic_strategy: PanicStrategy::Abort,
-            // from thumb_base, rust-lang/rust#44993.
-            emit_debug_gdb_scripts: false,
-            // from thumb_base, apparently gcc/clang give enums a minimum of 8 bits on no-os targets
-            c_enum_min_bits: 8,
 
-            ..Default::default()
+            ..super::thumb_base::opts()
         },
     }
 }

--- a/compiler/rustc_target/src/spec/armv5te_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv5te_none_eabi.rs
@@ -1,8 +1,6 @@
 //! Targets the ARMv5TE, with code as `a32` code by default.
 
-use crate::spec::{
-    cvs, LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOptions
-};
+use crate::spec::{cvs, LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {

--- a/compiler/rustc_target/src/spec/armv5te_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv5te_none_eabi.rs
@@ -1,0 +1,50 @@
+//! Targets the ARMv5TE, with code as `a32` code by default.
+
+use crate::spec::{
+    cvs, LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOptions
+};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "armv5te-none-eabi".into(),
+        pointer_width: 32,
+        arch: "arm".into(),
+        /* Data layout args are '-' separated:
+         * little endian
+         * stack is 64-bit aligned (EABI)
+         * pointers are 32-bit
+         * i64 must be 64-bit aligned (EABI)
+         * mangle names with ELF style
+         * native integers are 32-bit
+         * All other elements are default
+         */
+        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
+
+        options: TargetOptions {
+            abi: "eabi".into(),
+            linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
+            linker: Some("rust-lld".into()),
+            // extra args passed to the external assembler (assuming `arm-none-eabi-as`):
+            // * activate t32/a32 interworking
+            // * use arch ARMv5TE
+            // * use little-endian
+            asm_args: cvs!["-mthumb-interwork", "-march=armv5te", "-mlittle-endian",],
+            // minimum extra features, these cannot be disabled via -C
+            // Also force-enable 32-bit atomics, which allows the use of atomic load/store only.
+            // The resulting atomics are ABI incompatible with atomics backed by libatomic.
+            features: "+soft-float,+strict-align,+atomics-32".into(),
+            main_needs_argc_argv: false,
+            // don't have atomic compare-and-swap
+            atomic_cas: false,
+            has_thumb_interworking: true,
+            relocation_model: RelocModel::Static,
+            panic_strategy: PanicStrategy::Abort,
+            // from thumb_base, rust-lang/rust#44993.
+            emit_debug_gdb_scripts: false,
+            // from thumb_base, apparently gcc/clang give enums a minimum of 8 bits on no-os targets
+            c_enum_min_bits: 8,
+
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1082,6 +1082,8 @@ supported_targets! {
     ("mipsel-unknown-none", mipsel_unknown_none),
     ("thumbv4t-none-eabi", thumbv4t_none_eabi),
     ("armv4t-none-eabi", armv4t_none_eabi),
+    ("thumbv5te-none-eabi", thumbv5te_none_eabi),
+    ("armv5te-none-eabi", armv5te_none_eabi),
 
     ("aarch64_be-unknown-linux-gnu", aarch64_be_unknown_linux_gnu),
     ("aarch64-unknown-linux-gnu_ilp32", aarch64_unknown_linux_gnu_ilp32),

--- a/compiler/rustc_target/src/spec/thumbv5te_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/thumbv5te_none_eabi.rs
@@ -1,0 +1,41 @@
+//! Targets the ARMv5TE, with code as `t32` code by default.
+
+use crate::spec::{cvs, FramePointer, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "thumbv5te-none-eabi".into(),
+        pointer_width: 32,
+        arch: "arm".into(),
+        /* Data layout args are '-' separated:
+         * little endian
+         * stack is 64-bit aligned (EABI)
+         * pointers are 32-bit
+         * i64 must be 64-bit aligned (EABI)
+         * mangle names with ELF style
+         * native integers are 32-bit
+         * All other elements are default
+         */
+        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
+
+        options: TargetOptions {
+            abi: "eabi".into(),
+            // extra args passed to the external assembler (assuming `arm-none-eabi-as`):
+            // * activate t32/a32 interworking
+            // * use arch ARMv5TE
+            // * use little-endian
+            asm_args: cvs!["-mthumb-interwork", "-march=armv5te", "-mlittle-endian",],
+            // minimum extra features, these cannot be disabled via -C
+            // Also force-enable 32-bit atomics, which allows the use of atomic load/store only.
+            // The resulting atomics are ABI incompatible with atomics backed by libatomic.
+            features: "+soft-float,+strict-align,+atomics-32".into(),
+            frame_pointer: FramePointer::MayOmit,
+            main_needs_argc_argv: false,
+            // don't have atomic compare-and-swap
+            atomic_cas: false,
+            has_thumb_interworking: true,
+
+            ..super::thumb_base::opts()
+        },
+    }
+}

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -19,6 +19,7 @@
     - [\*-apple-watchos\*](platform-support/apple-watchos.md)
     - [aarch64-nintendo-switch-freestanding](platform-support/aarch64-nintendo-switch-freestanding.md)
     - [armv4t-none-eabi](platform-support/armv4t-none-eabi.md)
+    - [armv5te-none-eabi](platform-support/armv5te-none-eabi.md)
     - [armv6k-nintendo-3ds](platform-support/armv6k-nintendo-3ds.md)
     - [armv7-unknown-linux-uclibceabi](platform-support/armv7-unknown-linux-uclibceabi.md)
     - [armv7-unknown-linux-uclibceabihf](platform-support/armv7-unknown-linux-uclibceabihf.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -225,6 +225,7 @@ target | std | host | notes
 [`arm64_32-apple-watchos`](platform-support/apple-watchos.md) | ✓ | | ARM Apple WatchOS 64-bit with 32-bit pointers
 `armv4t-none-eabi` | * |  | ARMv4T A32
 `armv4t-unknown-linux-gnueabi` | ? |  |
+[`armv5te-none-eabi`](platform-support/armv5te-none-eabi.md) | * | | ARMv5TE A32
 `armv5te-unknown-linux-uclibceabi` | ? |  | ARMv5TE Linux with uClibc
 `armv6-unknown-freebsd` | ✓ | ✓ | ARMv6 FreeBSD
 `armv6-unknown-netbsd-eabihf` | ? |  |
@@ -291,6 +292,7 @@ target | std | host | notes
 `sparc64-unknown-netbsd` | ✓ | ✓ | NetBSD/sparc64
 [`sparc64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | OpenBSD/sparc64
 `thumbv4t-none-eabi` | * |  | ARMv4T T32
+[`thumbv5te-none-eabi`](platform-support/armv5te-none-eabi.md) | * | | ARMv5TE T32
 `thumbv7a-pc-windows-msvc` | ? |  |
 `thumbv7a-uwp-windows-msvc` | ✓ |  |
 `thumbv7neon-unknown-linux-musleabihf` | ? |  | Thumb2-mode ARMv7a Linux with NEON, MUSL

--- a/src/doc/rustc/src/platform-support/armv5te-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv5te-none-eabi.md
@@ -3,13 +3,10 @@
 **Tier: 3**
 
 Bare-metal target for any cpu in the ARMv5TE architecture family, supporting
-ARM/Thumb code interworking (aka `a32`/`t32`), with ARM code as the default code
+ARM/Thumb code interworking (aka `a32`/`t32`), with `a32` code as the default code
 generation.
 
-The `thumbv5te-none-eabi` target is the same as this one, but with THUMB code as the default.
-
-In particular this supports the main CPU of the Nintendo DS, but there's nothing DS
-specific with this target, so any ARMv5TE device should work fine.
+The `thumbv5te-none-eabi` target is the same as this one, but the instruction set defaults to `t32`.
 
 ## Target Maintainers
 
@@ -58,12 +55,6 @@ Most of `core` should work as expected, with the following notes:
 `alloc` is also supported, as long as you provide your own global allocator.
 
 Rust programs are output as ELF files.
-
-For running on DS hardware, you'll need to use an external tool to bundle this ELF file into an NDS binary. The `ndstool` utility included with devkitARM is one such tool that can do this for you:
-
-```shell
-ndstool -c [out_nds] -9 [in_elf]
-```
 
 ## Testing
 

--- a/src/doc/rustc/src/platform-support/armv5te-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv5te-none-eabi.md
@@ -1,0 +1,75 @@
+# `armv5te-none-eabi`
+
+**Tier: 3**
+
+Bare-metal target for any cpu in the ARMv5TE architecture family, supporting
+ARM/Thumb code interworking (aka `a32`/`t32`), with ARM code as the default code
+generation.
+
+The `thumbv5te-none-eabi` target is the same as this one, but with THUMB code as the default.
+
+In particular this supports the main CPU of the Nintendo DS, but there's nothing DS
+specific with this target, so any ARMv5TE device should work fine.
+
+## Target Maintainers
+
+* [@QuinnPainter](https://github.com/QuinnPainter)
+
+## Requirements
+
+The target is cross-compiled, and uses static linking.
+
+By default, the `lld` linker included with Rust will be used.
+
+However, you may want to use the `arm-none-eabi-ld` linker instead. This can be obtained for Windows/Mac/Linux from the [ARM
+Developer Website][arm-dev], or possibly from your OS's package manager. To use it, add the following to your `.cargo/config.toml`:
+
+```toml
+[target.armv5te-none-eabi]
+linker = "arm-none-eabi-ld"
+```
+
+[arm-dev]: https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain
+
+This target doesn't provide a linker script, you'll need to bring your own
+according to the specific device you want to target. Pass
+`-Clink-arg=-Tyour_script.ld` as a rustc argument to make the linker use
+`your_script.ld` during linking.
+
+## Building Rust Programs
+
+Because it is Tier 3, rust does not yet ship pre-compiled artifacts for this target.
+
+Just use the `build-std` nightly cargo feature to build the `core` library. You
+can pass this as a command line argument to cargo, or your `.cargo/config.toml`
+file might include the following lines:
+
+```toml
+[unstable]
+build-std = ["core"]
+```
+
+Most of `core` should work as expected, with the following notes:
+* the target is "soft float", so `f32` and `f64` operations are emulated in
+  software.
+* integer division is also emulated in software.
+* the target is old enough that it doesn't have atomic instructions.
+
+`alloc` is also supported, as long as you provide your own global allocator.
+
+Rust programs are output as ELF files.
+
+For running on DS hardware, you'll need to use an external tool to bundle this ELF file into an NDS binary. The `ndstool` utility included with devkitARM is one such tool that can do this for you:
+
+```shell
+ndstool -c [out_nds] -9 [in_elf]
+```
+
+## Testing
+
+This is a cross-compiled target that you will need to emulate during testing.
+
+Because this is a device-agnostic target, and the exact emulator that you'll
+need depends on the specific device you want to run your code on.
+
+For example, when programming for the DS, you can use one of the several available DS emulators, such as [melonDS](https://melonds.kuribo64.net/).


### PR DESCRIPTION
Creates two new Tier 3 targets, `armv5te-none-eabi` and `thumbv5te-none-eabi`. They are for the same target architecture (armv5te), but one defaults to the A32 instruction set and the other defaults to T32. Based on the existing `armv4t-none-eabi` and `thumbv4t-none-eabi` targets.

My particular use case for these targets is Nintendo DS homebrew, but they should be usable for any armv5te system.

Going through the Tier 3 target policy:

> A tier 3 target must have a designated developer or developers (the "target maintainers") on record to be CCed when issues arise regarding the target. (The mechanism to track and CC such developers may evolve over time.)

That will be me.

> Targets must use naming consistent with any existing targets.

Naming is consistent with previous targets.

>> Target names should not introduce undue confusion or ambiguity unless absolutely necessary to maintain ecosystem compatibility.

No ambiguity here.

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users.

Doesn't create any legal issues.

>> The target must not introduce license incompatibilities.

This doesn't introduce any new licenses.

>> Anything added to the Rust repository must be under the standard Rust license (MIT OR Apache-2.0).

Yep.

>> The target must not cause the Rust tools or libraries built for any other host (even when supporting cross-compilation to the target) to depend on any new dependency less permissive than the Rust licensing policy. This applies whether the dependency is a Rust crate that would require adding new license exceptions (as specified by the tidy tool in the rust-lang/rust repository), or whether the dependency is a native library or binary. In other words, the introduction of the target must not cause a user installing or running a version of Rust or the Rust tools to be subject to any new license requirements.

No new license requirements.

>> Compiling, linking, and emitting functional binaries, libraries, or other code for the target (whether hosted on the target itself or cross-compiling from another target) must not depend on proprietary (non-FOSS) libraries.

Everything this uses is FOSS, no proprietary required.

> Neither this policy nor any decisions made regarding targets shall create any binding agreement or estoppel by any party. If any member of an approving Rust team serves as one of the maintainers of a target, or has any legal or employment requirement (explicit or implicit) that might affect their decisions regarding a target, they must recuse themselves from any approval decisions regarding the target's tier status, though they may otherwise participate in discussions.

OK.

>> This requirement does not prevent part or all of this policy from being cited in an explicit contract or work agreement (e.g. to implement or maintain support for a target). This requirement exists to ensure that a developer or team responsible for reviewing and approving a target does not face any legal threats or obligations that would prevent them from freely exercising their judgment in such approval, even if such judgment involves subjective matters or goes beyond the letter of these requirements.

OK.

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate (core for most targets, alloc for targets that can support dynamic memory allocation, std for targets with an operating system or equivalent layer of system-provided functionality), but may leave some code unimplemented (either unavailable or stubbed out as appropriate), whether because the target makes it impossible to implement or challenging to implement. The authors of pull requests are not obligated to avoid calling any portions of the standard library on the basis of a tier 3 target not implementing those portions.

This is a bare-metal target with only support for `core` (and `alloc`, if the user provides an allocator).

> The target must provide documentation for the Rust community explaining how to build for the target, using cross-compilation if possible. If the target supports running binaries, or running tests (even if they do not pass), the documentation must explain how to run such binaries or tests for the target, using emulation if possible or dedicated hardware if necessary.

Documentation has been added.

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on a tier 3 target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding a tier 3 target, unless they have opted into such messages.

OK.

> Backlinks such as those generated by the issue/PR tracker when linking to an issue or PR are not considered a violation of this policy, within reason. However, such messages (even on a separate repository) must not generate notifications to anyone involved with a PR who has not requested such notifications.

OK.

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target.

This doesn't break any other targets.

>> In particular, this may come up when working on closely related targets, such as variations of the same architecture with different features. Avoid introducing unconditional uses of features that another variation of the target may not have; use conditional compilation or runtime detection, as appropriate, to let each target run code supported by that target.

No unnecessary unconditional features here.