### PR TITLE
rustdoc: fix treatment of backslash-escaped HTML

### DIFF
--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -278,7 +278,7 @@ impl<'a, 'tcx> DocVisitor for InvalidHtmlTagsLinter<'a, 'tcx> {
             for (event, range) in p {
                 match event {
                     Event::Start(Tag::CodeBlock(_)) => in_code_block = true,
-                    Event::Html(text) | Event::Text(text) if !in_code_block => {
+                    Event::Html(text) if !in_code_block => {
                         extract_tags(&mut tags, &text, range, &mut is_in_comment, &report_diag)
                     }
                     Event::End(Tag::CodeBlock(_)) => in_code_block = false,

--- a/src/test/rustdoc-ui/invalid-html-tags.rs
+++ b/src/test/rustdoc-ui/invalid-html-tags.rs
@@ -114,3 +114,10 @@ pub fn k() {}
 /// Web Components style </unopened-tag>
 //~^ ERROR unopened HTML tag `unopened-tag`
 pub fn m() {}
+
+/// backslashed \<a href="">
+pub fn no_error_1() {}
+
+/// backslashed \<<a href="">
+//~^ ERROR unclosed HTML tag `a`
+pub fn p() {}

--- a/src/test/rustdoc-ui/invalid-html-tags.stderr
+++ b/src/test/rustdoc-ui/invalid-html-tags.stderr
@@ -94,5 +94,11 @@ error: unclosed HTML tag `dashed-tags`
 LL | /// Web Components style <dashed-tags>
    |                          ^^^^^^^^^^^^^
 
-error: aborting due to 15 previous errors
+error: unclosed HTML tag `a`
+  --> $DIR/invalid-html-tags.rs:121:19
+   |
+LL | /// backslashed \<<a href="">
+   |                   ^^
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Try generating HTML for this markup:

    \<a href="https://example.com">example</a>

It will produce text, not HTML, in both rustdoc's real HTML output and in the commonmark reference implementation:

https://spec.commonmark.org/dingus/?text=%5C%3Ca%20href%3D%22https%3A%2F%2Fexample.com%22%3Eexample%3C%2Fa%3E

Part of https://github.com/rust-lang/rust/issues/67799