### PR TITLE
Fix ICE report flags display.

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1119,22 +1119,25 @@ fn extra_compiler_flags() -> Option<(Vec<String>, bool)> {
     while let Some(arg) = args.next() {
         if let Some(a) = ICE_REPORT_COMPILER_FLAGS.iter().find(|a| arg.starts_with(*a)) {
             let content = if arg.len() == a.len() {
+                // A space-separated option, like `-C incremental=foo` or `--crate-type rlib`
                 match args.next() {
                     Some(arg) => arg.to_string(),
                     None => continue,
                 }
             } else if arg.get(a.len()..a.len() + 1) == Some("=") {
+                // An equals option, like `--crate-type=rlib`
                 arg[a.len() + 1..].to_string()
             } else {
+                // A non-space option, like `-Cincremental=foo`
                 arg[a.len()..].to_string()
             };
-            if ICE_REPORT_COMPILER_FLAGS_EXCLUDE.iter().any(|exc| content.starts_with(exc)) {
+            let option = content.split_once('=').map(|s| s.0).unwrap_or(&content);
+            if ICE_REPORT_COMPILER_FLAGS_EXCLUDE.iter().any(|exc| option == *exc) {
                 excluded_cargo_defaults = true;
             } else {
                 result.push(a.to_string());
-                match ICE_REPORT_COMPILER_FLAGS_STRIP_VALUE.iter().find(|s| content.starts_with(*s))
-                {
-                    Some(s) => result.push(s.to_string()),
+                match ICE_REPORT_COMPILER_FLAGS_STRIP_VALUE.iter().find(|s| option == **s) {
+                    Some(s) => result.push(format!("{}=[REDACTED]", s)),
                     None => result.push(content),
                 }
             }


### PR DESCRIPTION
#92310 made some changes to the ICE report that displays the rustc flags, but it introduced a bug where a flag like `-Z incremental-verify-ich=yes` was being treated as-if it was `-Cincremental`. This corrupted the output and made it confusing. The cause was using `starts_with` instead of properly splitting the option.

For example, with the command like `rustc foo.rs -Cincremental=/tmp/a -Zincremental-verify-ich=yes --crate-type lib` would previously look like:

```
note: compiler flags: -C incremental -Z incremental --crate-type lib
```

It now looks like:

```
note: compiler flags: -C incremental=[REDACTED] -Z incremental-verify-ich=yes --crate-type lib
```

I added a `[REDACTED]` marker for `-Cincremental` so it is a little less confusing that a value has been removed.

Fixes #101588
