### PR TITLE
proc_macro/bridge: Eagerly pass TokenStream contents into the client

### DIFF
--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -60,26 +60,9 @@ macro_rules! with_api {
                 fn emit_diagnostic(diagnostic: Diagnostic<$S::Span>);
             },
             TokenStream {
-                fn drop($self: $S::TokenStream);
-                fn clone($self: &$S::TokenStream) -> $S::TokenStream;
-                fn is_empty($self: &$S::TokenStream) -> bool;
-                fn expand_expr($self: &$S::TokenStream) -> Result<$S::TokenStream, ()>;
+                fn expand_expr($self: $S::TokenStream) -> Result<$S::TokenStream, ()>;
                 fn from_str(src: &str) -> $S::TokenStream;
-                fn to_string($self: &$S::TokenStream) -> String;
-                fn from_token_tree(
-                    tree: TokenTree<$S::TokenStream, $S::Span, $S::Symbol>,
-                ) -> $S::TokenStream;
-                fn concat_trees(
-                    base: Option<$S::TokenStream>,
-                    trees: Vec<TokenTree<$S::TokenStream, $S::Span, $S::Symbol>>,
-                ) -> $S::TokenStream;
-                fn concat_streams(
-                    base: Option<$S::TokenStream>,
-                    streams: Vec<$S::TokenStream>,
-                ) -> $S::TokenStream;
-                fn into_trees(
-                    $self: $S::TokenStream
-                ) -> Vec<TokenTree<$S::TokenStream, $S::Span, $S::Symbol>>;
+                fn to_string($self: $S::TokenStream) -> String;
             },
             SourceFile {
                 fn drop($self: $S::SourceFile);
@@ -154,6 +137,8 @@ mod selfless_reify;
 pub mod server;
 #[allow(unsafe_code)]
 mod symbol;
+#[forbid(unsafe_code)]
+mod token_stream;
 
 use buffer::Buffer;
 pub use rpc::PanicMessage;
@@ -444,7 +429,7 @@ compound_traits!(struct DelimSpan<Span> { open, close, entire });
 #[derive(Clone)]
 pub struct Group<TokenStream, Span> {
     pub delimiter: Delimiter,
-    pub stream: Option<TokenStream>,
+    pub stream: TokenStream,
     pub span: DelimSpan<Span>,
 }
 

--- a/library/proc_macro/src/bridge/token_stream.rs
+++ b/library/proc_macro/src/bridge/token_stream.rs
@@ -1,0 +1,71 @@
+use super::server::RpcContext;
+use super::*;
+
+use std::rc::Rc;
+
+#[derive(Clone)]
+pub(crate) struct TokenStream {
+    pub(crate) tokens: Rc<Vec<crate::TokenTree>>,
+}
+
+impl TokenStream {
+    pub(crate) fn new(tokens: Vec<crate::TokenTree>) -> Self {
+        TokenStream { tokens: Rc::new(tokens) }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}
+
+impl<S> Encode<S> for TokenStream {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        let tts: Vec<_> = self
+            .tokens
+            .iter()
+            .map(|tt| match tt {
+                crate::TokenTree::Group(group) => TokenTree::Group(group.0.clone()),
+                crate::TokenTree::Punct(punct) => TokenTree::Punct(punct.0.clone()),
+                crate::TokenTree::Ident(ident) => TokenTree::Ident(ident.0.clone()),
+                crate::TokenTree::Literal(literal) => TokenTree::Literal(literal.0.clone()),
+            })
+            .collect();
+        tts.encode(w, s)
+    }
+}
+
+impl<S: server::Server> DecodeMut<'_, '_, client::HandleStore<server::MarkedTypes<S>>>
+    for Marked<S::TokenStream, TokenStream>
+{
+    fn decode(r: &mut Reader<'_>, s: &mut client::HandleStore<server::MarkedTypes<S>>) -> Self {
+        let tts: Vec<_> = DecodeMut::decode(r, s);
+        s.rpc_context.tokenstream_from_tts(tts.into_iter())
+    }
+}
+
+impl<S: server::Server> Encode<client::HandleStore<server::MarkedTypes<S>>>
+    for Marked<S::TokenStream, TokenStream>
+{
+    fn encode(self, w: &mut Writer, s: &mut client::HandleStore<server::MarkedTypes<S>>) {
+        let tts = s.rpc_context.tts_from_tokenstream(self);
+        tts.encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for TokenStream {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        TokenStream::new(
+            <Vec<_>>::decode(r, s)
+                .into_iter()
+                .map(|tt| match tt {
+                    TokenTree::Group(group) => crate::TokenTree::Group(crate::Group(group)),
+                    TokenTree::Punct(punct) => crate::TokenTree::Punct(crate::Punct(punct)),
+                    TokenTree::Ident(ident) => crate::TokenTree::Ident(crate::Ident(ident)),
+                    TokenTree::Literal(literal) => {
+                        crate::TokenTree::Literal(crate::Literal(literal))
+                    }
+                })
+                .collect(),
+        )
+    }
+}

--- a/src/test/rustdoc-ui/intra-doc/through-proc-macro.stderr
+++ b/src/test/rustdoc-ui/intra-doc/through-proc-macro.stderr
@@ -1,14 +1,19 @@
 warning: unresolved link to `Oooops`
-  --> $DIR/through-proc-macro.rs:13:10
+  --> $DIR/through-proc-macro.rs:13:5
    |
 LL |     /// [Oooops]
-   |          ^^^^^^ no item named `Oooops` in scope
+   |     ^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/through-proc-macro.rs:7:9
    |
 LL | #![warn(rustdoc::broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: the link appears in this line:
+           
+           [Oooops]
+            ^^^^^^
+   = note: no item named `Oooops` in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: 1 warning emitted

--- a/src/test/ui/proc-macro/capture-macro-rules-invoke.stdout
+++ b/src/test/ui/proc-macro/capture-macro-rules-invoke.stdout
@@ -11,9 +11,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         span: $DIR/capture-macro-rules-invoke.rs:21:21: 21:26 (#4),
     },
 ]
-PRINT-BANG INPUT (DISPLAY): 1 + 1, { "a" }, let a = 1;, String, my_name, 'a, my_val = 30,
-std::option::Option, pub(in some::path) , [a b c], -30
-PRINT-BANG RE-COLLECTED (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
+PRINT-BANG INPUT (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
 std :: option :: Option, pub(in some :: path), [a b c], - 30
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {

--- a/src/test/ui/proc-macro/capture-unglued-token.stdout
+++ b/src/test/ui/proc-macro/capture-unglued-token.stdout
@@ -1,5 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): Vec<u8>
-PRINT-BANG RE-COLLECTED (DISPLAY): Vec < u8 >
+PRINT-BANG INPUT (DISPLAY): Vec < u8 >
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {
         delimiter: None,

--- a/src/test/ui/proc-macro/doc-comment-preserved.stdout
+++ b/src/test/ui/proc-macro/doc-comment-preserved.stdout
@@ -1,12 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): /**
-*******
-* DOC *
-* DOC *
-* DOC *
-*******
-*/
- pub struct S ;
-PRINT-BANG RE-COLLECTED (DISPLAY): #[doc = "\n*******\n* DOC *\n* DOC *\n* DOC *\n*******\n"] pub struct S ;
+PRINT-BANG INPUT (DISPLAY): #[doc = "\n*******\n* DOC *\n* DOC *\n* DOC *\n*******\n"] pub struct S ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/src/test/ui/proc-macro/expr-stmt-nonterminal-tokens.stdout
+++ b/src/test/ui/proc-macro/expr-stmt-nonterminal-tokens.stdout
@@ -1,5 +1,4 @@
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = #[allow(warnings)] 0 ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = #[allow(warnings)] #[allow(warnings)] 0 ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = #[allow(warnings)] #[allow(warnings)] 0 ; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -122,8 +121,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #4 bytes(306..355),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 } ; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -280,8 +278,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #12 bytes(430..483),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH } ; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -358,8 +355,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #16 bytes(430..483),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 + 1; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 + 1 } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 + 1 } ; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -449,8 +445,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #20 bytes(430..483),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH + 1; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH + 1 } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH + 1 } ; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",

--- a/src/test/ui/proc-macro/inert-attribute-order.stdout
+++ b/src/test/ui/proc-macro/inert-attribute-order.stdout
@@ -1,7 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): /// 1
-#[rustfmt :: attr2] #[doc = "3"] #[doc = "4"] #[rustfmt :: attr5] /// 6
-#[print_attr(nodebug)] struct S ;
-PRINT-ATTR RE-COLLECTED (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
+PRINT-ATTR INPUT (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
 #[rustfmt :: attr5] #[doc = " 6"] #[print_attr(nodebug)] struct S ;
 PRINT-ATTR INPUT (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
 #[rustfmt :: attr5] #[doc = " 6"] struct S ;

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade-full.rs
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade-full.rs
@@ -4,10 +4,11 @@
 extern crate test_macros;
 
 #[derive(Print)]
+#[allow(unused)]
 enum ProceduralMasqueradeDummyType {
 //~^ ERROR using
 //~| WARN this was previously
-    Input
+    Input = (0, stringify!(input tokens!?)).0
 }
 
 fn main() {}

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade-full.stderr
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade-full.stderr
@@ -1,5 +1,5 @@
 error: using `procedural-masquerade` crate
-  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+  --> $DIR/issue-73933-procedural-masquerade-full.rs:8:6
    |
 LL | enum ProceduralMasqueradeDummyType {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ error: aborting due to previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: using `procedural-masquerade` crate
-  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+  --> $DIR/issue-73933-procedural-masquerade-full.rs:8:6
    |
 LL | enum ProceduralMasqueradeDummyType {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade-full.stdout
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade-full.stdout
@@ -1,0 +1,118 @@
+PRINT-DERIVE INPUT (DISPLAY): #[allow(unused)] enum ProceduralMasqueradeDummyType
+{ Input = (0, stringify! (input tokens! ?)).0, }
+PRINT-DERIVE INPUT (DEBUG): TokenStream [
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: #0 bytes(86..87),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "allow",
+                span: #0 bytes(88..93),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "unused",
+                        span: #0 bytes(94..100),
+                    },
+                ],
+                span: #0 bytes(93..101),
+            },
+        ],
+        span: #0 bytes(87..102),
+    },
+    Ident {
+        ident: "enum",
+        span: #0 bytes(103..107),
+    },
+    Ident {
+        ident: "ProceduralMasqueradeDummyType",
+        span: #0 bytes(108..137),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "Input",
+                span: #0 bytes(191..196),
+            },
+            Punct {
+                ch: '=',
+                spacing: Alone,
+                span: #0 bytes(197..198),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Literal {
+                        kind: Integer,
+                        symbol: "0",
+                        suffix: None,
+                        span: #0 bytes(200..201),
+                    },
+                    Punct {
+                        ch: ',',
+                        spacing: Alone,
+                        span: #0 bytes(201..202),
+                    },
+                    Ident {
+                        ident: "stringify",
+                        span: #0 bytes(203..212),
+                    },
+                    Punct {
+                        ch: '!',
+                        spacing: Alone,
+                        span: #0 bytes(212..213),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "input",
+                                span: #0 bytes(214..219),
+                            },
+                            Ident {
+                                ident: "tokens",
+                                span: #0 bytes(220..226),
+                            },
+                            Punct {
+                                ch: '!',
+                                spacing: Joint,
+                                span: #0 bytes(226..227),
+                            },
+                            Punct {
+                                ch: '?',
+                                spacing: Alone,
+                                span: #0 bytes(227..228),
+                            },
+                        ],
+                        span: #0 bytes(213..229),
+                    },
+                ],
+                span: #0 bytes(199..230),
+            },
+            Punct {
+                ch: '.',
+                spacing: Alone,
+                span: #0 bytes(230..231),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "0",
+                suffix: None,
+                span: #0 bytes(231..232),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: #0 bytes(233..234),
+            },
+        ],
+        span: #0 bytes(138..234),
+    },
+]

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
@@ -1,5 +1,4 @@
 PRINT-DERIVE INPUT (DISPLAY): enum ProceduralMasqueradeDummyType { Input, }
