### PR TITLE
Update LLVM used in x86 CI dist builds to `15.0.0`

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-14.0.5
+LLVM=llvmorg-15.0.0
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
LLVM 15.0.0 has been released, so we can use it in CI builds. We need (at least) LLVM 15 for BOLT, and we regularly update to most recent stable versions. It would also be good to first see the perf. effect of upgrading by itself, to have a better baseline for BOLT.

r? @Mark-Simulacrum