### PR TITLE
Rustdoc-Json: Correcty handle intra-doc-links to items without HTML page

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -510,7 +510,7 @@ impl Item {
             .get(&self.item_id)
             .map_or(&[][..], |v| v.as_slice())
             .iter()
-            .filter_map(|ItemLink { link: s, link_text, did, ref fragment }| {
+            .filter_map(|ItemLink { link: s, link_text, page_id: did, ref fragment }| {
                 debug!(?did);
                 if let Ok((mut href, ..)) = href(*did, cx) {
                     debug!(?href);
@@ -1134,7 +1134,10 @@ pub(crate) struct ItemLink {
     /// This may not be the same as `link` if there was a disambiguator
     /// in an intra-doc link (e.g. \[`fn@f`\])
     pub(crate) link_text: String,
-    pub(crate) did: DefId,
+    /// The `DefId` of the Item whose **HTML Page** contains the item being
+    /// linked to. This will be different to `item_id` on item's that don't
+    /// have their own page, such as struct fields and enum variants.
+    pub(crate) page_id: DefId,
     /// The url fragment to append to the link
     pub(crate) fragment: Option<UrlFragment>,
 }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -223,6 +223,9 @@ enum MalformedGenerics {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) enum UrlFragment {
     Item(DefId),
+    /// A part of a page that isn't a rust item.
+    ///
+    /// Eg: `[Vector Examples](std::vec::Vec#examples)`
     UserWritten(String),
 }
 
@@ -1127,7 +1130,7 @@ impl LinkCollector<'_, '_> {
                 Some(ItemLink {
                     link: ori_link.link.clone(),
                     link_text: link_text.clone(),
-                    did: res.def_id(self.cx.tcx),
+                    page_id: res.def_id(self.cx.tcx),
                     fragment,
                 })
             }
@@ -1146,11 +1149,12 @@ impl LinkCollector<'_, '_> {
                     item,
                     &diag_info,
                 )?;
-                let id = clean::register_res(self.cx, rustc_hir::def::Res::Def(kind, id));
+
+                let page_id = clean::register_res(self.cx, rustc_hir::def::Res::Def(kind, id));
                 Some(ItemLink {
                     link: ori_link.link.clone(),
                     link_text: link_text.clone(),
-                    did: id,
+                    page_id,
                     fragment,
                 })
             }

--- a/src/test/rustdoc-json/intra-doc-links/non_page.rs
+++ b/src/test/rustdoc-json/intra-doc-links/non_page.rs
@@ -1,0 +1,34 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/101531>,
+// where links where to the item who's HTML page had the item linked to.
+
+//! [`Struct::struct_field`]
+//! [`Enum::Variant`]
+//! [`Trait::AssocType`]
+//! [`Trait::ASSOC_CONST`]
+//! [`Trait::method`]
+
+// @set struct_field = "$.index[*][?(@.name=='struct_field')].id"
+// @set Variant = "$.index[*][?(@.name=='Variant')].id"
+// @set AssocType = "$.index[*][?(@.name=='AssocType')].id"
+// @set ASSOC_CONST = "$.index[*][?(@.name=='ASSOC_CONST')].id"
+// @set method = "$.index[*][?(@.name=='method')].id"
+
+// @is "$.index[*][?(@.name=='non_page')].links['`Struct::struct_field`']" $struct_field
+// @is "$.index[*][?(@.name=='non_page')].links['`Enum::Variant`']" $Variant
+// @is "$.index[*][?(@.name=='non_page')].links['`Trait::AssocType`']" $AssocType
+// @is "$.index[*][?(@.name=='non_page')].links['`Trait::ASSOC_CONST`']" $ASSOC_CONST
+// @is "$.index[*][?(@.name=='non_page')].links['`Trait::method`']" $method
+
+pub struct Struct {
+    pub struct_field: i32,
+}
+
+pub enum Enum {
+    Variant(),
+}
+
+pub trait Trait {
+    const ASSOC_CONST: i32;
+    type AssocType;
+    fn method();
+}

--- a/src/test/rustdoc-json/intra-doc-links/user_written.rs
+++ b/src/test/rustdoc-json/intra-doc-links/user_written.rs
@@ -1,0 +1,8 @@
+//! For motivation, see [the reasons](foo#reasons)
+
+/// # Reasons
+/// To test rustdoc json
+pub fn foo() {}
+
+// @set foo = "$.index[*][?(@.name=='foo')].id"
+// @is "$.index[*][?(@.name=='user_written')].links['foo#reasons']" $foo


### PR DESCRIPTION
Closes #101531

I renamed the `did` field in `ItemLink ` to more accurately describe what it does.

r? @jyn514 