### PR TITLE
Add `cstr!` macro.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,16 +1024,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11a39d776a3b35896711da8a04dc1835169dcd36f710878187637314e47941b"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "curl"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,7 +3265,6 @@ name = "rustc_codegen_llvm"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "cstr",
  "libc",
  "measureme",
  "object 0.29.0",

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -8,7 +8,6 @@ test = false
 
 [dependencies]
 bitflags = "1.0"
-cstr = "0.2"
 libc = "0.2"
 measureme = "10.0.0"
 object = { version = "0.29.0", default-features = false, features = ["std", "read_core", "archive", "coff", "elf", "macho", "pe"] }

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -19,8 +19,6 @@ use crate::context::CodegenCx;
 use crate::llvm;
 use crate::value::Value;
 
-use cstr::cstr;
-
 use rustc_codegen_ssa::base::maybe_create_entry_wrapper;
 use rustc_codegen_ssa::mono_item::MonoItemExt;
 use rustc_codegen_ssa::traits::*;
@@ -34,6 +32,7 @@ use rustc_session::config::DebugInfo;
 use rustc_span::symbol::Symbol;
 use rustc_target::spec::SanitizerSet;
 
+use std::ffi::cstr;
 use std::time::Instant;
 
 pub struct ValueIter<'ll> {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -6,7 +6,6 @@ use crate::llvm::{self, AtomicOrdering, AtomicRmwBinOp, BasicBlock};
 use crate::type_::Type;
 use crate::type_of::LayoutLlvmExt;
 use crate::value::Value;
-use cstr::cstr;
 use libc::{c_char, c_uint};
 use rustc_codegen_ssa::common::{IntPredicate, RealPredicate, SynchronizationScope, TypeKind};
 use rustc_codegen_ssa::mir::operand::{OperandRef, OperandValue};
@@ -23,7 +22,7 @@ use rustc_span::Span;
 use rustc_target::abi::{self, call::FnAbi, Align, Size, WrappingRange};
 use rustc_target::spec::{HasTargetSpec, Target};
 use std::borrow::Cow;
-use std::ffi::CStr;
+use std::ffi::{cstr, CStr};
 use std::iter;
 use std::ops::Deref;
 use std::ptr;
@@ -44,7 +43,7 @@ impl Drop for Builder<'_, '_, '_> {
 }
 
 // FIXME(eddyb) use a checked constructor when they become `const fn`.
-const EMPTY_C_STR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"\0") };
+const EMPTY_C_STR: &CStr = cstr!();
 
 /// Empty string, to be used where LLVM expects an instruction name, indicating
 /// that the instruction is to be left unnamed (i.e. numbered, in textual IR).

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -6,7 +6,6 @@ use crate::llvm_util;
 use crate::type_::Type;
 use crate::type_of::LayoutLlvmExt;
 use crate::value::Value;
-use cstr::cstr;
 use libc::c_uint;
 use rustc_codegen_ssa::traits::*;
 use rustc_hir::def_id::DefId;
@@ -22,6 +21,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_target::abi::{
     AddressSpace, Align, HasDataLayout, Primitive, Scalar, Size, WrappingRange,
 };
+use std::ffi::cstr;
 use std::ops::Range;
 
 pub fn const_alloc_to_llvm<'ll>(cx: &CodegenCx<'ll, '_>, alloc: ConstAllocation<'_>) -> &'ll Value {

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -8,7 +8,6 @@ use crate::llvm_util;
 use crate::type_::Type;
 use crate::value::Value;
 
-use cstr::cstr;
 use rustc_codegen_ssa::base::wants_msvc_seh;
 use rustc_codegen_ssa::traits::*;
 use rustc_data_structures::base_n;
@@ -33,7 +32,7 @@ use rustc_target::spec::{HasTargetSpec, RelocModel, Target, TlsModel};
 use smallvec::SmallVec;
 
 use std::cell::{Cell, RefCell};
-use std::ffi::CStr;
+use std::ffi::{cstr, CStr};
 use std::str;
 
 /// There is one `CodegenCx` per compilation unit. Each one has its own LLVM

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -20,7 +20,6 @@ use crate::llvm::debuginfo::{
 };
 use crate::value::Value;
 
-use cstr::cstr;
 use rustc_codegen_ssa::debuginfo::type_names::cpp_like_debuginfo;
 use rustc_codegen_ssa::debuginfo::type_names::VTableNameKind;
 use rustc_codegen_ssa::traits::*;
