### PR TITLE
Add `AsFd` implementations for stdio lock types on WASI.

### DIFF
--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -30,6 +30,13 @@ impl AsFd for Stdin {
     }
 }
 
+impl<'a> AsFd for StdinLock<'a> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(0) }
+    }
+}
+
 impl io::Read for Stdin {
     fn read(&mut self, data: &mut [u8]) -> io::Result<usize> {
         self.read_vectored(&mut [IoSliceMut::new(data)])
@@ -59,6 +66,13 @@ impl AsRawFd for Stdout {
 }
 
 impl AsFd for Stdout {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(1) }
+    }
+}
+
+impl<'a> AsFd for StdoutLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(1) }
@@ -97,6 +111,13 @@ impl AsRawFd for Stderr {
 }
 
 impl AsFd for Stderr {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(2) }
+    }
+}
+
+impl<'a> AsFd for StderrLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(2) }

--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -30,7 +30,8 @@ impl AsFd for Stdin {
     }
 }
 
-impl<'a> AsFd for StdinLock<'a> {
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl<'a> AsFd for io::StdinLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(0) }
@@ -72,7 +73,8 @@ impl AsFd for Stdout {
     }
 }
 
-impl<'a> AsFd for StdoutLock<'a> {
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl<'a> AsFd for io::StdoutLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(1) }
@@ -117,7 +119,8 @@ impl AsFd for Stderr {
     }
 }
 
-impl<'a> AsFd for StderrLock<'a> {
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl<'a> AsFd for io::StderrLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(2) }

--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -34,6 +34,7 @@ impl AsFd for Stdin {
 impl<'a> AsFd for io::StdinLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: user code should not close stdin out from under the standard library
         unsafe { BorrowedFd::borrow_raw(0) }
     }
 }
@@ -77,6 +78,7 @@ impl AsFd for Stdout {
 impl<'a> AsFd for io::StdoutLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: user code should not close stdout out from under the standard library
         unsafe { BorrowedFd::borrow_raw(1) }
     }
 }
@@ -123,6 +125,7 @@ impl AsFd for Stderr {
 impl<'a> AsFd for io::StderrLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: user code should not close stderr out from under the standard library
         unsafe { BorrowedFd::borrow_raw(2) }
     }
 }


### PR DESCRIPTION
This mirrors the implementations on Unix platforms, and also mirrors the existing `AsRawFd` impls.

This is similar to #100892, but is for the `*Lock` types.