### PR TITLE
Shrink span for bindings with subpatterns.

### DIFF
--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -1036,7 +1036,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             VarBindingForm {
                                 binding_mode,
                                 opt_ty_info,
-                                opt_match_place: Some((Some(place), span)),
+                                opt_match_place: Some((None, span)),
                                 pat_span: span,
                             },
                         )))))

--- a/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
@@ -8,13 +8,13 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
     let mut _4: bool;                    // in scope 0 at $DIR/exponential-or.rs:+2:70: +2:77
     let mut _5: bool;                    // in scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
     let mut _6: bool;                    // in scope 0 at $DIR/exponential-or.rs:+2:62: +2:67
-    let _7: u32;                         // in scope 0 at $DIR/exponential-or.rs:+2:10: +2:21
-    let _8: u32;                         // in scope 0 at $DIR/exponential-or.rs:+2:57: +2:78
+    let _7: u32;                         // in scope 0 at $DIR/exponential-or.rs:+2:10: +2:11
+    let _8: u32;                         // in scope 0 at $DIR/exponential-or.rs:+2:57: +2:58
     let mut _9: u32;                     // in scope 0 at $DIR/exponential-or.rs:+2:83: +2:84
     let mut _10: u32;                    // in scope 0 at $DIR/exponential-or.rs:+2:87: +2:88
     scope 1 {
-        debug y => _7;                   // in scope 1 at $DIR/exponential-or.rs:+2:10: +2:21
-        debug z => _8;                   // in scope 1 at $DIR/exponential-or.rs:+2:57: +2:78
+        debug y => _7;                   // in scope 1 at $DIR/exponential-or.rs:+2:10: +2:11
+        debug z => _8;                   // in scope 1 at $DIR/exponential-or.rs:+2:57: +2:58
     }
 
     bb0: {
@@ -61,10 +61,10 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
     }
 
     bb9: {
-        StorageLive(_7);                 // scope 0 at $DIR/exponential-or.rs:+2:10: +2:21
-        _7 = (_1.0: u32);                // scope 0 at $DIR/exponential-or.rs:+2:10: +2:21
-        StorageLive(_8);                 // scope 0 at $DIR/exponential-or.rs:+2:57: +2:78
-        _8 = (_1.3: u32);                // scope 0 at $DIR/exponential-or.rs:+2:57: +2:78
+        StorageLive(_7);                 // scope 0 at $DIR/exponential-or.rs:+2:10: +2:11
+        _7 = (_1.0: u32);                // scope 0 at $DIR/exponential-or.rs:+2:10: +2:11
+        StorageLive(_8);                 // scope 0 at $DIR/exponential-or.rs:+2:57: +2:58
+        _8 = (_1.3: u32);                // scope 0 at $DIR/exponential-or.rs:+2:57: +2:58
         StorageLive(_9);                 // scope 1 at $DIR/exponential-or.rs:+2:83: +2:84
         _9 = _7;                         // scope 1 at $DIR/exponential-or.rs:+2:83: +2:84
         StorageLive(_10);                // scope 1 at $DIR/exponential-or.rs:+2:87: +2:88

--- a/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
@@ -15,9 +15,9 @@ fn move_out_by_subslice() -> () {
     let mut _11: std::boxed::Box<i32>;   // in scope 0 at $DIR/uniform_array_move_out.rs:+1:21: +1:26
     scope 1 {
         debug a => _1;                   // in scope 1 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
-        let _12: [std::boxed::Box<i32>; 2]; // in scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
+        let _12: [std::boxed::Box<i32>; 2]; // in scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:12
         scope 4 {
-            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
+            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:+2:10: +2:12
         }
     }
     scope 2 {
@@ -77,8 +77,8 @@ fn move_out_by_subslice() -> () {
     bb6: {
         StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:+1:26: +1:27
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:+1:9: +1:10
-        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
-        _12 = move _1[0..2];             // scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:17
+        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:12
+        _12 = move _1[0..2];             // scope 1 at $DIR/uniform_array_move_out.rs:+2:10: +2:12
         _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:+0:27: +3:2
         drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:+3:1: +3:2
     }

--- a/src/test/ui/borrowck/bindings-after-at-or-patterns-slice-patterns-box-patterns.stderr
+++ b/src/test/ui/borrowck/bindings-after-at-or-patterns-slice-patterns-box-patterns.stderr
@@ -23,7 +23,7 @@ LL | fn bindings_after_at_slice_patterns_move_binding(x: [String; 4]) {
    |                                                  - move occurs because `x` has type `[String; 4]`, which does not implement the `Copy` trait
 LL |     match x {
 LL |         a @ [.., _] => (),
-   |         ----------- value moved here
+   |         - value moved here
 ...
 LL |     &x;
    |     ^^ value borrowed here after move
@@ -32,7 +32,7 @@ error[E0502]: cannot borrow `x` as immutable because it is also borrowed as muta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:28:5
    |
 LL |         ref mut foo @ [.., _] => Some(foo),
-   |         --------------------- mutable borrow occurs here
+   |         ----------- mutable borrow occurs here
 ...
 LL |     &x;
    |     ^^ immutable borrow occurs here
@@ -44,7 +44,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:50:5
    |
 LL |         [ref foo @ .., ref bar] => Some(foo),
-   |          ------------ immutable borrow occurs here
+   |          ------- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -56,7 +56,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:62:5
    |
 LL |         ref foo @ [.., ref bar] => Some(foo),
-   |         ----------------------- immutable borrow occurs here
+   |         ------- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -71,7 +71,7 @@ LL | fn bindings_after_at_or_patterns_move(x: Option<Test>) {
    |                                       - move occurs because `x` has type `Option<Test>`, which does not implement the `Copy` trait
 LL |     match x {
 LL |         foo @ Some(Test::Foo | Test::Bar) => (),
-   |         ---------------------------------
+   |         ---
    |         |
    |         value moved here
    |         value moved here
@@ -83,7 +83,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:86:5
    |
 LL |         ref foo @ Some(Test::Foo | Test::Bar) => Some(foo),
-   |         ------------------------------------- immutable borrow occurs here
+   |         ------- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -95,7 +95,7 @@ error[E0502]: cannot borrow `x` as immutable because it is also borrowed as muta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:98:5
    |
 LL |         ref mut foo @ Some(Test::Foo | Test::Bar) => Some(foo),
-   |         ----------------------------------------- mutable borrow occurs here
+   |         ----------- mutable borrow occurs here
 ...
 LL |     &x;
    |     ^^ immutable borrow occurs here
@@ -107,7 +107,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:112:5
    |
 LL |         ref foo @ Some(box ref s) => Some(foo),
-   |         ------------------------- immutable borrow occurs here
+   |         ------- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -122,7 +122,7 @@ LL | fn bindings_after_at_slice_patterns_or_patterns_moves(x: [Option<Test>; 4])
    |                                                       - move occurs because `x` has type `[Option<Test>; 4]`, which does not implement the `Copy` trait
 LL |     match x {
 LL |         a @ [.., Some(Test::Foo | Test::Bar)] => (),
-   |         -------------------------------------
+   |         -
    |         |
    |         value moved here
    |         value moved here
@@ -134,7 +134,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:144:5
    |
 LL |         ref a @ [ref b @ .., Some(Test::Foo | Test::Bar)] => Some(a),
-   |         ------------------------------------------------- immutable borrow occurs here
+   |         ----- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -146,7 +146,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:156:5
    |
 LL |         ref a @ [ref b @ .., Some(Test::Foo | Test::Bar)] => Some(b),
-   |                  ---------- immutable borrow occurs here
+   |                  ----- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -158,7 +158,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:170:5
    |
 LL |         [_, ref a @ Some(box ref b), ..] => Some(a),
-   |             ----------------------- immutable borrow occurs here
+   |             ----- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -170,7 +170,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:186:5
    |
 LL |         [_, ref a @ Some(box Test::Foo | box Test::Bar), ..] => Some(a),
-   |             ------------------------------------------- immutable borrow occurs here
+   |             ----- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here
@@ -182,7 +182,7 @@ error[E0502]: cannot borrow `x` as immutable because it is also borrowed as muta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:200:5
    |
 LL |         [_, ref mut a @ Some(box Test::Foo | box Test::Bar), ..] => Some(a),
-   |             ----------------------------------------------- mutable borrow occurs here
+   |             --------- mutable borrow occurs here
 ...
 LL |     &x;
    |     ^^ immutable borrow occurs here
@@ -194,7 +194,7 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/bindings-after-at-or-patterns-slice-patterns-box-patterns.rs:214:5
    |
 LL |         ref a @ [_, ref b @ Some(box Test::Foo | box Test::Bar), ..] => Some(a),
-   |         ------------------------------------------------------------ immutable borrow occurs here
+   |         ----- immutable borrow occurs here
 ...
 LL |     &mut x;
    |     ^^^^^^ mutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.stderr
@@ -200,7 +200,7 @@ LL |         let x = &mut v;
    |                 ------ borrow of `v` occurs here
 LL |         match v {
 LL |             &[x @ ..] => println!("{:?}", x),
-   |               ^^^^^^ use of borrowed `v`
+   |               ^ use of borrowed `v`
 ...
 LL |         drop(x);
    |              - borrow later used here
@@ -212,7 +212,7 @@ LL |         let x = &mut v;
    |                 ------ borrow of `v` occurs here
 ...
 LL |             &[_, x @ ..] => println!("{:?}", x),
-   |                  ^^^^^^ use of borrowed `v`
+   |                  ^ use of borrowed `v`
 ...
 LL |         drop(x);
    |              - borrow later used here
@@ -224,7 +224,7 @@ LL |         let x = &mut v;
    |                 ------ borrow of `v` occurs here
 ...
 LL |             &[x @ .., _] => println!("{:?}", x),
-   |               ^^^^^^ use of borrowed `v`
+   |               ^ use of borrowed `v`
 ...
 LL |         drop(x);
    |              - borrow later used here
@@ -236,7 +236,7 @@ LL |         let x = &mut v;
    |                 ------ borrow of `v` occurs here
 ...
 LL |             &[_, x @ .., _] => println!("{:?}", x),
-   |                  ^^^^^^ use of borrowed `v`
+   |                  ^ use of borrowed `v`
 ...
 LL |         drop(x);
    |              - borrow later used here

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-match.stderr
@@ -79,7 +79,7 @@ error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array-match.rs:89:11
    |
 LL |         [_y @ .., _, _] => {}
-   |          ------- value moved here
+   |          -- value moved here
 ...
 LL |         [(_x, _), _, _] => {}
    |           ^^ value used here after move
@@ -90,7 +90,7 @@ error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array-match.rs:99:15
    |
 LL |         [_, _, _y @ ..] => {}
-   |                ------- value moved here
+   |                -- value moved here
 ...
 LL |         [.., (_x, _)] => {}
    |               ^^ value used here after move
@@ -101,7 +101,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-match.rs:110:11
    |
 LL |         [x @ .., _] => {}
-   |          ------ value partially moved here
+   |          - value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.stderr
@@ -68,7 +68,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:85:11
    |
 LL |         [_, _y @ ..] => {}
-   |             ------- value partially moved here
+   |             -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
@@ -79,7 +79,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:96:11
    |
 LL |         [_y @ .., _] => {}
-   |          ------- value partially moved here
+   |          -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
@@ -90,7 +90,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:109:11
    |
 LL |         [x @ .., _, _] => {}
-   |          ------ value partially moved here
+   |          - value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.stderr
@@ -79,7 +79,7 @@ error[E0382]: borrow of moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:89:11
    |
 LL |         [_y @ .., _, _] => {}
-   |          ------- value moved here
+   |          -- value moved here
 ...
 LL |         [(ref _x, _), _, _] => {}
    |           ^^^^^^ value borrowed here after move
@@ -90,7 +90,7 @@ error[E0382]: borrow of moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:99:15
    |
 LL |         [_, _, _y @ ..] => {}
-   |                ------- value moved here
+   |                -- value moved here
 ...
 LL |         [.., (ref _x, _)] => {}
    |               ^^^^^^ value borrowed here after move
@@ -101,7 +101,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:110:11
    |
 LL |         [x @ .., _] => {}
-   |          ------ value partially moved here
+   |          - value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
@@ -134,7 +134,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:139:5
    |
 LL |         [_, _, _x @ ..] => {}
-   |                ------- value partially moved here
+   |                -- value partially moved here
 LL |     }
 LL |     a[0] = Default::default();
    |     ^^^^ value used here after partial move
@@ -145,7 +145,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:147:5
    |
 LL |         [_, _, _x @ ..] => {}
-   |                ------- value partially moved here
+   |                -- value partially moved here
 LL |     }
 LL |     a[0].1 = Default::default();
    |     ^^^^ value used here after partial move

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.stderr
@@ -68,7 +68,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:85:11
    |
 LL |         [_, _y @ ..] => {}
-   |             ------- value partially moved here
+   |             -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
@@ -79,7 +79,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:96:11
    |
 LL |         [_y @ .., _] => {}
-   |          ------- value partially moved here
+   |          -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
@@ -90,7 +90,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:109:11
    |
 LL |         [x @ .., _, _] => {}
-   |          ------ value partially moved here
+   |          - value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use.stderr
@@ -34,7 +34,7 @@ error[E0382]: borrow of partially moved value: `a`
 LL |     let [_x, _, _] = a;
    |          -- value partially moved here
 LL |     let [ref _y @ .., _, _] = a;
-   |          ^^^^^^^^^^^ value borrowed here after partial move
+   |          ^^^^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `a[..]` has type `(String, String)`, which does not implement the `Copy` trait
 
@@ -44,7 +44,7 @@ error[E0382]: borrow of partially moved value: `a`
 LL |     let [.., _x] = a;
    |              -- value partially moved here
 LL |     let [_, _, ref _y @ ..] = a;
-   |                ^^^^^^^^^^^ value borrowed here after partial move
+   |                ^^^^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `a[..]` has type `(String, String)`, which does not implement the `Copy` trait
 
@@ -54,7 +54,7 @@ error[E0382]: borrow of partially moved value: `a`
 LL |     let [(_x, _), _, _] = a;
    |           -- value partially moved here
 LL |     let [ref _y @ .., _, _] = a;
-   |          ^^^^^^^^^^^ value borrowed here after partial move
+   |          ^^^^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `a[..].0` has type `String`, which does not implement the `Copy` trait
 
@@ -64,7 +64,7 @@ error[E0382]: borrow of partially moved value: `a`
 LL |     let [.., (_x, _)] = a;
    |               -- value partially moved here
 LL |     let [_, _, ref _y @ ..] = a;
-   |                ^^^^^^^^^^^ value borrowed here after partial move
+   |                ^^^^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `a[..].0` has type `String`, which does not implement the `Copy` trait
 
@@ -72,7 +72,7 @@ error[E0382]: borrow of moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use.rs:54:11
    |
 LL |     let [_y @ .., _, _] = a;
-   |          ------- value moved here
+   |          -- value moved here
 LL |     let [(ref _x, _), _, _] = a;
    |           ^^^^^^ value borrowed here after move
    |
@@ -82,7 +82,7 @@ error[E0382]: borrow of moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use.rs:60:15
    |
 LL |     let [_, _, _y @ ..] = a;
-   |                ------- value moved here
+   |                -- value moved here
 LL |     let [.., (ref _x, _)] = a;
    |               ^^^^^^ value borrowed here after move
    |
@@ -92,9 +92,9 @@ error[E0382]: borrow of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:68:13
    |
 LL |     let [x @ .., _] = a;
-   |          ------ value partially moved here
+   |          - value partially moved here
 LL |     let [_, ref _y @ ..] = a;
-   |             ^^^^^^^^^^^ value borrowed here after partial move
+   |             ^^^^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `a[..]` has type `(String, String)`, which does not implement the `Copy` trait
 
@@ -122,7 +122,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:88:5
    |
 LL |     let [_, _, _x @ ..] = a;
-   |                ------- value partially moved here
+   |                -- value partially moved here
 LL |     a[0] = Default::default();
    |     ^^^^ value used here after partial move
    |
@@ -132,7 +132,7 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:94:5
    |
 LL |     let [_, _, _x @ ..] = a;
-   |                ------- value partially moved here
+   |                -- value partially moved here
 LL |     a[0].1 = Default::default();
    |     ^^^^ value used here after partial move
    |

--- a/src/test/ui/borrowck/borrowck-move-out-from-array.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array.stderr
@@ -34,7 +34,7 @@ error[E0382]: use of partially moved value: `a`
 LL |     let [_x, _, _] = a;
    |          -- value partially moved here
 LL |     let [_y @ .., _, _] = a;
-   |          ^^^^^^^ value used here after partial move
+   |          ^^ value used here after partial move
    |
    = note: partial move occurs because `a[..]` has type `(String, String)`, which does not implement the `Copy` trait
 
@@ -44,7 +44,7 @@ error[E0382]: use of partially moved value: `a`
 LL |     let [.., _x] = a;
    |              -- value partially moved here
 LL |     let [_, _, _y @ ..] = a;
-   |                ^^^^^^^ value used here after partial move
+   |                ^^ value used here after partial move
    |
    = note: partial move occurs because `a[..]` has type `(String, String)`, which does not implement the `Copy` trait
 
@@ -54,7 +54,7 @@ error[E0382]: use of partially moved value: `a`
 LL |     let [(_x, _), _, _] = a;
    |           -- value partially moved here
 LL |     let [_y @ .., _, _] = a;
-   |          ^^^^^^^ value used here after partial move
+   |          ^^ value used here after partial move
    |
    = note: partial move occurs because `a[..].0` has type `String`, which does not implement the `Copy` trait
 
@@ -64,7 +64,7 @@ error[E0382]: use of partially moved value: `a`
 LL |     let [.., (_x, _)] = a;
    |               -- value partially moved here
 LL |     let [_, _, _y @ ..] = a;
-   |                ^^^^^^^ value used here after partial move
+   |                ^^ value used here after partial move
    |
    = note: partial move occurs because `a[..].0` has type `String`, which does not implement the `Copy` trait
 
@@ -72,7 +72,7 @@ error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array.rs:54:11
    |
 LL |     let [_y @ .., _, _] = a;
-   |          ------- value moved here
+   |          -- value moved here
 LL |     let [(_x, _), _, _] = a;
    |           ^^ value used here after move
    |
@@ -82,7 +82,7 @@ error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array.rs:60:15
    |
 LL |     let [_, _, _y @ ..] = a;
-   |                ------- value moved here
+   |                -- value moved here
 LL |     let [.., (_x, _)] = a;
    |               ^^ value used here after move
    |
@@ -92,9 +92,9 @@ error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array.rs:68:13
    |
 LL |     let [x @ .., _] = a;
-   |          ------ value partially moved here
+   |          - value partially moved here
 LL |     let [_, _y @ ..] = a;
-   |             ^^^^^^^ value used here after partial move
+   |             ^^ value used here after partial move
    |
    = note: partial move occurs because `a[..]` has type `(String, String)`, which does not implement the `Copy` trait
 

--- a/src/test/ui/borrowck/borrowck-slice-pattern-element-loan-array.stderr
+++ b/src/test/ui/borrowck/borrowck-slice-pattern-element-loan-array.stderr
@@ -57,7 +57,7 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
 LL |     let [ref first, ref second, ..] = *s;
    |                     ---------- immutable borrow occurs here
 LL |     let [_, ref mut tail @ ..] = *s;
-   |             ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |             ^^^^^^^^^^^^ mutable borrow occurs here
 LL |     nop(&[first, second]);
    |                  ------ immutable borrow later used here
 
@@ -67,7 +67,7 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
 LL |     let [.., ref second, ref first] = *s;
    |              ---------- immutable borrow occurs here
 LL |     let [ref mut tail @ .., _] = *s;
-   |          ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |          ^^^^^^^^^^^^ mutable borrow occurs here
 LL |     nop(&[first, second]);
    |                  ------ immutable borrow later used here
 
@@ -75,9 +75,9 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
   --> $DIR/borrowck-slice-pattern-element-loan-array.rs:46:10
    |
 LL |     let [_,  ref s1 @ ..] = *s;
-   |              ----------- immutable borrow occurs here
+   |              ------ immutable borrow occurs here
 LL |     let [ref mut s2 @ .., _, _] = *s;
-   |          ^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |          ^^^^^^^^^^ mutable borrow occurs here
 LL |     nop_subslice(s1);
    |                  -- immutable borrow later used here
 

--- a/src/test/ui/borrowck/borrowck-slice-pattern-element-loan-slice.stderr
+++ b/src/test/ui/borrowck/borrowck-slice-pattern-element-loan-slice.stderr
@@ -88,7 +88,7 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
 LL |     if let [ref first, ref second, ..] = *s {
    |                        ---------- immutable borrow occurs here
 LL |         if let [_, ref mut tail @ ..] = *s {
-   |                    ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |                    ^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[first, second]);
    |                          ------ immutable borrow later used here
 
@@ -98,7 +98,7 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
 LL |     if let [.., ref second, ref first] = *s {
    |                 ---------- immutable borrow occurs here
 LL |         if let [ref mut tail @ .., _] = *s {
-   |                 ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |                 ^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[first, second]);
    |                          ------ immutable borrow later used here
 
@@ -106,9 +106,9 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
   --> $DIR/borrowck-slice-pattern-element-loan-slice.rs:65:17
    |
 LL |     if let [_, _, _, ref s1 @ ..] = *s {
-   |                      ----------- immutable borrow occurs here
+   |                      ------ immutable borrow occurs here
 LL |         if let [ref mut s2 @ .., _, _, _] = *s {
-   |                 ^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |                 ^^^^^^^^^^ mutable borrow occurs here
 LL |             nop_subslice(s1);
    |                          -- immutable borrow later used here
 

--- a/src/test/ui/borrowck/borrowck-vec-pattern-move-tail.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-move-tail.stderr
@@ -2,7 +2,7 @@ error[E0506]: cannot assign to `a[_]` because it is borrowed
   --> $DIR/borrowck-vec-pattern-move-tail.rs:8:5
    |
 LL |         [1, 2, ref tail @ ..] => tail,
-   |                ------------- borrow of `a[_]` occurs here
+   |                -------- borrow of `a[_]` occurs here
 ...
 LL |     a[2] = 0;
    |     ^^^^^^^^ assignment to borrowed `a[_]` occurs here

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -14,7 +14,7 @@ error[E0506]: cannot assign to `vec[_]` because it is borrowed
   --> $DIR/borrowck-vec-pattern-nesting.rs:23:13
    |
 LL |         &mut [ref _b @ ..] => {
-   |               ----------- borrow of `vec[_]` occurs here
+   |               ------ borrow of `vec[_]` occurs here
 LL |
 LL |             vec[0] = Box::new(4);
    |             ^^^^^^ assignment to borrowed `vec[_]` occurs here

--- a/src/test/ui/moves/move-out-of-array-ref.stderr
+++ b/src/test/ui/moves/move-out-of-array-ref.stderr
@@ -13,7 +13,7 @@ error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:13:27
    |
 LL |     let [_, s @ .. , _] = *a;
-   |             ------        ^^
+   |             -             ^^
    |             |             |
    |             |             cannot move out of here
    |             |             help: consider borrowing here: `&*a`
@@ -35,7 +35,7 @@ error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
   --> $DIR/move-out-of-array-ref.rs:23:27
    |
 LL |     let [_, s @ .. , _] = *a;
-   |             ------        ^^
+   |             -             ^^
    |             |             |
    |             |             cannot move out of here
    |             |             help: consider borrowing here: `&*a`

--- a/src/test/ui/moves/move-out-of-slice-2.stderr
+++ b/src/test/ui/moves/move-out-of-slice-2.stderr
@@ -14,7 +14,7 @@ LL |     match *a {
    |           ^^ cannot move out of here
 LL |
 LL |         [a @ ..] => {}
-   |          ------
+   |          -
    |          |
    |          data moved here
    |          move occurs because `a` has type `[A]`, which does not implement the `Copy` trait
@@ -26,7 +26,7 @@ LL |     match *b {
    |           ^^ cannot move out of here
 LL |
 LL |         [_, _, b @ .., _] => {}
-   |                ------
+   |                -
    |                |
    |                data moved here
    |                move occurs because `b` has type `[A]`, which does not implement the `Copy` trait
@@ -38,7 +38,7 @@ LL |     match *c {
    |           ^^ cannot move out of here
 LL |
 LL |         [c @ ..] => {}
-   |          ------
+   |          -
    |          |
    |          data moved here
    |          move occurs because `c` has type `[C]`, which does not implement the `Copy` trait
@@ -50,7 +50,7 @@ LL |     match *d {
    |           ^^ cannot move out of here
 LL |
 LL |         [_, _, d @ .., _] => {}
-   |                ------
+   |                -
    |                |
    |                data moved here
    |                move occurs because `d` has type `[C]`, which does not implement the `Copy` trait

--- a/src/test/ui/nll/issue-51244.stderr
+++ b/src/test/ui/nll/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     let ref my_ref @ _ = 0;
-   |         -------------- help: consider changing this to be a mutable reference: `ref mut my_ref @ _`
+   |         ---------- help: consider changing this to be a mutable reference: `ref mut my_ref`
 LL |     *my_ref = 0;
    |     ^^^^^^^^^^^ `my_ref` is a `&` reference, so the data it refers to cannot be written
 

--- a/src/test/ui/pattern/bindings-after-at/bind-by-move-neither-can-live-while-the-other-survives-1.stderr
+++ b/src/test/ui/pattern/bindings-after-at/bind-by-move-neither-can-live-while-the-other-survives-1.stderr
@@ -40,9 +40,8 @@ error[E0382]: borrow of moved value
   --> $DIR/bind-by-move-neither-can-live-while-the-other-survives-1.rs:12:14
    |
 LL |         Some(ref _y @ _z) => {}
-   |              ^^^^^^^^^--
-   |              |        |
-   |              |        value moved here
+   |              ^^^^^^   -- value moved here
+   |              |
    |              value borrowed here after move
    |
    = note: move occurs because value has type `X`, which does not implement the `Copy` trait
@@ -55,9 +54,8 @@ error[E0382]: borrow of moved value
   --> $DIR/bind-by-move-neither-can-live-while-the-other-survives-1.rs:26:14
    |
 LL |         Some(ref mut _y @ _z) => {}
-   |              ^^^^^^^^^^^^^--
-   |              |            |
-   |              |            value moved here
+   |              ^^^^^^^^^^   -- value moved here
+   |              |
    |              value borrowed here after move
    |
    = note: move occurs because value has type `X`, which does not implement the `Copy` trait

--- a/src/test/ui/pattern/bindings-after-at/bind-by-move-no-subbindings-fun-param.stderr
+++ b/src/test/ui/pattern/bindings-after-at/bind-by-move-no-subbindings-fun-param.stderr
@@ -2,9 +2,8 @@ error[E0382]: use of partially moved value
   --> $DIR/bind-by-move-no-subbindings-fun-param.rs:7:6
    |
 LL | fn f(a @ A(u): A) -> Box<u8> {
-   |      ^^^^^^-^
-   |      |     |
-   |      |     value partially moved here
+   |      ^     - value partially moved here
+   |      |
    |      value used here after partial move
    |
    = note: partial move occurs because value has type `Box<u8>`, which does not implement the `Copy` trait

--- a/src/test/ui/pattern/bindings-after-at/borrowck-move-and-move.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-move-and-move.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value
   --> $DIR/borrowck-move-and-move.rs:11:9
    |
 LL |     let a @ b = U;
-   |         ^^^^-   - move occurs because value has type `U`, which does not implement the `Copy` trait
+   |         ^   -   - move occurs because value has type `U`, which does not implement the `Copy` trait
    |         |   |
    |         |   value moved here
    |         value used here after move
@@ -11,9 +11,8 @@ error[E0382]: use of partially moved value
   --> $DIR/borrowck-move-and-move.rs:13:9
    |
 LL |     let a @ (b, c) = (U, U);
-   |         ^^^^^^^^-^
-   |         |       |
-   |         |       value partially moved here
+   |         ^       - value partially moved here
+   |         |
    |         value used here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -22,9 +21,8 @@ error[E0382]: use of partially moved value
   --> $DIR/borrowck-move-and-move.rs:15:9
    |
 LL |     let a @ (b, c) = (u(), u());
-   |         ^^^^^^^^-^
-   |         |       |
-   |         |       value partially moved here
+   |         ^       - value partially moved here
+   |         |
    |         value used here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -35,9 +33,8 @@ error[E0382]: use of moved value
 LL |     match Ok(U) {
    |           ----- move occurs because value has type `Result<U, U>`, which does not implement the `Copy` trait
 LL |         a @ Ok(b) | a @ Err(b) => {}
-   |         -------^-
-   |         |      |
-   |         |      value used here after move
+   |         -      ^ value used here after move
+   |         |
    |         value moved here
 
 error[E0382]: use of moved value
@@ -46,18 +43,16 @@ error[E0382]: use of moved value
 LL |     match Ok(U) {
    |           ----- move occurs because value has type `Result<U, U>`, which does not implement the `Copy` trait
 LL |         a @ Ok(b) | a @ Err(b) => {}
-   |                     --------^-
-   |                     |       |
-   |                     |       value used here after move
+   |                     -       ^ value used here after move
+   |                     |
    |                     value moved here
 
 error[E0382]: use of partially moved value
   --> $DIR/borrowck-move-and-move.rs:25:9
    |
 LL |         xs @ [a, .., b] => {}
-   |         ^^^^^^^^^^^^^-^
-   |         |            |
-   |         |            value partially moved here
+   |         ^^           - value partially moved here
+   |         |
    |         value used here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -66,9 +61,8 @@ error[E0382]: use of partially moved value
   --> $DIR/borrowck-move-and-move.rs:29:9
    |
 LL |         xs @ [_, ys @ .., _] => {}
-   |         ^^^^^^^^^-------^^^^
-   |         |        |
-   |         |        value partially moved here
+   |         ^^       -- value partially moved here
+   |         |
    |         value used here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -77,7 +71,7 @@ error[E0382]: use of moved value
   --> $DIR/borrowck-move-and-move.rs:22:12
    |
 LL |     fn fun(a @ b: U) {}
-   |            ^^^^-
+   |            ^----
    |            |   |
    |            |   value moved here
    |            value used here after move

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-at-and-box.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-at-and-box.stderr
@@ -74,9 +74,8 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-at-and-box.rs:31:9
    |
 LL |     let ref a @ box b = Box::new(NC);
-   |         ^^^^^^^^^^^^-
-   |         |           |
-   |         |           value moved here
+   |         ^^^^^       - value moved here
+   |         |
    |         value borrowed here after move
    |
    = note: move occurs because value has type `NC`, which does not implement the `Copy` trait
@@ -85,9 +84,8 @@ error[E0502]: cannot borrow value as immutable because it is also borrowed as mu
   --> $DIR/borrowck-pat-at-and-box.rs:38:9
    |
 LL |     let ref a @ box ref mut b = Box::new(NC);
-   |         ^^^^^^^^^^^^---------
-   |         |           |
-   |         |           mutable borrow occurs here
+   |         ^^^^^       --------- mutable borrow occurs here
+   |         |
    |         immutable borrow occurs here
 ...
 LL |     *b = NC;
@@ -97,9 +95,8 @@ error[E0502]: cannot borrow value as immutable because it is also borrowed as mu
   --> $DIR/borrowck-pat-at-and-box.rs:42:9
    |
 LL |     let ref a @ box ref mut b = Box::new(NC);
-   |         ^^^^^^^^^^^^---------
-   |         |           |
-   |         |           mutable borrow occurs here
+   |         ^^^^^       --------- mutable borrow occurs here
+   |         |
    |         immutable borrow occurs here
 ...
 LL |     *b = NC;
@@ -109,9 +106,8 @@ error[E0502]: cannot borrow value as mutable because it is also borrowed as immu
   --> $DIR/borrowck-pat-at-and-box.rs:48:9
    |
 LL |     let ref mut a @ box ref b = Box::new(NC);
-   |         ^^^^^^^^^^^^^^^^-----
-   |         |               |
-   |         |               immutable borrow occurs here
+   |         ^^^^^^^^^       ----- immutable borrow occurs here
+   |         |
    |         mutable borrow occurs here
 ...
 LL |     drop(b);
@@ -121,9 +117,8 @@ error[E0502]: cannot borrow value as mutable because it is also borrowed as immu
   --> $DIR/borrowck-pat-at-and-box.rs:62:9
    |
 LL |         ref mut a @ box ref b => {
-   |         ^^^^^^^^^^^^^^^^-----
-   |         |               |
-   |         |               immutable borrow occurs here
+   |         ^^^^^^^^^       ----- immutable borrow occurs here
+   |         |
    |         mutable borrow occurs here
 ...
 LL |             drop(b);
@@ -133,9 +128,8 @@ error[E0502]: cannot borrow value as mutable because it is also borrowed as immu
   --> $DIR/borrowck-pat-at-and-box.rs:54:11
    |
 LL |     fn f5(ref mut a @ box ref b: Box<NC>) {
-   |           ^^^^^^^^^^^^^^^^-----
-   |           |               |
-   |           |               immutable borrow occurs here
+   |           ^^^^^^^^^       ----- immutable borrow occurs here
+   |           |
    |           mutable borrow occurs here
 ...
 LL |         drop(b);

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref-inverse.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref-inverse.stderr
@@ -262,9 +262,8 @@ error[E0382]: use of partially moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:24:9
    |
 LL |     let a @ (mut b @ ref mut c, d @ ref e) = (U, U);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^---------^
-   |         |                       |
-   |         |                       value partially moved here
+   |         ^                       - value partially moved here
+   |         |
    |         value used here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -273,9 +272,8 @@ error[E0382]: use of partially moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:33:9
    |
 LL |     let a @ (mut b @ ref mut c, d @ ref e) = (u(), u());
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^---------^
-   |         |                       |
-   |         |                       value partially moved here
+   |         ^                       - value partially moved here
+   |         |
    |         value used here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -286,10 +284,7 @@ error[E0382]: use of moved value
 LL |     match Some((U, U)) {
    |           ------------ move occurs because value has type `Option<(U, U)>`, which does not implement the `Copy` trait
 LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
-   |         -----------------------------^^^^^^^^^--
-   |         |                            |
-   |         |                            value used here after move
-   |         value moved here
+   |         - value moved here           ^ value used here after move
 
 error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:55:30
@@ -297,9 +292,8 @@ error[E0382]: borrow of moved value
 LL |     match Some([U, U]) {
    |           ------------ move occurs because value has type `Option<[U; 2]>`, which does not implement the `Copy` trait
 LL |         mut a @ Some([ref b, ref mut c]) => {}
-   |         ---------------------^^^^^^^^^--
-   |         |                    |
-   |         |                    value borrowed here after move
+   |         -----                ^^^^^^^^^ value borrowed here after move
+   |         |
    |         value moved here
 
 error[E0382]: borrow of moved value
@@ -308,9 +302,8 @@ error[E0382]: borrow of moved value
 LL |     match Some(u()) {
    |           --------- move occurs because value has type `Option<U>`, which does not implement the `Copy` trait
 LL |         a @ Some(ref b) => {}
-   |         ---------^^^^^-
-   |         |        |
-   |         |        value borrowed here after move
+   |         -        ^^^^^ value borrowed here after move
+   |         |
    |         value moved here
 
 error[E0382]: use of moved value
@@ -319,10 +312,7 @@ error[E0382]: use of moved value
 LL |     match Some((u(), u())) {
    |           ---------------- move occurs because value has type `Option<(U, U)>`, which does not implement the `Copy` trait
 LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
-   |         -----------------------------^^^^^^^^^--
-   |         |                            |
-   |         |                            value used here after move
-   |         value moved here
+   |         - value moved here           ^ value used here after move
 
 error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:75:30
@@ -330,18 +320,16 @@ error[E0382]: borrow of moved value
 LL |     match Some([u(), u()]) {
    |           ---------------- move occurs because value has type `Option<[U; 2]>`, which does not implement the `Copy` trait
 LL |         mut a @ Some([ref b, ref mut c]) => {}
-   |         ---------------------^^^^^^^^^--
-   |         |                    |
-   |         |                    value borrowed here after move
+   |         -----                ^^^^^^^^^ value borrowed here after move
+   |         |
    |         value moved here
 
 error[E0382]: use of partially moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:14:11
    |
 LL |     fn f2(mut a @ (b @ ref c, mut d @ ref e): (U, U)) {}
-   |           ^^^^^^^^^^^^^^^^^^^^-------------^
-   |           |                   |
-   |           |                   value partially moved here
+   |           ^^^^^               ----- value partially moved here
+   |           |
    |           value used here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref.stderr
@@ -237,9 +237,8 @@ error[E0382]: borrow of partially moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:30:9
    |
 LL |     let ref mut a @ [b, mut c] = [U, U];
-   |         ^^^^^^^^^^^^^^^^-----^
-   |         |               |
-   |         |               value partially moved here
+   |         ^^^^^^^^^       ----- value partially moved here
+   |         |
    |         value borrowed here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -248,7 +247,7 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:33:9
    |
 LL |     let ref a @ b = u();
-   |         ^^^^^^^^-   --- move occurs because value has type `U`, which does not implement the `Copy` trait
+   |         ^^^^^   -   --- move occurs because value has type `U`, which does not implement the `Copy` trait
    |         |       |
    |         |       value moved here
    |         value borrowed here after move
@@ -257,9 +256,8 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:36:18
    |
 LL |     let ref a @ (ref b @ mut c, ref d @ e) = (u(), u());
-   |                  ^^^^^^^^-----
-   |                  |       |
-   |                  |       value moved here
+   |                  ^^^^^   ----- value moved here
+   |                  |
    |                  value borrowed here after move
    |
    = note: move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -268,9 +266,8 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:36:33
    |
 LL |     let ref a @ (ref b @ mut c, ref d @ e) = (u(), u());
-   |                                 ^^^^^^^^-
-   |                                 |       |
-   |                                 |       value moved here
+   |                                 ^^^^^   - value moved here
+   |                                 |
    |                                 value borrowed here after move
    |
    = note: move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -279,9 +276,8 @@ error[E0382]: borrow of partially moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:42:9
    |
 LL |     let ref mut a @ [b, mut c] = [u(), u()];
-   |         ^^^^^^^^^^^^^^^^-----^
-   |         |               |
-   |         |               value partially moved here
+   |         ^^^^^^^^^       ----- value partially moved here
+   |         |
    |         value borrowed here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -290,9 +286,8 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:69:23
    |
 LL |         ref a @ Some((ref b @ mut c, ref d @ e)) => {}
-   |                       ^^^^^^^^-----
-   |                       |       |
-   |                       |       value moved here
+   |                       ^^^^^   ----- value moved here
+   |                       |
    |                       value borrowed here after move
    |
    = note: move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -305,9 +300,8 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:69:38
    |
 LL |         ref a @ Some((ref b @ mut c, ref d @ e)) => {}
-   |                                      ^^^^^^^^-
-   |                                      |       |
-   |                                      |       value moved here
+   |                                      ^^^^^   - value moved here
+   |                                      |
    |                                      value borrowed here after move
    |
    = note: move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -320,7 +314,7 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:11:11
    |
 LL |     fn f1(ref a @ b: U) {}
-   |           ^^^^^^^^-
+   |           ^^^^^----
    |           |       |
    |           |       value moved here
    |           value borrowed here after move
@@ -330,9 +324,8 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:14:20
    |
 LL |     fn f2(ref a @ (ref b @ mut c, ref d @ e): (U, U)) {}
-   |                    ^^^^^^^^-----
-   |                    |       |
-   |                    |       value moved here
+   |                    ^^^^^   ----- value moved here
+   |                    |
    |                    value borrowed here after move
    |
    = note: move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -341,9 +334,8 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:14:35
    |
 LL |     fn f2(ref a @ (ref b @ mut c, ref d @ e): (U, U)) {}
-   |                                   ^^^^^^^^-
-   |                                   |       |
-   |                                   |       value moved here
+   |                                   ^^^^^   - value moved here
+   |                                   |
    |                                   value borrowed here after move
    |
    = note: move occurs because value has type `U`, which does not implement the `Copy` trait
@@ -352,9 +344,8 @@ error[E0382]: borrow of partially moved value
   --> $DIR/borrowck-pat-by-move-and-ref.rs:20:11
    |
 LL |     fn f3(ref mut a @ [b, mut c]: [U; 2]) {}
-   |           ^^^^^^^^^^^^^^^^-----^
-   |           |               |
-   |           |               value partially moved here
+   |           ^^^^^^^^^       ----- value partially moved here
+   |           |
    |           value borrowed here after partial move
    |
    = note: partial move occurs because value has type `U`, which does not implement the `Copy` trait

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
@@ -298,9 +298,8 @@ error[E0502]: cannot borrow value as immutable because it is also borrowed as mu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:8:31
    |
 LL |         ref mut z @ &mut Some(ref a) => {
-   |         ----------------------^^^^^-
-   |         |                     |
-   |         |                     immutable borrow occurs here
+   |         ---------             ^^^^^ immutable borrow occurs here
+   |         |
    |         mutable borrow occurs here
 ...
 LL |             **z = None;
@@ -310,9 +309,8 @@ error[E0502]: cannot borrow value as mutable because it is also borrowed as immu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:46:9
    |
 LL |     let ref mut a @ ref b = u();
-   |         ^^^^^^^^^^^^-----
-   |         |           |
-   |         |           immutable borrow occurs here
+   |         ^^^^^^^^^   ----- immutable borrow occurs here
+   |         |
    |         mutable borrow occurs here
 ...
 LL |     drop(b);
@@ -322,9 +320,8 @@ error[E0502]: cannot borrow value as immutable because it is also borrowed as mu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:51:9
    |
 LL |     let ref a @ ref mut b = u();
-   |         ^^^^^^^^---------
-   |         |       |
-   |         |       mutable borrow occurs here
+   |         ^^^^^   --------- mutable borrow occurs here
+   |         |
    |         immutable borrow occurs here
 ...
 LL |     *b = u();
@@ -334,9 +331,8 @@ error[E0502]: cannot borrow value as mutable because it is also borrowed as immu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:76:20
    |
 LL |         ref a @ Ok(ref mut b) | ref a @ Err(ref mut b) => {
-   |         -----------^^^^^^^^^-
-   |         |          |
-   |         |          mutable borrow occurs here
+   |         -----      ^^^^^^^^^ mutable borrow occurs here
+   |         |
    |         immutable borrow occurs here
 ...
 LL |             drop(a);
@@ -346,9 +342,8 @@ error[E0502]: cannot borrow value as mutable because it is also borrowed as immu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:76:45
    |
 LL |         ref a @ Ok(ref mut b) | ref a @ Err(ref mut b) => {
-   |                                 ------------^^^^^^^^^-
-   |                                 |           |
-   |                                 |           mutable borrow occurs here
+   |                                 -----       ^^^^^^^^^ mutable borrow occurs here
+   |                                 |
    |                                 immutable borrow occurs here
 ...
 LL |             drop(a);
@@ -406,9 +401,8 @@ error[E0502]: cannot borrow value as immutable because it is also borrowed as mu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:117:9
    |
 LL |     let ref a @ (ref mut b, ref mut c) = (U, U);
-   |         ^^^^^^^^^---------^^^^^^^^^^^^
-   |         |        |
-   |         |        mutable borrow occurs here
+   |         ^^^^^    --------- mutable borrow occurs here
+   |         |
    |         immutable borrow occurs here
 ...
 LL |     *b = U;
@@ -418,9 +412,8 @@ error[E0502]: cannot borrow value as immutable because it is also borrowed as mu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:123:9
    |
 LL |     let ref a @ (ref mut b, ref mut c) = (U, U);
-   |         ^^^^^^^^^---------^^^^^^^^^^^^
-   |         |        |
-   |         |        mutable borrow occurs here
+   |         ^^^^^    --------- mutable borrow occurs here
+   |         |
    |         immutable borrow occurs here
 ...
 LL |     *b = U;
@@ -430,9 +423,8 @@ error[E0502]: cannot borrow value as immutable because it is also borrowed as mu
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:129:9
    |
 LL |     let ref a @ (ref mut b, ref mut c) = (U, U);
-   |         ^^^^^^^^^---------^^^^^^^^^^^^
-   |         |        |
-   |         |        mutable borrow occurs here
+   |         ^^^^^    --------- mutable borrow occurs here
+   |         |
    |         immutable borrow occurs here
 LL |
 LL |     *b = U;
@@ -442,7 +434,7 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:28:30
    |
 LL |     fn f4_also_moved(ref a @ ref mut b @ c: U) {}
-   |                      --------^^^^^^^^^^^^-
+   |                      --------^^^^^^^^^----
    |                      |       |           |
    |                      |       |           value moved here
    |                      |       value borrowed here after move

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-twice.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-twice.stderr
@@ -262,9 +262,8 @@ error[E0499]: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-twice.rs:29:9
    |
 LL |     let ref mut a @ ref mut b = U;
-   |         ^^^^^^^^^^^^---------
-   |         |           |
-   |         |           first mutable borrow occurs here
+   |         ^^^^^^^^^   --------- first mutable borrow occurs here
+   |         |
    |         second mutable borrow occurs here
 ...
 LL |     drop(b);
@@ -274,9 +273,8 @@ error[E0499]: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-twice.rs:39:9
    |
 LL |     let ref mut a @ ref mut b = U;
-   |         ^^^^^^^^^^^^---------
-   |         |           |
-   |         |           first mutable borrow occurs here
+   |         ^^^^^^^^^   --------- first mutable borrow occurs here
+   |         |
    |         second mutable borrow occurs here
 ...
 LL |     *b = U;
@@ -286,9 +284,8 @@ error[E0499]: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-twice.rs:89:24
    |
 LL |         ref mut a @ Ok(ref mut b) | ref mut a @ Err(ref mut b) => {
-   |         ---------------^^^^^^^^^-
-   |         |              |
-   |         |              second mutable borrow occurs here
+   |         ---------      ^^^^^^^^^ second mutable borrow occurs here
+   |         |
    |         first mutable borrow occurs here
 ...
 LL |             *a = Err(U);
@@ -298,9 +295,8 @@ error[E0499]: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-twice.rs:89:53
    |
 LL |         ref mut a @ Ok(ref mut b) | ref mut a @ Err(ref mut b) => {
-   |                                     ----------------^^^^^^^^^-
-   |                                     |               |
-   |                                     |               second mutable borrow occurs here
+   |                                     ---------       ^^^^^^^^^ second mutable borrow occurs here
+   |                                     |
    |                                     first mutable borrow occurs here
 ...
 LL |             *a = Err(U);
@@ -310,9 +306,8 @@ error[E0499]: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-twice.rs:101:24
    |
 LL |         ref mut a @ Ok(ref mut b) | ref mut a @ Err(ref mut b) => {
-   |         ---------------^^^^^^^^^-
-   |         |              |
-   |         |              second mutable borrow occurs here
+   |         ---------      ^^^^^^^^^ second mutable borrow occurs here
+   |         |
    |         first mutable borrow occurs here
 ...
 LL |             drop(a);
@@ -322,9 +317,8 @@ error[E0499]: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-twice.rs:101:53
    |
 LL |         ref mut a @ Ok(ref mut b) | ref mut a @ Err(ref mut b) => {
-   |                                     ----------------^^^^^^^^^-
-   |                                     |               |
-   |                                     |               second mutable borrow occurs here
+   |                                     ---------       ^^^^^^^^^ second mutable borrow occurs here
+   |                                     |
    |                                     first mutable borrow occurs here
 ...
 LL |             drop(a);
@@ -334,7 +328,7 @@ error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-ref-mut-twice.rs:21:34
    |
 LL |     fn f4_also_moved(ref mut a @ ref mut b @ c: U) {}
-   |                      ------------^^^^^^^^^^^^-
+   |                      ------------^^^^^^^^^----
    |                      |           |           |
    |                      |           |           value moved here
    |                      |           value borrowed here after move

--- a/src/test/ui/pattern/bindings-after-at/copy-and-move-mixed.stderr
+++ b/src/test/ui/pattern/bindings-after-at/copy-and-move-mixed.stderr
@@ -2,9 +2,8 @@ error[E0382]: use of partially moved value
   --> $DIR/copy-and-move-mixed.rs:12:9
    |
 LL |     let a @ NC(b, c @ NC(d, e)) = NC(C, NC(C, C));
-   |         ^^^^^^^^^^------------^
-   |         |         |
-   |         |         value partially moved here
+   |         ^         - value partially moved here
+   |         |
    |         value used here after partial move
    |
    = note: partial move occurs because value has type `NC<C, C>`, which does not implement the `Copy` trait

--- a/src/test/ui/pattern/bindings-after-at/default-binding-modes-both-sides-independent.stderr
+++ b/src/test/ui/pattern/bindings-after-at/default-binding-modes-both-sides-independent.stderr
@@ -48,7 +48,7 @@ error[E0382]: borrow of moved value
   --> $DIR/default-binding-modes-both-sides-independent.rs:29:9
    |
 LL |     let ref mut a @ b = NotCopy;
-   |         ^^^^^^^^^^^^-   ------- move occurs because value has type `NotCopy`, which does not implement the `Copy` trait
+   |         ^^^^^^^^^   -   ------- move occurs because value has type `NotCopy`, which does not implement the `Copy` trait
    |         |           |
    |         |           value moved here
    |         value borrowed here after move

--- a/src/test/ui/pattern/bindings-after-at/nested-binding-modes-mut.stderr
+++ b/src/test/ui/pattern/bindings-after-at/nested-binding-modes-mut.stderr
@@ -11,7 +11,7 @@ error[E0596]: cannot borrow `not_mut` as mutable, as it is not declared as mutab
   --> $DIR/nested-binding-modes-mut.rs:9:5
    |
 LL |     let not_mut @ mut is_mut = 42;
-   |         -------------------- help: consider changing this to be mutable: `mut not_mut`
+   |         ------- help: consider changing this to be mutable: `mut not_mut`
 LL |     &mut is_mut;
 LL |     &mut not_mut;
    |     ^^^^^^^^^^^^ cannot borrow as mutable

--- a/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -35,7 +35,7 @@ error[E0502]: cannot borrow `arr[..]` as mutable because it is also borrowed as 
   --> $DIR/borrowck-move-ref-pattern.rs:13:16
    |
 LL |     let [ref _x0_hold, _x1, ref xs_hold @ ..] = arr;
-   |                             ---------------- immutable borrow occurs here
+   |                             ----------- immutable borrow occurs here
 ...
 LL |     let [_, _, ref mut _x2, _x3, mut _x4] = arr;
    |                ^^^^^^^^^^^ mutable borrow occurs here
@@ -47,7 +47,7 @@ error[E0505]: cannot move out of `arr[..]` because it is borrowed
   --> $DIR/borrowck-move-ref-pattern.rs:13:29
    |
 LL |     let [ref _x0_hold, _x1, ref xs_hold @ ..] = arr;
-   |                             ---------------- borrow of `arr[..]` occurs here
+   |                             ----------- borrow of `arr[..]` occurs here
 ...
 LL |     let [_, _, ref mut _x2, _x3, mut _x4] = arr;
    |                             ^^^ move out of `arr[..]` occurs here
@@ -59,7 +59,7 @@ error[E0505]: cannot move out of `arr[..]` because it is borrowed
   --> $DIR/borrowck-move-ref-pattern.rs:13:34
    |
 LL |     let [ref _x0_hold, _x1, ref xs_hold @ ..] = arr;
-   |                             ---------------- borrow of `arr[..]` occurs here
+   |                             ----------- borrow of `arr[..]` occurs here
 ...
 LL |     let [_, _, ref mut _x2, _x3, mut _x4] = arr;
    |                                  ^^^^^^^ move out of `arr[..]` occurs here


### PR DESCRIPTION
Bindings with nested patterns (`binding @ pat` syntax) currently point to the full pattern.  This PR proposes to shrink the span to stop before the `@`.  This makes the diagnostics for move/mutability conflicts clearer, as they not point to the `binding` only, instead of the full pat.

r? @estebank 