### PR TITLE
`thread::current_cpu` addition.

### DIFF
--- a/library/std/src/sys/hermit/thread.rs
+++ b/library/std/src/sys/hermit/thread.rs
@@ -101,6 +101,10 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()
 }
 
+pub fn current_cpu() -> io::Result<u32> {
+    unsupported()
+}
+
 pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> {

--- a/library/std/src/sys/itron/thread.rs
+++ b/library/std/src/sys/itron/thread.rs
@@ -347,3 +347,7 @@ unsafe fn terminate_and_delete_current_task() -> ! {
 pub fn available_parallelism() -> io::Result<crate::num::NonZeroUsize> {
     super::unsupported()
 }
+
+pub fn current_cpu() -> io::Result<u32> {
+    super::unsupported()
+}

--- a/library/std/src/sys/sgx/thread.rs
+++ b/library/std/src/sys/sgx/thread.rs
@@ -141,6 +141,10 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()
 }
 
+pub fn current_cpu() -> io::Result<u32> {
+    unsupported()
+}
+
 pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> {

--- a/library/std/src/sys/unsupported/thread.rs
+++ b/library/std/src/sys/unsupported/thread.rs
@@ -35,6 +35,10 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()
 }
 
+pub fn current_cpu() -> io::Result<u32> {
+    unsupported()
+}
+
 pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> {

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -70,6 +70,10 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()
 }
 
+pub fn current_cpu() -> io::Result<u32> {
+    unsupported()
+}
+
 pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> {

--- a/library/std/src/sys/wasm/atomics/thread.rs
+++ b/library/std/src/sys/wasm/atomics/thread.rs
@@ -44,6 +44,10 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()
 }
 
+pub fn current_cpu() -> io::Result<u32> {
+    unsupported()
+}
+
 pub mod guard {
     pub type Guard = !;
     pub unsafe fn current() -> Option<Guard> {

--- a/library/std/src/sys/windows/thread.rs
+++ b/library/std/src/sys/windows/thread.rs
@@ -113,6 +113,13 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     }
 }
 
+pub fn current_cpu() -> io::Result<u32> {
+    extern "C" {
+        fn GetCurrentProcessorNumber() -> u32;
+    }
+    Ok(unsafe { GetCurrentProcessorNumber() })
+}
+
 #[cfg_attr(test, allow(dead_code))]
 pub mod guard {
     pub type Guard = !;

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1652,3 +1652,22 @@ fn _assert_sync_and_send() {
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     imp::available_parallelism()
 }
+
+/// Fetches the running cpu from the current thread
+///
+/// # Examples
+///
+/// ```
+/// #![feature(current_cpu)]
+/// # #![allow(dead_code)]
+/// use std::{io, thread};
+///
+/// fn main() -> io::Result<()> {
+///     let cpu = thread::current_cpu()?;
+///     Ok(())
+/// }
+/// ```
+#[unstable(feature = "current_cpu", issue = "none")]
+pub fn current_cpu() -> io::Result<u32> {
+    imp::current_cpu()
+}


### PR DESCRIPTION
Allows to get the cpu id from the current running thread.