### PR TITLE
rustdoc: clean up DOM by removing `.dockblock-short p`

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1119,7 +1119,11 @@ impl MarkdownSummaryLine<'_> {
 
         let mut s = String::new();
 
-        html::push_html(&mut s, LinkReplacer::new(SummaryLine::new(p), links));
+        let without_paragraphs = LinkReplacer::new(SummaryLine::new(p), links).filter(|event| {
+            !matches!(event, Event::Start(Tag::Paragraph) | Event::End(Tag::Paragraph))
+        });
+
+        html::push_html(&mut s, without_paragraphs);
 
         s
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -609,16 +609,12 @@ h2.location a {
 .docblock-short {
 	overflow-wrap: break-word;
 	overflow-wrap: anywhere;
-}
-.docblock-short p {
-	display: inline;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	margin: 0;
 }
 /* Wrap non-pre code blocks (`text`) but not (```text```). */
 .docblock > :not(pre) > code,
-.docblock-short > :not(pre) > code {
+.docblock-short > code {
 	white-space: pre-wrap;
 }
 

--- a/src/test/rustdoc-gui/label-next-to-symbol.goml
+++ b/src/test/rustdoc-gui/label-next-to-symbol.goml
@@ -31,15 +31,9 @@ compare-elements-position: (
 )
 
 // Ensure no wrap
-compare-elements-position-near: (
-    "//*[@class='item-left module-item']//a[text()='replaced_function']",
-    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
-    {"y": 2},
-)
-// compare parent elements
 compare-elements-position: (
     "//*[@class='item-left module-item']//a[text()='replaced_function']/..",
-    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..",
+    "//*[@class='item-right docblock-short'][text()='a thing with a label']",
     ("y"),
 )
 
@@ -60,19 +54,13 @@ compare-elements-position: (
 )
 
 // Ensure wrap
-compare-elements-position-near-false: (
-    "//*[@class='item-left module-item']//a[text()='replaced_function']",
-    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
-    {"y": 12},
-)
-// compare parent elements
 compare-elements-position-false: (
     "//*[@class='item-left module-item']//a[text()='replaced_function']/..",
-    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..",
+    "//*[@class='item-right docblock-short'][text()='a thing with a label']",
     ("y"),
 )
 compare-elements-position-false: (
     ".item-left .stab.deprecated",
-    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
+    "//*[@class='item-right docblock-short'][text()='a thing with a label']",
     ("y"),
 )

--- a/src/test/rustdoc/short-docblock.rs
+++ b/src/test/rustdoc/short-docblock.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]/p' 'fooo'
-// @!has foo/index.html '//*[@class="item-right docblock-short"]/p/h1' 'fooo'
+// @has foo/index.html '//*[@class="item-right docblock-short"]' 'fooo'
+// @!has foo/index.html '//*[@class="item-right docblock-short"]/h1' 'fooo'
 // @has foo/fn.foo.html '//h2[@id="fooo"]/a[@href="#fooo"]' 'fooo'
 
 /// # fooo
@@ -9,8 +9,8 @@
 /// foo
 pub fn foo() {}
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]/p' 'mooood'
-// @!has foo/index.html '//*[@class="item-right docblock-short"]/p/h2' 'mooood'
+// @has foo/index.html '//*[@class="item-right docblock-short"]' 'mooood'
+// @!has foo/index.html '//*[@class="item-right docblock-short"]/h2' 'mooood'
 // @has foo/foo/index.html '//h3[@id="mooood"]/a[@href="#mooood"]' 'mooood'
 
 /// ## mooood
@@ -18,7 +18,7 @@ pub fn foo() {}
 /// foo mod
 pub mod foo {}
 
-// @has foo/index.html '//*[@class="item-right docblock-short"]/p/a[@href=\
+// @has foo/index.html '//*[@class="item-right docblock-short"]/a[@href=\
 //                      "https://nougat.world"]/code' 'nougat'
 
 /// [`nougat`](https://nougat.world)

--- a/src/test/rustdoc/trait-impl.rs
+++ b/src/test/rustdoc/trait-impl.rs
@@ -21,26 +21,26 @@ pub trait Trait {
 pub struct Struct;
 
 impl Trait for Struct {
-    // @has trait_impl/struct.Struct.html '//*[@id="method.a"]/../../div[@class="docblock"]/p' 'Some long docs'
-    // @!has - '//*[@id="method.a"]/../../div[@class="docblock"]/p' 'link will be added'
-    // @has - '//*[@id="method.a"]/../../div[@class="docblock"]/p/a' 'Read more'
-    // @has - '//*[@id="method.a"]/../../div[@class="docblock"]/p/a/@href' 'trait.Trait.html#tymethod.a'
+    // @has trait_impl/struct.Struct.html '//*[@id="method.a"]/../../div[@class="docblock"]' 'Some long docs'
+    // @!has - '//*[@id="method.a"]/../../div[@class="docblock"]' 'link will be added'
+    // @has - '//*[@id="method.a"]/../../div[@class="docblock"]/a' 'Read more'
+    // @has - '//*[@id="method.a"]/../../div[@class="docblock"]/a/@href' 'trait.Trait.html#tymethod.a'
     fn a() {}
 
-    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/p' 'These docs contain'
-    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/p/a' 'reference link'
-    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/p/a/@href' 'https://example.com'
-    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/p/a' 'Read more'
-    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/p/a/@href' 'trait.Trait.html#tymethod.b'
+    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]' 'These docs contain'
+    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/a' 'reference link'
+    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/a/@href' 'https://example.com'
+    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/a' 'Read more'
+    // @has - '//*[@id="method.b"]/../../div[@class="docblock"]/a/@href' 'trait.Trait.html#tymethod.b'
     fn b() {}
 
-    // @!has - '//*[@id="method.c"]/../../div[@class="docblock"]/p' 'code block'
+    // @!has - '//*[@id="method.c"]/../../div[@class="docblock"]' 'code block'
     // @has - '//*[@id="method.c"]/../../div[@class="docblock"]/a' 'Read more'
     // @has - '//*[@id="method.c"]/../../div[@class="docblock"]/a/@href' 'trait.Trait.html#tymethod.c'
     fn c() {}
 
-    // @has - '//*[@id="method.d"]/../../div[@class="docblock"]/p' 'Escaped formatting a*b*c* works'
-    // @!has - '//*[@id="method.d"]/../../div[@class="docblock"]/p/em' ''
+    // @has - '//*[@id="method.d"]/../../div[@class="docblock"]' 'Escaped formatting a*b*c* works'
+    // @!has - '//*[@id="method.d"]/../../div[@class="docblock"]/em' ''
     fn d() {}
 
     // @has - '//*[@id="impl-Trait-for-Struct"]/h3//a/@href' 'trait.Trait.html'


### PR DESCRIPTION
On https://doc.rust-lang.org/nightly/std/ this reduces the number out of `document.querySelectorAll("*").length` from 1278 to 1103.

Preview: https://notriddle.com/notriddle-rustdoc-test/docblock-short-p/std/index.html