### PR TITLE
rustdoc: remove redundant mobile-sized `.source nav:not(.sidebar).sub`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1887,10 +1887,6 @@ in storage.js plus the media query with (min-width: 701px)
 		background-color: var(--sidebar-background-color);
 	}
 
-	.source nav:not(.sidebar).sub {
-		margin-left: 32px;
-	}
-
 	.content {
 		margin-left: 0px;
 	}


### PR DESCRIPTION
It's redundant because there's already a selector `.source nav.sub` with exactly the same margin-left at [line 796].

[line 796]: https://github.com/rust-lang/rust/blob/84f0c3f79a85329dd79a54694ff8a7f427c842e9/src/librustdoc/html/static/css/rustdoc.css#L796

This selector was added in 1e98fb10274ea0245f865ddb1e295e454382000b, along with an identical desktop selector, but that desktop selector was removed in 6a5f8b1aef1417d7dc85b5d0a229d2db1930eb7c as part of a larger simplification.