### PR TITLE
rustdoc: remove unused CSS `#main-content > table td`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2047,11 +2047,6 @@ in storage.js plus the media query with (min-width: 701px)
 		height: 73px;
 	}
 
-	#main-content > table td {
-		word-break: break-word;
-		width: 50%;
-	}
-
 	#crate-search {
 		border-radius: 4px;
 	}


### PR DESCRIPTION
This rule was added in 4e2c59a970695b2809a0f68f2ffe415ebdb04913 to benefit the module items table. However, the module items table stopped using table tags when 6020c79ddeafe8d9760b27c14c39da81bac9b4a6 switched us over to grid layout.

You can see when this one used to be triggered by visiting <https://doc.rust-lang.org/1.54.0/alloc/slice/index.html#structs-1> in a very narrow window, but it doesn't any more, because the module table is now rendered using `<div>` tags.