### PR TITLE
Fix `-Zgcc-ld=lld`

### DIFF
--- a/src/test/run-make/issue-71519/Makefile
+++ b/src/test/run-make/issue-71519/Makefile
@@ -1,5 +1,6 @@
 include ../../run-make-fulldeps/tools.mk
 
+# ignore-msvc
 # needs-rust-lld
 all:
 	RUSTC_LOG=rustc_codegen_ssa::back::link=info $(RUSTC) -Z gcc-ld=lld -C link-args=-Wl,-v main.rs 2> $(TMPDIR)/output.txt


### PR DESCRIPTION
`-Zgcc-ld=lld` is currently broken. CI is currently ignoring its tests.

cc @Mark-Simulacrum on the `compiletest` change: I'm not sure which of `bootstrap`'s test step or `compiletest` is currently incorrect wrt windows' `--compile-lib-path`. Since `sysroot/bin` is passed on windows, that means that `compiletest` can't find `rust-lld` on windows and tests are currently ignored: it's looking for something that is in `sysroot/lib` instead. 

They are currently ignored on unixes for a different reason: the lld wrapper has a different name than what is checked.

(I've changed `compiletest` in this PR, just because I could make a very targeted change there, whereas completely changing the intentional lib path that is passed seemed it'd have wider reaching implications on all tests.)

And in both unix/win cases, I've changed the detection to look for `rust-lld` rather than the wrappers in `bin/gcc-ld/`. It seems like the more stable of all these executable names.

r? @petrochenkov 

I've tested the `lld-wrapper` change on linux and osx, but couldn't test on windows gnu targets (I only have MSVC targets, and these can't use `rust-lld` via `-Zgcc-ld=lld`, nor do they use the lld wrapper IIUC). 

I'd expect it to work whether or not the wrapper is called with or without an executable suffix. But at least now CI should test it in these targets.

Fixes #101370.