### PR TITLE
Added `interrupt` function for `std::process::Child`

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1860,6 +1860,38 @@ impl Child {
         self.handle.kill()
     }
 
+    /// Signals the child process to exit. If the child has already exited, an [`InvalidInput`]
+    /// error is returned.
+    /// 
+    /// Unlike [`kill`] this allows the process to catch the signal and gracefully exit.
+    ///
+    /// The mapping to [`ErrorKind`]s is not part of the compatibility contract of the function.
+    ///
+    /// This is equivalent to sending a SIGINT on Unix platforms.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```no_run
+    /// use std::process::Command;
+    ///
+    /// let mut command = Command::new("yes");
+    /// if let Ok(mut child) = command.spawn() {
+    ///     child.interrupt().expect("command wasn't running");
+    /// } else {
+    ///     println!("yes command didn't start");
+    /// }
+    /// ```
+    ///
+    /// [`ErrorKind`]: io::ErrorKind
+    /// [`InvalidInput`]: io::ErrorKind::InvalidInput
+    #[stable(feature = "process", since = "1.0.0")]
+    pub fn interrupt(&mut self) -> io::Result<()> {
+        self.handle.interrupt()
+    }
+
+
     /// Returns the OS-assigned process identifier associated with this child.
     ///
     /// # Examples

--- a/library/std/src/sys/unix/process/process_fuchsia.rs
+++ b/library/std/src/sys/unix/process/process_fuchsia.rs
@@ -160,6 +160,16 @@ impl Process {
         Ok(())
     }
 
+    pub fn interrupt(&mut self) -> io::Result<()> {
+        use crate::sys::process::zircon::*;
+
+        unsafe {
+            zx_cvt(zx_task_kill(self.handle.raw()))?;
+        }
+
+        Ok(())
+    }
+
     pub fn wait(&mut self) -> io::Result<ExitStatus> {
         use crate::default::Default;
         use crate::sys::process::zircon::*;

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -604,6 +604,20 @@ impl Process {
             cvt(unsafe { libc::kill(self.pid, libc::SIGKILL) }).map(drop)
         }
     }
+    
+    pub fn interrupt(&mut self) -> io::Result<()> {
+        // If we've already waited on this process then the pid can be recycled
+        // and used for another process, and we probably shouldn't be interrupting
+        // random processes, so just return an error.
+        if self.status.is_some() {
+            Err(io::const_io_error!(
+                ErrorKind::InvalidInput,
+                "invalid argument: can't interrupt an exited process",
+            ))
+        } else {
+            cvt(unsafe { libc::kill(self.pid, libc::SIGINT) }).map(drop)
+        }
+    }
 
     pub fn wait(&mut self) -> io::Result<ExitStatus> {
         use crate::sys::cvt_r;

--- a/library/std/src/sys/unix/process/process_unsupported.rs
+++ b/library/std/src/sys/unix/process/process_unsupported.rs
@@ -42,6 +42,10 @@ impl Process {
         unsupported()
     }
 
+    pub fn interrupt(&mut self) -> io::Result<()> {
+        unsupported()
+    }
+
     pub fn wait(&mut self) -> io::Result<ExitStatus> {
         unsupported()
     }

--- a/library/std/src/sys/unsupported/process.rs
+++ b/library/std/src/sys/unsupported/process.rs
@@ -182,6 +182,10 @@ impl Process {
         self.0
     }
 
+    pub fn interrupt(&mut self) -> io::Result<()> {
+        self.0
+    }
+
     pub fn wait(&mut self) -> io::Result<ExitStatus> {
         self.0
     }


### PR DESCRIPTION
Added an `interrupt` function to [`std::process::Child`](https://doc.rust-lang.org/std/process/struct.Child.html) which acts similar to the [`kill`](https://doc.rust-lang.org/std/process/struct.Child.html#method.kill) function but uses the `SIGINT` signal instead of `SIGKILL`. This allows the process to catch the signal and gracefully exit.

When working with binaries this is very important, considering a test where you need to spawn a server, interact with this server, then shutdown the server (this server may create local resources which require manual cleanup) (a little easier and safer than `unsafe { libc::kill(child.id() as i32, libc::SIGINT); }`).
```rust
#[test]
fn stress_test() {
    let server = std::process::Command::new("cargo")
            .args(["run", "--bin", "my-server"])
            .spawn()
            .unwrap();
    // Some interaction
    server.interrupt();
   // Some finishing work
}
```

It is better practice to interrupt applications to allow graceful shutdowns than to kill applications as this may leave remnants the application was not able to clean up. Really killing should only be used when applications are un-trusted or refuse to gracefully exit.

I would argue, `interrupt` should probably be more commonly used than [`kill`](https://doc.rust-lang.org/std/process/struct.Child.html#method.kill).

Although this is not changed in this PR, it might make sense in the future for [`std::process::Child`](https://doc.rust-lang.org/std/process/struct.Child.html) to implement [`std::ops::Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) like:
```rust
impl std::ops::Drop for std::process::Child {
    fn drop(&mut self) {
        self.interrupt();
    } 
}
```

The Fuschia implementation currently simply mimics `kill` I will look into Fuschia to see if I can fix this (I currently know basically nothing here).

ACP: https://github.com/rust-lang/libs-team/issues/97