### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -360,7 +360,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
                 diag.span_label(upvar_span, "captured outer variable");
                 diag.span_label(
-                    self.body.span,
+                    self.infcx.tcx.def_span(def_id),
                     format!("captured by this `{closure_kind}` closure"),
                 );
 

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -9,10 +9,7 @@ use rustc_middle::mir::{Mutability, Place, PlaceRef, ProjectionElem};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{
     hir::place::PlaceBase,
-    mir::{
-        self, BindingForm, ClearCrossCrate, ImplicitSelfKind, Local, LocalDecl, LocalInfo,
-        LocalKind, Location,
-    },
+    mir::{self, BindingForm, ClearCrossCrate, Local, LocalDecl, LocalInfo, LocalKind, Location},
 };
 use rustc_span::source_map::DesugaringKind;
 use rustc_span::symbol::{kw, Symbol};
@@ -312,7 +309,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     && !matches!(
                         decl.local_info,
                         Some(box LocalInfo::User(ClearCrossCrate::Set(BindingForm::ImplicitSelf(
-                            ImplicitSelfKind::MutRef
+                            hir::ImplicitSelfKind::MutRef
                         ))))
                     )
                 {
@@ -1077,7 +1074,7 @@ fn mut_borrow_of_mutable_ref(local_decl: &LocalDecl<'_>, local_name: Option<Symb
             //
             // Deliberately fall into this case for all implicit self types,
             // so that we don't fall in to the next case with them.
-            *kind == mir::ImplicitSelfKind::MutRef
+            *kind == hir::ImplicitSelfKind::MutRef
         }
         _ if Some(kw::SelfLower) == local_name => {
             // Otherwise, check if the name is the `self` keyword - in which case

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -973,6 +973,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
         let hir = self.infcx.tcx.hir();
         let closure_id = self.mir_hir_id();
+        let closure_span = self.infcx.tcx.def_span(self.mir_def_id());
         let fn_call_id = hir.get_parent_node(closure_id);
         let node = hir.get(fn_call_id);
         let def_id = hir.enclosing_body_owner(fn_call_id);
@@ -1024,7 +1025,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 if let Some(span) = arg {
                     err.span_label(span, "change this to accept `FnMut` instead of `Fn`");
                     err.span_label(func.span, "expects `Fn` instead of `FnMut`");
-                    err.span_label(self.body.span, "in this closure");
+                    err.span_label(closure_span, "in this closure");
                     look_at_return = false;
                 }
             }
@@ -1050,7 +1051,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                         sig.decl.output.span(),
                         "change this to return `FnMut` instead of `Fn`",
                     );
