### PR TITLE
rustdoc: remove no-op CSS `.search-results .result-name > span`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -987,12 +987,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	padding-right: 1em;
 }
 
-.search-results .result-name > span {
-	display: inline-block;
-	margin: 0;
-	font-weight: normal;
-}
-
 .popover {
 	font-size: 1rem;
 	position: absolute;

--- a/src/test/rustdoc-gui/search-result-display.goml
+++ b/src/test/rustdoc-gui/search-result-display.goml
@@ -13,6 +13,9 @@ size: (600, 100)
 // when computed it's larger.
 assert-css: (".search-results div.desc", {"width": "566px"})
 
+// The result set is all on one line.
+assert-css: (".search-results .result-name > span", {"display": "inline"})
+
 // Check that the crate filter `<select>` is correctly handled when it goes to next line.
 // To do so we need to update the length of one of its `<option>`.
 size: (900, 900)


### PR DESCRIPTION
The rule `display: inline-block` was added in 5afa52bc7dee683f25f437dddf338dbc6ad32eb8. The `margin: 0` and `font-weight: normal` were added in c01bd560e2f87a9a960ed071213edd70f73171a8.

Both seem to have been added to override class-based rules that were targetted at method sections. See <https://github.com/rust-lang/rust/blob/c01bd560e2f87a9a960ed071213edd70f73171a8/src/librustdoc/html/static/rustdoc.css#L140-L148> for an example. The selectors that these were meant to override were changed in a8318e420d19c364b1eec33956a86164941f6df4 and 76a3b609d0b93c5d8da5e4e3db37bd03e5cb1c30 to be more specific, so they no longer need to be overridden.