### PR TITLE
Stabilize `waker_getters`

### DIFF
--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -47,7 +47,7 @@ impl RawWaker {
     /// Get the `data` pointer used to create this `RawWaker`.
     #[inline]
     #[must_use]
-    #[unstable(feature = "waker_getters", issue = "87021")]
+    #[stable(feature = "waker_getters", since = "CURRENT_RUSTC_VERSION")]
     pub fn data(&self) -> *const () {
         self.data
     }
@@ -55,7 +55,7 @@ impl RawWaker {
     /// Get the `vtable` pointer used to create this `RawWaker`.
     #[inline]
     #[must_use]
-    #[unstable(feature = "waker_getters", issue = "87021")]
+    #[stable(feature = "waker_getters", since = "CURRENT_RUSTC_VERSION")]
     pub fn vtable(&self) -> &'static RawWakerVTable {
         self.vtable
     }
@@ -318,7 +318,7 @@ impl Waker {
     /// Get a reference to the underlying [`RawWaker`].
     #[inline]
     #[must_use]
-    #[unstable(feature = "waker_getters", issue = "87021")]
+    #[stable(feature = "waker_getters", since = "CURRENT_RUSTC_VERSION")]
     pub fn as_raw(&self) -> &RawWaker {
         &self.waker
     }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -95,7 +95,6 @@
 #![feature(unzip_option)]
 #![feature(const_array_from_ref)]
 #![feature(const_slice_from_ref)]
-#![feature(waker_getters)]
 #![feature(slice_flatten)]
 #![feature(provide_any)]
 #![feature(utf8_chunks)]


### PR DESCRIPTION
Close #96992
Close #87021

API summary:
```rust
// core::task
impl RawWaker {
    pub fn data(&self) -> *const ();
    pub fn vtable(&self) -> &'static RawWakerVTable;
}
impl Waker {
    pub fn as_raw(&self) -> &RawWaker;
}
```