-                    err.span_label(self.body.span, "in this closure");
+                    err.span_label(closure_span, "in this closure");
                 }
                 _ => {}
             }

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -389,8 +389,9 @@ pub(super) fn dump_annotation<'a, 'tcx>(
     // viewing the intraprocedural state, the -Zdump-mir output is
     // better.
 
+    let def_span = tcx.def_span(body.source.def_id());
     let mut err = if let Some(closure_region_requirements) = closure_region_requirements {
-        let mut err = tcx.sess.diagnostic().span_note_diag(body.span, "external requirements");
+        let mut err = tcx.sess.diagnostic().span_note_diag(def_span, "external requirements");
 
         regioncx.annotate(tcx, &mut err);
 
@@ -409,7 +410,7 @@ pub(super) fn dump_annotation<'a, 'tcx>(
 
         err
     } else {
-        let mut err = tcx.sess.diagnostic().span_note_diag(body.span, "no external requirements");
+        let mut err = tcx.sess.diagnostic().span_note_diag(def_span, "no external requirements");
         regioncx.annotate(tcx, &mut err);
 
         err

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2642,7 +2642,7 @@ pub struct FnDecl<'hir> {
 }
 
 /// Represents what type of implicit self a function has, if any.
-#[derive(Copy, Clone, Encodable, Decodable, Debug, HashStable_Generic)]
+#[derive(Copy, Clone, PartialEq, Eq, Encodable, Decodable, Debug, HashStable_Generic)]
 pub enum ImplicitSelfKind {
     /// Represents a `fn x(self);`.
     Imm,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -18,7 +18,7 @@ use rustc_data_structures::captures::Captures;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def::{CtorKind, Namespace};
 use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_ID};
-use rustc_hir::{self, GeneratorKind};
+use rustc_hir::{self, GeneratorKind, ImplicitSelfKind};
 use rustc_hir::{self as hir, HirId};
 use rustc_session::Session;
 use rustc_target::abi::{Size, VariantIdx};
@@ -651,22 +651,6 @@ pub enum BindingForm<'tcx> {
     ImplicitSelf(ImplicitSelfKind),
     /// Reference used in a guard expression to ensure immutability.
     RefForGuard,
-}
-
-/// Represents what type of implicit self a function has, if any.
-#[derive(Clone, Copy, PartialEq, Debug, TyEncodable, TyDecodable, HashStable)]
-pub enum ImplicitSelfKind {
-    /// Represents a `fn x(self);`.
-    Imm,
-    /// Represents a `fn x(mut self);`.
-    Mut,
-    /// Represents a `fn x(&self);`.
-    ImmRef,
-    /// Represents a `fn x(&mut self);`.
-    MutRef,
-    /// Represents when a function does not have a self argument or
-    /// when a function has a `self: X` argument.
-    None,
 }
 
 TrivialTypeTraversalAndLiftImpls! { BindingForm<'tcx>, }

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -73,6 +73,8 @@ macro_rules! thir_with_elements {
     }
 }
 
+pub const UPVAR_ENV_PARAM: ParamId = ParamId::from_u32(0);
+
 thir_with_elements! {
     arms: ArmId => Arm<'tcx> => "a{}",
     blocks: BlockId => Block => "b{}",
@@ -84,8 +86,8 @@ thir_with_elements! {
 /// Description of a type-checked function parameter.
 #[derive(Clone, Debug, HashStable)]
 pub struct Param<'tcx> {
-    /// The pattern that appears in the parameter list.
-    pub pat: Box<Pat<'tcx>>,
+    /// The pattern that appears in the parameter list, or None for implicit parameters.
+    pub pat: Option<Box<Pat<'tcx>>>,
     /// The possibly inferred type.
     pub ty: Ty<'tcx>,
     /// Span of the explicitly provided type, or None if inferred for closures.
@@ -93,7 +95,7 @@ pub struct Param<'tcx> {
     /// Whether this param is `self`, and how it is bound.
     pub self_kind: Option<hir::ImplicitSelfKind>,
     /// HirId for lints.
-    pub hir_id: hir::HirId,
+    pub hir_id: Option<hir::HirId>,
 }
 
 #[derive(Copy, Clone, Debug, HashStable)]

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -78,6 +78,22 @@ thir_with_elements! {
     blocks: BlockId => Block => "b{}",
     exprs: ExprId => Expr<'tcx> => "e{}",
     stmts: StmtId => Stmt<'tcx> => "s{}",
+    params: ParamId => Param<'tcx> => "p{}",
+}
+
+/// Description of a type-checked function parameter.
+#[derive(Clone, Debug, HashStable)]
+pub struct Param<'tcx> {
+    /// The pattern that appears in the parameter list.
+    pub pat: Box<Pat<'tcx>>,
+    /// The possibly inferred type.
+    pub ty: Ty<'tcx>,
+    /// Span of the explicitly provided type, or None if inferred for closures.
+    pub ty_span: Option<Span>,
+    /// Whether this param is `self`, and how it is bound.
+    pub self_kind: Option<hir::ImplicitSelfKind>,
+    /// HirId for lints.
+    pub hir_id: hir::HirId,
 }
 
 #[derive(Copy, Clone, Debug, HashStable)]
@@ -547,6 +563,15 @@ pub struct Pat<'tcx> {
 impl<'tcx> Pat<'tcx> {
     pub fn wildcard_from_ty(ty: Ty<'tcx>) -> Self {
         Pat { ty, span: DUMMY_SP, kind: PatKind::Wild }
+    }
+
+    pub fn simple_ident(&self) -> Option<Symbol> {
+        match self.kind {
+            PatKind::Binding { name, mode: BindingMode::ByValue, subpattern: None, .. } => {
+                Some(name)
+            }
+            _ => None,
+        }
     }
 }
 

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -570,7 +570,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             _ => {
                 let place_builder = unpack!(block = self.as_place_builder(block, initializer));
-                self.place_into_pattern(block, irrefutable_pat, place_builder, true)
+                self.place_into_pattern(block, &irrefutable_pat, place_builder, true)
             }
         }
     }

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -10,7 +10,7 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
-use rustc_hir::{GeneratorKind, Node};
+use rustc_hir::{GeneratorKind, ImplicitSelfKind, Node};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_middle::hir::place::PlaceBase as HirPlaceBase;
@@ -169,13 +169,7 @@ fn mir_build(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> Body<'_
                         // Make sure that inferred closure args have no type span
                         .and_then(|ty| if arg.pat.span != ty.span { Some(ty.span) } else { None });
                     self_arg = if index == 0 && fn_decl.implicit_self.has_implicit_self() {
-                        match fn_decl.implicit_self {
-                            hir::ImplicitSelfKind::Imm => Some(ImplicitSelfKind::Imm),
-                            hir::ImplicitSelfKind::Mut => Some(ImplicitSelfKind::Mut),
-                            hir::ImplicitSelfKind::ImmRef => Some(ImplicitSelfKind::ImmRef),
-                            hir::ImplicitSelfKind::MutRef => Some(ImplicitSelfKind::MutRef),
-                            _ => None,
-                        }
+                        Some(fn_decl.implicit_self)
                     } else {
                         None
                     };

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -67,49 +67,24 @@ fn mir_build(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> Body<'_
     }
 
     // Figure out what primary body this item has.
-    let (body_id, return_ty_span, span_with_body) = match tcx.hir().get(id) {
-        Node::Expr(hir::Expr {
-            kind: hir::ExprKind::Closure(hir::Closure { fn_decl, body, .. }),
-            ..
-        }) => (*body, fn_decl.output.span(), None),
-        Node::Item(hir::Item {
-            kind: hir::ItemKind::Fn(hir::FnSig { decl, .. }, _, body_id),
-            span,
-            ..
-        })
-        | Node::ImplItem(hir::ImplItem {
-            kind: hir::ImplItemKind::Fn(hir::FnSig { decl, .. }, body_id),
-            span,
-            ..
-        })
-        | Node::TraitItem(hir::TraitItem {
-            kind: hir::TraitItemKind::Fn(hir::FnSig { decl, .. }, hir::TraitFn::Provided(body_id)),
-            span,
-            ..
-        }) => {
-            // Use the `Span` of the `Item/ImplItem/TraitItem` as the body span,
-            // since the def span of a function does not include the body
-            (*body_id, decl.output.span(), Some(*span))
+    let body_id = tcx.hir().body_owned_by(def.did);
+    let span_with_body = tcx.hir().span_with_body(id);
+    let return_ty_span = if let Some(fn_decl) = tcx.hir().fn_decl_by_hir_id(id) {
+        fn_decl.output.span()
+    } else {
+        match tcx.hir().get(id) {
+            Node::Item(hir::Item {
+                kind: hir::ItemKind::Static(ty, _, _) | hir::ItemKind::Const(ty, _),
+                ..
+            })
+            | Node::ImplItem(hir::ImplItem { kind: hir::ImplItemKind::Const(ty, _), .. })
+            | Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Const(ty, _), .. }) => {
+                ty.span
+            }
+            Node::AnonConst(_) => tcx.def_span(def.did),
+            _ => span_bug!(tcx.def_span(def.did), "can't build MIR for {:?}", def.did),
         }
-        Node::Item(hir::Item {
-            kind: hir::ItemKind::Static(ty, _, body_id) | hir::ItemKind::Const(ty, body_id),
-            ..
-        })
-        | Node::ImplItem(hir::ImplItem { kind: hir::ImplItemKind::Const(ty, body_id), .. })
-        | Node::TraitItem(hir::TraitItem {
-            kind: hir::TraitItemKind::Const(ty, Some(body_id)),
-            ..
-        }) => (*body_id, ty.span, None),
-        Node::AnonConst(hir::AnonConst { body, hir_id, .. }) => {
-            (*body, tcx.hir().span(*hir_id), None)
-        }
-
-        _ => span_bug!(tcx.hir().span(id), "can't build MIR for {:?}", def.did),
     };
-
-    // If we don't have a specialized span for the body, just use the
-    // normal def span.
-    let span_with_body = span_with_body.unwrap_or_else(|| tcx.hir().span(id));
 
     tcx.infer_ctxt().enter(|infcx| {
         let body = if let Some(error_reported) = typeck_results.tainted_by_errors {
@@ -243,8 +218,6 @@ fn mir_build(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> Body<'_
             // We ran all queries that depended on THIR at the beginning
             // of `mir_build`, so now we can steal it
             let thir = thir.steal();
-
-            let span_with_body = span_with_body.to(tcx.hir().span(body_id.hir_id));
 
             build::construct_const(
                 &thir,

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -8,6 +8,7 @@ use crate::thir::util::UserAnnotatedTyHelpers;
 use rustc_data_structures::steal::Steal;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::HirId;
@@ -31,8 +32,21 @@ pub(crate) fn thir_body<'tcx>(
 
     let owner_id = hir.local_def_id_to_hir_id(owner_def.did);
     if let Some(ref fn_decl) = hir.fn_decl_by_hir_id(owner_id) {
+        let closure_env_param = cx.closure_env_param(owner_def.did, owner_id);
         let explicit_params = cx.explicit_params(owner_id, fn_decl, body);
-        cx.thir.params = explicit_params.collect();
+        cx.thir.params = closure_env_param.into_iter().chain(explicit_params).collect();
+
+        // The resume argument may be missing, in that case we need to provide it here.
+        // It will always be `()` in this case.
+        if tcx.def_kind(owner_def.did) == DefKind::Generator && body.params.is_empty() {
+            cx.thir.params.push(Param {
+                ty: tcx.mk_unit(),
+                pat: None,
+                ty_span: None,
+                self_kind: None,
+                hir_id: None,
+            });
+        }
     }
 
     Ok((tcx.alloc_steal_thir(cx.thir), expr))
@@ -94,6 +108,48 @@ impl<'tcx> Cx<'tcx> {
         pat_from_hir(self.tcx, self.param_env, self.typeck_results(), p)
     }
 
+    fn closure_env_param(&self, owner_def: LocalDefId, owner_id: HirId) -> Option<Param<'tcx>> {
+        match self.tcx.def_kind(owner_def) {
+            DefKind::Closure => {
+                let closure_ty = self.typeck_results.node_type(owner_id);
+
+                let ty::Closure(closure_def_id, closure_substs) = *closure_ty.kind() else {
+                    bug!("closure expr does not have closure type: {:?}", closure_ty);
+                };
+
+                let bound_vars = self.tcx.mk_bound_variable_kinds(std::iter::once(
+                    ty::BoundVariableKind::Region(ty::BrEnv),
+                ));
+                let br = ty::BoundRegion {
+                    var: ty::BoundVar::from_usize(bound_vars.len() - 1),
+                    kind: ty::BrEnv,
+                };
+                let env_region = ty::ReLateBound(ty::INNERMOST, br);
+                let closure_env_ty =
+                    self.tcx.closure_env_ty(closure_def_id, closure_substs, env_region).unwrap();
+                let liberated_closure_env_ty = self.tcx.erase_late_bound_regions(
+                    ty::Binder::bind_with_vars(closure_env_ty, bound_vars),
+                );
+                let env_param = Param {
+                    ty: liberated_closure_env_ty,
+                    pat: None,
+                    ty_span: None,
+                    self_kind: None,
+                    hir_id: None,
+                };
+
+                Some(env_param)
+            }
+            DefKind::Generator => {
+                let gen_ty = self.typeck_results.node_type(owner_id);
+                let gen_param =
+                    Param { ty: gen_ty, pat: None, ty_span: None, self_kind: None, hir_id: None };
+                Some(gen_param)
+            }
+            _ => None,
+        }
+    }
+
     fn explicit_params<'a>(
         &'a mut self,
         owner_id: HirId,
@@ -128,7 +184,7 @@ impl<'tcx> Cx<'tcx> {
             };
 
             let pat = self.pattern_from_hir(param.pat);
-            Param { pat, ty, ty_span, self_kind, hir_id: param.hir_id }
+            Param { pat: Some(pat), ty, ty_span, self_kind, hir_id: Some(param.hir_id) }
         })
     }
 }

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -66,11 +66,11 @@ struct Cx<'tcx> {
     tcx: TyCtxt<'tcx>,
     thir: Thir<'tcx>,
 
-    pub(crate) param_env: ty::ParamEnv<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
 
-    pub(crate) region_scope_tree: &'tcx region::ScopeTree,
-    pub(crate) typeck_results: &'tcx ty::TypeckResults<'tcx>,
-    pub(crate) rvalue_scopes: &'tcx RvalueScopes,
+    region_scope_tree: &'tcx region::ScopeTree,
+    typeck_results: &'tcx ty::TypeckResults<'tcx>,
+    rvalue_scopes: &'tcx RvalueScopes,
 
     /// When applying adjustments to the expression
     /// with the given `HirId`, use the given `Span`,
@@ -100,7 +100,7 @@ impl<'tcx> Cx<'tcx> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    pub(crate) fn pattern_from_hir(&mut self, p: &hir::Pat<'_>) -> Box<Pat<'tcx>> {
+    fn pattern_from_hir(&mut self, p: &hir::Pat<'_>) -> Box<Pat<'tcx>> {
         let p = match self.tcx.hir().get(p.hir_id) {
             Node::Pat(p) => p,
             node => bug!("pattern became {:?}", node),

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -29,22 +29,22 @@ use rustc_span::{Span, Symbol};
 use std::cmp::Ordering;
 
 #[derive(Clone, Debug)]
-pub(crate) enum PatternError {
+enum PatternError {
     AssocConstInPattern(Span),
     ConstParamInPattern(Span),
     StaticInPattern(Span),
     NonConstPath(Span),
 }
 
-pub(crate) struct PatCtxt<'a, 'tcx> {
-    pub(crate) tcx: TyCtxt<'tcx>,
-    pub(crate) param_env: ty::ParamEnv<'tcx>,
-    pub(crate) typeck_results: &'a ty::TypeckResults<'tcx>,
-    pub(crate) errors: Vec<PatternError>,
+struct PatCtxt<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    typeck_results: &'a ty::TypeckResults<'tcx>,
+    errors: Vec<PatternError>,
     include_lint_checks: bool,
 }
 
-pub(crate) fn pat_from_hir<'a, 'tcx>(
+pub(super) fn pat_from_hir<'a, 'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     typeck_results: &'a ty::TypeckResults<'tcx>,
@@ -61,7 +61,7 @@ pub(crate) fn pat_from_hir<'a, 'tcx>(
 }
 
 impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
-    pub(crate) fn new(
+    fn new(
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         typeck_results: &'a ty::TypeckResults<'tcx>,
@@ -69,12 +69,12 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         PatCtxt { tcx, param_env, typeck_results, errors: vec![], include_lint_checks: false }
     }
 
-    pub(crate) fn include_lint_checks(&mut self) -> &mut Self {
+    fn include_lint_checks(&mut self) -> &mut Self {
         self.include_lint_checks = true;
         self
     }
 
-    pub(crate) fn lower_pattern(&mut self, pat: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
+    fn lower_pattern(&mut self, pat: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
         // When implicit dereferences have been inserted in this pattern, the unadjusted lowered
         // pattern has the type that results *after* dereferencing. For example, in this code:
         //
@@ -622,7 +622,7 @@ impl<'tcx> UserAnnotatedTyHelpers<'tcx> for PatCtxt<'_, 'tcx> {
     }
 }
 
-pub(crate) trait PatternFoldable<'tcx>: Sized {
+trait PatternFoldable<'tcx>: Sized {
     fn fold_with<F: PatternFolder<'tcx>>(&self, folder: &mut F) -> Self {
         self.super_fold_with(folder)
     }
@@ -630,7 +630,7 @@ pub(crate) trait PatternFoldable<'tcx>: Sized {
     fn super_fold_with<F: PatternFolder<'tcx>>(&self, folder: &mut F) -> Self;
 }
 
-pub(crate) trait PatternFolder<'tcx>: Sized {
+trait PatternFolder<'tcx>: Sized {
     fn fold_pattern(&mut self, pattern: &Pat<'tcx>) -> Pat<'tcx> {
         pattern.super_fold_with(self)
     }

--- a/compiler/rustc_smir/src/mir.rs
+++ b/compiler/rustc_smir/src/mir.rs
@@ -1,10 +1,10 @@
+pub use crate::very_unstable::hir::ImplicitSelfKind;
 pub use crate::very_unstable::middle::mir::{
     visit::MutVisitor, AggregateKind, AssertKind, BasicBlock, BasicBlockData, BinOp, BindingForm,
     BlockTailInfo, Body, BorrowKind, CastKind, ClearCrossCrate, Constant, ConstantKind,
-    CopyNonOverlapping, Coverage, FakeReadCause, Field, GeneratorInfo, ImplicitSelfKind,
-    InlineAsmOperand, Local, LocalDecl, LocalInfo, LocalKind, Location, MirPhase, MirSource,
-    NullOp, Operand, Place, PlaceRef, ProjectionElem, ProjectionKind, Promoted, RetagKind, Rvalue,
-    Safety, SourceInfo, SourceScope, SourceScopeData, SourceScopeLocalData, Statement,
-    StatementKind, UnOp, UserTypeProjection, UserTypeProjections, VarBindingForm, VarDebugInfo,
-    VarDebugInfoContents,
+    CopyNonOverlapping, Coverage, FakeReadCause, Field, GeneratorInfo, InlineAsmOperand, Local,
+    LocalDecl, LocalInfo, LocalKind, Location, MirPhase, MirSource, NullOp, Operand, Place,
+    PlaceRef, ProjectionElem, ProjectionKind, Promoted, RetagKind, Rvalue, Safety, SourceInfo,
+    SourceScope, SourceScopeData, SourceScopeLocalData, Statement, StatementKind, UnOp,
+    UserTypeProjection, UserTypeProjections, VarBindingForm, VarDebugInfo, VarDebugInfoContents,
 };

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1520,35 +1520,7 @@ macro_rules! int_impl {
         ///
         /// # Examples
         ///
-        /// Standard signed bit integer implementation
-        ///
-        /// ```rs
-        /// #![feature(bigint_helper_methods)]
-        /// struct I16 {
-        ///     pub low: u8, // Low-order bytes has to be unsigned.
-        ///     /// Most Significant Data has to be of the same signedness as the desired type.
-        ///     /// So u8 to implement U16, i8 to implement I16.
-        ///     pub high: i8,
-        /// }
-        ///
-        /// impl I16 {
-        ///     /// Adds `rhs` to `self` and returns true if signed overflow occurs, false otherwise.
-        ///     pub fn overflowing_add(&mut self, rhs: Self) -> bool {
-        ///         let (low_res, low_carry) = self.low.carrying_add(rhs.low, false);
-        ///
-        ///         // The signed `carrying_add` method is used to detect signed overflow.
-        ///         let (high_res, high_carry) = self.high.carrying_add(rhs.high, low_carry);
-        ///
-        ///         self.low = low_res;
-        ///         self.high = high_res;
-        ///         high_carry
-        ///     }
-        /// }
-        ///
-        /// fn main() {}
-        /// ```
-        ///
-        /// General behavior
+        /// Basic usage:
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]
@@ -1644,35 +1616,7 @@ macro_rules! int_impl {
         ///
         /// # Examples
         ///
-        /// Standard signed bit integer implementation
-        ///
-        /// ```rs
-        /// #![feature(bigint_helper_methods)]
-        /// struct I16 {
-        ///     pub low: u8, // Low-order bytes has to be unsigned.
-        ///     /// Most Significant Data has to be of the same signedness as the desired type.
-        ///     /// So u8 to implement U16, i8 to implement I16.
-        ///     pub high: i8,
-        /// }
-        ///
-        /// impl I16 {
-        ///     /// Subtracts `rhs` from `self` and returns true if signed overflow occurs, false otherwise.
-        ///     pub fn overflowing_sub(&mut self, rhs: Self) -> bool {
-        ///         let (low_res, low_carry) = self.low.borrowing_sub(rhs.low, false);
-        ///
-        ///         // The signed `borrowing_sub` method is used to detect signed overflow.
-        ///         let (high_res, high_carry) = self.high.borrowing_sub(rhs.high, low_carry);
-        ///
-        ///         self.low = low_res;
-        ///         self.high = high_res;
-        ///         high_carry
-        ///     }
-        /// }
-        ///
-        /// fn main() {}
-        /// ```
-        ///
-        /// General behavior
+        /// Basic usage:
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1512,6 +1512,53 @@ macro_rules! int_impl {
             (a as Self, b)
         }
 
+        /// Calculates `self + rhs + carry` without the ability to overflow.
+        ///
+        /// Performs "ternary addition" which takes in an extra bit to add, and may return an
+        /// additional bit of overflow. This allows for chaining together multiple additions
+        /// to create "big integers" which represent larger values.
+        ///
+        #[doc = concat!("This can be thought of as a ", stringify!($BITS), "-bit \"full adder\", in the electronics sense.")]
+        ///
+        /// # Examples
+        ///
+        /// Basic usage
+        ///
+        /// ```
+        /// #![feature(bigint_helper_methods)]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".carrying_add(2, false), (7, false));")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".carrying_add(2, true), (8, false));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.carrying_add(1, false), (", stringify!($SelfT), "::MIN, true));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.carrying_add(0, true), (", stringify!($SelfT), "::MIN, true));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.carrying_add(1, true), (", stringify!($SelfT), "::MIN + 1, true));")]
+        #[doc = concat!("assert_eq!(",
+            stringify!($SelfT), "::MAX.carrying_add(", stringify!($SelfT), "::MAX, true), ",
+            "(-1, true));"
+        )]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.carrying_add(-1, true), (", stringify!($SelfT), "::MIN, false));")]
+        #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".carrying_add(", stringify!($SelfT), "::MAX, true), (", stringify!($SelfT), "::MIN, true));")]
+        /// ```
+        ///
+        /// If `carry` is false, this method is equivalent to [`overflowing_add`](Self::overflowing_add):
+        ///
+        /// ```
+        /// #![feature(bigint_helper_methods)]
+        #[doc = concat!("assert_eq!(5_", stringify!($SelfT), ".carrying_add(2, false), 5_", stringify!($SelfT), ".overflowing_add(2));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.carrying_add(1, false), ", stringify!($SelfT), "::MAX.overflowing_add(1));")]
+        /// ```
+        #[unstable(feature = "bigint_helper_methods", issue = "85532")]
+        #[rustc_const_unstable(feature = "const_bigint_helper_methods", issue = "85532")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
+            // note: longer-term this should be done via an intrinsic.
+            // note: no intermediate overflow is required (https://github.com/rust-lang/rust/issues/85532#issuecomment-1032214946).
+            let (a, b) = self.overflowing_add(rhs);
+            let (c, d) = a.overflowing_add(carry as $SelfT);
+            (c, b != d)
+        }
+
         /// Calculates `self` + `rhs` with an unsigned `rhs`
         ///
         /// Returns a tuple of the addition along with a boolean indicating
@@ -1561,6 +1608,39 @@ macro_rules! int_impl {
         pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
             let (a, b) = intrinsics::sub_with_overflow(self as $ActualT, rhs as $ActualT);
             (a as Self, b)
+        }
+
+        /// Calculates `self - rhs - borrow` without the ability to overflow.
+        ///
+        /// Performs "ternary subtraction" which takes in an extra bit to subtract, and may return
+        /// an additional bit of overflow. This allows for chaining together multiple subtractions
+        /// to create "big integers" which represent larger values.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage
+        ///
+        /// ```
+        /// #![feature(bigint_helper_methods)]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".borrowing_sub(2, false), (3, false));")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".borrowing_sub(2, true), (2, false));")]
+        #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".borrowing_sub(1, false), (-1, false));")]
+        #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".borrowing_sub(1, true), (-2, false));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.borrowing_sub(1, true), (", stringify!($SelfT), "::MAX - 1, true));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.borrowing_sub(-1, false), (", stringify!($SelfT), "::MIN, true));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.borrowing_sub(-1, true), (", stringify!($SelfT), "::MAX, false));")]
+        /// ```
+        #[unstable(feature = "bigint_helper_methods", issue = "85532")]
+        #[rustc_const_unstable(feature = "const_bigint_helper_methods", issue = "85532")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self, bool) {
+            // note: longer-term this should be done via an intrinsic.
+            // note: no intermediate overflow is required (https://github.com/rust-lang/rust/issues/85532#issuecomment-1032214946).
+            let (a, b) = self.overflowing_sub(rhs);
+            let (c, d) = a.overflowing_sub(borrow as $SelfT);
+            (c, b != d)
         }
 
         /// Calculates `self` - `rhs` with an unsigned `rhs`

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1514,15 +1514,41 @@ macro_rules! int_impl {
 
         /// Calculates `self + rhs + carry` without the ability to overflow.
         ///
-        /// Performs "ternary addition" which takes in an extra bit to add, and may return an
-        /// additional bit of overflow. This allows for chaining together multiple additions
-        /// to create "big integers" which represent larger values.
-        ///
-        #[doc = concat!("This can be thought of as a ", stringify!($BITS), "-bit \"full adder\", in the electronics sense.")]
+        /// Performs "signed ternary addition" which takes in an extra bit to add, and may return an
+        /// additional bit of overflow. This signed function is used only on the highest-ordered data,
+        /// for which the signed overflow result indicates whether the big integer overflowed or not.
         ///
         /// # Examples
         ///
-        /// Basic usage
+        /// Standard signed bit integer implementation
+        ///
+        /// ```rs
+        /// #![feature(bigint_helper_methods)]
+        /// struct I16 {
+        ///     pub low: u8, // Low-order bytes has to be unsigned.
+        ///     /// Most Significant Data has to be of the same signedness as the desired type.
+        ///     /// So u8 to implement U16, i8 to implement I16.
+        ///     pub high: i8,
+        /// }
+        ///
+        /// impl I16 {
+        ///     /// Adds `rhs` to `self` and returns true if signed overflow occurs, false otherwise.
+        ///     pub fn overflowing_add(&mut self, rhs: Self) -> bool {
+        ///         let (low_res, low_carry) = self.low.carrying_add(rhs.low, false);
+        ///
+        ///         // The signed `carrying_add` method is used to detect signed overflow.
+        ///         let (high_res, high_carry) = self.high.carrying_add(rhs.high, low_carry);
+        ///
+        ///         self.low = low_res;
+        ///         self.high = high_res;
+        ///         high_carry
+        ///     }
+        /// }
+        ///
+        /// fn main() {}
+        /// ```
+        ///
+        /// General behavior
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]
@@ -1612,13 +1638,41 @@ macro_rules! int_impl {
 
         /// Calculates `self - rhs - borrow` without the ability to overflow.
         ///
-        /// Performs "ternary subtraction" which takes in an extra bit to subtract, and may return
-        /// an additional bit of overflow. This allows for chaining together multiple subtractions
-        /// to create "big integers" which represent larger values.
+        /// Performs "signed ternary subtraction" which takes in an extra bit to subtract, and may return an
+        /// additional bit of overflow. This signed function is used only on the highest-ordered data,
+        /// for which the signed overflow result indicates whether the big integer overflowed or not.
         ///
         /// # Examples
         ///
-        /// Basic usage
+        /// Standard signed bit integer implementation
+        ///
+        /// ```rs
+        /// #![feature(bigint_helper_methods)]
+        /// struct I16 {
+        ///     pub low: u8, // Low-order bytes has to be unsigned.
+        ///     /// Most Significant Data has to be of the same signedness as the desired type.
+        ///     /// So u8 to implement U16, i8 to implement I16.
+        ///     pub high: i8,
+        /// }
+        ///
+        /// impl I16 {
+        ///     /// Subtracts `rhs` from `self` and returns true if signed overflow occurs, false otherwise.
+        ///     pub fn overflowing_sub(&mut self, rhs: Self) -> bool {
+        ///         let (low_res, low_carry) = self.low.borrowing_sub(rhs.low, false);
+        ///
+        ///         // The signed `borrowing_sub` method is used to detect signed overflow.
+        ///         let (high_res, high_carry) = self.high.borrowing_sub(rhs.high, low_carry);
+        ///
+        ///         self.low = low_res;
+        ///         self.high = high_res;
+        ///         high_carry
+        ///     }
+        /// }
+        ///
+        /// fn main() {}
+        /// ```
+        ///
+        /// General behavior
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -3,6 +3,7 @@
 #![feature(array_methods)]
 #![feature(array_windows)]
 #![feature(bench_black_box)]
+#![feature(bigint_helper_methods)]
 #![feature(cell_update)]
 #![feature(const_assume)]
 #![feature(const_black_box)]

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -338,6 +338,32 @@ macro_rules! int_module {
                 assert_eq!(MIN.checked_next_multiple_of(-3), None);
                 assert_eq!(MIN.checked_next_multiple_of(-1), Some(MIN));
             }
+
+            #[test]
+            fn test_carrying_add() {
+                assert_eq!($T::MAX.carrying_add(1, false), ($T::MIN, true));
+                assert_eq!($T::MAX.carrying_add(0, true), ($T::MIN, true));
+                assert_eq!($T::MAX.carrying_add(1, true), ($T::MIN + 1, true));
+                assert_eq!($T::MAX.carrying_add(-1, false), ($T::MAX - 1, false));
+                assert_eq!($T::MAX.carrying_add(-1, true), ($T::MAX, false)); // no intermediate overflow
+                assert_eq!($T::MIN.carrying_add(-1, false), ($T::MAX, true));
+                assert_eq!($T::MIN.carrying_add(-1, true), ($T::MIN, false)); // no intermediate overflow
+                assert_eq!((0 as $T).carrying_add($T::MAX, true), ($T::MIN, true));
+                assert_eq!((0 as $T).carrying_add($T::MIN, true), ($T::MIN + 1, false));
+            }
+
+            #[test]
+            fn test_borrowing_sub() {
+                assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
+                assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
+                assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
+                assert_eq!($T::MIN.borrowing_sub(-1, false), ($T::MIN + 1, false));
+                assert_eq!($T::MIN.borrowing_sub(-1, true), ($T::MIN, false)); // no intermediate overflow
+                assert_eq!($T::MAX.borrowing_sub(-1, false), ($T::MIN, true));
+                assert_eq!($T::MAX.borrowing_sub(-1, true), ($T::MAX, false)); // no intermediate overflow
+                assert_eq!((0 as $T).borrowing_sub($T::MIN, false), ($T::MIN, true));
+                assert_eq!((0 as $T).borrowing_sub($T::MIN, true), ($T::MAX, false));
+            }
         }
     };
 }

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -230,6 +230,28 @@ macro_rules! uint_module {
                 assert_eq!((1 as $T).checked_next_multiple_of(0), None);
                 assert_eq!(MAX.checked_next_multiple_of(2), None);
             }
+
+            #[test]
+            fn test_carrying_add() {
+                assert_eq!($T::MAX.carrying_add(1, false), (0, true));
+                assert_eq!($T::MAX.carrying_add(0, true), (0, true));
+                assert_eq!($T::MAX.carrying_add(1, true), (1, true));
+
+                assert_eq!($T::MIN.carrying_add($T::MAX, false), ($T::MAX, false));
+                assert_eq!($T::MIN.carrying_add(0, true), (1, false));
+                assert_eq!($T::MIN.carrying_add($T::MAX, true), (0, true));
+            }
+
+            #[test]
+            fn test_borrowing_sub() {
+                assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
+                assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
+                assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
+
+                assert_eq!($T::MAX.borrowing_sub($T::MAX, false), (0, false));
+                assert_eq!($T::MAX.borrowing_sub(0, true), ($T::MAX - 1, false));
+                assert_eq!($T::MAX.borrowing_sub($T::MAX, true), ($T::MAX, true));
+            }
         }
     };
 }

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -67,6 +67,7 @@ features = [
     "psapi",
     "impl-default",
     "timezoneapi",
+    "winbase",
 ]
 
 [dev-dependencies]

--- a/src/test/codegen/generator-debug-msvc.rs
+++ b/src/test/codegen/generator-debug-msvc.rs
@@ -27,11 +27,11 @@ fn generator_test() -> impl Generator<Yield = i32, Return = ()> {
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant1", scope: [[GEN]],
-// CHECK-SAME: file: [[FILE]], line: 14,
+// CHECK-SAME: file: [[FILE]], line: 18,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant2", scope: [[GEN]],
-// CHECK-SAME: file: [[FILE]], line: 14,
+// CHECK-SAME: file: [[FILE]], line: 18,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant3", scope: [[GEN]],

--- a/src/test/codegen/generator-debug.rs
+++ b/src/test/codegen/generator-debug.rs
@@ -33,11 +33,11 @@ fn generator_test() -> impl Generator<Yield = i32, Return = ()> {
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "1", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 14,
+// CHECK-SAME: file: [[FILE]], line: 18,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "2", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 14,
+// CHECK-SAME: file: [[FILE]], line: 18,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "3", scope: [[VARIANT]],

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -40,11 +40,11 @@
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:43: +0:44
-          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:44
+          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:45
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:44
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:45
       }
 - }
 - 

--- a/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
@@ -12,6 +12,6 @@ static BOP: &i32 = {
         _1 = &_2;                        // scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
         _0 = &(*_1);                     // scope 0 at $DIR/const-promotion-extern-static.rs:+0:20: +0:23
         StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:22: +0:23
-        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:23
+        return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:24
     }
 }

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -42,11 +42,11 @@
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:+0:54: +0:55
-          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:55
+          return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:56
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:55
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:+0:1: +0:56
       }
   }
 - 

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -15,70 +15,70 @@
 } */
 
 fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 10:17]) -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
