### PR TITLE
Check if TCS is a null pointer on SGX

### DIFF
--- a/library/std/src/sys/sgx/abi/thread.rs
+++ b/library/std/src/sys/sgx/abi/thread.rs
@@ -7,7 +7,11 @@ use fortanix_sgx_abi::Tcs;
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn current() -> Tcs {
     extern "C" {
-        fn get_tcs_addr() -> Tcs;
+        fn get_tcs_addr() -> *mut u8;
     }
-    unsafe { get_tcs_addr() }
+    let addr = unsafe { get_tcs_addr() };
+    match Tcs::new(addr) {
+        Some(tcs) => tcs,
+        None => rtabort!("TCS must not be placed at address zero (this is a linker error)"),
+    }
 }


### PR DESCRIPTION
The `EENTER` instruction only checks if the TCS is aligned, not if it zero. Saying the address returned is a `NonNull<u8>` (for which `Tcs` is a type alias) is unsound. As well-behaved runners will not put the TCS at address zero, so the definition of `Tcs` is correct. However, `std` should check the address before casting it to a `NonNull`.

ping @jethrogb @raoulstrackx
@rustbot label I-unsound