### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -52,7 +52,7 @@ impl AttrWrapper {
     // Prepend `self.attrs` to `attrs`.
     // FIXME: require passing an NT to prevent misuse of this method
     pub(crate) fn prepend_to_nt_inner(self, attrs: &mut AttrVec) {
-        let mut self_attrs = self.attrs.clone();
+        let mut self_attrs = self.attrs;
         std::mem::swap(attrs, &mut self_attrs);
         attrs.extend(self_attrs);
     }

--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -562,6 +562,7 @@ Finally, run the component:
 
 ```sh
 ${SDK_PATH}/tools/${ARCH}/ffx component run \
+    /core/ffx-laboratory:hello_fuchsia \
     fuchsia-pkg://hello-fuchsia/hello_fuchsia_manifest#meta/hello_fuchsia.cm
 ```
 
@@ -571,6 +572,7 @@ passed.
 ```sh
 ${SDK_PATH}/tools/${ARCH}/ffx component run \
     --recreate \
+    /core/ffx-laboratory:hello_fuchsia \
     fuchsia-pkg://hello-fuchsia/hello_fuchsia_manifest#meta/hello_fuchsia.cm
 ```
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -778,10 +778,6 @@ pre, .rustdoc.source .example-wrap {
 	margin-bottom: .6em;
 }
 
-.content .impl-items > .item-info {
-	margin-left: 40px;
-}
-
 .impl-items {
 	flex-basis: 100%;
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2007,6 +2007,11 @@ in storage.js plus the media query with (min-width: 701px)
 	#main-content > div > details.rustdoc-toggle > summary::before {
 		left: -11px;
 	}
