### PR TITLE
Add diagnostic arg 'current_crate'

### DIFF
--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -572,6 +572,7 @@ impl SessionDiagnostic<'_> for CannotFindCrate {
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
         let mut diag = handler.struct_err(rustc_errors::fluent::metadata::cannot_find_crate);
         diag.set_arg("crate_name", self.crate_name);
+        diag.set_arg("current_crate", self.current_crate);
         diag.set_arg("add_info", self.add_info);
         diag.set_arg("locator_triple", self.locator_triple.triple());
         diag.code(error_code!(E0463));


### PR DESCRIPTION
With this fix, I get almost the same error message as on stable, again.

However, I expected to get the new error message `std is required by {$current_crate} because it does not declare #![no_std]`, but I didn't. Instead, I got a new line `help: consider building the standard library from source with cargo build -Zbuild-std`. So I obviously do not fully understand what is going on.

In any case, the bug itself seems to be fixed by this patch.

Closes #101640