### PR TITLE
Normalize closure signature after construction

### DIFF
--- a/compiler/rustc_typeck/src/check/closure.rs
+++ b/compiler/rustc_typeck/src/check/closure.rs
@@ -624,6 +624,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ),
             bound_vars,
         );
+        // Astconv can't normalize inputs or outputs with escaping bound vars,
+        // so normalize them here, after we've wrapped them in a binder.
+        let result = self.normalize_associated_types_in(self.tcx.hir().span(hir_id), result);
 
         let c_result = self.inh.infcx.canonicalize_response(result);
         self.typeck_results.borrow_mut().user_provided_sigs.insert(expr_def_id, c_result);

--- a/src/test/ui/closures/issue-101696.rs
+++ b/src/test/ui/closures/issue-101696.rs
@@ -1,0 +1,36 @@
+// check-pass
+
+use std::marker::PhantomData;
+
+#[derive(Default)]
+struct MyType<'a> {
+    field: usize,
+    _phantom: PhantomData<&'a ()>,
+}
+
+#[derive(Default)]
+struct MyTypeVariant<'a> {
+    field: usize,
+    _phantom: PhantomData<&'a ()>,
+}
+
+trait AsVariantTrait {
+    type Type;
+}
+
+impl<'a> AsVariantTrait for MyType<'a> {
+    type Type = MyTypeVariant<'a>;
+}
+
+type Variant<G> = <G as AsVariantTrait>::Type;
+
+fn foo<T: Default, F: FnOnce(T)>(f: F) {
+    let input = T::default();
+    f(input);
+}
+
+fn main() {
+    foo(|a: <MyType as AsVariantTrait>::Type| {
+        a.field;
+    });
+}


### PR DESCRIPTION
Astconv can't normalize inputs or outputs with escaping bound vars ([see this](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_typeck/check/fn_ctxt/mod.rs.html#294)), so normalize them after we've wrapped them in a binder.

Fixes #101696