+
+	/* Align summary-nested and unnested item-info gizmos. */
+	.content .impl-items > .item-info {
+		margin-left: 34px;
+	}
 }
 
 @media print {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -782,10 +782,6 @@ pre, .rustdoc.source .example-wrap {
 	margin-left: 40px;
 }
 
-.methods > .item-info, .content .impl-items > .item-info {
-	margin-top: -8px;
-}
-
 .impl-items {
 	flex-basis: 100%;
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -486,7 +486,7 @@ impl FromWithTcx<clean::Type> for Type {
             },
             QPath(box clean::QPathData { assoc, self_type, trait_, .. }) => Type::QualifiedPath {
                 name: assoc.name.to_string(),
-                args: Box::new(assoc.args.clone().into_tcx(tcx)),
+                args: Box::new(assoc.args.into_tcx(tcx)),
                 self_type: Box::new(self_type.into_tcx(tcx)),
                 trait_: trait_.into_tcx(tcx),
             },

--- a/src/test/codegen/issue-98294-get-mut-copy-from-slice-opt.rs
+++ b/src/test/codegen/issue-98294-get-mut-copy-from-slice-opt.rs
@@ -1,0 +1,18 @@
+// min-llvm-version: 15.0.0
+// compile-flags: -O
+
+#![crate_type = "lib"]
+
+// There should be no calls to panic / len_mismatch_fail.
+
+#[no_mangle]
+pub fn test(a: &mut [u8], offset: usize, bytes: &[u8]) {
+    // CHECK-LABEL: @test(
+    // CHECK-NOT: call
+    // CHECK: call void @llvm.memcpy
+    // CHECK-NOT: call
+    // CHECK: }
+    if let Some(dst) = a.get_mut(offset..offset + bytes.len()) {
+        dst.copy_from_slice(bytes);
+    }
+}

--- a/src/test/rustdoc-gui/item-info-alignment.goml
+++ b/src/test/rustdoc-gui/item-info-alignment.goml
@@ -1,0 +1,10 @@
+// This test ensures that the "item-info" looks about the same
+// whether or not it's inside a toggle.
+goto: file://|DOC_PATH|/lib2/struct.ItemInfoAlignmentTest.html
+
+// First, we try it in "desktop" mode.
+size: (1200, 870)
+compare-elements-position: (".impl-items > .item-info", "summary > .item-info", ("x"))
+// Next, we try it in "mobile" mode (max-width: 700px).
+size: (650, 650)
+compare-elements-position: (".impl-items > .item-info", "summary > .item-info", ("x"))

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -170,3 +170,13 @@ where
     type Output;
     fn index(&self, index: Idx) -> &Self::Output;
 }
+
+pub struct ItemInfoAlignmentTest;
+
+impl ItemInfoAlignmentTest {
+    /// This method has docs
+    #[deprecated]
+    pub fn foo() {}
+    #[deprecated]
+    pub fn bar() {}
+}

--- a/src/test/ui/argument-suggestions/basic.stderr
+++ b/src/test/ui/argument-suggestions/basic.stderr
@@ -26,7 +26,7 @@ LL | fn extra() {}
 help: remove the extra argument
    |
 LL |     extra();
-   |     ~~~~~~~
+   |          ~~
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/basic.rs:22:5
@@ -42,7 +42,7 @@ LL | fn missing(_i: u32) {}
 help: provide the argument
    |
 LL |     missing(/* u32 */);
-   |     ~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/basic.rs:23:5
@@ -60,7 +60,7 @@ LL | fn swapped(_i: u32, _s: &str) {}
 help: swap these arguments
    |
 LL |     swapped(1, "");
-   |     ~~~~~~~~~~~~~~
+   |            ~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/basic.rs:24:5
@@ -79,7 +79,7 @@ LL | fn permuted(_x: X, _y: Y, _z: Z) {}
 help: reorder these arguments
    |
 LL |     permuted(X {}, Y {}, Z {});
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~
 
 error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/basic.rs:27:5
@@ -95,7 +95,7 @@ LL |     let closure = |x| x;
 help: provide the argument
    |
 LL |     closure(/* value */);
-   |     ~~~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/argument-suggestions/complex.stderr
+++ b/src/test/ui/argument-suggestions/complex.stderr
@@ -12,7 +12,7 @@ LL | fn complex(_i: u32, _s: &str, _e: E, _f: F, _g: G, _x: X, _y: Y, _z: Z ) {}
 help: did you mean
    |
 LL |   complex(/* u32 */, &"", /* E */, F::X2, G{}, X {}, Y {}, Z {});
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/argument-suggestions/exotic-calls.stderr
+++ b/src/test/ui/argument-suggestions/exotic-calls.stderr
@@ -12,7 +12,7 @@ LL | fn foo<T: Fn()>(t: T) {
 help: remove the extra argument
    |
 LL |     t();
-   |     ~~~
+   |      ~~
 
 error[E0057]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/exotic-calls.rs:7:5
@@ -28,7 +28,7 @@ LL | fn bar(t: impl Fn()) {
 help: remove the extra argument
    |
 LL |     t();
-   |     ~~~
+   |      ~~
 
 error[E0057]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/exotic-calls.rs:16:5
@@ -44,7 +44,7 @@ LL | fn baz() -> impl Fn() {
 help: remove the extra argument
    |
 LL |     baz()()
-   |
+   |          ~~
 
 error[E0057]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/exotic-calls.rs:22:5
@@ -60,7 +60,7 @@ LL |     let x = || {};
 help: remove the extra argument
    |
 LL |     x();
-   |     ~~~
+   |      ~~
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/argument-suggestions/extra_arguments.stderr
+++ b/src/test/ui/argument-suggestions/extra_arguments.stderr
@@ -12,7 +12,7 @@ LL | fn empty() {}
 help: remove the extra argument
    |
 LL |   empty();
-   |   ~~~~~~~
+   |        ~~
 
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:9:3
@@ -28,7 +28,7 @@ LL | fn one_arg(_a: i32) {}
 help: remove the extra argument
    |
 LL |   one_arg(1);
-   |   ~~~~~~~~~~
+   |          ~~~
 
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:10:3
@@ -44,7 +44,7 @@ LL | fn one_arg(_a: i32) {}
 help: remove the extra argument
    |
 LL |   one_arg(1);
-   |   ~~~~~~~~~~
+   |          ~~~
 
 error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:11:3
@@ -62,7 +62,7 @@ LL | fn one_arg(_a: i32) {}
 help: remove the extra arguments
    |
 LL |   one_arg(1);
-   |   ~~~~~~~~~~
+   |          ~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:13:3
@@ -78,7 +78,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
 help: remove the extra argument
    |
 LL |   two_arg_same(1, 1);
-   |   ~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:14:3
@@ -94,7 +94,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
 help: remove the extra argument
    |
 LL |   two_arg_same(1, 1);
-   |   ~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:16:3
@@ -110,7 +110,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
 help: remove the extra argument
    |
 LL |   two_arg_diff(1, "");
-   |   ~~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:17:3
@@ -126,7 +126,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
 help: remove the extra argument
    |
 LL |   two_arg_diff(1, "");
-   |   ~~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/extra_arguments.rs:18:3
@@ -144,7 +144,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
 help: remove the extra arguments
    |
 LL |   two_arg_diff(1, "");
-   |   ~~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/extra_arguments.rs:19:3
@@ -162,7 +162,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
 help: remove the extra arguments
    |
 LL |   two_arg_diff(1, "");
-   |   ~~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:22:3
@@ -178,7 +178,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
 help: remove the extra argument
    |
 LL |   two_arg_same(1, 1);
-   |   ~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:23:3
@@ -194,7 +194,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
 help: remove the extra argument
    |
 LL |   two_arg_diff(1, "");
-   |   ~~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:24:3
@@ -213,7 +213,7 @@ LL | fn two_arg_same(_a: i32, _b: i32) {}
 help: remove the extra argument
    |
 LL |   two_arg_same(1, 1);
-   |   ~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:30:3
@@ -232,7 +232,7 @@ LL | fn two_arg_diff(_a: i32, _b: &str) {}
 help: remove the extra argument
    |
 LL |   two_arg_diff(1, "");
-   |   ~~~~~~~~~~~~~~~~~~~
+   |               ~~~~~~~
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/argument-suggestions/issue-96638.stderr
+++ b/src/test/ui/argument-suggestions/issue-96638.stderr
@@ -14,7 +14,7 @@ LL | fn f(_: usize, _: &usize, _: usize) {}
 help: provide the argument
    |
 LL |     f(/* usize */, &x, /* usize */);
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/argument-suggestions/issue-97197.stderr
+++ b/src/test/ui/argument-suggestions/issue-97197.stderr
@@ -12,7 +12,7 @@ LL | pub fn g(a1: (), a2: bool, a3: bool, a4: bool, a5: bool, a6: ()) -> () {}
 help: provide the arguments
    |
 LL |     g((), /* bool */, /* bool */, /* bool */, /* bool */, ());
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/argument-suggestions/issue-97484.stderr
+++ b/src/test/ui/argument-suggestions/issue-97484.stderr
@@ -20,7 +20,7 @@ LL |     foo(&&A, B, C, D, &E, F, G);
 help: remove the extra arguments
    |
 LL |     foo(&&A, D, /* &E */, G);
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~
+   |        ~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/argument-suggestions/issue-98894.stderr
+++ b/src/test/ui/argument-suggestions/issue-98894.stderr
@@ -12,7 +12,7 @@ LL |     (|_, ()| ())(if true {} else {return;});
 help: provide the argument
    |
 LL |     (|_, ()| ())(if true {} else {return;}, ());
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/argument-suggestions/issue-98897.stderr
+++ b/src/test/ui/argument-suggestions/issue-98897.stderr
@@ -12,7 +12,7 @@ LL |     (|_, ()| ())([return, ()]);
 help: provide the argument
    |
 LL |     (|_, ()| ())([return, ()], ());
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/argument-suggestions/issue-99482.stderr
+++ b/src/test/ui/argument-suggestions/issue-99482.stderr
@@ -12,7 +12,7 @@ LL |     let f = |_: (), f: fn()| f;
 help: provide the argument
    |
 LL |     let _f = f((), main);
-   |              ~~~~~~~~~~~
+   |               ~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/argument-suggestions/missing_arguments.stderr
+++ b/src/test/ui/argument-suggestions/missing_arguments.stderr
@@ -12,7 +12,7 @@ LL | fn one_arg(_a: i32) {}
 help: provide the argument
    |
 LL |   one_arg(/* i32 */);
-   |   ~~~~~~~~~~~~~~~~~~
+   |          ~~~~~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:14:3
@@ -28,7 +28,7 @@ LL | fn two_same(_a: i32, _b: i32) {}
 help: provide the arguments
    |
 LL |   two_same(/* i32 */, /* i32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:15:3
@@ -44,7 +44,7 @@ LL | fn two_same(_a: i32, _b: i32) {}
 help: provide the argument
    |
 LL |   two_same(1, /* i32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:16:3
@@ -60,7 +60,7 @@ LL | fn two_diff(_a: i32, _b: f32) {}
 help: provide the arguments
    |
 LL |   two_diff(/* i32 */, /* f32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:17:3
@@ -76,7 +76,7 @@ LL | fn two_diff(_a: i32, _b: f32) {}
 help: provide the argument
    |
 LL |   two_diff(1, /* f32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:18:3
@@ -92,7 +92,7 @@ LL | fn two_diff(_a: i32, _b: f32) {}
 help: provide the argument
    |
 LL |   two_diff(/* i32 */, 1.0);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:21:3
@@ -108,7 +108,7 @@ LL | fn three_same(_a: i32, _b: i32, _c: i32) {}
 help: provide the arguments
    |
 LL |   three_same(/* i32 */, /* i32 */, /* i32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:22:3
@@ -124,7 +124,7 @@ LL | fn three_same(_a: i32, _b: i32, _c: i32) {}
 help: provide the arguments
    |
 LL |   three_same(1, /* i32 */, /* i32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:23:3
@@ -140,7 +140,7 @@ LL | fn three_same(_a: i32, _b: i32, _c: i32) {}
 help: provide the argument
    |
 LL |   three_same(1, 1, /* i32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:26:3
@@ -156,7 +156,7 @@ LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
 help: provide the argument
    |
 LL |   three_diff(/* i32 */, 1.0, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:27:3
@@ -172,7 +172,7 @@ LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
 help: provide the argument
    |
 LL |   three_diff(1, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:28:3
@@ -188,7 +188,7 @@ LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
 help: provide the argument
    |
 LL |   three_diff(1, 1.0, /* &str */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:29:3
@@ -204,7 +204,7 @@ LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
 help: provide the arguments
    |
 LL |   three_diff(/* i32 */, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:30:3
@@ -223,7 +223,7 @@ LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
 help: provide the arguments
    |
 LL |   three_diff(/* i32 */, 1.0, /* &str */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:31:3
@@ -239,7 +239,7 @@ LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
 help: provide the arguments
    |
 LL |   three_diff(1, /* f32 */, /* &str */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 4 arguments but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:34:3
@@ -255,7 +255,7 @@ LL | fn four_repeated(_a: i32, _b: f32, _c: f32, _d: &str) {}
 help: provide the arguments
    |
 LL |   four_repeated(/* i32 */, /* f32 */, /* f32 */, /* &str */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 4 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:35:3
@@ -271,7 +271,7 @@ LL | fn four_repeated(_a: i32, _b: f32, _c: f32, _d: &str) {}
 help: provide the arguments
    |
 LL |   four_repeated(1, /* f32 */, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 5 arguments but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:38:3
@@ -287,7 +287,7 @@ LL | fn complex(_a: i32, _b: f32, _c: i32, _d: f32, _e: &str) {}
 help: provide the arguments
    |
 LL |   complex(/* i32 */, /* f32 */, /* i32 */, /* f32 */, /* &str */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 5 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:39:3
@@ -303,7 +303,7 @@ LL | fn complex(_a: i32, _b: f32, _c: i32, _d: f32, _e: &str) {}
 help: provide the arguments
    |
 LL |   complex(1, /* f32 */, /* i32 */, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 19 previous errors
 

--- a/src/test/ui/argument-suggestions/mixed_cases.stderr
+++ b/src/test/ui/argument-suggestions/mixed_cases.stderr
@@ -14,7 +14,7 @@ LL | fn two_args(_a: i32, _b: f32) {}
 help: remove the extra argument
    |
 LL |   two_args(1, /* f32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> $DIR/mixed_cases.rs:11:3
@@ -33,7 +33,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: did you mean
    |
 LL |   three_args(1, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/mixed_cases.rs:14:3
@@ -52,7 +52,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: provide the argument
    |
 LL |   three_args(1, /* f32 */, /* &str */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/mixed_cases.rs:17:3
@@ -70,7 +70,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: did you mean
    |
 LL |   three_args(1, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/mixed_cases.rs:20:3
@@ -89,7 +89,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: swap these arguments
    |
 LL |   three_args(1, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/mixed_cases.rs:23:3
@@ -109,7 +109,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: did you mean
    |
 LL |   three_args(1, /* f32 */, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/argument-suggestions/permuted_arguments.stderr
+++ b/src/test/ui/argument-suggestions/permuted_arguments.stderr
@@ -15,7 +15,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: reorder these arguments
    |
 LL |   three_args(1, 1.0, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/permuted_arguments.rs:12:3
@@ -36,7 +36,7 @@ LL | fn many_args(_a: i32, _b: f32, _c: &str, _d: X, _e: Y) {}
 help: reorder these arguments
    |
 LL |   many_args(1, 1.0, "", X {}, Y {});
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/argument-suggestions/swapped_arguments.stderr
+++ b/src/test/ui/argument-suggestions/swapped_arguments.stderr
@@ -14,7 +14,7 @@ LL | fn two_args(_a: i32, _b: f32) {}
 help: swap these arguments
    |
 LL |   two_args(1, 1.0);
-   |   ~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/swapped_arguments.rs:9:3
@@ -32,7 +32,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: swap these arguments
    |
 LL |   three_args(1, 1.0, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/swapped_arguments.rs:10:3
@@ -50,7 +50,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: swap these arguments
    |
 LL |   three_args(1, 1.0, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/swapped_arguments.rs:11:3
@@ -68,7 +68,7 @@ LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
 help: swap these arguments
    |
 LL |   three_args(1, 1.0, "");
-   |   ~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/swapped_arguments.rs:13:3
@@ -88,7 +88,7 @@ LL | fn four_args(_a: i32, _b: f32, _c: &str, _d: X) {}
 help: did you mean
    |
 LL |   four_args(1, 1.0, "", X {});
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/c-variadic/variadic-ffi-1.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-1.stderr
@@ -18,7 +18,7 @@ LL |     fn foo(f: isize, x: u8, ...);
 help: provide the arguments
    |
 LL |         foo(/* isize */, /* u8 */);
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0060]: this function takes at least 2 arguments but 1 argument was supplied
   --> $DIR/variadic-ffi-1.rs:21:9
@@ -34,7 +34,7 @@ LL |     fn foo(f: isize, x: u8, ...);
 help: provide the argument
    |
 LL |         foo(1, /* u8 */);
-   |         ~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/variadic-ffi-1.rs:23:56

--- a/src/test/ui/error-codes/E0057.stderr
+++ b/src/test/ui/error-codes/E0057.stderr
@@ -12,7 +12,7 @@ LL |     let f = |x| x * 3;
 help: provide the argument
    |
 LL |     let a = f(/* value */);
-   |             ~~~~~~~~~~~~~~
+   |              ~~~~~~~~~~~~~
 
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/E0057.rs:5:13
@@ -28,7 +28,7 @@ LL |     let f = |x| x * 3;
 help: remove the extra argument
    |
 LL |     let c = f(2);
-   |             ~~~~
+   |              ~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0060.stderr
+++ b/src/test/ui/error-codes/E0060.stderr
@@ -12,7 +12,7 @@ LL |     fn printf(_: *const u8, ...) -> u32;
 help: provide the argument
    |
 LL |     unsafe { printf(/* *const u8 */); }
-   |              ~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0061.stderr
+++ b/src/test/ui/error-codes/E0061.stderr
@@ -12,7 +12,7 @@ LL | fn f(a: u16, b: &str) {}
 help: provide the argument
    |
 LL |     f(0, /* &str */);
-   |     ~~~~~~~~~~~~~~~~
+   |      ~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/E0061.rs:9:5
@@ -28,7 +28,7 @@ LL | fn f2(a: u16) {}
 help: provide the argument
    |
 LL |     f2(/* u16 */);
-   |     ~~~~~~~~~~~~~
+   |       ~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/higher-rank-trait-bounds/issue-58451.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-58451.stderr
@@ -12,7 +12,7 @@ LL | fn f<I>(i: I)
 help: provide the argument
    |
 LL |     f(&[f(/* value */)]);
-   |         ~~~~~~~~~~~~~~
+   |          ~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-16939.stderr
+++ b/src/test/ui/issues/issue-16939.stderr
@@ -12,7 +12,7 @@ LL | fn _foo<F: Fn()> (f: F) {
 help: remove the extra argument
    |
 LL |     |t| f();
-   |         ~~~
+   |          ~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-18819.stderr
+++ b/src/test/ui/issues/issue-18819.stderr
@@ -23,7 +23,7 @@ LL |     print_x(&X);
 help: provide the argument
    |
 LL |     print_x(/* &dyn Foo<Item = bool> */, /* &str */);
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-4935.stderr
+++ b/src/test/ui/issues/issue-4935.stderr
@@ -12,7 +12,7 @@ LL | fn foo(a: usize) {}
 help: remove the extra argument
    |
 LL | fn main() { foo(5) }
-   |             ~~~~~~
+   |                ~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/issue-26638.stderr
+++ b/src/test/ui/lifetimes/issue-26638.stderr
@@ -54,7 +54,7 @@ LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
 help: provide the argument
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter(/* &u8 */) }
-   |                                               ~~~~~~~~~~~~~~~
+   |                                                   ~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-26638.rs:5:47

--- a/src/test/ui/methods/method-call-err-msg.stderr
+++ b/src/test/ui/methods/method-call-err-msg.stderr
@@ -12,7 +12,7 @@ LL |     fn zero(self) -> Foo { self }
 help: remove the extra argument
    |
 LL |     x.zero()
-   |       ~~~~~~
+   |           ~~
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/method-call-err-msg.rs:14:7
@@ -28,7 +28,7 @@ LL |     fn one(self, _: isize) -> Foo { self }
 help: provide the argument
    |
 LL |      .one(/* isize */)
-   |       ~~~~~~~~~~~~~~~~
+   |          ~~~~~~~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/method-call-err-msg.rs:15:7
@@ -44,7 +44,7 @@ LL |     fn two(self, _: isize, _: isize) -> Foo { self }
 help: provide the argument
    |
 LL |      .two(0, /* isize */);
-   |       ~~~~~~~~~~~~~~~~~~~
+   |          ~~~~~~~~~~~~~~~~
 
 error[E0599]: `Foo` is not an iterator
   --> $DIR/method-call-err-msg.rs:19:7
@@ -84,7 +84,7 @@ LL |     fn three<T>(self, _: T, _: T, _: T) -> Foo { self }
 help: provide the arguments
    |
 LL |     y.three::<usize>(/* usize */, /* usize */, /* usize */);
-   |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -26,7 +26,7 @@ LL | impl FnMut<(isize,)> for S {
 help: provide the argument
    |
 LL |     let ans = s(/* isize */);
-   |               ~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~
 
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:31:15
@@ -44,7 +44,7 @@ LL | impl FnMut<(isize,)> for S {
 help: remove the extra argument
    |
 LL |     let ans = s(/* isize */);
-   |               ~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/not-enough-arguments.stderr
+++ b/src/test/ui/not-enough-arguments.stderr
@@ -12,7 +12,7 @@ LL | fn foo(a: isize, b: isize, c: isize, d:isize) {
 help: provide the argument
    |
 LL |   foo(1, 2, 3, /* isize */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |      ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 6 arguments but 3 arguments were supplied
   --> $DIR/not-enough-arguments.rs:29:3
@@ -40,7 +40,7 @@ LL |     f: i32,
 help: provide the arguments
    |
 LL |   bar(1, 2, 3, /* i32 */, /* i32 */, /* i32 */);
-   |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/resolve-primitive-fallback.stderr
+++ b/src/test/ui/resolve/resolve-primitive-fallback.stderr
@@ -34,7 +34,7 @@ LL | pub const fn size_of<T>() -> usize {
 help: remove the extra argument
    |
 LL |     std::mem::size_of();
-   |     ~~~~~~~~~~~~~~~~~~~
+   |                      ~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -64,7 +64,7 @@ LL | fn foo(Option<i32>, String) {}
 help: remove the extra argument
    |
 LL |     foo(Some(42), 2);
-   |     ~~~~~~~~~~~~~~~~
+   |        ~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-34264.rs:8:13
@@ -94,7 +94,7 @@ LL | fn bar(x, y: usize) {}
 help: remove the extra argument
    |
 LL |     bar(1, 2);
-   |     ~~~~~~~~~
+   |        ~~~~~~
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/missing-unit-argument.stderr
+++ b/src/test/ui/span/missing-unit-argument.stderr
@@ -12,7 +12,7 @@ LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: provide the argument
    |
 LL |     let _: Result<(), String> = Ok(());
-   |                                 ~~~~~~
+   |                                   ~~~~
 
 error[E0061]: this function takes 2 arguments but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:12:5
@@ -28,7 +28,7 @@ LL | fn foo(():(), ():()) {}
 help: provide the arguments
    |
 LL |     foo((), ());
-   |     ~~~~~~~~~~~
+   |        ~~~~~~~~
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing-unit-argument.rs:13:5
@@ -44,7 +44,7 @@ LL | fn foo(():(), ():()) {}
 help: provide the argument
    |
 LL |     foo((), ());
-   |     ~~~~~~~~~~~
+   |        ~~~~~~~~
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:14:5
@@ -60,7 +60,7 @@ LL | fn bar(():()) {}
 help: provide the argument
    |
 LL |     bar(());
-   |     ~~~~~~~
+   |        ~~~~
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:15:7
@@ -76,7 +76,7 @@ LL |     fn baz(self, (): ()) { }
 help: provide the argument
    |
 LL |     S.baz(());
-   |       ~~~~~~~
+   |          ~~~~
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:16:7
@@ -92,7 +92,7 @@ LL |     fn generic<T>(self, _: T) { }
 help: provide the argument
    |
 LL |     S.generic::<()>(());
-   |       ~~~~~~~~~~~~~~~~~
+   |                    ~~~~
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -19,7 +19,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: remove the extra argument
    |
 LL |     let _: Option<(i32, bool)> = Some(/* (i32, bool) */);
-   |                                  ~~~~~~~~~~~~~~~~~~~~~~~
+   |                                      ~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:8:5
@@ -42,7 +42,7 @@ LL | fn int_bool(_: (i32, bool)) {
 help: remove the extra argument
    |
 LL |     int_bool(/* (i32, bool) */);
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:11:28
@@ -58,7 +58,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: provide the argument
    |
 LL |     let _: Option<(i8,)> = Some(/* (i8,) */);
-   |                            ~~~~~~~~~~~~~~~~~
+   |                                ~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/args-instead-of-tuple-errors.rs:14:34

--- a/src/test/ui/suggestions/args-instead-of-tuple.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple.stderr
@@ -44,7 +44,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: provide the argument
    |
 LL |     let _: Option<()> = Some(());
-   |                         ~~~~~~~~
+   |                             ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/args-instead-of-tuple.rs:14:34

--- a/src/test/ui/tuple/wrong_argument_ice-3.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-3.stderr
@@ -19,7 +19,7 @@ LL |     pub fn push(&mut self, value: T) {
 help: remove the extra argument
    |
 LL |         groups.push(/* (Vec<String>, Vec<Process>) */);
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/tuple/wrong_argument_ice-4.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-4.stderr
@@ -16,7 +16,7 @@ LL |     (|| {})(|| {
 help: remove the extra argument
    |
 LL |     (|| {})();
-   |     ~~~~~~~~~
+   |            ~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
@@ -12,7 +12,7 @@ LL |     V(u8)
 help: provide the argument
    |
 LL |     <E>::V(/* u8 */);
-   |     ~~~~~~~~~~~~~~~~
+   |           ~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:22:17

--- a/src/test/ui/type/type-ascription-instead-of-initializer.stderr
+++ b/src/test/ui/type/type-ascription-instead-of-initializer.stderr
@@ -21,7 +21,7 @@ LL |     pub fn with_capacity(capacity: usize) -> Self {
 help: remove the extra argument
    |
 LL |     let x: Vec::with_capacity(10);
-   |            ~~~~~~~~~~~~~~~~~~~~~~
+   |                              ~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/remove-extra-argument.stderr
+++ b/src/test/ui/typeck/remove-extra-argument.stderr
@@ -12,7 +12,7 @@ LL | fn l(_a: Vec<u8>) {}
 help: remove the extra argument
    |
 LL |     l(vec![])
-   |
+   |      ~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/struct-enum-wrong-args.stderr
+++ b/src/test/ui/typeck/struct-enum-wrong-args.stderr
@@ -12,7 +12,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: remove the extra argument
    |
 LL |     let _ = Some(3);
-   |             ~~~~~~~
+   |                 ~~~
 
 error[E0061]: this enum variant takes 1 argument but 3 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:7:13
@@ -30,7 +30,7 @@ LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: remove the extra arguments
    |
 LL |     let _ = Ok(3);
-   |             ~~~~~
+   |               ~~~
 
 error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:8:13
@@ -46,7 +46,7 @@ LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: provide the argument
    |
 LL |     let _ = Ok(/* value */);
-   |             ~~~~~~~~~~~~~~~
+   |               ~~~~~~~~~~~~~
 
 error[E0061]: this struct takes 1 argument but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:9:13
@@ -62,7 +62,7 @@ LL | struct Wrapper(i32);
 help: provide the argument
    |
 LL |     let _ = Wrapper(/* i32 */);
-   |             ~~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~
 
 error[E0061]: this struct takes 1 argument but 2 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:10:13
@@ -78,7 +78,7 @@ LL | struct Wrapper(i32);
 help: remove the extra argument
    |
 LL |     let _ = Wrapper(5);
-   |             ~~~~~~~~~~
+   |                    ~~~
 
 error[E0061]: this struct takes 2 arguments but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:11:13
@@ -94,7 +94,7 @@ LL | struct DoubleWrapper(i32, i32);
 help: provide the arguments
    |
 LL |     let _ = DoubleWrapper(/* i32 */, /* i32 */);
-   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                          ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0061]: this struct takes 2 arguments but 1 argument was supplied
   --> $DIR/struct-enum-wrong-args.rs:12:13
@@ -110,7 +110,7 @@ LL | struct DoubleWrapper(i32, i32);
 help: provide the argument
    |
 LL |     let _ = DoubleWrapper(5, /* i32 */);
-   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                          ~~~~~~~~~~~~~~
 
 error[E0061]: this struct takes 2 arguments but 3 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:13:13
@@ -126,7 +126,7 @@ LL | struct DoubleWrapper(i32, i32);
 help: remove the extra argument
    |
 LL |     let _ = DoubleWrapper(5, 2);
-   |             ~~~~~~~~~~~~~~~~~~~
+   |                          ~~~~~~
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #101232 (Add test for #98294)
 - #101335 (rustdoc: remove old CSS selector that causes weird spacing)
 - #101347 (ffx component run should provide a collection)
 - #101364 (Shrink suggestion span of argument mismatch error)
 - #101365 (remove redundant clones)

Failed merges:

 - #101349 (rustdoc: remove `.impl-items { flex-basis }` CSS, not in flex container)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101232,101335,101347,101364,101365)
<!-- homu-ignore:end -->