### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -67,7 +67,7 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
                 span,
                 reason,
                 is_bytestr,
-                source_map: sess.source_map(),
+                start_point_span: sess.source_map().start_point(span),
             });
         }
     }

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -63,7 +63,12 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
             sess.emit_err(session_diagnostics::MultipleStabilityLevels { span });
         }
         AttrError::UnsupportedLiteral(reason, is_bytestr) => {
-            sess.emit_err(session_diagnostics::UnsupportedLiteral { span, reason, is_bytestr, source_map: sess.source_map() });
+            sess.emit_err(session_diagnostics::UnsupportedLiteral {
+                span,
+                reason,
+                is_bytestr,
+                source_map: sess.source_map(),
+            });
         }
     }
 }

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -63,7 +63,7 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
             sess.emit_err(session_diagnostics::MultipleStabilityLevels { span });
         }
         AttrError::UnsupportedLiteral(reason, is_bytestr) => {
-            sess.emit_err(session_diagnostics::UnsupportedLiteral { span, reason, is_bytestr });
+            sess.emit_err(session_diagnostics::UnsupportedLiteral { span, reason, is_bytestr, source_map: sess.source_map() });
         }
     }
 }

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -6,7 +6,7 @@ use rustc_errors::{
 };
 use rustc_macros::SessionDiagnostic;
 use rustc_session::SessionDiagnostic;
-use rustc_span::{Span, Symbol, source_map::SourceMap};
+use rustc_span::{source_map::SourceMap, Span, Symbol};
 
 use crate::UnsupportedLiteralReason;
 

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -6,7 +6,7 @@ use rustc_errors::{
 };
 use rustc_macros::SessionDiagnostic;
 use rustc_session::SessionDiagnostic;
-use rustc_span::{source_map::SourceMap, Span, Symbol};
+use rustc_span::{Span, Symbol};
 
 use crate::UnsupportedLiteralReason;
 
@@ -202,14 +202,14 @@ pub(crate) struct InvalidReprHintNoValue {
 }
 
 // Error code: E0565
-pub(crate) struct UnsupportedLiteral<'a> {
+pub(crate) struct UnsupportedLiteral {
     pub span: Span,
     pub reason: UnsupportedLiteralReason,
     pub is_bytestr: bool,
-    pub source_map: &'a SourceMap,
+    pub start_point_span: Span,
 }
 
-impl<'a> SessionDiagnostic<'a> for UnsupportedLiteral<'a> {
+impl<'a> SessionDiagnostic<'a> for UnsupportedLiteral {
     fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut diag = handler.struct_span_err_with_code(
             self.span,
@@ -227,7 +227,7 @@ impl<'a> SessionDiagnostic<'a> for UnsupportedLiteral<'a> {
         );
         if self.is_bytestr {
             diag.span_suggestion(
-                self.source_map.start_point(self.span),
+                self.start_point_span,
                 fluent::attr::unsupported_literal_suggestion,
                 "",
                 Applicability::MaybeIncorrect,

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1098,6 +1098,28 @@ impl Handler {
         );
         std::mem::take(&mut self.inner.borrow_mut().fulfilled_expectations)
     }
+
+    pub fn span_to_snippet_from_emitter(
+        &self,
+        span: rustc_span::Span,
+    ) -> Option<Result<String, rustc_span::SpanSnippetError>> {
+        self.inner
+            .borrow()
+            .emitter
+            .source_map()
+            .map_or_else(|| Option::None, |sm| Some(sm.span_to_snippet(span)))
+    }
+
+    pub fn span_start_point_from_emitter(
+        &self,
+        span: rustc_span::Span,
+    ) -> Option<rustc_span::Span> {
+        self.inner
+            .borrow()
+            .emitter
+            .source_map()
+            .map_or_else(|| Option::None, |sm| Some(sm.start_point(span)))
+    }
 }
 
 impl HandlerInner {

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1098,28 +1098,6 @@ impl Handler {
         );
         std::mem::take(&mut self.inner.borrow_mut().fulfilled_expectations)
     }
-
-    pub fn span_to_snippet_from_emitter(
-        &self,
-        span: rustc_span::Span,
-    ) -> Option<Result<String, rustc_span::SpanSnippetError>> {
-        self.inner
-            .borrow()
-            .emitter
-            .source_map()
-            .map_or_else(|| Option::None, |sm| Some(sm.span_to_snippet(span)))
-    }
-
-    pub fn span_start_point_from_emitter(
-        &self,
-        span: rustc_span::Span,
-    ) -> Option<rustc_span::Span> {
-        self.inner
-            .borrow()
-            .emitter
-            .source_map()
-            .map_or_else(|| Option::None, |sm| Some(sm.start_point(span)))
-    }
 }
 
 impl HandlerInner {

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -341,7 +341,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 multi_suggestions,
                 bad_label,
             }
-            .into_diagnostic(&self.tcx.sess.parse_sess),
+            .into_diagnostic(&self.tcx.sess.parse_sess.span_diagnostic),
             TypeAnnotationNeeded::E0283 => AmbigousImpl {
                 span,
                 source_kind,
@@ -351,7 +351,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 multi_suggestions,
                 bad_label,
             }
-            .into_diagnostic(&self.tcx.sess.parse_sess),
+            .into_diagnostic(&self.tcx.sess.parse_sess.span_diagnostic),
             TypeAnnotationNeeded::E0284 => AmbigousReturn {
                 span,
                 source_kind,
@@ -361,7 +361,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 multi_suggestions,
                 bad_label,
             }
-            .into_diagnostic(&self.tcx.sess.parse_sess),
+            .into_diagnostic(&self.tcx.sess.parse_sess.span_diagnostic),
         }
     }
 
@@ -537,7 +537,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 multi_suggestions,
                 bad_label: None,
             }
-            .into_diagnostic(&self.tcx.sess.parse_sess),
+            .into_diagnostic(&self.tcx.sess.parse_sess.span_diagnostic),
             TypeAnnotationNeeded::E0283 => AmbigousImpl {
                 span,
                 source_kind,
@@ -547,7 +547,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 multi_suggestions,
                 bad_label: None,
             }
-            .into_diagnostic(&self.tcx.sess.parse_sess),
+            .into_diagnostic(&self.tcx.sess.parse_sess.span_diagnostic),
             TypeAnnotationNeeded::E0284 => AmbigousReturn {
                 span,
                 source_kind,
@@ -557,7 +557,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 multi_suggestions,
                 bad_label: None,
             }
-            .into_diagnostic(&self.tcx.sess.parse_sess),
+            .into_diagnostic(&self.tcx.sess.parse_sess.span_diagnostic),
         }
     }
 
@@ -575,7 +575,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             span,
             generator_kind: GeneratorKindAsDiagArg(kind),
         }
-        .into_diagnostic(&self.tcx.sess.parse_sess)
+        .into_diagnostic(&self.tcx.sess.parse_sess.span_diagnostic)
     }
 }
 

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -1,6 +1,6 @@
-use rustc_errors::{fluent, AddSubdiagnostic, ErrorGuaranteed};
+use rustc_errors::{fluent, AddSubdiagnostic, ErrorGuaranteed, Handler};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
-use rustc_session::{lint::Level, parse::ParseSess, SessionDiagnostic};
+use rustc_session::{lint::Level, SessionDiagnostic};
 use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic)]
