### PR TITLE
rustdoc: add hash to filename of toolchain files

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -239,9 +239,6 @@ pub(crate) struct RenderOptions {
     pub(crate) default_settings: FxHashMap<String, String>,
     /// If present, suffix added to CSS/JavaScript files when referencing them in generated pages.
     pub(crate) resource_suffix: String,
-    /// Whether to run the static CSS/JavaScript through a minifier when outputting them. `true` by
-    /// default.
-    pub(crate) enable_minification: bool,
     /// Whether to create an index page in the root of the output directory. If this is true but
     /// `enable_index_page` is None, generate a static listing of crates instead.
     pub(crate) enable_index_page: bool,
@@ -416,7 +413,9 @@ impl Options {
 
         let to_check = matches.opt_strs("check-theme");
         if !to_check.is_empty() {
-            let paths = match theme::load_css_paths(static_files::themes::LIGHT) {
+            let paths = match theme::load_css_paths(
+                std::str::from_utf8(static_files::STATIC_FILES.theme_light_css.bytes).unwrap(),
+            ) {
                 Ok(p) => p,
                 Err(e) => {
                     diag.struct_err(&e.to_string()).emit();
@@ -557,7 +556,9 @@ impl Options {
 
         let mut themes = Vec::new();
         if matches.opt_present("theme") {
-            let paths = match theme::load_css_paths(static_files::themes::LIGHT) {
+            let paths = match theme::load_css_paths(
+                std::str::from_utf8(static_files::STATIC_FILES.theme_light_css.bytes).unwrap(),
+            ) {
                 Ok(p) => p,
                 Err(e) => {
                     diag.struct_err(&e.to_string()).emit();
@@ -675,7 +676,6 @@ impl Options {
             ModuleSorting::Alphabetical
         };
         let resource_suffix = matches.opt_str("resource-suffix").unwrap_or_default();
-        let enable_minification = !matches.opt_present("disable-minification");
         let markdown_no_toc = matches.opt_present("markdown-no-toc");
         let markdown_css = matches.opt_strs("markdown-css");
         let markdown_playground_url = matches.opt_str("markdown-playground-url");
@@ -768,7 +768,6 @@ impl Options {
             extern_html_root_takes_precedence,
             default_settings,
             resource_suffix,
-            enable_minification,
             enable_index_page,
             index_page,
             static_root_path,

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -2,12 +2,13 @@ use std::path::PathBuf;
 
 use rustc_data_structures::fx::FxHashMap;
 
-use crate::error::Error;
 use crate::externalfiles::ExternalHtml;
 use crate::html::format::{Buffer, Print};
 use crate::html::render::{ensure_trailing_slash, StylePath};
 
 use askama::Template;
+
+use super::static_files::{StaticFiles, STATIC_FILES};
 
 #[derive(Clone)]
 pub(crate) struct Layout {
@@ -45,6 +46,9 @@ struct PageLayout<'a> {
     static_root_path: &'a str,
     page: &'a Page<'a>,
     layout: &'a Layout,
+
+    files: &'static StaticFiles,
+
     themes: Vec<String>,
     sidebar: String,
     content: String,
@@ -61,12 +65,9 @@ pub(crate) fn render<T: Print, S: Print>(
 ) -> String {
     let static_root_path = page.get_static_root_path();
     let krate_with_trailing_slash = ensure_trailing_slash(&layout.krate).to_string();
-    let mut themes: Vec<String> = style_files
-        .iter()
-        .map(StylePath::basename)
-        .collect::<Result<_, Error>>()
-        .unwrap_or_default();
+    let mut themes: Vec<String> = style_files.iter().map(|s| s.basename().unwrap()).collect();
     themes.sort();
+
     let rustdoc_version = rustc_interface::util::version_str().unwrap_or("unknown version");
     let content = Buffer::html().to_display(t); // Note: This must happen before making the sidebar.
     let sidebar = Buffer::html().to_display(sidebar);
@@ -74,6 +75,7 @@ pub(crate) fn render<T: Print, S: Print>(
         static_root_path,
         page,
         layout,
+        files: &STATIC_FILES,
         themes,
         sidebar,
         content,

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -35,15 +35,18 @@ pub(crate) struct Page<'a> {
 }
 
 impl<'a> Page<'a> {
-    pub(crate) fn get_static_root_path(&self) -> &str {
-        self.static_root_path.unwrap_or(self.root_path)
+    pub(crate) fn get_static_root_path(&self) -> String {
+        match self.static_root_path {
+            Some(s) => s.to_string(),
+            None => format!("{}{}", self.root_path, "static.files/"),
+        }
     }
 }
 
 #[derive(Template)]
 #[template(path = "page.html")]
 struct PageLayout<'a> {
-    static_root_path: &'a str,
+    static_root_path: String,
     page: &'a Page<'a>,
     layout: &'a Layout,
 

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -38,7 +38,7 @@ impl<'a> Page<'a> {
     pub(crate) fn get_static_root_path(&self) -> String {
         match self.static_root_path {
             Some(s) => s.to_string(),
-            None => format!("{}{}", self.root_path, "static.files/"),
+            None => format!("{}static.files/", self.root_path),
         }
     }
 }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -636,7 +636,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                      <link rel=\"stylesheet\" type=\"text/css\" \
                          href=\"{static_root_path}{settings_css}\">\
                      <script defer src=\"{static_root_path}{settings_js}\"></script>",
-                    static_root_path = page.static_root_path.unwrap_or(""),
+                    static_root_path = page.get_static_root_path(),
                     settings_css = static_files::STATIC_FILES.settings_css,
                     settings_js = static_files::STATIC_FILES.settings_js,
                 )

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -32,7 +32,7 @@ use crate::html::escape::Escape;
 use crate::html::format::{join_with_double_colon, Buffer};
 use crate::html::markdown::{self, plain_text_summary, ErrorCodes, IdMap};
 use crate::html::url_parts_builder::UrlPartsBuilder;
-use crate::html::{layout, sources};
+use crate::html::{layout, sources, static_files};
 use crate::scrape_examples::AllCallLocations;
 use crate::try_err;
 
@@ -498,7 +498,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         );
 
         let (sender, receiver) = channel();
-        let mut scx = SharedContext {
+        let scx = SharedContext {
             tcx,
             src_root,
             local_sources,
@@ -520,19 +520,6 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             cache,
             call_locations,
         };
-
-        // Add the default themes to the `Vec` of stylepaths
-        //
-        // Note that these must be added before `sources::render` is called
-        // so that the resulting source pages are styled
-        //
-        // `light.css` is not disabled because it is the stylesheet that stays loaded
-        // by the browser as the theme stylesheet. The theme system (hackily) works by
-        // changing the href to this stylesheet. All other themes are disabled to
-        // prevent rule conflicts
-        scx.style_files.push(StylePath { path: PathBuf::from("light.css") });
-        scx.style_files.push(StylePath { path: PathBuf::from("dark.css") });
-        scx.style_files.push(StylePath { path: PathBuf::from("ayu.css") });
 
         let dst = output;
         scx.ensure_dir(&dst)?;
@@ -647,10 +634,11 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                         </section>\
                      </noscript>\
                      <link rel=\"stylesheet\" type=\"text/css\" \
-                         href=\"{root_path}settings{suffix}.css\">\
-                     <script defer src=\"{root_path}settings{suffix}.js\"></script>",
-                    root_path = page.static_root_path.unwrap_or(""),
-                    suffix = page.resource_suffix,
+                         href=\"{static_root_path}{settings_css}\">\
+                     <script defer src=\"{static_root_path}{settings_js}\"></script>",
+                    static_root_path = page.static_root_path.unwrap_or(""),
+                    settings_css = static_files::STATIC_FILES.settings_css,
+                    settings_js = static_files::STATIC_FILES.settings_js,
                 )
             },
             &shared.style_files,

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -30,10 +30,10 @@ use crate::html::format::{
     join_with_double_colon, print_abi_with_space, print_constness_with_space, print_where_clause,
     Buffer, Ending, PrintWithSpace,
 };
-use crate::html::highlight;
 use crate::html::layout::Page;
 use crate::html::markdown::{HeadingOffset, MarkdownSummaryLine};
 use crate::html::url_parts_builder::UrlPartsBuilder;
+use crate::html::{highlight, static_files};
 
 use askama::Template;
 use itertools::Itertools;
@@ -52,8 +52,8 @@ struct PathComponent {
 #[derive(Template)]
 #[template(path = "print_item.html")]
 struct ItemVars<'a> {
-    page: &'a Page<'a>,
     static_root_path: &'a str,
+    clipboard_svg: &'static static_files::StaticFile,
     typ: &'a str,
     name: &'a str,
     item_type: &'a str,
@@ -147,8 +147,8 @@ pub(super) fn print_item(
     };
 
     let item_vars = ItemVars {
-        page,
         static_root_path: page.get_static_root_path(),
+        clipboard_svg: &static_files::STATIC_FILES.clipboard_svg,
         typ,
         name: item.name.as_ref().unwrap().as_str(),
         item_type: &item.type_().to_string(),

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -147,7 +147,7 @@ pub(super) fn print_item(
     };
 
     let item_vars = ItemVars {
-        static_root_path: page.get_static_root_path(),
+        static_root_path: &page.get_static_root_path(),
         clipboard_svg: &static_files::STATIC_FILES.clipboard_svg,
         typ,
         name: item.name.as_ref().unwrap().as_str(),

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -85,12 +85,11 @@ pub(super) fn write_shared(
     }
 
     if options.emit.is_empty() || options.emit.contains(&EmitType::Toolchain) {
-        for f in static_files::STATIC_FILES_LIST {
-            let filename = cx.dst.join(
-                Path::new("static.files/").join(static_files::static_filename(f.filename, f.bytes)),
-            );
-            cx.shared.fs.write(filename, f.minified())?;
-        }
+        let static_dir = cx.dst.join(Path::new("static.files"));
+        static_files::for_each(|f: &static_files::StaticFile| {
+            let filename = static_dir.join(f.output_filename());
+            cx.shared.fs.write(filename, f.minified())
+        })?;
     }
 
     /// Read a file and return all lines that match the `"{crate}":{data},` format,

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -24,7 +24,8 @@ use crate::{try_err, try_none};
 ///    URL if the contents change, so they are safe to cache with the
 ///    `Cache-Control: immutable` directive. They are written under the static.files/
 ///    directory and are written when --emit-type is empty (default) or contains
-///    "toolchain-specific".
+///    "toolchain-specific". If using the --static-root-path flag, it should point
+///    to a URL path prefix where each of these filenames can be fetched.
 ///  - Invocation specific files. These are generated based on the crate(s) being
 ///    documented. Their filenames need to be predictable without knowing their
 ///    contents, so they do not include a hash in their filename and are not safe to
@@ -85,8 +86,10 @@ pub(super) fn write_shared(
 
     if options.emit.is_empty() || options.emit.contains(&EmitType::Toolchain) {
         for f in static_files::STATIC_FILES_LIST {
-            let filename = static_files::static_filename(f.filename, f.bytes);
-            cx.shared.fs.write(cx.dst.join(filename), f.minified())?;
+            let filename = cx.dst.join(
+                Path::new("static.files/").join(static_files::static_filename(f.filename, f.bytes)),
+            );
+            cx.shared.fs.write(filename, f.minified())?;
         }
     }
 

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -1,10 +1,8 @@
-use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io::{self, BufReader};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 use std::rc::Rc;
-use std::sync::LazyLock as Lazy;
 
 use itertools::Itertools;
 use rustc_data_structures::flock;
@@ -20,123 +18,19 @@ use crate::error::Error;
 use crate::html::{layout, static_files};
 use crate::{try_err, try_none};
 
-static FILES_UNVERSIONED: Lazy<FxHashMap<&str, &[u8]>> = Lazy::new(|| {
-    map! {
-        "FiraSans-Regular.woff2" => static_files::fira_sans::REGULAR,
-        "FiraSans-Medium.woff2" => static_files::fira_sans::MEDIUM,
-        "FiraSans-LICENSE.txt" => static_files::fira_sans::LICENSE,
-        "SourceSerif4-Regular.ttf.woff2" => static_files::source_serif_4::REGULAR,
-        "SourceSerif4-Bold.ttf.woff2" => static_files::source_serif_4::BOLD,
-        "SourceSerif4-It.ttf.woff2" => static_files::source_serif_4::ITALIC,
-        "SourceSerif4-LICENSE.md" => static_files::source_serif_4::LICENSE,
-        "SourceCodePro-Regular.ttf.woff2" => static_files::source_code_pro::REGULAR,
-        "SourceCodePro-Semibold.ttf.woff2" => static_files::source_code_pro::SEMIBOLD,
-        "SourceCodePro-It.ttf.woff2" => static_files::source_code_pro::ITALIC,
-        "SourceCodePro-LICENSE.txt" => static_files::source_code_pro::LICENSE,
-        "NanumBarunGothic.ttf.woff2" => static_files::nanum_barun_gothic::REGULAR,
-        "NanumBarunGothic-LICENSE.txt" => static_files::nanum_barun_gothic::LICENSE,
-        "LICENSE-MIT.txt" => static_files::LICENSE_MIT,
-        "LICENSE-APACHE.txt" => static_files::LICENSE_APACHE,
-        "COPYRIGHT.txt" => static_files::COPYRIGHT,
-    }
-});
-
-enum SharedResource<'a> {
-    /// This file will never change, no matter what toolchain is used to build it.
-    ///
-    /// It does not have a resource suffix.
-    Unversioned { name: &'static str },
-    /// This file may change depending on the toolchain.
-    ///
-    /// It has a resource suffix.
-    ToolchainSpecific { basename: &'static str },
-    /// This file may change for any crate within a build, or based on the CLI arguments.
-    ///
-    /// This differs from normal invocation-specific files because it has a resource suffix.
-    InvocationSpecific { basename: &'a str },
-}
-
-impl SharedResource<'_> {
-    fn extension(&self) -> Option<&OsStr> {
-        use SharedResource::*;
-        match self {
-            Unversioned { name }
-            | ToolchainSpecific { basename: name }
-            | InvocationSpecific { basename: name } => Path::new(name).extension(),
-        }
-    }
-
-    fn path(&self, cx: &Context<'_>) -> PathBuf {
-        match self {
-            SharedResource::Unversioned { name } => cx.dst.join(name),
-            SharedResource::ToolchainSpecific { basename } => cx.suffix_path(basename),
-            SharedResource::InvocationSpecific { basename } => cx.suffix_path(basename),
-        }
-    }
-
-    fn should_emit(&self, emit: &[EmitType]) -> bool {
-        if emit.is_empty() {
-            return true;
-        }
-        let kind = match self {
-            SharedResource::Unversioned { .. } => EmitType::Unversioned,
-            SharedResource::ToolchainSpecific { .. } => EmitType::Toolchain,
-            SharedResource::InvocationSpecific { .. } => EmitType::InvocationSpecific,
-        };
-        emit.contains(&kind)
-    }
-}
-
-impl Context<'_> {
-    fn suffix_path(&self, filename: &str) -> PathBuf {
-        // We use splitn vs Path::extension here because we might get a filename
-        // like `style.min.css` and we want to process that into
-        // `style-suffix.min.css`.  Path::extension would just return `css`
-        // which would result in `style.min-suffix.css` which isn't what we
-        // want.
-        let (base, ext) = filename.split_once('.').unwrap();
-        let filename = format!("{}{}.{}", base, self.shared.resource_suffix, ext);
-        self.dst.join(&filename)
-    }
-
-    fn write_shared(
-        &self,
-        resource: SharedResource<'_>,
-        contents: impl 'static + Send + AsRef<[u8]>,
-        emit: &[EmitType],
-    ) -> Result<(), Error> {
-        if resource.should_emit(emit) {
-            self.shared.fs.write(resource.path(self), contents)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn write_minify(
-        &self,
-        resource: SharedResource<'_>,
-        contents: impl 'static + Send + AsRef<str> + AsRef<[u8]>,
-        minify: bool,
-        emit: &[EmitType],
-    ) -> Result<(), Error> {
-        if minify {
-            let contents = contents.as_ref();
-            let contents = if resource.extension() == Some(OsStr::new("css")) {
-                minifier::css::minify(contents)
-                    .map_err(|e| {
-                        Error::new(format!("failed to minify CSS file: {}", e), resource.path(self))
-                    })?
-                    .to_string()
-            } else {
-                minifier::js::minify(contents).to_string()
-            };
-            self.write_shared(resource, contents, emit)
-        } else {
-            self.write_shared(resource, contents, emit)
-        }
-    }
-}
-
+/// Rustdoc writes out two kinds of shared files:
+///  - Static files, which are embedded in the rustdoc binary and are written with a
+///    filename that includes a hash of their contents. These will always have a new
+///    URL if the contents change, so they are safe to cache with the
+///    `Cache-Control: immutable` directive. They are written under the static.files/
+///    directory and are written when --emit-type is empty (default) or contains
+///    "toolchain-specific".
+///  - Invocation specific files. These are generated based on the crate(s) being
+///    documented. Their filenames need to be predictable without knowing their
+///    contents, so they do not include a hash in their filename and are not safe to
+///    cache with `Cache-Control: immutable`. They include the contents of the
+///    --resource-suffix flag and are emitted when --emit-type is empty (default)
+///    or contains "invocation-specific".
 pub(super) fn write_shared(
     cx: &mut Context<'_>,
     krate: &Crate,
@@ -149,139 +43,51 @@ pub(super) fn write_shared(
     let lock_file = cx.dst.join(".lock");
     let _lock = try_err!(flock::Lock::new(&lock_file, true, true, true), &lock_file);
 
-    // Minified resources are usually toolchain resources. If they're not, they should use `cx.write_minify` directly.
-    fn write_minify(
-        basename: &'static str,
-        contents: impl 'static + Send + AsRef<str> + AsRef<[u8]>,
-        cx: &Context<'_>,
-        options: &RenderOptions,
-    ) -> Result<(), Error> {
-        cx.write_minify(
-            SharedResource::ToolchainSpecific { basename },
-            contents,
-            options.enable_minification,
-            &options.emit,
-        )
-    }
-
-    // Toolchain resources should never be dynamic.
-    let write_toolchain = |p: &'static _, c: &'static _| {
-        cx.write_shared(SharedResource::ToolchainSpecific { basename: p }, c, &options.emit)
-    };
-
-    // Crate resources should always be dynamic.
-    let write_crate = |p: &_, make_content: &dyn Fn() -> Result<Vec<u8>, Error>| {
+    // InvocationSpecific resources should always be dynamic.
+    let write_invocation_specific = |p: &str, make_content: &dyn Fn() -> Result<Vec<u8>, Error>| {
         let content = make_content()?;
-        cx.write_shared(SharedResource::InvocationSpecific { basename: p }, content, &options.emit)
+        if options.emit.is_empty() || options.emit.contains(&EmitType::InvocationSpecific) {
+            let output_filename = static_files::suffix_path(p, &cx.shared.resource_suffix);
+            cx.shared.fs.write(cx.dst.join(output_filename), content)
+        } else {
+            Ok(())
+        }
     };
 
-    // Given "foo.svg", return e.g. "url(\"foo1.58.0.svg\")"
-    fn ver_url(cx: &Context<'_>, basename: &'static str) -> String {
-        format!(
-            "url(\"{}\")",
-            SharedResource::ToolchainSpecific { basename }
-                .path(cx)
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-        )
-    }
+    cx.shared
+        .fs
+        .create_dir_all(cx.dst.join("static.files"))
+        .map_err(|e| PathError::new(e, "static.files"))?;
 
-    // We use the AUTOREPLACE mechanism to inject into our static JS and CSS certain
-    // values that are only known at doc build time. Since this mechanism is somewhat
-    // surprising when reading the code, please limit it to rustdoc.css.
-    write_minify(
-        "rustdoc.css",
-        static_files::RUSTDOC_CSS
-            .replace(
-                "/* AUTOREPLACE: */url(\"toggle-minus.svg\")",
-                &ver_url(cx, "toggle-minus.svg"),
-            )
-            .replace("/* AUTOREPLACE: */url(\"toggle-plus.svg\")", &ver_url(cx, "toggle-plus.svg"))
-            .replace("/* AUTOREPLACE: */url(\"down-arrow.svg\")", &ver_url(cx, "down-arrow.svg")),
-        cx,
-        options,
-    )?;
-
-    // Add all the static files. These may already exist, but we just
-    // overwrite them anyway to make sure that they're fresh and up-to-date.
-    write_minify("settings.css", static_files::SETTINGS_CSS, cx, options)?;
-    write_minify("noscript.css", static_files::NOSCRIPT_CSS, cx, options)?;
-
-    // To avoid "light.css" to be overwritten, we'll first run over the received themes and only
-    // then we'll run over the "official" styles.
-    let mut themes: FxHashSet<String> = FxHashSet::default();
-
+    // Handle added third-party themes
     for entry in &cx.shared.style_files {
         let theme = entry.basename()?;
         let extension =
             try_none!(try_none!(entry.path.extension(), &entry.path).to_str(), &entry.path);
 
-        // Handle the official themes
-        match theme.as_str() {
-            "light" => write_minify("light.css", static_files::themes::LIGHT, cx, options)?,
-            "dark" => write_minify("dark.css", static_files::themes::DARK, cx, options)?,
-            "ayu" => write_minify("ayu.css", static_files::themes::AYU, cx, options)?,
-            _ => {
-                // Handle added third-party themes
-                let filename = format!("{}.{}", theme, extension);
-                write_crate(&filename, &|| Ok(try_err!(fs::read(&entry.path), &entry.path)))?;
-            }
-        };
+        // Skip the official themes. They are written below as part of STATIC_FILES_LIST.
+        if matches!(theme.as_str(), "light" | "dark" | "ayu") {
+            continue;
+        }
 
-        themes.insert(theme.to_owned());
+        let bytes = try_err!(fs::read(&entry.path), &entry.path);
+        let filename = format!("{}{}.{}", theme, cx.shared.resource_suffix, extension);
+        cx.shared.fs.write(cx.dst.join(filename), bytes)?;
     }
 
-    if (*cx.shared).layout.logo.is_empty() {
-        write_toolchain("rust-logo.svg", static_files::RUST_LOGO_SVG)?;
-    }
-    if (*cx.shared).layout.favicon.is_empty() {
-        write_toolchain("favicon.svg", static_files::RUST_FAVICON_SVG)?;
-        write_toolchain("favicon-16x16.png", static_files::RUST_FAVICON_PNG_16)?;
-        write_toolchain("favicon-32x32.png", static_files::RUST_FAVICON_PNG_32)?;
-    }
-    write_toolchain("wheel.svg", static_files::WHEEL_SVG)?;
-    write_toolchain("clipboard.svg", static_files::CLIPBOARD_SVG)?;
-    write_toolchain("down-arrow.svg", static_files::DOWN_ARROW_SVG)?;
-    write_toolchain("toggle-minus.svg", static_files::TOGGLE_MINUS_PNG)?;
-    write_toolchain("toggle-plus.svg", static_files::TOGGLE_PLUS_PNG)?;
-
-    let mut themes: Vec<&String> = themes.iter().collect();
-    themes.sort();
-
-    write_minify("main.js", static_files::MAIN_JS, cx, options)?;
-    write_minify("search.js", static_files::SEARCH_JS, cx, options)?;
-    write_minify("settings.js", static_files::SETTINGS_JS, cx, options)?;
-
-    if cx.include_sources {
-        write_minify("source-script.js", static_files::sidebar::SOURCE_SCRIPT, cx, options)?;
-    }
-
-    write_minify("storage.js", static_files::STORAGE_JS, cx, options)?;
-
-    if cx.shared.layout.scrape_examples_extension {
-        cx.write_minify(
-            SharedResource::InvocationSpecific { basename: "scrape-examples.js" },
-            static_files::SCRAPE_EXAMPLES_JS,
-            options.enable_minification,
-            &options.emit,
-        )?;
-    }
-
+    // When the user adds their own CSS files with --extend-css, we write that as an
+    // invocation-specific file (that is, with a resource suffix).
     if let Some(ref css) = cx.shared.layout.css_file_extension {
         let buffer = try_err!(fs::read_to_string(css), css);
-        // This varies based on the invocation, so it can't go through the write_minify wrapper.
-        cx.write_minify(
-            SharedResource::InvocationSpecific { basename: "theme.css" },
-            buffer,
-            options.enable_minification,
-            &options.emit,
-        )?;
+        let path = static_files::suffix_path("theme.css", &cx.shared.resource_suffix);
+        cx.shared.fs.write(cx.dst.join(path), buffer)?;
     }
-    write_minify("normalize.css", static_files::NORMALIZE_CSS, cx, options)?;
-    for (name, contents) in &*FILES_UNVERSIONED {
-        cx.write_shared(SharedResource::Unversioned { name }, contents, &options.emit)?;
+
+    if options.emit.is_empty() || options.emit.contains(&EmitType::Toolchain) {
+        for f in static_files::STATIC_FILES_LIST {
+            let filename = static_files::static_filename(f.filename, f.bytes);
+            cx.shared.fs.write(cx.dst.join(filename), f.minified())?;
+        }
     }
 
     /// Read a file and return all lines that match the `"{crate}":{data},` format,
@@ -463,7 +269,7 @@ pub(super) fn write_shared(
             v.push_str("\\\n}');\ncreateSourceSidebar();\n");
             Ok(v.into_bytes())
         };
-        write_crate("source-files.js", &make_sources)?;
+        write_invocation_specific("source-files.js", &make_sources)?;
     }
 
     // Update the search index and crate list.
@@ -477,7 +283,7 @@ pub(super) fn write_shared(
     // Sort the indexes by crate so the file will be generated identically even
     // with rustdoc running in parallel.
     all_indexes.sort();
-    write_crate("search-index.js", &|| {
+    write_invocation_specific("search-index.js", &|| {
         let mut v = String::from("var searchIndex = JSON.parse('{\\\n");
         v.push_str(&all_indexes.join(",\\\n"));
         v.push_str(
@@ -490,7 +296,7 @@ if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
         Ok(v.into_bytes())
     })?;
 
-    write_crate("crates.js", &|| {
+    write_invocation_specific("crates.js", &|| {
         let krates = krates.iter().map(|k| format!("\"{}\"", k)).join(",");
         Ok(format!("window.ALL_CRATES = [{}];", krates).into_bytes())
     })?;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -4,7 +4,7 @@
 	font-style: normal;
 	font-weight: 400;
 	src: local('Fira Sans'),
-		url("FiraSans-Regular.woff2") format("woff2");
+		url("FiraSans-Regular-018c141bf0843ffd.woff2") format("woff2");
 	font-display: swap;
 }
 @font-face {
@@ -12,7 +12,7 @@
 	font-style: normal;
 	font-weight: 500;
 	src: local('Fira Sans Medium'),
-		url("FiraSans-Medium.woff2") format("woff2");
+		url("FiraSans-Medium-8f9a781e4970d388.woff2") format("woff2");
 	font-display: swap;
 }
 
@@ -22,7 +22,7 @@
 	font-style: normal;
 	font-weight: 400;
 	src: local('Source Serif 4'),
-		url("SourceSerif4-Regular.ttf.woff2") format("woff2");
+		url("SourceSerif4-Regular-1f7d512b176f0f72.ttf.woff2") format("woff2");
 	font-display: swap;
 }
 @font-face {
@@ -30,7 +30,7 @@
 	font-style: italic;
 	font-weight: 400;
 	src: local('Source Serif 4 Italic'),
-		url("SourceSerif4-It.ttf.woff2") format("woff2");
+		url("SourceSerif4-It-d034fe4ef9d0fa00.ttf.woff2") format("woff2");
 	font-display: swap;
 }
 @font-face {
@@ -38,7 +38,7 @@
 	font-style: normal;
 	font-weight: 700;
 	src: local('Source Serif 4 Bold'),
-		url("SourceSerif4-Bold.ttf.woff2") format("woff2");
+		url("SourceSerif4-Bold-124a1ca42af929b6.ttf.woff2") format("woff2");
 	font-display: swap;
 }
 
@@ -49,28 +49,28 @@
 	font-weight: 400;
 	/* Avoid using locally installed font because bad versions are in circulation:
 	 * see https://github.com/rust-lang/rust/issues/24355 */
-	src: url("SourceCodePro-Regular.ttf.woff2") format("woff2");
+	src: url("SourceCodePro-Regular-562dcc5011b6de7d.ttf.woff2") format("woff2");
 	font-display: swap;
 }
 @font-face {
 	font-family: 'Source Code Pro';
 	font-style: italic;
 	font-weight: 400;
-	src: url("SourceCodePro-It.ttf.woff2") format("woff2");
+	src: url("SourceCodePro-It-1cc31594bf4f1f79.ttf.woff2") format("woff2");
 	font-display: swap;
 }
 @font-face {
 	font-family: 'Source Code Pro';
 	font-style: normal;
 	font-weight: 600;
-	src: url("SourceCodePro-Semibold.ttf.woff2") format("woff2");
+	src: url("SourceCodePro-Semibold-d899c5a5c4aeb14a.ttf.woff2") format("woff2");
 	font-display: swap;
 }
 
 /* Avoid using legacy CJK serif fonts in Windows like Batang. */
 @font-face {
 	font-family: 'NanumBarunGothic';
-	src: url("NanumBarunGothic.ttf.woff2") format("woff2");
+	src: url("NanumBarunGothic-0f09457c7a19b7c6.ttf.woff2") format("woff2");
 	font-display: swap;
 	unicode-range: U+AC00-D7AF, U+1100-11FF, U+3130-318F, U+A960-A97F, U+D7B0-D7FF;
 }
@@ -848,7 +848,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	background-size: 20px;
 	background-position: calc(100% - 2px) 56%;
 	/* image is black color, themes should apply a "filter" property to change the color */
-	background-image: /* AUTOREPLACE: */url("down-arrow.svg");
+	background-image: url("down-arrow-2d685a4bae708e15.svg");
 }
 #crate-search > option {
 	font-size: 1rem;
@@ -1625,11 +1625,11 @@ details.rustdoc-toggle[open] > summary.hideme > span {
 
 details.rustdoc-toggle[open] > summary::before,
 details.rustdoc-toggle[open] > summary.hideme::before {
-	background-image: /* AUTOREPLACE: */url("toggle-minus.svg");
+	background-image: url("toggle-minus-31bbd6e4c77f5c96.svg");
 }
 
 details.rustdoc-toggle > summary::before {
-	background-image: /* AUTOREPLACE: */url("toggle-plus.svg");
+	background-image: url("toggle-plus-1092eb4930d581b0.svg");
 }
 
 details.rustdoc-toggle[open] > summary::before,

--- a/src/librustdoc/html/static/fonts/README.txt
+++ b/src/librustdoc/html/static/fonts/README.txt
@@ -1,0 +1,12 @@
+The Nanum Barun Gothic fonts are shipped with rustdoc because the default fonts
+on many Windows installs render Korean very badly. See:
+ - https://github.com/rust-lang/rust/pull/84048,
+ - https://github.com/rust-lang/rust/issues/84035
+ - https://github.com/rust-lang/rust/pull/90232
+
+The font files were generated with these commands:
+
+```sh
+pyftsubset NanumBarunGothic.ttf \
+--unicodes=U+AC00-D7AF:U+1100-11FF,U+3130-318F,U+A960-A97F,U+D7B0-D7FF \
+--output-file=NanumBarunGothic.ttf.woff2 --flavor=woff2

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -183,9 +183,9 @@ function browserSupportsHistoryApi() {
 }
 
 // eslint-disable-next-line no-unused-vars
-function loadCss(cssFileName) {
+function loadCss(cssUrl) {
     const link = document.createElement("link");
-    link.href = resourcePath(cssFileName, ".css");
+    link.href = cssUrl;
     link.type = "text/css";
     link.rel = "stylesheet";
     document.getElementsByTagName("head")[0].appendChild(link);
@@ -208,8 +208,8 @@ function loadCss(cssFileName) {
         event.preventDefault();
         // Sending request for the CSS and the JS files at the same time so it will
         // hopefully be loaded when the JS will generate the settings content.
-        loadCss("settings");
-        loadScript(resourcePath("settings", ".js"));
+        loadCss(getVar("static-root-path") + getVar("settings-css"));
+        loadScript(getVar("static-root-path") + getVar("settings-js"));
     };
 
     window.searchState = {
@@ -286,7 +286,7 @@ function loadCss(cssFileName) {
             function loadSearch() {
                 if (!searchLoaded) {
                     searchLoaded = true;
-                    loadScript(resourcePath("search", ".js"));
+                    loadScript(getVar("static-root-path") + getVar("search-js"));
                     loadScript(resourcePath("search-index", ".js"));
                 }
             }

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -154,7 +154,9 @@
      * @return {HTMLElement}
      */
     function buildSettingsPage() {
-        const themes = getVar("themes").split(",");
+        const theme_names = getVar("themes").split(",").filter(t => t);
+        theme_names.push("light", "dark", "ayu");
+
         const settings = [
             {
                 "name": "Use system theme",
@@ -165,19 +167,19 @@
                 "name": "Theme",
                 "js_name": "theme",
                 "default": "light",
-                "options": themes,
+                "options": theme_names,
             },
             {
                 "name": "Preferred light theme",
                 "js_name": "preferred-light-theme",
                 "default": "light",
-                "options": themes,
+                "options": theme_names,
             },
             {
                 "name": "Preferred dark theme",
                 "js_name": "preferred-dark-theme",
                 "default": "dark",
-                "options": themes,
+                "options": theme_names,
             },
             {
                 "name": "Auto-hide item contents for large items",

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -126,33 +126,29 @@ function getCurrentValue(name) {
     }
 }
 
-function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
-    const newHref = mainStyleElem.href.replace(
-        /\/rustdoc([^/]*)\.css/, "/" + newTheme + "$1" + ".css");
-
+function switchTheme(styleElem, mainStyleElem, newThemeName, saveTheme) {
     // If this new value comes from a system setting or from the previously
     // saved theme, no need to save it.
     if (saveTheme) {
-        updateLocalStorage("theme", newTheme);
+        updateLocalStorage("theme", newThemeName);
     }
 
-    if (styleElem.href === newHref) {
-        return;
-    }
-
-    let found = false;
     if (savedHref.length === 0) {
         onEachLazy(document.getElementsByTagName("link"), el => {
             savedHref.push(el.href);
         });
     }
-    onEach(savedHref, el => {
-        if (el === newHref) {
-            found = true;
+    const newHref = savedHref.find(url => {
+        const m = url.match(/static\.files\/(.*)-[a-f0-9]{16}\.css$/);
+        if (m && m[1] === newThemeName) {
+            return true;
+        }
+        const m2 = url.match(/\/([^/]*)\.css$/);
+        if (m2 && m2[1].startsWith(newThemeName)) {
             return true;
         }
     });
-    if (found) {
+    if (newHref && newHref !== styleElem.href) {
         styleElem.href = newHref;
     }
 }

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -5,7 +5,7 @@
 
 use rustc_data_structures::fx::FxHasher;
 use std::hash::Hasher;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{fmt, str};
 
 pub(crate) struct StaticFile {
@@ -51,7 +51,7 @@ pub(crate) fn suffix_path(filename: &str, suffix: &str) -> PathBuf {
 
 pub(crate) fn static_filename(filename: &str, contents: &[u8]) -> PathBuf {
     let filename = filename.rsplit("/").next().unwrap();
-    Path::new("static.files").join(suffix_path(filename, &static_suffix(contents)))
+    suffix_path(filename, &static_suffix(contents))
 }
 
 fn static_suffix(bytes: &[u8]) -> String {

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -2,167 +2,119 @@
 //!
 //! All the static files are included here for centralized access in case anything other than the
 //! HTML rendering code (say, the theme checker) needs to access one of these files.
-//!
-//! Note about types: CSS and JavaScript files are included as `&'static str` to allow for the
-//! minifier to run on them. All other files are included as `&'static [u8]` so they can be
-//! directly written to a `Write` handle.
 
-/// The file contents of the main `rustdoc.css` file, responsible for the core layout of the page.
-pub(crate) static RUSTDOC_CSS: &str = include_str!("static/css/rustdoc.css");
+use rustc_data_structures::fx::FxHasher;
+use std::hash::Hasher;
+use std::path::{Path, PathBuf};
+use std::{fmt, str};
 
-/// The file contents of `settings.css`, responsible for the items on the settings page.
-pub(crate) static SETTINGS_CSS: &str = include_str!("static/css/settings.css");
-
-/// The file contents of the `noscript.css` file, used in case JS isn't supported or is disabled.
-pub(crate) static NOSCRIPT_CSS: &str = include_str!("static/css/noscript.css");
-
-/// The file contents of `normalize.css`, included to even out standard elements between browser
-/// implementations.
-pub(crate) static NORMALIZE_CSS: &str = include_str!("static/css/normalize.css");
-
-/// The file contents of `main.js`, which contains the core JavaScript used on documentation pages,
-/// including search behavior and docblock folding, among others.
-pub(crate) static MAIN_JS: &str = include_str!("static/js/main.js");
-
-/// The file contents of `search.js`, which contains the search behavior.
-pub(crate) static SEARCH_JS: &str = include_str!("static/js/search.js");
-
-/// The file contents of `settings.js`, which contains the JavaScript used to handle the settings
-/// page.
-pub(crate) static SETTINGS_JS: &str = include_str!("static/js/settings.js");
-
-/// The file contents of `storage.js`, which contains functionality related to browser Local
-/// Storage, used to store documentation settings.
-pub(crate) static STORAGE_JS: &str = include_str!("static/js/storage.js");
-
-/// The file contents of `scraped-examples.js`, which contains functionality related to the
-/// --scrape-examples flag that inserts automatically-found examples of usages of items.
-pub(crate) static SCRAPE_EXAMPLES_JS: &str = include_str!("static/js/scrape-examples.js");
-
-pub(crate) static SCRAPE_EXAMPLES_HELP_MD: &str = include_str!("static/scrape-examples-help.md");
-
-/// The file contents of `wheel.svg`, the icon used for the settings button.
-pub(crate) static WHEEL_SVG: &[u8] = include_bytes!("static/images/wheel.svg");
-
-/// The file contents of `clipboard.svg`, the icon used for the "copy path" button.
-pub(crate) static CLIPBOARD_SVG: &[u8] = include_bytes!("static/images/clipboard.svg");
-
-/// The file contents of `down-arrow.svg`, the icon used for the crate choice combobox.
-pub(crate) static DOWN_ARROW_SVG: &[u8] = include_bytes!("static/images/down-arrow.svg");
-
-/// The file contents of `toggle-minus.svg`, the icon used for opened toggles.
-pub(crate) static TOGGLE_MINUS_PNG: &[u8] = include_bytes!("static/images/toggle-minus.svg");
-
-/// The file contents of `toggle-plus.svg`, the icon used for closed toggles.
-pub(crate) static TOGGLE_PLUS_PNG: &[u8] = include_bytes!("static/images/toggle-plus.svg");
-
-/// The contents of `COPYRIGHT.txt`, the license listing for files distributed with documentation
-/// output.
-pub(crate) static COPYRIGHT: &[u8] = include_bytes!("static/COPYRIGHT.txt");
-
-/// The contents of `LICENSE-APACHE.txt`, the text of the Apache License, version 2.0.
-pub(crate) static LICENSE_APACHE: &[u8] = include_bytes!("static/LICENSE-APACHE.txt");
-
-/// The contents of `LICENSE-MIT.txt`, the text of the MIT License.
-pub(crate) static LICENSE_MIT: &[u8] = include_bytes!("static/LICENSE-MIT.txt");
-
-/// The contents of `rust-logo.svg`, the default icon of the documentation.
-pub(crate) static RUST_LOGO_SVG: &[u8] = include_bytes!("static/images/rust-logo.svg");
-
-/// The default documentation favicons (SVG and PNG fallbacks)
-pub(crate) static RUST_FAVICON_SVG: &[u8] = include_bytes!("static/images/favicon.svg");
-pub(crate) static RUST_FAVICON_PNG_16: &[u8] = include_bytes!("static/images/favicon-16x16.png");
-pub(crate) static RUST_FAVICON_PNG_32: &[u8] = include_bytes!("static/images/favicon-32x32.png");
-
-/// The built-in themes given to every documentation site.
-pub(crate) mod themes {
-    /// The "light" theme, selected by default when no setting is available. Used as the basis for
-    /// the `--check-theme` functionality.
-    pub(crate) static LIGHT: &str = include_str!("static/css/themes/light.css");
-
-    /// The "dark" theme.
-    pub(crate) static DARK: &str = include_str!("static/css/themes/dark.css");
-
-    /// The "ayu" theme.
-    pub(crate) static AYU: &str = include_str!("static/css/themes/ayu.css");
+pub(crate) struct StaticFile {
+    pub(crate) filename: &'static str,
+    pub(crate) bytes: &'static [u8],
 }
 
-/// Files related to the Fira Sans font.
-pub(crate) mod fira_sans {
-    /// The file `FiraSans-Regular.woff2`, the Regular variant of the Fira Sans font in woff2.
-    pub(crate) static REGULAR: &[u8] = include_bytes!("static/fonts/FiraSans-Regular.woff2");
+impl StaticFile {
+    pub(crate) fn minified(&self) -> Vec<u8> {
+        if self.filename.ends_with(".css") {
+            minifier::css::minify(str::from_utf8(self.bytes).unwrap()).unwrap().to_string().into()
+        } else if self.filename.ends_with(".js") {
+            minifier::js::minify(str::from_utf8(self.bytes).unwrap()).to_string().into()
+        } else {
+            self.bytes.to_owned()
+        }
+    }
 
-    /// The file `FiraSans-Medium.woff2`, the Medium variant of the Fira Sans font in woff2.
-    pub(crate) static MEDIUM: &[u8] = include_bytes!("static/fonts/FiraSans-Medium.woff2");
-
-    /// The file `FiraSans-LICENSE.txt`, the license text for the Fira Sans font.
-    pub(crate) static LICENSE: &[u8] = include_bytes!("static/fonts/FiraSans-LICENSE.txt");
+    pub(crate) fn output_filename(&self) -> PathBuf {
+        static_filename(self.filename, self.bytes)
+    }
 }
 
-/// Files related to the Source Serif 4 font.
-pub(crate) mod source_serif_4 {
-    /// The file `SourceSerif4-Regular.ttf.woff2`, the Regular variant of the Source Serif 4 font in
-    /// woff2.
-    pub(crate) static REGULAR: &[u8] =
-        include_bytes!("static/fonts/SourceSerif4-Regular.ttf.woff2");
-
-    /// The file `SourceSerif4-Bold.ttf.woff2`, the Bold variant of the Source Serif 4 font in
-    /// woff2.
-    pub(crate) static BOLD: &[u8] = include_bytes!("static/fonts/SourceSerif4-Bold.ttf.woff2");
-
-    /// The file `SourceSerif4-It.ttf.woff2`, the Italic variant of the Source Serif 4 font in
-    /// woff2.
-    pub(crate) static ITALIC: &[u8] = include_bytes!("static/fonts/SourceSerif4-It.ttf.woff2");
-
-    /// The file `SourceSerif4-LICENSE.txt`, the license text for the Source Serif 4 font.
-    pub(crate) static LICENSE: &[u8] = include_bytes!("static/fonts/SourceSerif4-LICENSE.md");
+/// The Display implementation for a StaticFile outputs its filename. This makes it
+/// convenient to interpolate static files into HTML templates.
+impl fmt::Display for StaticFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.output_filename().display())
+    }
 }
 
-/// Files related to the Source Code Pro font.
-pub(crate) mod source_code_pro {
-    /// The file `SourceCodePro-Regular.ttf.woff2`, the Regular variant of the Source Code Pro font
-    /// in woff2.
-    pub(crate) static REGULAR: &[u8] =
-        include_bytes!("static/fonts/SourceCodePro-Regular.ttf.woff2");
-
-    /// The file `SourceCodePro-Semibold.ttf.woff2`, the Semibold variant of the Source Code Pro
-    /// font in woff2.
-    pub(crate) static SEMIBOLD: &[u8] =
-        include_bytes!("static/fonts/SourceCodePro-Semibold.ttf.woff2");
-
-    /// The file `SourceCodePro-It.ttf.woff2`, the Italic variant of the Source Code Pro font in
-    /// woff2.
-    pub(crate) static ITALIC: &[u8] = include_bytes!("static/fonts/SourceCodePro-It.ttf.woff2");
-
-    /// The file `SourceCodePro-LICENSE.txt`, the license text of the Source Code Pro font.
-    pub(crate) static LICENSE: &[u8] = include_bytes!("static/fonts/SourceCodePro-LICENSE.txt");
+/// Insert the provided suffix into a filename just before the extension.
+pub(crate) fn suffix_path(filename: &str, suffix: &str) -> PathBuf {
+    // We use splitn vs Path::extension here because we might get a filename
+    // like `style.min.css` and we want to process that into
+    // `style-suffix.min.css`.  Path::extension would just return `css`
+    // which would result in `style.min-suffix.css` which isn't what we
+    // want.
+    let (base, ext) = filename.split_once('.').unwrap();
+    let filename = format!("{}{}.{}", base, suffix, ext);
+    filename.into()
 }
 
-/// Files related to the Nanum Barun Gothic font.
-///
-/// These files are used to avoid some legacy CJK serif fonts in Windows.
-///
-/// Note that the Noto Sans KR font, which was used previously but was not very readable on Windows,
-/// has been replaced by the Nanum Barun Gothic font. This is due to Windows' implementation of font
-/// rendering that distorts OpenType fonts too much.
-///
-/// The font files were generated with these commands:
-///
-/// ```sh
-/// pyftsubset NanumBarunGothic.ttf \
-/// --unicodes=U+AC00-D7AF,U+1100-11FF,U+3130-318F,U+A960-A97F,U+D7B0-D7FF \
-/// --output-file=NanumBarunGothic.ttf.woff2 --flavor=woff2
-/// ```
-pub(crate) mod nanum_barun_gothic {
-    /// The file `NanumBarunGothic.ttf.woff2`, the Regular variant of the Nanum Barun Gothic font.
-    pub(crate) static REGULAR: &[u8] = include_bytes!("static/fonts/NanumBarunGothic.ttf.woff2");
-
-    /// The file `NanumBarunGothic-LICENSE.txt`, the license text of the Nanum Barun Gothic font.
-    pub(crate) static LICENSE: &[u8] = include_bytes!("static/fonts/NanumBarunGothic-LICENSE.txt");
+pub(crate) fn static_filename(filename: &str, contents: &[u8]) -> PathBuf {
+    let filename = filename.rsplit("/").next().unwrap();
+    Path::new("static.files").join(suffix_path(filename, &static_suffix(contents)))
 }
 
-/// Files related to the sidebar in rustdoc sources.
-pub(crate) mod sidebar {
-    /// File script to handle sidebar.
-    pub(crate) static SOURCE_SCRIPT: &str = include_str!("static/js/source-script.js");
+fn static_suffix(bytes: &[u8]) -> String {
+    let mut hasher = FxHasher::default();
+    hasher.write(bytes);
+    format!("-{:016x}", hasher.finish())
 }
+
+macro_rules! static_files {
+    ($($field:ident => $file_path:literal,)+) => {
+        pub(crate) struct StaticFiles {
+            $(pub $field: StaticFile,)+
+        }
+
+        pub(crate) const STATIC_FILES: StaticFiles = StaticFiles {
+            $($field: StaticFile { filename: $file_path, bytes: include_bytes!($file_path) },)+
+        };
+
+        pub(crate) static STATIC_FILES_LIST: &[&'static StaticFile] = &[
+            $(&STATIC_FILES.$field,)+
+        ];
+    }
+}
+
+static_files! {
+    rustdoc_css => "static/css/rustdoc.css",
+    settings_css => "static/css/settings.css",
+    noscript_css => "static/css/noscript.css",
+    normalize_css => "static/css/normalize.css",
+    main_js => "static/js/main.js",
+    search_js => "static/js/search.js",
+    settings_js => "static/js/settings.js",
+    source_script_js => "static/js/source-script.js",
+    storage_js => "static/js/storage.js",
+    scrape_examples_js => "static/js/scrape-examples.js",
+    wheel_svg => "static/images/wheel.svg",
+    clipboard_svg => "static/images/clipboard.svg",
+    down_arrow_svg => "static/images/down-arrow.svg",
+    toggle_minus_png => "static/images/toggle-minus.svg",
+    toggle_plus_png => "static/images/toggle-plus.svg",
+    copyright => "static/COPYRIGHT.txt",
+    license_apache => "static/LICENSE-APACHE.txt",
+    license_mit => "static/LICENSE-MIT.txt",
+    rust_logo_svg => "static/images/rust-logo.svg",
+    rust_favicon_svg => "static/images/favicon.svg",
+    rust_favicon_png_16 => "static/images/favicon-16x16.png",
+    rust_favicon_png_32 => "static/images/favicon-32x32.png",
+    theme_light_css => "static/css/themes/light.css",
+    theme_dark_css => "static/css/themes/dark.css",
+    theme_ayu_css => "static/css/themes/ayu.css",
+    fira_sans_regular => "static/fonts/FiraSans-Regular.woff2",
+    fira_sans_medium => "static/fonts/FiraSans-Medium.woff2",
+    fira_sans_license => "static/fonts/FiraSans-LICENSE.txt",
+    source_serif_4_regular => "static/fonts/SourceSerif4-Regular.ttf.woff2",
+    source_serif_4_bold => "static/fonts/SourceSerif4-Bold.ttf.woff2",
+    source_serif_4_italic => "static/fonts/SourceSerif4-It.ttf.woff2",
+    source_serif_4_license => "static/fonts/SourceSerif4-LICENSE.md",
+    source_code_pro_regular => "static/fonts/SourceCodePro-Regular.ttf.woff2",
+    source_code_pro_semibold => "static/fonts/SourceCodePro-Semibold.ttf.woff2",
+    source_code_pro_italic => "static/fonts/SourceCodePro-It.ttf.woff2",
+    source_code_pro_license => "static/fonts/SourceCodePro-LICENSE.txt",
+    nanum_barun_gothic_regular => "static/fonts/NanumBarunGothic.ttf.woff2",
+    nanum_barun_gothic_license => "static/fonts/NanumBarunGothic-LICENSE.txt",
+}
+
+pub(crate) static SCRAPE_EXAMPLES_HELP_MD: &str = include_str!("static/js/scrape-examples.js");

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -7,48 +7,44 @@
     <meta name="description" content="{{page.description}}"> {#- -#}
     <meta name="keywords" content="{{page.keywords}}"> {#- -#}
     <title>{{page.title}}</title> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}SourceSerif4-Regular.ttf.woff2"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}FiraSans-Regular.woff2"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}FiraSans-Medium.woff2"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}SourceCodePro-Regular.ttf.woff2"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}SourceSerif4-Bold.ttf.woff2"> {#- -#}
-    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}SourceCodePro-Semibold.ttf.woff2"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_regular}}"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_regular}}"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_medium}}"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_regular}}"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_bold}}"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_semibold}}"> {#- -#}
     <link rel="stylesheet" {# -#}
-          href="{{static_root_path|safe}}normalize{{page.resource_suffix}}.css"> {#- -#}
+          href="{{static_root_path|safe}}{{files.normalize_css}}"> {#- -#}
     <link rel="stylesheet" {# -#}
-          href="{{static_root_path|safe}}rustdoc{{page.resource_suffix}}.css" {# -#}
+          href="{{static_root_path|safe}}{{files.rustdoc_css}}" {# -#}
           id="mainThemeStyle"> {#- -#}
+    <link rel="stylesheet" id="themeStyle" href="{{static_root_path|safe}}{{files.theme_light_css}}"> {#- -#}
+    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_dark_css}}"> {#- -#}
+    <link rel="stylesheet" disabled href="{{static_root_path|safe}}{{files.theme_ayu_css}}"> {#- -#}
     {%- for theme in themes -%}
-        <link rel="stylesheet" {# -#}
-            href="{{static_root_path|safe}}{{theme}}{{page.resource_suffix}}.css" {# -#}
-        {%- if theme == "light" -%}
-            id="themeStyle"
-        {%- else -%}
-            disabled
-        {%- endif -%}
-        >
+        <link rel="stylesheet" disabled href="{{page.root_path|safe}}{{theme}}{{page.resource_suffix}}.css"> {#- -#}
     {%- endfor -%}
     <script id="default-settings" {# -#}
       {% for (k, v) in layout.default_settings %}
         data-{{k}}="{{v}}"
       {%- endfor -%}
     ></script> {#- -#}
-    <script src="{{static_root_path|safe}}storage{{page.resource_suffix}}.js"></script> {#- -#}
+    <script src="{{static_root_path|safe}}{{files.storage_js}}"></script> {#- -#}
     {%- if page.css_class.contains("crate") -%}
     <script defer src="{{page.root_path|safe}}crates{{page.resource_suffix}}.js"></script> {#- -#}
     {%- else if page.css_class == "source" -%}
-    <script defer src="{{static_root_path|safe}}source-script{{page.resource_suffix}}.js"></script> {#- -#}
+    <script defer src="{{static_root_path|safe}}{{files.source_script_js}}"></script> {#- -#}
     <script defer src="{{page.root_path|safe}}source-files{{page.resource_suffix}}.js"></script> {#- -#}
     {%- else if !page.css_class.contains("mod") -%}
     <script defer src="sidebar-items{{page.resource_suffix}}.js"></script> {#- -#}
     {%- endif -%}
-    <script defer src="{{static_root_path|safe}}main{{page.resource_suffix}}.js"></script> {#- -#}
+    <script defer src="{{static_root_path|safe}}{{files.main_js}}"></script> {#- -#}
     {%- if layout.scrape_examples_extension -%}
-    <script defer src="{{page.root_path|safe}}scrape-examples{{page.resource_suffix}}.js"></script> {#- -#}
+    <script defer src="{{page.root_path|safe}}{{files.scrape_examples_js}}"></script> {#- -#}
     {%- endif -%}
     <noscript> {#- -#}
         <link rel="stylesheet" {# -#}
-           href="{{static_root_path|safe}}noscript{{page.resource_suffix}}.css"> {#- -#}
+           href="{{static_root_path|safe}}{{files.noscript_css}}"> {#- -#}
     </noscript> {#- -#}
     {%- if layout.css_file_extension.is_some() -%}
         <link rel="stylesheet" {# -#}
@@ -58,11 +54,11 @@
         <link rel="icon" href="{{layout.favicon}}"> {#- -#}
     {%- else -%}
         <link rel="alternate icon" type="image/png" {# -#}
-            href="{{static_root_path|safe}}favicon-16x16{{page.resource_suffix}}.png"> {#- -#}
+            href="{{static_root_path|safe}}{{files.rust_favicon_png_16}}"> {#- -#}
         <link rel="alternate icon" type="image/png" {# -#}
-            href="{{static_root_path|safe}}favicon-32x32{{page.resource_suffix}}.png"> {#- -#}
+            href="{{static_root_path|safe}}{{files.rust_favicon_png_32}}"> {#- -#}
         <link rel="icon" type="image/svg+xml" {# -#}
-            href="{{static_root_path|safe}}favicon{{page.resource_suffix}}.svg"> {#- -#}
+            href="{{static_root_path|safe}}{{files.rust_favicon_svg}}"> {#- -#}
     {%- endif -%}
     {{- layout.external_html.in_header|safe -}}
 </head> {#- -#}
@@ -81,7 +77,7 @@
             {%- if !layout.logo.is_empty() -%}
                 <img src="{{layout.logo}}" alt="logo"> {#- -#}
             {%- else -%}
-                <img class="rust-logo" src="{{static_root_path|safe}}rust-logo{{page.resource_suffix}}.svg" alt="logo"> {#- -#}
+                <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {#- -#}
             {%- endif -%}
             </div> {#- -#}
         </a> {#- -#}
@@ -95,7 +91,7 @@
                 {%- if !layout.logo.is_empty()  %}
                     <img src="{{layout.logo}}" alt="logo"> {#- -#}
                 {%- else -%}
-                    <img class="rust-logo" src="{{static_root_path|safe}}rust-logo{{page.resource_suffix}}.svg" alt="logo"> {#- -#}
+                    <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {#- -#}
                 {%- endif -%}
             </div> {#- -#}
         </a> {#- -#}
@@ -110,7 +106,7 @@
                     {%- if !layout.logo.is_empty()  %}
                         <img src="{{layout.logo}}" alt="logo"> {#- -#}
                     {%- else -%}
-                        <img class="rust-logo" src="{{static_root_path|safe}}rust-logo{{page.resource_suffix}}.svg" alt="logo"> {#- -#}
+                        <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {#- -#}
                     {%- endif -%}
                 </a> {#- -#}
                 {%- endif -%}
@@ -129,7 +125,7 @@
                     <div id="settings-menu" tabindex="-1"> {#- -#}
                         <a href="{{page.root_path|safe}}settings.html" title="settings"> {#- -#}
                             <img width="22" height="22" alt="Change settings" {# -#}
-                             src="{{static_root_path|safe}}wheel{{page.resource_suffix}}.svg"> {#- -#}
+                            src="{{static_root_path|safe}}{{files.wheel_svg}}"> {#- -#}
                         </a> {#- -#}
                     </div> {#- -#}
                 </form> {#- -#}
@@ -140,10 +136,14 @@
     {{- layout.external_html.after_content|safe -}}
     <div id="rustdoc-vars" {# -#}
          data-root-path="{{page.root_path|safe}}" {# -#}
+         data-static-root-path="{{static_root_path|safe}}" {# -#}
          data-current-crate="{{layout.krate}}" {# -#}
          data-themes="{{themes|join(",") }}" {# -#}
          data-resource-suffix="{{page.resource_suffix}}" {# -#}
          data-rustdoc-version="{{rustdoc_version}}" {# -#}
+         data-search-js="{{files.search_js}}" {# -#}
+         data-settings-js="{{files.settings_js}}" {# -#}
+         data-settings-css="{{files.settings_css}}" {# -#}
     > {#- -#}
     </div> {#- -#}
 </body> {#- -#}

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -7,7 +7,7 @@
         {%- endfor -%}
         <a class="{{item_type}}" href="#">{{name}}</a> {#- -#}
         <button id="copy-path" onclick="copy_path(this)" title="Copy item path to clipboard"> {#- -#}
-            <img src="{{static_root_path|safe}}clipboard{{page.resource_suffix}}.svg" {# -#}
+        <img src="{{static_root_path|safe}}{{clipboard_svg}}" {# -#}
                 width="19" height="18" {# -#}
                 alt="Copy item path"> {#- -#}
         </button> {#- -#}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -469,9 +469,6 @@ fn opts() -> Vec<RustcOptGroup> {
         stable("json", |o| {
             o.optopt("", "json", "Configure the structure of JSON diagnostics", "CONFIG")
         }),
-        unstable("disable-minification", |o| {
-            o.optflagmulti("", "disable-minification", "Disable minification applied on JS files")
-        }),
         stable("allow", |o| o.optmulti("A", "allow", "Set lint allowed", "LINT")),
         stable("warn", |o| o.optmulti("W", "warn", "Set lint warnings", "LINT")),
         stable("force-warn", |o| o.optmulti("", "force-warn", "Set lint force-warn", "LINT")),
@@ -610,6 +607,7 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         // deprecated / removed options
+        unstable("disable-minification", |o| o.optflagmulti("", "disable-minification", "removed")),
         stable("plugin-path", |o| {
             o.optmulti(
                 "",

--- a/src/test/run-make/emit-shared-files/Makefile
+++ b/src/test/run-make/emit-shared-files/Makefile
@@ -23,24 +23,24 @@ invocation-only:
 
 toolchain-only:
 	$(RUSTDOC) -Z unstable-options --emit=toolchain-shared-resources --output $(TOOLCHAIN_ONLY) --resource-suffix=-xxx --extend-css z.css x.rs
-	[ -e $(TOOLCHAIN_ONLY)/storage-xxx.js ]
-	! [ -e $(TOOLCHAIN_ONLY)/SourceSerif4-It.ttf.woff2 ]
+	[ -e $(TOOLCHAIN_ONLY)/static.files/storage-*.js ]
+	[ -e $(TOOLCHAIN_ONLY)/static.files/SourceSerif4-It-*.ttf.woff2 ]
 	! [ -e $(TOOLCHAIN_ONLY)/search-index-xxx.js ]
 	! [ -e $(TOOLCHAIN_ONLY)/x/index.html ]
 	! [ -e $(TOOLCHAIN_ONLY)/theme.css ]
 
-	[ -e $(TOOLCHAIN_ONLY)/main-xxx.js ]
+	[ -e $(TOOLCHAIN_ONLY)/static.files/main-*.js ]
 	! [ -e $(TOOLCHAIN_ONLY)/y-xxx.css ]
 
 all-shared:
 	$(RUSTDOC) -Z unstable-options --emit=toolchain-shared-resources,unversioned-shared-resources --output $(ALL_SHARED) --resource-suffix=-xxx --extend-css z.css x.rs
-	[ -e $(ALL_SHARED)/storage-xxx.js ]
-	[ -e $(ALL_SHARED)/SourceSerif4-It.ttf.woff2 ]
+	[ -e $(ALL_SHARED)/static.files/storage-*.js ]
+	[ -e $(ALL_SHARED)/static.files/SourceSerif4-It-*.ttf.woff2 ]
 	! [ -e $(ALL_SHARED)/search-index-xxx.js ]
 	! [ -e $(ALL_SHARED)/settings.html ]
 	! [ -e $(ALL_SHARED)/x ]
 	! [ -e $(ALL_SHARED)/src ]
 	! [ -e $(ALL_SHARED)/theme.css ]
 
-	[ -e $(ALL_SHARED)/main-xxx.js ]
+	[ -e $(ALL_SHARED)/static.files/main-*.js ]
 	! [ -e $(ALL_SHARED)/y-xxx.css ]

--- a/src/test/run-make/issue-88756-default-output/output-default.stdout
+++ b/src/test/run-make/issue-88756-default-output/output-default.stdout
@@ -115,8 +115,6 @@ Options:
                         Provide width of the output for truncated error
                         messages
         --json CONFIG   Configure the structure of JSON diagnostics
-        --disable-minification 
-                        Disable minification applied on JS files
     -A, --allow LINT    Set lint allowed
     -W, --warn LINT     Set lint warnings
         --force-warn LINT
@@ -173,6 +171,8 @@ Options:
         --scrape-tests  Include test code when scraping examples
         --with-examples path to function call information (for displaying examples in the documentation)
                         
+        --disable-minification 
+                        removed
         --plugin-path DIR
                         removed, see issue #44136
                         <https://github.com/rust-lang/rust/issues/44136> for

--- a/src/test/rustdoc/static-root-path.rs
+++ b/src/test/rustdoc/static-root-path.rs
@@ -1,18 +1,18 @@
 // compile-flags:-Z unstable-options --static-root-path /cache/
 
 // @has static_root_path/struct.SomeStruct.html
-// @matchesraw - '"/cache/main\.js"'
-// @!matchesraw - '"\.\./main\.js"'
+// @matchesraw - '"/cache/static.files/main-'
+// @!matchesraw - '"\.\./main'
 // @matchesraw - 'data-root-path="\.\./"'
 // @!matchesraw - '"/cache/search-index\.js"'
 pub struct SomeStruct;
 
 // @has src/static_root_path/static-root-path.rs.html
-// @matchesraw - '"/cache/source-script\.js"'
-// @!matchesraw - '"\.\./\.\./source-script\.js"'
+// @matchesraw - '"/cache/static.files/source-script-'
+// @!matchesraw - '"\.\./\.\./source-script'
 // @matchesraw - '"\.\./\.\./source-files.js"'
 // @!matchesraw - '"/cache/source-files\.js"'
 
 // @has settings.html
-// @matchesraw - '/cache/settings\.js'
-// @!matchesraw - '\./settings\.js'
+// @matchesraw - '/cache/static.files/settings-'
+// @!matchesraw - '\../settings'

--- a/src/test/rustdoc/static-root-path.rs
+++ b/src/test/rustdoc/static-root-path.rs
@@ -1,18 +1,18 @@
 // compile-flags:-Z unstable-options --static-root-path /cache/
 
 // @has static_root_path/struct.SomeStruct.html
-// @matchesraw - '"/cache/static.files/main-'
+// @matchesraw - '"/cache/main-'
 // @!matchesraw - '"\.\./main'
 // @matchesraw - 'data-root-path="\.\./"'
 // @!matchesraw - '"/cache/search-index\.js"'
 pub struct SomeStruct;
 
 // @has src/static_root_path/static-root-path.rs.html
-// @matchesraw - '"/cache/static.files/source-script-'
+// @matchesraw - '"/cache/source-script-'
 // @!matchesraw - '"\.\./\.\./source-script'
 // @matchesraw - '"\.\./\.\./source-files.js"'
 // @!matchesraw - '"/cache/source-files\.js"'
 
 // @has settings.html
-// @matchesraw - '/cache/static.files/settings-'
+// @matchesraw - '/cache/settings-'
 // @!matchesraw - '\../settings'

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -307,10 +307,13 @@ function runChecks(testFile, doSearch, parseQuery) {
  *   `parseQuery` function exported from the search module.
  */
 function loadSearchJS(doc_folder, resource_suffix) {
-    const searchJs = path.join(doc_folder, "search" + resource_suffix + ".js");
     const searchIndexJs = path.join(doc_folder, "search-index" + resource_suffix + ".js");
     const searchIndex = require(searchIndexJs);
-    const searchModule = require(searchJs);
+
+    const staticFiles = path.join(doc_folder, "static.files");
+    const searchJs = fs.readdirSync(staticFiles).find(
+        f => f.match(/search.*\.js$/));
+    const searchModule = require(path.join(staticFiles, searchJs));
     const searchWords = searchModule.initSearch(searchIndex.searchIndex);
 
     return {


### PR DESCRIPTION
All static files used by rustdoc are now stored in static.files/ and their filenames include a hash of their contents. Their filenames no longer include the contents of the --resource-suffix flag. This clarifies caching semantics. Anything in static.files can use Cache-Control: immutable because any updates will show up as a new URL.

Invocation-specific files like crates-NN.js, search-index-NN.js, and sidebar-items-NN.js still get the resource suffix.

This has a useful side effect: once toolchain files aren't affected by resource suffix, it will become possible for docs.rs to include crate version in the resource suffix. That should fix a caching issue with `/latest/` URLs: https://github.com/rust-lang/docs.rs/issues/1593. My goal is that it should be safe to serve all rustdoc JS, CSS, and fonts with infinite caching headers, even when new versions of a crate are uploaded in the same place as old versions.

The --disable-minification flag is removed because it would vary the output of static files based on invocation flags. Instead, for rustdoc development purposes it's preferable to symlink static files to a non-minified copy for quick iteration.

Example listing:

```
$ cd build/x86_64-unknown-linux-gnu/doc/ && find . | egrep 'js$|css$' | egrep -v 'sidebar-items|implementors' | sort
./crates1.65.0.js
./rust.css
./search-index1.65.0.js
./source-files1.65.0.js
./static.files/ayu-2bfd0af01c176fd5.css
./static.files/dark-95d11b5416841799.css
./static.files/light-c83a97e93a11f15a.css
./static.files/main-efc63f77fb116394.js
./static.files/normalize-76eba96aa4d2e634.css
./static.files/noscript-5bf457055038775c.css
./static.files/rustdoc-7a422337900fa894.css
./static.files/scrape-examples-3dd10048bcead3a4.js
./static.files/search-47f3c289722672cf.js
./static.files/settings-17b08337296ac774.js
./static.files/settings-3f95eacb845293c0.css
./static.files/source-script-215e9db86679192e.js
./static.files/storage-26d846fcae82ff09.js
```

Fixes #98413