-    let mut _2: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
-    let _3: std::string::String;         // in scope 0 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
-    let _4: ();                          // in scope 0 at $DIR/generator-drop-cleanup.rs:12:9: 12:14
-    let mut _5: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:12:9: 12:14
-    let mut _6: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:10:18: 10:18
-    let mut _7: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
-    let mut _8: u32;                     // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+    let mut _0: ();                      // return place in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
+    let mut _2: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
+    let _3: std::string::String;         // in scope 0 at $DIR/generator-drop-cleanup.rs:+1:13: +1:15
+    let _4: ();                          // in scope 0 at $DIR/generator-drop-cleanup.rs:+2:9: +2:14
+    let mut _5: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+2:9: +2:14
+    let mut _6: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:18: +0:18
+    let mut _7: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
+    let mut _8: u32;                     // in scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     scope 1 {
-        debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
+        debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:+1:13: +1:15
     }
 
     bb0: {
-        _8 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
-        switchInt(move _8) -> [0_u32: bb7, 3_u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        _8 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
+        switchInt(move _8) -> [0_u32: bb7, 3_u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 
     bb1: {
-        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
-        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
-        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:+2:13: +2:14
+        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:+2:14: +2:15
+        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb2: {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb3: {
-        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 
     bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 
     bb5 (cleanup): {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
+        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb6: {
-        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 
     bb7: {
-        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 
     bb8: {
-        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+3:5: +3:6
     }
 
     bb9: {
-        goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 
     bb10: {
-        StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
-        StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
-        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
+        StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
+        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 
     bb11: {
-        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +0:17
+        return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:+0:15: +3:6
     }
 }

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -3,122 +3,122 @@
 fn main::{closure#0}(_1: [generator@$DIR/generator-storage-dead-unwind.rs:22:16: 22:18], _2: ()) -> ()
 yields ()
  {
-    let mut _0: ();                      // return place in scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 22:19
-    let _3: Foo;                         // in scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-    let _5: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-    let mut _6: ();                      // in scope 0 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-    let _7: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
-    let mut _8: Foo;                     // in scope 0 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-    let _9: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
-    let mut _10: Bar;                    // in scope 0 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
+    let mut _0: ();                      // return place in scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:19: +0:19
+    let _3: Foo;                         // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
+    let _5: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+    let mut _6: ();                      // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+    let _7: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
+    let mut _8: Foo;                     // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
+    let _9: ();                          // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
+    let mut _10: Bar;                    // in scope 0 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
     scope 1 {
-        debug a => _3;                   // in scope 1 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-        let _4: Bar;                     // in scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
+        debug a => _3;                   // in scope 1 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
+        let _4: Bar;                     // in scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
         scope 2 {
-            debug b => _4;               // in scope 2 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
+            debug b => _4;               // in scope 2 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
         }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-        _3 = Foo(const 5_i32);           // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
-        StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
-        _4 = Bar(const 6_i32);           // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
-        StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        _6 = ();                         // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        _5 = yield(move _6) -> [resume: bb1, drop: bb6]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:13: +1:14
+        _3 = Foo(const 5_i32);           // scope 0 at $DIR/generator-storage-dead-unwind.rs:+1:17: +1:23
+        StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:13: +2:14
+        _4 = Bar(const 6_i32);           // scope 1 at $DIR/generator-storage-dead-unwind.rs:+2:17: +2:23
+        StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+        StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+        _6 = ();                         // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
+        _5 = yield(move _6) -> [resume: bb1, drop: bb6]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:9: +3:14
     }
 
     bb1: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
-        StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
-        StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-        _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb10]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:13: +3:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:14: +3:15
+        StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
+        StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
+        _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:14: +4:15
+        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb10]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:9: +4:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:26:9: 26:13
                                          // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(<ZST>) }
     }
 
     bb2: {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
-        StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
-        StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
-        _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
-        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:15: +4:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:16: +4:17
+        StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
+        StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
+        _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:14: +5:15
+        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:9: +5:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:27:9: 27:13
                                          // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(<ZST>) }
     }
 
     bb3: {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
-        _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        goto -> bb4;                     // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:15: +5:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:16: +5:17
+        _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:19: +6:6
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        goto -> bb4;                     // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb4: {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb5, unwind: bb14]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> [return: bb5, unwind: bb14]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb5: {
-        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:18: +0:18
+        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:6: +6:6
     }
 
     bb6: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_3) -> [return: bb7, unwind: bb15]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:13: +3:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+3:14: +3:15
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_3) -> [return: bb7, unwind: bb15]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb7: {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb8, unwind: bb14]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> [return: bb8, unwind: bb14]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb8: {
-        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:16: +0:18
+        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:16: +6:6
     }
 
     bb9 (cleanup): {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:15: +5:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+5:16: +5:17
         goto -> bb12;                    // scope 2 at no-location
     }
 
     bb10 (cleanup): {
-        goto -> bb11;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
+        goto -> bb11;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:15: +4:16
     }
 
     bb11 (cleanup): {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:15: +4:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:+4:16: +4:17
         goto -> bb12;                    // scope 2 at no-location
     }
 
     bb12 (cleanup): {
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        goto -> bb13;                    // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        goto -> bb13;                    // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb13 (cleanup): {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb14;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> bb14;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 
     bb14 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:16: +0:18
+        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:+0:16: +6:6
     }
 
     bb15 (cleanup): {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb14;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
+        drop(_1) -> bb14;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:+6:5: +6:6
     }
 }

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -16,69 +16,69 @@
 
 fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]>, _2: u8) -> GeneratorState<(), ()> {
     debug _x => _10;                     // in scope 0 at $DIR/generator-tiny.rs:+0:17: +0:19
-    let mut _0: std::ops::GeneratorState<(), ()>; // return place in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-    let _3: HasDrop;                     // in scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
-    let mut _4: !;                       // in scope 0 at $DIR/generator-tiny.rs:21:9: 24:10
-    let mut _5: ();                      // in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-    let _6: u8;                          // in scope 0 at $DIR/generator-tiny.rs:22:13: 22:18
-    let mut _7: ();                      // in scope 0 at $DIR/generator-tiny.rs:22:13: 22:18
-    let _8: ();                          // in scope 0 at $DIR/generator-tiny.rs:23:13: 23:21
-    let mut _9: ();                      // in scope 0 at $DIR/generator-tiny.rs:19:25: 19:25
+    let mut _0: std::ops::GeneratorState<(), ()>; // return place in scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+    let _3: HasDrop;                     // in scope 0 at $DIR/generator-tiny.rs:+1:13: +1:15
+    let mut _4: !;                       // in scope 0 at $DIR/generator-tiny.rs:+2:9: +5:10
+    let mut _5: ();                      // in scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+    let _6: u8;                          // in scope 0 at $DIR/generator-tiny.rs:+3:13: +3:18
+    let mut _7: ();                      // in scope 0 at $DIR/generator-tiny.rs:+3:13: +3:18
+    let _8: ();                          // in scope 0 at $DIR/generator-tiny.rs:+4:13: +4:21
+    let mut _9: ();                      // in scope 0 at $DIR/generator-tiny.rs:+0:25: +0:25
     let _10: u8;                         // in scope 0 at $DIR/generator-tiny.rs:+0:17: +0:19
-    let mut _11: u32;                    // in scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+    let mut _11: u32;                    // in scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
     scope 1 {
-        debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:20:13: 20:15
+        debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:+1:13: +1:15
     }
 
     bb0: {
-        _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))); // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-        switchInt(move _11) -> [0_u32: bb1, 3_u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))); // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+        switchInt(move _11) -> [0_u32: bb1, 3_u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
     }
 
     bb1: {
-        _10 = move _2;                   // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-        nop;                             // scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
-        (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop) = HasDrop; // scope 0 at $DIR/generator-tiny.rs:20:18: 20:25
-        StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
-        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
+        _10 = move _2;                   // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+        nop;                             // scope 0 at $DIR/generator-tiny.rs:+1:13: +1:15
+        (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24])) as variant#3).0: HasDrop) = HasDrop; // scope 0 at $DIR/generator-tiny.rs:+1:18: +1:25
+        StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
+        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
     }
 
     bb2: {
-        StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        _7 = ();                         // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))) = 3; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        return;                          // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        _7 = ();                         // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 19:24]))) = 3; // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
+        return;                          // scope 1 at $DIR/generator-tiny.rs:+3:13: +3:18
     }
 
     bb3: {
-        StorageDead(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:17: 22:18
-        StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:18: 22:19
-        StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
-        _8 = callee() -> bb4;            // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
+        StorageDead(_7);                 // scope 1 at $DIR/generator-tiny.rs:+3:17: +3:18
+        StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:+3:18: +3:19
+        StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:+4:13: +4:21
+        _8 = callee() -> bb4;            // scope 1 at $DIR/generator-tiny.rs:+4:13: +4:21
                                          // mir::Constant
                                          // + span: $DIR/generator-tiny.rs:23:13: 23:19
                                          // + literal: Const { ty: fn() {callee}, val: Value(<ZST>) }
     }
 
     bb4: {
-        StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:21: 23:22
-        _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:21:14: 24:10
-        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
+        StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:+4:21: +4:22
+        _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:+2:14: +5:10
+        goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:+2:9: +5:10
     }
 
     bb5: {
-        StorageLive(_4);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-        StorageLive(_6);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-        StorageLive(_7);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-        _6 = move _2;                    // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
-        goto -> bb3;                     // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        StorageLive(_4);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+        StorageLive(_6);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+        StorageLive(_7);                 // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+        _6 = move _2;                    // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
+        goto -> bb3;                     // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
     }
 
     bb6: {
-        unreachable;                     // scope 0 at $DIR/generator-tiny.rs:+0:16: +0:24
+        unreachable;                     // scope 0 at $DIR/generator-tiny.rs:+0:16: +6:6
     }
 }

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -19,8 +19,8 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
             debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline-closure-captures.rs:+0:17: +0:18
             let mut _10: i32;            // in scope 2 at $DIR/inline-closure-captures.rs:+1:19: +1:20
             let mut _11: T;              // in scope 2 at $DIR/inline-closure-captures.rs:+1:22: +1:23
