### PR TITLE
llvm-wrapper: adapt for LLVM API changes

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -936,12 +936,14 @@ LLVMRustOptimizeWithNewPassManager(
           /*CompileKernel=*/false);
       OptimizerLastEPCallbacks.push_back(
         [Options](ModulePassManager &MPM, OptimizationLevel Level) {
-#if LLVM_VERSION_GE(14, 0)
+#if LLVM_VERSION_GE(14, 0) && LLVM_VERSION_LT(16, 0)
           MPM.addPass(ModuleMemorySanitizerPass(Options));
 #else
           MPM.addPass(MemorySanitizerPass(Options));
 #endif
+#if LLVM_VERSION_LT(16, 0)
           MPM.addPass(createModuleToFunctionPassAdaptor(MemorySanitizerPass(Options)));
+#endif
         }
       );
     }
@@ -972,7 +974,11 @@ LLVMRustOptimizeWithNewPassManager(
             /*UseAfterScope=*/true,
             AsanDetectStackUseAfterReturnMode::Runtime,
           };
+#if LLVM_VERSION_LT(16, 0)
           MPM.addPass(ModuleAddressSanitizerPass(opts));
+#else
+          MPM.addPass(AddressSanitizerPass(opts));
+#endif
 #else
           MPM.addPass(ModuleAddressSanitizerPass(
               /*CompileKernel=*/false, SanitizerOptions->SanitizeAddressRecover));


### PR DESCRIPTION
No functional changes intended.

Adapts PassWrapper for a few recent LLVM API changes:
* https://github.com/llvm/llvm-project/commit/e7bac3b9fa739f8d167a390a547068aad1d424a7
* https://github.com/llvm/llvm-project/commit/93600eb50ceeec83c488ded24fa0fd25f997fec6
* https://github.com/llvm/llvm-project/commit/5e38b2a456df6e263a509af60a731cec57310498

Note that `ModuleMemorySanitizerPass` was renamed back to its pre-14 name, `MemorySanitizerPass`, hence the funky `#if LLVM_VERSION_GE(14, 0) && LLVM_VERSION_LT(16, 0)` guard.

Found via our experimental rust + llvm at HEAD bot: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/13290#018315e6-24e1-44c8-b56d-9aad9be11c29