### PR TITLE
Fix `std::collections::HashSet::drain` documentation

### DIFF
--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -239,7 +239,7 @@ impl<T, S> HashSet<T, S> {
     ///
     /// If the returned iterator is dropped before being fully consumed, it
     /// drops the remaining elements. The returned iterator keeps a mutable
-    /// borrow on the vector to optimize its implementation.
+    /// borrow on the set to optimize its implementation.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Hi!

`std::collections::HashSet::drain` contains small typo in the docstring.

I didn't read too much about the model of contributing to Rust, so merge this PR or close and fix the typo the right way :)

Thanks for Rust!