### PR TITLE
Add @obi1kenobi to the cc list for rustdoc-json-types

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -345,6 +345,7 @@ cc = [
     "@CraftSpider",
     "@aDotInTheVoid",
     "@Enselic",
+    "@obi1kenobi",
 ]
 
 [mentions."src/tools/cargo"]


### PR DESCRIPTION
I'm one of the maintainers of `cargo-semver-checks`, and as mentioned [in Zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Long.20Term.20Rustdoc.20JSON.20Stability) it's very useful to me to know about upcoming rustdoc JSON types changes so I can be ready to publish new `cargo-semver-checks` releases compatible with the new JSON format.