### PR TITLE
Impove diagnostic for `.await`ing non-futures

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1160,8 +1160,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // and if not maybe suggest doing something else? If we kept the expression around we
                     // could also check if it is an fn call (very likely) and suggest changing *that*, if
                     // it is from the local crate.
-                    err.span_suggestion_verbose(
-                        expr.span.shrink_to_hi().with_hi(span.hi()),
+                    err.span_suggestion(
+                        span,
                         "remove the `.await`",
                         "",
                         Applicability::MachineApplicable,

--- a/src/test/ui/async-await/issue-101715.rs
+++ b/src/test/ui/async-await/issue-101715.rs
@@ -1,0 +1,17 @@
+// edition:2018
+
+struct S;
+
+impl S {
+    fn very_long_method_name_the_longest_method_name_in_the_whole_universe(self) {}
+}
+
+async fn foo() {
+    S.very_long_method_name_the_longest_method_name_in_the_whole_universe()
+        .await
+        //~^ error: `()` is not a future
+        //~| help: remove the `.await`
+        //~| help: the trait `Future` is not implemented for `()`
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issue-101715.stderr
+++ b/src/test/ui/async-await/issue-101715.stderr
@@ -1,0 +1,16 @@
+error[E0277]: `()` is not a future
+  --> $DIR/issue-101715.rs:11:9
+   |
+LL |         .await
+   |         ^^^^^^
+   |         |
+   |         `()` is not a future
+   |         help: remove the `.await`
+   |
+   = help: the trait `Future` is not implemented for `()`
+   = note: () must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `()` to implement `IntoFuture`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/issue-70594.stderr
+++ b/src/test/ui/async-await/issue-70594.stderr
@@ -22,16 +22,14 @@ error[E0277]: `()` is not a future
   --> $DIR/issue-70594.rs:4:11
    |
 LL |     [1; ().await];
-   |           ^^^^^^ `()` is not a future
+   |           ^^^^^^
+   |           |
+   |           `()` is not a future
+   |           help: remove the `.await`
    |
    = help: the trait `Future` is not implemented for `()`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
-help: remove the `.await`
-   |
-LL -     [1; ().await];
-LL +     [1; ()];
-   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/async-await/issues/issue-62009-1.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-1.stderr
@@ -28,16 +28,14 @@ error[E0277]: `[closure@$DIR/issue-62009-1.rs:12:6: 12:9]` is not a future
   --> $DIR/issue-62009-1.rs:12:15
    |
 LL |     (|_| 2333).await;
-   |               ^^^^^^ `[closure@$DIR/issue-62009-1.rs:12:6: 12:9]` is not a future
+   |               ^^^^^^
+   |               |
+   |               `[closure@$DIR/issue-62009-1.rs:12:6: 12:9]` is not a future
+   |               help: remove the `.await`
    |
    = help: the trait `Future` is not implemented for closure `[closure@$DIR/issue-62009-1.rs:12:6: 12:9]`
    = note: [closure@$DIR/issue-62009-1.rs:12:6: 12:9] must be a future or must implement `IntoFuture` to be awaited
    = note: required for `[closure@$DIR/issue-62009-1.rs:12:6: 12:9]` to implement `IntoFuture`
-help: remove the `.await`
-   |
-LL -     (|_| 2333).await;
-LL +     (|_| 2333);
-   |
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Strip leading whitespace from the span and use a non-verbose suggestion.
fixes #101715