-            let mut _12: &i32;           // in scope 2 at $DIR/inline-closure-captures.rs:+1:13: +1:17
-            let mut _13: &T;             // in scope 2 at $DIR/inline-closure-captures.rs:+1:13: +1:17
+            let mut _12: &i32;           // in scope 2 at $DIR/inline-closure-captures.rs:+1:13: +1:24
+            let mut _13: &T;             // in scope 2 at $DIR/inline-closure-captures.rs:+1:13: +1:24
         }
     }
 

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -29,10 +29,10 @@
 +         let mut _9: bool;                // in scope 6 at $DIR/inline-generator.rs:15:20: 15:21
 +         let mut _10: bool;               // in scope 6 at $DIR/inline-generator.rs:15:9: 15:9
 +         let _11: bool;                   // in scope 6 at $DIR/inline-generator.rs:15:6: 15:7
-+         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         let mut _13: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         let mut _14: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         let mut _15: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         let mut _13: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         let mut _14: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         let mut _15: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +     }
   
       bb0: {
@@ -75,9 +75,9 @@
 +         _7 = const false;                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 +         StorageLive(_10);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
 +         StorageLive(_11);                // scope 0 at $DIR/inline-generator.rs:+1:14: +1:46
-+         _13 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         _12 = discriminant((*_13));      // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         _13 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         _12 = discriminant((*_13));      // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
       }
   
 -     bb3: {
@@ -98,7 +98,7 @@
 +     }
 + 
 +     bb3: {
-+         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
 +         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
 +         _9 = _11;                        // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
@@ -126,23 +126,23 @@
 +     }
 + 
 +     bb7: {
-+         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
-+         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
-+         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         _15 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         discriminant((*_15)) = 1;        // scope 6 at $DIR/inline-generator.rs:15:8: 15:8
-+         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:8: 15:8
++         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         _15 = deref_copy (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         discriminant((*_15)) = 1;        // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:41: 15:41
 +     }
 + 
 +     bb8: {
-+         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +     }
 + 
 +     bb9: {
-+         unreachable;                     // scope 6 at $DIR/inline-generator.rs:15:5: 15:8
++         unreachable;                     // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
       }
   }
   

