### PR TITLE
[crater experiment] Enable LLVM assertions

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -77,6 +77,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
+      --set llvm.assertions=true \
       --set rust.jemalloc \
       --set rust.use-lld=true
 ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \


### PR DESCRIPTION
r? @ghost

Enabling LLVM assertions on Linux so that we can do a crater run to look for issues similar to https://github.com/rust-lang/rust/issues/101585