### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3047,6 +3047,7 @@ mod size_asserts {
     static_assert_size!(Fn, 192);
     static_assert_size!(ForeignItem, 96);
     static_assert_size!(ForeignItemKind, 24);
+    static_assert_size!(GenericArg, 24);
     static_assert_size!(GenericBound, 88);
     static_assert_size!(Generics, 72);
     static_assert_size!(Impl, 200);
@@ -3054,6 +3055,8 @@ mod size_asserts {
     static_assert_size!(ItemKind, 112);
     static_assert_size!(Lit, 48);
     static_assert_size!(LitKind, 24);
+    static_assert_size!(Local, 72);
+    static_assert_size!(Param, 40);
     static_assert_size!(Pat, 120);
     static_assert_size!(PatKind, 96);
     static_assert_size!(Path, 40);

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -155,26 +155,26 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 let op = match *op {
                     InlineAsmOperand::In { reg, ref expr } => hir::InlineAsmOperand::In {
                         reg: lower_reg(reg),
-                        expr: self.lower_expr_mut(expr),
+                        expr: self.lower_expr(expr),
                     },
                     InlineAsmOperand::Out { reg, late, ref expr } => hir::InlineAsmOperand::Out {
                         reg: lower_reg(reg),
                         late,
-                        expr: expr.as_ref().map(|expr| self.lower_expr_mut(expr)),
+                        expr: expr.as_ref().map(|expr| self.lower_expr(expr)),
                     },
                     InlineAsmOperand::InOut { reg, late, ref expr } => {
                         hir::InlineAsmOperand::InOut {
                             reg: lower_reg(reg),
                             late,
-                            expr: self.lower_expr_mut(expr),
+                            expr: self.lower_expr(expr),
                         }
                     }
                     InlineAsmOperand::SplitInOut { reg, late, ref in_expr, ref out_expr } => {
                         hir::InlineAsmOperand::SplitInOut {
                             reg: lower_reg(reg),
                             late,
-                            in_expr: self.lower_expr_mut(in_expr),
-                            out_expr: out_expr.as_ref().map(|expr| self.lower_expr_mut(expr)),
+                            in_expr: self.lower_expr(in_expr),
+                            out_expr: out_expr.as_ref().map(|expr| self.lower_expr(expr)),
                         }
                     }
                     InlineAsmOperand::Const { ref anon_const } => {

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -120,7 +120,7 @@ impl<'a, 'hir> ItemLowerer<'a, 'hir> {
         self.with_lctx(CRATE_NODE_ID, |lctx| {
             let module = lctx.lower_mod(&c.items, &c.spans);
             lctx.lower_attrs(hir::CRATE_HIR_ID, &c.attrs);
-            hir::OwnerNode::Crate(lctx.arena.alloc(module))
+            hir::OwnerNode::Crate(module)
         })
     }
 
@@ -158,14 +158,18 @@ impl<'a, 'hir> ItemLowerer<'a, 'hir> {
 }
 
 impl<'hir> LoweringContext<'_, 'hir> {
-    pub(super) fn lower_mod(&mut self, items: &[P<Item>], spans: &ModSpans) -> hir::Mod<'hir> {
-        hir::Mod {
+    pub(super) fn lower_mod(
+        &mut self,
+        items: &[P<Item>],
+        spans: &ModSpans,
+    ) -> &'hir hir::Mod<'hir> {
+        self.arena.alloc(hir::Mod {
             spans: hir::ModSpans {
                 inner_span: self.lower_span(spans.inner_span),
                 inject_use_span: self.lower_span(spans.inject_use_span),
             },
             item_ids: self.arena.alloc_from_iter(items.iter().flat_map(|x| self.lower_item_ref(x))),
-        }
+        })
     }
 
     pub(super) fn lower_item_ref(&mut self, i: &Item) -> SmallVec<[hir::ItemId; 1]> {

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -947,7 +947,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
         params: &'hir [hir::Param<'hir>],
         value: hir::Expr<'hir>,
     ) -> hir::BodyId {
-        let body = hir::Body { generator_kind: self.generator_kind, params, value };
+        let body = hir::Body {
+            generator_kind: self.generator_kind,
+            params,
+            value: self.arena.alloc(value),
+        };
         let id = body.id();
         debug_assert_eq!(id.hir_id.owner, self.current_hir_id_owner);
         self.bodies.push((id.hir_id.local_id, self.arena.alloc(body)));

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1152,7 +1152,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     }
                     _ => {}
                 }
-                GenericArg::Type(self.lower_ty_direct(&ty, itctx))
+                GenericArg::Type(self.lower_ty(&ty, itctx))
             }
             ast::GenericArg::Const(ct) => GenericArg::Const(ConstArg {
                 value: self.lower_anon_const(&ct),

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -359,7 +359,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             }
             FnRetTy::Default(_) => self.arena.alloc(self.ty_tup(*span, &[])),
         };
