### PR TITLE
Avoid infinite recursion on error case in `get_path_res`.

### DIFF
--- a/compiler/rustc_save_analysis/src/lib.rs
+++ b/compiler/rustc_save_analysis/src/lib.rs
@@ -600,8 +600,9 @@ impl<'tcx> SaveContext<'tcx> {
                 if seg.res != Res::Err {
                     seg.res
                 } else {
+                    // Avoid infinite recursion!
                     let parent_node = self.tcx.hir().get_parent_node(hir_id);
-                    self.get_path_res(parent_node)
+                    if parent_node != hir_id { self.get_path_res(parent_node) } else { Res::Err }
                 }
             }
 

--- a/src/test/ui/save-analysis/issue-101505.rs
+++ b/src/test/ui/save-analysis/issue-101505.rs
@@ -1,0 +1,7 @@
+// compile-flags: -Zsave-analysis
+
+// Check that this doesn't loop infinitely.
+
+fn a(self) {} //~ ERROR `self` parameter is only allowed in associated functions
+
+fn main() {}

--- a/src/test/ui/save-analysis/issue-101505.stderr
+++ b/src/test/ui/save-analysis/issue-101505.stderr
@@ -1,0 +1,10 @@
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/issue-101505.rs:5:6
+   |
+LL | fn a(self) {}
+   |      ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #101505.

r? @petrochenkov 