### PR TITLE
Adapt test for msan message change

### DIFF
--- a/src/test/ui/sanitize/memory-eager.rs
+++ b/src/test/ui/sanitize/memory-eager.rs
@@ -10,7 +10,7 @@
 // run-fail
 // error-pattern: MemorySanitizer: use-of-uninitialized-value
 // error-pattern: Uninitialized value was created by an allocation
-// error-pattern: in the stack frame of function 'random'
+// error-pattern: in the stack frame
 //
 // This test case intentionally limits the usage of the std,
 // since it will be linked with an uninstrumented version of it.


### PR DESCRIPTION
Similar to rust-lang/rust#100445, this adapts the new test added by rust-lang/rust#99207 to some relatively recent [LLVM changes](https://github.com/llvm/llvm-project/commit/057cabd997aeaef136e1e14f2ee645bd5bb197dd) that removed the function name from msan messages.

Found via our experimental rust + llvm @ HEAD bot:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/13347#018321b2-0cc3-4c91-b4db-774477e8b074

@rustbot label +llvm-main