### PR TITLE
rustdoc: remove redundant CSS `.out-of-band > span.since { position }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1274,7 +1274,6 @@ a.test-arrow:hover {
 }
 
 .out-of-band > span.since {
-	position: initial;
 	font-size: 1.25rem;
 }
 


### PR DESCRIPTION
At the time this CSS was added, it was just `span.since`, because the version info could be rendered in two different ways:

 1. `<div class='since'>` was used for associated items like methods. It was absolutely positioned, and the selector in rustdoc.css that targetted it was just `.since`.

    https://github.com/rust-lang/rust/blob/a5a2f2b951ea982a666eaf52b1874d8f1b17290b/src/librustdoc/html/static/rustdoc.css#L522-L529

 2. `<span class='since'>` was introduced in a5a2f2b951ea982a666eaf52b1874d8f1b17290b for page-global version info, so that it could be laid out alongside the `[-]`/`[+]` button. This CSS rule was added to override the absolute position introduced in (1).

    https://github.com/rust-lang/rust/blob/a5a2f2b951ea982a666eaf52b1874d8f1b17290b/src/librustdoc/html/static/rustdoc.css#L637-L641

The selector was changed in 8fc6e420d16dc882f2047e6ec1b981cac5ef0d14 so that everything could use a `<span>` tag, but the dichotomy of the absolutely-positioned version info for associated items and the static positioned item version info remained.

The absolutely positioned `.since` was changed to one nested below a `<div class="rightside">` container in 5de1391b88007a1d4f7b1517657a86aae352af1e, so the version information is now always statically-positioned, and, as described in the commit message, "their DOM representation is consistent."