### PR TITLE
rustdoc mobile: move notable traits to return type

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1973,12 +1973,6 @@ in storage.js plus the media query with (min-width: 701px)
 		display: none !important;
 	}
 
-	.notable-traits {
-		position: absolute;
-		left: -22px;
-		top: 24px;
-	}
-
 	#titles > button > div.count {
 		float: left;
 		width: 100%;


### PR DESCRIPTION
These were originally on the left, but were moved to the return type in c90fb7185a5febb00b7f8ccb49abceacd41bad6e. The CSS rule for mobile did not get updated at the time, so updating it now.

r? @notriddle