-        let args = smallvec![GenericArg::Type(self.ty_tup(*inputs_span, inputs))];
+        let args = smallvec![GenericArg::Type(self.arena.alloc(self.ty_tup(*inputs_span, inputs)))];
         let binding = self.output_ty_binding(output_ty.span, output_ty);
         (
             GenericArgsCtor {

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -258,7 +258,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             let ty = place.ty(self.body, self.infcx.tcx).ty;
 
             // If we're in pattern, we do nothing in favor of the previous suggestion (#80913).
-            if is_loop_move & !in_pattern {
+            // Same for if we're in a loop, see #101119.
+            if is_loop_move & !in_pattern && !matches!(use_spans, UseSpans::ClosureUse { .. }) {
                 if let ty::Ref(_, _, hir::Mutability::Mut) = ty.kind() {
                     // We have a `&mut` ref, we need to reborrow on each iteration (#62112).
                     err.span_suggestion_verbose(

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1273,7 +1273,7 @@ pub enum StmtKind<'hir> {
     Semi(&'hir Expr<'hir>),
 }
 
-/// Represents a `let` statement (i.e., `let <pat>:<ty> = <expr>;`).
+/// Represents a `let` statement (i.e., `let <pat>:<ty> = <init>;`).
 #[derive(Debug, HashStable_Generic)]
 pub struct Local<'hir> {
     pub pat: &'hir Pat<'hir>,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -265,7 +265,7 @@ impl InferArg {
 #[derive(Debug, HashStable_Generic)]
 pub enum GenericArg<'hir> {
     Lifetime(Lifetime),
-    Type(Ty<'hir>),
+    Type(&'hir Ty<'hir>),
     Const(ConstArg),
     Infer(InferArg),
 }
@@ -3502,7 +3502,7 @@ mod size_asserts {
     static_assert_size!(FnDecl<'_>, 40);
     static_assert_size!(ForeignItem<'_>, 72);
     static_assert_size!(ForeignItemKind<'_>, 40);
-    static_assert_size!(GenericArg<'_>, 80);
+    static_assert_size!(GenericArg<'_>, 40);
     static_assert_size!(GenericBound<'_>, 48);
     static_assert_size!(Generics<'_>, 56);
     static_assert_size!(Impl<'_>, 80);

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2991,7 +2991,7 @@ pub enum ItemKind<'hir> {
     /// A MBE macro definition (`macro_rules!` or `macro`).
     Macro(ast::MacroDef, MacroKind),
     /// A module.
-    Mod(Mod<'hir>),
+    Mod(&'hir Mod<'hir>),
     /// An external module, e.g. `extern { .. }`.
     ForeignMod { abi: Abi, items: &'hir [ForeignItemRef] },
     /// Module-level inline assembly (from `global_asm!`).

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1438,7 +1438,7 @@ pub struct BodyId {
 #[derive(Debug, HashStable_Generic)]
 pub struct Body<'hir> {
     pub params: &'hir [Param<'hir>],
-    pub value: Expr<'hir>,
+    pub value: &'hir Expr<'hir>,
     pub generator_kind: Option<GeneratorKind>,
 }
 
@@ -2561,23 +2561,23 @@ pub enum TyKind<'hir> {
 pub enum InlineAsmOperand<'hir> {
     In {
         reg: InlineAsmRegOrRegClass,
-        expr: Expr<'hir>,
+        expr: &'hir Expr<'hir>,
     },
     Out {
         reg: InlineAsmRegOrRegClass,
         late: bool,
-        expr: Option<Expr<'hir>>,
+        expr: Option<&'hir Expr<'hir>>,
     },
     InOut {
         reg: InlineAsmRegOrRegClass,
         late: bool,
-        expr: Expr<'hir>,
+        expr: &'hir Expr<'hir>,
     },
     SplitInOut {
         reg: InlineAsmRegOrRegClass,
         late: bool,
-        in_expr: Expr<'hir>,
-        out_expr: Option<Expr<'hir>>,
+        in_expr: &'hir Expr<'hir>,
+        out_expr: Option<&'hir Expr<'hir>>,
     },
     Const {
         anon_const: AnonConst,
@@ -3496,7 +3496,7 @@ mod size_asserts {
     use super::*;
     // These are in alphabetical order, which is easy to maintain.
     static_assert_size!(Block<'_>, 48);
-    static_assert_size!(Body<'_>, 80);
+    static_assert_size!(Body<'_>, 32);
     static_assert_size!(Expr<'_>, 56);
     static_assert_size!(ExprKind<'_>, 40);
     static_assert_size!(FnDecl<'_>, 40);

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3495,16 +3495,32 @@ impl<'hir> Node<'hir> {
 mod size_asserts {
     use super::*;
     // These are in alphabetical order, which is easy to maintain.
-    static_assert_size!(Block<'static>, 48);
-    static_assert_size!(Expr<'static>, 56);
-    static_assert_size!(ForeignItem<'static>, 72);
+    static_assert_size!(Block<'_>, 48);
+    static_assert_size!(Body<'_>, 80);
+    static_assert_size!(Expr<'_>, 56);
+    static_assert_size!(ExprKind<'_>, 40);
+    static_assert_size!(FnDecl<'_>, 40);
+    static_assert_size!(ForeignItem<'_>, 72);
+    static_assert_size!(ForeignItemKind<'_>, 40);
+    static_assert_size!(GenericArg<'_>, 80);
     static_assert_size!(GenericBound<'_>, 48);
-    static_assert_size!(Generics<'static>, 56);
-    static_assert_size!(ImplItem<'static>, 88);
-    static_assert_size!(Impl<'static>, 80);
-    static_assert_size!(Item<'static>, 80);
-    static_assert_size!(Pat<'static>, 88);
-    static_assert_size!(QPath<'static>, 24);
-    static_assert_size!(TraitItem<'static>, 96);
-    static_assert_size!(Ty<'static>, 72);
+    static_assert_size!(Generics<'_>, 56);
+    static_assert_size!(Impl<'_>, 80);
+    static_assert_size!(ImplItem<'_>, 88);
+    static_assert_size!(ImplItemKind<'_>, 40);
+    static_assert_size!(Item<'_>, 80);
+    static_assert_size!(ItemKind<'_>, 48);
+    static_assert_size!(Local<'_>, 64);
+    static_assert_size!(Param<'_>, 32);
+    static_assert_size!(Pat<'_>, 88);
+    static_assert_size!(PatKind<'_>, 64);
+    static_assert_size!(Path<'_>, 48);
+    static_assert_size!(PathSegment<'_>, 56);
+    static_assert_size!(QPath<'_>, 24);
+    static_assert_size!(Stmt<'_>, 32);
+    static_assert_size!(StmtKind<'_>, 16);
+    static_assert_size!(TraitItem<'_>, 96);
+    static_assert_size!(TraitItemKind<'_>, 56);
+    static_assert_size!(Ty<'_>, 72);
+    static_assert_size!(TyKind<'_>, 56);
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -280,7 +280,7 @@ impl GenericArg<'_> {
         }
     }
 
-    pub fn id(&self) -> HirId {
+    pub fn hir_id(&self) -> HirId {
         match self {
             GenericArg::Lifetime(l) => l.hir_id,
             GenericArg::Type(t) => t.hir_id,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -69,7 +69,7 @@ pub fn parse<'a>(sess: &'a Session, input: &Input) -> PResult<'a, ast::Crate> {
     }
 
     if sess.opts.unstable_opts.hir_stats {
-        hir_stats::print_ast_stats(&krate, "PRE EXPANSION AST STATS");
+        hir_stats::print_ast_stats(&krate, "PRE EXPANSION AST STATS", "ast-stats-1");
     }
 
     Ok(krate)
@@ -416,7 +416,7 @@ pub fn configure_and_expand(
     }
 
     if sess.opts.unstable_opts.hir_stats {
-        hir_stats::print_ast_stats(&krate, "POST EXPANSION AST STATS");
+        hir_stats::print_ast_stats(&krate, "POST EXPANSION AST STATS", "ast-stats-2");
     }
 
     resolver.resolve_crate(&krate);

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -842,7 +842,7 @@ pub trait LintContext: Sized {
                     if let Some(positional_arg_to_replace) = position_sp_to_replace {
                         let name = if is_formatting_arg { named_arg_name + "$" } else { named_arg_name };
                         let span_to_replace = if let Ok(positional_arg_content) =
-                            self.sess().source_map().span_to_snippet(positional_arg_to_replace) && positional_arg_content.starts_with(":") {
+                            self.sess().source_map().span_to_snippet(positional_arg_to_replace) && positional_arg_content.starts_with(':') {
                             positional_arg_to_replace.shrink_to_lo()
                         } else {
                             positional_arg_to_replace

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3407,7 +3407,7 @@ declare_lint! {
     ///
     /// ### Example of drop reorder
     ///
-    /// ```rust,compile_fail
+    /// ```rust,edition2018,compile_fail
     /// #![deny(rust_2021_incompatible_closure_captures)]
     /// # #![allow(unused)]
     ///
@@ -3443,7 +3443,7 @@ declare_lint! {
     ///
     /// ### Example of auto-trait
     ///
-    /// ```rust,compile_fail
+    /// ```rust,edition2018,compile_fail
     /// #![deny(rust_2021_incompatible_closure_captures)]
     /// use std::thread;
     ///

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1378,19 +1378,11 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         let tcx = self.tcx;
 
-        let keys_and_jobs = tcx
-            .mir_keys(())
-            .iter()
-            .filter_map(|&def_id| {
-                let (encode_const, encode_opt) = should_encode_mir(tcx, def_id);
-                if encode_const || encode_opt {
-                    Some((def_id, encode_const, encode_opt))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        for (def_id, encode_const, encode_opt) in keys_and_jobs.into_iter() {
+        let keys_and_jobs = tcx.mir_keys(()).iter().filter_map(|&def_id| {
+            let (encode_const, encode_opt) = should_encode_mir(tcx, def_id);
+            if encode_const || encode_opt { Some((def_id, encode_const, encode_opt)) } else { None }
+        });
+        for (def_id, encode_const, encode_opt) in keys_and_jobs {
             debug_assert!(encode_const || encode_opt);
 
             debug!("EntryBuilder::encode_mir({:?})", def_id);

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -301,10 +301,6 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_path(self, path)
     }
 
-    // `PathSegment` has one inline use (in `ast::ExprKind::MethodCall`) and
-    // one non-inline use (in `Path::segments`). The latter case is more common
-    // than the former case, so we implement this visitor and tolerate the
-    // double counting in the former case.
     fn visit_path_segment(&mut self, path_span: Span, path_segment: &'v hir::PathSegment<'v>) {
         self.record("PathSegment", Id::None, path_segment);
         hir_visit::walk_path_segment(self, path_span, path_segment)
@@ -509,6 +505,10 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
     // common, so we don't implement `visit_use_tree` and tolerate the missed
     // coverage in the latter case.
 
+    // `PathSegment` has one inline use (in `ast::ExprKind::MethodCall`) and
+    // one non-inline use (in `ast::Path::segments`). The latter case is more
+    // common than the former case, so we implement this visitor and tolerate
+    // the double counting in the former case.
     fn visit_path_segment(&mut self, path_span: Span, path_segment: &'v ast::PathSegment) {
         self.record("PathSegment", Id::None, path_segment);
         ast_visit::walk_path_segment(self, path_span, path_segment)

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -168,6 +168,22 @@ impl<'k> StatCollector<'k> {
     }
 }
 
+// Used to avoid boilerplate for types with many variants.
+macro_rules! record_variants {
+    (
+        ($self:ident, $val:expr, $kind:expr, $id:expr, $mod:ident, $ty:ty, $tykind:ident),
+        [$($variant:ident),*]
+    ) => {
+        match $kind {
+            $(
+                $mod::$tykind::$variant { .. } => {
+                    $self.record_variant(stringify!($ty), stringify!($variant), $id, $val)
+                }
+            )*
+        }
+    };
+}
+
 impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     fn visit_param(&mut self, param: &'v hir::Param<'v>) {
         self.record("Param", Id::Node(param.hir_id), param);
@@ -200,12 +216,46 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_item(&mut self, i: &'v hir::Item<'v>) {
-        self.record("Item", Id::Node(i.hir_id()), i);
+        record_variants!(
+            (self, i, i.kind, Id::Node(i.hir_id()), hir, Item, ItemKind),
+            [
+                ExternCrate,
+                Use,
+                Static,
+                Const,
+                Fn,
+                Macro,
+                Mod,
+                ForeignMod,
+                GlobalAsm,
+                TyAlias,
+                OpaqueTy,
+                Enum,
+                Struct,
+                Union,
+                Trait,
+                TraitAlias,
+                Impl
+            ]
+        );
         hir_visit::walk_item(self, i)
     }
 
+    fn visit_body(&mut self, b: &'v hir::Body<'v>) {
+        self.record("Body", Id::None, b);
+        hir_visit::walk_body(self, b);
+    }
+
+    fn visit_mod(&mut self, m: &'v hir::Mod<'v>, _s: Span, n: HirId) {
+        self.record("Mod", Id::None, m);
+        hir_visit::walk_mod(self, m, n)
+    }
+
     fn visit_foreign_item(&mut self, i: &'v hir::ForeignItem<'v>) {
-        self.record("ForeignItem", Id::Node(i.hir_id()), i);
+        record_variants!(
+            (self, i, i.kind, Id::Node(i.hir_id()), hir, ForeignItem, ForeignItemKind),
+            [Fn, Static, Type]
+        );
         hir_visit::walk_foreign_item(self, i)
     }
 
@@ -220,7 +270,10 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_stmt(&mut self, s: &'v hir::Stmt<'v>) {
-        self.record("Stmt", Id::Node(s.hir_id), s);
+        record_variants!(
+            (self, s, s.kind, Id::Node(s.hir_id), hir, Stmt, StmtKind),
+            [Local, Item, Expr, Semi]
+        );
         hir_visit::walk_stmt(self, s)
     }
 
@@ -230,18 +283,78 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_pat(&mut self, p: &'v hir::Pat<'v>) {
-        self.record("Pat", Id::Node(p.hir_id), p);
+        record_variants!(
+            (self, p, p.kind, Id::Node(p.hir_id), hir, Pat, PatKind),
+            [Wild, Binding, Struct, TupleStruct, Or, Path, Tuple, Box, Ref, Lit, Range, Slice]
+        );
         hir_visit::walk_pat(self, p)
     }
 
-    fn visit_expr(&mut self, ex: &'v hir::Expr<'v>) {
-        self.record("Expr", Id::Node(ex.hir_id), ex);
-        hir_visit::walk_expr(self, ex)
+    fn visit_pat_field(&mut self, f: &'v hir::PatField<'v>) {
+        self.record("PatField", Id::Node(f.hir_id), f);
+        hir_visit::walk_pat_field(self, f)
+    }
+
+    fn visit_expr(&mut self, e: &'v hir::Expr<'v>) {
+        record_variants!(
+            (self, e, e.kind, Id::Node(e.hir_id), hir, Expr, ExprKind),
+            [
+                Box, ConstBlock, Array, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type,
+                DropTemps, Let, If, Loop, Match, Closure, Block, Assign, AssignOp, Field, Index,
+                Path, AddrOf, Break, Continue, Ret, InlineAsm, Struct, Repeat, Yield, Err
+            ]
+        );
+        hir_visit::walk_expr(self, e)
+    }
+
+    fn visit_let_expr(&mut self, lex: &'v hir::Let<'v>) {
+        self.record("Let", Id::Node(lex.hir_id), lex);
+        hir_visit::walk_let_expr(self, lex)
+    }
+
+    fn visit_expr_field(&mut self, f: &'v hir::ExprField<'v>) {
+        self.record("ExprField", Id::Node(f.hir_id), f);
+        hir_visit::walk_expr_field(self, f)
     }
 
     fn visit_ty(&mut self, t: &'v hir::Ty<'v>) {
-        self.record("Ty", Id::Node(t.hir_id), t);
+        record_variants!(
+            (self, t, t.kind, Id::Node(t.hir_id), hir, Ty, TyKind),
+            [
+                Slice,
+                Array,
+                Ptr,
+                Rptr,
+                BareFn,
+                Never,
+                Tup,
+                Path,
+                OpaqueDef,
+                TraitObject,
+                Typeof,
+                Infer,
+                Err
+            ]
+        );
         hir_visit::walk_ty(self, t)
+    }
+
+    fn visit_generic_param(&mut self, p: &'v hir::GenericParam<'v>) {
+        self.record("GenericParam", Id::Node(p.hir_id), p);
+        hir_visit::walk_generic_param(self, p)
+    }
+
+    fn visit_generics(&mut self, g: &'v hir::Generics<'v>) {
+        self.record("Generics", Id::None, g);
+        hir_visit::walk_generics(self, g)
+    }
+
+    fn visit_where_predicate(&mut self, p: &'v hir::WherePredicate<'v>) {
+        record_variants!(
+            (self, p, p, Id::None, hir, WherePredicate, WherePredicate),
+            [BoundPredicate, RegionPredicate, EqPredicate]
+        );
+        hir_visit::walk_where_predicate(self, p)
     }
 
     fn visit_fn(
@@ -256,24 +369,49 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_fn(self, fk, fd, b, s, id)
     }
 
-    fn visit_where_predicate(&mut self, predicate: &'v hir::WherePredicate<'v>) {
-        self.record("WherePredicate", Id::None, predicate);
-        hir_visit::walk_where_predicate(self, predicate)
+    fn visit_use(&mut self, p: &'v hir::Path<'v>, hir_id: hir::HirId) {
+        // This is `visit_use`, but the type is `Path` so record it that way.
+        self.record("Path", Id::None, p);
+        hir_visit::walk_use(self, p, hir_id)
     }
 
     fn visit_trait_item(&mut self, ti: &'v hir::TraitItem<'v>) {
-        self.record("TraitItem", Id::Node(ti.hir_id()), ti);
+        record_variants!(
+            (self, ti, ti.kind, Id::Node(ti.hir_id()), hir, TraitItem, TraitItemKind),
+            [Const, Fn, Type]
+        );
         hir_visit::walk_trait_item(self, ti)
     }
 
+    fn visit_trait_item_ref(&mut self, ti: &'v hir::TraitItemRef) {
+        self.record("TraitItemRef", Id::Node(ti.id.hir_id()), ti);
+        hir_visit::walk_trait_item_ref(self, ti)
+    }
+
     fn visit_impl_item(&mut self, ii: &'v hir::ImplItem<'v>) {
-        self.record("ImplItem", Id::Node(ii.hir_id()), ii);
+        record_variants!(
+            (self, ii, ii.kind, Id::Node(ii.hir_id()), hir, ImplItem, ImplItemKind),
+            [Const, Fn, TyAlias]
+        );
         hir_visit::walk_impl_item(self, ii)
     }
 
-    fn visit_param_bound(&mut self, bounds: &'v hir::GenericBound<'v>) {
-        self.record("GenericBound", Id::None, bounds);
-        hir_visit::walk_param_bound(self, bounds)
+    fn visit_foreign_item_ref(&mut self, fi: &'v hir::ForeignItemRef) {
+        self.record("ForeignItemRef", Id::Node(fi.id.hir_id()), fi);
+        hir_visit::walk_foreign_item_ref(self, fi)
+    }
+
+    fn visit_impl_item_ref(&mut self, ii: &'v hir::ImplItemRef) {
+        self.record("ImplItemRef", Id::Node(ii.id.hir_id()), ii);
+        hir_visit::walk_impl_item_ref(self, ii)
+    }
+
+    fn visit_param_bound(&mut self, b: &'v hir::GenericBound<'v>) {
+        record_variants!(
+            (self, b, b, Id::None, hir, GenericBound, GenericBound),
+            [Trait, LangItemTrait, Outlives]
+        );
+        hir_visit::walk_param_bound(self, b)
     }
 
     fn visit_field_def(&mut self, s: &'v hir::FieldDef<'v>) {
@@ -286,14 +424,17 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_variant(self, v)
     }
 
-    fn visit_lifetime(&mut self, lifetime: &'v hir::Lifetime) {
-        self.record("Lifetime", Id::Node(lifetime.hir_id), lifetime);
-        hir_visit::walk_lifetime(self, lifetime)
-    }
-
-    fn visit_qpath(&mut self, qpath: &'v hir::QPath<'v>, id: hir::HirId, span: Span) {
-        self.record("QPath", Id::None, qpath);
-        hir_visit::walk_qpath(self, qpath, id, span)
+    fn visit_generic_arg(&mut self, ga: &'v hir::GenericArg<'v>) {
+        record_variants!(
+            (self, ga, ga, Id::Node(ga.hir_id()), hir, GenericArg, GenericArg),
+            [Lifetime, Type, Const, Infer]
+        );
+        match ga {
+            hir::GenericArg::Lifetime(lt) => self.visit_lifetime(lt),
+            hir::GenericArg::Type(ty) => self.visit_ty(ty),
+            hir::GenericArg::Const(ct) => self.visit_anon_const(&ct.value),
+            hir::GenericArg::Infer(inf) => self.visit_infer(inf),
+        }
     }
 
     fn visit_path(&mut self, path: &'v hir::Path<'v>, _id: hir::HirId) {
@@ -306,6 +447,11 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_path_segment(self, path_span, path_segment)
     }
 
+    fn visit_generic_args(&mut self, sp: Span, ga: &'v hir::GenericArgs<'v>) {
+        self.record("GenericArgs", Id::None, ga);
+        hir_visit::walk_generic_args(self, sp, ga)
+    }
+
     fn visit_assoc_type_binding(&mut self, type_binding: &'v hir::TypeBinding<'v>) {
         self.record("TypeBinding", Id::Node(type_binding.hir_id), type_binding);
         hir_visit::walk_assoc_type_binding(self, type_binding)
@@ -314,28 +460,17 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     fn visit_attribute(&mut self, attr: &'v ast::Attribute) {
         self.record("Attribute", Id::Attr(attr.id), attr);
     }
-}
 
-// Used to avoid boilerplate for types with many variants.
-macro_rules! record_variants {
-    (
-        ($self:ident, $val:expr, $kind:expr, $ty:ty, $tykind:ident), // mandatory pieces
-        [$($variant:ident),*]
-    ) => {
-        match $kind {
-            $(
-                ast::$tykind::$variant { .. } => {
-                    $self.record_variant(stringify!($ty), stringify!($variant), Id::None, $val)
-                }
-            )*
-        }
-    };
+    fn visit_inline_asm(&mut self, asm: &'v hir::InlineAsm<'v>, id: HirId) {
+        self.record("InlineAsm", Id::None, asm);
+        hir_visit::walk_inline_asm(self, asm, id);
+    }
 }
 
 impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
     fn visit_foreign_item(&mut self, i: &'v ast::ForeignItem) {
         record_variants!(
-            (self, i, i.kind, ForeignItem, ForeignItemKind),
+            (self, i, i.kind, Id::None, ast, ForeignItem, ForeignItemKind),
             [Static, Fn, TyAlias, MacCall]
         );
         ast_visit::walk_foreign_item(self, i)
@@ -343,7 +478,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
     fn visit_item(&mut self, i: &'v ast::Item) {
         record_variants!(
-            (self, i, i.kind, Item, ItemKind),
+            (self, i, i.kind, Id::None, ast, Item, ItemKind),
             [
                 ExternCrate,
                 Use,
@@ -379,7 +514,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
     fn visit_stmt(&mut self, s: &'v ast::Stmt) {
         record_variants!(
-            (self, s, s.kind, Stmt, StmtKind),
+            (self, s, s.kind, Id::None, ast, Stmt, StmtKind),
             [Local, Item, Expr, Semi, Empty, MacCall]
         );
         ast_visit::walk_stmt(self, s)
@@ -397,7 +532,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
     fn visit_pat(&mut self, p: &'v ast::Pat) {
         record_variants!(
-            (self, p, p.kind, Pat, PatKind),
+            (self, p, p.kind, Id::None, ast, Pat, PatKind),
             [
                 Wild,
                 Ident,
@@ -421,7 +556,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
     fn visit_expr(&mut self, e: &'v ast::Expr) {
         record_variants!(
-            (self, e, e.kind, Expr, ExprKind),
+            (self, e, e.kind, Id::None, ast, Expr, ExprKind),
             [
                 Box, Array, ConstBlock, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type, Let,
                 If, While, ForLoop, Loop, Match, Closure, Block, Async, Await, TryBlock, Assign,
@@ -434,7 +569,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
     fn visit_ty(&mut self, t: &'v ast::Ty) {
         record_variants!(
-            (self, t, t.kind, Ty, TyKind),
+            (self, t, t.kind, Id::None, ast, Ty, TyKind),
             [
                 Slice,
                 Array,
@@ -466,7 +601,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
     fn visit_where_predicate(&mut self, p: &'v ast::WherePredicate) {
         record_variants!(
-            (self, p, p, WherePredicate, WherePredicate),
+            (self, p, p, Id::None, ast, WherePredicate, WherePredicate),
             [BoundPredicate, RegionPredicate, EqPredicate]
         );
         ast_visit::walk_where_predicate(self, p)
@@ -479,14 +614,17 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
     fn visit_assoc_item(&mut self, i: &'v ast::AssocItem, ctxt: ast_visit::AssocCtxt) {
         record_variants!(
-            (self, i, i.kind, AssocItem, AssocItemKind),
+            (self, i, i.kind, Id::None, ast, AssocItem, AssocItemKind),
             [Const, Fn, TyAlias, MacCall]
         );
         ast_visit::walk_assoc_item(self, i, ctxt);
     }
 
     fn visit_param_bound(&mut self, b: &'v ast::GenericBound, _ctxt: BoundKind) {
-        record_variants!((self, b, b, GenericBound, GenericBound), [Trait, Outlives]);
+        record_variants!(
+            (self, b, b, Id::None, ast, GenericBound, GenericBound),
+            [Trait, Outlives]
+        );
         ast_visit::walk_param_bound(self, b)
     }
 
@@ -519,12 +657,18 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
     // common, so we implement `visit_generic_args` and tolerate the double
     // counting in the former case.
     fn visit_generic_args(&mut self, sp: Span, g: &'v ast::GenericArgs) {
-        record_variants!((self, g, g, GenericArgs, GenericArgs), [AngleBracketed, Parenthesized]);
+        record_variants!(
+            (self, g, g, Id::None, ast, GenericArgs, GenericArgs),
+            [AngleBracketed, Parenthesized]
+        );
         ast_visit::walk_generic_args(self, sp, g)
     }
 
     fn visit_attribute(&mut self, attr: &'v ast::Attribute) {
-        record_variants!((self, attr, attr.kind, Attribute, AttrKind), [Normal, DocComment]);
+        record_variants!(
+            (self, attr, attr.kind, Id::None, ast, Attribute, AttrKind),
+            [Normal, DocComment]
+        );
         ast_visit::walk_attribute(self, attr)
     }
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1393,7 +1393,7 @@ impl<'a> Resolver<'a> {
 
         // If only some candidates are accessible, take just them
         if !candidates.iter().all(|v: &ImportSuggestion| !v.accessible) {
-            candidates = candidates.into_iter().filter(|x| x.accessible).collect();
+            candidates.retain(|x| x.accessible)
         }
 
         candidates

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -974,7 +974,7 @@ impl<'tcx> DumpVisitor<'tcx> {
         self.process_macro_use(trait_item.span);
         match trait_item.kind {
             hir::TraitItemKind::Const(ref ty, body) => {
-                let body = body.map(|b| &self.tcx.hir().body(b).value);
+                let body = body.map(|b| self.tcx.hir().body(b).value);
                 let attrs = self.tcx.hir().attrs(trait_item.hir_id());
                 self.process_assoc_const(
                     trait_item.def_id,

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -648,7 +648,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 multispan.push_span_label(span_late, note);
                 tcx.struct_span_lint_hir(
                     LATE_BOUND_LIFETIME_ARGUMENTS,
-                    args.args[0].id(),
+                    args.args[0].hir_id(),
                     multispan,
                     |lint| {
                         lint.build(msg).emit();

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -398,7 +398,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     if has_default {
                         tcx.check_optional_stability(
                             param.def_id,
-                            Some(arg.id()),
+                            Some(arg.hir_id()),
                             arg.span(),
                             None,
                             AllowUnstable::No,

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -42,6 +42,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.suggest_boxing_when_appropriate(err, expr, expected, expr_ty);
         self.suggest_missing_parentheses(err, expr);
         self.suggest_block_to_brackets_peeling_refs(err, expr, expr_ty, expected);
+        self.suggest_copied_or_cloned(err, expr, expr_ty, expected);
         self.note_type_is_not_clone(err, expected, expr_ty, expr);
         self.note_need_for_fn_pointer(err, expected, expr_ty);
         self.note_internal_mutation_in_method(err, expr, expected, expr_ty);

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -2024,6 +2024,10 @@ fn should_do_rust_2021_incompatible_closure_captures_analysis(
     tcx: TyCtxt<'_>,
     closure_id: hir::HirId,
 ) -> bool {
+    if tcx.sess.rust_2021() {
+        return false;
+    }
+
     let (level, _) =
         tcx.lint_level_at_node(lint::builtin::RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES, closure_id);
 

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -79,7 +79,7 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                         args.args
                             .iter()
                             .filter(|arg| arg.is_ty_or_const())
-                            .position(|arg| arg.id() == hir_id)
+                            .position(|arg| arg.hir_id() == hir_id)
                     })
                     .unwrap_or_else(|| {
                         bug!("no arg matching AnonConst in segment");
@@ -112,7 +112,7 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                     args.args
                         .iter()
                         .filter(|arg| arg.is_ty_or_const())
-                        .position(|arg| arg.id() == hir_id)
+                        .position(|arg| arg.hir_id() == hir_id)
                 })
                 .unwrap_or_else(|| {
                     bug!("no arg matching AnonConst in segment");
@@ -166,7 +166,7 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                 args.args
                 .iter()
                 .filter(|arg| arg.is_ty_or_const())
-                .position(|arg| arg.id() == hir_id)
+                .position(|arg| arg.hir_id() == hir_id)
                 .map(|index| (index, seg)).or_else(|| args.bindings
                     .iter()
                     .filter_map(TypeBinding::opt_const)
@@ -229,7 +229,7 @@ fn get_path_containing_arg_in_pat<'hir>(
             .iter()
             .filter_map(|seg| seg.args)
             .flat_map(|args| args.args)
-            .any(|arg| arg.id() == arg_id)
+            .any(|arg| arg.hir_id() == arg_id)
     };
     let mut arg_path = None;
     pat.walk(|pat| match pat.kind {

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -429,7 +429,7 @@ mod cgroups {
                         Some(b"") => Cgroup::V2,
                         Some(controllers)
                             if from_utf8(controllers)
-                                .is_ok_and(|c| c.split(",").any(|c| c == "cpu")) =>
+                                .is_ok_and(|c| c.split(',').any(|c| c == "cpu")) =>
                         {
                             Cgroup::V1
                         }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2367,9 +2367,9 @@ pub(crate) fn get_filtered_impls_for_reference<'a>(
     let Some(v) = shared.cache.impls.get(&def_id) else { return (Vec::new(), Vec::new(), Vec::new()) };
     // Since there is no "direct implementation" on the reference primitive type, we filter out
     // every implementation which isn't a trait implementation.
-    let traits: Vec<_> = v.iter().filter(|i| i.inner_impl().trait_.is_some()).collect();
+    let traits = v.iter().filter(|i| i.inner_impl().trait_.is_some());
     let (synthetic, concrete): (Vec<&Impl>, Vec<&Impl>) =
-        traits.into_iter().partition(|t| t.inner_impl().kind.is_auto());
+        traits.partition(|t| t.inner_impl().kind.is_auto());
 
     let (blanket_impl, concrete): (Vec<&Impl>, _) =
         concrete.into_iter().partition(|t| t.inner_impl().kind.is_blanket());

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -312,7 +312,7 @@ pub(super) fn write_shared(
                 if line.starts_with(&prefix) {
                     continue;
                 }
-                if line.ends_with(",") {
+                if line.ends_with(',') {
                     ret.push(line[..line.len() - 1].to_string());
                 } else {
                     // No comma (it's the case for the last added crate line)

--- a/src/test/ui/borrowck/issue-101119.rs
+++ b/src/test/ui/borrowck/issue-101119.rs
@@ -1,0 +1,16 @@
+struct State;
+
+fn once(_: impl FnOnce()) {}
+
+fn fill_memory_blocks_mt(state: &mut State) {
+    loop {
+        once(move || {
+            //~^ ERROR use of moved value: `state`
+            fill_segment(state);
+        });
+    }
+}
+
+fn fill_segment(_: &mut State) {}
+
+fn main() {}

--- a/src/test/ui/borrowck/issue-101119.stderr
+++ b/src/test/ui/borrowck/issue-101119.stderr
@@ -1,0 +1,15 @@
+error[E0382]: use of moved value: `state`
+  --> $DIR/issue-101119.rs:7:14
+   |
+LL | fn fill_memory_blocks_mt(state: &mut State) {
+   |                          ----- move occurs because `state` has type `&mut State`, which does not implement the `Copy` trait
+LL |     loop {
+LL |         once(move || {
+   |              ^^^^^^^ value moved into closure here, in previous iteration of loop
+LL |
+LL |             fill_segment(state);
+   |                          ----- use occurs due to use in closure
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/lint/issue-101284.rs
+++ b/src/test/ui/lint/issue-101284.rs
@@ -1,0 +1,15 @@
+// check-pass
+// edition:2021
+#![deny(rust_2021_compatibility)]
+
+pub struct Warns {
+    // `Arc` has significant drop
+    _significant_drop: std::sync::Arc<()>,
+    field: String,
+}
+
+pub fn test(w: Warns) {
+    _ = || drop(w.field);
+}
+
+fn main() {}

--- a/src/test/ui/stats/hir-stats.stderr
+++ b/src/test/ui/stats/hir-stats.stderr
@@ -118,28 +118,60 @@ ast-stats-2
 hir-stats HIR STATS
 hir-stats Name                Accumulated Size         Count     Item Size
 hir-stats ----------------------------------------------------------------
-hir-stats Param                     64 ( 0.7%)             2            32
-hir-stats Local                     64 ( 0.7%)             1            64
-hir-stats ForeignItem               72 ( 0.8%)             1            72
+hir-stats ForeignItemRef            24 ( 0.2%)             1            24
+hir-stats Mod                       32 ( 0.3%)             1            32
+hir-stats ExprField                 40 ( 0.4%)             1            40
+hir-stats TraitItemRef              56 ( 0.6%)             2            28
+hir-stats Param                     64 ( 0.6%)             2            32
+hir-stats Local                     64 ( 0.6%)             1            64
+hir-stats InlineAsm                 72 ( 0.7%)             1            72
+hir-stats ImplItemRef               72 ( 0.7%)             2            36
 hir-stats FieldDef                  96 ( 1.0%)             2            48
 hir-stats Arm                       96 ( 1.0%)             2            48
+hir-stats Body                      96 ( 1.0%)             3            32
 hir-stats Stmt                      96 ( 1.0%)             3            32
-hir-stats FnDecl                   120 ( 1.3%)             3            40
-hir-stats Attribute                128 ( 1.4%)             4            32
-hir-stats Lifetime                 128 ( 1.4%)             4            32
-hir-stats Variant                  160 ( 1.7%)             2            80
-hir-stats ImplItem                 176 ( 1.9%)             2            88
-hir-stats GenericBound             192 ( 2.1%)             4            48
-hir-stats TraitItem                192 ( 2.1%)             2            96
-hir-stats WherePredicate           216 ( 2.3%)             3            72
-hir-stats Block                    288 ( 3.1%)             6            48
-hir-stats QPath                    408 ( 4.4%)            17            24
-hir-stats Pat                      440 ( 4.8%)             5            88
-hir-stats Expr                     672 ( 7.3%)            12            56
-hir-stats Item                     960 (10.4%)            12            80
-hir-stats Ty                     1_152 (12.4%)            16            72
-hir-stats Path                   1_296 (14.0%)            27            48
-hir-stats PathSegment            2_240 (24.2%)            40            56
+hir-stats - Local                     32 ( 0.3%)             1
+hir-stats - Semi                      32 ( 0.3%)             1
+hir-stats - Expr                      32 ( 0.3%)             1
+hir-stats FnDecl                   120 ( 1.2%)             3            40
+hir-stats Attribute                128 ( 1.3%)             4            32
+hir-stats GenericArgs              144 ( 1.4%)             3            48
+hir-stats Variant                  160 ( 1.6%)             2            80
+hir-stats GenericArg               160 ( 1.6%)             4            40
+hir-stats - Type                      40 ( 0.4%)             1
+hir-stats - Lifetime                 120 ( 1.2%)             3
+hir-stats GenericBound             192 ( 1.9%)             4            48
+hir-stats - Trait                    192 ( 1.9%)             4
+hir-stats WherePredicate           216 ( 2.1%)             3            72
+hir-stats - BoundPredicate           216 ( 2.1%)             3
+hir-stats Block                    288 ( 2.9%)             6            48
+hir-stats GenericParam             400 ( 4.0%)             5            80
+hir-stats Pat                      440 ( 4.4%)             5            88
+hir-stats - Wild                      88 ( 0.9%)             1
+hir-stats - Struct                    88 ( 0.9%)             1
+hir-stats - Binding                  264 ( 2.6%)             3
+hir-stats Generics                 560 ( 5.5%)            10            56
+hir-stats Expr                     672 ( 6.7%)            12            56
+hir-stats - Path                      56 ( 0.6%)             1
+hir-stats - Struct                    56 ( 0.6%)             1
+hir-stats - Match                     56 ( 0.6%)             1
+hir-stats - InlineAsm                 56 ( 0.6%)             1
+hir-stats - Lit                      112 ( 1.1%)             2
+hir-stats - Block                    336 ( 3.3%)             6
+hir-stats Item                     960 ( 9.5%)            12            80
+hir-stats - Trait                     80 ( 0.8%)             1
+hir-stats - Enum                      80 ( 0.8%)             1
+hir-stats - ExternCrate               80 ( 0.8%)             1
+hir-stats - ForeignMod                80 ( 0.8%)             1
+hir-stats - Impl                      80 ( 0.8%)             1
+hir-stats - Fn                       160 ( 1.6%)             2
+hir-stats - Use                      400 ( 4.0%)             5
+hir-stats Ty                     1_080 (10.7%)            15            72
+hir-stats - Ptr                       72 ( 0.7%)             1
+hir-stats - Rptr                      72 ( 0.7%)             1
+hir-stats - Path                     936 ( 9.3%)            13
+hir-stats Path                   1_536 (15.2%)            32            48
+hir-stats PathSegment            2_240 (22.2%)            40            56
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  9_256
+hir-stats Total                 10_104
 hir-stats

--- a/src/test/ui/stats/hir-stats.stderr
+++ b/src/test/ui/stats/hir-stats.stderr
@@ -1,151 +1,145 @@
-
-PRE EXPANSION AST STATS
-
-Name                Accumulated Size         Count     Item Size
-----------------------------------------------------------------
-ExprField                 48 ( 0.6%)             1            48
-Crate                     56 ( 0.7%)             1            56
-Attribute                 64 ( 0.8%)             2            32
-- Normal                    32 ( 0.4%)             1
-- DocComment                32 ( 0.4%)             1
-GenericArgs               64 ( 0.8%)             1            64
-- AngleBracketed            64 ( 0.8%)             1
-Local                     72 ( 0.9%)             1            72
-WherePredicate            72 ( 0.9%)             1            72
-- BoundPredicate            72 ( 0.9%)             1
-Arm                       96 ( 1.1%)             2            48
-ForeignItem               96 ( 1.1%)             1            96
-- Fn                        96 ( 1.1%)             1
-FieldDef                 160 ( 1.9%)             2            80
-Stmt                     160 ( 1.9%)             5            32
-- Local                     32 ( 0.4%)             1
-- MacCall                   32 ( 0.4%)             1
-- Expr                      96 ( 1.1%)             3
-Param                    160 ( 1.9%)             4            40
-FnDecl                   200 ( 2.4%)             5            40
-Variant                  240 ( 2.8%)             2           120
-Block                    288 ( 3.4%)             6            48
-GenericBound             352 ( 4.2%)             4            88
-- Trait                    352 ( 4.2%)             4
-AssocItem                416 ( 4.9%)             4           104
-- TyAlias                  208 ( 2.5%)             2
-- Fn                       208 ( 2.5%)             2
-GenericParam             520 ( 6.1%)             5           104
-PathSegment              720 ( 8.5%)            30            24
-Expr                     832 ( 9.8%)             8           104
-- Path                     104 ( 1.2%)             1
-- Match                    104 ( 1.2%)             1
-- Struct                   104 ( 1.2%)             1
-- Lit                      208 ( 2.5%)             2
-- Block                    312 ( 3.7%)             3
-Pat                      840 ( 9.9%)             7           120
-- Struct                   120 ( 1.4%)             1
-- Wild                     120 ( 1.4%)             1
-- Ident                    600 ( 7.1%)             5
-Ty                     1_344 (15.9%)            14            96
-- Rptr                      96 ( 1.1%)             1
-- Ptr                       96 ( 1.1%)             1
-- ImplicitSelf             192 ( 2.3%)             2
-- Path                     960 (11.4%)            10
-Item                   1_656 (19.6%)             9           184
-- Trait                    184 ( 2.2%)             1
-- Enum                     184 ( 2.2%)             1
-- ForeignMod               184 ( 2.2%)             1
-- Impl                     184 ( 2.2%)             1
-- Fn                       368 ( 4.4%)             2
-- Use                      552 ( 6.5%)             3
-----------------------------------------------------------------
-Total                  8_456
-
-
-POST EXPANSION AST STATS
-
-Name                Accumulated Size         Count     Item Size
-----------------------------------------------------------------
-ExprField                 48 ( 0.5%)             1            48
-Crate                     56 ( 0.6%)             1            56
-GenericArgs               64 ( 0.7%)             1            64
-- AngleBracketed            64 ( 0.7%)             1
-Local                     72 ( 0.8%)             1            72
-WherePredicate            72 ( 0.8%)             1            72
-- BoundPredicate            72 ( 0.8%)             1
-Arm                       96 ( 1.0%)             2            48
-ForeignItem               96 ( 1.0%)             1            96
-- Fn                        96 ( 1.0%)             1
-InlineAsm                120 ( 1.3%)             1           120
-Attribute                128 ( 1.4%)             4            32
-- DocComment                32 ( 0.3%)             1
-- Normal                    96 ( 1.0%)             3
-FieldDef                 160 ( 1.7%)             2            80
-Stmt                     160 ( 1.7%)             5            32
-- Local                     32 ( 0.3%)             1
-- Semi                      32 ( 0.3%)             1
-- Expr                      96 ( 1.0%)             3
-Param                    160 ( 1.7%)             4            40
-FnDecl                   200 ( 2.2%)             5            40
-Variant                  240 ( 2.6%)             2           120
-Block                    288 ( 3.1%)             6            48
-GenericBound             352 ( 3.8%)             4            88
-- Trait                    352 ( 3.8%)             4
-AssocItem                416 ( 4.5%)             4           104
-- TyAlias                  208 ( 2.3%)             2
-- Fn                       208 ( 2.3%)             2
-GenericParam             520 ( 5.7%)             5           104
-PathSegment              792 ( 8.6%)            33            24
-Pat                      840 ( 9.1%)             7           120
-- Struct                   120 ( 1.3%)             1
-- Wild                     120 ( 1.3%)             1
-- Ident                    600 ( 6.5%)             5
-Expr                     936 (10.2%)             9           104
-- Path                     104 ( 1.1%)             1
-- Match                    104 ( 1.1%)             1
-- Struct                   104 ( 1.1%)             1
-- InlineAsm                104 ( 1.1%)             1
-- Lit                      208 ( 2.3%)             2
-- Block                    312 ( 3.4%)             3
-Ty                     1_344 (14.6%)            14            96
-- Rptr                      96 ( 1.0%)             1
-- Ptr                       96 ( 1.0%)             1
-- ImplicitSelf             192 ( 2.1%)             2
-- Path                     960 (10.5%)            10
-Item                   2_024 (22.0%)            11           184
-- Trait                    184 ( 2.0%)             1
-- Enum                     184 ( 2.0%)             1
-- ExternCrate              184 ( 2.0%)             1
-- ForeignMod               184 ( 2.0%)             1
-- Impl                     184 ( 2.0%)             1
-- Fn                       368 ( 4.0%)             2
-- Use                      736 ( 8.0%)             4
-----------------------------------------------------------------
-Total                  9_184
-
-
-HIR STATS
-
-Name                Accumulated Size         Count     Item Size
-----------------------------------------------------------------
-Param                     64 ( 0.7%)             2            32
-Local                     64 ( 0.7%)             1            64
-ForeignItem               72 ( 0.8%)             1            72
-FieldDef                  96 ( 1.0%)             2            48
-Arm                       96 ( 1.0%)             2            48
-Stmt                      96 ( 1.0%)             3            32
-FnDecl                   120 ( 1.3%)             3            40
-Attribute                128 ( 1.4%)             4            32
-Lifetime                 128 ( 1.4%)             4            32
-Variant                  160 ( 1.7%)             2            80
-ImplItem                 176 ( 1.9%)             2            88
-GenericBound             192 ( 2.1%)             4            48
-TraitItem                192 ( 2.1%)             2            96
-WherePredicate           216 ( 2.3%)             3            72
-Block                    288 ( 3.1%)             6            48
-QPath                    408 ( 4.4%)            17            24
-Pat                      440 ( 4.8%)             5            88
-Expr                     672 ( 7.3%)            12            56
-Item                     960 (10.4%)            12            80
-Ty                     1_152 (12.4%)            16            72
-Path                   1_296 (14.0%)            27            48
-PathSegment            2_240 (24.2%)            40            56
-----------------------------------------------------------------
-Total                  9_256
-
+ast-stats-1 PRE EXPANSION AST STATS
+ast-stats-1 Name                Accumulated Size         Count     Item Size
+ast-stats-1 ----------------------------------------------------------------
+ast-stats-1 ExprField                 48 ( 0.6%)             1            48
+ast-stats-1 Crate                     56 ( 0.7%)             1            56
+ast-stats-1 Attribute                 64 ( 0.8%)             2            32
+ast-stats-1 - Normal                    32 ( 0.4%)             1
+ast-stats-1 - DocComment                32 ( 0.4%)             1
+ast-stats-1 GenericArgs               64 ( 0.8%)             1            64
+ast-stats-1 - AngleBracketed            64 ( 0.8%)             1
+ast-stats-1 Local                     72 ( 0.9%)             1            72
+ast-stats-1 WherePredicate            72 ( 0.9%)             1            72
+ast-stats-1 - BoundPredicate            72 ( 0.9%)             1
+ast-stats-1 Arm                       96 ( 1.1%)             2            48
+ast-stats-1 ForeignItem               96 ( 1.1%)             1            96
+ast-stats-1 - Fn                        96 ( 1.1%)             1
+ast-stats-1 FieldDef                 160 ( 1.9%)             2            80
+ast-stats-1 Stmt                     160 ( 1.9%)             5            32
+ast-stats-1 - Local                     32 ( 0.4%)             1
+ast-stats-1 - MacCall                   32 ( 0.4%)             1
+ast-stats-1 - Expr                      96 ( 1.1%)             3
+ast-stats-1 Param                    160 ( 1.9%)             4            40
+ast-stats-1 FnDecl                   200 ( 2.4%)             5            40
+ast-stats-1 Variant                  240 ( 2.8%)             2           120
+ast-stats-1 Block                    288 ( 3.4%)             6            48
+ast-stats-1 GenericBound             352 ( 4.2%)             4            88
+ast-stats-1 - Trait                    352 ( 4.2%)             4
+ast-stats-1 AssocItem                416 ( 4.9%)             4           104
+ast-stats-1 - TyAlias                  208 ( 2.5%)             2
+ast-stats-1 - Fn                       208 ( 2.5%)             2
+ast-stats-1 GenericParam             520 ( 6.1%)             5           104
+ast-stats-1 PathSegment              720 ( 8.5%)            30            24
+ast-stats-1 Expr                     832 ( 9.8%)             8           104
+ast-stats-1 - Path                     104 ( 1.2%)             1
+ast-stats-1 - Match                    104 ( 1.2%)             1
+ast-stats-1 - Struct                   104 ( 1.2%)             1
+ast-stats-1 - Lit                      208 ( 2.5%)             2
+ast-stats-1 - Block                    312 ( 3.7%)             3
+ast-stats-1 Pat                      840 ( 9.9%)             7           120
+ast-stats-1 - Struct                   120 ( 1.4%)             1
+ast-stats-1 - Wild                     120 ( 1.4%)             1
+ast-stats-1 - Ident                    600 ( 7.1%)             5
+ast-stats-1 Ty                     1_344 (15.9%)            14            96
+ast-stats-1 - Rptr                      96 ( 1.1%)             1
+ast-stats-1 - Ptr                       96 ( 1.1%)             1
+ast-stats-1 - ImplicitSelf             192 ( 2.3%)             2
+ast-stats-1 - Path                     960 (11.4%)            10
+ast-stats-1 Item                   1_656 (19.6%)             9           184
+ast-stats-1 - Trait                    184 ( 2.2%)             1
+ast-stats-1 - Enum                     184 ( 2.2%)             1
+ast-stats-1 - ForeignMod               184 ( 2.2%)             1
+ast-stats-1 - Impl                     184 ( 2.2%)             1
+ast-stats-1 - Fn                       368 ( 4.4%)             2
+ast-stats-1 - Use                      552 ( 6.5%)             3
+ast-stats-1 ----------------------------------------------------------------
+ast-stats-1 Total                  8_456
+ast-stats-1
+ast-stats-2 POST EXPANSION AST STATS
+ast-stats-2 Name                Accumulated Size         Count     Item Size
+ast-stats-2 ----------------------------------------------------------------
+ast-stats-2 ExprField                 48 ( 0.5%)             1            48
+ast-stats-2 Crate                     56 ( 0.6%)             1            56
+ast-stats-2 GenericArgs               64 ( 0.7%)             1            64
+ast-stats-2 - AngleBracketed            64 ( 0.7%)             1
+ast-stats-2 Local                     72 ( 0.8%)             1            72
+ast-stats-2 WherePredicate            72 ( 0.8%)             1            72
+ast-stats-2 - BoundPredicate            72 ( 0.8%)             1
+ast-stats-2 Arm                       96 ( 1.0%)             2            48
+ast-stats-2 ForeignItem               96 ( 1.0%)             1            96
+ast-stats-2 - Fn                        96 ( 1.0%)             1
+ast-stats-2 InlineAsm                120 ( 1.3%)             1           120
+ast-stats-2 Attribute                128 ( 1.4%)             4            32
+ast-stats-2 - DocComment                32 ( 0.3%)             1
+ast-stats-2 - Normal                    96 ( 1.0%)             3
+ast-stats-2 FieldDef                 160 ( 1.7%)             2            80
+ast-stats-2 Stmt                     160 ( 1.7%)             5            32
+ast-stats-2 - Local                     32 ( 0.3%)             1
+ast-stats-2 - Semi                      32 ( 0.3%)             1
+ast-stats-2 - Expr                      96 ( 1.0%)             3
+ast-stats-2 Param                    160 ( 1.7%)             4            40
+ast-stats-2 FnDecl                   200 ( 2.2%)             5            40
+ast-stats-2 Variant                  240 ( 2.6%)             2           120
+ast-stats-2 Block                    288 ( 3.1%)             6            48
+ast-stats-2 GenericBound             352 ( 3.8%)             4            88
+ast-stats-2 - Trait                    352 ( 3.8%)             4
+ast-stats-2 AssocItem                416 ( 4.5%)             4           104
+ast-stats-2 - TyAlias                  208 ( 2.3%)             2
+ast-stats-2 - Fn                       208 ( 2.3%)             2
+ast-stats-2 GenericParam             520 ( 5.7%)             5           104
+ast-stats-2 PathSegment              792 ( 8.6%)            33            24
+ast-stats-2 Pat                      840 ( 9.1%)             7           120
+ast-stats-2 - Struct                   120 ( 1.3%)             1
+ast-stats-2 - Wild                     120 ( 1.3%)             1
+ast-stats-2 - Ident                    600 ( 6.5%)             5
+ast-stats-2 Expr                     936 (10.2%)             9           104
+ast-stats-2 - Path                     104 ( 1.1%)             1
+ast-stats-2 - Match                    104 ( 1.1%)             1
+ast-stats-2 - Struct                   104 ( 1.1%)             1
+ast-stats-2 - InlineAsm                104 ( 1.1%)             1
+ast-stats-2 - Lit                      208 ( 2.3%)             2
+ast-stats-2 - Block                    312 ( 3.4%)             3
+ast-stats-2 Ty                     1_344 (14.6%)            14            96
+ast-stats-2 - Rptr                      96 ( 1.0%)             1
+ast-stats-2 - Ptr                       96 ( 1.0%)             1
+ast-stats-2 - ImplicitSelf             192 ( 2.1%)             2
+ast-stats-2 - Path                     960 (10.5%)            10
+ast-stats-2 Item                   2_024 (22.0%)            11           184
+ast-stats-2 - Trait                    184 ( 2.0%)             1
+ast-stats-2 - Enum                     184 ( 2.0%)             1
+ast-stats-2 - ExternCrate              184 ( 2.0%)             1
+ast-stats-2 - ForeignMod               184 ( 2.0%)             1
+ast-stats-2 - Impl                     184 ( 2.0%)             1
+ast-stats-2 - Fn                       368 ( 4.0%)             2
+ast-stats-2 - Use                      736 ( 8.0%)             4
+ast-stats-2 ----------------------------------------------------------------
+ast-stats-2 Total                  9_184
+ast-stats-2
+hir-stats HIR STATS
+hir-stats Name                Accumulated Size         Count     Item Size
+hir-stats ----------------------------------------------------------------
+hir-stats Param                     64 ( 0.7%)             2            32
+hir-stats Local                     64 ( 0.7%)             1            64
+hir-stats ForeignItem               72 ( 0.8%)             1            72
+hir-stats FieldDef                  96 ( 1.0%)             2            48
+hir-stats Arm                       96 ( 1.0%)             2            48
+hir-stats Stmt                      96 ( 1.0%)             3            32
+hir-stats FnDecl                   120 ( 1.3%)             3            40
+hir-stats Attribute                128 ( 1.4%)             4            32
+hir-stats Lifetime                 128 ( 1.4%)             4            32
+hir-stats Variant                  160 ( 1.7%)             2            80
+hir-stats ImplItem                 176 ( 1.9%)             2            88
+hir-stats GenericBound             192 ( 2.1%)             4            48
+hir-stats TraitItem                192 ( 2.1%)             2            96
+hir-stats WherePredicate           216 ( 2.3%)             3            72
+hir-stats Block                    288 ( 3.1%)             6            48
+hir-stats QPath                    408 ( 4.4%)            17            24
+hir-stats Pat                      440 ( 4.8%)             5            88
+hir-stats Expr                     672 ( 7.3%)            12            56
+hir-stats Item                     960 (10.4%)            12            80
+hir-stats Ty                     1_152 (12.4%)            16            72
+hir-stats Path                   1_296 (14.0%)            27            48
+hir-stats PathSegment            2_240 (24.2%)            40            56
+hir-stats ----------------------------------------------------------------
+hir-stats Total                  9_256
+hir-stats

--- a/src/test/ui/suggestions/copied-and-cloned.fixed
+++ b/src/test/ui/suggestions/copied-and-cloned.fixed
@@ -1,0 +1,23 @@
+// run-rustfix
+
+fn expect<T>(_: T) {}
+
+fn main() {
+    let x = Some(&());
+    expect::<Option<()>>(x.copied());
+    //~^ ERROR mismatched types
+    //~| HELP use `Option::copied` to copy the value inside the `Option`
+    let x = Ok(&());
+    expect::<Result<(), ()>>(x.copied());
+    //~^ ERROR mismatched types
+    //~| HELP use `Result::copied` to copy the value inside the `Result`
+    let s = String::new();
+    let x = Some(&s);
+    expect::<Option<String>>(x.cloned());
+    //~^ ERROR mismatched types
+    //~| HELP use `Option::cloned` to clone the value inside the `Option`
+    let x = Ok(&s);
+    expect::<Result<String, ()>>(x.cloned());
+    //~^ ERROR mismatched types
+    //~| HELP use `Result::cloned` to clone the value inside the `Result`
+}

--- a/src/test/ui/suggestions/copied-and-cloned.rs
+++ b/src/test/ui/suggestions/copied-and-cloned.rs
@@ -1,0 +1,23 @@
+// run-rustfix
+
+fn expect<T>(_: T) {}
+
+fn main() {
+    let x = Some(&());
+    expect::<Option<()>>(x);
+    //~^ ERROR mismatched types
+    //~| HELP use `Option::copied` to copy the value inside the `Option`
+    let x = Ok(&());
+    expect::<Result<(), ()>>(x);
+    //~^ ERROR mismatched types
+    //~| HELP use `Result::copied` to copy the value inside the `Result`
+    let s = String::new();
+    let x = Some(&s);
+    expect::<Option<String>>(x);
+    //~^ ERROR mismatched types
+    //~| HELP use `Option::cloned` to clone the value inside the `Option`
+    let x = Ok(&s);
+    expect::<Result<String, ()>>(x);
+    //~^ ERROR mismatched types
+    //~| HELP use `Result::cloned` to clone the value inside the `Result`
+}

--- a/src/test/ui/suggestions/copied-and-cloned.stderr
+++ b/src/test/ui/suggestions/copied-and-cloned.stderr
@@ -1,0 +1,83 @@
+error[E0308]: mismatched types
+  --> $DIR/copied-and-cloned.rs:7:26
+   |
+LL |     expect::<Option<()>>(x);
+   |     -------------------- ^ expected `()`, found `&()`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected enum `Option<()>`
+              found enum `Option<&()>`
+note: function defined here
+  --> $DIR/copied-and-cloned.rs:3:4
+   |
+LL | fn expect<T>(_: T) {}
+   |    ^^^^^^    ----
+help: use `Option::copied` to copy the value inside the `Option`
+   |
+LL |     expect::<Option<()>>(x.copied());
+   |                           +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/copied-and-cloned.rs:11:30
+   |
+LL |     expect::<Result<(), ()>>(x);
+   |     ------------------------ ^ expected `()`, found `&()`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected enum `Result<(), ()>`
+              found enum `Result<&(), _>`
+note: function defined here
+  --> $DIR/copied-and-cloned.rs:3:4
+   |
+LL | fn expect<T>(_: T) {}
+   |    ^^^^^^    ----
+help: use `Result::copied` to copy the value inside the `Result`
+   |
+LL |     expect::<Result<(), ()>>(x.copied());
+   |                               +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/copied-and-cloned.rs:16:30
+   |
+LL |     expect::<Option<String>>(x);
+   |     ------------------------ ^ expected struct `String`, found `&String`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected enum `Option<String>`
+              found enum `Option<&String>`
+note: function defined here
+  --> $DIR/copied-and-cloned.rs:3:4
+   |
+LL | fn expect<T>(_: T) {}
+   |    ^^^^^^    ----
+help: use `Option::cloned` to clone the value inside the `Option`
+   |
+LL |     expect::<Option<String>>(x.cloned());
+   |                               +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/copied-and-cloned.rs:20:34
+   |
+LL |     expect::<Result<String, ()>>(x);
+   |     ---------------------------- ^ expected struct `String`, found `&String`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected enum `Result<String, ()>`
+              found enum `Result<&String, _>`
+note: function defined here
+  --> $DIR/copied-and-cloned.rs:3:4
+   |
+LL | fn expect<T>(_: T) {}
+   |    ^^^^^^    ----
+help: use `Result::cloned` to clone the value inside the `Result`
+   |
+LL |     expect::<Result<String, ()>>(x.cloned());
+   |                                   +++++++++
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
@@ -178,9 +178,9 @@ fn never_loop_expr(expr: &Expr<'_>, main_loop_id: HirId) -> NeverLoopResult {
                 InlineAsmOperand::In { expr, .. } | InlineAsmOperand::InOut { expr, .. } => {
                     never_loop_expr(expr, main_loop_id)
                 },
-                InlineAsmOperand::Out { expr, .. } => never_loop_expr_all(&mut expr.iter(), main_loop_id),
+                InlineAsmOperand::Out { expr, .. } => never_loop_expr_all(&mut expr.iter().copied(), main_loop_id),
                 InlineAsmOperand::SplitInOut { in_expr, out_expr, .. } => {
-                    never_loop_expr_all(&mut once(in_expr).chain(out_expr.iter()), main_loop_id)
+                    never_loop_expr_all(&mut once(*in_expr).chain(out_expr.iter().copied()), main_loop_id)
                 },
                 InlineAsmOperand::Const { .. }
                 | InlineAsmOperand::SymFn { .. }

--- a/src/tools/clippy/clippy_lints/src/manual_bits.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_bits.rs
@@ -105,7 +105,7 @@ fn get_size_of_ty<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) -> Option<
         if let Some(def_id) = cx.qpath_res(count_func_qpath, count_func.hir_id).opt_def_id();
         if cx.tcx.is_diagnostic_item(sym::mem_size_of, def_id);
         then {
-            cx.typeck_results().node_substs(count_func.hir_id).types().next().map(|resolved_ty| (real_ty, resolved_ty))
+            cx.typeck_results().node_substs(count_func.hir_id).types().next().map(|resolved_ty| (*real_ty, resolved_ty))
         } else {
             None
         }

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -595,7 +595,7 @@ impl<'a, 'tcx> PrintVisitor<'a, 'tcx> {
     }
 
     fn body(&self, body_id: &Binding<hir::BodyId>) {
-        let expr = &self.cx.tcx.hir().body(body_id.value).value;
+        let expr = self.cx.tcx.hir().body(body_id.value).value;
         bind!(self, expr);
         out!("let {expr} = &cx.tcx.hir().body({body_id}).value;");
         self.expr(expr);

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -1804,7 +1804,7 @@ pub fn is_expr_identity_function(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool 
             }
         };
 
-        let mut expr = &func.value;
+        let mut expr = func.value;
         loop {
             match expr.kind {
                 #[rustfmt::skip]

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -333,7 +333,7 @@ pub fn qpath_generic_tys<'tcx>(qpath: &QPath<'tcx>) -> impl Iterator<Item = &'tc
         .map_or(&[][..], |a| a.args)
         .iter()
         .filter_map(|a| match a {
-            hir::GenericArg::Type(ty) => Some(ty),
+            hir::GenericArg::Type(ty) => Some(*ty),
             _ => None,
         })
 }


### PR DESCRIPTION
Successful merges:

 - #101142 (Improve HIR stats)
 - #101367 (Suggest `{Option,Result}::{copied,clone}()` to satisfy type mismatch)
 - #101391 (more clippy::perf fixes)
 - #101409 (Don't fire `rust_2021_incompatible_closure_captures` in `edition = 2021` crates)
 - #101420 (Fix `hir::Local` doc to match with the variable name used: `init`)
 - #101429 (Don't suggest reborrow if usage is inside a closure)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101142,101367,101391,101409,101420,101429)
<!-- homu-ignore:end -->