### PR TITLE
Use linker plugin LTO for compiling `rustc`

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 use crate::builder::Cargo;
 use crate::builder::{Builder, Kind, RunConfig, ShouldRun, Step};
 use crate::cache::{Interned, INTERNER};
-use crate::config::{LlvmLibunwind, RustcLto, TargetSelection};
+use crate::config::{LlvmLibunwind, TargetSelection};
 use crate::dist;
 use crate::native;
 use crate::tool::SourceType;
@@ -702,7 +702,7 @@ impl Step for Rustc {
         }
 
         // cfg(bootstrap): remove if condition once the bootstrap compiler supports dylib LTO
-        if compiler.stage != 0 {
+        /*if compiler.stage != 0 {
             match builder.config.rust_lto {
                 RustcLto::Thin | RustcLto::Fat => {
                     // Since using LTO for optimizing dylibs is currently experimental,
@@ -721,6 +721,22 @@ impl Step for Rustc {
                 }
                 RustcLto::ThinLocal => { /* Do nothing, this is the default */ }
             }
+        }*/
+
+        if compiler.stage == 1 {
+            // let build_bin = builder.llvm_out(builder.config.build).join("build").join("bin");
+            // let clang = build_bin.join("clang");
+            // let clang = PathBuf::from("/projects/personal/llvm-project/build/install/bin/clang");
+            cargo.rustflag("-Clinker-plugin-lto");
+            // cargo.rustflag(&format!("-Clinker={}", clang.display()));
+            // cargo.rustflag("-Clink-arg=-fuse-ld=lld");
+
+            // let path = builder.ensure(CrtBeginEnd {
+            //     target
+            // });
+            // cargo.rustflag(&format!("-Clink-args=-L{}", path.display()));
+            // cargo.rustflag(&format!("-Clink-args=-B{}", path.display()));
+            // cargo.rustflag(&format!("-Clink-args=--gcc-toolchain={}", path.display()));
         }
 
         builder.info(&format!(

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -63,6 +63,8 @@ RUN curl -LS -o perf.zip https://github.com/rust-lang/rustc-perf/archive/$PERF_C
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
+RUN yum install -y libgcc.x86_64 libgcc.i686
+
 ENV PGO_HOST=x86_64-unknown-linux-gnu
 
 ENV HOSTS=x86_64-unknown-linux-gnu
@@ -77,6 +79,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
+      --set llvm.clang=true \
       --set rust.jemalloc \
       --set rust.use-lld=true \
       --set rust.lto=thin


### PR DESCRIPTION
This is yet another alternative to https://github.com/rust-lang/rust/pull/97154 and https://github.com/rust-lang/rust/pull/101403 that experiments with using LTO for compiling `rustc`. Here I try what happens if we apply the linker plugin LTO feature.

r? @ghost