### PR TITLE
rustdoc: remove `.impl-items { flex-basis }` CSS, not in flex container

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -778,10 +778,6 @@ pre, .rustdoc.source .example-wrap {
 	margin-bottom: .6em;
 }
 
-.impl-items {
-	flex-basis: 100%;
-}
-
 #main-content > .item-info {
 	margin-top: 0;
 	margin-left: 0;


### PR DESCRIPTION
Added in 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9

For this to actually do anything, [according to MDN] (and Firefox Dev Tools), it must be a "flex item", which only happens if its a direct child of a node with `display: flex` on it. It seems like it could not have worked at the time when this rule was added, because the only items in `rustdoc.css` with `display: flex` active were:

* `#help`

  This should not contain anything like this.

* `.impl-items h4, h4.impl, h3.impl`

  These are all headers, so they shouldn't contain `.impl-items` either.

* `.content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant`

  Associated constants and methods definitely shouldn't contain a list of impl items, and the `.type` class seems to refer to type aliases, which, when shown inside of an impl, only show a link to the aliased type.

[according to MDN]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis

Nowadays, `display: flex` is a lot more prolific, but `.impl-items` still seems to only be used in plain block parents:

* If it's not a trait impl, then it's nested below a `<div>` with an id but no class, added in a5216cf67d93de97091b41ecba85de2e08f39863. This will be `display: block`, probably. For example, [vec deref]
* Inherent impls also get a `<div>` tag, for example [vec impl], and they are also wrapped by their own non-flexbox `<details>` tag.
* If it's a tait implementation, then it's also nested below a `<details>` container, like [deref cstring].

[vec impl]: https://doc.rust-lang.org/1.63.0/std/vec/struct.Vec.html#impl
[vec deref]: https://doc.rust-lang.org/1.63.0/std/vec/struct.Vec.html#deref-methods-%5BT%5D
[deref cstring]: https://doc.rust-lang.org/1.63.0/std/ops/trait.Deref.html#impl-Deref

Also, this would imply that trait items ought to take up as much space as possible, pushing everything else to the edge of the screen. If this is nested directly below the `.rustdoc` container, which has a row basis, that would be bad.