### PR TITLE
Update logic around PGO staging

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -69,15 +69,12 @@ pub struct Flags {
 
     pub llvm_skip_rebuild: Option<bool>,
 
-    pub rust_profile_use: Option<String>,
     pub rust_profile_generate: Option<String>,
+    pub rust_profile_use: Option<String>,
 
+    pub llvm_profile_generate: Option<String>,
     pub llvm_profile_use: Option<String>,
-    // LLVM doesn't support a custom location for generating profile
-    // information.
-    //
-    // llvm_out/build/profiles/ is the location this writes to.
-    pub llvm_profile_generate: bool,
+
     pub llvm_bolt_profile_generate: bool,
     pub llvm_bolt_profile_use: Option<String>,
 }
@@ -698,7 +695,7 @@ Arguments:
             rust_profile_use: matches.opt_str("rust-profile-use"),
             rust_profile_generate: matches.opt_str("rust-profile-generate"),
             llvm_profile_use: matches.opt_str("llvm-profile-use"),
-            llvm_profile_generate: matches.opt_present("llvm-profile-generate"),
+            llvm_profile_generate: matches.opt_str("llvm-profile-generate"),
             llvm_bolt_profile_generate: matches.opt_present("llvm-bolt-profile-generate"),
             llvm_bolt_profile_use: matches.opt_str("llvm-bolt-profile-use"),
         }

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -320,11 +320,9 @@ impl Step for Llvm {
         // This flag makes sure `FileCheck` is copied in the final binaries directory.
         cfg.define("LLVM_INSTALL_UTILS", "ON");
 
-        if builder.config.llvm_profile_generate {
+        if let Some(path) = &builder.config.llvm_profile_generate {
             cfg.define("LLVM_BUILD_INSTRUMENTED", "IR");
-            if let Ok(llvm_profile_dir) = std::env::var("LLVM_PROFILE_DIR") {
-                cfg.define("LLVM_PROFILE_DATA_DIR", llvm_profile_dir);
-            }
+            cfg.define("LLVM_PROFILE_DATA_DIR", &path);
             cfg.define("LLVM_BUILD_RUNTIME", "No");
         }
         if let Some(path) = builder.config.llvm_profile_use.as_ref() {
@@ -822,7 +820,7 @@ impl Step for Lld {
         // when doing PGO on CI, cmake or clang-cl don't automatically link clang's
         // profiler runtime in. In that case, we need to manually ask cmake to do it, to avoid
         // linking errors, much like LLVM's cmake setup does in that situation.
-        if builder.config.llvm_profile_generate && target.contains("msvc") {
+        if builder.config.llvm_profile_generate.is_some() && target.contains("msvc") {
             if let Some(clang_cl_path) = builder.config.llvm_clang_cl.as_ref() {
                 // Find clang's runtime library directory and push that as a search path to the
                 // cmake linker flags.

--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -84,14 +84,14 @@ LLVM_PROFILE_DIRECTORY_ROOT=$PGO_TMP/llvm-pgo
 # separate phases. This increases build time -- though not by a huge amount --
 # but prevents any problems from arising due to different profiling runtimes
 # being simultaneously linked in.
-# LLVM IR PGO does not respect LLVM_PROFILE_FILE, so we have to set the profiling file
-# path through our custom environment variable. We include the PID in the directory path
-# to avoid updates to profile files being lost because of race conditions.
-LLVM_PROFILE_DIR=${LLVM_PROFILE_DIRECTORY_ROOT}/prof-%p python3 $CHECKOUT/x.py build \
+# LLVM IR PGO does not respect LLVM_PROFILE_FILE, so we have to set the profiling path
+# through the LLVM build system in src/bootstrap/native.rs. We include the PID in the
+# directory path to avoid updates to profile files being lost because of race conditions.
+python3 $CHECKOUT/x.py build \
     --target=$PGO_HOST \
     --host=$PGO_HOST \
     --stage 2 library/std \
-    --llvm-profile-generate
+    --llvm-profile-generate=${LLVM_PROFILE_DIRECTORY_ROOT}/prof-%p
 
 # Compile rustc-perf:
 # - get the expected commit source code: on linux, the Dockerfile downloads a source archive before


### PR DESCRIPTION
PGO instrumentation occurs fairly late in the code generation pipeline after many transformations and optimizations are applied.  This means that profiles for the same source code can differ if the binary that generated them was compiled with a different compiler or options.

When bootstrapping the Rust compiler this is relevant because it means that profiles that are generated by the Stage 1 compiler may have entries with checksums that don't match the functions in the Stage 2 compiler.  This isn't actively harmful, but it may prevent some functions in later stage compilers from receiving profile-guided optimizations.

This commit changes the build system to instrument the Stage 2 and 3 compilers (with one exception discussed below) and to use the provided profile to optimize the compiler at every stage.

Not instrumenting the Stage 1 compiler has two advantages:
1. It decreases the size of the eventual profile (as there currently isn't a way to provide a separate profile path name to each stage)
2. It speeds up the bootstrap process; instrumented binaries are slower and if we aren't going to use the profile from the Stage 1 compiler we might as well not generate it

Because the LLVM libraries are compiled only once if they are PGO instrumented then the compiler must be PGO instrumented at every stage, including Stage 1.

CI definitions will need to be modified to use the Stage 2 compiler when generating PGO profiles.