### PR TITLE
Only encode return-position `impl Trait` in trait when parent function has a default body

### DIFF
--- a/src/test/ui/impl-trait/in-trait/encode.rs
+++ b/src/test/ui/impl-trait/in-trait/encode.rs
@@ -1,0 +1,9 @@
+// build-pass
+// compile-flags: --crate-type=lib
+
+#![feature(return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+trait Foo {
+    fn bar() -> impl Sized;
+}


### PR DESCRIPTION
Semi-blocked on #101679, because I can't currently write a test for when we _should_ encode the type of the return-position `impl Trait` in trait, which is when a trait has a default function body, like so:

```rust
trait Foo {
  fn bar() -> impl Sized { }
}
```

Though this can land even without #101679, since it does prevent ICEs from occuring any time you use `#![feature(return_position_impl_trait_in_trait)]` in a library, which is kind annoying.