### PR TITLE
Stabilize `nonzero_bits`

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1106,12 +1106,11 @@ macro_rules! nonzero_bits {
                 /// # Examples
                 ///
                 /// ```
-                /// #![feature(nonzero_bits)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::BITS, ", stringify!($Int), "::BITS);")]
                 /// ```
-                #[unstable(feature = "nonzero_bits", issue = "94881")]
+                #[stable(feature = "nonzero_bits", since = "CURRENT_RUSTC_VERSION")]
                 pub const BITS: u32 = <$Int>::BITS;
             }
         )+


### PR DESCRIPTION
Closes #94881, implemented by #93292.

This change stabilizes the associated `BITS` constant for `NonZero{U,I}{8,16,32,64,128,size}` integers, e.g.:

```rs
impl NonZeroUsize {
    pub const BITS: u32 = usize::BITS;
}
```