### PR TITLE
Some more cleanup in `core`

### DIFF
--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -64,7 +64,7 @@ macro_rules! iterator {
         // backwards by `n`. `n` must not exceed `self.len()`.
         macro_rules! zst_shrink {
             ($self: ident, $n: ident) => {
-                $self.end = $self.end.wrapping_byte_offset(-$n);
+                $self.end = $self.end.wrapping_byte_sub($n);
             }
         }
 
@@ -82,7 +82,7 @@ macro_rules! iterator {
             // returning the old start.
             // Unsafe because the offset must not exceed `self.len()`.
             #[inline(always)]
-            unsafe fn post_inc_start(&mut self, offset: isize) -> * $raw_mut T {
+            unsafe fn post_inc_start(&mut self, offset: usize) -> * $raw_mut T {
                 if mem::size_of::<T>() == 0 {
                     zst_shrink!(self, offset);
                     self.ptr.as_ptr()
@@ -90,7 +90,7 @@ macro_rules! iterator {
                     let old = self.ptr.as_ptr();
                     // SAFETY: the caller guarantees that `offset` doesn't exceed `self.len()`,
                     // so this new pointer is inside `self` and thus guaranteed to be non-null.
-                    self.ptr = unsafe { NonNull::new_unchecked(self.ptr.as_ptr().offset(offset)) };
+                    self.ptr = unsafe { NonNull::new_unchecked(self.ptr.as_ptr().add(offset)) };
                     old
                 }
             }
@@ -99,7 +99,7 @@ macro_rules! iterator {
             // returning the new end.
             // Unsafe because the offset must not exceed `self.len()`.
             #[inline(always)]
-            unsafe fn pre_dec_end(&mut self, offset: isize) -> * $raw_mut T {
+            unsafe fn pre_dec_end(&mut self, offset: usize) -> * $raw_mut T {
                 if mem::size_of::<T>() == 0 {
                     zst_shrink!(self, offset);
                     self.ptr.as_ptr()
@@ -107,7 +107,7 @@ macro_rules! iterator {
                     // SAFETY: the caller guarantees that `offset` doesn't exceed `self.len()`,
                     // which is guaranteed to not overflow an `isize`. Also, the resulting pointer
                     // is in bounds of `slice`, which fulfills the other requirements for `offset`.
-                    self.end = unsafe { self.end.offset(-offset) };
+                    self.end = unsafe { self.end.sub(offset) };
                     self.end
                 }
             }
@@ -180,7 +180,7 @@ macro_rules! iterator {
                 }
                 // SAFETY: We are in bounds. `post_inc_start` does the right thing even for ZSTs.
                 unsafe {
-                    self.post_inc_start(n as isize);
+                    self.post_inc_start(n);
                     Some(next_unchecked!(self))
                 }
             }
@@ -189,7 +189,7 @@ macro_rules! iterator {
             fn advance_by(&mut self, n: usize) -> Result<(), usize> {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
-                unsafe { self.post_inc_start(advance as isize) };
+                unsafe { self.post_inc_start(advance) };
                 if advance == n { Ok(()) } else { Err(advance) }
             }
 
@@ -375,7 +375,7 @@ macro_rules! iterator {
                 }
                 // SAFETY: We are in bounds. `pre_dec_end` does the right thing even for ZSTs.
                 unsafe {
-                    self.pre_dec_end(n as isize);
+                    self.pre_dec_end(n);
                     Some(next_back_unchecked!(self))
                 }
             }
@@ -384,7 +384,7 @@ macro_rules! iterator {
             fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
-                unsafe { self.pre_dec_end(advance as isize) };
+                unsafe { self.pre_dec_end(advance) };
                 if advance == n { Ok(()) } else { Err(advance) }
             }
         }

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -365,12 +365,12 @@ where
         if count > 0 {
             macro_rules! left {
                 () => {
-                    l.add(*start_l as usize)
+                    l.add(usize::from(*start_l))
                 };
             }
             macro_rules! right {
                 () => {
-                    r.sub((*start_r as usize) + 1)
+                    r.sub(usize::from(*start_r) + 1)
                 };
             }
 
@@ -458,7 +458,7 @@ where
             //    the last block, so the `l.offset` calls are valid.
             unsafe {
                 end_l = end_l.sub(1);
-                ptr::swap(l.add(*end_l as usize), r.sub(1));
+                ptr::swap(l.add(usize::from(*end_l)), r.sub(1));
                 r = r.sub(1);
             }
         }
@@ -471,7 +471,7 @@ where
             // SAFETY: See the reasoning in [remaining-elements-safety].
             unsafe {
                 end_r = end_r.sub(1);
-                ptr::swap(l, r.sub((*end_r as usize) + 1));
+                ptr::swap(l, r.sub(usize::from(*end_r) + 1));
                 l = l.add(1);
             }
         }


### PR DESCRIPTION
- remove some integer casts from slice iter (proposed in https://github.com/rust-lang/rust/pull/100819#discussion_r951113196)
- replace `as usize` casts with `usize::from` in slice sort (proposed in https://github.com/rust-lang/rust/pull/100822#discussion_r950768698)

r? @scottmcm 