### PR TITLE
Reorder nesting scopes and declare bindings without drop schedule

### DIFF
--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -119,10 +119,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 } => {
                     let ignores_expr_result = matches!(pattern.kind, PatKind::Wild);
                     this.block_context.push(BlockFrame::Statement { ignores_expr_result });
+
+                    // Lower the `else` block first because its parent scope is actually
+                    // enclosing the rest of the `let .. else ..` parts.
+                    let else_block_span = this.thir[*else_block].span;
                     // This place is not really used because this destination place
                     // should never be used to take values at the end of the failure
                     // block.
-                    let else_block_span = this.thir[*else_block].span;
                     let dummy_place = this.temp(this.tcx.types.never, else_block_span);
                     let failure_entry = this.cfg.start_new_block();
                     let failure_block;

--- a/compiler/rustc_typeck/src/check/region.rs
+++ b/compiler/rustc_typeck/src/check/region.rs
@@ -144,6 +144,7 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
                     // the sequence of visits agree with the order in the default
                     // `hir::intravisit` visitor.
                     mem::swap(&mut prev_cx, &mut visitor.cx);
+                    visitor.terminating_scopes.insert(els.hir_id.local_id);
                     visitor.visit_block(els);
                     // From now on, we continue normally.
                     visitor.cx = prev_cx;

--- a/compiler/rustc_typeck/src/check/region.rs
+++ b/compiler/rustc_typeck/src/check/region.rs
@@ -126,6 +126,20 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
 
         for (i, statement) in blk.stmts.iter().enumerate() {
             match statement.kind {
+                hir::StmtKind::Local(hir::Local { els: Some(els), .. }) => {
+                    // Let-else has a special lexical structure for variables.
+                    let mut prev_cx = visitor.cx;
+                    visitor.enter_scope(Scope {
+                        id: blk.hir_id.local_id,
+                        data: ScopeData::Remainder(FirstStatementIndex::new(i)),
+                    });
+                    visitor.cx.var_parent = visitor.cx.parent;
+                    visitor.visit_stmt(statement);
+                    mem::swap(&mut prev_cx, &mut visitor.cx);
+                    // We need to back out temporarily and
+                    visitor.visit_block(els);
+                    visitor.cx = prev_cx;
+                }
                 hir::StmtKind::Local(..) | hir::StmtKind::Item(..) => {
                     // Each declaration introduces a subscope for bindings
                     // introduced by the declaration; this subscope covers a
@@ -138,10 +152,10 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
                         data: ScopeData::Remainder(FirstStatementIndex::new(i)),
                     });
                     visitor.cx.var_parent = visitor.cx.parent;
+                    visitor.visit_stmt(statement)
                 }
-                hir::StmtKind::Expr(..) | hir::StmtKind::Semi(..) => {}
+                hir::StmtKind::Expr(..) | hir::StmtKind::Semi(..) => visitor.visit_stmt(statement),
             }
-            visitor.visit_stmt(statement)
         }
         walk_list!(visitor, visit_expr, &blk.expr);
     }
@@ -460,7 +474,6 @@ fn resolve_local<'tcx>(
     visitor: &mut RegionResolutionVisitor<'tcx>,
     pat: Option<&'tcx hir::Pat<'tcx>>,
     init: Option<&'tcx hir::Expr<'tcx>>,
-    els: Option<&'tcx hir::Block<'tcx>>,
 ) {
     debug!("resolve_local(pat={:?}, init={:?})", pat, init);
 
@@ -546,9 +559,6 @@ fn resolve_local<'tcx>(
     }
     if let Some(pat) = pat {
         visitor.visit_pat(pat);
-    }
-    if let Some(els) = els {
-        visitor.visit_block(els);
     }
 
     /// Returns `true` if `pat` match the `P&` non-terminal.
@@ -766,7 +776,7 @@ impl<'tcx> Visitor<'tcx> for RegionResolutionVisitor<'tcx> {
             // (i.e., `'static`), which means that after `g` returns, it drops,
             // and all the associated destruction scope rules apply.
             self.cx.var_parent = None;
-            resolve_local(self, None, Some(&body.value), None);
+            resolve_local(self, None, Some(&body.value));
         }
 
         if body.generator_kind.is_some() {
@@ -793,7 +803,7 @@ impl<'tcx> Visitor<'tcx> for RegionResolutionVisitor<'tcx> {
         resolve_expr(self, ex);
     }
     fn visit_local(&mut self, l: &'tcx Local<'tcx>) {
-        resolve_local(self, Some(&l.pat), l.init, l.els)
+        resolve_local(self, Some(&l.pat), l.init)
     }
 }
 

--- a/src/test/ui/async-await/async-await-let-else.no-drop-tracking.stderr
+++ b/src/test/ui/async-await/async-await-let-else.no-drop-tracking.stderr
@@ -35,8 +35,7 @@ LL |         bar2(Rc::new(())).await
    |              |
    |              has type `Rc<()>` which is not `Send`
 LL |     };
-LL | }
-   | - `Rc::new(())` is later dropped here
+   |     - `Rc::new(())` is later dropped here
 note: required by a bound in `is_send`
   --> $DIR/async-await-let-else.rs:19:15
    |

--- a/src/test/ui/async-await/async-await-let-else.no-drop-tracking.stderr
+++ b/src/test/ui/async-await/async-await-let-else.no-drop-tracking.stderr
@@ -35,7 +35,8 @@ LL |         bar2(Rc::new(())).await
    |              |
    |              has type `Rc<()>` which is not `Send`
 LL |     };
-   |      - `Rc::new(())` is later dropped here
+LL | }
+   | - `Rc::new(())` is later dropped here
 note: required by a bound in `is_send`
   --> $DIR/async-await-let-else.rs:19:15
    |

--- a/src/test/ui/let-else/issue-99975.rs
+++ b/src/test/ui/let-else/issue-99975.rs
@@ -1,0 +1,20 @@
+// run-pass
+// compile-flags: -C opt-level=3 -Zvalidate-mir
+
+#![feature(let_else)]
+
+fn return_result() -> Option<String> {
+    Some("ok".to_string())
+}
+
+fn start() -> String {
+    let Some(content) = return_result() else {
+        return "none".to_string()
+    };
+
+    content
+}
+
+fn main() {
+    start();
+}

--- a/src/test/ui/let-else/let-else-temporary-lifetime.rs
+++ b/src/test/ui/let-else/let-else-temporary-lifetime.rs
@@ -1,4 +1,5 @@
 // run-pass
+// compile-flags: -Zvalidate-mir
 #![feature(let_else)]
 
 use std::fmt::Display;


### PR DESCRIPTION
Fix #99228 
Fix #99975 

Storages are previously not declared before entering the `else` block of a `let .. else` statement. However, when breaking out of the pattern matching into the `else` block, those storages are recorded as scheduled for drops. This is not expected.

This MR fixes this issue by not scheduling the drops for those storages.

cc @est31 