-PRINT-DERIVE RE-COLLECTED (DISPLAY): enum ProceduralMasqueradeDummyType { Input }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -14,9 +13,14 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         stream: TokenStream [
             Ident {
                 ident: "Input",
-                span: #0 bytes(315..320),
+                span: #0 bytes(174..179),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: #0 bytes(180..181),
             },
         ],
-        span: #0 bytes(121..322),
+        span: #0 bytes(121..181),
     },
 ]

--- a/src/test/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
+++ b/src/test/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
@@ -1,7 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): foo! { #[fake_attr] mod bar {
-    #![doc = r" Foo"]
-} }
-PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): foo! { #[fake_attr] mod bar { #! [doc = r" Foo"] } }
+PRINT-BANG INPUT (DISPLAY): foo! { #[fake_attr] mod bar { #! [doc = r" Foo"] } }
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "foo",

--- a/src/test/ui/proc-macro/nonterminal-expansion.stdout
+++ b/src/test/ui/proc-macro/nonterminal-expansion.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR_ARGS INPUT (DISPLAY): a, line!(), b
-PRINT-ATTR_ARGS RE-COLLECTED (DISPLAY): a, line! (), b
+PRINT-ATTR_ARGS INPUT (DISPLAY): a, line! (), b
 PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     Ident {
         ident: "a",

--- a/src/test/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/src/test/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -1,5 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct S;
-PRINT-BANG RE-COLLECTED (DISPLAY): struct S ;
+PRINT-BANG INPUT (DISPLAY): struct S ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {
         delimiter: None,


### PR DESCRIPTION
This change could improve performance, especially in cases like with the
cross-thread backend which have expensive RPC. It handles this by moving
more of the logic for TokenStream into the client, storing a
`Rc<Vec<TokenTree>>` directly, rather than converting to/from the
compiler representation over RPC for every change.

As this eagerly decomposes interpolated AST fragments, this ended up
changing the output of `TokenStream::to_string()`. To keep up
compatibility for now, formatting is still performed using RPC and
`rustc_ast_pretty`, however in the future we may look into decoupling
proc-macro formatting from `rustc_ast_pretty`, and doing it in the
client.

One side-effect of this was that the workaround for the
procedural-masquerade crate had to be updated to work with the new
approach, as we couldn't depend on the AST fragment printer to format
the input. To do this, a real `,` token is now inserted when passing the
enum to a proc-macro rather than depending on the pretty-printing
behaviour. From local tests it appears that the new output should be
compatible enough to work with older versions of procedural-masquerade.

The new conversion between the proc-macro and compiler representations
of a `TokenStream` is now handled by the `RpcContext` type provided by
the proc-macro server. This type is a distinct value which will be
fetched and stored by the server before commands are run, such that the
decoders can have access to relevant state. In the future, we may also
change the symbol handling code to work off of `RpcContext` rather than
being static methods on the `Server` trait.