### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/session.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/session.ftl
@@ -56,3 +56,13 @@ session_target_invalid_bits_size = {$err}
 session_target_stack_protector_not_supported = `-Z stack-protector={$stack_protector}` is not supported for target {$target_triple} and will be ignored
 
 session_split_debuginfo_unstable_platform = `-Csplit-debuginfo={$debuginfo}` is unstable on this platform
+
+session_file_is_not_writeable = output file {$file} is not writeable -- check its permissions
+
+session_crate_name_does_not_match = `--crate-name` and `#[crate_name]` are required to match, but `{$s}` != `{$name}`
+
+session_crate_name_invalid = crate names cannot start with a `-`, but `{$s}` has a leading hyphen
+
+session_crate_name_empty = crate name must not be empty
+
+session_invalid_character_in_create_name = invalid character `{$character}` in crate name: `{$crate_name}`

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -13,9 +13,9 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_data_structures = { path = "../rustc_data_structures" }
+rustc_target = { path = "../rustc_target" }
 rustc_hir = { path = "../rustc_hir" }
 rustc_lint_defs = { path = "../rustc_lint_defs" }
-rustc_target = { path = "../rustc_target" }
 unicode-width = "0.1.4"
 atty = "0.2"
 termcolor = "1.0"

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1704,7 +1704,7 @@ impl EmitterWriter {
         {
             notice_capitalization |= only_capitalization;
 
-            let has_deletion = parts.iter().any(|p| p.is_deletion());
+            let has_deletion = parts.iter().any(|p| p.is_deletion(sm));
             let is_multiline = complete.lines().count() > 1;
 
             if let Some(span) = span.primary_span() {

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -151,21 +151,20 @@ pub struct SubstitutionHighlight {
 
 impl SubstitutionPart {
     pub fn is_addition(&self, sm: &SourceMap) -> bool {
-        !self.snippet.is_empty()
-            && sm
-                .span_to_snippet(self.span)
-                .map_or(self.span.is_empty(), |snippet| snippet.trim().is_empty())
+        !self.snippet.is_empty() && !self.replaces_meaningful_content(sm)
     }
 
-    pub fn is_deletion(&self) -> bool {
-        self.snippet.trim().is_empty()
+    pub fn is_deletion(&self, sm: &SourceMap) -> bool {
+        self.snippet.trim().is_empty() && self.replaces_meaningful_content(sm)
     }
 
     pub fn is_replacement(&self, sm: &SourceMap) -> bool {
-        !self.snippet.is_empty()
-            && sm
-                .span_to_snippet(self.span)
-                .map_or(!self.span.is_empty(), |snippet| !snippet.trim().is_empty())
+        !self.snippet.is_empty() && self.replaces_meaningful_content(sm)
+    }
+
+    fn replaces_meaningful_content(&self, sm: &SourceMap) -> bool {
+        sm.span_to_snippet(self.span)
+            .map_or(!self.span.is_empty(), |snippet| !snippet.trim().is_empty())
     }
 }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1,6 +1,7 @@
 //! Contains infrastructure for configuring the compiler, including parsing
 //! command-line options.
 
+use crate::errors::TargetDataLayoutParseError;
 pub use crate::options::*;
 
 use crate::search_paths::SearchPath;
@@ -898,7 +899,7 @@ fn default_configuration(sess: &Session) -> CrateConfig {
     let max_atomic_width = sess.target.max_atomic_width();
     let atomic_cas = sess.target.atomic_cas;
     let layout = TargetDataLayout::parse(&sess.target).unwrap_or_else(|err| {
-        sess.emit_fatal(err);
+        sess.emit_fatal(TargetDataLayoutParseError { err });
     });
 
     let mut ret = CrateConfig::default();

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1,7 +1,6 @@
 //! Contains infrastructure for configuring the compiler, including parsing
 //! command-line options.
 
-use crate::errors::TargetDataLayoutParseError;
 pub use crate::options::*;
 
 use crate::search_paths::SearchPath;
@@ -899,7 +898,7 @@ fn default_configuration(sess: &Session) -> CrateConfig {
     let max_atomic_width = sess.target.max_atomic_width();
     let atomic_cas = sess.target.atomic_cas;
     let layout = TargetDataLayout::parse(&sess.target).unwrap_or_else(|err| {
-        sess.emit_fatal(TargetDataLayoutParseError { err });
+        sess.emit_fatal(err);
     });
 
     let mut ret = CrateConfig::default();

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -9,6 +9,8 @@
 #![feature(map_many_mut)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -297,6 +297,8 @@ impl Session {
     }
 
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_warn<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -305,6 +307,8 @@ impl Session {
         self.diagnostic().struct_span_warn(sp, msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_warn_with_expectation<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -314,6 +318,8 @@ impl Session {
         self.diagnostic().struct_span_warn_with_expectation(sp, msg, id)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_warn_with_code<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -323,10 +329,14 @@ impl Session {
         self.diagnostic().struct_span_warn_with_code(sp, msg, code)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_warn(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         self.diagnostic().struct_warn(msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_warn_with_expectation(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -335,6 +345,8 @@ impl Session {
         self.diagnostic().struct_warn_with_expectation(msg, id)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_allow<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -343,10 +355,14 @@ impl Session {
         self.diagnostic().struct_span_allow(sp, msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_allow(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         self.diagnostic().struct_allow(msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_expect(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -355,6 +371,8 @@ impl Session {
         self.diagnostic().struct_expect(msg, id)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_err<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -363,6 +381,8 @@ impl Session {
         self.diagnostic().struct_span_err(sp, msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_err_with_code<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -373,6 +393,8 @@ impl Session {
     }
     // FIXME: This method should be removed (every error should have an associated error code).
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_err(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -380,6 +402,8 @@ impl Session {
         self.parse_sess.struct_err(msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_err_with_code(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -388,6 +412,8 @@ impl Session {
         self.diagnostic().struct_err_with_code(msg, code)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_warn_with_code(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -396,6 +422,8 @@ impl Session {
         self.diagnostic().struct_warn_with_code(msg, code)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_fatal<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -404,6 +432,8 @@ impl Session {
         self.diagnostic().struct_span_fatal(sp, msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_span_fatal_with_code<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -413,15 +443,21 @@ impl Session {
         self.diagnostic().struct_span_fatal_with_code(sp, msg, code)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn struct_fatal(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, !> {
         self.diagnostic().struct_fatal(msg)
     }
 
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn span_fatal<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) -> ! {
         self.diagnostic().span_fatal(sp, msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn span_fatal_with_code<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -431,10 +467,14 @@ impl Session {
         self.diagnostic().span_fatal_with_code(sp, msg, code)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn fatal(&self, msg: impl Into<DiagnosticMessage>) -> ! {
         self.diagnostic().fatal(msg).raise()
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn span_err_or_warn<S: Into<MultiSpan>>(
         &self,
         is_warning: bool,
@@ -448,6 +488,8 @@ impl Session {
         }
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn span_err<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -456,6 +498,8 @@ impl Session {
         self.diagnostic().span_err(sp, msg)
     }
     #[rustc_lint_diagnostics]
+    #[allow(rustc::untranslatable_diagnostic)]
+    #[allow(rustc::diagnostic_outside_of_impl)]
     pub fn span_err_with_code<S: Into<MultiSpan>>(
         &self,
         sp: S,

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -2667,7 +2667,10 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 self.normalize_ty(ast_ty.span, array_ty)
             }
             hir::TyKind::Typeof(ref e) => {
-                let ty = tcx.type_of(tcx.hir().local_def_id(e.hir_id));
+                let ty_erased = tcx.type_of(tcx.hir().local_def_id(e.hir_id));
+                let ty = tcx.fold_regions(ty_erased, |r, _| {
+                    if r.is_erased() { tcx.lifetimes.re_static } else { r }
+                });
                 let span = ast_ty.span;
                 tcx.sess.emit_err(TypeofReservedKeywordUsed {
                     span,

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -121,10 +121,10 @@ enum FromBytesWithNulErrorKind {
 }
 
 impl FromBytesWithNulError {
-    fn interior_nul(pos: usize) -> FromBytesWithNulError {
+    const fn interior_nul(pos: usize) -> FromBytesWithNulError {
         FromBytesWithNulError { kind: FromBytesWithNulErrorKind::InteriorNul(pos) }
     }
-    fn not_nul_terminated() -> FromBytesWithNulError {
+    const fn not_nul_terminated() -> FromBytesWithNulError {
         FromBytesWithNulError { kind: FromBytesWithNulErrorKind::NotNulTerminated }
     }
 
@@ -299,7 +299,8 @@ impl CStr {
     /// ```
     ///
     #[unstable(feature = "cstr_from_bytes_until_nul", issue = "95027")]
-    pub fn from_bytes_until_nul(bytes: &[u8]) -> Result<&CStr, FromBytesUntilNulError> {
+    #[rustc_const_unstable(feature = "cstr_from_bytes_until_nul", issue = "95027")]
+    pub const fn from_bytes_until_nul(bytes: &[u8]) -> Result<&CStr, FromBytesUntilNulError> {
         let nul_pos = memchr::memchr(0, bytes);
         match nul_pos {
             Some(nul_pos) => {
@@ -348,7 +349,8 @@ impl CStr {
     /// assert!(cstr.is_err());
     /// ```
     #[stable(feature = "cstr_from_bytes", since = "1.10.0")]
-    pub fn from_bytes_with_nul(bytes: &[u8]) -> Result<&Self, FromBytesWithNulError> {
+    #[rustc_const_unstable(feature = "const_cstr_methods", issue = "101719")]
+    pub const fn from_bytes_with_nul(bytes: &[u8]) -> Result<&Self, FromBytesWithNulError> {
         let nul_pos = memchr::memchr(0, bytes);
         match nul_pos {
             Some(nul_pos) if nul_pos + 1 == bytes.len() => {
@@ -497,7 +499,8 @@ impl CStr {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn to_bytes(&self) -> &[u8] {
+    #[rustc_const_unstable(feature = "const_cstr_methods", issue = "101719")]
+    pub const fn to_bytes(&self) -> &[u8] {
         let bytes = self.to_bytes_with_nul();
         // SAFETY: to_bytes_with_nul returns slice with length at least 1
         unsafe { bytes.get_unchecked(..bytes.len() - 1) }
@@ -524,7 +527,8 @@ impl CStr {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn to_bytes_with_nul(&self) -> &[u8] {
+    #[rustc_const_unstable(feature = "const_cstr_methods", issue = "101719")]
+    pub const fn to_bytes_with_nul(&self) -> &[u8] {
         // SAFETY: Transmuting a slice of `c_char`s to a slice of `u8`s
         // is safe on all supported targets.
         unsafe { &*(&self.inner as *const [c_char] as *const [u8]) }
@@ -547,7 +551,8 @@ impl CStr {
     /// assert_eq!(cstr.to_str(), Ok("foo"));
     /// ```
     #[stable(feature = "cstr_to_str", since = "1.4.0")]
-    pub fn to_str(&self) -> Result<&str, str::Utf8Error> {
+    #[rustc_const_unstable(feature = "const_cstr_methods", issue = "101719")]
+    pub const fn to_str(&self) -> Result<&str, str::Utf8Error> {
         // N.B., when `CStr` is changed to perform the length check in `.to_bytes()`
         // instead of in `from_ptr()`, it may be worth considering if this should
         // be rewritten to do the UTF-8 check inline with the length calculation

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -157,6 +157,7 @@
 #![feature(const_slice_from_ref)]
 #![feature(const_slice_index)]
 #![feature(const_is_char_boundary)]
+#![feature(const_cstr_methods)]
 //
 // Language features:
 #![feature(abi_unadjusted)]

--- a/library/core/src/slice/memchr.rs
+++ b/library/core/src/slice/memchr.rs
@@ -2,6 +2,7 @@
 // Copyright 2015 Andrew Gallant, bluss and Nicolas Koch
 
 use crate::cmp;
+use crate::intrinsics;
 use crate::mem;
 
 const LO_USIZE: usize = usize::repeat_u8(0x01);
@@ -35,13 +36,31 @@ fn repeat_byte(b: u8) -> usize {
 /// Returns the first index matching the byte `x` in `text`.
 #[must_use]
 #[inline]
-pub fn memchr(x: u8, text: &[u8]) -> Option<usize> {
-    // Fast path for small slices
-    if text.len() < 2 * USIZE_BYTES {
-        return text.iter().position(|elt| *elt == x);
+pub const fn memchr(x: u8, text: &[u8]) -> Option<usize> {
+    #[inline]
+    fn rt_impl(x: u8, text: &[u8]) -> Option<usize> {
+        // Fast path for small slices
+        if text.len() < 2 * USIZE_BYTES {
+            return text.iter().position(|elt| *elt == x);
+        }
+
+        memchr_general_case(x, text)
     }
 
-    memchr_general_case(x, text)
+    const fn const_impl(x: u8, bytes: &[u8]) -> Option<usize> {
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == x {
+                return Some(i);
+            }
+            i += 1;
+        }
+
+        None
+    }
+
+    // SAFETY: The const and runtime versions have identical behavior
+    unsafe { intrinsics::const_eval_select((x, text), const_impl, rt_impl) }
 }
 
 fn memchr_general_case(x: u8, text: &[u8]) -> Option<usize> {

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -94,6 +94,34 @@ fn extract_path_backwards(text: &str, end_pos: usize) -> Option<usize> {
     if current_pos == end_pos { None } else { Some(current_pos) }
 }
 
+fn extract_path_forward(text: &str, start_pos: usize) -> Option<usize> {
+    use rustc_lexer::{is_id_continue, is_id_start};
+    let mut current_pos = start_pos;
+    loop {
+        if current_pos < text.len() && text[current_pos..].starts_with("::") {
+            current_pos += 2;
+        } else {
+            break;
+        }
+        let mut chars = text[current_pos..].chars();
+        if let Some(c) = chars.next() {
+            if is_id_start(c) {
+                current_pos += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+        while let Some(c) = chars.next() {
+            if is_id_continue(c) {
+                current_pos += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+    }
+    if current_pos == start_pos { None } else { Some(current_pos) }
+}
+
 fn is_valid_for_html_tag_name(c: char, is_empty: bool) -> bool {
     // https://spec.commonmark.org/0.30/#raw-html
     //
@@ -218,19 +246,68 @@ impl<'a, 'tcx> DocVisitor for InvalidHtmlTagsLinter<'a, 'tcx> {
                     // If a tag looks like `<this>`, it might actually be a generic.
                     // We don't try to detect stuff `<like, this>` because that's not valid HTML,
                     // and we don't try to detect stuff `<like this>` because that's not valid Rust.
-                    if let Some(Some(generics_start)) = (is_open_tag
-                        && dox[..range.end].ends_with('>'))
+                    let mut generics_end = range.end;
+                    if let Some(Some(mut generics_start)) = (is_open_tag
+                        && dox[..generics_end].ends_with('>'))
                     .then(|| extract_path_backwards(&dox, range.start))
                     {
+                        while generics_start != 0
+                            && generics_end < dox.len()
+                            && dox.as_bytes()[generics_start - 1] == b'<'
+                            && dox.as_bytes()[generics_end] == b'>'
+                        {
+                            generics_end += 1;
+                            generics_start -= 1;
+                            if let Some(new_start) = extract_path_backwards(&dox, generics_start) {
+                                generics_start = new_start;
+                            }
+                            if let Some(new_end) = extract_path_forward(&dox, generics_end) {
+                                generics_end = new_end;
+                            }
+                        }
+                        if let Some(new_end) = extract_path_forward(&dox, generics_end) {
+                            generics_end = new_end;
+                        }
                         let generics_sp = match super::source_span_for_markdown_range(
                             tcx,
                             &dox,
-                            &(generics_start..range.end),
+                            &(generics_start..generics_end),
                             &item.attrs,
                         ) {
                             Some(sp) => sp,
                             None => item.attr_span(tcx),
                         };
+                        // Sometimes, we only extract part of a path. For example, consider this:
+                        //
+                        //     <[u32] as IntoIter<u32>>::Item
+                        //                       ^^^^^ unclosed HTML tag `u32`
+                        //
+                        // We don't have any code for parsing fully-qualified trait paths.
+                        // In theory, we could add it, but doing it correctly would require
+                        // parsing the entire path grammar, which is problematic because of
+                        // overlap between the path grammar and Markdown.
+                        //
+                        // The example above shows that ambiguity. Is `[u32]` intended to be an
+                        // intra-doc link to the u32 primitive, or is it intended to be a slice?
+                        //
+                        // If the below conditional were removed, we would suggest this, which is
+                        // not what the user probably wants.
+                        //
+                        //     <[u32] as `IntoIter<u32>`>::Item
+                        //
+                        // We know that the user actually wants to wrap the whole thing in a code
+                        // block, but the only reason we know that is because `u32` does not, in
+                        // fact, implement IntoIter. If the example looks like this:
+                        //
+                        //     <[Vec<i32>] as IntoIter<i32>::Item
+                        //
+                        // The ideal fix would be significantly different.
+                        if (generics_start > 0 && dox.as_bytes()[generics_start - 1] == b'<')
+                            || (generics_end < dox.len() && dox.as_bytes()[generics_end] == b'>')
+                        {
+                            diag.emit();
+                            return;
+                        }
                         // multipart form is chosen here because ``Vec<i32>`` would be confusing.
                         diag.multipart_suggestion(
                             "try marking as source code",

--- a/src/test/rustdoc-ui/suggestions/html-as-generics-no-suggestions.rs
+++ b/src/test/rustdoc-ui/suggestions/html-as-generics-no-suggestions.rs
@@ -8,6 +8,48 @@ pub struct ConstGeneric;
 // HTML tags cannot contain commas, so no error.
 pub struct MultipleGenerics;
 
+/// This <[u32] as Iterator<Item>> thing!
+//~^ERROR unclosed HTML tag `Item`
+// Some forms of fully-qualified path are simultaneously valid HTML tags
+// with attributes. They produce an error, but no suggestion, because figuring
+// out if this is valid would require parsing the entire path grammar.
+//
+// The important part is that we don't produce any *wrong* suggestions.
+// While several other examples below are added to make sure we don't
+// produce suggestions when given complex paths, this example is the actual
+// reason behind not just using the real path parser. It's ambiguous: there's
+// no way to locally reason out whether that `[u32]` is intended to be a slice
+// or an intra-doc link.
+pub struct FullyQualifiedPathsDoNotCount;
+
+/// This <Vec as IntoIter>::Iter thing!
+//~^ERROR unclosed HTML tag `Vec`
+// Some forms of fully-qualified path are simultaneously valid HTML tags
+// with attributes. They produce an error, but no suggestion, because figuring
+// out if this is valid would require parsing the entire path grammar.
+pub struct FullyQualifiedPathsDoNotCount1;
+
+/// This Vec<Vec as IntoIter>::Iter thing!
+//~^ERROR unclosed HTML tag `Vec`
+// Some forms of fully-qualified path are simultaneously valid HTML tags
+// with attributes. They produce an error, but no suggestion, because figuring
+// out if this is valid would require parsing the entire path grammar.
+pub struct FullyQualifiedPathsDoNotCount2;
+
+/// This Vec<Vec as IntoIter> thing!
+//~^ERROR unclosed HTML tag `Vec`
+// Some forms of fully-qualified path are simultaneously valid HTML tags
+// with attributes. They produce an error, but no suggestion, because figuring
+// out if this is valid would require parsing the entire path grammar.
+pub struct FullyQualifiedPathsDoNotCount3;
+
+/// This Vec<Vec<i32> as IntoIter> thing!
+//~^ERROR unclosed HTML tag `i32`
+// Some forms of fully-qualified path are simultaneously valid HTML tags
+// with attributes. They produce an error, but no suggestion, because figuring
+// out if this is valid would require parsing the entire path grammar.
+pub struct FullyQualifiedPathsDoNotCount4;
+
 /// This Vec<i32 class="test"> thing!
 //~^ERROR unclosed HTML tag `i32`
 // HTML attributes shouldn't be treated as Rust syntax, so no suggestions.

--- a/src/test/rustdoc-ui/suggestions/html-as-generics-no-suggestions.stderr
+++ b/src/test/rustdoc-ui/suggestions/html-as-generics-no-suggestions.stderr
@@ -1,8 +1,8 @@
-error: unclosed HTML tag `i32`
-  --> $DIR/html-as-generics-no-suggestions.rs:11:13
+error: unclosed HTML tag `Item`
+  --> $DIR/html-as-generics-no-suggestions.rs:11:28
    |
-LL | /// This Vec<i32 class="test"> thing!
-   |             ^^^^
+LL | /// This <[u32] as Iterator<Item>> thing!
+   |                            ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/html-as-generics-no-suggestions.rs:1:9
@@ -10,29 +10,59 @@ note: the lint level is defined here
 LL | #![deny(rustdoc::invalid_html_tags)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: unclosed HTML tag `Vec`
+  --> $DIR/html-as-generics-no-suggestions.rs:25:10
+   |
+LL | /// This <Vec as IntoIter>::Iter thing!
+   |          ^^^^
+
+error: unclosed HTML tag `Vec`
+  --> $DIR/html-as-generics-no-suggestions.rs:32:13
+   |
+LL | /// This Vec<Vec as IntoIter>::Iter thing!
+   |             ^^^^
+
+error: unclosed HTML tag `Vec`
+  --> $DIR/html-as-generics-no-suggestions.rs:39:13
+   |
+LL | /// This Vec<Vec as IntoIter> thing!
+   |             ^^^^
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics-no-suggestions.rs:46:17
+   |
+LL | /// This Vec<Vec<i32> as IntoIter> thing!
+   |                 ^^^^^
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics-no-suggestions.rs:53:13
+   |
+LL | /// This Vec<i32 class="test"> thing!
+   |             ^^^^
+
 error: unopened HTML tag `i32`
-  --> $DIR/html-as-generics-no-suggestions.rs:20:13
+  --> $DIR/html-as-generics-no-suggestions.rs:62:13
    |
 LL | /// This Vec</i32> thing!
    |             ^^^^^^
 
 error: unclosed HTML tag `i32`
-  --> $DIR/html-as-generics-no-suggestions.rs:25:13
+  --> $DIR/html-as-generics-no-suggestions.rs:67:13
    |
 LL | /// This 123<i32> thing!
    |             ^^^^^
 
 error: unclosed HTML tag `i32`
-  --> $DIR/html-as-generics-no-suggestions.rs:30:14
+  --> $DIR/html-as-generics-no-suggestions.rs:72:14
    |
 LL | /// This Vec:<i32> thing!
    |              ^^^^^
 
 error: unclosed HTML tag `i32`
-  --> $DIR/html-as-generics-no-suggestions.rs:35:39
+  --> $DIR/html-as-generics-no-suggestions.rs:77:39
    |
 LL | /// This [link](https://rust-lang.org)<i32> thing!
    |                                       ^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/rustdoc-ui/suggestions/html-as-generics.fixed
+++ b/src/test/rustdoc-ui/suggestions/html-as-generics.fixed
@@ -30,3 +30,43 @@ pub struct BareTurbofish;
 //~^ERROR unclosed HTML tag `i32`
 //~|HELP try marking as source
 pub struct Nested;
+
+/// Nested generics `Vec<Vec<u32>>`
+//~^ ERROR unclosed HTML tag `u32`
+//~|HELP try marking as source
+pub struct NestedGenerics;
+
+/// Generics with path `Vec<i32>::Iter`
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct GenericsWithPath;
+
+/// Generics with path `<Vec<i32>>::Iter`
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPath;
+
+/// Generics with path `Vec<Vec<i32>>::Iter`
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPath2;
+
+/// Generics with bump `<Vec<i32>>`s
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithBump;
+
+/// Generics with bump `Vec<Vec<i32>>`s
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithBump2;
+
+/// Generics with punct `<Vec<i32>>`!
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPunct;
+
+/// Generics with punct `Vec<Vec<i32>>`!
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPunct2;

--- a/src/test/rustdoc-ui/suggestions/html-as-generics.rs
+++ b/src/test/rustdoc-ui/suggestions/html-as-generics.rs
@@ -30,3 +30,43 @@ pub struct BareTurbofish;
 //~^ERROR unclosed HTML tag `i32`
 //~|HELP try marking as source
 pub struct Nested;
+
+/// Nested generics Vec<Vec<u32>>
+//~^ ERROR unclosed HTML tag `u32`
+//~|HELP try marking as source
+pub struct NestedGenerics;
+
+/// Generics with path Vec<i32>::Iter
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct GenericsWithPath;
+
+/// Generics with path <Vec<i32>>::Iter
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPath;
+
+/// Generics with path Vec<Vec<i32>>::Iter
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPath2;
+
+/// Generics with bump <Vec<i32>>s
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithBump;
+
+/// Generics with bump Vec<Vec<i32>>s
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithBump2;
+
+/// Generics with punct <Vec<i32>>!
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPunct;
+
+/// Generics with punct Vec<Vec<i32>>!
+//~^ ERROR unclosed HTML tag `i32`
+//~|HELP try marking as source
+pub struct NestedGenericsWithPunct2;

--- a/src/test/rustdoc-ui/suggestions/html-as-generics.stderr
+++ b/src/test/rustdoc-ui/suggestions/html-as-generics.stderr
@@ -69,5 +69,93 @@ help: try marking as source code
 LL | /// This <span>`Vec::<i32>`</span> thing!
    |                +          +
 
-error: aborting due to 6 previous errors
+error: unclosed HTML tag `u32`
+  --> $DIR/html-as-generics.rs:34:28
+   |
+LL | /// Nested generics Vec<Vec<u32>>
+   |                            ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Nested generics `Vec<Vec<u32>>`
+   |                     +             +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics.rs:39:27
+   |
+LL | /// Generics with path Vec<i32>::Iter
+   |                           ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Generics with path `Vec<i32>::Iter`
+   |                        +              +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics.rs:44:28
+   |
+LL | /// Generics with path <Vec<i32>>::Iter
+   |                            ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Generics with path `<Vec<i32>>::Iter`
+   |                        +                +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics.rs:49:31
+   |
+LL | /// Generics with path Vec<Vec<i32>>::Iter
+   |                               ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Generics with path `Vec<Vec<i32>>::Iter`
+   |                        +                   +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics.rs:54:28
+   |
+LL | /// Generics with bump <Vec<i32>>s
+   |                            ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Generics with bump `<Vec<i32>>`s
+   |                        +          +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics.rs:59:31
+   |
+LL | /// Generics with bump Vec<Vec<i32>>s
+   |                               ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Generics with bump `Vec<Vec<i32>>`s
+   |                        +             +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics.rs:64:29
+   |
+LL | /// Generics with punct <Vec<i32>>!
+   |                             ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Generics with punct `<Vec<i32>>`!
+   |                         +          +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics.rs:69:32
+   |
+LL | /// Generics with punct Vec<Vec<i32>>!
+   |                                ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// Generics with punct `Vec<Vec<i32>>`!
+   |                         +             +
+
+error: aborting due to 14 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -13,9 +13,8 @@ LL | #[deny(bare_trait_objects)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |
+LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   |                 +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
@@ -27,9 +26,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |
+LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   |                                   +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:17:14
@@ -41,9 +39,8 @@ LL |     let _x: &SomeTrait = todo!();
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     let _x: &SomeTrait = todo!();
-LL +     let _x: &dyn SomeTrait = todo!();
-   |
+LL |     let _x: &dyn SomeTrait = todo!();
+   |              +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:17
@@ -55,9 +52,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |
+LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   |                 +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:17
@@ -69,9 +65,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |
+LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   |                 +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
@@ -83,9 +78,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |
+LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   |                                   +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
@@ -97,9 +91,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |
+LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   |                                   +++
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -6,9 +6,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
 help: add `dyn` keyword before this trait
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |
+LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   |                 +++
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-2021-edition-error.rs:3:35
@@ -18,9 +17,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
 help: add `dyn` keyword before this trait
    |
-LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |
+LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   |                                   +++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
+++ b/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
@@ -13,9 +13,8 @@ LL | #![deny(bare_trait_objects)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -         <fmt::Debug>::fmt(self, f)
-LL +         <dyn fmt::Debug>::fmt(self, f)
-   |
+LL |         <dyn fmt::Debug>::fmt(self, f)
+   |          +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
+++ b/src/test/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
@@ -6,9 +6,8 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |
 help: add `dyn` keyword before this trait
    |
-LL - fn ice() -> impl AsRef<Fn(&())> {
-LL + fn ice() -> impl AsRef<dyn Fn(&())> {
-   |
+LL | fn ice() -> impl AsRef<dyn Fn(&())> {
+   |                        +++
 
 error[E0277]: the trait bound `(): AsRef<(dyn for<'r> Fn(&'r ()) + 'static)>` is not satisfied
   --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:13

--- a/src/test/ui/issues/issue-86756.stderr
+++ b/src/test/ui/issues/issue-86756.stderr
@@ -25,9 +25,8 @@ LL |     eq::<dyn, Foo>
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     eq::<dyn, Foo>
-LL +     eq::<dyn, dyn Foo>
-   |
+LL |     eq::<dyn, dyn Foo>
+   |               +++
 
 error[E0107]: missing generics for trait `Foo`
   --> $DIR/issue-86756.rs:5:15

--- a/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -9,9 +9,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
@@ -23,9 +22,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
@@ -37,9 +35,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/src/test/ui/lint/force-warn/cap-lints-allow.stderr
@@ -9,9 +9,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/cap-lints-allow.rs:8:25
@@ -23,9 +22,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/cap-lints-allow.rs:8:25
@@ -37,9 +35,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -9,9 +9,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
@@ -23,9 +22,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
@@ -37,9 +35,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -9,9 +9,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-lint-group.rs:10:25
@@ -23,9 +22,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-lint-group.rs:10:25
@@ -37,9 +35,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -9,9 +9,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
@@ -23,9 +22,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
@@ -37,9 +35,8 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub fn function(_x: Box<SomeTrait>) {}
-LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   |
+LL | pub fn function(_x: Box<dyn SomeTrait>) {}
+   |                         +++
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/parser/increment-notfixed.stderr
+++ b/src/test/ui/parser/increment-notfixed.stderr
@@ -8,9 +8,8 @@ help: use `+= 1` instead
    |
 LL |     { let tmp = i; i += 1; tmp };
    |     +++++++++++  ~~~~~~~~~~~~~~~
-LL -     i++;
-LL +     i += 1;
-   |
+LL |     i += 1;
+   |       ~~~~
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:17:12
@@ -24,9 +23,8 @@ help: use `+= 1` instead
    |
 LL |     while { let tmp = i; i += 1; tmp } < 5 {
    |           +++++++++++  ~~~~~~~~~~~~~~~
-LL -     while i++ < 5 {
-LL +     while i += 1 < 5 {
-   |
+LL |     while i += 1 < 5 {
+   |             ~~~~
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:25:8
@@ -38,9 +36,8 @@ help: use `+= 1` instead
    |
 LL |     { let tmp_ = tmp; tmp += 1; tmp_ };
    |     ++++++++++++    ~~~~~~~~~~~~~~~~~~
-LL -     tmp++;
-LL +     tmp += 1;
-   |
+LL |     tmp += 1;
+   |         ~~~~
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:31:14
@@ -54,9 +51,8 @@ help: use `+= 1` instead
    |
 LL |     while { let tmp_ = tmp; tmp += 1; tmp_ } < 5 {
    |           ++++++++++++    ~~~~~~~~~~~~~~~~~~
-LL -     while tmp++ < 5 {
-LL +     while tmp += 1 < 5 {
-   |
+LL |     while tmp += 1 < 5 {
+   |               ~~~~
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:39:16
@@ -68,9 +64,8 @@ help: use `+= 1` instead
    |
 LL |     { let tmp = foo.bar.qux; foo.bar.qux += 1; tmp };
    |     +++++++++++            ~~~~~~~~~~~~~~~~~~~~~~~~~
-LL -     foo.bar.qux++;
-LL +     foo.bar.qux += 1;
-   |
+LL |     foo.bar.qux += 1;
+   |                 ~~~~
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:49:10
@@ -82,9 +77,8 @@ help: use `+= 1` instead
    |
 LL |     { let tmp = s.tmp; s.tmp += 1; tmp };
    |     +++++++++++      ~~~~~~~~~~~~~~~~~~~
-LL -     s.tmp++;
-LL +     s.tmp += 1;
-   |
+LL |     s.tmp += 1;
+   |           ~~~~
 
 error: Rust has no prefix increment operator
   --> $DIR/increment-notfixed.rs:56:5

--- a/src/test/ui/parser/trait-object-trait-parens.stderr
+++ b/src/test/ui/parser/trait-object-trait-parens.stderr
@@ -27,9 +27,8 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
-LL +     let _: Box<dyn (Obj) + (?Sized) + (for<'a> Trait<'a>)>;
-   |
+LL |     let _: Box<dyn (Obj) + (?Sized) + (for<'a> Trait<'a>)>;
+   |                +++
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:8:35
@@ -52,9 +51,8 @@ LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
-LL +     let _: Box<dyn ?Sized + (for<'a> Trait<'a>) + (Obj)>;
-   |
+LL |     let _: Box<dyn ?Sized + (for<'a> Trait<'a>) + (Obj)>;
+   |                +++
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:13:47
@@ -77,9 +75,8 @@ LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
-LL +     let _: Box<dyn for<'a> Trait<'a> + (Obj) + (?Sized)>;
-   |
+LL |     let _: Box<dyn for<'a> Trait<'a> + (Obj) + (?Sized)>;
+   |                +++
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:18:36

--- a/src/test/ui/proc-macro/dollar-crate-issue-101211.rs
+++ b/src/test/ui/proc-macro/dollar-crate-issue-101211.rs
@@ -1,0 +1,29 @@
+// check-pass
+// edition:2021
+// aux-build:test-macros.rs
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+macro_rules! foo {
+    ($($path:ident)::*) => (
+        test_macros::recollect!(
+            $($path)::*
+        )
+    )
+}
+
+macro_rules! baz {
+    () => (
+        foo!($crate::BAR)
+    )
+}
+
+pub const BAR: u32 = 19;
+
+fn main(){
+    std::println!("{}", baz!());
+}

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -14,7 +14,7 @@ LL | #![warn(rust_2021_prefixes_incompatible_syntax)]
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m2!(z "hey");
-   |
+   |          +
 
 warning: prefix `prefix` is unknown
   --> $DIR/reserved-prefixes-migration.rs:19:9
@@ -27,7 +27,7 @@ LL |     m2!(prefix"hey");
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m2!(prefix "hey");
-   |
+   |               +
 
 warning: prefix `hey` is unknown
   --> $DIR/reserved-prefixes-migration.rs:22:9
@@ -40,7 +40,7 @@ LL |     m3!(hey#123);
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #123);
-   |
+   |            +
 
 warning: prefix `hey` is unknown
   --> $DIR/reserved-prefixes-migration.rs:25:9
@@ -53,7 +53,7 @@ LL |     m3!(hey#hey);
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #hey);
-   |
+   |            +
 
 warning: prefix `kind` is unknown
   --> $DIR/reserved-prefixes-migration.rs:35:14
@@ -66,7 +66,7 @@ LL |     #name = #kind#value
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     #name = #kind #value
-   |
+   |                  +
 
 warning: 5 warnings emitted
 

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -13,8 +13,7 @@ LL | #![warn(rust_2021_prefixes_incompatible_syntax)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
-LL -     m2!(z"hey");
-LL +     m2!(z "hey");
+LL |     m2!(z "hey");
    |
 
 warning: prefix `prefix` is unknown
@@ -27,8 +26,7 @@ LL |     m2!(prefix"hey");
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
-LL -     m2!(prefix"hey");
-LL +     m2!(prefix "hey");
+LL |     m2!(prefix "hey");
    |
 
 warning: prefix `hey` is unknown
@@ -41,8 +39,7 @@ LL |     m3!(hey#123);
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
-LL -     m3!(hey#123);
-LL +     m3!(hey #123);
+LL |     m3!(hey #123);
    |
 
 warning: prefix `hey` is unknown
@@ -55,8 +52,7 @@ LL |     m3!(hey#hey);
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
-LL -     m3!(hey#hey);
-LL +     m3!(hey #hey);
+LL |     m3!(hey #hey);
    |
 
 warning: prefix `kind` is unknown
@@ -69,8 +65,7 @@ LL |     #name = #kind#value
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
-LL -     #name = #kind#value
-LL +     #name = #kind #value
+LL |     #name = #kind #value
    |
 
 warning: 5 warnings emitted

--- a/src/test/ui/rust-2021/reserved-prefixes.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes.stderr
@@ -7,8 +7,7 @@ LL |     demo3!(foo#bar);
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo3!(foo#bar);
-LL +     demo3!(foo #bar);
+LL |     demo3!(foo #bar);
    |
 
 error: prefix `foo` is unknown
@@ -20,8 +19,7 @@ LL |     demo2!(foo"bar");
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo2!(foo"bar");
-LL +     demo2!(foo "bar");
+LL |     demo2!(foo "bar");
    |
 
 error: prefix `foo` is unknown
@@ -33,8 +31,7 @@ LL |     demo2!(foo'b');
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo2!(foo'b');
-LL +     demo2!(foo 'b');
+LL |     demo2!(foo 'b');
    |
 
 error: prefix `foo` is unknown
@@ -46,8 +43,7 @@ LL |     demo2!(foo'b);
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo2!(foo'b);
-LL +     demo2!(foo 'b);
+LL |     demo2!(foo 'b);
    |
 
 error: prefix `foo` is unknown
@@ -59,8 +55,7 @@ LL |     demo3!(foo# bar);
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo3!(foo# bar);
-LL +     demo3!(foo # bar);
+LL |     demo3!(foo # bar);
    |
 
 error: prefix `foo` is unknown
@@ -72,8 +67,7 @@ LL |     demo4!(foo#! bar);
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo4!(foo#! bar);
-LL +     demo4!(foo #! bar);
+LL |     demo4!(foo #! bar);
    |
 
 error: prefix `foo` is unknown
@@ -85,8 +79,7 @@ LL |     demo4!(foo## bar);
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo4!(foo## bar);
-LL +     demo4!(foo ## bar);
+LL |     demo4!(foo ## bar);
    |
 
 error: prefix `foo` is unknown
@@ -98,8 +91,7 @@ LL |     demo4!(foo#bar#);
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo4!(foo#bar#);
-LL +     demo4!(foo #bar#);
+LL |     demo4!(foo #bar#);
    |
 
 error: prefix `bar` is unknown
@@ -111,8 +103,7 @@ LL |     demo4!(foo#bar#);
    = note: prefixed identifiers and literals are reserved since Rust 2021
 help: consider inserting whitespace here
    |
-LL -     demo4!(foo#bar#);
-LL +     demo4!(foo#bar #);
+LL |     demo4!(foo#bar #);
    |
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/rust-2021/reserved-prefixes.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes.stderr
@@ -8,7 +8,7 @@ LL |     demo3!(foo#bar);
 help: consider inserting whitespace here
    |
 LL |     demo3!(foo #bar);
-   |
+   |               +
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:17:12
@@ -20,7 +20,7 @@ LL |     demo2!(foo"bar");
 help: consider inserting whitespace here
    |
 LL |     demo2!(foo "bar");
-   |
+   |               +
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:18:12
@@ -32,7 +32,7 @@ LL |     demo2!(foo'b');
 help: consider inserting whitespace here
    |
 LL |     demo2!(foo 'b');
-   |
+   |               +
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:20:12
@@ -44,7 +44,7 @@ LL |     demo2!(foo'b);
 help: consider inserting whitespace here
    |
 LL |     demo2!(foo 'b);
-   |
+   |               +
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:21:12
@@ -56,7 +56,7 @@ LL |     demo3!(foo# bar);
 help: consider inserting whitespace here
    |
 LL |     demo3!(foo # bar);
-   |
+   |               +
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:22:12
@@ -68,7 +68,7 @@ LL |     demo4!(foo#! bar);
 help: consider inserting whitespace here
    |
 LL |     demo4!(foo #! bar);
-   |
+   |               +
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:23:12
@@ -80,7 +80,7 @@ LL |     demo4!(foo## bar);
 help: consider inserting whitespace here
    |
 LL |     demo4!(foo ## bar);
-   |
+   |               +
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:25:12
@@ -92,7 +92,7 @@ LL |     demo4!(foo#bar#);
 help: consider inserting whitespace here
    |
 LL |     demo4!(foo #bar#);
-   |
+   |               +
 
 error: prefix `bar` is unknown
   --> $DIR/reserved-prefixes.rs:25:16
@@ -104,7 +104,7 @@ LL |     demo4!(foo#bar#);
 help: consider inserting whitespace here
    |
 LL |     demo4!(foo#bar #);
-   |
+   |                   +
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/suggestions/issue-61963.stderr
+++ b/src/test/ui/suggestions/issue-61963.stderr
@@ -13,9 +13,8 @@ LL | #![deny(bare_trait_objects)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     bar: Box<Bar>,
-LL +     bar: Box<dyn Bar>,
-   |
+LL |     bar: Box<dyn Bar>,
+   |              +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -27,9 +26,8 @@ LL | pub struct Foo {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub struct Foo {
-LL + dyn pub struct Foo {
-   |
+LL | dyn pub struct Foo {
+   | +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:28:14
@@ -41,9 +39,8 @@ LL |     bar: Box<Bar>,
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     bar: Box<Bar>,
-LL +     bar: Box<dyn Bar>,
-   |
+LL |     bar: Box<dyn Bar>,
+   |              +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:28:14
@@ -55,9 +52,8 @@ LL |     bar: Box<Bar>,
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL -     bar: Box<Bar>,
-LL +     bar: Box<dyn Bar>,
-   |
+LL |     bar: Box<dyn Bar>,
+   |              +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -69,9 +65,8 @@ LL | pub struct Foo {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub struct Foo {
-LL + dyn pub struct Foo {
-   |
+LL | dyn pub struct Foo {
+   | +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -83,9 +78,8 @@ LL | pub struct Foo {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub struct Foo {
-LL + dyn pub struct Foo {
-   |
+LL | dyn pub struct Foo {
+   | +++
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -97,9 +91,8 @@ LL | pub struct Foo {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - pub struct Foo {
-LL + dyn pub struct Foo {
-   |
+LL | dyn pub struct Foo {
+   | +++
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/suggestions/suggest-blanket-impl-local-trait.stderr
+++ b/src/test/ui/suggestions/suggest-blanket-impl-local-trait.stderr
@@ -6,9 +6,8 @@ LL | impl LocalTraitTwo for LocalTraitOne {}
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl LocalTraitTwo for LocalTraitOne {}
-LL + impl LocalTraitTwo for dyn LocalTraitOne {}
-   |
+LL | impl LocalTraitTwo for dyn LocalTraitOne {}
+   |                        +++
 help: alternatively use a blanket implementation to implement `LocalTraitTwo` for all types that also implement `LocalTraitOne`
    |
 LL | impl<T: LocalTraitOne> LocalTraitTwo for T {}
@@ -22,9 +21,8 @@ LL | impl fmt::Display for LocalTraitOne {
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl fmt::Display for LocalTraitOne {
-LL + impl fmt::Display for dyn LocalTraitOne {
-   |
+LL | impl fmt::Display for dyn LocalTraitOne {
+   |                       +++
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/suggest-blanket-impl-local-trait.rs:26:23
@@ -34,9 +32,8 @@ LL | impl fmt::Display for LocalTraitTwo + Send {
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl fmt::Display for LocalTraitTwo + Send {
-LL + impl fmt::Display for dyn LocalTraitTwo + Send {
-   |
+LL | impl fmt::Display for dyn LocalTraitTwo + Send {
+   |                       +++
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/suggest-blanket-impl-local-trait.rs:34:24
@@ -46,9 +43,8 @@ LL | impl LocalTraitOne for fmt::Display {}
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl LocalTraitOne for fmt::Display {}
-LL + impl LocalTraitOne for dyn fmt::Display {}
-   |
+LL | impl LocalTraitOne for dyn fmt::Display {}
+   |                        +++
 help: alternatively use a blanket implementation to implement `LocalTraitOne` for all types that also implement `fmt::Display`
    |
 LL | impl<T: fmt::Display> LocalTraitOne for T {}
@@ -62,9 +58,8 @@ LL | impl LocalTraitOne for fmt::Display + Send {}
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl LocalTraitOne for fmt::Display + Send {}
-LL + impl LocalTraitOne for dyn fmt::Display + Send {}
-   |
+LL | impl LocalTraitOne for dyn fmt::Display + Send {}
+   |                        +++
 help: alternatively use a blanket implementation to implement `LocalTraitOne` for all types that also implement `fmt::Display + Send`
    |
 LL | impl<T: fmt::Display + Send> LocalTraitOne for T {}
@@ -78,9 +73,8 @@ LL | impl<E> GenericTrait<E> for LocalTraitOne {}
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl<E> GenericTrait<E> for LocalTraitOne {}
-LL + impl<E> GenericTrait<E> for dyn LocalTraitOne {}
-   |
+LL | impl<E> GenericTrait<E> for dyn LocalTraitOne {}
+   |                             +++
 help: alternatively use a blanket implementation to implement `GenericTrait<E>` for all types that also implement `LocalTraitOne`
    |
 LL | impl<E, T: LocalTraitOne> GenericTrait<E> for T {}
@@ -94,9 +88,8 @@ LL | impl<T, E> GenericTraitTwo<E> for GenericTrait<T> {}
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl<T, E> GenericTraitTwo<E> for GenericTrait<T> {}
-LL + impl<T, E> GenericTraitTwo<E> for dyn GenericTrait<T> {}
-   |
+LL | impl<T, E> GenericTraitTwo<E> for dyn GenericTrait<T> {}
+   |                                   +++
 help: alternatively use a blanket implementation to implement `GenericTraitTwo<E>` for all types that also implement `GenericTrait<T>`
    |
 LL | impl<T, E, U: GenericTrait<T>> GenericTraitTwo<E> for U {}

--- a/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
+++ b/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
@@ -39,9 +39,8 @@ LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |
 help: add `dyn` keyword before this trait
    |
-LL - impl<'a, T> Struct<T> for Trait<'a, T> {}
-LL + impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
-   |
+LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
+   |                           +++
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -42,9 +42,8 @@ LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - impl<'a, T> Struct<T> for Trait<'a, T> {}
-LL + impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
-   |
+LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
+   |                           +++
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/src/test/ui/traits/bound/not-on-bare-trait.stderr
+++ b/src/test/ui/traits/bound/not-on-bare-trait.stderr
@@ -9,9 +9,8 @@ LL | fn foo(_x: Foo + Send) {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: use `dyn`
    |
-LL - fn foo(_x: Foo + Send) {
-LL + fn foo(_x: dyn Foo + Send) {
-   |
+LL | fn foo(_x: dyn Foo + Send) {
+   |            +++
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:7:8

--- a/src/test/ui/typeof/issue-100183.rs
+++ b/src/test/ui/typeof/issue-100183.rs
@@ -1,0 +1,6 @@
+struct Struct {
+    y: (typeof("hey"),),
+    //~^ ERROR `typeof` is a reserved keyword but unimplemented
+}
+
+fn main() {}

--- a/src/test/ui/typeof/issue-100183.stderr
+++ b/src/test/ui/typeof/issue-100183.stderr
@@ -1,0 +1,14 @@
+error[E0516]: `typeof` is a reserved keyword but unimplemented
+  --> $DIR/issue-100183.rs:2:9
+   |
+LL |     y: (typeof("hey"),),
+   |         ^^^^^^^^^^^^^ reserved keyword
+   |
+help: consider replacing `typeof(...)` with an actual type
+   |
+LL |     y: (&'static str,),
+   |         ~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0516`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,6 +11,7 @@ allow-unauthenticated = [
     "S-*",
     "T-*",
     "WG-*",
+    "const-hack",
     "needs-fcp",
     "relnotes",
     "requires-nightly",


### PR DESCRIPTION
Successful merges:

 - #100185 (Fix `ReErased` leaking into typeck due to `typeof(...)` recovery)
 - #100291 (constify some `CStr` methods)
 - #101266 (translations(rustc_session): migrates rustc_session to use SessionDiagnostic - Final)
 - #101677 (Add test for #101211)
 - #101700 (A `SubstitutionPart` is not considered a deletion if it replaces nothing with nothing)
 - #101724 (Allow unauthenticated users to add the `const-hack` label)
 - #101731 (rustdoc: improve rustdoc HTML suggestions handling of nested generics)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100185,100291,101266,101677,101700,101724,101731)
<!-- homu-ignore:end -->