### PR TITLE
Prefer explict closure sig types over expected ones

### DIFF
--- a/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
@@ -14,7 +14,7 @@ fn main::{closure#0}(_1: &[closure@main::{closure#0}], _2: &i32) -> &i32 {
         StorageLive(_3);                 // scope 0 at $DIR/retag.rs:+1:13: +1:15
         _3 = _2;                         // scope 0 at $DIR/retag.rs:+1:18: +1:19
         Retag(_3);                       // scope 0 at $DIR/retag.rs:+1:18: +1:19
-        _0 = _2;                         // scope 1 at $DIR/retag.rs:+2:9: +2:10
+        _0 = &(*_2);                     // scope 1 at $DIR/retag.rs:+2:9: +2:10
         Retag(_0);                       // scope 1 at $DIR/retag.rs:+2:9: +2:10
         StorageDead(_3);                 // scope 0 at $DIR/retag.rs:+3:5: +3:6
         return;                          // scope 0 at $DIR/retag.rs:+3:6: +3:6

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -25,8 +25,8 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
    |                                                 ^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'r> fn(&'r u32)`
-              found fn pointer `fn(&u32)`
+   = note: expected fn pointer `fn(&u32)`
+              found fn pointer `for<'r> fn(&'r u32)`
 
 error[E0308]: mismatched types
   --> $DIR/expect-fn-supply-fn.rs:39:50
@@ -34,8 +34,8 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
    |                                                  ^ one type is more general than the other
    |
-   = note: expected fn pointer `fn(&'x u32)`
-              found fn pointer `for<'r> fn(&'r u32)`
+   = note: expected fn pointer `for<'r> fn(&'r u32)`
+              found fn pointer `fn(&u32)`
 
 error[E0308]: mismatched types
   --> $DIR/expect-fn-supply-fn.rs:48:50
@@ -43,8 +43,8 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
    |                                                  ^ one type is more general than the other
    |
-   = note: expected fn pointer `fn(&u32)`
-              found fn pointer `for<'r> fn(&'r u32)`
+   = note: expected fn pointer `for<'r> fn(&'r u32)`
+              found fn pointer `fn(&u32)`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/closure-expected-type/expect-two-infer-vars-supply-ty-with-bound-region.stderr
+++ b/src/test/ui/closure-expected-type/expect-two-infer-vars-supply-ty-with-bound-region.stderr
@@ -6,7 +6,7 @@ LL |     with_closure(|x: u32, y| {});
    |
 help: consider giving this closure parameter an explicit type
    |
-LL |     with_closure(|x: u32, y: B| {});
+LL |     with_closure(|x: u32, y: _| {});
    |                            +++
 
 error: aborting due to previous error

--- a/src/test/ui/type-alias-impl-trait/closure_args.rs
+++ b/src/test/ui/type-alias-impl-trait/closure_args.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+// regression test for https://github.com/rust-lang/rust/issues/100800
+
+#![feature(type_alias_impl_trait)]
+
+trait Anything {}
+impl<T> Anything for T {}
+type Input = impl Anything;
+fn run<F: FnOnce(Input) -> ()>(f: F, i: Input) {
+    f(i);
+}
+
+fn main() {
+    run(|x: u32| {println!("{x}");}, 0);
+}

--- a/src/test/ui/type-alias-impl-trait/closure_args2.rs
+++ b/src/test/ui/type-alias-impl-trait/closure_args2.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+#![feature(type_alias_impl_trait)]
+
+trait Foo {
+    // This was reachable in https://github.com/rust-lang/rust/issues/100800
+    fn foo(&self) { unreachable!() }
+}
+impl<T> Foo for T {}
+
+struct B;
+impl B {
+    fn foo(&self) {}
+}
+
+type Input = impl Foo;
+fn run1<F: FnOnce(Input)>(f: F, i: Input) {f(i)}
+fn run2<F: FnOnce(B)>(f: F, i: B) {f(i)}
+
+fn main() {
+    run1(|x: B| {x.foo()}, B);
+    run2(|x: B| {x.foo()}, B);
+}

--- a/src/test/ui/type-alias-impl-trait/issue-60371.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-60371.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `(): Bug` is not satisfied
   --> $DIR/issue-60371.rs:10:40
    |
 LL |     const FUN: fn() -> Self::Item = || ();
-   |                                        ^ the trait `Bug` is not implemented for `()`
+   |                                        ^^ the trait `Bug` is not implemented for `()`
    |
    = help: the trait `Bug` is implemented for `&()`
 


### PR DESCRIPTION
fixes #100800

Previously we only checked that given closure arguments are equal to expected closure arguments, but now we choose the given closure arguments for the signature that is used when type checking the closure body, and keep the other signature for the type of the closure as seen outside of it.