### PR TITLE
rustdoc: remove old CSS selector that causes weird spacing

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -778,10 +778,6 @@ pre, .rustdoc.source .example-wrap {
 	margin-bottom: .6em;
 }
 
-.content .impl-items > .item-info {
-	margin-left: 40px;
-}
-
 .impl-items {
 	flex-basis: 100%;
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2007,6 +2007,11 @@ in storage.js plus the media query with (min-width: 701px)
 	#main-content > div > details.rustdoc-toggle > summary::before {
 		left: -11px;
 	}
+
+	/* Align summary-nested and unnested item-info gizmos. */
+	.content .impl-items > .item-info {
+		margin-left: 34px;
+	}
 }
 
 @media print {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -782,10 +782,6 @@ pre, .rustdoc.source .example-wrap {
 	margin-left: 40px;
 }
 
-.methods > .item-info, .content .impl-items > .item-info {
-	margin-top: -8px;
-}
-
 .impl-items {
 	flex-basis: 100%;
 }

--- a/src/test/rustdoc-gui/item-info-alignment.goml
+++ b/src/test/rustdoc-gui/item-info-alignment.goml
@@ -1,0 +1,10 @@
+// This test ensures that the "item-info" looks about the same
+// whether or not it's inside a toggle.
+goto: file://|DOC_PATH|/lib2/struct.ItemInfoAlignmentTest.html
+
+// First, we try it in "desktop" mode.
+size: (1200, 870)
+compare-elements-position: (".impl-items > .item-info", "summary > .item-info", ("x"))
+// Next, we try it in "mobile" mode (max-width: 700px).
+size: (650, 650)
+compare-elements-position: (".impl-items > .item-info", "summary > .item-info", ("x"))

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -170,3 +170,13 @@ where
     type Output;
     fn index(&self, index: Idx) -> &Self::Output;
 }
+
+pub struct ItemInfoAlignmentTest;
+
+impl ItemInfoAlignmentTest {
+    /// This method has docs
+    #[deprecated]
+    pub fn foo() {}
+    #[deprecated]
+    pub fn bar() {}
+}


### PR DESCRIPTION
It was added with e08a84a0c18739417a50c3e46917ced5037244eb (actually, it was called `.methods > .stability` at the time) and was directly nested that way.

**EDIT**: It is technically reachable code still, but it seems wrong.

## With the old CSS rule still present

https://notriddle.com/notriddle-rustdoc-test/weird-spacing/lib/struct.Foo.html

![image](https://user-images.githubusercontent.com/1593513/188216226-c667c560-d33d-494f-a492-4e0ec3ac0009.png)

## Version 2 (an older version of this PR)

https://notriddle.com/notriddle-rustdoc-test/normal-spacing-2/lib/struct.Foo.html

![image](https://user-images.githubusercontent.com/1593513/188216418-9fcd3109-f1b2-425d-b4fc-0c6b3b54e48e.png)

## Version 3 (with alignment fix for mobile)

https://notriddle.com/notriddle-rustdoc-test/normal-spacing-3/lib/struct.Foo.html

![image](https://user-images.githubusercontent.com/1593513/188223161-0e1ebce7-842f-41cb-8a0c-ae43aedcfccc.png)
