### PR TITLE
Better documentation for env::home_dir()'s broken behaviour

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -573,8 +573,8 @@ impl Error for JoinPathsError {
 /// # Deprecation
 ///
 /// This function is deprecated because the behaviour on Windows is not correct.
-/// The 'HOME' environment variable has no meaning on Windows so it should not
-/// be checked. This result is that under Cygwin or Mingw it will return `/home/you`
+/// The 'HOME' environment variable is not standard on Windows, and may not produce
+/// desired results; for instance, under Cygwin or Mingw it will return `/home/you`
 /// when it should return `C:\Users\you`.
 ///
 /// # Examples

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -570,6 +570,13 @@ impl Error for JoinPathsError {
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-getuserprofiledirectorya
 ///
+/// # Deprecation
+///
+/// This function is deprecated because the behaviour on Windows is not correct.
+/// The 'HOME' environment variable has no meaning on Windows so it should not
+/// be checked. This result is that under Cygwin or Mingw it will return `/home/you`
+/// when it should return `C:\Users\you`.
+///
 /// # Examples
 ///
 /// ```
@@ -582,7 +589,7 @@ impl Error for JoinPathsError {
 /// ```
 #[deprecated(
     since = "1.29.0",
-    note = "This function's behavior is unexpected and probably not what you want. \
+    note = "This function's behavior may be unexpected on Windows. \
             Consider using a crate from crates.io instead."
 )]
 #[must_use]


### PR DESCRIPTION
This improves the documentation to say *why* it was deprecated. The reason was because it reads `HOME` on Windows which is meaningless there. Note that the PR that deprecated it stated that returning an empty string if `HOME` is set to an empty string was a problem, however I can find no evidence that this is the case. `cd` handles it fine whereas if `HOME` is unset it gives an explicit `HOME not set` error.

* Original deprecation reason: https://internals.rust-lang.org/t/deprecate-or-break-fix-std-env-home-dir/7315
* Original deprecation PR: https://github.com/rust-lang/rust/pull/51656

See #71684