--- a/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
@@ -3,20 +3,20 @@
 fn main::{closure#0}(_1: &[closure@main::{closure#0}], _2: &i32) -> &i32 {
     debug x => _2;                       // in scope 0 at $DIR/retag.rs:+0:32: +0:33
     let mut _0: &i32;                    // return place in scope 0 at $DIR/retag.rs:+0:44: +0:48
-    let _3: &i32;                        // in scope 0 at $DIR/retag.rs:42:13: 42:15
+    let _3: &i32;                        // in scope 0 at $DIR/retag.rs:+1:13: +1:15
     scope 1 {
-        debug _y => _3;                  // in scope 1 at $DIR/retag.rs:42:13: 42:15
+        debug _y => _3;                  // in scope 1 at $DIR/retag.rs:+1:13: +1:15
     }
 
     bb0: {
-        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:+0:31: +0:48
+        Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:+0:31: +3:6
         Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:+0:32: +0:33
-        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:42:13: 42:15
-        _3 = _2;                         // scope 0 at $DIR/retag.rs:42:18: 42:19
-        Retag(_3);                       // scope 0 at $DIR/retag.rs:42:18: 42:19
-        _0 = _2;                         // scope 1 at $DIR/retag.rs:43:9: 43:10
-        Retag(_0);                       // scope 1 at $DIR/retag.rs:43:9: 43:10
-        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:44:5: 44:6
-        return;                          // scope 0 at $DIR/retag.rs:+0:48: +0:48
+        StorageLive(_3);                 // scope 0 at $DIR/retag.rs:+1:13: +1:15
+        _3 = _2;                         // scope 0 at $DIR/retag.rs:+1:18: +1:19
+        Retag(_3);                       // scope 0 at $DIR/retag.rs:+1:18: +1:19
+        _0 = _2;                         // scope 1 at $DIR/retag.rs:+2:9: +2:10
+        Retag(_0);                       // scope 1 at $DIR/retag.rs:+2:9: +2:10
+        StorageDead(_3);                 // scope 0 at $DIR/retag.rs:+3:5: +3:6
+        return;                          // scope 0 at $DIR/retag.rs:+3:6: +3:6
     }
 }

--- a/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
@@ -198,6 +198,6 @@ static XXX: &Foo = {
         _0 = &(*_1);                     // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:28: +18:2
         StorageDead(_5);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+18:1: +18:2
         StorageDead(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:+18:1: +18:2
-        return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:1: +18:2
+        return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:+0:1: +18:3
     }
 }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
@@ -5,6 +5,6 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT: i32 = 
 
     bb0: {
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:+0:38: +0:39
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:39
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:40
     }
 }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
@@ -5,6 +5,6 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 9:7>::ASSOCIATED_CONSTANT: i32 = 
 
     bb0: {
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:+0:38: +0:39
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:39
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:+0:5: +0:40
     }
 }

--- a/src/test/run-make/coverage-reports/expected_show_coverage.closure.txt
+++ b/src/test/run-make/coverage-reports/expected_show_coverage.closure.txt
@@ -37,7 +37,7 @@
    37|      0|            countdown = 10;
    38|      0|        }
    39|      0|        "alt string 2".to_owned()
-   40|       |    };
+   40|      0|    };
    41|      1|    println!(
    42|      1|        "The string or alt: {}"
    43|      1|        ,
@@ -79,7 +79,7 @@
    79|      0|            countdown = 10;
    80|      1|        }
    81|      1|        "alt string 4".to_owned()
-   82|       |    };
+   82|      1|    };
    83|      1|    println!(
    84|      1|        "The string or alt: {}"
    85|      1|        ,
@@ -101,7 +101,7 @@
   101|      0|            countdown = 10;
   102|      5|        }
   103|      5|        format!("'{}'", val)
-  104|       |    };
+  104|      5|    };
   105|      1|    println!(
   106|      1|        "Repeated, quoted string: {:?}"
   107|      1|        ,
@@ -125,7 +125,7 @@
   125|      0|            countdown = 10;
   126|      0|        }
   127|      0|        "closure should be unused".to_owned()
-  128|       |    };
+  128|      0|    };
   129|       |
   130|      1|    let mut countdown = 10;
   131|      1|    let _short_unused_closure = | _unused_arg: u8 | countdown += 1;
@@ -177,7 +177,7 @@
   173|      0|            println!(
   174|      0|                "not called: {}",
   175|      0|                if is_true { "check" } else { "me" }
-  176|       |            )
+  176|      0|            )
   177|       |    ;
   178|       |
   179|      1|    let short_used_not_covered_closure_line_break_block_embedded_branch =
@@ -187,7 +187,7 @@
   183|      0|                "not called: {}",
   184|      0|                if is_true { "check" } else { "me" }
   185|       |            )
-  186|       |        }
+  186|      0|        }
   187|       |    ;
   188|       |
   189|      1|    let short_used_covered_closure_line_break_no_block_embedded_branch =
@@ -196,7 +196,7 @@
   192|      1|                "not called: {}",
   193|      1|                if is_true { "check" } else { "me" }
                                                             ^0
-  194|       |            )
+  194|      1|            )
   195|       |    ;
   196|       |
   197|      1|    let short_used_covered_closure_line_break_block_embedded_branch =
@@ -207,7 +207,7 @@
   202|      1|                if is_true { "check" } else { "me" }
                                                             ^0
   203|       |            )
