### PR TITLE
proc_macro/bridge: Add #[inline] to RunningSameThreadGuard methods

### DIFF
--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -160,6 +160,7 @@ thread_local! {
 struct RunningSameThreadGuard(());
 
 impl RunningSameThreadGuard {
+    #[inline]
     fn new() -> Self {
         let already_running = ALREADY_RUNNING_SAME_THREAD.replace(true);
         assert!(
@@ -171,6 +172,7 @@ impl RunningSameThreadGuard {
 }
 
 impl Drop for RunningSameThreadGuard {
+    #[inline]
     fn drop(&mut self) {
         ALREADY_RUNNING_SAME_THREAD.set(false);
     }


### PR DESCRIPTION
This is a potential fix to the perf regression from #101414.

r? @eddyb