### PR TITLE
updated description of File struct in std::fs

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -19,7 +19,7 @@ use crate::sys::fs as fs_imp;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::time::SystemTime;
 
-/// A reference to an open file on the filesystem.
+/// An object providing access to an open file on the filesystem.
 ///
 /// An instance of a `File` can be read and/or written depending on what options
 /// it was opened with. Files also implement [`Seek`] to alter the logical cursor


### PR DESCRIPTION
I've seen several folks confused by the description of `std::fs::File` as "A reference to an open file on the filesystem." Apparently the word `reference` is sometimes taken to mean a Rust `&` reference, leading to confusion. Here's a recent representative [Reddit thread](https://www.reddit.com/r/rust/comments/x4k0lv/comment/imxu7v2/?utm_source=share&utm_medium=web2x&context=3), but I've seen this before as well.

This patch changes the description to "An object providing access to an open file on the filesystem." Hopefully this is clearer.

