### PR TITLE
rustdoc: remove unused mobile CSS `.rustdoc { flex-direction }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1762,7 +1762,6 @@ in storage.js plus the media query with (min-width: 701px)
 		padding-top: 0px;
 	}
 
-	.rustdoc,
 	.main-heading {
 		flex-direction: column;
 	}


### PR DESCRIPTION
According to MDN, [flex-direction] only applies to [flex containers], which are boxes with `display: flex` or `inline-flex`.

However, the `.rustdoc` body container is not a flex-container on mobile. A few lines above, it's set to `display: block`, so this selector does not have any effect.

[flex-direction]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction

[flex containers]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox#the_flex_container