### PR TITLE
Recover from using `;` as separator between fields

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1526,6 +1526,17 @@ impl<'a> Parser<'a> {
         if self.token == token::Comma {
             seen_comma = true;
         }
+        if self.eat(&token::Semi) {
+            let sp = self.prev_token.span;
+            let mut err = self.struct_span_err(sp, format!("{adt_ty} fields are separated by `,`"));
+            err.span_suggestion_short(
+                sp,
+                "replace `;` with `,`",
+                ",",
+                Applicability::MachineApplicable,
+            );
+            return Err(err);
+        }
         match self.token.kind {
             token::Comma => {
                 self.bump();

--- a/src/test/ui/parser/recover-field-semi.rs
+++ b/src/test/ui/parser/recover-field-semi.rs
@@ -1,0 +1,16 @@
+struct Foo {
+    foo: i32;
+    //~^ ERROR struct fields are separated by `,`
+}
+
+union Bar { //~ ERROR
+    foo: i32;
+    //~^ ERROR union fields are separated by `,`
+}
+
+enum Baz {
+    Qux { foo: i32; }
+    //~^ ERROR struct fields are separated by `,`
+}
+
+fn main() {}

--- a/src/test/ui/parser/recover-field-semi.stderr
+++ b/src/test/ui/parser/recover-field-semi.stderr
@@ -1,0 +1,29 @@
+error: struct fields are separated by `,`
+  --> $DIR/recover-field-semi.rs:2:13
+   |
+LL |     foo: i32;
+   |             ^ help: replace `;` with `,`
+
+error: union fields are separated by `,`
+  --> $DIR/recover-field-semi.rs:7:13
+   |
+LL |     foo: i32;
+   |             ^ help: replace `;` with `,`
+
+error: struct fields are separated by `,`
+  --> $DIR/recover-field-semi.rs:12:19
+   |
+LL |     Qux { foo: i32; }
+   |                   ^ help: replace `;` with `,`
+
+error: unions cannot have zero fields
+  --> $DIR/recover-field-semi.rs:6:1
+   |
+LL | / union Bar {
+LL | |     foo: i32;
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/parser/removed-syntax-field-semicolon.rs
+++ b/src/test/ui/parser/removed-syntax-field-semicolon.rs
@@ -1,6 +1,6 @@
 struct S {
     bar: ();
-    //~^ ERROR expected `,`, or `}`, found `;`
+    //~^ ERROR struct fields are separated by `,`
 }
 
 fn main() {}

--- a/src/test/ui/parser/removed-syntax-field-semicolon.stderr
+++ b/src/test/ui/parser/removed-syntax-field-semicolon.stderr
@@ -1,8 +1,8 @@
-error: expected `,`, or `}`, found `;`
+error: struct fields are separated by `,`
   --> $DIR/removed-syntax-field-semicolon.rs:2:12
    |
 LL |     bar: ();
-   |            ^
+   |            ^ help: replace `;` with `,`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Partially fixes #101440 (only for record structs).

Doing that for tuple structs is harder as their parsing passes through a bunch of helper functions. I don't know how to do that. But [their error message is better anyway](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cc6ee8bb2593596c0cea89d49e79bcb4) and suggests using a comma, even if it doesn't suggest replacing the semicolon with it.