@@ -45,6 +44,7 @@ use smallvec::smallvec;
 
 use libc::{c_char, c_longlong, c_uint};
 use std::borrow::Cow;
+use std::ffi::cstr;
 use std::fmt::{self, Write};
 use std::hash::{Hash, Hasher};
 use std::iter;

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(let_chains)]
 #![feature(extern_types)]
 #![feature(once_cell)]
+#![feature(cstr_macro)]
 #![feature(iter_intersperse)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -184,7 +184,7 @@ impl fmt::Debug for CStr {
 /// ```
 /// #![feature(cstr_macro)]
 ///
-/// use core::ffi::CStr;
+/// use core::ffi::{cstr, CStr};
 ///
 /// const HELLO: &CStr = cstr!("Hello, world!");
 /// assert_eq!(HELLO.to_bytes_with_nul(), b"Hello, world!\0");
@@ -196,16 +196,17 @@ impl fmt::Debug for CStr {
 /// ```compile_fail
 /// #![feature(const_cstr_from_bytes)]
 ///
-/// use core::ffi::CStr;
+/// use core::ffi::{cstr, CStr};
 ///
 /// const HELLO: &CStr = cstr!("Hello, world!\0"); // compile fail!
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[unstable(feature = "cstr_macro", issue = "101607")]
 #[rustc_diagnostic_item = "core_cstr_macro"]
-macro_rules! cstr {
+#[doc(hidden)]
+macro_rules! __cstr_macro_impl {
     () => {
-        cstr!("")
+        __cstr_macro_impl!("")
     };
     ($s:literal) => {{
         const BYTES: &[u8] = $crate::ffi::__cstr_macro_impl_as_bytes($s);
@@ -216,6 +217,9 @@ macro_rules! cstr {
         CSTR
     }};
 }
+#[unstable(feature = "cstr_macro", issue = "101607")]
+#[doc(inline)]
+pub use __cstr_macro_impl as cstr;
 
 #[unstable(feature = "cstr_macro", issue = "101607")]
 #[doc(hidden)]

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -177,7 +177,7 @@ impl fmt::Debug for CStr {
     }
 }
 
-/// Converts a string or byte literal to a `&'static Cstr`.
+/// Converts a `const` string or byte slice to a `&'static Cstr`.
 ///
 /// # Examples
 ///
@@ -208,7 +208,7 @@ macro_rules! __cstr_macro_impl {
     () => {
         __cstr_macro_impl!("")
     };
-    ($s:literal) => {{
+    ($s:expr) => {{
         const BYTES: &[u8] = $crate::ffi::__cstr_macro_impl_as_bytes($s);
         const BYTES_WITH_NUL: [u8; { BYTES.len() + 1 }] =
             $crate::ffi::__cstr_macro_impl_to_bytes_with_nul(BYTES);

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -21,7 +21,10 @@ mod c_str;
 
 #[unstable(feature = "cstr_macro", issue = "101607")]
 #[doc(hidden)]
-pub use self::c_str::__cstr_macro_impl;
+pub use self::c_str::{
+    __cstr_macro_impl_as_bytes, __cstr_macro_impl_from_bytes_with_nul,
+    __cstr_macro_impl_to_bytes_with_nul,
+};
 
 macro_rules! type_alias_no_nz {
     {

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -23,7 +23,7 @@ mod c_str;
 #[doc(hidden)]
 pub use self::c_str::{
     __cstr_macro_impl_as_bytes, __cstr_macro_impl_from_bytes_with_nul,
-    __cstr_macro_impl_to_bytes_with_nul,
+    __cstr_macro_impl_to_bytes_with_nul, cstr,
 };
 
 macro_rules! type_alias_no_nz {

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -19,6 +19,10 @@ pub use self::c_str::{CStr, FromBytesUntilNulError, FromBytesWithNulError};
 
 mod c_str;
 
+#[unstable(feature = "cstr_macro", issue = "101607")]
+#[doc(hidden)]
+pub use self::c_str::__cstr_macro_impl;
+
 macro_rules! type_alias_no_nz {
     {
       $Docfile:tt, $Alias:ident = $Real:ty;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -166,6 +166,7 @@
 #![feature(const_is_char_boundary)]
 #![feature(const_cstr_methods)]
 #![feature(is_ascii_octdigit)]
+#![feature(cstr_macro)]
 //
 // Language features:
 #![feature(abi_unadjusted)]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2560,7 +2560,8 @@ impl str {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl AsRef<[u8]> for str {
+#[rustc_const_unstable(feature = "cstr_macro", issue = "101607")]
+impl const AsRef<[u8]> for str {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -160,6 +160,9 @@ pub use core::ffi::{
     c_ulong, c_ulonglong, c_ushort,
 };
 
+#[unstable(feature = "cstr_macro", issue = "101607")]
+pub use core::ffi::cstr;
+
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub use core::ffi::c_void;
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -314,6 +314,7 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(const_maybe_uninit_uninit_array)]
 #![feature(const_waker)]
+#![feature(cstr_macro)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -616,9 +616,6 @@ pub use core::{
     module_path, option_env, stringify, trace_macros,
 };
 
-#[unstable(feature = "cstr_macro", issue = "101607")]
-pub use core::cstr;
-
 #[unstable(
     feature = "concat_bytes",
     issue = "87555",

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -616,6 +616,9 @@ pub use core::{
     module_path, option_env, stringify, trace_macros,
 };
 
+#[unstable(feature = "cstr_macro", issue = "101607")]
+pub use core::cstr;
+
 #[unstable(
     feature = "concat_bytes",
     issue = "87555",

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, nonstandard_style)]
 
-use crate::ffi::CStr;
+use crate::ffi::cstr;
 use crate::io::ErrorKind;
 
 pub use self::rand::hashmap_random_keys;
@@ -75,7 +75,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
     // thread-id for the main thread and so renaming the main thread will rename the
     // process and we only want to enable this on platforms we've tested.
     if cfg!(target_os = "macos") {
-        thread::Thread::set_name(&CStr::from_bytes_with_nul_unchecked(b"main\0"));
+        thread::Thread::set_name(cstr!("main"));
     }
 
     unsafe fn sanitize_standard_fds() {

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(test, allow(dead_code))]
 #![unstable(issue = "none", feature = "windows_c")]
 
-use crate::ffi::CStr;
+use crate::ffi::{cstr, CStr};
 use crate::mem;
 use crate::os::raw::{c_char, c_int, c_long, c_longlong, c_uint, c_ulong, c_ushort};
 use crate::os::windows::io::{BorrowedHandle, HandleOrInvalid, HandleOrNull};
@@ -1245,7 +1245,7 @@ extern "system" {
 // Functions that aren't available on every version of Windows that we support,
 // but we still use them and just provide some form of a fallback implementation.
 compat_fn_with_fallback! {
-    pub static KERNEL32: &CStr = ansi_str!("kernel32");
+    pub static KERNEL32: &CStr = cstr!("kernel32");
 
     // >= Win10 1607
     // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
@@ -1280,7 +1280,7 @@ compat_fn_optional! {
 }
 
 compat_fn_with_fallback! {
-    pub static NTDLL: &CStr = ansi_str!("ntdll");
+    pub static NTDLL: &CStr = cstr!("ntdll");
 
     pub fn NtCreateFile(
         FileHandle: *mut HANDLE,

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, nonstandard_style)]
 
-use crate::ffi::{CStr, OsStr, OsString};
+use crate::ffi::{cstr, OsStr, OsString};
 use crate::io::ErrorKind;
 use crate::mem::MaybeUninit;
 use crate::os::windows::ffi::{OsStrExt, OsStringExt};
@@ -53,7 +53,7 @@ pub unsafe fn init(_argc: isize, _argv: *const *const u8, _sigpipe: u8) {
 
     // Normally, `thread::spawn` will call `Thread::set_name` but since this thread already
     // exists, we have to call it ourselves.
-    thread::Thread::set_name(&CStr::from_bytes_with_nul_unchecked(b"main\0"));
+    thread::Thread::set_name(cstr!("main"));
 }
 
 // SAFETY: must be called only once during runtime cleanup.

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -105,7 +105,6 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "crossbeam-epoch",
     "crossbeam-utils",
     "crypto-common",
-    "cstr",
     "datafrog",
     "difference",
     "digest",


### PR DESCRIPTION
This adds a `cstr!` macro for easily creating `&'static Cstr`.

ACP: https://github.com/rust-lang/libs-team/issues/103