-  204|       |        }
+  204|      1|        }
   205|       |    ;
   206|       |
   207|      1|    if is_false {

--- a/src/test/run-make/coverage-reports/expected_show_coverage.yield.txt
+++ b/src/test/run-make/coverage-reports/expected_show_coverage.yield.txt
@@ -8,7 +8,7 @@
     8|      1|    let mut generator = || {
     9|      1|        yield 1;
    10|      1|        return "foo"
-   11|       |    };
+   11|      1|    };
    12|       |
    13|      1|    match Pin::new(&mut generator).resume(()) {
    14|      1|        GeneratorState::Yielded(1) => {}
@@ -24,7 +24,7 @@
    24|      1|        yield 2;
    25|      0|        yield 3;
    26|      0|        return "foo"
-   27|       |    };
+   27|      0|    };
    28|       |
    29|      1|    match Pin::new(&mut generator).resume(()) {
    30|      1|        GeneratorState::Yielded(1) => {}

--- a/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -2,13 +2,13 @@ error[E0391]: cycle detected when const-evaluating + checking `Tr::A`
   --> $DIR/defaults-cyclic-fail.rs:5:5
    |
 LL |     const A: u8 = Self::B;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: ...which requires const-evaluating + checking `Tr::B`...
   --> $DIR/defaults-cyclic-fail.rs:8:5
    |
 LL |     const B: u8 = Self::A;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `Tr::A`, completing the cycle
 note: cycle used when const-evaluating + checking `main::promoted[1]`
   --> $DIR/defaults-cyclic-fail.rs:16:16

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -13,7 +13,7 @@ note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
    |
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -13,7 +13,7 @@ note: ...which requires const-evaluating + checking `DEFAULT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
    |
 LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `FooDefault::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -13,7 +13,7 @@ note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
    |

--- a/src/test/ui/consts/issue-36163.stderr
+++ b/src/test/ui/consts/issue-36163.stderr
@@ -8,7 +8,7 @@ note: ...which requires const-evaluating + checking `A`...
   --> $DIR/issue-36163.rs:1:1
    |
 LL | const A: isize = Foo::B as isize;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `Foo::B::{constant#0}`, completing the cycle
 note: cycle used when simplifying constant for the type system `Foo::B::{constant#0}`
   --> $DIR/issue-36163.rs:4:9

--- a/src/test/ui/impl-trait/auto-trait-leak.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak.stderr
@@ -29,6 +29,11 @@ note: ...which requires building MIR for `cycle1`...
    |
 LL | fn cycle1() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires building THIR for `cycle1`...
+  --> $DIR/auto-trait-leak.rs:12:1
+   |
+LL | fn cycle1() -> impl Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires type-checking `cycle1`...
   --> $DIR/auto-trait-leak.rs:14:5
    |
@@ -61,6 +66,11 @@ note: ...which requires unsafety-checking `cycle2`...
 LL | fn cycle2() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires building MIR for `cycle2`...
+  --> $DIR/auto-trait-leak.rs:19:1
+   |
+LL | fn cycle2() -> impl Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires building THIR for `cycle2`...
   --> $DIR/auto-trait-leak.rs:19:1
    |
 LL | fn cycle2() -> impl Clone {

--- a/src/test/ui/issues/issue-17252.stderr
+++ b/src/test/ui/issues/issue-17252.stderr
@@ -2,7 +2,7 @@ error[E0391]: cycle detected when const-evaluating + checking `FOO`
   --> $DIR/issue-17252.rs:1:1
    |
 LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires const-evaluating + checking `FOO` again
 note: cycle used when const-evaluating + checking `main::{constant#0}`

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -2,13 +2,13 @@ error[E0391]: cycle detected when const-evaluating + checking `A`
   --> $DIR/issue-23302-3.rs:1:1
    |
 LL | const A: i32 = B;
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^
    |
 note: ...which requires const-evaluating + checking `B`...
   --> $DIR/issue-23302-3.rs:3:1
    |
 LL | const B: i32 = A;
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `A`, completing the cycle
 note: cycle used when simplifying constant for the type system `A`
   --> $DIR/issue-23302-3.rs:1:1

--- a/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/escape-argument-callee.rs:26:38
    |
 LL |         let mut closure = expect_sig(|p, y| *p = y);
-   |                                      ^^^^^^^^^^^^^
+   |                                      ^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,
@@ -22,14 +22,8 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
 note: no external requirements
   --> $DIR/escape-argument-callee.rs:20:1
    |
-LL | / fn test() {
-LL | |     let x = 44;
-LL | |     let mut p = &x;
-LL | |
-...  |
-LL | |     deref(p);
-LL | | }
-   | |_^
+LL | fn test() {
+   | ^^^^^^^^^
    |
    = note: defining type: test
 

--- a/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/escape-argument-callee.rs:26:38
    |
 LL |         let mut closure = expect_sig(|p, y| *p = y);
-   |                                      ^^^^^^
+   |                                      ^^^^^^^^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/escape-argument.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/escape-argument.rs:26:38
    |
 LL |         let mut closure = expect_sig(|p, y| *p = y);
-   |                                      ^^^^^^^^^^^^^
+   |                                      ^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,
@@ -13,14 +13,8 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
 note: no external requirements
   --> $DIR/escape-argument.rs:20:1
    |
-LL | / fn test() {
-LL | |     let x = 44;
-LL | |     let mut p = &x;
-LL | |
-...  |
-LL | |     deref(p);
-LL | | }
-   | |_^
+LL | fn test() {
+   | ^^^^^^^^^
    |
    = note: defining type: test
 

--- a/src/test/ui/nll/closure-requirements/escape-argument.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/escape-argument.rs:26:38
    |
 LL |         let mut closure = expect_sig(|p, y| *p = y);
-   |                                      ^^^^^^
+   |                                      ^^^^^^^^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/escape-upvar-nested.rs:21:32
    |
 LL |             let mut closure1 = || p = &y;
-   |                                ^^^^^^^^^
+   |                                ^^
    |
    = note: defining type: test::{closure#0}::{closure#0} with closure substs [
                i16,
@@ -15,12 +15,8 @@ LL |             let mut closure1 = || p = &y;
 note: external requirements
   --> $DIR/escape-upvar-nested.rs:20:27
    |
-LL |           let mut closure = || {
-   |  ___________________________^
-LL | |             let mut closure1 = || p = &y;
-LL | |             closure1();
-LL | |         };
-   | |_________^
+LL |         let mut closure = || {
+   |                           ^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,
@@ -33,14 +29,8 @@ LL | |         };
 note: no external requirements
   --> $DIR/escape-upvar-nested.rs:13:1
    |
-LL | / fn test() {
-LL | |     let x = 44;
-LL | |     let mut p = &x;
-LL | |
-...  |
-LL | |     deref(p);
-LL | | }
-   | |_^
+LL | fn test() {
+   | ^^^^^^^^^
    |
    = note: defining type: test
 

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/escape-upvar-nested.rs:21:32
    |
 LL |             let mut closure1 = || p = &y;
-   |                                ^^
+   |                                ^^^^^^^^^
    |
    = note: defining type: test::{closure#0}::{closure#0} with closure substs [
                i16,
@@ -15,8 +15,12 @@ LL |             let mut closure1 = || p = &y;
 note: external requirements
   --> $DIR/escape-upvar-nested.rs:20:27
    |
-LL |         let mut closure = || {
-   |                           ^^
+LL |           let mut closure = || {
+   |  ___________________________^
+LL | |             let mut closure1 = || p = &y;
+LL | |             closure1();
+LL | |         };
+   | |_________^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/escape-upvar-ref.rs:23:27
    |
 LL |         let mut closure = || p = &y;
-   |                           ^^^^^^^^^
+   |                           ^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,
@@ -15,14 +15,8 @@ LL |         let mut closure = || p = &y;
 note: no external requirements
   --> $DIR/escape-upvar-ref.rs:17:1
    |
-LL | / fn test() {
-LL | |     let x = 44;
-LL | |     let mut p = &x;
-LL | |
-...  |
-LL | |     deref(p);
-LL | | }
-   | |_^
+LL | fn test() {
+   | ^^^^^^^^^
    |
    = note: defining type: test
 

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/escape-upvar-ref.rs:23:27
    |
 LL |         let mut closure = || p = &y;
-   |                           ^^
+   |                           ^^^^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -1,12 +1,8 @@
 note: no external requirements
   --> $DIR/propagate-approximated-fail-no-postdom.rs:43:9
    |
-LL | /         |_outlives1, _outlives2, _outlives3, x, y| {
-LL | |             // Only works if 'x: 'y:
-LL | |             let p = x.get();
-LL | |             demand_y(x, y, p)
-LL | |         },
-   | |_________^
+LL |         |_outlives1, _outlives2, _outlives3, x, y| {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
@@ -31,14 +27,8 @@ LL |             demand_y(x, y, p)
 note: no external requirements
   --> $DIR/propagate-approximated-fail-no-postdom.rs:38:1
    |
-LL | / fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {
-LL | |     establish_relationships(
-LL | |         cell_a,
-LL | |         cell_b,
-...  |
-LL | |     );
-LL | | }
-   | |_^
+LL | fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -1,8 +1,12 @@
 note: no external requirements
   --> $DIR/propagate-approximated-fail-no-postdom.rs:43:9
    |
-LL |         |_outlives1, _outlives2, _outlives3, x, y| {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /         |_outlives1, _outlives2, _outlives3, x, y| {
+LL | |             // Only works if 'x: 'y:
+LL | |             let p = x.get();
+LL | |             demand_y(x, y, p)
+LL | |         },
+   | |_________^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -1,13 +1,8 @@
 note: external requirements
   --> $DIR/propagate-approximated-ref.rs:43:47
    |
-LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |  _______________________________________________^
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |
-LL | |     });
-   | |_____^
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
@@ -22,14 +17,8 @@ LL | |     });
 note: no external requirements
   --> $DIR/propagate-approximated-ref.rs:42:1
    |
-LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-LL | |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |
-LL | |     });
-LL | | }
-   | |_^
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -1,8 +1,13 @@
 note: external requirements
   --> $DIR/propagate-approximated-ref.rs:43:47
    |
-LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |  _______________________________________________^
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(x, y, x.get())
+LL | |
+LL | |     });
+   | |_____^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -1,12 +1,8 @@
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:21:15
    |
-LL |       foo(cell, |cell_a, cell_x| {
-   |  _______________^
-LL | |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-LL | |
-LL | |     })
-   | |_____^
+LL |     foo(cell, |cell_a, cell_x| {
+   |               ^^^^^^^^^^^^^^^^
    |
    = note: defining type: case1::{closure#0} with closure substs [
                i32,
@@ -27,25 +23,16 @@ LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:18:1
    |
-LL | / fn case1() {
-LL | |     let a = 0;
-LL | |     let cell = Cell::new(&a);
-LL | |     foo(cell, |cell_a, cell_x| {
-...  |
-LL | |     })
-LL | | }
-   | |_^
+LL | fn case1() {
+   | ^^^^^^^^^^
    |
    = note: defining type: case1
 
 note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:35:15
    |
-LL |       foo(cell, |cell_a, cell_x| {
-   |  _______________^
-LL | |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static -> borrow error
-LL | |     })
-   | |_____^
+LL |     foo(cell, |cell_a, cell_x| {
+   |               ^^^^^^^^^^^^^^^^
    |
    = note: defining type: case2::{closure#0} with closure substs [
                i32,
@@ -58,14 +45,8 @@ LL | |     })
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:28:1
    |
-LL | / fn case2() {
-LL | |     let a = 0;
-LL | |     let cell = Cell::new(&a);
-LL | |
-...  |
-LL | |     })
-LL | | }
-   | |_^
+LL | fn case2() {
+   | ^^^^^^^^^^
    |
    = note: defining type: case2
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -1,8 +1,12 @@
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:21:15
    |
-LL |     foo(cell, |cell_a, cell_x| {
-   |               ^^^^^^^^^^^^^^^^
+LL |       foo(cell, |cell_a, cell_x| {
+   |  _______________^
+LL | |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
+LL | |
+LL | |     })
+   | |_____^
    |
    = note: defining type: case1::{closure#0} with closure substs [
                i32,
@@ -37,8 +41,11 @@ LL | | }
 note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:35:15
    |
-LL |     foo(cell, |cell_a, cell_x| {
-   |               ^^^^^^^^^^^^^^^^
+LL |       foo(cell, |cell_a, cell_x| {
+   |  _______________^
+LL | |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static -> borrow error
+LL | |     })
+   | |_____^
    |
    = note: defining type: case2::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -1,14 +1,8 @@
 note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:32:47
    |
-LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-   |  _______________________________________________^
-LL | |
-LL | |
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |     });
-   | |_____^
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
+   |                                               ^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
@@ -23,14 +17,8 @@ LL | |     });
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:31:1
    |
-LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-LL | |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-LL | |
-LL | |
-...  |
-LL | |     });
-LL | | }
-   | |_^
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -1,8 +1,14 @@
 note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:32:47
    |
-LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-   |                                               ^^^^^^^^^^^^^^^^^
+LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
+   |  _______________________________________________^
+LL | |
+LL | |
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(x, y, x.get())
+LL | |     });
+   | |_____^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -1,8 +1,14 @@
 note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:35:47
    |
-LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |  _______________________________________________^
+LL | |
+LL | |
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(x, y, x.get())
+LL | |     });
+   | |_____^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -1,14 +1,8 @@
 note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:35:47
    |
-LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |  _______________________________________________^
-LL | |
-LL | |
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |     });
-   | |_____^
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
@@ -23,14 +17,8 @@ LL | |     });
 note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:34:1
    |
-LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-LL | |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-LL | |
-LL | |
-...  |
-LL | |     });
-LL | | }
-   | |_^
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -1,13 +1,8 @@
 note: external requirements
   --> $DIR/propagate-approximated-val.rs:36:45
    |
