### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ defaults:
     shell: bash
 jobs:
   pr:
+    permissions:
+      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
     name: PR
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
@@ -144,6 +146,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}"
         if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
   auto:
+    permissions:
+      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
     name: auto
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
@@ -549,6 +553,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}"
         if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
   try:
+    permissions:
+      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
     name: try
     env:
       CI_JOB_NAME: "${{ matrix.name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ defaults:
 jobs:
   pr:
     permissions:
-      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
+      actions: write
     name: PR
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
@@ -147,7 +147,7 @@ jobs:
         if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
   auto:
     permissions:
-      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
+      actions: write
     name: auto
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
@@ -554,7 +554,7 @@ jobs:
         if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
   try:
     permissions:
-      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
+      actions: write
     name: try
     env:
       CI_JOB_NAME: "${{ matrix.name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ name: CI
   pull_request:
     branches:
       - "**"
+permissions:
+  contents: read
 defaults:
   run:
     shell: bash

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -264,6 +264,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     # On Linux, macOS, and Windows, use the system-provided bash as the default

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -277,7 +277,7 @@ defaults:
 jobs:
   pr:
     permissions:
-      actions: write
+      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
     <<: *base-ci-job
     name: PR
     env:
@@ -299,7 +299,7 @@ jobs:
 
   auto:
     permissions:
-      actions: write
+      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
     <<: *base-ci-job
     name: auto
     env:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -276,6 +276,8 @@ defaults:
 
 jobs:
   pr:
+    permissions:
+      actions: write
     <<: *base-ci-job
     name: PR
     env:
@@ -296,6 +298,8 @@ jobs:
             <<: *job-linux-xl
 
   auto:
+    permissions:
+      actions: write
     <<: *base-ci-job
     name: auto
     env:
@@ -722,6 +726,8 @@ jobs:
             <<: *job-windows-xl
 
   try:
+    permissions:
+      actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds
     <<: *base-ci-job
     name: try
     env:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.