### PR TITLE
rustdoc: remove unused CSS `#results > table`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -609,11 +609,6 @@ h2.location a {
 	text-align: center;
 }
 
-#results > table {
-	width: 100%;
-	table-layout: fixed;
-}
-
 .content > .example-wrap pre.line-numbers {
 	position: relative;
 	-webkit-user-select: none;


### PR DESCRIPTION
This code was added in 96ef2f8ab9bbea24b71c7441ee534407949848db to improve rendering of the search results table, but results have not used a table since b615c0c85469c94041a5e68b9d8b68dcf799f9f1 switched it to rendering with `<div>` tags.