-LL |       establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
-   |  _____________________________________________^
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(outlives1, outlives2, x.get())
-LL | |
-LL | |     });
-   | |_____^
+LL |     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,
@@ -22,14 +17,8 @@ LL | |     });
 note: no external requirements
   --> $DIR/propagate-approximated-val.rs:35:1
    |
-LL | / fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-LL | |     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(outlives1, outlives2, x.get())
-LL | |
-LL | |     });
-LL | | }
-   | |_^
+LL | fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: test
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -1,8 +1,13 @@
 note: external requirements
   --> $DIR/propagate-approximated-val.rs:36:45
    |
-LL |     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
+   |  _____________________________________________^
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(outlives1, outlives2, x.get())
+LL | |
+LL | |     });
+   | |_____^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
@@ -1,12 +1,8 @@
 note: external requirements
   --> $DIR/propagate-despite-same-free-region.rs:42:9
    |
-LL | /         |_outlives1, _outlives2, x, y| {
-LL | |             // Only works if 'x: 'y:
-LL | |             let p = x.get();
-LL | |             demand_y(x, y, p)
-LL | |         },
-   | |_________^
+LL |         |_outlives1, _outlives2, x, y| {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
@@ -20,14 +16,8 @@ LL | |         },
 note: no external requirements
   --> $DIR/propagate-despite-same-free-region.rs:39:1
    |
-LL | / fn supply<'a>(cell_a: Cell<&'a u32>) {
-LL | |     establish_relationships(
-LL | |         cell_a,
-LL | |         |_outlives1, _outlives2, x, y| {
-...  |
-LL | |     );
-LL | | }
-   | |_^
+LL | fn supply<'a>(cell_a: Cell<&'a u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
@@ -1,8 +1,12 @@
 note: external requirements
   --> $DIR/propagate-despite-same-free-region.rs:42:9
    |
-LL |         |_outlives1, _outlives2, x, y| {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /         |_outlives1, _outlives2, x, y| {
+LL | |             // Only works if 'x: 'y:
+LL | |             let p = x.get();
+LL | |             demand_y(x, y, p)
+LL | |         },
+   | |_________^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -1,8 +1,13 @@
 note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:35:47
    |
-LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-   |                                               ^^^^^^^^^^^^^^^^^
+LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
+   |  _______________________________________________^
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(x, y, x.get())
+LL | |
+LL | |     });
+   | |_____^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -1,13 +1,8 @@
 note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:35:47
    |
-LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-   |  _______________________________________________^
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |
-LL | |     });
-   | |_____^
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
+   |                                               ^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
@@ -31,14 +26,8 @@ LL |         demand_y(x, y, x.get())
 note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:34:1
    |
-LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-LL | |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |
-LL | |     });
-LL | | }
-   | |_^
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -1,8 +1,13 @@
 note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:39:47
    |
-LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |  _______________________________________________^
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(x, y, x.get())
+LL | |
+LL | |     });
+   | |_____^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -1,13 +1,8 @@
 note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:39:47
    |
-LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |  _______________________________________________^
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |
-LL | |     });
-   | |_____^
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply::{closure#0} with closure substs [
                i16,
@@ -31,14 +26,8 @@ LL |         demand_y(x, y, x.get())
 note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:38:1
    |
-LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-LL | |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |
-LL | |     });
-LL | | }
-   | |_^
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -1,15 +1,8 @@
 note: external requirements
   --> $DIR/propagate-from-trait-match.rs:32:36
    |
-LL |       establish_relationships(value, |value| {
-   |  ____________________________________^
-LL | |
-LL | |
-LL | |         // This function call requires that
-...  |
-LL | |         require(value);
-LL | |     });
-   | |_____^
+LL |     establish_relationships(value, |value| {
+   |                                    ^^^^^^^
    |
    = note: defining type: supply::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -25,11 +18,7 @@ note: no external requirements
 LL | / fn supply<'a, T>(value: T)
 LL | | where
 LL | |     T: Trait<'a>,
-LL | | {
-...  |
-LL | |     });
-LL | | }
-   | |_^
+   | |_________________^
    |
    = note: defining type: supply::<'_#1r, T>
 

--- a/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -1,8 +1,15 @@
 note: external requirements
   --> $DIR/propagate-from-trait-match.rs:32:36
    |
