### PR TITLE
Remove the span from `ast::Lit`.

### DIFF
--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -372,7 +372,7 @@ pub fn visit_mac_args<T: MutVisitor>(args: &mut MacArgs, vis: &mut T) {
             vis.visit_span(eq_span);
             vis.visit_expr(expr);
         }
-        MacArgs::Eq(_, MacArgsEq::Hir(lit)) => {
+        MacArgs::Eq(_, MacArgsEq::Hir(lit, _)) => {
             unreachable!("in literal form when visiting mac args eq: {:?}", lit)
         }
     }
@@ -617,7 +617,7 @@ pub fn noop_visit_macro_def<T: MutVisitor>(macro_def: &mut MacroDef, vis: &mut T
 pub fn noop_visit_meta_list_item<T: MutVisitor>(li: &mut NestedMetaItem, vis: &mut T) {
     match li {
         NestedMetaItem::MetaItem(mi) => vis.visit_meta_item(mi),
-        NestedMetaItem::Literal(_lit) => {}
+        NestedMetaItem::Literal(_lit, _lit_span) => {}
     }
 }
 
@@ -626,7 +626,7 @@ pub fn noop_visit_meta_item<T: MutVisitor>(mi: &mut MetaItem, vis: &mut T) {
     match kind {
         MetaItemKind::Word => {}
         MetaItemKind::List(mis) => visit_vec(mis, |mi| vis.visit_meta_list_item(mi)),
-        MetaItemKind::NameValue(_s) => {}
+        MetaItemKind::NameValue(_s, _) => {}
     }
     vis.visit_span(span);
 }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -939,7 +939,7 @@ pub fn walk_mac_args<'a, V: Visitor<'a>>(visitor: &mut V, args: &'a MacArgs) {
         MacArgs::Empty => {}
         MacArgs::Delimited(_dspan, _delim, _tokens) => {}
         MacArgs::Eq(_eq_span, MacArgsEq::Ast(expr)) => visitor.visit_expr(expr),
-        MacArgs::Eq(_, MacArgsEq::Hir(lit)) => {
+        MacArgs::Eq(_, MacArgsEq::Hir(lit, _)) => {
             unreachable!("in literal form when walking mac args eq: {:?}", lit)
         }
     }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -85,7 +85,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     hir::ExprKind::Unary(op, ohs)
                 }
                 ExprKind::Lit(ref l) => {
-                    hir::ExprKind::Lit(respan(self.lower_span(l.span), l.kind.clone()))
+                    hir::ExprKind::Lit(respan(self.lower_span(e.span), l.kind.clone()))
                 }
                 ExprKind::Cast(ref expr, ref ty) => {
                     let expr = self.lower_expr(expr);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -928,12 +928,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     Lit {
                         token_lit: token::Lit::new(token::LitKind::Err, kw::Empty, None),
                         kind: LitKind::Err,
-                        span: DUMMY_SP,
                     }
                 };
-                MacArgs::Eq(eq_span, MacArgsEq::Hir(lit))
+                MacArgs::Eq(eq_span, MacArgsEq::Hir(lit, expr.span))
             }
-            MacArgs::Eq(_, MacArgsEq::Hir(ref lit)) => {
+            MacArgs::Eq(_, MacArgsEq::Hir(ref lit, _)) => {
                 unreachable!("in literal form when lowering mac args eq: {:?}", lit)
             }
         }

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -320,7 +320,7 @@ impl<'a> State<'a> {
                 self.print_expr_addr_of(k, m, expr);
             }
             ast::ExprKind::Lit(ref lit) => {
-                self.print_literal(lit);
+                self.print_literal(lit, expr.span);
             }
             ast::ExprKind::Cast(ref expr, ref ty) => {
                 let prec = AssocOp::As.precedence() as i8;

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -207,7 +207,7 @@ impl<'a> State<'a> {
                     s.word("extern");
                 }));
                 if let Some(abi) = nmod.abi {
-                    self.print_literal(&abi.as_lit());
+                    self.print_literal(&abi.as_lit(), abi.span);
                     self.nbsp();
                 }
                 self.bopen();

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -457,7 +457,7 @@ fn parse_clobber_abi<'a>(p: &mut Parser<'a>, args: &mut AsmArgs) -> PResult<'a, 
                 if p.eat(&token::CloseDelim(Delimiter::Parenthesis)) {
                     break;
                 }
