### PR TITLE
Adding ignore-fuchsia arg to non-applicable compiler ui tests

### DIFF
--- a/src/test/ui/env-funky-keys.rs
+++ b/src/test/ui/env-funky-keys.rs
@@ -6,6 +6,7 @@
 // ignore-emscripten no execve
 // ignore-sgx no execve
 // ignore-vxworks no execve
+// ignore-fuchsia no 'execve'
 // no-prefer-dynamic
 
 #![feature(rustc_private)]

--- a/src/test/ui/process/core-run-destroy.rs
+++ b/src/test/ui/process/core-run-destroy.rs
@@ -8,6 +8,7 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-vxworks no 'cat' and 'sleep'
+// ignore-fuchsia no 'cat'
 
 // N.B., these tests kill child processes. Valgrind sees these children as leaking
 // memory, which makes for some *confusing* logs. That's why these are here

--- a/src/test/ui/process/process-envs.rs
+++ b/src/test/ui/process/process-envs.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-vxworks no 'env'
+// ignore-fuchsia no 'env'
 
 use std::process::Command;
 use std::env;

--- a/src/test/ui/process/process-remove-from-env.rs
+++ b/src/test/ui/process/process-remove-from-env.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-vxworks no 'env'
+// ignore-fuchsia no 'env'
 
 use std::process::Command;
 use std::env;

--- a/src/test/ui/process/process-sigpipe.rs
+++ b/src/test/ui/process/process-sigpipe.rs
@@ -14,6 +14,7 @@
 
 // ignore-emscripten no threads support
 // ignore-vxworks no 'sh'
+// ignore-fuchsia no 'sh'
 
 use std::process;
 use std::thread;

--- a/src/test/ui/wait-forked-but-failed-child.rs
+++ b/src/test/ui/wait-forked-but-failed-child.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-vxworks no 'ps'
+// ignore-fuchsia no 'ps'
 
 #![feature(rustc_private)]
 


### PR DESCRIPTION
Adding `ignore-fuchsia` flag to tests involving `std::process::Command` calls, and `execve` calls