-LL |     establish_relationships(value, |value| {
-   |                                    ^^^^^^^
+LL |       establish_relationships(value, |value| {
+   |  ____________________________________^
+LL | |
+LL | |
+LL | |         // This function call requires that
+...  |
+LL | |         require(value);
+LL | |     });
+   | |_____^
    |
    = note: defining type: supply::<'_#1r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/return-wrong-bound-region.rs:11:16
    |
 LL |     expect_sig(|a, b| b); // ought to return `a`
-   |                ^^^^^^^^
+   |                ^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,
@@ -22,11 +22,8 @@ LL |     expect_sig(|a, b| b); // ought to return `a`
 note: no external requirements
   --> $DIR/return-wrong-bound-region.rs:10:1
    |
-LL | / fn test() {
-LL | |     expect_sig(|a, b| b); // ought to return `a`
-LL | |
-LL | | }
-   | |_^
+LL | fn test() {
+   | ^^^^^^^^^
    |
    = note: defining type: test
 

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/return-wrong-bound-region.rs:11:16
    |
 LL |     expect_sig(|a, b| b); // ought to return `a`
-   |                ^^^^^^
+   |                ^^^^^^^^
    |
    = note: defining type: test::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:25:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: defining type: no_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -18,11 +18,7 @@ note: no external requirements
 LL | / fn no_region<'a, T>(x: Box<T>) -> Box<dyn Anything + 'a>
 LL | | where
 LL | |     T: Iterator,
-LL | | {
-LL | |     with_signature(x, |mut y| Box::new(y.next()))
-LL | |
-LL | | }
-   | |_^
+   | |________________^
    |
    = note: defining type: no_region::<'_#1r, T>
 
@@ -39,7 +35,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:34:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: defining type: correct_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -55,10 +51,7 @@ note: no external requirements
 LL | / fn correct_region<'a, T>(x: Box<T>) -> Box<dyn Anything + 'a>
 LL | | where
 LL | |     T: 'a + Iterator,
-LL | | {
-LL | |     with_signature(x, |mut y| Box::new(y.next()))
-LL | | }
-   | |_^
+   | |_____________________^
    |
    = note: defining type: correct_region::<'_#1r, T>
 
@@ -66,7 +59,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:42:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: defining type: wrong_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -82,11 +75,7 @@ note: no external requirements
 LL | / fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<dyn Anything + 'a>
 LL | | where
 LL | |     T: 'b + Iterator,
-LL | | {
-LL | |     with_signature(x, |mut y| Box::new(y.next()))
-LL | |
-LL | | }
-   | |_^
+   | |_____________________^
    |
    = note: defining type: wrong_region::<'_#1r, '_#2r, T>
 
@@ -103,7 +92,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:52:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -120,10 +109,7 @@ LL | / fn outlives_region<'a, 'b, T>(x: Box<T>) -> Box<dyn Anything + 'a>
 LL | | where
 LL | |     T: 'b + Iterator,
 LL | |     'b: 'a,
-LL | | {
-LL | |     with_signature(x, |mut y| Box::new(y.next()))
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: outlives_region::<'_#1r, '_#2r, T>
 

--- a/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:25:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -39,7 +39,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:34:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: correct_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -66,7 +66,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:42:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: wrong_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -103,7 +103,7 @@ note: external requirements
   --> $DIR/projection-no-regions-closure.rs:52:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:45:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -56,7 +56,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:56:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -109,7 +109,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:70:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -137,7 +137,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:80:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:45:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -20,11 +20,7 @@ note: no external requirements
 LL | / fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
-LL | | {
-...  |
-LL | |
-LL | | }
-   | |_^
+   | |____________________^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>
 
@@ -56,7 +52,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:56:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -74,10 +70,7 @@ LL | / fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
-...  |
-LL | |
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
@@ -109,7 +102,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:70:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -126,10 +119,7 @@ LL | / fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |_____________________^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
@@ -137,7 +127,7 @@ note: external requirements
   --> $DIR/projection-one-region-closure.rs:80:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -155,10 +145,8 @@ LL | / fn elements_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T: 'a,
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+LL | |     'b: 'a,
+   | |___________^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:37:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -44,7 +44,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -85,7 +85,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:60:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -113,7 +113,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:69:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -141,7 +141,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:81:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:37:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -19,11 +19,7 @@ note: no external requirements
 LL | / fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | |
-LL | | }
-   | |_^
+   | |____________________^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>
 
@@ -44,7 +40,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -61,10 +57,7 @@ LL | / fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
-...  |
-LL | |
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
@@ -85,7 +78,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:60:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -102,10 +95,7 @@ LL | / fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |_____________________^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
@@ -113,7 +103,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:69:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -130,10 +120,7 @@ LL | / fn elements_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'b: 'a,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 
@@ -141,7 +128,7 @@ note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:81:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -157,11 +144,7 @@ note: no external requirements
 LL | / fn one_region<'a, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'a>,
-LL | | {
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |____________________^
    |
    = note: defining type: one_region::<'_#1r, T>
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:36:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -28,7 +28,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:45:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -54,7 +54,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:64:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -80,7 +80,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:73:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -106,7 +106,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:85:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -2,7 +2,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:36:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -17,10 +17,7 @@ note: no external requirements
 LL | / fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |____________________^
    |
    = note: defining type: no_relationships_late::<'_#1r, T>
 
@@ -28,7 +25,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:45:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -43,10 +40,7 @@ LL | / fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'a: 'a,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
@@ -54,7 +48,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:64:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -69,10 +63,7 @@ LL | / fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     T::AssocType: 'a,
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |_____________________^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
@@ -80,7 +71,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:73:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -95,10 +86,7 @@ LL | / fn elements_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b>,
 LL | |     'b: 'a,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 
@@ -106,7 +94,7 @@ note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:85:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -120,11 +108,7 @@ note: no external requirements
 LL | / fn one_region<'a, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'a>,
-LL | | {
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |____________________^
    |
    = note: defining type: one_region::<'_#1r, T>
 

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -40,7 +40,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -77,7 +77,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -105,7 +105,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:70:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -133,7 +133,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:79:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -161,7 +161,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: two_regions::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -203,7 +203,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:97:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -231,7 +231,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:109:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -19,11 +19,7 @@ note: no external requirements
 LL | / fn no_relationships_late<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b, 'c>,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | |
-LL | | }
-   | |_^
+   | |________________________^
    |
    = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>
 
@@ -40,7 +36,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -57,10 +53,7 @@ LL | / fn no_relationships_early<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b, 'c>,
 LL | |     'a: 'a,
-...  |
-LL | |
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>
 
@@ -77,7 +70,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -94,10 +87,7 @@ LL | / fn projection_outlives<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b, 'c>,
 LL | |     T::AssocType: 'a,
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |_____________________^
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>
 
@@ -105,7 +95,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:70:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -122,10 +112,7 @@ LL | / fn elements_outlive1<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b, 'c>,
 LL | |     'b: 'a,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>
 
@@ -133,7 +120,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:79:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>::{closure#0} with closure substs [
                i32,
@@ -150,10 +137,7 @@ LL | / fn elements_outlive2<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b, 'c>,
 LL | |     'c: 'a,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>
 
@@ -161,7 +145,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: two_regions::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -178,11 +162,7 @@ note: no external requirements
 LL | / fn two_regions<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b, 'b>,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | |
-LL | | }
-   | |_^
+   | |________________________^
    |
    = note: defining type: two_regions::<'_#1r, T>
 
@@ -203,7 +183,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:97:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -220,10 +200,7 @@ LL | / fn two_regions_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'b, 'b>,
 LL | |     'b: 'a,
-LL | | {
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>
 
@@ -231,7 +208,7 @@ note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:109:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^
    |
    = note: defining type: one_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -247,11 +224,7 @@ note: no external requirements
 LL | / fn one_region<'a, T>(cell: Cell<&'a ()>, t: T)
 LL | | where
 LL | |     T: Anything<'a, 'a>,
-LL | | {
-...  |
-LL | |     with_signature(cell, t, |cell, t| require(cell, t));
-LL | | }
-   | |_^
+   | |________________________^
    |
    = note: defining type: one_region::<'_#1r, T>
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:24:24
    |
 LL |     twice(cell, value, |a, b| invoke(a, b));
-   |                        ^^^^^^
+   |                        ^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: generic::<T>::{closure#0} with closure substs [
                i16,
@@ -27,7 +27,7 @@ note: external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:29:24
    |
 LL |     twice(cell, value, |a, b| invoke(a, b));
-   |                        ^^^^^^
+   |                        ^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: generic_fail::<T>::{closure#0} with closure substs [
                i16,

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:24:24
    |
 LL |     twice(cell, value, |a, b| invoke(a, b));
-   |                        ^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^
    |
    = note: defining type: generic::<T>::{closure#0} with closure substs [
                i16,
@@ -15,11 +15,8 @@ LL |     twice(cell, value, |a, b| invoke(a, b));
 note: no external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:22:1
    |
-LL | / fn generic<T>(value: T) {
-LL | |     let cell = Cell::new(&());
-LL | |     twice(cell, value, |a, b| invoke(a, b));
-LL | | }
-   | |_^
+LL | fn generic<T>(value: T) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: generic::<T>
 
@@ -27,7 +24,7 @@ note: external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:29:24
    |
 LL |     twice(cell, value, |a, b| invoke(a, b));
-   |                        ^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^
    |
    = note: defining type: generic_fail::<T>::{closure#0} with closure substs [
                i16,
@@ -41,11 +38,8 @@ LL |     twice(cell, value, |a, b| invoke(a, b));
 note: no external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:28:1
    |
-LL | / fn generic_fail<'a, T>(cell: Cell<&'a ()>, value: T) {
-LL | |     twice(cell, value, |a, b| invoke(a, b));
-LL | |
-LL | | }
-   | |_^
+LL | fn generic_fail<'a, T>(cell: Cell<&'a ()>, value: T) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: generic_fail::<T>
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:26:23
    |
 LL |     with_signature(x, |y| y)
-   |                       ^^^
+   |                       ^^^^^
    |
    = note: defining type: no_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -2,7 +2,7 @@ note: external requirements
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:26:23
    |
 LL |     with_signature(x, |y| y)
-   |                       ^^^^^
+   |                       ^^^
    |
    = note: defining type: no_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -18,11 +18,7 @@ note: no external requirements
 LL | / fn no_region<'a, T>(x: Box<T>) -> Box<dyn Debug + 'a>
 LL | | where
 LL | |     T: Debug,
-LL | | {
-...  |
-LL | |
-LL | | }
-   | |_^
+   | |_____________^
    |
    = note: defining type: no_region::<'_#1r, T>
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -1,15 +1,8 @@
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:27:26
    |
-LL |       with_signature(a, b, |x, y| {
-   |  __________________________^
-LL | |
-LL | |         //
-LL | |         // See `correct_region`, which explains the point of this
-...  |
-LL | |         require(&x, &y)
-LL | |     })
-   | |_____^
+LL |     with_signature(a, b, |x, y| {
+   |                          ^^^^^^
    |
    = note: defining type: no_region::<T>::{closure#0} with closure substs [
                i32,
@@ -23,14 +16,8 @@ LL | |     })
 note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:26:1
    |
-LL | / fn no_region<'a, T>(a: Cell<&'a ()>, b: T) {
-LL | |     with_signature(a, b, |x, y| {
-LL | |
-LL | |         //
-...  |
-LL | |     })
-LL | | }
-   | |_^
+LL | fn no_region<'a, T>(a: Cell<&'a ()>, b: T) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defining type: no_region::<T>
 
@@ -55,15 +42,8 @@ LL | fn no_region<'a, T: 'a>(a: Cell<&'a ()>, b: T) {
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:43:26
    |
-LL |       with_signature(a, b, |x, y| {
-   |  __________________________^
-LL | |         // Key point of this test:
-LL | |         //
-LL | |         // The *closure* is being type-checked with all of its free
-...  |
-LL | |         require(&x, &y)
-LL | |     })
-   | |_____^
+LL |     with_signature(a, b, |x, y| {
+   |                          ^^^^^^
    |
    = note: defining type: correct_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -79,24 +59,15 @@ note: no external requirements
 LL | / fn correct_region<'a, T>(a: Cell<&'a ()>, b: T)
 LL | | where
 LL | |     T: 'a,
-LL | | {
-...  |
-LL | |     })
-LL | | }
-   | |_^
+   | |__________^
    |
    = note: defining type: correct_region::<'_#1r, T>
 
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:64:26
    |
-LL |       with_signature(a, b, |x, y| {
-   |  __________________________^
-LL | |
-LL | |         // See `correct_region`
-LL | |         require(&x, &y)
-LL | |     })
-   | |_____^
+LL |     with_signature(a, b, |x, y| {
+   |                          ^^^^^^
    |
    = note: defining type: wrong_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -113,11 +84,7 @@ note: no external requirements
 LL | / fn wrong_region<'a, 'b, T>(a: Cell<&'a ()>, b: T)
 LL | | where
 LL | |     T: 'b,
-LL | | {
-...  |
-LL | |     })
-LL | | }
-   | |_^
+   | |__________^
    |
    = note: defining type: wrong_region::<'_#1r, T>
 
@@ -140,12 +107,8 @@ LL |     T: 'b + 'a,
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:77:26
    |
-LL |       with_signature(a, b, |x, y| {
-   |  __________________________^
-LL | |         // See `correct_region`
-LL | |         require(&x, &y)
-LL | |     })
-   | |_____^
+LL |     with_signature(a, b, |x, y| {
+   |                          ^^^^^^
    |
    = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,
@@ -162,10 +125,7 @@ LL | / fn outlives_region<'a, 'b, T>(a: Cell<&'a ()>, b: T)
 LL | | where
 LL | |     T: 'b,
 LL | |     'b: 'a,
-...  |
-LL | |     })
-LL | | }
-   | |_^
+   | |___________^
    |
    = note: defining type: outlives_region::<'_#1r, '_#2r, T>
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -1,8 +1,15 @@
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:27:26
    |
-LL |     with_signature(a, b, |x, y| {
-   |                          ^^^^^^
+LL |       with_signature(a, b, |x, y| {
+   |  __________________________^
+LL | |
+LL | |         //
+LL | |         // See `correct_region`, which explains the point of this
+...  |
+LL | |         require(&x, &y)
+LL | |     })
+   | |_____^
    |
    = note: defining type: no_region::<T>::{closure#0} with closure substs [
                i32,
@@ -48,8 +55,15 @@ LL | fn no_region<'a, T: 'a>(a: Cell<&'a ()>, b: T) {
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:43:26
    |
-LL |     with_signature(a, b, |x, y| {
-   |                          ^^^^^^
+LL |       with_signature(a, b, |x, y| {
+   |  __________________________^
+LL | |         // Key point of this test:
+LL | |         //
+LL | |         // The *closure* is being type-checked with all of its free
+...  |
+LL | |         require(&x, &y)
+LL | |     })
+   | |_____^
    |
    = note: defining type: correct_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -76,8 +90,13 @@ LL | | }
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:64:26
    |
-LL |     with_signature(a, b, |x, y| {
-   |                          ^^^^^^
+LL |       with_signature(a, b, |x, y| {
+   |  __________________________^
+LL | |
+LL | |         // See `correct_region`
+LL | |         require(&x, &y)
+LL | |     })
+   | |_____^
    |
    = note: defining type: wrong_region::<'_#1r, T>::{closure#0} with closure substs [
                i32,
@@ -121,8 +140,12 @@ LL |     T: 'b + 'a,
 note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:77:26
    |
-LL |     with_signature(a, b, |x, y| {
-   |                          ^^^^^^
+LL |       with_signature(a, b, |x, y| {
+   |  __________________________^
+LL | |         // See `correct_region`
+LL | |         require(&x, &y)
+LL | |     })
+   | |_____^
    |
    = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{closure#0} with closure substs [
                i32,

--- a/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
@@ -30,14 +30,15 @@ error[E0597]: `c` does not live long enough
    |
 LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
-LL |     let _closure = || {
-   |                     - `c` dropped here while still borrowed
 ...
 LL |             SomeEnum::SomeVariant(Cell::new(&c)),
    |                                   ----------^^-
    |                                   |         |
    |                                   |         borrowed value does not live long enough
    |                                   argument requires that `c` is borrowed for `'a`
+...
+LL |     };
+   |     - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
@@ -28,28 +28,28 @@ error[E0597]: `c` does not live long enough
    |
 LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
-LL |     let _closure = || {
-   |                     - `c` dropped here while still borrowed
 ...
 LL |         f(&c);
    |         --^^-
    |         | |
    |         | borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'a`
+LL |     };
+   |     - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:53:11
    |
 LL |     let f = SomeStruct::<&'a u32>;
    |         - lifetime `'1` appears in the type of `f`
-LL |     let _closure = || {
-   |                     - `c` dropped here while still borrowed
-LL |         let c = 66;
+...
 LL |         f(&c);
    |         --^^-
    |         | |
    |         | borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'1`
+LL |     };
+   |     - `c` dropped here while still borrowed
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/nll/user-annotations/fns.stderr
+++ b/src/test/ui/nll/user-annotations/fns.stderr
@@ -28,14 +28,14 @@ error[E0597]: `c` does not live long enough
    |
 LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
-LL |     let _closure = || {
-   |                     - `c` dropped here while still borrowed
-LL |         let c = 66;
+...
 LL |         some_fn::<&'a u32>(&c);
    |         -------------------^^-
    |         |                  |
    |         |                  borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'a`
+LL |     };
+   |     - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-call.stderr
+++ b/src/test/ui/nll/user-annotations/method-call.stderr
@@ -29,14 +29,13 @@ error[E0597]: `c` does not live long enough
 LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
-LL |     let _closure = || {
-   |                     - `c` dropped here while still borrowed
-LL |         let c = 66;
 LL |         a.method::<&'a u32>(b,  &c);
    |         ------------------------^^-
    |         |                       |
    |         |                       borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'a`
+LL |     };
+   |     - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
@@ -29,14 +29,13 @@ error[E0597]: `c` does not live long enough
 LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
-LL |     let _closure = || {
-   |                     - `c` dropped here while still borrowed
-LL |         let c = 66;
 LL |         <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
    |         -------------------------------------------^^-
    |         |                                          |
    |         |                                          borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'a`
+LL |     };
+   |     - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/thir-tree.stdout
+++ b/src/test/ui/thir-tree.stdout
@@ -54,5 +54,6 @@ Thir {
         },
     ],
     stmts: [],
+    params: [],
 }
 


### PR DESCRIPTION
Successful merges:

 - #93873 (Reimplement `carrying_add` and `borrowing_sub` for signed integers.)
 - #101086 (Compute information about function parameters on THIR)
 - #101455 (Avoid UB in the Windows filesystem code in... bootstrap?)

Failed merges:

 - #101399 (Shrink span for bindings with subpatterns.)
 - #101435 (Remove unnecessary `EMIT_MIR_FOR_EACH_BITWIDTH`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93873,101086,101455)
<!-- homu-ignore:end -->