### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.5"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.5"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",


### PR DESCRIPTION
8 commits in 4ed54cecce3ce9ab6ff058781f4c8a500ee6b8b5..646e9a0b9ea8354cc409d05f10e8dc752c5de78e
2022-08-27 18:41:39 +0000 to 2022-09-02 14:29:28 +0000
- Support inheriting jobserver fd for external subcommands (rust-lang/cargo#10511)
- refactor(cli): Lazy load config (rust-lang/cargo#11029)
- chore: Don't show genned docs in ripgrep (rust-lang/cargo#11040)
- Document private items for Cargo and publish under contributor guide (rust-lang/cargo#11019)
- Add names to CI jobs (rust-lang/cargo#11039)
- Rework test error handling (rust-lang/cargo#11028)
- Very slight `cargo add` documentation improvements (rust-lang/cargo#11033)
- Update compiling requirements. (rust-lang/cargo#11030)