### PR TITLE
rustdoc: remove unused CSS `div.impl-items > div`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -197,10 +197,6 @@ h4.code-header {
 	position: relative;
 }
 
-div.impl-items > div {
-	padding-left: 0;
-}
-
 h1, h2, h3, h4, h5, h6,
 .sidebar,
 .mobile-topbar,
@@ -212,7 +208,6 @@ a.source,
 span.since,
 #source-sidebar, #sidebar-toggle,
 details.rustdoc-toggle > summary::before,
-div.impl-items > div:not(.docblock):not(.item-info),
 .content ul.crate a.crate,
 a.srclink,
 #help-button > button,


### PR DESCRIPTION
This was added in 9077d540da944c41678a7129e04e7fc5d7e38582 to override the style on `<div>` tags that were acting as headers. These `<div>` tags were replaced with `<section>` tags in 32f62607c3142dfc9eb56a0bd72dee298ca43358, but this CSS was probably already redundant even then (the headers had already been replaced with real `<h3>` and `<h4>` tags in 76a3b609d0b93c5d8da5e4e3db37bd03e5cb1c30).