### PR TITLE
Use RelocModel::Pic for UEFI targets

### DIFF
--- a/compiler/rustc_target/src/spec/tests/tests_impl.rs
+++ b/compiler/rustc_target/src/spec/tests/tests_impl.rs
@@ -146,7 +146,8 @@ impl Target {
         if self.position_independent_executables && !triple.ends_with("-linuxkernel") {
             assert_eq!(self.relocation_model, RelocModel::Pic);
         }
-        if self.relocation_model == RelocModel::Pic {
+        // The UEFI targets do not support dynamic linking but still require PIC (#101377).
+        if self.relocation_model == RelocModel::Pic && self.os != "uefi" {
             assert!(self.dynamic_linking || self.position_independent_executables);
         }
         if self.static_position_independent_executables {

--- a/compiler/rustc_target/src/spec/uefi_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/uefi_msvc_base.rs
@@ -10,7 +10,7 @@
 // code runs in the same environment, no process separation is supported.
 
 use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy};
-use crate::spec::{RelocModel, StackProbeType, TargetOptions};
+use crate::spec::{StackProbeType, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     let mut base = super::msvc_base::opts();
@@ -47,7 +47,6 @@ pub fn opts() -> TargetOptions {
         stack_probes: StackProbeType::Call,
         singlethread: true,
         linker: Some("rust-lld".into()),
-        relocation_model: RelocModel::Static,
         ..base
     }
 }

--- a/src/test/codegen/abi-efiapi.rs
+++ b/src/test/codegen/abi-efiapi.rs
@@ -24,7 +24,7 @@ trait Freeze { }
 #[lang="copy"]
 trait Copy { }
 
-//x86_64: define dso_local win64cc void @has_efiapi
+//x86_64: define win64cc void @has_efiapi
 //i686: define void @has_efiapi
 //aarch64: define dso_local void @has_efiapi
 //arm: define dso_local void @has_efiapi


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/100537, the relocation model for UEFI targets was changed from PIC (the default value) to
static. There was some dicussion of this change here: https://github.com/rust-lang/rust/pull/100537#discussion_r952363012

It turns out that this can cause compilation to fail as described in https://github.com/rust-lang/rust/issues/101377, so switch back to PIC.

Fixes https://github.com/rust-lang/rust/issues/101377