### PR TITLE
Recover from typo where == is used in place of =

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -153,3 +153,6 @@ parser_left_arrow_operator = unexpected token: `<-`
 
 parser_remove_let = expected pattern, found `let`
     .suggestion = remove the unnecessary `let` keyword
+
+parser_use_eq_instead = unexpected `==`
+    .suggestion = try using `=` instead

--- a/src/test/ui/parser/issue-101477-enum.fixed
+++ b/src/test/ui/parser/issue-101477-enum.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+
+#[allow(dead_code)]
+enum Demo {
+    A = 1,
+    B = 2 //~ ERROR unexpected `==`
+    //~^ expected item, found `==`
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-101477-enum.rs
+++ b/src/test/ui/parser/issue-101477-enum.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+
+#[allow(dead_code)]
+enum Demo {
+    A = 1,
+    B == 2 //~ ERROR unexpected `==`
+    //~^ expected item, found `==`
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-101477-enum.stderr
+++ b/src/test/ui/parser/issue-101477-enum.stderr
@@ -1,0 +1,14 @@
+error: unexpected `==`
+  --> $DIR/issue-101477-enum.rs:6:7
+   |
+LL |     B == 2
+   |       ^^ help: try using `=` instead
+
+error: expected item, found `==`
+  --> $DIR/issue-101477-enum.rs:6:7
+   |
+LL |     B == 2
+   |       ^^ expected item
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/issue-101477-let.fixed
+++ b/src/test/ui/parser/issue-101477-let.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+
+fn main() {
+    let x = 2; //~ ERROR unexpected `==`
+    println!("x: {}", x)
+}

--- a/src/test/ui/parser/issue-101477-let.rs
+++ b/src/test/ui/parser/issue-101477-let.rs
@@ -1,0 +1,6 @@
+// run-rustfix
+
+fn main() {
+    let x == 2; //~ ERROR unexpected `==`
+    println!("x: {}", x)
+}

--- a/src/test/ui/parser/issue-101477-let.stderr
+++ b/src/test/ui/parser/issue-101477-let.stderr
@@ -1,0 +1,8 @@
+error: unexpected `==`
+  --> $DIR/issue-101477-let.rs:4:11
+   |
+LL |     let x == 2;
+   |           ^^ help: try using `=` instead
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #101477