### PR TITLE
Avoid `Iterator::last`

### DIFF
--- a/compiler/rustc_borrowck/src/location.rs
+++ b/compiler/rustc_borrowck/src/location.rs
@@ -86,8 +86,7 @@ impl LocationTable {
         let (block, &first_index) = self
             .statements_before_block
             .iter_enumerated()
-            .filter(|(_, first_index)| **first_index <= point_index)
-            .last()
+            .rfind(|&(_, &first_index)| first_index <= point_index)
             .unwrap();
 
         let statement_index = (point_index - first_index) / 2;

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -576,8 +576,7 @@ impl<'hir> Generics<'hir> {
         if self.has_where_clause_predicates {
             self.predicates
                 .iter()
-                .filter(|p| p.in_where_clause())
-                .last()
+                .rfind(|&p| p.in_where_clause())
                 .map_or(end, |p| p.span())
                 .shrink_to_hi()
                 .to(end)

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -719,7 +719,7 @@ fn get_nullable_type<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'t
     Some(match *ty.kind() {
         ty::Adt(field_def, field_substs) => {
             let inner_field_ty = {
-                let first_non_zst_ty = field_def
+                let mut first_non_zst_ty = field_def
                     .variants()
                     .iter()
                     .filter_map(|v| transparent_newtype_field(cx.tcx, v));
@@ -729,7 +729,7 @@ fn get_nullable_type<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'t
                     "Wrong number of fields for transparent type"
                 );
                 first_non_zst_ty
-                    .last()
+                    .next_back()
                     .expect("No non-zst fields in transparent type.")
                     .ty(tcx, field_substs)
             };

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -617,9 +617,9 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         .filter(|&sp| sp != base_error.span)
                         .collect();
 
-                    let start_span = bounds.iter().map(|bound| bound.span()).next().unwrap();
+                    let start_span = bounds[0].span();
                     // `end_span` is the end of the poly trait ref (Foo + 'baz + Bar><)
-                    let end_span = bounds.iter().map(|bound| bound.span()).last().unwrap();
+                    let end_span = bounds.last().unwrap().span();
                     // `last_bound_span` is the last bound of the poly trait ref (Foo + >'baz< + Bar)
                     let last_bound_span = spans.last().cloned().unwrap();
                     let mut multi_span: MultiSpan = spans.clone().into();

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1309,10 +1309,8 @@ pub fn build_session(
     let warnings_allow = sopts
         .lint_opts
         .iter()
-        .filter(|&&(ref key, _)| *key == "warnings")
-        .map(|&(_, ref level)| *level == lint::Allow)
-        .last()
-        .unwrap_or(false);
+        .rfind(|&&(ref key, _)| *key == "warnings")
+        .map_or(false, |&(_, level)| level == lint::Allow);
     let cap_lints_allow = sopts.lint_cap.map_or(false, |cap| cap == lint::Allow);
     let can_emit_warnings = !(warnings_allow || cap_lints_allow);
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -587,7 +587,7 @@ fn generate_macro_def_id_path(
             }
         })
         .collect();
-    let relative = fqp.iter().map(|elem| elem.to_string());
+    let mut relative = fqp.iter().map(|elem| elem.to_string());
     let cstore = CStore::from_tcx(tcx);
     // We need this to prevent a `panic` when this function is used from intra doc links...
     if !cstore.has_crate_data(def_id.krate) {
@@ -607,7 +607,7 @@ fn generate_macro_def_id_path(
     let mut path = if is_macro_2 {
         once(crate_name.clone()).chain(relative).collect()
     } else {
-        vec![crate_name.clone(), relative.last().unwrap()]
+        vec![crate_name.clone(), relative.next_back().unwrap()]
     };
     if path.len() < 2 {
         // The minimum we can have is the crate name followed by the macro name. If shorter, then

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2594,7 +2594,7 @@ impl<'test> TestCx<'test> {
                     }
                     None
                 } else {
-                    let sline = line.split("///").last().unwrap_or("");
+                    let sline = line.rsplit("///").next().unwrap();
                     let line = sline.trim_start();
                     if line.starts_with("```") {
                         if ignore {


### PR DESCRIPTION
Adapters like `Filter` and `Map` use the default implementation of `Iterator::last` which is not short-circuiting (and so does `core::str::Split`). The predicate function will be run for every single item of the underlying iterator. I hope that removing those calls to `last` results in slight performance improvements.

