### PR TITLE
rustdoc: remove unused CSS `.content .methods > div`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -747,11 +747,6 @@ pre, .rustdoc.source .example-wrap {
 	font-size: 0.875rem;
 }
 
-.content .methods > div:not(.notable-traits):not(.method) {
-	margin-left: 40px;
-	margin-bottom: 15px;
-}
-
 .item-info {
 	display: block;
 }


### PR DESCRIPTION
This selector has its roots in these commits:

  * current version:

    `.content .methods > div:not(.notable-traits):not(.method)` from 9077d540da944c41678a7129e04e7fc5d7e38582

  * intermediate version:

    `.content .methods > div:not(.important-traits)` from d86621f69e827361e47bc6c4b2c7fd5319155227

  * original version:

    `.content .methods > div { margin-left: 40px; }` from 0a46933c4d81573e78ce16cd215ba155a3114fce

Based on the call stack, where [`class='methods'`] calls `trait_item` and [`trait_item`] calls [`document`], this div selector was probably intended to target docblock and stability tags.

In the current version of the code, neither of these can possibly be nested directly below the `class='methods'` wrapper, because the [current version of the `trait_item` function] always wraps them in a `<details>` tag if they exist. The only div tag that can possibly be nested directly below it now is the one with class `method`, which is explicitly excluded.

[`class='methods'`]: https://github.com/rust-lang/rust/blob/0a46933c4d81573e78ce16cd215ba155a3114fce/src/librustdoc/html/render.rs#L1811-L1842

[`trait_item`]: https://github.com/rust-lang/rust/blob/0a46933c4d81573e78ce16cd215ba155a3114fce/src/librustdoc/html/render.rs#L1807

[`document`]: https://github.com/rust-lang/rust/blob/0a46933c4d81573e78ce16cd215ba155a3114fce/src/librustdoc/html/render.rs#L1515-L1523

[current version of the `trait_item` function]: https://github.com/rust-lang/rust/blob/e7c7aa7288559f8e5ea7ce3543ff946b09783628/src/librustdoc/html/render/print_item.rs#L710