### PR TITLE
rustdoc: remove no-op CSS `#settings-menu { padding: 0 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1449,9 +1449,7 @@ pre.rust {
 	border-radius: 2px;
 	cursor: pointer;
 }
-#settings-menu {
-	padding: 0;
-}
+
 #settings-menu > a, #help-button > button {
 	padding: 5px;
 	height: 100%;


### PR DESCRIPTION
This CSS was added in 5e01ba36c9f1037c4cf3e7421413fc6c41f85d05, and served to override CSS right above it that set a 5px padding for several kinds of buttons in the same toolbar:

https://github.com/rust-lang/rust/blob/5e01ba36c9f1037c4cf3e7421413fc6c41f85d05/src/librustdoc/html/static/css/rustdoc.css#L1400-L1409

The CSS that it overrode is still there, but now it only applies to `#settings-menu > a`, so there's nothing to override.

https://github.com/rust-lang/rust/blob/24d69920201563f0ee7b530f1cda0f171b205cc2/src/librustdoc/html/static/css/rustdoc.css#L1445-L1454