### PR TITLE
Revert "Mention rust-analyzer maintainers when `proc_macro` bridge is changed"

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -316,9 +316,6 @@ Examples of `T-libs-api` changes:
 * Changing observable runtime behavior of library APIs
 """
 
-[mentions."library/proc_macro/src/bridge"]
-cc = ["@rust-lang/wg-rls-2"]
-
 [mentions."src/librustdoc/clean/types.rs"]
 cc = ["@camelid"]
 


### PR DESCRIPTION
Reverts rust-lang/rust#99183

rust-analyzer is now a subtree, and CI fails when the `proc_macro` bridge changes break our tests, so these notifications aren't needed anymore.