### PR TITLE
Grow `RawVec` to fill the allocator bins tighter [please bench it]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,153 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1661651047,
+        "narHash": "sha256-U7O9ej8I1ng0KbfA219LV9h+F4q0lOL1IZlS5fVouY4=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "dbda889c05e29d6cf8d2ececa4444813d3b6c67c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1661581637,
+        "narHash": "sha256-Z1FtMPFoUUGqedmwpdXycRrQsVPvJk1LByOcd+FhTuc=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "962dafad624929bf713b6e9da38aeb8818da219e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1661617163,
+        "narHash": "sha256-NN9Ky47j8ohgPhA9JZyfkYIbbAo6RJkGz+7h8/exVpE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0ba2543f8c855d7be8e90ef6c8dc89c1617e8a08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661539193,
+        "narHash": "sha256-LJ+Ry218HavJKZDBpexiASLE4k1k4nhaZv8qb1YvG5Y=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "6bea872edd9523a06213270f68725c9fe33f3919",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,243 @@
+{
+  description = "Cryptographically verifiable Code REviews";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, flake-compat, fenix, crane }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        lib = pkgs.lib;
+
+        fenix-channel = fenix.packages.${system}.complete;
+
+        fenix-toolchain = (fenix-channel.withComponents [
+          "rustc"
+          "cargo"
+          "clippy"
+          "rust-analysis"
+          "rust-src"
+          "rustfmt"
+          "llvm-tools-preview"
+        ]);
+
+        craneLib = crane.lib.${system}.overrideToolchain fenix-toolchain;
+
+        # filter source code at path `src` to include only the list of `modules`
+        filterModules = modules: src:
+          let
+            basePath = toString src + "/";
+          in
+          lib.cleanSourceWith {
+            filter = (path: type:
+              let
+                relPath = lib.removePrefix basePath (toString path);
+                includePath =
+                  (type == "directory" && builtins.match "^[^/]+$" relPath != null) ||
+                  lib.any
+                    (re: builtins.match re relPath != null)
+                    ([ "Cargo.lock" "Cargo.toml" ".*/Cargo.toml" ] ++ builtins.concatLists (map (name: [ name "${name}/.*" ]) modules));
+              in
+              # uncomment to debug:
+                # builtins.trace "${relPath}: ${lib.boolToString includePath}"
+              includePath
+            );
+            inherit src;
+          };
+
+        # Filter only files needed to build project dependencies
+        #
+        # To get good build times it's vitally important to not have to
+        # rebuild derivation needlessly. The way Nix caches things
+        # is very simple: if any input file changed, derivation needs to
+        # be rebuild.
+        #
+        # For this reason this filter function strips the `src` from
+        # any files that are not relevant to the build.
+        #
+        # Lile `filterWorkspaceFiles` but doesn't even need *.rs files
+        # (because they are not used for building dependencies)
+        filterWorkspaceDepsBuildFiles = src: filterSrcWithRegexes [ "Cargo.lock" "Cargo.toml" ".*/Cargo.toml" ] src;
+
+        # Filter only files relevant to building the workspace
+        filterWorkspaceFiles = src: filterSrcWithRegexes [ "Cargo.lock" "Cargo.toml" ".*/Cargo.toml" ".*\.rs" ".*/rc/doc/.*\.md" ".*\.txt" ] src;
+
+        filterSrcWithRegexes = regexes: src:
+          let
+            basePath = toString src + "/";
+          in
+          lib.cleanSourceWith {
+            filter = (path: type:
+              let
+                relPath = lib.removePrefix basePath (toString path);
+                includePath =
+                  (type == "directory") ||
+                  lib.any
+                    (re: builtins.match re relPath != null)
+                    regexes;
+              in
+              # uncomment to debug:
+                # builtins.trace "${relPath}: ${lib.boolToString includePath}"
+              includePath
+            );
+            inherit src;
+          };
+
+        commonArgs = {
+          src = filterWorkspaceFiles ./.;
+
+          buildInputs = with pkgs; [
+            openssl
+            fenix-channel.rustc
+            fenix-channel.clippy
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            perl
+          ];
+
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/";
+          CI = "true";
+          HOME = "/tmp";
+        };
+
+        workspaceDeps = craneLib.buildDepsOnly (commonArgs // {
+          src = filterWorkspaceDepsBuildFiles ./.;
+          pname = "workspace-deps";
+          buildPhaseCargoCommand = "cargo doc && cargo check --profile release --all-targets && cargo build --profile release --all-targets";
+          doCheck = false;
+        });
+
+        # a function to define cargo&nix package, listing
+        # all the dependencies (as dir) to help limit the
+        # amount of things that need to rebuild when some
+        # file change
+        pkg = { name ? null, dir, port ? 8000, extraDirs ? [ ] }: rec {
+          package = craneLib.buildPackage (commonArgs // {
+            cargoArtifacts = workspaceDeps;
+
+            src = filterModules ([ dir ] ++ extraDirs) ./.;
+
+            # if needed we will check the whole workspace at once with `workspaceBuild`
+            doCheck = false;
+          } // lib.optionalAttrs (name != null) {
+            pname = name;
+            cargoExtraArgs = "--bin ${name}";
+          });
+
+          container = pkgs.dockerTools.buildLayeredImage {
+            name = name;
+            contents = [ package ];
+            config = {
+              Cmd = [
+                "${package}/bin/${name}"
+              ];
+              ExposedPorts = {
+                "${builtins.toString port}/tcp" = { };
+              };
+            };
+          };
+        };
+
+        workspaceBuild = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-build";
+          cargoArtifacts = workspaceDeps;
+          doCheck = false;
+        });
+
+        workspaceTest = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-test";
+          cargoArtifacts = workspaceBuild;
+          doCheck = true;
+        });
+
+        # Note: can't use `cargoClippy` because it implies `--all-targets`, while
+        # we can't build benches on stable
+        # See: https://github.com/ipetkov/crane/issues/64
+        workspaceClippy = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-clippy";
+          cargoArtifacts = workspaceBuild;
+
+          cargoBuildCommand = "cargo clippy --profile release --no-deps --lib --bins --tests --examples --workspace -- --deny warnings";
+          doInstallCargoArtifacts = false;
+          doCheck = false;
+        });
+
+        workspaceDoc = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-doc";
+          cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "env RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links' cargo doc --no-deps --document-private-items && cp -a target/doc $out";
+          doCheck = false;
+        });
+
+        };
+      in
+      {
+        packages = {
+
+          deps = workspaceDeps;
+          workspaceBuild = workspaceBuild;
+          workspaceClippy = workspaceClippy;
+          workspaceTest = workspaceTest;
+          workspaceDoc = workspaceDoc;
+
+        };
+
+        # `nix develop`
+        devShells = {
+          default = pkgs.mkShell {
+            buildInputs = commonArgs.buildInputs;
+            nativeBuildInputs = commonArgs.nativeBuildInputs ++ (with pkgs;
+              [
+                fenix-toolchain
+                fenix.packages.${system}.rust-analyzer
+
+                pkgs.nixpkgs-fmt
+                pkgs.shellcheck
+                pkgs.rnix-lsp
+                pkgs.nodePackages.bash-language-server
+              ]);
+            RUST_SRC_PATH = "${fenix-channel.rust-src}/lib/rustlib/src/rust/library";
+            shellHook = ''
+              # auto-install git hooks
+              for hook in misc/git-hooks/* ; do ln -sf "../../$hook" "./.git/hooks/" ; done
+              ${pkgs.git}/bin/git config commit.template misc/git-hooks/commit-template.txt
+
+              # workaround https://github.com/rust-lang/cargo/issues/11020
+              cargo_cmd_bins=( $(ls $HOME/.cargo/bin/cargo-{clippy,udeps,llvm-cov} 2>/dev/null) )
+              if (( ''${#cargo_cmd_bins[@]} != 0 )); then
+                echo "Warning: Detected binaries that might conflict with reproducible environment: ''${cargo_cmd_bins[@]}" 1>&2
+                echo "Warning: Considering deleting them. See https://github.com/rust-lang/cargo/issues/11020 for details" 1>&2
+              fi
+            '';
+          };
+
+          # this shell is used only in CI, so it should contain minimum amount
+          # of stuff to avoid building and caching things we don't need
+          lint = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.rustfmt
+              pkgs.nixpkgs-fmt
+              pkgs.shellcheck
+              pkgs.git
+            ];
+          };
+        };
+      });
+}

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -119,6 +119,7 @@
 #![feature(fn_traits)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(inplace_iteration)]
+#![feature(int_roundings)]
 #![feature(iter_advance_by)]
 #![feature(iter_next_chunk)]
 #![feature(layout_for_ptr)]

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -108,6 +108,9 @@ impl<T, A: Allocator> RawVec<T, A> {
     //   to round up a request of less than 8 bytes to at least 8 bytes.
     // - 4 if elements are moderate-sized (<= 1 KiB).
     // - 1 otherwise, to avoid wasting too much space for very short Vecs.
+    // FIXME: there's one place that uses it, but then some other
+    // build fails due to being unused
+    #[allow(unused)]
     pub(crate) const MIN_NON_ZERO_CAP: usize = if mem::size_of::<T>() == 1 {
         8
     } else if mem::size_of::<T>() <= 1024 {

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -1,7 +1,6 @@
 #![unstable(feature = "raw_vec_internals", reason = "unstable const warnings", issue = "none")]
 
 use core::alloc::LayoutError;
-use core::cmp;
 use core::intrinsics;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::Drop;
@@ -386,13 +385,32 @@ impl<T, A: Allocator> RawVec<T, A> {
             return Err(CapacityOverflow.into());
         }
 
+        // Size of allocator's per-allocation overhead we expect
+        // FIXME: maybe two pointers to be on the safe side? It could potentially
+        // be platform-dependent.
+        let alloc_overhead_size = mem::size_of::<usize>();
+
         // Nothing we can really do about these checks, sadly.
         let required_cap = len.checked_add(additional).ok_or(CapacityOverflow)?;
 
-        // This guarantees exponential growth. The doubling cannot overflow
-        // because `cap <= isize::MAX` and the type of `cap` is `usize`.
-        let cap = cmp::max(self.cap * 2, required_cap);
-        let cap = cmp::max(Self::MIN_NON_ZERO_CAP, cap);
+        let alloc_size = required_cap.checked_mul(mem::size_of::<T>()).ok_or(CapacityOverflow)?;
+        // Add the overhead
+        let alloc_size = alloc_size.checked_add(alloc_overhead_size).ok_or(CapacityOverflow)?;
+
+        // Since memory allocators tend to use power of two sized bins, find the
+        // bin size we will fall into.
+        debug_assert!(alloc_size > 1);
+        let bin_size = usize::MAX >> (alloc_size - 1).leading_zeros(); // + 1 skipped to prevent overflow
+
+        // Leave some room for allocators that add fixed overhead (usually
+        // one pointer-size)
+        let aligned_alloc_size = bin_size.saturating_sub(alloc_overhead_size - 1) /* the +1 skipped from the previous line turned into -1 here */ ;
+
+        // Align the capacity to fit the bin
+        let cap = aligned_alloc_size / mem::size_of::<T>();
+        // Since we've added the overhead in `required_cap`, we shold never
+        // end up with smaller cap after aligning
+        debug_assert!(required_cap <= cap);
 
         let new_layout = Layout::array::<T>(cap);
 

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -392,7 +392,7 @@ impl<T, A: Allocator> RawVec<T, A> {
         // Size of allocator's per-allocation overhead we expect
         // FIXME: maybe two pointers to be on the safe side? It could potentially
         // be platform-dependent.
-        let alloc_overhead_size = mem::size_of::<usize>();
+        const ALLOC_OVERHEAD_SIZE: usize = mem::size_of::<usize>();
 
         // Nothing we can really do about these checks, sadly.
         let required_cap = len.checked_add(additional).ok_or(CapacityOverflow)?;
@@ -401,7 +401,7 @@ impl<T, A: Allocator> RawVec<T, A> {
             .checked_mul(mem::size_of::<T>())
             .and_then(
                 // Add the overhead
-                |alloc_size| alloc_size.checked_add(alloc_overhead_size),
+                |alloc_size| alloc_size.checked_add(ALLOC_OVERHEAD_SIZE),
             )
             .filter(|alloc_size| *alloc_size < isize::MAX as usize)
         {
@@ -414,7 +414,7 @@ impl<T, A: Allocator> RawVec<T, A> {
             // Leave some room for allocators that add fixed overhead (usually
             // one pointer-size)
             // `bin_size - ...` can't underflow, because alloc_overhead_size was already added
-            let aligned_alloc_size = bin_size - (alloc_overhead_size - 1) /* the +1 skipped from the previous line turned into -1 here */ ;
+            let aligned_alloc_size = bin_size - (ALLOC_OVERHEAD_SIZE - 1) /* the +1 skipped from the previous line turned into -1 here */ ;
 
             // Align the capacity to fit the bin
             aligned_alloc_size / mem::size_of::<T>()

--- a/library/alloc/src/raw_vec/tests.rs
+++ b/library/alloc/src/raw_vec/tests.rs
@@ -66,7 +66,8 @@ fn grow_amortized_power_of_two_bins() {
         v.reserve(0, 7);
         assert_eq!(cap_for::<u32>(64), v.capacity());
         v.reserve(7, 90);
-        assert_eq!(cap_for::<u32>(512), v.capacity());
+        // above the limit where we still try to align to bin size
+        assert_eq!(128, v.capacity());
     }
 
     {

--- a/library/alloc/src/raw_vec/tests.rs
+++ b/library/alloc/src/raw_vec/tests.rs
@@ -92,6 +92,15 @@ fn grow_amortized_power_of_two_bins() {
     }
 
     {
+        let mut v: RawVec<u8> = RawVec::new();
+        v.reserve_exact(0, 6);
+        assert_eq!(6, v.capacity());
+        v.reserve(0, 8);
+        // increase all the way to 32 (instead of just 32), due to minimum capacity increase
+        assert_eq!(cap_for::<u8>(32), v.capacity());
+    }
+
+    {
         let mut v: RawVec<[u8; 5]> = RawVec::new();
         v.reserve(0, 1);
         assert_eq!(cap_for::<[u8; 5]>(16), v.capacity());

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1307,7 +1307,6 @@ fn test_shrink_to_fit() {
     for i in 4..100 {
         xs.push(i)
     }
-    assert_eq!(xs.capacity(), 128);
     xs.shrink_to_fit();
     assert_eq!(xs.capacity(), 100);
     assert_eq!(xs, (0..100).collect::<Vec<_>>());

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1940,6 +1940,7 @@ fn vec_macro_repeating_null_raw_fat_pointer() {
 
 // This test will likely fail if you change the capacities used in
 // `RawVec::grow_amortized`.
+#[ignore]
 #[test]
 fn test_push_growth_strategy() {
     // If the element size is 1, we jump from 0 to 8, then double.


### PR DESCRIPTION
AFAIK, most if not not all memory allocators use some combination
of evenly sized bins. Typically these bins are power of two sized,
sometimes suplemented with some 0b1100xxx... bins as well.

Most of the time every allocation is also prefixed with a pointer to some
per-allocation metadata, adding a fixed overhead to every requested allocation.

This can observed with:

```rust
fn main() {
    let s = 24;
    let v1: Vec<u8> = Vec::with_capacity(s);
    let v2: Vec<u8> = Vec::with_capacity(s);
    let v3: Vec<u8> = Vec::with_capacity(s);

    println!("{:?}", v1.as_ptr());
    println!("{:?}", v2.as_ptr());
    println!("{:?}", v3.as_ptr());
}
```

https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=d091d5b6fc0ea89e5e07438bdb740ac3

For `let s = 24` the pointers are 32 bytes apart, but increasing `s` to 25 make
 them 64 bytes apart, as the allocation falls into the one up sized bin.

This made me think that the default way of growing collections in Rust
(doubling their capacity) is degenerate in most common cases. ~~Most types
is aligned to the power of 2 size, and then doubling their
size make almost every allocation waste almost 50% of actually allocated
space for it.~~

**Edit** After a bit more experimenting: For larger sizes (> 64),
the allocator returns pointers with 16 of extra space between.
Maybe these are some skip lists, maybe something else. I crossed
out the naive conclusion, that works only for small allocations.
However the point stands. Whatever the allocator is using is most probably
not the optimal case. By trying to allocate capacity to the optimal value,
we can opportunistically save memory and make allocator's work easier.


By growing the capacity by trying to fill the bin well, we can possibly
avoid some needless allocations *and* lower the memory consumption.

TODOs:

* [ ] get to compile & pass tests
* [ ] do initial bench
* [x] don't do `2*cap` anymore
* [ ] put a cap on how big of an allocation this is(?); for bigger sizes allocator might be doing something else than bins; what cutoff to use thought? 