### PR TITLE
Adding needs-unwind arg to applicable compiler ui tests

### DIFF
--- a/src/test/ui/asm/x86_64/may_unwind.rs
+++ b/src/test/ui/asm/x86_64/may_unwind.rs
@@ -1,6 +1,7 @@
 // only-x86_64
 // run-pass
 // needs-asm-support
+// needs-unwind
 
 #![feature(asm_sym, asm_unwind)]
 

--- a/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
+++ b/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
@@ -2,6 +2,7 @@
 // error-pattern:diverging_fn called
 // error-pattern:0 dropped
 // ignore-emscripten no processes
+// needs-unwind this test checks that a destructor is called after panicking
 
 struct Droppable(u8);
 impl Drop for Droppable {

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-1.rs:6:1
+  --> $DIR/invalid-punct-ident-1.rs:7:1
    |
 LL | invalid_punct!();
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-2.rs:6:1
+  --> $DIR/invalid-punct-ident-2.rs:7:1
    |
 LL | invalid_ident!();
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-3.rs:6:1
+  --> $DIR/invalid-punct-ident-3.rs:7:1
    |
 LL | invalid_raw_ident!();
    | ^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
@@ -1,5 +1,5 @@
 error: unexpected closing delimiter: `)`
-  --> $DIR/invalid-punct-ident-4.rs:6:1
+  --> $DIR/invalid-punct-ident-4.rs:7:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^ unexpected closing delimiter
@@ -7,13 +7,13 @@ LL | lexer_failure!();
    = note: this error originates in the macro `lexer_failure` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-4.rs:6:1
+  --> $DIR/invalid-punct-ident-4.rs:7:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-punct-ident-4.rs:11:33
+  --> $DIR/invalid-punct-ident-4.rs:12:33
    |
 LL |     let _recovery_witness: () = 0;
    |                            --   ^ expected `()`, found integer

--- a/src/test/ui/proc-macro/issue-36935.rs
+++ b/src/test/ui/proc-macro/issue-36935.rs
@@ -1,4 +1,5 @@
 // aux-build:test-macros.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate test_macros;

--- a/src/test/ui/proc-macro/issue-36935.stderr
+++ b/src/test/ui/proc-macro/issue-36935.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Baz` is defined multiple times
-  --> $DIR/issue-36935.rs:7:1
+  --> $DIR/issue-36935.rs:8:1
    |
 LL | struct Baz {
    | ^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | struct Baz {
    = note: `Baz` must be defined only once in the type namespace of this module
 
 error: proc-macro derive panicked
-  --> $DIR/issue-36935.rs:6:20
+  --> $DIR/issue-36935.rs:7:20
    |
 LL | #[derive(Identity, Panic)]
    |                    ^^^^^

--- a/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.rs
+++ b/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.rs
@@ -1,5 +1,6 @@
 // aux-build:proc-macro-panic.rs
 // edition:2018
+// needs-unwind proc macro panics to report errors
 
 // Regression test for issue #76270
 // Tests that we don't print an ICE message when a panic

--- a/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.stderr
+++ b/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/issue-76270-panic-in-libproc-macro.rs:10:1
+  --> $DIR/issue-76270-panic-in-libproc-macro.rs:11:1
    |
 LL | proc_macro_panic::panic_in_libproc_macro!();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/load-panic-backtrace.rs
+++ b/src/test/ui/proc-macro/load-panic-backtrace.rs
@@ -3,6 +3,7 @@
 // rustc-env:RUST_BACKTRACE=0
 // normalize-stderr-test "thread '.*' panicked " -> ""
 // normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate test_macros;

--- a/src/test/ui/proc-macro/load-panic-backtrace.stderr
+++ b/src/test/ui/proc-macro/load-panic-backtrace.stderr
@@ -1,6 +1,6 @@
 at 'panic-derive', $DIR/auxiliary/test-macros.rs:43:5
 error: proc-macro derive panicked
-  --> $DIR/load-panic-backtrace.rs:10:10
+  --> $DIR/load-panic-backtrace.rs:11:10
    |
 LL | #[derive(Panic)]
    |          ^^^^^

--- a/src/test/ui/proc-macro/load-panic.rs
+++ b/src/test/ui/proc-macro/load-panic.rs
@@ -1,4 +1,5 @@
 // aux-build:test-macros.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate test_macros;

--- a/src/test/ui/proc-macro/load-panic.stderr
+++ b/src/test/ui/proc-macro/load-panic.stderr
@@ -1,5 +1,5 @@
 error: proc-macro derive panicked
-  --> $DIR/load-panic.rs:6:10
+  --> $DIR/load-panic.rs:7:10
    |
 LL | #[derive(Panic)]
    |          ^^^^^


### PR DESCRIPTION
Adding `needs-unwind` arg to applicable compiler ui tests