### PR TITLE
Rustdoc-Json: Don't loose subitems of foreign traits.

### DIFF
--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -49,6 +49,8 @@ def check_generic_param(param):
         ty = param["kind"]["type"]
         if ty["default"]:
             check_type(ty["default"])
+        for bound in ty["bounds"]:
+            check_generic_bound(bound)
     elif "const" in param["kind"]:
         check_type(param["kind"]["const"])
 
@@ -88,8 +90,11 @@ def check_path(path):
                 check_type(input_ty)
             if args["parenthesized"]["output"]:
                 check_type(args["parenthesized"]["output"])
-    if not valid_id(path["id"]):
-        print("Type contained an invalid ID:", path["id"])
+
+    if path["id"] in crate["index"]:
+        work_list.add(path["id"])
+    elif path["id"] not in crate["paths"]:
+        print("Id not in index or paths:", path["id"])
         sys.exit(1)
 
 def check_type(ty):

--- a/src/test/rustdoc-json/traits/uses_extern_trait.rs
+++ b/src/test/rustdoc-json/traits/uses_extern_trait.rs
@@ -1,0 +1,7 @@
+#![no_std]
+pub fn drop_default<T: core::default::Default>(_x: T) {}
+
+// FIXME(adotinthevoid): Theses shouldn't be here
+// @has "$.index[*][?(@.name=='Debug')]"
+// @set Debug_fmt = "$.index[*][?(@.name=='Debug')].inner.items[*]"
+// @has "$.index[*][?(@.name=='fmt')].id" $Debug_fmt


### PR DESCRIPTION
Previously, we'd clone the index, and extend it with foreign traits. But when doing this, traits would render their subitems without them going into the index being used in the output leading to dangling ID's.

r? @GuillaumeGomez 