### PR TITLE
rustdoc: remove unused CSS `#search { position: relative }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -596,10 +596,6 @@ h2.location a {
 	margin: 0;
 }
 
-#search {
-	position: relative;
-}
-
 .search-loading {
 	text-align: center;
 }
@@ -977,7 +973,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 
 .search-results > a {
 	display: block;
-	width: 100%;
 	/* A little margin ensures the browser's outlining of focused links has room to display. */
 	margin-left: 2px;
 	margin-right: 2px;

--- a/src/test/rustdoc-gui/search-result-display.goml
+++ b/src/test/rustdoc-gui/search-result-display.goml
@@ -7,11 +7,11 @@ press-key: 'Enter'
 wait-for: "#crate-search"
 // The width is returned by "getComputedStyle" which returns the exact number instead of the
 // CSS rule which is "50%"...
-assert-css: (".search-results div.desc", {"width": "295px"})
+assert-css: (".search-results div.desc", {"width": "293px"})
 size: (600, 100)
 // As counter-intuitive as it may seem, in this width, the width is "100%", which is why
 // when computed it's larger.
-assert-css: (".search-results div.desc", {"width": "570px"})
+assert-css: (".search-results div.desc", {"width": "566px"})
 
 // Check that the crate filter `<select>` is correctly handled when it goes to next line.
 // To do so we need to update the length of one of its `<option>`.


### PR DESCRIPTION
This was added in 611d0e6ccef8b60fa86ff5aa8fe3571cd36c444a, to allow its child `#results` element to be absolutely positioned inside it. The child stopped being absolute in 8c0469552e879f6319f8f96db660bab9eae1de5c.

To keep the layout looking the same, the links need to not have `width: 100%` any more, relying instead on the box naturally growing to fit because it has `display: block`.