### PR TITLE
Move `Queries::new` out of the macro

### DIFF
--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -48,7 +48,7 @@ cfg_if! {
         /// the native atomic types.
         /// You should use this type through the `AtomicU64`, `AtomicUsize`, etc, type aliases
         /// as it's not intended to be used separately.
-        #[derive(Debug)]
+        #[derive(Debug, Default)]
         pub struct Atomic<T: Copy>(Cell<T>);
 
         impl<T: Copy> Atomic<T> {

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -5,7 +5,7 @@
 use crate::keys::Key;
 use crate::{on_disk_cache, Queries};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::Lock;
+use rustc_data_structures::sync::{AtomicU64, Lock};
 use rustc_errors::{Diagnostic, Handler};
 use rustc_middle::dep_graph::{
     self, DepKind, DepKindStruct, DepNode, DepNodeIndex, SerializedDepNodeIndex,
@@ -501,9 +501,28 @@ macro_rules! define_queries {
     }
 }
 
+use crate::{ExternProviders, OnDiskCache, Providers};
+
+impl<'tcx> Queries<'tcx> {
+    pub fn new(
+        local_providers: Providers,
+        extern_providers: ExternProviders,
+        on_disk_cache: Option<OnDiskCache<'tcx>>,
+    ) -> Self {
+        Queries {
+            local_providers: Box::new(local_providers),
+            extern_providers: Box::new(extern_providers),
+            on_disk_cache,
+            jobs: AtomicU64::new(1),
+            ..Queries::default()
+        }
+    }
+}
+
 macro_rules! define_queries_struct {
     (
      input: ($(([$($modifiers:tt)*] [$($attr:tt)*] [$name:ident]))*)) => {
+        #[derive(Default)]
         pub struct Queries<'tcx> {
             local_providers: Box<Providers>,
             extern_providers: Box<ExternProviders>,
@@ -516,20 +535,6 @@ macro_rules! define_queries_struct {
         }
 
         impl<'tcx> Queries<'tcx> {
-            pub fn new(
-                local_providers: Providers,
-                extern_providers: ExternProviders,
-                on_disk_cache: Option<OnDiskCache<'tcx>>,
-            ) -> Self {
-                Queries {
-                    local_providers: Box::new(local_providers),
-                    extern_providers: Box::new(extern_providers),
-                    on_disk_cache,
-                    jobs: AtomicU64::new(1),
-                    $($name: Default::default()),*
-                }
-            }
-
             pub(crate) fn try_collect_active_jobs(
                 &'tcx self,
                 tcx: TyCtxt<'tcx>,


### PR DESCRIPTION
Split out from https://github.com/rust-lang/rust/pull/101178 to make sure it's not contributing to the perf impact.

r? @cjgillot