### PR TITLE
Forbid mixing `System` with direct system allocator calls

### DIFF
--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -68,7 +68,10 @@ pub use alloc_crate::alloc::*;
 /// The default memory allocator provided by the operating system.
 ///
 /// This is based on `malloc` on Unix platforms and `HeapAlloc` on Windows,
-/// plus related functions.
+/// plus related functions. However, it is not valid to mix use of the backing
+/// system allocator with `System`, as this implementation may include extra
+/// work, such as to serve alignment requests greater than the alignment
+/// provided directly by the backing system allocator.
 ///
 /// This type implements the `GlobalAlloc` trait and Rust programs by default
 /// work as if they had this definition:


### PR DESCRIPTION
e.g. [on windows](https://github.com/rust-lang/rust/blob/dec689432fac6720b2f18101ac28a21add98b1b8/library/std/src/sys/windows/alloc.rs#L129-L178), trying to mix `System::alloc` and `HeapFree` will not work because of the extra work done to serve higher alignments.