### PR TITLE
rustdoc: remove outdated CSS `.sub-variant > div > .item-info`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -770,10 +770,6 @@ pre, .rustdoc.source .example-wrap {
 	margin-left: 24px;
 }
 
-.sub-variant > div > .item-info {
-	margin-top: initial;
-}
-
 .content .impl-items .docblock, .content .impl-items .item-info {
 	margin-bottom: .6em;
 }


### PR DESCRIPTION
This CSS still matches sometimes, as you can see in <https://doc.rust-lang.org/1.63.0/std/collections/enum.TryReserveErrorKind.html#variant.AllocError.fields>, but since nothing else is setting `margin-top`, putting it back to `initial` does nothing.

This selector was added here, but it was called `.stability` instead of `.item-info` at the time, probably as an override for the selector immediately above it that sets a negative margin:

https://github.com/rust-lang/rust/blob/2fd378b82b14f2746462018e8510e15a079818a0/src/librustdoc/html/static/rustdoc.css#L514-L522

That negative margin was removed in 593d6d1cb15c55c88319470dabb40126c7b7f1e2.