-                let span = opt_lit.map_or(p.token.span, |lit| lit.span);
+                let span = opt_lit.map_or(p.token.span, |(_lit, span)| span);
                 let mut err =
                     p.sess.span_diagnostic.struct_span_err(span, "expected string literal");
                 err.span_label(span, "not a string literal");

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1218,7 +1218,7 @@ pub fn expr_to_spanned_string<'a>(
         ast::ExprKind::Lit(ref l) => match l.kind {
             ast::LitKind::Str(s, style) => return Ok((s, style, expr.span)),
             ast::LitKind::ByteStr(_) => {
-                let mut err = cx.struct_span_err(l.span, err_msg);
+                let mut err = cx.struct_span_err(expr.span, err_msg);
                 err.span_suggestion(
                     expr.span.shrink_to_lo(),
                     "consider removing the leading `b`",
@@ -1228,7 +1228,7 @@ pub fn expr_to_spanned_string<'a>(
                 Some((err, true))
             }
             ast::LitKind::Err => None,
-            _ => Some((cx.struct_span_err(l.span, err_msg), false)),
+            _ => Some((cx.struct_span_err(expr.span, err_msg), false)),
         },
         ast::ExprKind::Err => None,
         _ => Some((cx.struct_span_err(expr.span, err_msg), false)),

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -330,7 +330,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     fn expr_lit(&self, span: Span, lit_kind: ast::LitKind) -> P<ast::Expr> {
-        let lit = ast::Lit::from_lit_kind(lit_kind, span);
+        let lit = ast::Lit::from_lit_kind(lit_kind);
         self.expr(span, ast::ExprKind::Lit(lit))
     }
 

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -502,11 +502,11 @@ impl server::TokenStream for Rustc<'_, '_> {
             ast::ExprKind::Lit(l) if l.token_lit.kind == token::Bool => {
                 Ok(tokenstream::TokenStream::token_alone(
                     token::Ident(l.token_lit.symbol, false),
-                    l.span,
+                    expr.span,
                 ))
             }
             ast::ExprKind::Lit(l) => {
-                Ok(tokenstream::TokenStream::token_alone(token::Literal(l.token_lit), l.span))
+                Ok(tokenstream::TokenStream::token_alone(token::Literal(l.token_lit), expr.span))
             }
             ast::ExprKind::Unary(ast::UnOp::Neg, e) => match &e.kind {
                 ast::ExprKind::Lit(l) => match l.token_lit {
@@ -517,7 +517,7 @@ impl server::TokenStream for Rustc<'_, '_> {
                             tokenstream::TokenTree::token_alone(token::BinOp(token::Minus), e.span),
                             tokenstream::TokenTree::token_alone(
                                 token::Literal(l.token_lit),
-                                l.span,
+                                e.span,
                             ),
                         ]))
                     }

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -109,7 +109,7 @@ pub fn parse_cfgspecs(cfgspecs: Vec<String>) -> FxHashSet<(String, Option<String
                             }
                             match &meta_item.kind {
                                 MetaItemKind::List(..) => {}
-                                MetaItemKind::NameValue(lit) if !lit.kind.is_str() => {
+                                MetaItemKind::NameValue(lit, _) if !lit.kind.is_str() => {
                                     error!("argument value must be a string");
                                 }
                                 MetaItemKind::NameValue(..) | MetaItemKind::Word => {

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -473,8 +473,7 @@ pub(crate) fn check_attr_crate_type(
                     return;
                 }
 
-                if let ast::MetaItemKind::NameValue(spanned) = a.meta_kind().unwrap() {
-                    let span = spanned.span;
+                if let ast::MetaItemKind::NameValue(_lit, lit_span) = a.meta_kind().unwrap() {
                     let lev_candidate = find_best_match_for_name(
                         &CRATE_TYPES.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
                         n,
@@ -484,10 +483,10 @@ pub(crate) fn check_attr_crate_type(
                         lint_buffer.buffer_lint_with_diagnostic(
                             lint::builtin::UNKNOWN_CRATE_TYPES,
                             ast::CRATE_NODE_ID,
-                            span,
+                            lit_span,
                             "invalid `crate_type` value",
                             BuiltinLintDiagnostics::UnknownCrateTypes(
-                                span,
+                                lit_span,
                                 "did you mean".to_string(),
                                 format!("\"{}\"", candidate),
                             ),
@@ -496,7 +495,7 @@ pub(crate) fn check_attr_crate_type(
                         lint_buffer.buffer_lint(
                             lint::builtin::UNKNOWN_CRATE_TYPES,
                             ast::CRATE_NODE_ID,
-                            span,
+                            lit_span,
                             "invalid `crate_type` value",
                         );
                     }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -99,9 +99,10 @@ fn pierce_parens(mut expr: &ast::Expr) -> &ast::Expr {
 impl EarlyLintPass for WhileTrue {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
         if let ast::ExprKind::While(cond, _, label) = &e.kind {
-            if let ast::ExprKind::Lit(ref lit) = pierce_parens(cond).kind {
+            let pierced_expr = pierce_parens(cond);
+            if let ast::ExprKind::Lit(ref lit) = pierced_expr.kind {
                 if let ast::LitKind::Bool(true) = lit.kind {
-                    if !lit.span.from_expansion() {
+                    if !pierced_expr.span.from_expansion() {
                         let condition_span = e.span.with_hi(cond.span.hi());
                         cx.struct_span_lint(WHILE_TRUE, condition_span, |lint| {
                             lint.build(fluent::lint::builtin_while_true)

--- a/compiler/rustc_lint/src/hidden_unicode_codepoints.rs
+++ b/compiler/rustc_lint/src/hidden_unicode_codepoints.rs
@@ -119,8 +119,8 @@ impl EarlyLintPass for HiddenUnicodeCodepoints {
 
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
         // byte strings are already handled well enough by `EscapeError::NonAsciiCharInByteString`
-        let (text, span, padding) = match &expr.kind {
-            ast::ExprKind::Lit(ast::Lit { token_lit, kind, span }) => {
+        let (text, padding) = match &expr.kind {
+            ast::ExprKind::Lit(ast::Lit { token_lit, kind }) => {
                 let text = token_lit.symbol;
                 if !contains_text_flow_control_chars(text.as_str()) {
                     return;
@@ -132,10 +132,10 @@ impl EarlyLintPass for HiddenUnicodeCodepoints {
                     ast::LitKind::Str(_, ast::StrStyle::Raw(val)) => *val as u32 + 2,
                     _ => return,
                 };
-                (text, span, padding)
+                (text, padding)
             }
             _ => return,
         };
-        self.lint_text_direction_codepoint(cx, text, *span, padding, true, "literal");
+        self.lint_text_direction_codepoint(cx, text, expr.span, padding, true, "literal");
     }
 }

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -316,7 +316,7 @@ impl<'s> LintLevelsBuilder<'s> {
             if let Some(item) = tail_li.meta_item() {
                 match item.kind {
                     ast::MetaItemKind::Word => {} // actual lint names handled later
-                    ast::MetaItemKind::NameValue(ref name_value) => {
+                    ast::MetaItemKind::NameValue(ref name_value, name_value_span) => {
                         if item.path == sym::reason {
                             if let ast::LitKind::Str(rationale, _) = name_value.kind {
                                 if !self.sess.features_untracked().lint_reasons {
@@ -331,9 +331,9 @@ impl<'s> LintLevelsBuilder<'s> {
                                 reason = Some(rationale);
                             } else {
                                 sess.emit_err(MalformedAttribute {
-                                    span: name_value.span,
+                                    span: name_value_span,
                                     sub: MalformedAttributeSub::ReasonMustBeStringLiteral(
-                                        name_value.span,
+                                        name_value_span,
                                     ),
                                 });
                             }
@@ -369,7 +369,7 @@ impl<'s> LintLevelsBuilder<'s> {
                     ast::NestedMetaItem::MetaItem(meta_item) if meta_item.is_word() => meta_item,
                     _ => {
                         if let Some(item) = li.meta_item() {
-                            if let ast::MetaItemKind::NameValue(_) = item.kind {
+                            if let ast::MetaItemKind::NameValue(..) = item.kind {
                                 if item.path == sym::reason {
                                     sess.emit_err(MalformedAttribute {
                                         span: sp,

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -345,13 +345,13 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
                 .find_by_name(&cx.tcx.hir().attrs(hir::CRATE_HIR_ID), sym::crate_name)
                 .and_then(|attr| attr.meta())
                 .and_then(|meta| {
-                    meta.name_value_literal().and_then(|lit| {
+                    meta.name_value_literal_and_span().and_then(|(lit, lit_span)| {
                         if let ast::LitKind::Str(name, ..) = lit.kind {
                             // Discard the double quotes surrounding the literal.
                             let sp = cx
                                 .sess()
                                 .source_map()
-                                .span_to_snippet(lit.span)
+                                .span_to_snippet(lit_span)
                                 .ok()
                                 .and_then(|snippet| {
                                     let left = snippet.find('"')?;
@@ -359,12 +359,12 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
                                         snippet.rfind('"').map(|pos| snippet.len() - pos)?;
 
                                     Some(
-                                        lit.span
-                                            .with_lo(lit.span.lo() + BytePos(left as u32 + 1))
-                                            .with_hi(lit.span.hi() - BytePos(right as u32)),
+                                        lit_span
+                                            .with_lo(lit_span.lo() + BytePos(left as u32 + 1))
+                                            .with_hi(lit_span.hi() - BytePos(right as u32)),
                                     )
                                 })
-                                .unwrap_or(lit.span);
+                                .unwrap_or(lit_span);
 
                             Some(Ident::new(name, sp))
                         } else {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1205,11 +1205,7 @@ impl<'tcx> TyCtxt<'tcx> {
             };
             debug!("layout_scalar_valid_range: attr={:?}", attr);
             if let Some(
-                &[
-                    ast::NestedMetaItem::Literal(ast::Lit {
-                        kind: ast::LitKind::Int(a, _), ..
-                    }),
-                ],
+                &[ast::NestedMetaItem::Literal(ast::Lit { kind: ast::LitKind::Int(a, _), .. }, _)],
             ) = attr.meta_item_list().as_deref()
             {
                 Bound::Included(a)

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1381,12 +1381,12 @@ impl<'a> Parser<'a> {
     fn parse_abi(&mut self) -> Option<StrLit> {
         match self.parse_str_lit() {
             Ok(str_lit) => Some(str_lit),
-            Err(Some(lit)) => match lit.kind {
+            Err(Some((lit, span))) => match lit.kind {
                 ast::LitKind::Err => None,
                 _ => {
-                    self.struct_span_err(lit.span, "non-string ABI literal")
+                    self.struct_span_err(span, "non-string ABI literal")
                         .span_suggestion(
-                            lit.span,
+                            span,
                             "specify the ABI with a string literal",
                             "\"C\"",
                             Applicability::MaybeIncorrect,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1327,7 +1327,7 @@ impl CheckAttrVisitor<'_> {
             return false;
         };
 
-        if matches!(&list[..], &[NestedMetaItem::Literal(Lit { kind: LitKind::Int(..), .. })]) {
+        if matches!(&list[..], &[NestedMetaItem::Literal(Lit { kind: LitKind::Int(..), .. }, _)]) {
             true
         } else {
             self.tcx.sess.emit_err(errors::RustcLayoutScalarValidRangeArg { attr_span: attr.span });
@@ -1995,7 +1995,7 @@ impl CheckAttrVisitor<'_> {
             ) && let Some(meta) = attr.meta_item_list()
             && meta.len() == 1
             && let Some(item) = meta[0].meta_item()
-            && let MetaItemKind::NameValue(_) = &item.kind
+            && let MetaItemKind::NameValue(..) = &item.kind
             && item.path == sym::reason
         {
             errors::UnusedNote::NoLints { name: attr.name_or_empty() }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -3126,7 +3126,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
                     InlineAttr::None
                 }
             }
-            Some(MetaItemKind::NameValue(_)) => ia,
+            Some(MetaItemKind::NameValue(..)) => ia,
             None => ia,
         }
     });
@@ -3155,7 +3155,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
                     OptimizeAttr::None
                 }
             }
-            Some(MetaItemKind::NameValue(_)) => ia,
+            Some(MetaItemKind::NameValue(..)) => ia,
             None => ia,
         }
     });

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -50,8 +50,8 @@ impl Cfg {
     ) -> Result<Option<Cfg>, InvalidCfgError> {
         match nested_cfg {
             NestedMetaItem::MetaItem(ref cfg) => Cfg::parse_without(cfg, exclude),
-            NestedMetaItem::Literal(ref lit) => {
-                Err(InvalidCfgError { msg: "unexpected literal", span: lit.span })
+            NestedMetaItem::Literal(_, lit_span) => {
+                Err(InvalidCfgError { msg: "unexpected literal", span: *lit_span })
             }
         }
     }
@@ -74,7 +74,7 @@ impl Cfg {
                 let cfg = Cfg::Cfg(name, None);
                 if exclude.contains(&cfg) { Ok(None) } else { Ok(Some(cfg)) }
             }
-            MetaItemKind::NameValue(ref lit) => match lit.kind {
+            MetaItemKind::NameValue(ref lit, lit_span) => match lit.kind {
                 LitKind::Str(value, _) => {
                     let cfg = Cfg::Cfg(name, Some(value));
                     if exclude.contains(&cfg) { Ok(None) } else { Ok(Some(cfg)) }
@@ -83,7 +83,7 @@ impl Cfg {
                     // FIXME: if the main #[cfg] syntax decided to support non-string literals,
                     // this should be changed as well.
                     msg: "value of cfg option should be a string literal",
-                    span: lit.span,
+                    span: lit_span,
                 }),
             },
             MetaItemKind::List(ref items) => {

--- a/src/tools/clippy/clippy_lints/src/attrs.rs
+++ b/src/tools/clippy/clippy_lints/src/attrs.rs
@@ -318,7 +318,7 @@ impl<'tcx> LateLintPass<'tcx> for Attributes {
                 for item in items {
                     if_chain! {
                         if let NestedMetaItem::MetaItem(mi) = &item;
-                        if let MetaItemKind::NameValue(lit) = &mi.kind;
+                        if let MetaItemKind::NameValue(lit, _) = &mi.kind;
                         if mi.has_name(sym::since);
                         then {
                             check_semver(cx, item.span(), lit);
@@ -457,7 +457,7 @@ fn check_lint_reason(cx: &LateContext<'_>, name: Symbol, items: &[NestedMetaItem
 
     // Check if the reason is present
     if let Some(item) = items.last().and_then(NestedMetaItem::meta_item)
-        && let MetaItemKind::NameValue(_) = &item.kind
+        && let MetaItemKind::NameValue(..) = &item.kind
         && item.path == sym::reason
     {
         return;

--- a/src/tools/clippy/clippy_lints/src/misc_early/literal_suffix.rs
+++ b/src/tools/clippy/clippy_lints/src/misc_early/literal_suffix.rs
@@ -1,11 +1,17 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use rustc_ast::ast::Lit;
 use rustc_errors::Applicability;
 use rustc_lint::EarlyContext;
+use rustc_span::Span;
 
 use super::{SEPARATED_LITERAL_SUFFIX, UNSEPARATED_LITERAL_SUFFIX};
 
-pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, lit_snip: &str, suffix: &str, sugg_type: &str) {
+pub(super) fn check(
+    cx: &EarlyContext<'_>,
+    lit_span: Span,
+    lit_snip: &str,
+    suffix: &str,
+    sugg_type: &str
+) {
     let maybe_last_sep_idx = if let Some(val) = lit_snip.len().checked_sub(suffix.len() + 1) {
         val
     } else {
@@ -17,7 +23,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, lit_snip: &str, suffix: &s
             span_lint_and_sugg(
                 cx,
                 SEPARATED_LITERAL_SUFFIX,
-                lit.span,
+                lit_span,
                 &format!("{} type suffix should not be separated by an underscore", sugg_type),
                 "remove the underscore",
                 format!("{}{}", &lit_snip[..maybe_last_sep_idx], suffix),
@@ -27,7 +33,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, lit_snip: &str, suffix: &s
             span_lint_and_sugg(
                 cx,
                 UNSEPARATED_LITERAL_SUFFIX,
-                lit.span,
+                lit_span,
                 &format!("{} type suffix should be separated by an underscore", sugg_type),
                 "add an underscore",
                 format!("{}_{}", &lit_snip[..=maybe_last_sep_idx], suffix),

--- a/src/tools/clippy/clippy_lints/src/misc_early/mixed_case_hex_literals.rs
+++ b/src/tools/clippy/clippy_lints/src/misc_early/mixed_case_hex_literals.rs
@@ -1,10 +1,10 @@
 use clippy_utils::diagnostics::span_lint;
-use rustc_ast::ast::Lit;
 use rustc_lint::EarlyContext;
+use rustc_span::Span;
 
 use super::MIXED_CASE_HEX_LITERALS;
 
-pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, suffix: &str, lit_snip: &str) {
+pub(super) fn check(cx: &EarlyContext<'_>, lit_span: Span, suffix: &str, lit_snip: &str) {
     let maybe_last_sep_idx = if let Some(val) = lit_snip.len().checked_sub(suffix.len() + 1) {
         val
     } else {
@@ -25,7 +25,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, suffix: &str, lit_snip: &s
             span_lint(
                 cx,
                 MIXED_CASE_HEX_LITERALS,
-                lit.span,
+                lit_span,
                 "inconsistent casing in hexadecimal literal",
             );
             break;

--- a/src/tools/clippy/clippy_lints/src/misc_early/zero_prefixed_literal.rs
+++ b/src/tools/clippy/clippy_lints/src/misc_early/zero_prefixed_literal.rs
@@ -1,25 +1,25 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_ast::ast::Lit;
 use rustc_errors::Applicability;
 use rustc_lint::EarlyContext;
+use rustc_span::Span;
 
 use super::ZERO_PREFIXED_LITERAL;
 
-pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, lit_snip: &str) {
+pub(super) fn check(cx: &EarlyContext<'_>, lit_span: Span, lit_snip: &str) {
     span_lint_and_then(
         cx,
         ZERO_PREFIXED_LITERAL,
-        lit.span,
+        lit_span,
         "this is a decimal constant",
         |diag| {
             diag.span_suggestion(
-                lit.span,
+                lit_span,
                 "if you mean to use a decimal constant, remove the `0` to avoid confusion",
                 lit_snip.trim_start_matches(|c| c == '_' || c == '0').to_string(),
                 Applicability::MaybeIncorrect,
             );
             diag.span_suggestion(
-                lit.span,
+                lit_span,
                 "if you mean to use an octal constant, use `0o`",
                 format!("0o{}", lit_snip.trim_start_matches(|c| c == '_' || c == '0')),
                 Applicability::MaybeIncorrect,

--- a/src/tools/clippy/clippy_lints/src/octal_escapes.rs
+++ b/src/tools/clippy/clippy_lints/src/octal_escapes.rs
@@ -58,9 +58,9 @@ impl EarlyLintPass for OctalEscapes {
 
         if let ExprKind::Lit(lit) = &expr.kind {
             if matches!(lit.token_lit.kind, LitKind::Str) {
-                check_lit(cx, &lit.token_lit, lit.span, true);
+                check_lit(cx, &lit.token_lit, expr.span, true);
             } else if matches!(lit.token_lit.kind, LitKind::ByteStr) {
-                check_lit(cx, &lit.token_lit, lit.span, false);
+                check_lit(cx, &lit.token_lit, expr.span, false);
             }
         }
     }

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -706,7 +706,7 @@ pub fn eq_mac_args(l: &MacArgs, r: &MacArgs) -> bool {
         (Empty, Empty) => true,
         (Delimited(_, ld, lts), Delimited(_, rd, rts)) => ld == rd && lts.eq_unspanned(rts),
         (Eq(_, MacArgsEq::Ast(le)), Eq(_, MacArgsEq::Ast(re))) => eq_expr(le, re),
-        (Eq(_, MacArgsEq::Hir(ll)), Eq(_, MacArgsEq::Hir(rl))) => ll.kind == rl.kind,
+        (Eq(_, MacArgsEq::Hir(ll, _)), Eq(_, MacArgsEq::Hir(rl, _))) => ll.kind == rl.kind,
         _ => false,
     }
 }

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -263,7 +263,7 @@ fn is_skip(meta_item: &MetaItem) -> bool {
 fn is_skip_nested(meta_item: &NestedMetaItem) -> bool {
     match meta_item {
         NestedMetaItem::MetaItem(ref mi) => is_skip(mi),
-        NestedMetaItem::Literal(_) => false,
+        NestedMetaItem::Literal(..) => false,
     }
 }
 


### PR DESCRIPTION
In the most common case, the `Lit` is stored within an `Expr`, which records the same span.

For other cases, we can store the span next to the `Lit`.

r? @ghost