@@ -122,9 +122,9 @@ pub struct CheckNameUnknown {
 impl SessionDiagnostic<'_> for CheckNameUnknown {
     fn into_diagnostic(
         self,
-        sess: &ParseSess,
+        handler: &Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(fluent::lint::check_name_unknown);
+        let mut diag = handler.struct_err(fluent::lint::check_name_unknown);
         diag.code(rustc_errors::error_code!(E0602));
         if let Some(suggestion) = self.suggestion {
             diag.help(fluent::lint::help);

--- a/compiler/rustc_macros/src/diagnostics/diagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic.rs
@@ -88,7 +88,7 @@ impl<'a> SessionDiagnosticDerive<'a> {
             {
                 fn into_diagnostic(
                     self,
-                    #sess: &'__session_diagnostic_sess rustc_session::parse::ParseSess
+                    #sess: &'__session_diagnostic_sess rustc_errors::Handler
                 ) -> rustc_errors::DiagnosticBuilder<'__session_diagnostic_sess, G> {
                     use rustc_errors::IntoDiagnosticArg;
                     #implementation

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -424,9 +424,9 @@ pub(crate) struct MultipleCandidates {
 impl SessionDiagnostic<'_> for MultipleCandidates {
     fn into_diagnostic(
         self,
-        sess: &'_ rustc_session::parse::ParseSess,
+        handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(rustc_errors::fluent::metadata::multiple_candidates);
+        let mut diag = handler.struct_err(rustc_errors::fluent::metadata::multiple_candidates);
         diag.set_arg("crate_name", self.crate_name);
         diag.set_arg("flavor", self.flavor);
         diag.code(error_code!(E0465));
@@ -540,9 +540,9 @@ pub struct InvalidMetadataFiles {
 impl SessionDiagnostic<'_> for InvalidMetadataFiles {
     fn into_diagnostic(
         self,
-        sess: &'_ rustc_session::parse::ParseSess,
+        handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(rustc_errors::fluent::metadata::invalid_meta_files);
+        let mut diag = handler.struct_err(rustc_errors::fluent::metadata::invalid_meta_files);
         diag.set_arg("crate_name", self.crate_name);
         diag.set_arg("add_info", self.add_info);
         diag.code(error_code!(E0786));
@@ -568,9 +568,9 @@ pub struct CannotFindCrate {
 impl SessionDiagnostic<'_> for CannotFindCrate {
     fn into_diagnostic(
         self,
-        sess: &'_ rustc_session::parse::ParseSess,
+        handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(rustc_errors::fluent::metadata::cannot_find_crate);
+        let mut diag = handler.struct_err(rustc_errors::fluent::metadata::cannot_find_crate);
         diag.set_arg("crate_name", self.crate_name);
         diag.set_arg("add_info", self.add_info);
         diag.set_arg("locator_triple", self.locator_triple.triple());

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -839,10 +839,6 @@ pub struct LocalDecl<'tcx> {
     pub source_info: SourceInfo,
 }
 
-// `LocalDecl` is used a lot. Make sure it doesn't unintentionally get bigger.
-#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-static_assert_size!(LocalDecl<'_>, 56);
-
 /// Extra information about a some locals that's used for diagnostics and for
 /// classifying variables into local variables, statics, etc, which is needed e.g.
 /// for unsafety checking.
@@ -1316,10 +1312,6 @@ pub struct Statement<'tcx> {
     pub source_info: SourceInfo,
     pub kind: StatementKind<'tcx>,
 }
-
-// `Statement` is used a lot. Make sure it doesn't unintentionally get bigger.
-#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-static_assert_size!(Statement<'_>, 32);
 
 impl Statement<'_> {
     /// Changes a statement to a nop. This is both faster than deleting instructions and avoids
@@ -2899,4 +2891,18 @@ impl Location {
             dominators.is_dominated_by(other.block, self.block)
         }
     }
+}
+
+// Some nodes are used a lot. Make sure they don't unintentionally get bigger.
+#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+mod size_asserts {
+    use super::*;
+    use rustc_data_structures::static_assert_size;
+    // These are in alphabetical order, which is easy to maintain.
+    static_assert_size!(BasicBlockData<'_>, 144);
+    static_assert_size!(LocalDecl<'_>, 56);
+    static_assert_size!(Statement<'_>, 32);
+    static_assert_size!(StatementKind<'_>, 16);
+    static_assert_size!(Terminator<'_>, 112);
+    static_assert_size!(TerminatorKind<'_>, 96);
 }

--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -754,8 +754,8 @@ fn lint_non_exhaustive_omitted_patterns<'p, 'tcx>(
     hir_id: HirId,
     witnesses: Vec<DeconstructedPat<'p, 'tcx>>,
 ) {
-    let joined_patterns = joined_uncovered_patterns(cx, &witnesses);
     cx.tcx.struct_span_lint_hir(NON_EXHAUSTIVE_OMITTED_PATTERNS, hir_id, sp, |build| {
+        let joined_patterns = joined_uncovered_patterns(cx, &witnesses);
         let mut lint = build.build("some variants are not matched explicitly");
         lint.span_label(sp, pattern_not_covered_label(&witnesses, &joined_patterns));
         lint.help(

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -47,9 +47,10 @@ pub struct UnusedGenericParams {
 impl SessionDiagnostic<'_> for UnusedGenericParams {
     fn into_diagnostic(
         self,
-        sess: &'_ rustc_session::parse::ParseSess,
+        handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(rustc_errors::fluent::monomorphize::unused_generic_params);
+        let mut diag =
+            handler.struct_err(rustc_errors::fluent::monomorphize::unused_generic_params);
         diag.set_span(self.span);
         for (span, name) in self.param_spans.into_iter().zip(self.param_names) {
             // FIXME: I can figure out how to do a label with a fluent string with a fixed message,

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1997,7 +1997,7 @@ impl<'a> Parser<'a> {
                     return Err(MissingSemicolonBeforeArray {
                         open_delim: open_delim_span,
                         semicolon: prev_span.shrink_to_hi(),
-                    }.into_diagnostic(self.sess));
+                    }.into_diagnostic(&self.sess.span_diagnostic));
                 }
                 Ok(_) => (),
                 Err(err) => err.cancel(),
@@ -2745,7 +2745,8 @@ impl<'a> Parser<'a> {
     fn parse_try_block(&mut self, span_lo: Span) -> PResult<'a, P<Expr>> {
         let (attrs, body) = self.parse_inner_attrs_and_block()?;
         if self.eat_keyword(kw::Catch) {
-            Err(CatchAfterTry { span: self.prev_token.span }.into_diagnostic(self.sess))
+            Err(CatchAfterTry { span: self.prev_token.span }
+                .into_diagnostic(&self.sess.span_diagnostic))
         } else {
             let span = span_lo.to(body.span);
             self.sess.gated_spans.gate(sym::try_blocks, span);

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1526,6 +1526,17 @@ impl<'a> Parser<'a> {
         if self.token == token::Comma {
             seen_comma = true;
         }
+        if self.eat(&token::Semi) {
+            let sp = self.prev_token.span;
+            let mut err = self.struct_span_err(sp, format!("{adt_ty} fields are separated by `,`"));
+            err.span_suggestion_short(
+                sp,
+                "replace `;` with `,`",
+                ",",
+                Applicability::MachineApplicable,
+            );
+            return Err(err);
+        }
         match self.token.kind {
             token::Comma => {
                 self.bump();

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -572,7 +572,7 @@ pub(crate) fn report_cycle<'a>(
         stack_count,
     };
 
-    cycle_diag.into_diagnostic(&sess.parse_sess)
+    cycle_diag.into_diagnostic(&sess.parse_sess.span_diagnostic)
 }
 
 pub fn print_query_stack<CTX: QueryContext>(

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -343,7 +343,7 @@ impl ParseSess {
         &'a self,
         err: impl SessionDiagnostic<'a>,
     ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
-        err.into_diagnostic(self)
+        err.into_diagnostic(&self.span_diagnostic)
     }
 
     pub fn emit_err<'a>(&'a self, err: impl SessionDiagnostic<'a>) -> ErrorGuaranteed {
@@ -354,7 +354,7 @@ impl ParseSess {
         &'a self,
         warning: impl SessionDiagnostic<'a, ()>,
     ) -> DiagnosticBuilder<'a, ()> {
-        warning.into_diagnostic(self)
+        warning.into_diagnostic(&self.span_diagnostic)
     }
 
     pub fn emit_warning<'a>(&'a self, warning: impl SessionDiagnostic<'a, ()>) {
@@ -365,7 +365,7 @@ impl ParseSess {
         &'a self,
         fatal: impl SessionDiagnostic<'a, !>,
     ) -> DiagnosticBuilder<'a, !> {
-        fatal.into_diagnostic(self)
+        fatal.into_diagnostic(&self.span_diagnostic)
     }
 
     pub fn emit_fatal<'a>(&'a self, fatal: impl SessionDiagnostic<'a, !>) -> ! {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -21,7 +21,7 @@ use rustc_errors::json::JsonEmitter;
 use rustc_errors::registry::Registry;
 use rustc_errors::{
     error_code, fallback_fluent_bundle, DiagnosticBuilder, DiagnosticId, DiagnosticMessage,
-    EmissionGuarantee, ErrorGuaranteed, FluentBundle, LazyFallbackBundle, MultiSpan,
+    EmissionGuarantee, ErrorGuaranteed, FluentBundle, Handler, LazyFallbackBundle, MultiSpan,
 };
 use rustc_macros::HashStable_Generic;
 pub use rustc_span::def_id::StableCrateId;
@@ -220,9 +220,9 @@ pub struct PerfStats {
 /// `#[derive(SessionDiagnostic)]` -- see [rustc_macros::SessionDiagnostic].
 #[rustc_diagnostic_item = "SessionDiagnostic"]
 pub trait SessionDiagnostic<'a, T: EmissionGuarantee = ErrorGuaranteed> {
-    /// Write out as a diagnostic out of `sess`.
+    /// Write out as a diagnostic out of `Handler`.
     #[must_use]
-    fn into_diagnostic(self, sess: &'a ParseSess) -> DiagnosticBuilder<'a, T>;
+    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, T>;
 }
 
 impl Session {

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -1,7 +1,7 @@
-use rustc_errors::{fluent, ErrorGuaranteed};
+use rustc_errors::{fluent, ErrorGuaranteed, Handler};
 use rustc_macros::SessionDiagnostic;
 use rustc_middle::ty::{PolyTraitRef, Ty, Unevaluated};
-use rustc_session::{parse::ParseSess, Limit, SessionDiagnostic};
+use rustc_session::{Limit, SessionDiagnostic};
 use rustc_span::{Span, Symbol};
 
 #[derive(SessionDiagnostic)]
@@ -69,9 +69,9 @@ pub struct NegativePositiveConflict<'a> {
 impl SessionDiagnostic<'_> for NegativePositiveConflict<'_> {
     fn into_diagnostic(
         self,
-        sess: &ParseSess,
+        handler: &Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(fluent::trait_selection::negative_positive_conflict);
+        let mut diag = handler.struct_err(fluent::trait_selection::negative_positive_conflict);
         diag.set_arg("trait_desc", self.trait_desc);
         diag.set_arg(
             "self_desc",

--- a/compiler/rustc_typeck/src/astconv/errors.rs
+++ b/compiler/rustc_typeck/src/astconv/errors.rs
@@ -29,7 +29,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         self.tcx().sess.emit_err(MissingTypeParams {
             span,
             def_span: self.tcx().def_span(def_id),
-            source_map: self.tcx().sess.source_map(),
+            span_snippet: self.tcx().sess.source_map().span_to_snippet(span).ok(),
             missing_type_params,
             empty_generic_args,
         });

--- a/compiler/rustc_typeck/src/astconv/errors.rs
+++ b/compiler/rustc_typeck/src/astconv/errors.rs
@@ -29,6 +29,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         self.tcx().sess.emit_err(MissingTypeParams {
             span,
             def_span: self.tcx().def_span(def_id),
+            source_map: self.tcx().sess.source_map(),
             missing_type_params,
             empty_generic_args,
         });

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -3,7 +3,7 @@ use rustc_errors::{error_code, Applicability, DiagnosticBuilder, ErrorGuaranteed
 use rustc_macros::{LintDiagnostic, SessionDiagnostic, SessionSubdiagnostic};
 use rustc_middle::ty::Ty;
 use rustc_session::SessionDiagnostic;
-use rustc_span::{symbol::Ident, Span, Symbol, source_map::SourceMap};
+use rustc_span::{source_map::SourceMap, symbol::Ident, Span, Symbol};
 
 #[derive(SessionDiagnostic)]
 #[diag(typeck::field_multiply_specified_in_initializer, code = "E0062")]

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -270,12 +270,9 @@ impl<'a> SessionDiagnostic<'a> for MissingTypeParams {
         err.span_label(self.def_span, rustc_errors::fluent::typeck::label);
 
         let mut suggested = false;
-        if let (Some(snippet), true) = (
-            self.span_snippet,
-            // Don't suggest setting the type params if there are some already: the order is
-            // tricky to get right and the user will already know what the syntax is.
-            self.empty_generic_args,
-        ) {
+        // Don't suggest setting the type params if there are some already: the order is
+        // tricky to get right and the user will already know what the syntax is.
+        if let Some(snippet) = self.span_snippet && self.empty_generic_args {
             if snippet.ends_with('>') {
                 // The user wrote `Trait<'a, T>` or similar. To provide an accurate suggestion
                 // we would have to preserve the right order. For now, as clearly the user is

--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -144,10 +144,10 @@ while work_list:
         ) - visited
     elif item["kind"] == "variant":
         if item["inner"]["variant_kind"] == "tuple":
-            for ty in item["inner"]["variant_inner"]:
-                check_type(ty)
+            for field_id in filter(None, item["inner"]["variant_inner"]):
+                work_list.add(field_id)
         elif item["inner"]["variant_kind"] == "struct":
-            work_list |= set(item["inner"]["variant_inner"]) - visited
+            work_list |= set(item["inner"]["variant_inner"]["fields"]) - visited
     elif item["kind"] in ("function", "method"):
         check_generics(item["inner"]["generics"])
         check_decl(item["inner"]["decl"])

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 19;
+pub const FORMAT_VERSION: u32 = 20;
 
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
@@ -308,9 +308,36 @@ pub struct Enum {
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "variant_kind", content = "variant_inner")]
 pub enum Variant {
+    /// A variant with no parentheses, and possible discriminant.
+    ///
+    /// ```rust
+    /// enum Demo {
+    ///     PlainVariant,
+    ///     PlainWithDiscriminant = 1,
+    /// }
+    /// ```
     Plain(Option<Discriminant>),
-    Tuple(Vec<Type>),
-    Struct(Vec<Id>),
+    /// A variant with unnamed fields.
+    ///
+    /// Unlike most of json, `#[doc(hidden)]` fields will be given as `None`
+    /// instead of being ommited, because order matters.
+    ///
+    /// ```rust
+    /// enum Demo {
+    ///     TupleVariant(i32),
+    ///     EmptyTupleVariant(),
+    /// }
+    /// ```
+    Tuple(Vec<Option<Id>>),
+    /// A variant with named fields.
+    ///
+    /// ```rust
+    /// enum Demo {
+    ///     StructVariant { x: i32 },
+    ///     EmptyStructVariant {},
+    /// }
+    /// ```
+    Struct { fields: Vec<Id>, fields_stripped: bool },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/test/rustdoc-json/enums/field_hidden.rs
+++ b/src/test/rustdoc-json/enums/field_hidden.rs
@@ -6,7 +6,7 @@
 // @has "$.index[*][?(@.name=='ParseError')]"
 // @has "$.index[*][?(@.name=='UnexpectedEndTag')]"
 // @is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant_kind" '"tuple"'
-// @is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant_inner" []
+// @is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant_inner" [null]
 
 pub enum ParseError {
     UnexpectedEndTag(#[doc(hidden)] u32),

--- a/src/test/rustdoc-json/enums/kind.rs
+++ b/src/test/rustdoc-json/enums/kind.rs
@@ -1,0 +1,37 @@
+// ignore-tidy-linelength
+
+#![feature(no_core)]
+#![no_core]
+
+pub enum Foo {
+    // @set Unit = "$.index[*][?(@.name=='Unit')].id"
+    // @is "$.index[*][?(@.name=='Unit')].inner.variant_kind" '"plain"'
+    // @is "$.index[*][?(@.name=='Unit')].inner.variant_inner" null
+    Unit,
+    // @set Named = "$.index[*][?(@.name=='Named')].id"
+    // @is "$.index[*][?(@.name=='Named')].inner.variant_kind" '"struct"'
+    // @is "$.index[*][?(@.name=='Named')].inner.variant_inner" '{"fields": [], "fields_stripped": false}'
+    Named {},
+    // @set Tuple = "$.index[*][?(@.name=='Tuple')].id"
+    // @is "$.index[*][?(@.name=='Tuple')].inner.variant_kind" '"tuple"'
+    // @is "$.index[*][?(@.name=='Tuple')].inner.variant_inner" []
+    Tuple(),
+    // @set NamedField = "$.index[*][?(@.name=='NamedField')].id"
+    // @set x = "$.index[*][?(@.name=='x' && @.kind=='struct_field')].id"
+    // @is "$.index[*][?(@.name=='NamedField')].inner.variant_kind" '"struct"'
+    // @is "$.index[*][?(@.name=='NamedField')].inner.variant_inner.fields[*]" $x
+    // @is "$.index[*][?(@.name=='NamedField')].inner.variant_inner.fields_stripped" false
+    NamedField { x: i32 },
+    // @set TupleField = "$.index[*][?(@.name=='TupleField')].id"
+    // @is "$.index[*][?(@.name=='TupleField')].inner.variant_kind" '"tuple"'
+    // @set tup_field = "$.index[*][?(@.name=='0' && @.kind=='struct_field')].id"
+    // @is "$.index[*][?(@.name=='TupleField')].inner.variant_inner[*]" $tup_field
+    TupleField(i32),
+}
+
+// @is    "$.index[*][?(@.name=='Foo')].inner.variants[0]" $Unit
+// @is    "$.index[*][?(@.name=='Foo')].inner.variants[1]" $Named
+// @is    "$.index[*][?(@.name=='Foo')].inner.variants[2]" $Tuple
+// @is    "$.index[*][?(@.name=='Foo')].inner.variants[3]" $NamedField
+// @is    "$.index[*][?(@.name=='Foo')].inner.variants[4]" $TupleField
+// @count "$.index[*][?(@.name=='Foo')].inner.variants[*]" 5

--- a/src/test/rustdoc-json/enums/struct_field_hidden.rs
+++ b/src/test/rustdoc-json/enums/struct_field_hidden.rs
@@ -1,0 +1,17 @@
+pub enum Foo {
+    Variant {
+        #[doc(hidden)]
+        a: i32,
+        // @set b = "$.index[*][?(@.name=='b')].id"
+        b: i32,
+        #[doc(hidden)]
+        x: i32,
+        // @set y = "$.index[*][?(@.name=='y')].id"
+        y: i32,
+    },
+    // @is "$.index[*][?(@.name=='Variant')].inner.variant_kind" '"struct"'
+    // @is "$.index[*][?(@.name=='Variant')].inner.variant_inner.fields_stripped" true
+    // @is "$.index[*][?(@.name=='Variant')].inner.variant_inner.fields[0]" $b
+    // @is "$.index[*][?(@.name=='Variant')].inner.variant_inner.fields[1]" $y
+    // @count "$.index[*][?(@.name=='Variant')].inner.variant_inner.fields[*]" 2
+}

--- a/src/test/rustdoc-json/enums/tuple_fields_hidden.rs
+++ b/src/test/rustdoc-json/enums/tuple_fields_hidden.rs
@@ -1,0 +1,94 @@
+#![feature(no_core)]
+#![no_core]
+
+// @set 1.1.0 = "$.index[*][?(@.docs=='1.1.0')].id"
+// @set 2.1.0 = "$.index[*][?(@.docs=='2.1.0')].id"
+// @set 2.1.1 = "$.index[*][?(@.docs=='2.1.1')].id"
+// @set 2.2.1 = "$.index[*][?(@.docs=='2.2.1')].id"
+// @set 2.3.0 = "$.index[*][?(@.docs=='2.3.0')].id"
+// @set 3.1.1 = "$.index[*][?(@.docs=='3.1.1')].id"
+// @set 3.1.2 = "$.index[*][?(@.docs=='3.1.2')].id"
+// @set 3.2.0 = "$.index[*][?(@.docs=='3.2.0')].id"
+// @set 3.2.2 = "$.index[*][?(@.docs=='3.2.2')].id"
+// @set 3.3.0 = "$.index[*][?(@.docs=='3.3.0')].id"
+// @set 3.3.1 = "$.index[*][?(@.docs=='3.3.1')].id"
+
+pub enum EnumWithStrippedTupleVariants {
+    // @is    "$.index[*][?(@.name=='None')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='None')].inner.variant_inner[*]" 0
+    None(),
+
+    // @is    "$.index[*][?(@.name=='One')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='One')].inner.variant_inner[*]" 1
+    // @is    "$.index[*][?(@.name=='One')].inner.variant_inner[0]" $1.1.0
+    One(/** 1.1.0*/ bool),
+    // @is    "$.index[*][?(@.name=='OneHidden')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='OneHidden')].inner.variant_inner[*]" 1
+    // @is    "$.index[*][?(@.name=='OneHidden')].inner.variant_inner[0]" null
+    OneHidden(#[doc(hidden)] bool),
+
+    // @is    "$.index[*][?(@.name=='Two')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='Two')].inner.variant_inner[*]" 2
+    // @is    "$.index[*][?(@.name=='Two')].inner.variant_inner[0]" $2.1.0
+    // @is    "$.index[*][?(@.name=='Two')].inner.variant_inner[1]" $2.1.1
+    Two(/** 2.1.0*/ bool, /** 2.1.1*/ bool),
+    // @is    "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant_inner[*]" 2
+    // @is    "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant_inner[0]" null
+    // @is    "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant_inner[1]" $2.2.1
+    TwoLeftHidden(#[doc(hidden)] bool, /** 2.2.1*/ bool),
+    // @is    "$.index[*][?(@.name=='TwoRightHidden')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='TwoRightHidden')].inner.variant_inner[*]" 2
+    // @is    "$.index[*][?(@.name=='TwoRightHidden')].inner.variant_inner[0]" $2.3.0
+    // @is    "$.index[*][?(@.name=='TwoRightHidden')].inner.variant_inner[1]" null
+    TwoRightHidden(/** 2.3.0*/ bool, #[doc(hidden)] bool),
+    // @is    "$.index[*][?(@.name=='TwoBothHidden')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='TwoBothHidden')].inner.variant_inner[*]" 2
+    // @is    "$.index[*][?(@.name=='TwoBothHidden')].inner.variant_inner[0]" null
+    // @is    "$.index[*][?(@.name=='TwoBothHidden')].inner.variant_inner[1]" null
+    TwoBothHidden(#[doc(hidden)] bool, #[doc(hidden)] bool),
+
+    // @is    "$.index[*][?(@.name=='Three1')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='Three1')].inner.variant_inner[*]" 3
+    // @is    "$.index[*][?(@.name=='Three1')].inner.variant_inner[0]" null
+    // @is    "$.index[*][?(@.name=='Three1')].inner.variant_inner[1]" $3.1.1
+    // @is    "$.index[*][?(@.name=='Three1')].inner.variant_inner[2]" $3.1.2
+    Three1(#[doc(hidden)] bool, /** 3.1.1*/ bool, /** 3.1.2*/ bool),
+    // @is    "$.index[*][?(@.name=='Three2')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='Three2')].inner.variant_inner[*]" 3
+    // @is    "$.index[*][?(@.name=='Three2')].inner.variant_inner[0]" $3.2.0
+    // @is    "$.index[*][?(@.name=='Three2')].inner.variant_inner[1]" null
+    // @is    "$.index[*][?(@.name=='Three2')].inner.variant_inner[2]" $3.2.2
+    Three2(/** 3.2.0*/ bool, #[doc(hidden)] bool, /** 3.2.2*/ bool),
+    // @is    "$.index[*][?(@.name=='Three3')].inner.variant_kind" '"tuple"'
+    // @count "$.index[*][?(@.name=='Three3')].inner.variant_inner[*]" 3
+    // @is    "$.index[*][?(@.name=='Three3')].inner.variant_inner[0]" $3.3.0
+    // @is    "$.index[*][?(@.name=='Three3')].inner.variant_inner[1]" $3.3.1
+    // @is    "$.index[*][?(@.name=='Three3')].inner.variant_inner[2]" null
+    Three3(/** 3.3.0*/ bool, /** 3.3.1*/ bool, #[doc(hidden)] bool),
+}
+
+
+// @is "$.index[*][?(@.docs=='1.1.0')].name" '"0"'
+// @is "$.index[*][?(@.docs=='2.1.0')].name" '"0"'
+// @is "$.index[*][?(@.docs=='2.1.1')].name" '"1"'
+// @is "$.index[*][?(@.docs=='2.2.1')].name" '"1"'
+// @is "$.index[*][?(@.docs=='2.3.0')].name" '"0"'
+// @is "$.index[*][?(@.docs=='3.1.1')].name" '"1"'
+// @is "$.index[*][?(@.docs=='3.1.2')].name" '"2"'
+// @is "$.index[*][?(@.docs=='3.2.0')].name" '"0"'
+// @is "$.index[*][?(@.docs=='3.2.2')].name" '"2"'
+// @is "$.index[*][?(@.docs=='3.3.0')].name" '"0"'
+// @is "$.index[*][?(@.docs=='3.3.1')].name" '"1"'
+
+// @is "$.index[*][?(@.docs=='1.1.0')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='2.1.0')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='2.1.1')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='2.2.1')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='2.3.0')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='3.1.1')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='3.1.2')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='3.2.0')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='3.2.2')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='3.3.0')].inner" '{"kind": "primitive", "inner": "bool"}'
+// @is "$.index[*][?(@.docs=='3.3.1')].inner" '{"kind": "primitive", "inner": "bool"}'

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.rs
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.rs
@@ -11,9 +11,9 @@ extern crate rustc_macros;
 extern crate rustc_session;
 extern crate rustc_span;
 
-use rustc_errors::{AddSubdiagnostic, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, fluent};
+use rustc_errors::{AddSubdiagnostic, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, Handler, fluent};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
-use rustc_session::{parse::ParseSess, SessionDiagnostic};
+use rustc_session::SessionDiagnostic;
 use rustc_span::Span;
 
 #[derive(SessionDiagnostic)]
@@ -33,8 +33,8 @@ struct Note {
 pub struct UntranslatableInSessionDiagnostic;
 
 impl<'a> SessionDiagnostic<'a, ErrorGuaranteed> for UntranslatableInSessionDiagnostic {
-    fn into_diagnostic(self, sess: &'a ParseSess) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
-        sess.struct_err("untranslatable diagnostic")
+    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
+        handler.struct_err("untranslatable diagnostic")
         //~^ ERROR diagnostics should be created using translatable messages
     }
 }
@@ -42,8 +42,8 @@ impl<'a> SessionDiagnostic<'a, ErrorGuaranteed> for UntranslatableInSessionDiagn
 pub struct TranslatableInSessionDiagnostic;
 
 impl<'a> SessionDiagnostic<'a, ErrorGuaranteed> for TranslatableInSessionDiagnostic {
-    fn into_diagnostic(self, sess: &'a ParseSess) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
-        sess.struct_err(fluent::parser::expect_path)
+    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
+        handler.struct_err(fluent::parser::expect_path)
     }
 }
 
@@ -64,11 +64,11 @@ impl AddSubdiagnostic for TranslatableInAddSubdiagnostic {
     }
 }
 
-pub fn make_diagnostics<'a>(sess: &'a ParseSess) {
-    let _diag = sess.struct_err(fluent::parser::expect_path);
+pub fn make_diagnostics<'a>(handler: &'a Handler) {
+    let _diag = handler.struct_err(fluent::parser::expect_path);
     //~^ ERROR diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
 
-    let _diag = sess.struct_err("untranslatable diagnostic");
+    let _diag = handler.struct_err("untranslatable diagnostic");
     //~^ ERROR diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
     //~^^ ERROR diagnostics should be created using translatable messages
 }
@@ -76,6 +76,6 @@ pub fn make_diagnostics<'a>(sess: &'a ParseSess) {
 // Check that `rustc_lint_diagnostics`-annotated functions aren't themselves linted.
 
 #[rustc_lint_diagnostics]
-pub fn skipped_because_of_annotation<'a>(sess: &'a ParseSess) {
-    let _diag = sess.struct_err("untranslatable diagnostic"); // okay!
+pub fn skipped_because_of_annotation<'a>(handler: &'a Handler) {
+    let _diag = handler.struct_err("untranslatable diagnostic"); // okay!
 }

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.rs
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.rs
@@ -11,7 +11,9 @@ extern crate rustc_macros;
 extern crate rustc_session;
 extern crate rustc_span;
 
-use rustc_errors::{AddSubdiagnostic, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, Handler, fluent};
+use rustc_errors::{
+    AddSubdiagnostic, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, Handler, fluent
+};
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_session::SessionDiagnostic;
 use rustc_span::Span;

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
@@ -1,5 +1,5 @@
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:37:17
+  --> $DIR/diagnostics.rs:39:17
    |
 LL |         handler.struct_err("untranslatable diagnostic")
    |                 ^^^^^^^^^^
@@ -11,13 +11,13 @@ LL | #![deny(rustc::untranslatable_diagnostic)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:54:14
+  --> $DIR/diagnostics.rs:56:14
    |
 LL |         diag.note("untranslatable diagnostic");
    |              ^^^^
 
 error: diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
-  --> $DIR/diagnostics.rs:68:25
+  --> $DIR/diagnostics.rs:70:25
    |
 LL |     let _diag = handler.struct_err(fluent::parser::expect_path);
    |                         ^^^^^^^^^^
@@ -29,13 +29,13 @@ LL | #![deny(rustc::diagnostic_outside_of_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
-  --> $DIR/diagnostics.rs:71:25
+  --> $DIR/diagnostics.rs:73:25
    |
 LL |     let _diag = handler.struct_err("untranslatable diagnostic");
    |                         ^^^^^^^^^^
 
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:71:25
+  --> $DIR/diagnostics.rs:73:25
    |
 LL |     let _diag = handler.struct_err("untranslatable diagnostic");
    |                         ^^^^^^^^^^

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
@@ -1,8 +1,8 @@
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:37:14
+  --> $DIR/diagnostics.rs:37:17
    |
-LL |         sess.struct_err("untranslatable diagnostic")
-   |              ^^^^^^^^^^
+LL |         handler.struct_err("untranslatable diagnostic")
+   |                 ^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/diagnostics.rs:6:9
@@ -17,10 +17,10 @@ LL |         diag.note("untranslatable diagnostic");
    |              ^^^^
 
 error: diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
-  --> $DIR/diagnostics.rs:68:22
+  --> $DIR/diagnostics.rs:68:25
    |
-LL |     let _diag = sess.struct_err(fluent::parser::expect_path);
-   |                      ^^^^^^^^^^
+LL |     let _diag = handler.struct_err(fluent::parser::expect_path);
+   |                         ^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/diagnostics.rs:7:9
@@ -29,16 +29,16 @@ LL | #![deny(rustc::diagnostic_outside_of_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostics should only be created in `SessionDiagnostic`/`AddSubdiagnostic` impls
-  --> $DIR/diagnostics.rs:71:22
+  --> $DIR/diagnostics.rs:71:25
    |
-LL |     let _diag = sess.struct_err("untranslatable diagnostic");
-   |                      ^^^^^^^^^^
+LL |     let _diag = handler.struct_err("untranslatable diagnostic");
+   |                         ^^^^^^^^^^
 
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:71:22
+  --> $DIR/diagnostics.rs:71:25
    |
-LL |     let _diag = sess.struct_err("untranslatable diagnostic");
-   |                      ^^^^^^^^^^
+LL |     let _diag = handler.struct_err("untranslatable diagnostic");
+   |                         ^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/match/non-exhaustive-match.rs
+++ b/src/test/ui/closures/2229_closure_analysis/match/non-exhaustive-match.rs
@@ -24,7 +24,7 @@ fn main() {
     let _a = || { match l1 { L1::A => (), L1::B => () } };
     // (except if the match is already non-exhaustive)
     let _b = || { match l1 { L1::A => () } };
-    //~^ ERROR: non-exhaustive patterns: `B` not covered [E0004]
+    //~^ ERROR: non-exhaustive patterns: `L1::B` not covered [E0004]
 
     // l2 should not be captured as it is a non-exhaustive SingleVariant
     // defined in this crate

--- a/src/test/ui/closures/2229_closure_analysis/match/non-exhaustive-match.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/match/non-exhaustive-match.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `B` not covered
+error[E0004]: non-exhaustive patterns: `L1::B` not covered
   --> $DIR/non-exhaustive-match.rs:26:25
    |
 LL |     let _b = || { match l1 { L1::A => () } };
-   |                         ^^ pattern `B` not covered
+   |                         ^^ pattern `L1::B` not covered
    |
 note: `L1` defined here
   --> $DIR/non-exhaustive-match.rs:12:14
@@ -12,8 +12,8 @@ LL | enum L1 { A, B }
    = note: the matched value is of type `L1`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |     let _b = || { match l1 { L1::A => (), B => todo!() } };
-   |                                         ++++++++++++++
+LL |     let _b = || { match l1 { L1::A => (), L1::B => todo!() } };
+   |                                         ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: type `E1` is non-empty
   --> $DIR/non-exhaustive-match.rs:37:25

--- a/src/test/ui/empty/empty-never-array.rs
+++ b/src/test/ui/empty/empty-never-array.rs
@@ -8,7 +8,7 @@ enum Helper<T, U> {
 
 fn transmute<T, U>(t: T) -> U {
     let Helper::U(u) = Helper::T(t, []);
-    //~^ ERROR refutable pattern in local binding: `T(_, _)` not covered
+    //~^ ERROR refutable pattern in local binding: `Helper::T(_, _)` not covered
     u
 }
 

--- a/src/test/ui/empty/empty-never-array.stderr
+++ b/src/test/ui/empty/empty-never-array.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `T(_, _)` not covered
+error[E0005]: refutable pattern in local binding: `Helper::T(_, _)` not covered
   --> $DIR/empty-never-array.rs:10:9
    |
 LL |     let Helper::U(u) = Helper::T(t, []);
-   |         ^^^^^^^^^^^^ pattern `T(_, _)` not covered
+   |         ^^^^^^^^^^^^ pattern `Helper::T(_, _)` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/error-codes/E0004.stderr
+++ b/src/test/ui/error-codes/E0004.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `HastaLaVistaBaby` not covered
+error[E0004]: non-exhaustive patterns: `Terminator::HastaLaVistaBaby` not covered
   --> $DIR/E0004.rs:9:11
    |
 LL |     match x {
-   |           ^ pattern `HastaLaVistaBaby` not covered
+   |           ^ pattern `Terminator::HastaLaVistaBaby` not covered
    |
 note: `Terminator` defined here
   --> $DIR/E0004.rs:2:5
@@ -15,7 +15,7 @@ LL |     HastaLaVistaBaby,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Terminator::TalkToMyHand => {}
-LL +         HastaLaVistaBaby => todo!()
+LL +         Terminator::HastaLaVistaBaby => todo!()
    |
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.rs
+++ b/src/test/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.rs
@@ -21,7 +21,7 @@ fn main() {
         Foo::A => {}
         Foo::B => {}
     }
-    //~^^^^ ERROR non-exhaustive patterns: `C` not covered
+    //~^^^^ ERROR non-exhaustive patterns: `Foo::C` not covered
 
     match Foo::A {
         Foo::A => {}

--- a/src/test/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
+++ b/src/test/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
@@ -99,11 +99,11 @@ LL |         #[warn(non_exhaustive_omitted_patterns)]
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
 
-error[E0004]: non-exhaustive patterns: `C` not covered
+error[E0004]: non-exhaustive patterns: `Foo::C` not covered
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:20:11
    |
 LL |     match Foo::A {
-   |           ^^^^^^ pattern `C` not covered
+   |           ^^^^^^ pattern `Foo::C` not covered
    |
 note: `Foo` defined here
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:12:15
@@ -116,7 +116,7 @@ LL |         A, B, C,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Foo::B => {}
-LL +         C => todo!()
+LL +         Foo::C => todo!()
    |
 
 error: aborting due to previous error; 10 warnings emitted

--- a/src/test/ui/issue-94866.stderr
+++ b/src/test/ui/issue-94866.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `B` not covered
+error[E0004]: non-exhaustive patterns: `Enum::B` not covered
   --> $DIR/issue-94866.rs:10:11
    |
 LL |     match Enum::A {
-   |           ^^^^^^^ pattern `B` not covered
+   |           ^^^^^^^ pattern `Enum::B` not covered
    |
 note: `Enum` defined here
   --> $DIR/issue-94866.rs:7:16
@@ -13,7 +13,7 @@ LL | enum Enum { A, B }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~     Enum::A => m!(),
-LL +     B => todo!()
+LL +     Enum::B => todo!()
    |
 
 error: aborting due to previous error

--- a/src/test/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.rs
+++ b/src/test/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.rs
@@ -1,0 +1,9 @@
+fn no_restriction<T>(x: &()) -> &() {
+    with_restriction::<T>(x) //~ ERROR the parameter type `T` may not live long enough
+}
+
+fn with_restriction<'b, T: 'b>(x: &'b ()) -> &'b () {
+    x
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
+++ b/src/test/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
@@ -1,0 +1,23 @@
+error[E0311]: the parameter type `T` may not live long enough
+  --> $DIR/suggest-introducing-and-adding-missing-lifetime.rs:2:5
+   |
+LL |     with_restriction::<T>(x)
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the parameter type `T` must be valid for the anonymous lifetime defined here...
+  --> $DIR/suggest-introducing-and-adding-missing-lifetime.rs:1:25
+   |
+LL | fn no_restriction<T>(x: &()) -> &() {
+   |                         ^^^
+note: ...so that the type `T` will meet its required lifetime bounds
+  --> $DIR/suggest-introducing-and-adding-missing-lifetime.rs:2:5
+   |
+LL |     with_restriction::<T>(x)
+   |     ^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn no_restriction<'a, T: 'a>(x: &()) -> &() {
+   |                   +++  ++++
+
+error: aborting due to previous error
+

--- a/src/test/ui/match/match_non_exhaustive.rs
+++ b/src/test/ui/match/match_non_exhaustive.rs
@@ -21,7 +21,7 @@ fn main() {
     match l { L::A => (), L::B => () };
     // (except if the match is already non-exhaustive)
     match l { L::A => () };
-    //~^ ERROR: non-exhaustive patterns: `B` not covered [E0004]
+    //~^ ERROR: non-exhaustive patterns: `L::B` not covered [E0004]
 
     // E1 is not visibly uninhabited from here
     let (e1, e2) = bar();

--- a/src/test/ui/match/match_non_exhaustive.stderr
+++ b/src/test/ui/match/match_non_exhaustive.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `B` not covered
+error[E0004]: non-exhaustive patterns: `L::B` not covered
   --> $DIR/match_non_exhaustive.rs:23:11
    |
 LL |     match l { L::A => () };
-   |           ^ pattern `B` not covered
+   |           ^ pattern `L::B` not covered
    |
 note: `L` defined here
   --> $DIR/match_non_exhaustive.rs:10:13
@@ -12,8 +12,8 @@ LL | enum L { A, B }
    = note: the matched value is of type `L`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |     match l { L::A => (), B => todo!() };
-   |                         ++++++++++++++
+LL |     match l { L::A => (), L::B => todo!() };
+   |                         +++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: type `E1` is non-empty
   --> $DIR/match_non_exhaustive.rs:28:11

--- a/src/test/ui/parser/recover-field-semi.rs
+++ b/src/test/ui/parser/recover-field-semi.rs
@@ -1,0 +1,16 @@
+struct Foo {
+    foo: i32;
+    //~^ ERROR struct fields are separated by `,`
+}
+
+union Bar { //~ ERROR
+    foo: i32;
+    //~^ ERROR union fields are separated by `,`
+}
+
+enum Baz {
+    Qux { foo: i32; }
+    //~^ ERROR struct fields are separated by `,`
+}
+
+fn main() {}

--- a/src/test/ui/parser/recover-field-semi.stderr
+++ b/src/test/ui/parser/recover-field-semi.stderr
@@ -1,0 +1,29 @@
+error: struct fields are separated by `,`
+  --> $DIR/recover-field-semi.rs:2:13
+   |
+LL |     foo: i32;
+   |             ^ help: replace `;` with `,`
+
+error: union fields are separated by `,`
+  --> $DIR/recover-field-semi.rs:7:13
+   |
+LL |     foo: i32;
+   |             ^ help: replace `;` with `,`
+
+error: struct fields are separated by `,`
+  --> $DIR/recover-field-semi.rs:12:19
+   |
+LL |     Qux { foo: i32; }
+   |                   ^ help: replace `;` with `,`
+
+error: unions cannot have zero fields
+  --> $DIR/recover-field-semi.rs:6:1
+   |
+LL | / union Bar {
+LL | |     foo: i32;
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/parser/removed-syntax-field-semicolon.rs
+++ b/src/test/ui/parser/removed-syntax-field-semicolon.rs
@@ -1,6 +1,6 @@
 struct S {
     bar: ();
-    //~^ ERROR expected `,`, or `}`, found `;`
+    //~^ ERROR struct fields are separated by `,`
 }
 
 fn main() {}

--- a/src/test/ui/parser/removed-syntax-field-semicolon.stderr
+++ b/src/test/ui/parser/removed-syntax-field-semicolon.stderr
@@ -1,8 +1,8 @@
-error: expected `,`, or `}`, found `;`
+error: struct fields are separated by `,`
   --> $DIR/removed-syntax-field-semicolon.rs:2:12
    |
 LL |     bar: ();
-   |            ^
+   |            ^ help: replace `;` with `,`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.rs
+++ b/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.rs
@@ -22,22 +22,22 @@ fn main() {
         HiddenEnum::A => {}
         HiddenEnum::C => {}
     }
-    //~^^^^ non-exhaustive patterns: `B` not covered
+    //~^^^^ non-exhaustive patterns: `HiddenEnum::B` not covered
 
     match HiddenEnum::A {
         HiddenEnum::A => {}
     }
-    //~^^^ non-exhaustive patterns: `B` and `_` not covered
+    //~^^^ non-exhaustive patterns: `HiddenEnum::B` and `_` not covered
 
     match None {
         None => {}
         Some(HiddenEnum::A) => {}
     }
-    //~^^^^ non-exhaustive patterns: `Some(B)` and `Some(_)` not covered
+    //~^^^^ non-exhaustive patterns: `Some(HiddenEnum::B)` and `Some(_)` not covered
 
     match InCrate::A {
         InCrate::A => {}
         InCrate::B => {}
     }
-    //~^^^^ non-exhaustive patterns: `C` not covered
+    //~^^^^ non-exhaustive patterns: `InCrate::C` not covered
 }

--- a/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
@@ -16,11 +16,11 @@ LL ~         HiddenEnum::B => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `B` not covered
+error[E0004]: non-exhaustive patterns: `HiddenEnum::B` not covered
   --> $DIR/doc-hidden-non-exhaustive.rs:21:11
    |
 LL |     match HiddenEnum::A {
-   |           ^^^^^^^^^^^^^ pattern `B` not covered
+   |           ^^^^^^^^^^^^^ pattern `HiddenEnum::B` not covered
    |
 note: `HiddenEnum` defined here
   --> $DIR/auxiliary/hidden.rs:3:5
@@ -34,14 +34,14 @@ LL |     B,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         HiddenEnum::C => {}
-LL +         B => todo!()
+LL +         HiddenEnum::B => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `B` and `_` not covered
+error[E0004]: non-exhaustive patterns: `HiddenEnum::B` and `_` not covered
   --> $DIR/doc-hidden-non-exhaustive.rs:27:11
    |
 LL |     match HiddenEnum::A {
-   |           ^^^^^^^^^^^^^ patterns `B` and `_` not covered
+   |           ^^^^^^^^^^^^^ patterns `HiddenEnum::B` and `_` not covered
    |
 note: `HiddenEnum` defined here
   --> $DIR/auxiliary/hidden.rs:3:5
@@ -55,14 +55,14 @@ LL |     B,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         HiddenEnum::A => {}
-LL +         B | _ => todo!()
+LL +         HiddenEnum::B | _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Some(B)` and `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Some(HiddenEnum::B)` and `Some(_)` not covered
   --> $DIR/doc-hidden-non-exhaustive.rs:32:11
    |
 LL |     match None {
-   |           ^^^^ patterns `Some(B)` and `Some(_)` not covered
+   |           ^^^^ patterns `Some(HiddenEnum::B)` and `Some(_)` not covered
    |
 note: `Option<HiddenEnum>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -76,14 +76,14 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Some(HiddenEnum::A) => {}
-LL +         Some(B) | Some(_) => todo!()
+LL +         Some(HiddenEnum::B) | Some(_) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `C` not covered
+error[E0004]: non-exhaustive patterns: `InCrate::C` not covered
   --> $DIR/doc-hidden-non-exhaustive.rs:38:11
    |
 LL |     match InCrate::A {
-   |           ^^^^^^^^^^ pattern `C` not covered
+   |           ^^^^^^^^^^ pattern `InCrate::C` not covered
    |
 note: `InCrate` defined here
   --> $DIR/doc-hidden-non-exhaustive.rs:11:5
@@ -97,7 +97,7 @@ LL |     C,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         InCrate::B => {}
-LL +         C => todo!()
+LL +         InCrate::C => todo!()
    |
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
@@ -105,11 +105,11 @@ LL | union NonEmptyUnion2 {
    = note: the matched value is of type `NonEmptyUnion2`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:83:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
   --> $DIR/empty-match.rs:24:5
@@ -121,11 +121,11 @@ LL |     Foo(bool),
    = note: the matched value is of type `NonEmptyEnum1`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:84:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
   --> $DIR/empty-match.rs:27:5
@@ -139,11 +139,11 @@ LL |     Bar,
    = note: the matched value is of type `NonEmptyEnum2`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
-error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:85:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
-   |                    ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
+   |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
   --> $DIR/empty-match.rs:30:6
@@ -238,11 +238,11 @@ LL ~             _ if false => {}
 LL +             NonEmptyUnion2 { .. } => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:92:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
   --> $DIR/empty-match.rs:24:5
@@ -255,14 +255,14 @@ LL |     Foo(bool),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             _ if false => {}
-LL +             Foo(_) => todo!()
+LL +             NonEmptyEnum1::Foo(_) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:93:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
   --> $DIR/empty-match.rs:27:5
@@ -277,14 +277,14 @@ LL |     Bar,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~             _ if false => {}
-LL +             Foo(_) | Bar => todo!()
+LL +             NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:94:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
-   |                        ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
+   |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
   --> $DIR/empty-match.rs:30:6

--- a/src/test/ui/pattern/usefulness/empty-match.normal.stderr
+++ b/src/test/ui/pattern/usefulness/empty-match.normal.stderr
@@ -105,11 +105,11 @@ LL | union NonEmptyUnion2 {
    = note: the matched value is of type `NonEmptyUnion2`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:83:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
   --> $DIR/empty-match.rs:24:5
@@ -121,11 +121,11 @@ LL |     Foo(bool),
    = note: the matched value is of type `NonEmptyEnum1`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:84:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
   --> $DIR/empty-match.rs:27:5
@@ -139,11 +139,11 @@ LL |     Bar,
    = note: the matched value is of type `NonEmptyEnum2`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
-error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:85:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
-   |                    ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
+   |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
   --> $DIR/empty-match.rs:30:6
@@ -238,11 +238,11 @@ LL ~             _ if false => {}
 LL +             NonEmptyUnion2 { .. } => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:92:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
   --> $DIR/empty-match.rs:24:5
@@ -255,14 +255,14 @@ LL |     Foo(bool),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             _ if false => {}
-LL +             Foo(_) => todo!()
+LL +             NonEmptyEnum1::Foo(_) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:93:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
   --> $DIR/empty-match.rs:27:5
@@ -277,14 +277,14 @@ LL |     Bar,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~             _ if false => {}
-LL +             Foo(_) | Bar => todo!()
+LL +             NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:94:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
-   |                        ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
+   |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
   --> $DIR/empty-match.rs:30:6

--- a/src/test/ui/pattern/usefulness/empty-match.rs
+++ b/src/test/ui/pattern/usefulness/empty-match.rs
@@ -80,16 +80,16 @@ fn main() {
     match_no_arms!(NonEmptyStruct2(true)); //~ ERROR type `NonEmptyStruct2` is non-empty
     match_no_arms!((NonEmptyUnion1 { foo: () })); //~ ERROR type `NonEmptyUnion1` is non-empty
     match_no_arms!((NonEmptyUnion2 { foo: () })); //~ ERROR type `NonEmptyUnion2` is non-empty
-    match_no_arms!(NonEmptyEnum1::Foo(true)); //~ ERROR `Foo(_)` not covered
-    match_no_arms!(NonEmptyEnum2::Foo(true)); //~ ERROR `Foo(_)` and `Bar` not covered
-    match_no_arms!(NonEmptyEnum5::V1); //~ ERROR `V1`, `V2`, `V3` and 2 more not covered
+    match_no_arms!(NonEmptyEnum1::Foo(true)); //~ ERROR `NonEmptyEnum1::Foo(_)` not covered
+    match_no_arms!(NonEmptyEnum2::Foo(true)); //~ ERROR `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
+    match_no_arms!(NonEmptyEnum5::V1); //~ ERROR `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
 
     match_guarded_arm!(0u8); //~ ERROR `_` not covered
     match_guarded_arm!(NonEmptyStruct1); //~ ERROR `NonEmptyStruct1` not covered
     match_guarded_arm!(NonEmptyStruct2(true)); //~ ERROR `NonEmptyStruct2(_)` not covered
     match_guarded_arm!((NonEmptyUnion1 { foo: () })); //~ ERROR `NonEmptyUnion1 { .. }` not covered
     match_guarded_arm!((NonEmptyUnion2 { foo: () })); //~ ERROR `NonEmptyUnion2 { .. }` not covered
-    match_guarded_arm!(NonEmptyEnum1::Foo(true)); //~ ERROR `Foo(_)` not covered
-    match_guarded_arm!(NonEmptyEnum2::Foo(true)); //~ ERROR `Foo(_)` and `Bar` not covered
-    match_guarded_arm!(NonEmptyEnum5::V1); //~ ERROR `V1`, `V2`, `V3` and 2 more not covered
+    match_guarded_arm!(NonEmptyEnum1::Foo(true)); //~ ERROR `NonEmptyEnum1::Foo(_)` not covered
+    match_guarded_arm!(NonEmptyEnum2::Foo(true)); //~ ERROR `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
+    match_guarded_arm!(NonEmptyEnum5::V1); //~ ERROR `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
 }

--- a/src/test/ui/pattern/usefulness/issue-15129.rs
+++ b/src/test/ui/pattern/usefulness/issue-15129.rs
@@ -10,7 +10,7 @@ pub enum V {
 
 fn main() {
     match (T::T1(()), V::V2(true)) {
-        //~^ ERROR non-exhaustive patterns: `(T1(()), V2(_))` and `(T2(()), V1(_))` not covered
+        //~^ ERROR non-exhaustive patterns: `(T::T1(()), V::V2(_))` and `(T::T2(()), V::V1(_))` not covered
         (T::T1(()), V::V1(i)) => (),
         (T::T2(()), V::V2(b)) => (),
     }

--- a/src/test/ui/pattern/usefulness/issue-15129.stderr
+++ b/src/test/ui/pattern/usefulness/issue-15129.stderr
@@ -1,14 +1,14 @@
-error[E0004]: non-exhaustive patterns: `(T1(()), V2(_))` and `(T2(()), V1(_))` not covered
+error[E0004]: non-exhaustive patterns: `(T::T1(()), V::V2(_))` and `(T::T2(()), V::V1(_))` not covered
   --> $DIR/issue-15129.rs:12:11
    |
 LL |     match (T::T1(()), V::V2(true)) {
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `(T1(()), V2(_))` and `(T2(()), V1(_))` not covered
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `(T::T1(()), V::V2(_))` and `(T::T2(()), V::V1(_))` not covered
    |
    = note: the matched value is of type `(T, V)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         (T::T2(()), V::V2(b)) => (),
-LL ~         (T1(()), V2(_)) | (T2(()), V1(_)) => todo!(),
+LL ~         (T::T1(()), V::V2(_)) | (T::T2(()), V::V1(_)) => todo!(),
    |
 
 error: aborting due to previous error

--- a/src/test/ui/pattern/usefulness/issue-31561.rs
+++ b/src/test/ui/pattern/usefulness/issue-31561.rs
@@ -6,5 +6,5 @@ enum Thing {
 
 fn main() {
     let Thing::Foo(y) = Thing::Foo(1);
-    //~^ ERROR refutable pattern in local binding: `Bar` and `Baz` not covered
+    //~^ ERROR refutable pattern in local binding: `Thing::Bar` and `Thing::Baz` not covered
 }

--- a/src/test/ui/pattern/usefulness/issue-31561.stderr
+++ b/src/test/ui/pattern/usefulness/issue-31561.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `Bar` and `Baz` not covered
+error[E0005]: refutable pattern in local binding: `Thing::Bar` and `Thing::Baz` not covered
   --> $DIR/issue-31561.rs:8:9
    |
 LL |     let Thing::Foo(y) = Thing::Foo(1);
-   |         ^^^^^^^^^^^^^ patterns `Bar` and `Baz` not covered
+   |         ^^^^^^^^^^^^^ patterns `Thing::Bar` and `Thing::Baz` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/pattern/usefulness/issue-35609.stderr
+++ b/src/test/ui/pattern/usefulness/issue-35609.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `(B, _)`, `(C, _)`, `(D, _)` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `(Enum::B, _)`, `(Enum::C, _)`, `(Enum::D, _)` and 2 more not covered
   --> $DIR/issue-35609.rs:10:11
    |
 LL |     match (A, ()) {
-   |           ^^^^^^^ patterns `(B, _)`, `(C, _)`, `(D, _)` and 2 more not covered
+   |           ^^^^^^^ patterns `(Enum::B, _)`, `(Enum::C, _)`, `(Enum::D, _)` and 2 more not covered
    |
    = note: the matched value is of type `(Enum, ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
@@ -11,11 +11,11 @@ LL ~         (A, _) => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `(_, B)`, `(_, C)`, `(_, D)` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `(_, Enum::B)`, `(_, Enum::C)`, `(_, Enum::D)` and 2 more not covered
   --> $DIR/issue-35609.rs:14:11
    |
 LL |     match (A, A) {
-   |           ^^^^^^ patterns `(_, B)`, `(_, C)`, `(_, D)` and 2 more not covered
+   |           ^^^^^^ patterns `(_, Enum::B)`, `(_, Enum::C)`, `(_, Enum::D)` and 2 more not covered
    |
    = note: the matched value is of type `(Enum, Enum)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
@@ -24,11 +24,11 @@ LL ~         (_, A) => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `((Enum::B, _), _)`, `((Enum::C, _), _)`, `((Enum::D, _), _)` and 2 more not covered
   --> $DIR/issue-35609.rs:18:11
    |
 LL |     match ((A, ()), ()) {
-   |           ^^^^^^^^^^^^^ patterns `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
+   |           ^^^^^^^^^^^^^ patterns `((Enum::B, _), _)`, `((Enum::C, _), _)`, `((Enum::D, _), _)` and 2 more not covered
    |
    = note: the matched value is of type `((Enum, ()), ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
@@ -37,11 +37,11 @@ LL ~         ((A, ()), _) => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `((Enum::B, _), _)`, `((Enum::C, _), _)`, `((Enum::D, _), _)` and 2 more not covered
   --> $DIR/issue-35609.rs:22:11
    |
 LL |     match ((A, ()), A) {
-   |           ^^^^^^^^^^^^ patterns `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
+   |           ^^^^^^^^^^^^ patterns `((Enum::B, _), _)`, `((Enum::C, _), _)`, `((Enum::D, _), _)` and 2 more not covered
    |
    = note: the matched value is of type `((Enum, ()), Enum)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
@@ -50,11 +50,11 @@ LL ~         ((A, ()), _) => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `((Enum::B, _), _)`, `((Enum::C, _), _)`, `((Enum::D, _), _)` and 2 more not covered
   --> $DIR/issue-35609.rs:26:11
    |
 LL |     match ((A, ()), ()) {
-   |           ^^^^^^^^^^^^^ patterns `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
+   |           ^^^^^^^^^^^^^ patterns `((Enum::B, _), _)`, `((Enum::C, _), _)`, `((Enum::D, _), _)` and 2 more not covered
    |
    = note: the matched value is of type `((Enum, ()), ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
@@ -63,11 +63,11 @@ LL ~         ((A, _), _) => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `S(B, _)`, `S(C, _)`, `S(D, _)` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `S(Enum::B, _)`, `S(Enum::C, _)`, `S(Enum::D, _)` and 2 more not covered
   --> $DIR/issue-35609.rs:31:11
    |
 LL |     match S(A, ()) {
-   |           ^^^^^^^^ patterns `S(B, _)`, `S(C, _)`, `S(D, _)` and 2 more not covered
+   |           ^^^^^^^^ patterns `S(Enum::B, _)`, `S(Enum::C, _)`, `S(Enum::D, _)` and 2 more not covered
    |
 note: `S` defined here
   --> $DIR/issue-35609.rs:6:8
@@ -81,11 +81,11 @@ LL ~         S(A, _) => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Sd { x: B, .. }`, `Sd { x: C, .. }`, `Sd { x: D, .. }` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `Sd { x: Enum::B, .. }`, `Sd { x: Enum::C, .. }`, `Sd { x: Enum::D, .. }` and 2 more not covered
   --> $DIR/issue-35609.rs:35:11
    |
 LL |     match (Sd { x: A, y: () }) {
-   |           ^^^^^^^^^^^^^^^^^^^^ patterns `Sd { x: B, .. }`, `Sd { x: C, .. }`, `Sd { x: D, .. }` and 2 more not covered
+   |           ^^^^^^^^^^^^^^^^^^^^ patterns `Sd { x: Enum::B, .. }`, `Sd { x: Enum::C, .. }`, `Sd { x: Enum::D, .. }` and 2 more not covered
    |
 note: `Sd` defined here
   --> $DIR/issue-35609.rs:7:8
@@ -99,11 +99,11 @@ LL ~         Sd { x: A, y: _ } => {}
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Some(B)`, `Some(C)`, `Some(D)` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `Some(Enum::B)`, `Some(Enum::C)`, `Some(Enum::D)` and 2 more not covered
   --> $DIR/issue-35609.rs:39:11
    |
 LL |     match Some(A) {
-   |           ^^^^^^^ patterns `Some(B)`, `Some(C)`, `Some(D)` and 2 more not covered
+   |           ^^^^^^^ patterns `Some(Enum::B)`, `Some(Enum::C)`, `Some(Enum::D)` and 2 more not covered
    |
 note: `Option<Enum>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/src/test/ui/pattern/usefulness/issue-39362.stderr
+++ b/src/test/ui/pattern/usefulness/issue-39362.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `Bar { bar: C, .. }`, `Bar { bar: D, .. }`, `Bar { bar: E, .. }` and 1 more not covered
+error[E0004]: non-exhaustive patterns: `Foo::Bar { bar: Bar::C, .. }`, `Foo::Bar { bar: Bar::D, .. }`, `Foo::Bar { bar: Bar::E, .. }` and 1 more not covered
   --> $DIR/issue-39362.rs:10:11
    |
 LL |     match f {
-   |           ^ patterns `Bar { bar: C, .. }`, `Bar { bar: D, .. }`, `Bar { bar: E, .. }` and 1 more not covered
+   |           ^ patterns `Foo::Bar { bar: Bar::C, .. }`, `Foo::Bar { bar: Bar::D, .. }`, `Foo::Bar { bar: Bar::E, .. }` and 1 more not covered
    |
 note: `Foo` defined here
   --> $DIR/issue-39362.rs:2:5

--- a/src/test/ui/pattern/usefulness/issue-40221.stderr
+++ b/src/test/ui/pattern/usefulness/issue-40221.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `C(QA)` not covered
+error[E0004]: non-exhaustive patterns: `P::C(PC::QA)` not covered
   --> $DIR/issue-40221.rs:11:11
    |
 LL |     match proto {
-   |           ^^^^^ pattern `C(QA)` not covered
+   |           ^^^^^ pattern `P::C(PC::QA)` not covered
    |
 note: `P` defined here
   --> $DIR/issue-40221.rs:2:5
@@ -15,7 +15,7 @@ LL |     C(PC),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         P::C(PC::Q) => (),
-LL ~         C(QA) => todo!(),
+LL ~         P::C(PC::QA) => todo!(),
    |
 
 error: aborting due to previous error

--- a/src/test/ui/pattern/usefulness/issue-50900.rs
+++ b/src/test/ui/pattern/usefulness/issue-50900.rs
@@ -13,7 +13,7 @@ impl Tag {
 
 fn main() {
     match Tag::ExifIFDPointer {
-    //~^ ERROR: non-exhaustive patterns: `Tag(Exif, _)` not covered
+    //~^ ERROR: non-exhaustive patterns: `Tag(Context::Exif, _)` not covered
         Tag::ExifIFDPointer => {}
     }
 }

--- a/src/test/ui/pattern/usefulness/issue-50900.stderr
+++ b/src/test/ui/pattern/usefulness/issue-50900.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `Tag(Exif, _)` not covered
+error[E0004]: non-exhaustive patterns: `Tag(Context::Exif, _)` not covered
   --> $DIR/issue-50900.rs:15:11
    |
 LL |     match Tag::ExifIFDPointer {
-   |           ^^^^^^^^^^^^^^^^^^^ pattern `Tag(Exif, _)` not covered
+   |           ^^^^^^^^^^^^^^^^^^^ pattern `Tag(Context::Exif, _)` not covered
    |
 note: `Tag` defined here
   --> $DIR/issue-50900.rs:2:12
@@ -13,7 +13,7 @@ LL | pub struct Tag(pub Context, pub u16);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Tag::ExifIFDPointer => {}
-LL +         Tag(Exif, _) => todo!()
+LL +         Tag(Context::Exif, _) => todo!()
    |
 
 error: aborting due to previous error

--- a/src/test/ui/pattern/usefulness/issue-56379.rs
+++ b/src/test/ui/pattern/usefulness/issue-56379.rs
@@ -6,7 +6,7 @@ enum Foo {
 
 fn main() {
     match Foo::A(true) {
-        //~^ ERROR non-exhaustive patterns: `A(false)`, `B(false)` and `C(false)` not covered
+        //~^ ERROR non-exhaustive patterns: `Foo::A(false)`, `Foo::B(false)` and `Foo::C(false)` not covered
         Foo::A(true) => {}
         Foo::B(true) => {}
         Foo::C(true) => {}

--- a/src/test/ui/pattern/usefulness/issue-56379.stderr
+++ b/src/test/ui/pattern/usefulness/issue-56379.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `A(false)`, `B(false)` and `C(false)` not covered
+error[E0004]: non-exhaustive patterns: `Foo::A(false)`, `Foo::B(false)` and `Foo::C(false)` not covered
   --> $DIR/issue-56379.rs:8:11
    |
 LL |     match Foo::A(true) {
-   |           ^^^^^^^^^^^^ patterns `A(false)`, `B(false)` and `C(false)` not covered
+   |           ^^^^^^^^^^^^ patterns `Foo::A(false)`, `Foo::B(false)` and `Foo::C(false)` not covered
    |
 note: `Foo` defined here
   --> $DIR/issue-56379.rs:2:5
@@ -19,7 +19,7 @@ LL |     C(bool),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Foo::C(true) => {}
-LL +         A(false) | B(false) | C(false) => todo!()
+LL +         Foo::A(false) | Foo::B(false) | Foo::C(false) => todo!()
    |
 
 error: aborting due to previous error

--- a/src/test/ui/pattern/usefulness/issue-72377.rs
+++ b/src/test/ui/pattern/usefulness/issue-72377.rs
@@ -6,7 +6,7 @@ fn main() {
     let y = Some(X::A);
 
     match (x, y) {
-        //~^ ERROR non-exhaustive patterns: `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2
+        //~^ ERROR non-exhaustive patterns: `(X::A, Some(X::A))`, `(X::A, Some(X::B))`, `(X::B, Some(X::B))` and 2
         //~| more not covered
         (_, None) => false,
         (v, Some(w)) if v == w => true,

--- a/src/test/ui/pattern/usefulness/issue-72377.stderr
+++ b/src/test/ui/pattern/usefulness/issue-72377.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2 more not covered
+error[E0004]: non-exhaustive patterns: `(X::A, Some(X::A))`, `(X::A, Some(X::B))`, `(X::B, Some(X::B))` and 2 more not covered
   --> $DIR/issue-72377.rs:8:11
    |
 LL |     match (x, y) {
-   |           ^^^^^^ patterns `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2 more not covered
+   |           ^^^^^^ patterns `(X::A, Some(X::A))`, `(X::A, Some(X::B))`, `(X::B, Some(X::B))` and 2 more not covered
    |
    = note: the matched value is of type `(X, Option<X>)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms

--- a/src/test/ui/pattern/usefulness/match-arm-statics-2.rs
+++ b/src/test/ui/pattern/usefulness/match-arm-statics-2.rs
@@ -27,7 +27,7 @@ const EAST: Direction = East;
 
 fn nonexhaustive_2() {
     match Some(Some(North)) {
-    //~^ ERROR non-exhaustive patterns: `Some(Some(West))` not covered
+    //~^ ERROR non-exhaustive patterns: `Some(Some(Direction::West))` not covered
         Some(NONE) => (),
         Some(Some(North)) => (),
         Some(Some(EAST)) => (),
@@ -46,7 +46,7 @@ const STATIC_FOO: Foo = Foo { bar: None, baz: NEW_FALSE };
 
 fn nonexhaustive_3() {
     match (Foo { bar: Some(North), baz: NewBool(true) }) {
-    //~^ ERROR non-exhaustive patterns: `Foo { bar: Some(North), baz: NewBool(true) }`
+    //~^ ERROR non-exhaustive patterns: `Foo { bar: Some(Direction::North), baz: NewBool(true) }`
         Foo { bar: None, baz: NewBool(true) } => (),
         Foo { bar: _, baz: NEW_FALSE } => (),
         Foo { bar: Some(West), baz: NewBool(true) } => (),

--- a/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
@@ -11,11 +11,11 @@ LL ~         (false, true) => (),
 LL +         (true, false) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Some(Some(West))` not covered
+error[E0004]: non-exhaustive patterns: `Some(Some(Direction::West))` not covered
   --> $DIR/match-arm-statics-2.rs:29:11
    |
 LL |     match Some(Some(North)) {
-   |           ^^^^^^^^^^^^^^^^^ pattern `Some(Some(West))` not covered
+   |           ^^^^^^^^^^^^^^^^^ pattern `Some(Some(Direction::West))` not covered
    |
 note: `Option<Option<Direction>>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -32,14 +32,14 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => (),
-LL +         Some(Some(West)) => todo!()
+LL +         Some(Some(Direction::West)) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Foo { bar: Some(North), baz: NewBool(true) }` not covered
+error[E0004]: non-exhaustive patterns: `Foo { bar: Some(Direction::North), baz: NewBool(true) }` not covered
   --> $DIR/match-arm-statics-2.rs:48:11
    |
 LL |     match (Foo { bar: Some(North), baz: NewBool(true) }) {
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo { bar: Some(North), baz: NewBool(true) }` not covered
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo { bar: Some(Direction::North), baz: NewBool(true) }` not covered
    |
 note: `Foo` defined here
   --> $DIR/match-arm-statics-2.rs:40:8
@@ -50,7 +50,7 @@ LL | struct Foo {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Foo { bar: Some(EAST), .. } => (),
-LL +         Foo { bar: Some(North), baz: NewBool(true) } => todo!()
+LL +         Foo { bar: Some(Direction::North), baz: NewBool(true) } => todo!()
    |
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/pattern/usefulness/non-exhaustive-defined-here.rs
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-defined-here.rs
@@ -35,43 +35,43 @@ enum E {
 
 fn by_val(e: E) {
     let e1 = e.clone();
-    match e1 { //~ ERROR non-exhaustive patterns: `B` and `C` not covered
-        //~^ NOTE patterns `B` and `C` not covered
+    match e1 { //~ ERROR non-exhaustive patterns: `E::B` and `E::C` not covered
+        //~^ NOTE patterns `E::B` and `E::C` not covered
         //~| NOTE the matched value is of type `E`
         E::A => {}
     }
 
-    let E::A = e; //~ ERROR refutable pattern in local binding: `B` and `C` not covered
-    //~^ NOTE patterns `B` and `C` not covered
+    let E::A = e; //~ ERROR refutable pattern in local binding: `E::B` and `E::C` not covered
+    //~^ NOTE patterns `E::B` and `E::C` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with
     //~| NOTE for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
     //~| NOTE the matched value is of type `E`
 }
 
 fn by_ref_once(e: &E) {
-    match e { //~ ERROR non-exhaustive patterns: `&B` and `&C` not covered
-    //~^ NOTE patterns `&B` and `&C` not covered
+    match e { //~ ERROR non-exhaustive patterns: `&E::B` and `&E::C` not covered
+    //~^ NOTE patterns `&E::B` and `&E::C` not covered
     //~| NOTE the matched value is of type `&E`
         E::A => {}
     }
 
-    let E::A = e; //~ ERROR refutable pattern in local binding: `&B` and `&C` not covered
-    //~^ NOTE patterns `&B` and `&C` not covered
+    let E::A = e; //~ ERROR refutable pattern in local binding: `&E::B` and `&E::C` not covered
+    //~^ NOTE patterns `&E::B` and `&E::C` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with
     //~| NOTE for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
     //~| NOTE the matched value is of type `&E`
 }
 
 fn by_ref_thrice(e: & &mut &E) {
-    match e { //~ ERROR non-exhaustive patterns: `&&mut &B` and `&&mut &C` not covered
-    //~^ NOTE patterns `&&mut &B` and `&&mut &C` not covered
+    match e { //~ ERROR non-exhaustive patterns: `&&mut &E::B` and `&&mut &E::C` not covered
+    //~^ NOTE patterns `&&mut &E::B` and `&&mut &E::C` not covered
     //~| NOTE the matched value is of type `&&mut &E`
         E::A => {}
     }
 
     let E::A = e;
-    //~^ ERROR refutable pattern in local binding: `&&mut &B` and `&&mut &C` not covered
-    //~| NOTE patterns `&&mut &B` and `&&mut &C` not covered
+    //~^ ERROR refutable pattern in local binding: `&&mut &E::B` and `&&mut &E::C` not covered
+    //~| NOTE patterns `&&mut &E::B` and `&&mut &E::C` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with
     //~| NOTE for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
     //~| NOTE the matched value is of type `&&mut &E`
@@ -89,15 +89,15 @@ enum Opt {
 }
 
 fn ref_pat(e: Opt) {
-    match e {//~ ERROR non-exhaustive patterns: `None` not covered
-        //~^ NOTE pattern `None` not covered
+    match e {//~ ERROR non-exhaustive patterns: `Opt::None` not covered
+        //~^ NOTE pattern `Opt::None` not covered
         //~| NOTE the matched value is of type `Opt`
         Opt::Some(ref _x) => {}
     }
 
-    let Opt::Some(ref _x) = e; //~ ERROR refutable pattern in local binding: `None` not covered
+    let Opt::Some(ref _x) = e; //~ ERROR refutable pattern in local binding: `Opt::None` not covered
     //~^ NOTE the matched value is of type `Opt`
-    //~| NOTE pattern `None` not covered
+    //~| NOTE pattern `Opt::None` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with
     //~| NOTE for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
 }

--- a/src/test/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `B` and `C` not covered
+error[E0004]: non-exhaustive patterns: `E::B` and `E::C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:38:11
    |
 LL |     match e1 {
-   |           ^^ patterns `B` and `C` not covered
+   |           ^^ patterns `E::B` and `E::C` not covered
    |
 note: `E` defined here
   --> $DIR/non-exhaustive-defined-here.rs:14:5
@@ -19,14 +19,14 @@ LL |     C
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         E::A => {}
-LL +         B | C => todo!()
+LL +         E::B | E::C => todo!()
    |
 
-error[E0005]: refutable pattern in local binding: `B` and `C` not covered
+error[E0005]: refutable pattern in local binding: `E::B` and `E::C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:44:9
    |
 LL |     let E::A = e;
-   |         ^^^^ patterns `B` and `C` not covered
+   |         ^^^^ patterns `E::B` and `E::C` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -47,11 +47,11 @@ help: you might want to use `if let` to ignore the variants that aren't matched
 LL |     if let E::A = e { todo!() }
    |     ++              ~~~~~~~~~~~
 
-error[E0004]: non-exhaustive patterns: `&B` and `&C` not covered
+error[E0004]: non-exhaustive patterns: `&E::B` and `&E::C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:52:11
    |
 LL |     match e {
-   |           ^ patterns `&B` and `&C` not covered
+   |           ^ patterns `&E::B` and `&E::C` not covered
    |
 note: `E` defined here
   --> $DIR/non-exhaustive-defined-here.rs:14:5
@@ -68,14 +68,14 @@ LL |     C
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         E::A => {}
-LL +         &B | &C => todo!()
+LL +         &E::B | &E::C => todo!()
    |
 
-error[E0005]: refutable pattern in local binding: `&B` and `&C` not covered
+error[E0005]: refutable pattern in local binding: `&E::B` and `&E::C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:58:9
    |
 LL |     let E::A = e;
-   |         ^^^^ patterns `&B` and `&C` not covered
+   |         ^^^^ patterns `&E::B` and `&E::C` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -96,11 +96,11 @@ help: you might want to use `if let` to ignore the variants that aren't matched
 LL |     if let E::A = e { todo!() }
    |     ++              ~~~~~~~~~~~
 
-error[E0004]: non-exhaustive patterns: `&&mut &B` and `&&mut &C` not covered
+error[E0004]: non-exhaustive patterns: `&&mut &E::B` and `&&mut &E::C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:66:11
    |
 LL |     match e {
-   |           ^ patterns `&&mut &B` and `&&mut &C` not covered
+   |           ^ patterns `&&mut &E::B` and `&&mut &E::C` not covered
    |
 note: `E` defined here
   --> $DIR/non-exhaustive-defined-here.rs:14:5
@@ -117,14 +117,14 @@ LL |     C
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         E::A => {}
-LL +         &&mut &B | &&mut &C => todo!()
+LL +         &&mut &E::B | &&mut &E::C => todo!()
    |
 
-error[E0005]: refutable pattern in local binding: `&&mut &B` and `&&mut &C` not covered
+error[E0005]: refutable pattern in local binding: `&&mut &E::B` and `&&mut &E::C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:72:9
    |
 LL |     let E::A = e;
-   |         ^^^^ patterns `&&mut &B` and `&&mut &C` not covered
+   |         ^^^^ patterns `&&mut &E::B` and `&&mut &E::C` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -145,11 +145,11 @@ help: you might want to use `if let` to ignore the variants that aren't matched
 LL |     if let E::A = e { todo!() }
    |     ++              ~~~~~~~~~~~
 
-error[E0004]: non-exhaustive patterns: `None` not covered
+error[E0004]: non-exhaustive patterns: `Opt::None` not covered
   --> $DIR/non-exhaustive-defined-here.rs:92:11
    |
 LL |     match e {
-   |           ^ pattern `None` not covered
+   |           ^ pattern `Opt::None` not covered
    |
 note: `Opt` defined here
   --> $DIR/non-exhaustive-defined-here.rs:84:5
@@ -163,14 +163,14 @@ LL |     None,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Opt::Some(ref _x) => {}
-LL +         None => todo!()
+LL +         Opt::None => todo!()
    |
 
-error[E0005]: refutable pattern in local binding: `None` not covered
+error[E0005]: refutable pattern in local binding: `Opt::None` not covered
   --> $DIR/non-exhaustive-defined-here.rs:98:9
    |
 LL |     let Opt::Some(ref _x) = e;
-   |         ^^^^^^^^^^^^^^^^^ pattern `None` not covered
+   |         ^^^^^^^^^^^^^^^^^ pattern `Opt::None` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match-nested.rs
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match-nested.rs
@@ -12,7 +12,7 @@ fn match_nested_vecs<'a, T>(l1: Option<&'a [T]>, l2: Result<&'a [T], ()>) -> &'s
 
 fn main() {
     let x = T::A(U::C);
-    match x { //~ ERROR non-exhaustive patterns: `A(C)` not covered
+    match x { //~ ERROR non-exhaustive patterns: `T::A(U::C)` not covered
         T::A(U::D) => { panic!("hello"); }
         T::B => { panic!("goodbye"); }
     }

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match-nested.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match-nested.stderr
@@ -11,11 +11,11 @@ LL ~         (None, Ok(&[_, _, ..])) => "None, Ok(at least two elements)",
 LL +         (Some(&[]), Err(_)) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `A(C)` not covered
+error[E0004]: non-exhaustive patterns: `T::A(U::C)` not covered
   --> $DIR/non-exhaustive-match-nested.rs:15:11
    |
 LL |     match x {
-   |           ^ pattern `A(C)` not covered
+   |           ^ pattern `T::A(U::C)` not covered
    |
 note: `T` defined here
   --> $DIR/non-exhaustive-match-nested.rs:1:10
@@ -26,7 +26,7 @@ LL | enum T { A(U), B }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         T::B => { panic!("goodbye"); }
-LL +         A(C) => todo!()
+LL +         T::A(U::C) => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.rs
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.rs
@@ -4,7 +4,7 @@ enum T { A, B }
 
 fn main() {
     let x = T::A;
-    match x { T::B => { } } //~ ERROR non-exhaustive patterns: `A` not covered
+    match x { T::B => { } } //~ ERROR non-exhaustive patterns: `T::A` not covered
     match true { //~ ERROR non-exhaustive patterns: `false` not covered
       true => {}
     }
@@ -15,11 +15,11 @@ fn main() {
                       //  and `(_, _, 5_i32..=i32::MAX)` not covered
       (_, _, 4) => {}
     }
-    match (T::A, T::A) { //~ ERROR non-exhaustive patterns: `(A, A)` and `(B, B)` not covered
+    match (T::A, T::A) { //~ ERROR non-exhaustive patterns: `(T::A, T::A)` and `(T::B, T::B)` not covered
       (T::A, T::B) => {}
       (T::B, T::A) => {}
     }
-    match T::A { //~ ERROR non-exhaustive patterns: `B` not covered
+    match T::A { //~ ERROR non-exhaustive patterns: `T::B` not covered
       T::A => {}
     }
     // This is exhaustive, though the algorithm got it wrong at one point

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `A` not covered
+error[E0004]: non-exhaustive patterns: `T::A` not covered
   --> $DIR/non-exhaustive-match.rs:7:11
    |
 LL |     match x { T::B => { } }
-   |           ^ pattern `A` not covered
+   |           ^ pattern `T::A` not covered
    |
 note: `T` defined here
   --> $DIR/non-exhaustive-match.rs:3:10
@@ -12,8 +12,8 @@ LL | enum T { A, B }
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |     match x { T::B => { }, A => todo!() }
-   |                          ++++++++++++++
+LL |     match x { T::B => { }, T::A => todo!() }
+   |                          +++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `false` not covered
   --> $DIR/non-exhaustive-match.rs:8:11
@@ -62,24 +62,24 @@ LL ~       (_, _, 4) => {}
 LL +       (_, _, i32::MIN..=3_i32) | (_, _, 5_i32..=i32::MAX) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `(A, A)` and `(B, B)` not covered
+error[E0004]: non-exhaustive patterns: `(T::A, T::A)` and `(T::B, T::B)` not covered
   --> $DIR/non-exhaustive-match.rs:18:11
    |
 LL |     match (T::A, T::A) {
-   |           ^^^^^^^^^^^^ patterns `(A, A)` and `(B, B)` not covered
+   |           ^^^^^^^^^^^^ patterns `(T::A, T::A)` and `(T::B, T::B)` not covered
    |
    = note: the matched value is of type `(T, T)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~       (T::B, T::A) => {}
-LL +       (A, A) | (B, B) => todo!()
+LL +       (T::A, T::A) | (T::B, T::B) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `B` not covered
+error[E0004]: non-exhaustive patterns: `T::B` not covered
   --> $DIR/non-exhaustive-match.rs:22:11
    |
 LL |     match T::A {
-   |           ^^^^ pattern `B` not covered
+   |           ^^^^ pattern `T::B` not covered
    |
 note: `T` defined here
   --> $DIR/non-exhaustive-match.rs:3:13
@@ -90,7 +90,7 @@ LL | enum T { A, B }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~       T::A => {}
-LL +       B => todo!()
+LL +       T::B => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `[]` not covered

--- a/src/test/ui/pattern/usefulness/non-exhaustive-pattern-witness.rs
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-pattern-witness.rs
@@ -21,7 +21,7 @@ enum Color {
 
 fn enum_with_single_missing_variant() {
     match Color::Red {
-    //~^ ERROR non-exhaustive patterns: `Red` not covered
+    //~^ ERROR non-exhaustive patterns: `Color::Red` not covered
         Color::CustomRGBA { .. } => (),
         Color::Green => ()
     }
@@ -33,7 +33,7 @@ enum Direction {
 
 fn enum_with_multiple_missing_variants() {
     match Direction::North {
-    //~^ ERROR non-exhaustive patterns: `East`, `South` and `West` not covered
+    //~^ ERROR non-exhaustive patterns: `Direction::East`, `Direction::South` and `Direction::West` not covered
         Direction::North => ()
     }
 }
@@ -44,7 +44,7 @@ enum ExcessiveEnum {
 
 fn enum_with_excessive_missing_variants() {
     match ExcessiveEnum::First {
-    //~^ ERROR `Second`, `Third`, `Fourth` and 8 more not covered
+    //~^ ERROR `ExcessiveEnum::Second`, `ExcessiveEnum::Third`, `ExcessiveEnum::Fourth` and 8 more not covered
 
         ExcessiveEnum::First => ()
     }
@@ -52,7 +52,7 @@ fn enum_with_excessive_missing_variants() {
 
 fn enum_struct_variant() {
     match Color::Red {
-    //~^ ERROR non-exhaustive patterns: `CustomRGBA { a: true, .. }` not covered
+    //~^ ERROR non-exhaustive patterns: `Color::CustomRGBA { a: true, .. }` not covered
         Color::Red => (),
         Color::Green => (),
         Color::CustomRGBA { a: false, r: _, g: _, b: 0 } => (),
@@ -68,7 +68,7 @@ enum Enum {
 fn vectors_with_nested_enums() {
     let x: &'static [Enum] = &[Enum::First, Enum::Second(false)];
     match *x {
-    //~^ ERROR non-exhaustive patterns: `[Second(true), Second(false)]` not covered
+    //~^ ERROR non-exhaustive patterns: `[Enum::Second(true), Enum::Second(false)]` not covered
         [] => (),
         [_] => (),
         [Enum::First, _] => (),

--- a/src/test/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
@@ -16,11 +16,11 @@ LL ~         Foo { first: false, second: Some([1, 2, 3, 4]) } => (),
 LL +         Foo { first: false, second: Some([_, _, _, _]) } => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Red` not covered
+error[E0004]: non-exhaustive patterns: `Color::Red` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:23:11
    |
 LL |     match Color::Red {
-   |           ^^^^^^^^^^ pattern `Red` not covered
+   |           ^^^^^^^^^^ pattern `Color::Red` not covered
    |
 note: `Color` defined here
   --> $DIR/non-exhaustive-pattern-witness.rs:17:5
@@ -33,14 +33,14 @@ LL |     Red,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Color::Green => (),
-LL +         Red => todo!()
+LL +         Color::Red => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `East`, `South` and `West` not covered
+error[E0004]: non-exhaustive patterns: `Direction::East`, `Direction::South` and `Direction::West` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:35:11
    |
 LL |     match Direction::North {
-   |           ^^^^^^^^^^^^^^^^ patterns `East`, `South` and `West` not covered
+   |           ^^^^^^^^^^^^^^^^ patterns `Direction::East`, `Direction::South` and `Direction::West` not covered
    |
 note: `Direction` defined here
   --> $DIR/non-exhaustive-pattern-witness.rs:31:12
@@ -56,14 +56,14 @@ LL |     North, East, South, West
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Direction::North => (),
-LL +         East | South | West => todo!()
+LL +         Direction::East | Direction::South | Direction::West => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Second`, `Third`, `Fourth` and 8 more not covered
+error[E0004]: non-exhaustive patterns: `ExcessiveEnum::Second`, `ExcessiveEnum::Third`, `ExcessiveEnum::Fourth` and 8 more not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:46:11
    |
 LL |     match ExcessiveEnum::First {
-   |           ^^^^^^^^^^^^^^^^^^^^ patterns `Second`, `Third`, `Fourth` and 8 more not covered
+   |           ^^^^^^^^^^^^^^^^^^^^ patterns `ExcessiveEnum::Second`, `ExcessiveEnum::Third`, `ExcessiveEnum::Fourth` and 8 more not covered
    |
 note: `ExcessiveEnum` defined here
   --> $DIR/non-exhaustive-pattern-witness.rs:41:6
@@ -77,11 +77,11 @@ LL ~         ExcessiveEnum::First => (),
 LL +         _ => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `CustomRGBA { a: true, .. }` not covered
+error[E0004]: non-exhaustive patterns: `Color::CustomRGBA { a: true, .. }` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:54:11
    |
 LL |     match Color::Red {
-   |           ^^^^^^^^^^ pattern `CustomRGBA { a: true, .. }` not covered
+   |           ^^^^^^^^^^ pattern `Color::CustomRGBA { a: true, .. }` not covered
    |
 note: `Color` defined here
   --> $DIR/non-exhaustive-pattern-witness.rs:19:5
@@ -95,20 +95,20 @@ LL |     CustomRGBA { a: bool, r: u8, g: u8, b: u8 }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Color::CustomRGBA { a: false, r: _, g: _, b: _ } => (),
-LL +         CustomRGBA { a: true, .. } => todo!()
+LL +         Color::CustomRGBA { a: true, .. } => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `[Second(true), Second(false)]` not covered
+error[E0004]: non-exhaustive patterns: `[Enum::Second(true), Enum::Second(false)]` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:70:11
    |
 LL |     match *x {
-   |           ^^ pattern `[Second(true), Second(false)]` not covered
+   |           ^^ pattern `[Enum::Second(true), Enum::Second(false)]` not covered
    |
    = note: the matched value is of type `[Enum]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         [_, _, ref tail @ .., _] => (),
-LL +         [Second(true), Second(false)] => todo!()
+LL +         [Enum::Second(true), Enum::Second(false)] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `((), false)` not covered

--- a/src/test/ui/pattern/usefulness/stable-gated-patterns.rs
+++ b/src/test/ui/pattern/usefulness/stable-gated-patterns.rs
@@ -8,7 +8,7 @@ fn main() {
     match UnstableEnum::Stable {
         UnstableEnum::Stable => {}
     }
-    //~^^^ non-exhaustive patterns: `Stable2` and `_` not covered
+    //~^^^ non-exhaustive patterns: `UnstableEnum::Stable2` and `_` not covered
 
     match UnstableEnum::Stable {
         UnstableEnum::Stable => {}

--- a/src/test/ui/pattern/usefulness/stable-gated-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/stable-gated-patterns.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `Stable2` and `_` not covered
+error[E0004]: non-exhaustive patterns: `UnstableEnum::Stable2` and `_` not covered
   --> $DIR/stable-gated-patterns.rs:8:11
    |
 LL |     match UnstableEnum::Stable {
-   |           ^^^^^^^^^^^^^^^^^^^^ patterns `Stable2` and `_` not covered
+   |           ^^^^^^^^^^^^^^^^^^^^ patterns `UnstableEnum::Stable2` and `_` not covered
    |
 note: `UnstableEnum` defined here
   --> $DIR/auxiliary/unstable.rs:9:5
@@ -16,7 +16,7 @@ LL |     Stable2,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         UnstableEnum::Stable => {}
-LL +         Stable2 | _ => todo!()
+LL +         UnstableEnum::Stable2 | _ => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `_` not covered

--- a/src/test/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `B { x: Some(_) }` not covered
+error[E0004]: non-exhaustive patterns: `A::B { x: Some(_) }` not covered
   --> $DIR/struct-like-enum-nonexhaustive.rs:8:11
    |
 LL |     match x {
-   |           ^ pattern `B { x: Some(_) }` not covered
+   |           ^ pattern `A::B { x: Some(_) }` not covered
    |
 note: `A` defined here
   --> $DIR/struct-like-enum-nonexhaustive.rs:2:5
@@ -15,7 +15,7 @@ LL |     B { x: Option<isize> },
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         A::B { x: None } => {}
-LL +         B { x: Some(_) } => todo!()
+LL +         A::B { x: Some(_) } => todo!()
    |
 
 error: aborting due to previous error

--- a/src/test/ui/pattern/usefulness/unstable-gated-patterns.rs
+++ b/src/test/ui/pattern/usefulness/unstable-gated-patterns.rs
@@ -11,7 +11,7 @@ fn main() {
         UnstableEnum::Stable => {}
         UnstableEnum::Stable2 => {}
     }
-    //~^^^^ non-exhaustive patterns: `Unstable` not covered
+    //~^^^^ non-exhaustive patterns: `UnstableEnum::Unstable` not covered
 
     // Ok: all variants are explicitly matched
     match UnstableEnum::Stable {

--- a/src/test/ui/pattern/usefulness/unstable-gated-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/unstable-gated-patterns.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `Unstable` not covered
+error[E0004]: non-exhaustive patterns: `UnstableEnum::Unstable` not covered
   --> $DIR/unstable-gated-patterns.rs:10:11
    |
 LL |     match UnstableEnum::Stable {
-   |           ^^^^^^^^^^^^^^^^^^^^ pattern `Unstable` not covered
+   |           ^^^^^^^^^^^^^^^^^^^^ pattern `UnstableEnum::Unstable` not covered
    |
 note: `UnstableEnum` defined here
   --> $DIR/auxiliary/unstable.rs:11:5
@@ -16,7 +16,7 @@ LL |     Unstable,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         UnstableEnum::Stable2 => {}
-LL +         Unstable => todo!()
+LL +         UnstableEnum::Unstable => todo!()
    |
 
 error: aborting due to previous error

--- a/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
@@ -31,7 +31,7 @@ fn empty_non_exhaustive(x: EmptyNonExhaustiveEnum) {
 
 fn main() {
     match NonExhaustiveEnum::Unit {}
-    //~^ ERROR `Unit`, `Tuple(_)` and `Struct { .. }` not covered [E0004]
+    //~^ ERROR `NonExhaustiveEnum::Unit`, `NonExhaustiveEnum::Tuple(_)` and `NonExhaustiveEnum::Struct { .. }` not covered [E0004]
     match NormalEnum::Unit {}
-    //~^ ERROR `Unit`, `Tuple(_)` and `Struct { .. }` not covered [E0004]
+    //~^ ERROR `NormalEnum::Unit`, `NormalEnum::Tuple(_)` and `NormalEnum::Struct { .. }` not covered [E0004]
 }

--- a/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -10,11 +10,11 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `Unit`, `Tuple(_)` and `Struct { .. }` not covered
+error[E0004]: non-exhaustive patterns: `NonExhaustiveEnum::Unit`, `NonExhaustiveEnum::Tuple(_)` and `NonExhaustiveEnum::Struct { .. }` not covered
   --> $DIR/enum_same_crate_empty_match.rs:33:11
    |
 LL |     match NonExhaustiveEnum::Unit {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^ patterns `Unit`, `Tuple(_)` and `Struct { .. }` not covered
+   |           ^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonExhaustiveEnum::Unit`, `NonExhaustiveEnum::Tuple(_)` and `NonExhaustiveEnum::Struct { .. }` not covered
    |
 note: `NonExhaustiveEnum` defined here
   --> $DIR/enum_same_crate_empty_match.rs:5:5
@@ -33,15 +33,15 @@ LL |     Struct { field: u32 }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match NonExhaustiveEnum::Unit {
-LL +         Unit | Tuple(_) | Struct { .. } => todo!(),
+LL +         NonExhaustiveEnum::Unit | NonExhaustiveEnum::Tuple(_) | NonExhaustiveEnum::Struct { .. } => todo!(),
 LL +     }
    |
 
-error[E0004]: non-exhaustive patterns: `Unit`, `Tuple(_)` and `Struct { .. }` not covered
+error[E0004]: non-exhaustive patterns: `NormalEnum::Unit`, `NormalEnum::Tuple(_)` and `NormalEnum::Struct { .. }` not covered
   --> $DIR/enum_same_crate_empty_match.rs:35:11
    |
 LL |     match NormalEnum::Unit {}
-   |           ^^^^^^^^^^^^^^^^ patterns `Unit`, `Tuple(_)` and `Struct { .. }` not covered
+   |           ^^^^^^^^^^^^^^^^ patterns `NormalEnum::Unit`, `NormalEnum::Tuple(_)` and `NormalEnum::Struct { .. }` not covered
    |
 note: `NormalEnum` defined here
   --> $DIR/enum_same_crate_empty_match.rs:14:5
@@ -60,7 +60,7 @@ LL |     Struct { field: u32 }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match NormalEnum::Unit {
-LL +         Unit | Tuple(_) | Struct { .. } => todo!(),
+LL +         NormalEnum::Unit | NormalEnum::Tuple(_) | NormalEnum::Struct { .. } => todo!(),
 LL +     }
    |
 

--- a/src/test/ui/rfc-2008-non-exhaustive/omitted-patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/omitted-patterns.stderr
@@ -81,7 +81,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:58:9
    |
 LL |         _ => {}
-   |         ^ pattern `Struct { .. }` not covered
+   |         ^ pattern `NonExhaustiveEnum::Struct { .. }` not covered
    |
 note: the lint level is defined here
   --> $DIR/omitted-patterns.rs:57:16
@@ -95,7 +95,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:65:9
    |
 LL |         _ => {}
-   |         ^ pattern `Tuple(_)` not covered
+   |         ^ pattern `NonExhaustiveEnum::Tuple(_)` not covered
    |
 note: the lint level is defined here
   --> $DIR/omitted-patterns.rs:64:16
@@ -109,7 +109,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:75:9
    |
 LL |         _ => {}
-   |         ^ pattern `Unit` not covered
+   |         ^ pattern `NonExhaustiveEnum::Unit` not covered
    |
 note: the lint level is defined here
   --> $DIR/omitted-patterns.rs:74:16
@@ -123,7 +123,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:92:32
    |
 LL |         NestedNonExhaustive::A(_) => {}
-   |                                ^ patterns `Tuple(_)` and `Struct { .. }` not covered
+   |                                ^ patterns `NonExhaustiveEnum::Tuple(_)` and `NonExhaustiveEnum::Struct { .. }` not covered
    |
 note: the lint level is defined here
   --> $DIR/omitted-patterns.rs:89:12
@@ -137,7 +137,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:94:9
    |
 LL |         _ => {}
-   |         ^ pattern `C` not covered
+   |         ^ pattern `NestedNonExhaustive::C` not covered
    |
    = help: ensure that all variants are matched explicitly by adding the suggested match arms
    = note: the matched value is of type `NestedNonExhaustive` and the `non_exhaustive_omitted_patterns` attribute was found
@@ -146,7 +146,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:132:9
    |
 LL |         _ => {}
-   |         ^ pattern `A(_)` not covered
+   |         ^ pattern `NonExhaustiveSingleVariant::A(_)` not covered
    |
 note: the lint level is defined here
   --> $DIR/omitted-patterns.rs:130:12
@@ -160,7 +160,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:144:9
    |
 LL |         _ => {}
-   |         ^ pattern `Unstable` not covered
+   |         ^ pattern `UnstableEnum::Unstable` not covered
    |
 note: the lint level is defined here
   --> $DIR/omitted-patterns.rs:143:16
@@ -174,7 +174,7 @@ error: some variants are not matched explicitly
   --> $DIR/omitted-patterns.rs:168:9
    |
 LL |         _ => {}
-   |         ^ pattern `Unstable2` not covered
+   |         ^ pattern `OnlyUnstableEnum::Unstable2` not covered
    |
 note: the lint level is defined here
   --> $DIR/omitted-patterns.rs:165:12

--- a/src/test/ui/rfc-2008-non-exhaustive/stable-omitted-patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/stable-omitted-patterns.stderr
@@ -16,7 +16,7 @@ error: some variants are not matched explicitly
   --> $DIR/stable-omitted-patterns.rs:23:9
    |
 LL |         _ => {}
-   |         ^ pattern `Stable2` not covered
+   |         ^ pattern `UnstableEnum::Stable2` not covered
    |
 note: the lint level is defined here
   --> $DIR/stable-omitted-patterns.rs:22:16

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -55,11 +55,11 @@ LL +         _ => todo!(),
 LL ~     }
    |
 
-error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
+error[E0004]: non-exhaustive patterns: `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
   --> $DIR/match.rs:31:11
    |
 LL |     match x {}
-   |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered
+   |           ^ patterns `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
    |
 note: `UninhabitedVariants` defined here
   --> $DIR/auxiliary/uninhabited.rs:17:23
@@ -74,7 +74,7 @@ LL |     #[non_exhaustive] Struct { x: ! }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match x {
-LL +         Tuple(_) | Struct { .. } => todo!(),
+LL +         UninhabitedVariants::Tuple(_) | UninhabitedVariants::Struct { .. } => todo!(),
 LL ~     }
    |
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
@@ -36,11 +36,11 @@ LL +         _ => todo!(),
 LL ~     }
    |
 
-error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
+error[E0004]: non-exhaustive patterns: `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
   --> $DIR/match_same_crate.rs:38:11
    |
 LL |     match x {}
-   |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered
+   |           ^ patterns `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
    |
 note: `UninhabitedVariants` defined here
   --> $DIR/match_same_crate.rs:16:23
@@ -55,7 +55,7 @@ LL |     #[non_exhaustive] Struct { x: ! }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match x {
-LL +         Tuple(_) | Struct { .. } => todo!(),
+LL +         UninhabitedVariants::Tuple(_) | UninhabitedVariants::Struct { .. } => todo!(),
 LL ~     }
    |
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -55,11 +55,11 @@ LL +         _ => todo!(),
 LL ~     }
    |
 
-error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
+error[E0004]: non-exhaustive patterns: `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
   --> $DIR/match_with_exhaustive_patterns.rs:34:11
    |
 LL |     match x {}
-   |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered
+   |           ^ patterns `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
    |
 note: `UninhabitedVariants` defined here
   --> $DIR/auxiliary/uninhabited.rs:17:23
@@ -74,7 +74,7 @@ LL |     #[non_exhaustive] Struct { x: ! }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match x {
-LL +         Tuple(_) | Struct { .. } => todo!(),
+LL +         UninhabitedVariants::Tuple(_) | UninhabitedVariants::Struct { .. } => todo!(),
 LL ~     }
    |
 

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
@@ -22,8 +22,8 @@ LL | |     });
    | |______^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn func<T: Test + 'a>(foo: &Foo, t: T) {
-   |                 ++++
+LL | fn func<'a, T: Test + 'a>(foo: &Foo, t: T) {
+   |         +++         ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -47,8 +47,10 @@ LL | |     }
    | |_____^
 help: consider adding an explicit lifetime bound...
    |
-LL |     G: Get<T> + 'a,
-   |               ++++
+LL ~ fn bar<'a, G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+LL | where
+LL ~     G: Get<T> + 'a,
+   |
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:52:5
@@ -74,8 +76,8 @@ LL | |     }
    | |_____^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn qux<'a, G: 'a + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-   |                  ++++
+LL | fn qux<'b, 'a, G: 'a + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |        +++           ++++
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:61:9
@@ -101,8 +103,8 @@ LL | |         }
    | |_________^
 help: consider adding an explicit lifetime bound...
    |
-LL |     fn qux<'b, G: Get<T> + 'b + 'c, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
-   |                               ++++
+LL |     fn qux<'c, 'b, G: Get<T> + 'b + 'c, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
+   |            +++                    ++++
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:73:5
@@ -130,8 +132,8 @@ LL | |     }
    | |_____^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn bat<'a, G: 'a + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
-   |                  ++++
+LL | fn bat<'b, 'a, G: 'a + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
+   |        +++           ++++
 
 error[E0621]: explicit lifetime required in the type of `dest`
   --> $DIR/missing-lifetimes-in-signature.rs:73:5

--- a/src/test/ui/uninhabited/uninhabited-irrefutable.rs
+++ b/src/test/ui/uninhabited/uninhabited-irrefutable.rs
@@ -24,5 +24,5 @@ enum Foo {
 
 fn main() {
     let x: Foo = Foo::D(123, 456);
-    let Foo::D(_y, _z) = x; //~ ERROR refutable pattern in local binding: `A(_)` not covered
+    let Foo::D(_y, _z) = x; //~ ERROR refutable pattern in local binding: `Foo::A(_)` not covered
 }

--- a/src/test/ui/uninhabited/uninhabited-irrefutable.stderr
+++ b/src/test/ui/uninhabited/uninhabited-irrefutable.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `A(_)` not covered
+error[E0005]: refutable pattern in local binding: `Foo::A(_)` not covered
   --> $DIR/uninhabited-irrefutable.rs:27:9
    |
 LL |     let Foo::D(_y, _z) = x;
-   |         ^^^^^^^^^^^^^^ pattern `A(_)` not covered
+   |         ^^^^^^^^^^^^^^ pattern `Foo::A(_)` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html


### PR DESCRIPTION
Successful merges:

 - #101357 (Include enum path in variant suggestion)
 - #101434 (Update `SessionDiagnostic::into_diagnostic` to take `Handler` instead of `ParseSess`)
 - #101445 (Suggest introducing an explicit lifetime if it does not exist)
 - #101457 (Recover from using `;` as separator between fields)
 - #101462 (Rustdoc-Json: Store Variant Fields as their own item.)
 - #101471 (Report number of delayed bugs properly with `-Ztreat-err-as-bug`)
 - #101473 (Add more size assertions for MIR types.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101357,101434,101445,101457,101462,101471,101473)
<!-- homu-ignore:end -->