### PR TITLE
Note if mismatched types have a similar name

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1779,11 +1779,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                         .tcx
                                         .parent_module_from_def_id(defid.expect_local())
                                         .to_def_id();
-                                    let module_name =
-                                        self.tcx.def_path(module).to_string_no_crate_verbose();
-                                    format!(
-                                        "{name} is defined in module {module_name} of the current crate"
-                                    )
+                                    let module_name = self.tcx.def_path(module).to_string_no_crate_verbose();
+                                    format!("{name} is defined in module `crate{module_name}` of the current crate")
                                 } else if defid.is_local() {
                                     format!("{name} is defined in the current crate")
                                 } else {

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,6 +20,8 @@
 #![cfg_attr(bootstrap, feature(label_break_value))]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(let_else))]
+#![feature(let_else)]
+#![feature(if_let_guard)]
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(try_blocks)]

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,7 +20,6 @@
 #![cfg_attr(bootstrap, feature(label_break_value))]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(let_else))]
-#![feature(let_else)]
 #![feature(if_let_guard)]
 #![feature(min_specialization)]
 #![feature(never_type)]

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -19,7 +19,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_index::vec::Idx;
 use rustc_macros::HashStable;
-use rustc_span::symbol::{kw, Symbol};
+use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_target::abi::VariantIdx;
 use rustc_target::spec::abi;
 use std::borrow::Cow;
@@ -2272,6 +2272,35 @@ impl<'tcx> Ty<'tcx> {
             ty::Bound(..) | ty::Placeholder(..) => {
                 bug!("`is_trivially_pure_clone_copy` applied to unexpected type: {:?}", self);
             }
+        }
+    }
+
+    // If `self` is a primitive, return its [`Symbol`].
+    pub fn primitive_symbol(self) -> Option<Symbol> {
+        match self.kind() {
+            ty::Bool => Some(sym::bool),
+            ty::Char => Some(sym::char),
+            ty::Float(f) => match f {
+                ty::FloatTy::F32 => Some(sym::f32),
+                ty::FloatTy::F64 => Some(sym::f64),
+            },
+            ty::Int(f) => match f {
+                ty::IntTy::Isize => Some(sym::isize),
+                ty::IntTy::I8 => Some(sym::i8),
+                ty::IntTy::I16 => Some(sym::i16),
+                ty::IntTy::I32 => Some(sym::i32),
+                ty::IntTy::I64 => Some(sym::i64),
+                ty::IntTy::I128 => Some(sym::i128),
+            },
+            ty::Uint(f) => match f {
+                ty::UintTy::Usize => Some(sym::usize),
+                ty::UintTy::U8 => Some(sym::u8),
+                ty::UintTy::U16 => Some(sym::u16),
+                ty::UintTy::U32 => Some(sym::u32),
+                ty::UintTy::U64 => Some(sym::u64),
+                ty::UintTy::U128 => Some(sym::u128),
+            },
+            _ => None,
         }
     }
 }

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -7,12 +7,12 @@ LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
    |
    = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
-note: enum `x::Foo` is defined in module ::x of the current crate
+note: enum `x::Foo` is defined in module `crate::x` of the current crate
   --> $DIR/fully-qualified-type-name2.rs:4:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^
-note: enum `y::Foo` is defined in module ::y of the current crate
+note: enum `y::Foo` is defined in module `crate::y` of the current crate
   --> $DIR/fully-qualified-type-name2.rs:8:5
    |
 LL |     pub enum Foo { }

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -7,12 +7,12 @@ LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
    |
    = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
-note: enum `x::Foo` is defined in the current crate.
+note: enum `x::Foo` is defined in module ::x of the current crate
   --> $DIR/fully-qualified-type-name2.rs:4:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^
