### PR TITLE
rustdoc: remove unused CSS `#implementations-list > h3 > span.in-band`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1528,10 +1528,6 @@ kbd {
 	cursor: default;
 }
 
-#implementations-list > h3 > span.in-band {
-	width: 100%;
-}
-
 #main-content > ul {
 	padding-left: 10px;
 }


### PR DESCRIPTION
This was added in 51f26acaea46afd630fbab4ca441748802d20670 to help with the display of an `<h3>` tag that has a `<span class='in-band'>` inside.

The way implementation lists were rendered was changed in 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9 to have `<code class='in-band'>`, making this CSS unused.

Then it was turned into a `<div>` in 9077d540da944c41678a7129e04e7fc5d7e38582 without issue.

Finally, the header itself acquired the `in-band` class in 76a3b609d0b93c5d8da5e4e3db37bd03e5cb1c30.