### PR TITLE
rustdoc: remove no-op `#search`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1891,10 +1891,6 @@ in storage.js plus the media query with (min-width: 701px)
 		margin-top: 10px;
 	}
 
-	#search {
-		padding: 0;
-	}
-
 	.anchor {
 		display: none !important;
 	}

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1892,7 +1892,6 @@ in storage.js plus the media query with (min-width: 701px)
 	}
 
 	#search {
-		margin-left: 0;
 		padding: 0;
 	}
 


### PR DESCRIPTION
The margin rule was added in c729e4dca7581fcd060978bcb0d7f98ea4eb6b82 to remove an unnecessary left margin that was present on desktop. This desktop-mode margin was itself removed in 135281ed1525db15edd8ebd092aa10aa40df2386.

The padding rule was added in 135281ed1525db15edd8ebd092aa10aa40df2386 when converting the rule for `#main`, but didn't do anything even then.