### PR TITLE
rustdoc: remove unused CSS `#main-content > .since`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -704,9 +704,6 @@ pre, .rustdoc.source .example-wrap {
 #main-content {
 	position: relative;
 }
-#main-content > .since {
-	top: inherit;
-}
 
 .content table {
 	border-spacing: 0 5px;


### PR DESCRIPTION
I missed one from #101298