### PR TITLE
Be careful about `expr_ty_adjusted` when noting block tail type

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2713,12 +2713,13 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         Some(t) if t.hir_owner == parent_id => t,
                         _ => self.tcx.typeck(parent_id),
                     };
-                    let ty = typeck_results.expr_ty_adjusted(expr);
-                    let span = expr.peel_blocks().span;
+                    let expr = expr.peel_blocks();
+                    let ty = typeck_results.expr_ty_adjusted_opt(expr).unwrap_or(tcx.ty_error());
+                    let span = expr.span;
                     if Some(span) != err.span.primary_span() {
                         err.span_label(
                             span,
-                            &if ty.references_error() {
+                            if ty.references_error() {
                                 String::new()
                             } else {
                                 format!("this tail expression is of type `{:?}`", ty)

--- a/src/test/ui/expr/malformed_closure/ruby_style_closure.stderr
+++ b/src/test/ui/expr/malformed_closure/ruby_style_closure.stderr
@@ -14,7 +14,7 @@ LL |       let p = Some(45).and_then({
 LL | |
 LL | |         |x| println!("doubling {}", x);
 LL | |         Some(x * 2)
-   | |         -----------
+   | |         ----------- this tail expression is of type `std::option::Option<_>`
 LL | |
 LL | |     });
    | |_____^ expected an `FnOnce<({integer},)>` closure, found `Option<_>`

--- a/src/test/ui/suggestions/issue-101623.rs
+++ b/src/test/ui/suggestions/issue-101623.rs
@@ -1,0 +1,25 @@
+pub struct Stuff {
+    inner: *mut (),
+}
+
+pub struct Wrap<T>(T);
+
+fn fun<T>(t: T) -> Wrap<T> {
+    todo!()
+}
+
+pub trait Trait<'de> {
+    fn do_stuff(_: Wrap<&'de mut Self>);
+}
+
+impl<'a> Trait<'a> for () {
+    fn do_stuff(_: Wrap<&'a mut Self>) {}
+}
+
+fn fun2(t: &mut Stuff) -> () {
+    let Stuff { inner, .. } = t;
+    Trait::do_stuff({ fun(&mut *inner) });
+    //~^ ERROR the trait bound `*mut (): Trait<'_>` is not satisfied
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-101623.stderr
+++ b/src/test/ui/suggestions/issue-101623.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `*mut (): Trait<'_>` is not satisfied
+  --> $DIR/issue-101623.rs:21:21
+   |
+LL |     Trait::do_stuff({ fun(&mut *inner) });
+   |     --------------- ^^----------------^^
+   |     |               |
+   |     |               the trait `Trait<'_>` is not implemented for `*mut ()`
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Trait<'a>` is implemented for `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #101623