-note: enum `y::Foo` is defined in the current crate.
+note: enum `y::Foo` is defined in module ::y of the current crate
   --> $DIR/fully-qualified-type-name2.rs:8:5
    |
 LL |     pub enum Foo { }

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -5,6 +5,18 @@ LL | fn bar(x: x::Foo) -> y::Foo {
    |                      ------ expected `y::Foo` because of return type
 LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
+   |
+   = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
+note: enum `x::Foo` is defined in the current crate.
+  --> $DIR/fully-qualified-type-name2.rs:4:5
+   |
+LL |     pub enum Foo { }
+   |     ^^^^^^^^^^^^
+note: enum `y::Foo` is defined in the current crate.
+  --> $DIR/fully-qualified-type-name2.rs:8:5
+   |
+LL |     pub enum Foo { }
+   |     ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-56943.stderr
+++ b/src/test/ui/issues/issue-56943.stderr
@@ -5,6 +5,18 @@ LL |     let _: issue_56943::S = issue_56943::S2;
    |            --------------   ^^^^^^^^^^^^^^^ expected struct `S`, found struct `S2`
    |            |
    |            expected due to this
+   |
+   = note: struct `S2` and struct `S` have similar names, but are actually distinct types
+note: struct `S2` is defined in crate `issue_56943`.
+  --> $DIR/auxiliary/issue-56943.rs:2:9
+   |
+LL | mod m { pub struct S; }
+   |         ^^^^^^^^^^^^
+note: struct `S` is defined in crate `issue_56943`.
+  --> $DIR/auxiliary/issue-56943.rs:1:1
+   |
+LL | pub struct S;
+   | ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-56943.stderr
+++ b/src/test/ui/issues/issue-56943.stderr
@@ -5,18 +5,6 @@ LL |     let _: issue_56943::S = issue_56943::S2;
    |            --------------   ^^^^^^^^^^^^^^^ expected struct `S`, found struct `S2`
    |            |
    |            expected due to this
-   |
-   = note: struct `S2` and struct `S` have similar names, but are actually distinct types
-note: struct `S2` is defined in crate `issue_56943`.
-  --> $DIR/auxiliary/issue-56943.rs:2:9
-   |
-LL | mod m { pub struct S; }
-   |         ^^^^^^^^^^^^
-note: struct `S` is defined in crate `issue_56943`.
-  --> $DIR/auxiliary/issue-56943.rs:1:1
-   |
-LL | pub struct S;
-   | ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/show_module.rs
+++ b/src/test/ui/mismatched_types/show_module.rs
@@ -1,0 +1,18 @@
+pub mod blah{
+    pub mod baz{
+        pub struct Foo;
+    }
+}
+
+pub mod meh{
+    pub struct Foo;
+}
+
+pub type Foo = blah::baz::Foo;
+
+fn foo() -> Foo {
+    meh::Foo
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn main(){}

--- a/src/test/ui/mismatched_types/show_module.rs
+++ b/src/test/ui/mismatched_types/show_module.rs
@@ -1,10 +1,10 @@
-pub mod blah{
-    pub mod baz{
+pub mod blah {
+    pub mod baz {
         pub struct Foo;
     }
 }
 
-pub mod meh{
+pub mod meh {
     pub struct Foo;
 }
 
@@ -15,4 +15,4 @@ fn foo() -> Foo {
     //~^ ERROR mismatched types [E0308]
 }
 
-fn main(){}
+fn main() {}

--- a/src/test/ui/mismatched_types/show_module.stderr
+++ b/src/test/ui/mismatched_types/show_module.stderr
@@ -7,12 +7,12 @@ LL |     meh::Foo
    |     ^^^^^^^^ expected struct `baz::Foo`, found struct `meh::Foo`
    |
    = note: struct `meh::Foo` and struct `baz::Foo` have similar names, but are actually distinct types
-note: struct `meh::Foo` is defined in module ::meh of the current crate
+note: struct `meh::Foo` is defined in module `crate::meh` of the current crate
   --> $DIR/show_module.rs:8:5
    |
 LL |     pub struct Foo;
    |     ^^^^^^^^^^^^^^
-note: struct `baz::Foo` is defined in module ::blah::baz of the current crate
+note: struct `baz::Foo` is defined in module `crate::blah::baz` of the current crate
   --> $DIR/show_module.rs:3:9
    |
 LL |         pub struct Foo;

--- a/src/test/ui/mismatched_types/show_module.stderr
+++ b/src/test/ui/mismatched_types/show_module.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/show_module.rs:14:5
+   |
+LL | fn foo() -> Foo {
+   |             --- expected `baz::Foo` because of return type
+LL |     meh::Foo
+   |     ^^^^^^^^ expected struct `baz::Foo`, found struct `meh::Foo`
+   |
+   = note: struct `meh::Foo` and struct `baz::Foo` have similar names, but are actually distinct types
+note: struct `meh::Foo` is defined in module ::meh of the current crate
+  --> $DIR/show_module.rs:8:5
+   |
+LL |     pub struct Foo;
+   |     ^^^^^^^^^^^^^^
+note: struct `baz::Foo` is defined in module ::blah::baz of the current crate
+  --> $DIR/show_module.rs:3:9
+   |
+LL |         pub struct Foo;
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/similar_paths.rs
+++ b/src/test/ui/mismatched_types/similar_paths.rs
@@ -1,11 +1,11 @@
-enum Option<T>{
+enum Option<T> {
     Some(T),
     None,
 }
 
-pub fn foo() -> Option<u8>{
+pub fn foo() -> Option<u8> {
     Some(42_u8)
     //~^ ERROR mismatched types [E0308]
 }
 
-fn main(){}
+fn main() {}

--- a/src/test/ui/mismatched_types/similar_paths.rs
+++ b/src/test/ui/mismatched_types/similar_paths.rs
@@ -1,0 +1,11 @@
+enum Option<T>{
+    Some(T),
+    None,
+}
+
+pub fn foo() -> Option<u8>{
+    Some(42_u8)
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn main(){}

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/similar_paths.rs:7:5
+   |
+LL | pub fn foo() -> Option<u8>{
+   |                 ---------- expected `Option<u8>` because of return type
+LL |     Some(42_u8)
+   |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
+   |
+   = note: enum `std::option::Option` and enum `Option` have similar names, but are actually distinct types
+note: enum `std::option::Option` is defined in the standard library.
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL | pub enum Option<T> {
+   | ^^^^^^^^^^^^^^^^^^
+note: enum `Option` is defined in the current crate.
+  --> $DIR/similar_paths.rs:1:1
+   |
+LL | enum Option<T>{
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -7,12 +7,12 @@ LL |     Some(42_u8)
    |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
    |
    = note: enum `std::option::Option` and enum `Option` have similar names, but are actually distinct types
-note: enum `std::option::Option` is defined in the standard library.
+note: enum `std::option::Option` is defined in crate `core`
   --> $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {
    | ^^^^^^^^^^^^^^^^^^
-note: enum `Option` is defined in the current crate.
+note: enum `Option` is defined in the current crate
   --> $DIR/similar_paths.rs:1:1
    |
 LL | enum Option<T>{

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
   --> $DIR/similar_paths.rs:7:5
    |
-LL | pub fn foo() -> Option<u8>{
+LL | pub fn foo() -> Option<u8> {
    |                 ---------- expected `Option<u8>` because of return type
 LL |     Some(42_u8)
    |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
@@ -15,7 +15,7 @@ LL | pub enum Option<T> {
 note: enum `Option` is defined in the current crate
   --> $DIR/similar_paths.rs:1:1
    |
-LL | enum Option<T>{
+LL | enum Option<T> {
    | ^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/mismatched_types/similar_paths_primitive.rs
+++ b/src/test/ui/mismatched_types/similar_paths_primitive.rs
@@ -1,0 +1,10 @@
+#![allow(non_camel_case_types)]
+
+struct bool;
+
+fn foo(_: bool) {}
+
+fn main() {
+    foo(true);
+    //~^ ERROR mismatched types [E0308]
+}

--- a/src/test/ui/mismatched_types/similar_paths_primitive.stderr
+++ b/src/test/ui/mismatched_types/similar_paths_primitive.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/similar_paths_primitive.rs:8:9
+   |
+LL |     foo(true);
+   |     --- ^^^^ expected struct `bool`, found `bool`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: bool and struct `bool` have similar names, but are actually distinct types
+   = note: bool is a primitive defined by the language
+note: struct `bool` is defined in the current crate
+  --> $DIR/similar_paths_primitive.rs:3:1
+   |
+LL | struct bool;
+   | ^^^^^^^^^^^
+note: function defined here
+  --> $DIR/similar_paths_primitive.rs:5:4
+   |
+LL | fn foo(_: bool) {}
+   |    ^^^ -------
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/type/type-mismatch-same-crate-name.stderr
+++ b/src/test/ui/type/type-mismatch-same-crate-name.stderr
@@ -6,6 +6,17 @@ LL |         a::try_foo(foo2);
    |         |
    |         arguments to this function are incorrect
    |
+   = note: struct `main::a::Foo` and struct `main::a::Foo` have similar names, but are actually distinct types
+note: struct `main::a::Foo` is defined in crate `crate_a2`.
+  --> $DIR/auxiliary/crate_a2.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
+note: struct `main::a::Foo` is defined in crate `crate_a1`.
+  --> $DIR/auxiliary/crate_a1.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `crate_a1` are being used?
 note: function defined here
   --> $DIR/auxiliary/crate_a1.rs:10:8

--- a/src/test/ui/type/type-mismatch-same-crate-name.stderr
+++ b/src/test/ui/type/type-mismatch-same-crate-name.stderr
@@ -7,12 +7,12 @@ LL |         a::try_foo(foo2);
    |         arguments to this function are incorrect
    |
    = note: struct `main::a::Foo` and struct `main::a::Foo` have similar names, but are actually distinct types
-note: struct `main::a::Foo` is defined in crate `crate_a2`.
+note: struct `main::a::Foo` is defined in crate `crate_a2`
   --> $DIR/auxiliary/crate_a2.rs:1:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
-note: struct `main::a::Foo` is defined in crate `crate_a1`.
+note: struct `main::a::Foo` is defined in crate `crate_a1`
   --> $DIR/auxiliary/crate_a1.rs:1:1
    |
 LL | pub struct Foo;


### PR DESCRIPTION
If users get a type error between similarly named types, it will point out that these are actually different types, and where they were defined.