### PR TITLE
Allow unauthenticated users to add the `const-hack` label

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,6 +11,7 @@ allow-unauthenticated = [
     "S-*",
     "T-*",
     "WG-*",
+    "const-hack",
     "needs-fcp",
     "relnotes",
     "requires-nightly",


### PR DESCRIPTION
Observed in #101401.

cc @oli-obk 

