### PR TITLE
Check that the types in return position `impl Trait` in traits are well-formed

### DIFF
--- a/src/test/ui/impl-trait/in-trait/wf-bounds.rs
+++ b/src/test/ui/impl-trait/in-trait/wf-bounds.rs
@@ -1,0 +1,16 @@
+// issue #101663
+
+#![feature(return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+trait Wf<T> {}
+
+trait Uwu {
+    fn nya() -> impl Wf<Vec<[u8]>>;
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+
+    fn nya2() -> impl Wf<[u8]>;
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/in-trait/wf-bounds.stderr
+++ b/src/test/ui/impl-trait/in-trait/wf-bounds.stderr
@@ -1,0 +1,33 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/wf-bounds.rs:9:22
+   |
+LL |     fn nya() -> impl Wf<Vec<[u8]>>;
+   |                      ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                ^ required by this bound in `Vec`
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/wf-bounds.rs:12:23
+   |
+LL |     fn nya2() -> impl Wf<[u8]>;
+   |                       ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `Wf`
+  --> $DIR/wf-bounds.rs:6:10
+   |
+LL | trait Wf<T> {}
+   |          ^ required by this bound in `Wf`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait Wf<T: ?Sized> {}
+   |           ++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This effectively duplicates `check_associated_type_bounds`, but that shouldn't be for long, since we're going to remove it once we refactor RPITITs into regular associated items. 

Fixes #101663

---

We don't check

```rust
trait Foo {
  fn bar() -> impl ?Sized;
}
```

currently, but that's for a different reason, which is that we don't currently check that a trait function's return type is sized (i.e. `fn bar() -> [u8]` also works in a trait). 