### PR TITLE
rustdoc: remove outdated CSS `.content table` etc

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -686,15 +686,6 @@ pre, .rustdoc.source .example-wrap {
 	position: relative;
 }
 
-.content table {
-	border-spacing: 0 5px;
-}
-.content td { vertical-align: top; }
-.content td:first-child { padding-right: 20px; }
-.content td p:first-child { margin-top: 0; }
-.content td h1, .content td h2 { margin-left: 0; font-size: 1.125rem; }
-.content tr:first-child td { border-top: 0; }
-
 .docblock table {
 	margin: .5em 0;
 	width: calc(100% - 2px);
@@ -705,6 +696,7 @@ pre, .rustdoc.source .example-wrap {
 .docblock table td {
 	padding: .5em;
 	border: 1px dashed var(--border-color);
+	vertical-align: top;
 }
 
 .docblock table th {


### PR DESCRIPTION
# Screenshot before

![image](https://user-images.githubusercontent.com/1593513/189992665-238aab28-d224-4466-901c-6e35e79182fb.png)

# Screenshot after

![image](https://user-images.githubusercontent.com/1593513/189992762-35c8efe4-e980-40bd-b72c-3ae4cfd6f830.png)

# Description

The `.content table` / `.content td` / `.content tr` family of selectors date back to 4fd061c426902b0904c65e64a3780b21f9ab3afb, when module indexes and other parts of rustdoc used `<table>` tags for layout and content presentation. The `.content td h1, .content td h2` has only been changed since then to tweak the font size in dd5ff428edbc7cd4fa600b81f27bbec28589704f.

https://github.com/rust-lang/rust/blob/4fd061c426902b0904c65e64a3780b21f9ab3afb/src/rustdoc_ng/html/static/main.css#L155-L162

This CSS would have affected:

  * search result tables, which were removed in b615c0c85469c94041a5e68b9d8b68dcf799f9f1
  * module item tables, which were removed in 6020c79ddeafe8d9760b27c14c39da81bac9b4a6
  * docblock tables from markdown, which still exist

It may also have affected a few other tables over the last decade, but they've been gradually replaced with grid layouts and flexbox to make layouts that work better on narrow viewports. For example, 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9.

These rules have no affect on the appearance of docblock tables
---------------------------------------------------------------

    .content table {
        border-spacing: 0 5px;
    }

According to MDN, [border-spacing] only has an effect when `border-collapse` is `separate`. However, `border-collapse: collapse` is set globally for all tables, so this rule does nothing.

[border-spacing]: https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing

    .content td p:first-child { margin-top: 0; }

Tables with paragraphs in them are impossible without dropping down to raw HTML. Also, the rustdoc stylesheet sets paragraphs to have no top margin anyway, so this rule is a no-op.

    .content td h1, .content td h2 { margin-left: 0; font-size: 1.125rem; }

Tables with headers in them are impossible without dropping down to raw HTML. This is considered unlikely, especially since it looks weird right now (`.docblock h2` has an underline that is redundant with the table cell's own border).

    .content tr:first-child td { border-top: 0; }

This has no effect because of border collapsing.

This rule is removed, because tables look fine without it
---------------------------------------------------------

    .content td:first-child { padding-right: 20px; }

By removing this rule, the first cell in each row has the same padding as all other cells in the row.

This rule is kept, and converted to directly target `.docblock`
---------------------------------------------------------------

    .content td { vertical-align: top; }

Removing this rule would cause it to be aligned to the middle instead.