### PR TITLE
Adding "backtrace off" option for fuchsia targets

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -295,23 +295,22 @@ pub fn get_backtrace_style() -> Option<BacktraceStyle> {
         return Some(style);
     }
 
-    // Setting environment variables for Fuchsia components isn't a standard
-    // or easily supported workflow. For now, display backtraces by default.
-    let format = if cfg!(target_os = "fuchsia") {
-        BacktraceStyle::Full
-    } else {
-        crate::env::var_os("RUST_BACKTRACE")
-            .map(|x| {
-                if &x == "0" {
-                    BacktraceStyle::Off
-                } else if &x == "full" {
-                    BacktraceStyle::Full
-                } else {
-                    BacktraceStyle::Short
-                }
-            })
-            .unwrap_or(BacktraceStyle::Off)
-    };
+    let format = crate::env::var_os("RUST_BACKTRACE")
+        .map(|x| {
+            if &x == "0" {
+                BacktraceStyle::Off
+            } else if &x == "full" {
+                BacktraceStyle::Full
+            } else {
+                BacktraceStyle::Short
+            }
+        })
+        .unwrap_or(if cfg!(target_os = "fuchsia") {
+            // Fuchsia components default to full backtrace.
+            BacktraceStyle::Full
+        } else {
+            BacktraceStyle::Off
+        });
     set_backtrace_style(format);
     Some(format)
 }


### PR DESCRIPTION
Used for improving compiler test suite results on Fuchsia targets