### PR TITLE
Update test output for drop tracking

### DIFF
--- a/src/test/ui/async-await/async-await-let-else.drop-tracking.stderr
+++ b/src/test/ui/async-await/async-await-let-else.drop-tracking.stderr
@@ -1,12 +1,12 @@
 error: future cannot be sent between threads safely
-  --> $DIR/async-await-let-else.rs:45:13
+  --> $DIR/async-await-let-else.rs:48:13
    |
 LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/async-await-let-else.rs:8:14
+  --> $DIR/async-await-let-else.rs:11:14
    |
 LL |         let r = Rc::new(());
    |             - has type `Rc<()>` which is not `Send`
@@ -15,67 +15,82 @@ LL |         bar().await
 LL |     };
    |     - `r` is later dropped here
 note: required by a bound in `is_send`
-  --> $DIR/async-await-let-else.rs:16:15
+  --> $DIR/async-await-let-else.rs:19:15
    |
 LL | fn is_send<T: Send>(_: T) {}
    |               ^^^^ required by this bound in `is_send`
 
-error: future cannot be sent between threads safely
-  --> $DIR/async-await-let-else.rs:47:13
+error[E0277]: `Rc<()>` cannot be sent between threads safely
+  --> $DIR/async-await-let-else.rs:50:13
    |
+LL | async fn foo2(x: Option<bool>) {
+   |                                - within this `impl Future<Output = ()>`
+...
 LL |     is_send(foo2(Some(true)));
-   |             ^^^^^^^^^^^^^^^^ future returned by `foo2` is not `Send`
+   |     ------- ^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-note: future is not `Send` as this value is used across an await
-  --> $DIR/async-await-let-else.rs:20:26
+note: required because it's used within this `async fn` body
+  --> $DIR/async-await-let-else.rs:27:29
    |
-LL |         bar2(Rc::new(())).await
-   |              ----------- ^^^^^^ await occurs here, with `Rc::new(())` maybe used later
-   |              |
-   |              has type `Rc<()>` which is not `Send`
-LL |     };
-   |      - `Rc::new(())` is later dropped here
+LL |   async fn bar2<T>(_: T) -> ! {
+   |  _____________________________^
+LL | |     panic!()
+LL | | }
+   | |_^
+   = note: required because it captures the following types: `ResumeTy`, `Option<bool>`, `impl Future<Output = !>`, `()`
+note: required because it's used within this `async fn` body
+  --> $DIR/async-await-let-else.rs:21:32
+   |
+LL |   async fn foo2(x: Option<bool>) {
+   |  ________________________________^
+LL | |     let Some(_) = x else {
+LL | |         bar2(Rc::new(())).await
+LL | |     };
+LL | | }
+   | |_^
 note: required by a bound in `is_send`
-  --> $DIR/async-await-let-else.rs:16:15
+  --> $DIR/async-await-let-else.rs:19:15
    |
 LL | fn is_send<T: Send>(_: T) {}
    |               ^^^^ required by this bound in `is_send`
 
 error: future cannot be sent between threads safely
-  --> $DIR/async-await-let-else.rs:49:13
+  --> $DIR/async-await-let-else.rs:52:13
    |
 LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/async-await-let-else.rs:30:28
+  --> $DIR/async-await-let-else.rs:33:28
    |
 LL |         (Rc::new(()), bar().await);
    |          -----------       ^^^^^^ await occurs here, with `Rc::new(())` maybe used later
    |          |
    |          has type `Rc<()>` which is not `Send`
 note: `Rc::new(())` is later dropped here
-  --> $DIR/async-await-let-else.rs:30:35
+  --> $DIR/async-await-let-else.rs:33:35
    |
 LL |         (Rc::new(()), bar().await);
    |                                   ^
 note: required by a bound in `is_send`
-  --> $DIR/async-await-let-else.rs:16:15
+  --> $DIR/async-await-let-else.rs:19:15
    |
 LL | fn is_send<T: Send>(_: T) {}
    |               ^^^^ required by this bound in `is_send`
 
 error: future cannot be sent between threads safely
-  --> $DIR/async-await-let-else.rs:51:13
+  --> $DIR/async-await-let-else.rs:54:13
    |
 LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/async-await-let-else.rs:38:14
+  --> $DIR/async-await-let-else.rs:41:14
    |
 LL |         let r = Rc::new(());
    |             - has type `Rc<()>` which is not `Send`
@@ -85,10 +100,11 @@ LL |         bar().await;
 LL |     };
    |     - `r` is later dropped here
 note: required by a bound in `is_send`
-  --> $DIR/async-await-let-else.rs:16:15
+  --> $DIR/async-await-let-else.rs:19:15
    |
 LL | fn is_send<T: Send>(_: T) {}
    |               ^^^^ required by this bound in `is_send`
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/async-await-let-else.no-drop-tracking.stderr
+++ b/src/test/ui/async-await/async-await-let-else.no-drop-tracking.stderr
@@ -1,0 +1,94 @@
+error: future cannot be sent between threads safely
+  --> $DIR/async-await-let-else.rs:48:13
+   |
+LL |     is_send(foo(Some(true)));
+   |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
+   |
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+note: future is not `Send` as this value is used across an await
+  --> $DIR/async-await-let-else.rs:11:14
+   |
+LL |         let r = Rc::new(());
+   |             - has type `Rc<()>` which is not `Send`
+LL |         bar().await
+   |              ^^^^^^ await occurs here, with `r` maybe used later
+LL |     };
+   |     - `r` is later dropped here
+note: required by a bound in `is_send`
+  --> $DIR/async-await-let-else.rs:19:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
+
+error: future cannot be sent between threads safely
+  --> $DIR/async-await-let-else.rs:50:13
+   |
+LL |     is_send(foo2(Some(true)));
+   |             ^^^^^^^^^^^^^^^^ future returned by `foo2` is not `Send`
+   |
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+note: future is not `Send` as this value is used across an await
+  --> $DIR/async-await-let-else.rs:23:26
+   |
+LL |         bar2(Rc::new(())).await
+   |              ----------- ^^^^^^ await occurs here, with `Rc::new(())` maybe used later
+   |              |
+   |              has type `Rc<()>` which is not `Send`
+LL |     };
+   |      - `Rc::new(())` is later dropped here
+note: required by a bound in `is_send`
+  --> $DIR/async-await-let-else.rs:19:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
+
+error: future cannot be sent between threads safely
+  --> $DIR/async-await-let-else.rs:52:13
+   |
+LL |     is_send(foo3(Some(true)));
+   |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
+   |
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+note: future is not `Send` as this value is used across an await
+  --> $DIR/async-await-let-else.rs:33:28
+   |
+LL |         (Rc::new(()), bar().await);
+   |          -----------       ^^^^^^ await occurs here, with `Rc::new(())` maybe used later
+   |          |
+   |          has type `Rc<()>` which is not `Send`
+note: `Rc::new(())` is later dropped here
+  --> $DIR/async-await-let-else.rs:33:35
+   |
+LL |         (Rc::new(()), bar().await);
+   |                                   ^
+note: required by a bound in `is_send`
+  --> $DIR/async-await-let-else.rs:19:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
+
+error: future cannot be sent between threads safely
+  --> $DIR/async-await-let-else.rs:54:13
+   |
+LL |     is_send(foo4(Some(true)));
+   |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
+   |
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+note: future is not `Send` as this value is used across an await
+  --> $DIR/async-await-let-else.rs:41:14
+   |
+LL |         let r = Rc::new(());
+   |             - has type `Rc<()>` which is not `Send`
+LL |         bar().await;
+   |              ^^^^^^ await occurs here, with `r` maybe used later
+...
+LL |     };
+   |     - `r` is later dropped here
+note: required by a bound in `is_send`
+  --> $DIR/async-await-let-else.rs:19:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/async-await/async-await-let-else.rs
+++ b/src/test/ui/async-await/async-await-let-else.rs
@@ -1,4 +1,7 @@
 // edition:2021
+// revisions: drop-tracking no-drop-tracking
+// [drop-tracking] compile-flags: -Zdrop-tracking=yes
+// [no-drop-tracking] compile-flags: -Zdrop-tracking=no
 #![feature(let_else)]
 use std::rc::Rc;
 
@@ -43,11 +46,11 @@ async fn foo4(x: Option<bool>) {
 
 fn main() {
     is_send(foo(Some(true)));
-    //~^ ERROR future cannot be sent between threads safely
+    //~^ ERROR cannot be sent between threads safely
     is_send(foo2(Some(true)));
-    //~^ ERROR future cannot be sent between threads safely
+    //~^ ERROR cannot be sent between threads safely
     is_send(foo3(Some(true)));
-    //~^ ERROR future cannot be sent between threads safely
+    //~^ ERROR cannot be sent between threads safely
     is_send(foo4(Some(true)));
-    //~^ ERROR future cannot be sent between threads safely
+    //~^ ERROR cannot be sent between threads safely
 }

--- a/src/test/ui/async-await/issue-64130-4-async-move.drop-tracking.stderr
+++ b/src/test/ui/async-await/issue-64130-4-async-move.drop-tracking.stderr
@@ -1,12 +1,12 @@
 error: future cannot be sent between threads safely
-  --> $DIR/issue-64130-4-async-move.rs:15:17
+  --> $DIR/issue-64130-4-async-move.rs:19:17
    |
 LL | pub fn foo() -> impl Future + Send {
    |                 ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `(dyn Any + Send + 'static)`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/issue-64130-4-async-move.rs:21:31
+  --> $DIR/issue-64130-4-async-move.rs:25:31
    |
 LL |         match client.status() {
    |               ------ has type `&Client` which is not `Send`
@@ -17,7 +17,7 @@ LL |                 let _x = get().await;
 LL |     }
    |     - `client` is later dropped here
 help: consider moving this into a `let` binding to create a shorter lived borrow
-  --> $DIR/issue-64130-4-async-move.rs:19:15
+  --> $DIR/issue-64130-4-async-move.rs:23:15
    |
 LL |         match client.status() {
    |               ^^^^^^^^^^^^^^^

--- a/src/test/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
+++ b/src/test/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
@@ -1,0 +1,26 @@
+error: future cannot be sent between threads safely
+  --> $DIR/issue-64130-4-async-move.rs:19:17
+   |
+LL | pub fn foo() -> impl Future + Send {
+   |                 ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
+   |
+   = help: the trait `Sync` is not implemented for `(dyn Any + Send + 'static)`
+note: future is not `Send` as this value is used across an await
+  --> $DIR/issue-64130-4-async-move.rs:25:31
+   |
+LL |         match client.status() {
+   |               ------ has type `&Client` which is not `Send`
+LL |             200 => {
+LL |                 let _x = get().await;
+   |                               ^^^^^^ await occurs here, with `client` maybe used later
+...
+LL |     }
+   |     - `client` is later dropped here
+help: consider moving this into a `let` binding to create a shorter lived borrow
+  --> $DIR/issue-64130-4-async-move.rs:23:15
+   |
+LL |         match client.status() {
+   |               ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/async-await/issue-64130-4-async-move.rs
+++ b/src/test/ui/async-await/issue-64130-4-async-move.rs
@@ -1,4 +1,8 @@
 // edition:2018
+// revisions: no_drop_tracking drop_tracking
+// [drop_tracking] check-pass
+// [drop_tracking] compile-flags: -Zdrop-tracking=yes
+// [no_drop_tracking] compile-flags: -Zdrop-tracking=no
 use std::any::Any;
 use std::future::Future;
 
@@ -10,16 +14,16 @@ impl Client {
     }
 }
 
-async fn get() { }
+async fn get() {}
 
 pub fn foo() -> impl Future + Send {
-    //~^ ERROR future cannot be sent between threads safely
+    //[no_drop_tracking]~^ ERROR future cannot be sent between threads safely
     let client = Client(Box::new(true));
     async move {
         match client.status() {
             200 => {
                 let _x = get().await;
-            },
+            }
             _ => (),
         }
     }

--- a/src/test/ui/async-await/issue-68112.drop_tracking.stderr
+++ b/src/test/ui/async-await/issue-68112.drop_tracking.stderr
@@ -1,0 +1,79 @@
+error: future cannot be sent between threads safely
+  --> $DIR/issue-68112.rs:37:18
+   |
+LL |     require_send(send_fut);
+   |                  ^^^^^^^^ future created by async block is not `Send`
+   |
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+note: future is not `Send` as it awaits another future which is not `Send`
+  --> $DIR/issue-68112.rs:34:17
+   |
+LL |         let _ = non_send_fut.await;
+   |                 ^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:14:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
+
+error: future cannot be sent between threads safely
+  --> $DIR/issue-68112.rs:46:18
+   |
+LL |     require_send(send_fut);
+   |                  ^^^^^^^^ future created by async block is not `Send`
+   |
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+note: future is not `Send` as it awaits another future which is not `Send`
+  --> $DIR/issue-68112.rs:43:17
+   |
+LL |         let _ = make_non_send_future1().await;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:14:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
+
+error[E0277]: `RefCell<i32>` cannot be shared between threads safely
+  --> $DIR/issue-68112.rs:65:18
+   |
+LL |     require_send(send_fut);
+   |     ------------ ^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = note: required for `Arc<RefCell<i32>>` to implement `Send`
+note: required because it's used within this `async fn` body
+  --> $DIR/issue-68112.rs:50:31
+   |
+LL |   async fn ready2<T>(t: T) -> T {
+   |  _______________________________^
+LL | |     t
+LL | | }
+   | |_^
+note: required because it appears within the type `impl Future<Output = Arc<RefCell<i32>>>`
+  --> $DIR/issue-68112.rs:53:31
+   |
+LL | fn make_non_send_future2() -> impl Future<Output = Arc<RefCell<i32>>> {
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: required because it captures the following types: `ResumeTy`, `impl Future<Output = Arc<RefCell<i32>>>`, `()`, `Ready<i32>`
+note: required because it's used within this `async` block
+  --> $DIR/issue-68112.rs:60:26
+   |
+LL |       let send_fut = async {
+   |  __________________________^
+LL | |         let non_send_fut = make_non_send_future2();
+LL | |         let _ = non_send_fut.await;
+LL | |         ready(0).await;
+LL | |     };
+   | |_____^
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:14:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/issue-68112.no_drop_tracking.stderr
+++ b/src/test/ui/async-await/issue-68112.no_drop_tracking.stderr
@@ -1,41 +1,41 @@
 error: future cannot be sent between threads safely
-  --> $DIR/issue-68112.rs:34:18
+  --> $DIR/issue-68112.rs:37:18
    |
 LL |     require_send(send_fut);
    |                  ^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
 note: future is not `Send` as it awaits another future which is not `Send`
-  --> $DIR/issue-68112.rs:31:17
+  --> $DIR/issue-68112.rs:34:17
    |
 LL |         let _ = non_send_fut.await;
    |                 ^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
 note: required by a bound in `require_send`
-  --> $DIR/issue-68112.rs:11:25
+  --> $DIR/issue-68112.rs:14:25
    |
 LL | fn require_send(_: impl Send) {}
    |                         ^^^^ required by this bound in `require_send`
 
 error: future cannot be sent between threads safely
-  --> $DIR/issue-68112.rs:43:18
+  --> $DIR/issue-68112.rs:46:18
    |
 LL |     require_send(send_fut);
    |                  ^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
 note: future is not `Send` as it awaits another future which is not `Send`
-  --> $DIR/issue-68112.rs:40:17
+  --> $DIR/issue-68112.rs:43:17
    |
 LL |         let _ = make_non_send_future1().await;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
 note: required by a bound in `require_send`
-  --> $DIR/issue-68112.rs:11:25
+  --> $DIR/issue-68112.rs:14:25
    |
 LL | fn require_send(_: impl Send) {}
    |                         ^^^^ required by this bound in `require_send`
 
 error[E0277]: `RefCell<i32>` cannot be shared between threads safely
-  --> $DIR/issue-68112.rs:60:18
+  --> $DIR/issue-68112.rs:65:18
    |
 LL |     require_send(send_fut);
    |     ------------ ^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
@@ -45,18 +45,21 @@ LL |     require_send(send_fut);
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: required for `Arc<RefCell<i32>>` to implement `Send`
 note: required because it's used within this `async fn` body
-  --> $DIR/issue-68112.rs:47:31
+  --> $DIR/issue-68112.rs:50:31
    |
-LL | async fn ready2<T>(t: T) -> T { t }
-   |                               ^^^^^
+LL |   async fn ready2<T>(t: T) -> T {
+   |  _______________________________^
+LL | |     t
+LL | | }
+   | |_^
 note: required because it appears within the type `impl Future<Output = Arc<RefCell<i32>>>`
-  --> $DIR/issue-68112.rs:48:31
+  --> $DIR/issue-68112.rs:53:31
    |
 LL | fn make_non_send_future2() -> impl Future<Output = Arc<RefCell<i32>>> {
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required because it captures the following types: `ResumeTy`, `impl Future<Output = Arc<RefCell<i32>>>`, `()`, `i32`, `Ready<i32>`
 note: required because it's used within this `async` block
-  --> $DIR/issue-68112.rs:55:26
+  --> $DIR/issue-68112.rs:60:26
    |
 LL |       let send_fut = async {
    |  __________________________^
@@ -66,7 +69,7 @@ LL | |         ready(0).await;
 LL | |     };
    | |_____^
 note: required by a bound in `require_send`
-  --> $DIR/issue-68112.rs:11:25
+  --> $DIR/issue-68112.rs:14:25
    |
 LL | fn require_send(_: impl Send) {}
    |                         ^^^^ required by this bound in `require_send`

--- a/src/test/ui/async-await/issue-68112.rs
+++ b/src/test/ui/async-await/issue-68112.rs
@@ -1,10 +1,13 @@
 // edition:2018
+// revisions: no_drop_tracking drop_tracking
+// [drop_tracking] compile-flags: -Zdrop-tracking=yes
+// [no_drop_tracking] compile-flags: -Zdrop-tracking=no
 
 use std::{
-    future::Future,
     cell::RefCell,
-    sync::Arc,
+    future::Future,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -44,7 +47,9 @@ fn test1_no_let() {
     //~^ ERROR future cannot be sent between threads
 }
 
-async fn ready2<T>(t: T) -> T { t }
+async fn ready2<T>(t: T) -> T {
+    t
+}
 fn make_non_send_future2() -> impl Future<Output = Arc<RefCell<i32>>> {
     ready2(Arc::new(RefCell::new(0)))
 }

--- a/src/test/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
+++ b/src/test/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `Sender<i32>` cannot be shared between threads safely
-  --> $DIR/issue-70935-complex-spans.rs:12:45
+  --> $DIR/issue-70935-complex-spans.rs:13:45
    |
 LL | fn foo(tx: std::sync::mpsc::Sender<i32>) -> impl Future + Send {
    |                                             ^^^^^^^^^^^^^^^^^^ `Sender<i32>` cannot be shared between threads safely
@@ -7,12 +7,12 @@ LL | fn foo(tx: std::sync::mpsc::Sender<i32>) -> impl Future + Send {
    = help: the trait `Sync` is not implemented for `Sender<i32>`
    = note: required for `&Sender<i32>` to implement `Send`
 note: required because it's used within this closure
-  --> $DIR/issue-70935-complex-spans.rs:16:13
+  --> $DIR/issue-70935-complex-spans.rs:17:13
    |
 LL |         baz(|| async{
    |             ^^
 note: required because it's used within this `async fn` body
-  --> $DIR/issue-70935-complex-spans.rs:9:67
+  --> $DIR/issue-70935-complex-spans.rs:10:67
    |
 LL |   async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
    |  ___________________________________________________________________^
@@ -20,7 +20,7 @@ LL | | }
    | |_^
    = note: required because it captures the following types: `ResumeTy`, `impl for<'r, 's, 't0> Future<Output = ()>`, `()`
 note: required because it's used within this `async` block
-  --> $DIR/issue-70935-complex-spans.rs:15:16
+  --> $DIR/issue-70935-complex-spans.rs:16:16
    |
 LL |       async move {
    |  ________________^

--- a/src/test/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
+++ b/src/test/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
@@ -1,12 +1,12 @@
 error: future cannot be sent between threads safely
-  --> $DIR/issue-70935-complex-spans.rs:12:45
+  --> $DIR/issue-70935-complex-spans.rs:13:45
    |
 LL | fn foo(tx: std::sync::mpsc::Sender<i32>) -> impl Future + Send {
    |                                             ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `Sender<i32>`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/issue-70935-complex-spans.rs:18:11
+  --> $DIR/issue-70935-complex-spans.rs:19:11
    |
 LL |           baz(|| async{
    |  _____________-
@@ -14,9 +14,9 @@ LL | |             foo(tx.clone());
 LL | |         }).await;
    | |         - ^^^^^^ await occurs here, with the value maybe used later
    | |_________|
-   |           has type `[closure@$DIR/issue-70935-complex-spans.rs:16:13: 16:15]` which is not `Send`
+   |           has type `[closure@$DIR/issue-70935-complex-spans.rs:17:13: 17:15]` which is not `Send`
 note: the value is later dropped here
-  --> $DIR/issue-70935-complex-spans.rs:18:17
+  --> $DIR/issue-70935-complex-spans.rs:19:17
    |
 LL |         }).await;
    |                 ^

--- a/src/test/ui/async-await/issue-70935-complex-spans.rs
+++ b/src/test/ui/async-await/issue-70935-complex-spans.rs
@@ -1,5 +1,6 @@
 // edition:2018
-// revisions: normal drop_tracking
+// revisions: no_drop_tracking drop_tracking
+// [no_drop_tracking]compile-flags:-Zdrop-tracking=no
 // [drop_tracking]compile-flags:-Zdrop-tracking
 // #70935: Check if we do not emit snippet
 // with newlines which lead complex diagnostics.
@@ -10,7 +11,7 @@ async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
 }
 
 fn foo(tx: std::sync::mpsc::Sender<i32>) -> impl Future + Send {
-    //[normal]~^ ERROR future cannot be sent between threads safely
+    //[no_drop_tracking]~^ ERROR future cannot be sent between threads safely
     //[drop_tracking]~^^ ERROR `Sender<i32>` cannot be shared between threads
     async move {
         baz(|| async{

--- a/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
+++ b/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
@@ -1,5 +1,5 @@
 error: future cannot be sent between threads safely
-  --> $DIR/issue-65436-raw-ptr-not-send.rs:12:17
+  --> $DIR/issue-65436-raw-ptr-not-send.rs:16:17
    |
 LL |       assert_send(async {
    |  _________________^
@@ -10,24 +10,24 @@ LL | |     })
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const u8`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/issue-65436-raw-ptr-not-send.rs:14:35
+  --> $DIR/issue-65436-raw-ptr-not-send.rs:18:35
    |
 LL |         bar(Foo(std::ptr::null())).await;
    |                 ----------------  ^^^^^^ await occurs here, with `std::ptr::null()` maybe used later
    |                 |
    |                 has type `*const u8` which is not `Send`
 note: `std::ptr::null()` is later dropped here
-  --> $DIR/issue-65436-raw-ptr-not-send.rs:14:41
+  --> $DIR/issue-65436-raw-ptr-not-send.rs:18:41
    |
 LL |         bar(Foo(std::ptr::null())).await;
    |                                         ^
 help: consider moving this into a `let` binding to create a shorter lived borrow
-  --> $DIR/issue-65436-raw-ptr-not-send.rs:14:13
+  --> $DIR/issue-65436-raw-ptr-not-send.rs:18:13
    |
 LL |         bar(Foo(std::ptr::null())).await;
    |             ^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `assert_send`
-  --> $DIR/issue-65436-raw-ptr-not-send.rs:9:19
+  --> $DIR/issue-65436-raw-ptr-not-send.rs:13:19
    |
 LL | fn assert_send<T: Send>(_: T) {}
    |                   ^^^^ required by this bound in `assert_send`

--- a/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.rs
+++ b/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.rs
@@ -1,4 +1,8 @@
 // edition:2018
+// revisions: no_drop_tracking drop_tracking
+// [drop_tracking] check-pass
+// [drop_tracking] compile-flags: -Zdrop-tracking=yes
+// [no_drop_tracking] compile-flags: -Zdrop-tracking=no
 
 struct Foo(*const u8);
 
@@ -10,7 +14,7 @@ fn assert_send<T: Send>(_: T) {}
 
 fn main() {
     assert_send(async {
-    //~^ ERROR future cannot be sent between threads safely
+        //[no_drop_tracking]~^ ERROR future cannot be sent between threads safely
         bar(Foo(std::ptr::null())).await;
     })
 }

--- a/src/test/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
+++ b/src/test/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `NotSend` cannot be sent between threads safely
-  --> $DIR/partial-drop-partial-reinit.rs:6:16
+  --> $DIR/partial-drop-partial-reinit.rs:9:16
    |
 LL |     gimme_send(foo());
    |     ---------- ^^^^^ `NotSend` cannot be sent between threads safely
@@ -11,9 +11,9 @@ LL | async fn foo() {
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
    = note: required because it appears within the type `(NotSend,)`
-   = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `impl Future<Output = ()>`, `()`
+   = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `()`, `impl Future<Output = ()>`
 note: required because it's used within this `async fn` body
-  --> $DIR/partial-drop-partial-reinit.rs:28:16
+  --> $DIR/partial-drop-partial-reinit.rs:31:16
    |
 LL |   async fn foo() {
    |  ________________^
@@ -25,7 +25,7 @@ LL | |     bar().await;
 LL | | }
    | |_^
 note: required by a bound in `gimme_send`
-  --> $DIR/partial-drop-partial-reinit.rs:14:18
+  --> $DIR/partial-drop-partial-reinit.rs:17:18
    |
 LL | fn gimme_send<T: Send>(t: T) {
    |                  ^^^^ required by this bound in `gimme_send`

--- a/src/test/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
+++ b/src/test/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
@@ -1,0 +1,35 @@
+error[E0277]: `NotSend` cannot be sent between threads safely
+  --> $DIR/partial-drop-partial-reinit.rs:9:16
+   |
+LL |     gimme_send(foo());
+   |     ---------- ^^^^^ `NotSend` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
+...
+LL | async fn foo() {
+   |                - within this `impl Future<Output = ()>`
+   |
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
+   = note: required because it appears within the type `(NotSend,)`
+   = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `impl Future<Output = ()>`, `()`
+note: required because it's used within this `async fn` body
+  --> $DIR/partial-drop-partial-reinit.rs:31:16
+   |
+LL |   async fn foo() {
+   |  ________________^
+LL | |
+LL | |
+LL | |     let mut x = (NotSend {},);
+...  |
+LL | |     bar().await;
+LL | | }
+   | |_^
+note: required by a bound in `gimme_send`
+  --> $DIR/partial-drop-partial-reinit.rs:17:18
+   |
+LL | fn gimme_send<T: Send>(t: T) {
+   |                  ^^^^ required by this bound in `gimme_send`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/partial-drop-partial-reinit.rs
+++ b/src/test/ui/async-await/partial-drop-partial-reinit.rs
@@ -1,4 +1,7 @@
 // edition:2021
+// revisions: no_drop_tracking drop_tracking
+// [drop_tracking] compile-flags: -Zdrop-tracking=yes
+// [no_drop_tracking] compile-flags: -Zdrop-tracking=no
 #![feature(negative_impls)]
 #![allow(unused)]
 
@@ -12,8 +15,8 @@ fn main() {
 }
 
 fn gimme_send<T: Send>(t: T) {
-//~^ NOTE required by this bound
-//~| NOTE required by a bound
+    //~^ NOTE required by this bound
+    //~| NOTE required by a bound
     drop(t);
 }
 
@@ -26,8 +29,8 @@ impl Drop for NotSend {
 impl !Send for NotSend {}
 
 async fn foo() {
-//~^ NOTE used within this `async fn` body
-//~| NOTE within this `impl Future
+    //~^ NOTE used within this `async fn` body
+    //~| NOTE within this `impl Future
     let mut x = (NotSend {},);
     drop(x.0);
     x.0 = NotSend {};

--- a/src/test/ui/lint/must_not_suspend/ref.drop_tracking.stderr
+++ b/src/test/ui/lint/must_not_suspend/ref.drop_tracking.stderr
@@ -1,27 +1,27 @@
-error: `Umm` held across a suspend point, but should not be
-  --> $DIR/ref.rs:18:26
+error: reference to `Umm` held across a suspend point, but should not be
+  --> $DIR/ref.rs:21:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
+   |             ^^^^^
 LL |
 LL |         other().await;
    |                ------ the value is held across this suspend point
    |
 note: the lint level is defined here
-  --> $DIR/ref.rs:3:9
+  --> $DIR/ref.rs:6:9
    |
 LL | #![deny(must_not_suspend)]
    |         ^^^^^^^^^^^^^^^^
 note: You gotta use Umm's, ya know?
-  --> $DIR/ref.rs:18:26
+  --> $DIR/ref.rs:21:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
+   |             ^^^^^
 help: consider using a block (`{ ... }`) to shrink the value's scope, ending before the suspend point
-  --> $DIR/ref.rs:18:26
+  --> $DIR/ref.rs:21:13
    |
 LL |         let guard = &mut self.u;
-   |                          ^^^^^^
+   |             ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/must_not_suspend/ref.no_drop_tracking.stderr
+++ b/src/test/ui/lint/must_not_suspend/ref.no_drop_tracking.stderr
@@ -1,0 +1,27 @@
+error: `Umm` held across a suspend point, but should not be
+  --> $DIR/ref.rs:21:26
+   |
+LL |         let guard = &mut self.u;
+   |                          ^^^^^^
+LL |
+LL |         other().await;
+   |                ------ the value is held across this suspend point
+   |
+note: the lint level is defined here
+  --> $DIR/ref.rs:6:9
+   |
+LL | #![deny(must_not_suspend)]
+   |         ^^^^^^^^^^^^^^^^
+note: You gotta use Umm's, ya know?
+  --> $DIR/ref.rs:21:26
+   |
+LL |         let guard = &mut self.u;
+   |                          ^^^^^^
+help: consider using a block (`{ ... }`) to shrink the value's scope, ending before the suspend point
+  --> $DIR/ref.rs:21:26
+   |
+LL |         let guard = &mut self.u;
+   |                          ^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/must_not_suspend/ref.rs
+++ b/src/test/ui/lint/must_not_suspend/ref.rs
@@ -1,10 +1,13 @@
 // edition:2018
+// revisions: no_drop_tracking drop_tracking
+// [drop_tracking] compile-flags: -Zdrop-tracking=yes
+// [no_drop_tracking] compile-flags: -Zdrop-tracking=no
 #![feature(must_not_suspend)]
 #![deny(must_not_suspend)]
 
 #[must_not_suspend = "You gotta use Umm's, ya know?"]
 struct Umm {
-    i: i64
+    i: i64,
 }
 
 struct Bar {
@@ -19,11 +22,8 @@ impl Bar {
 
         other().await;
 
-        *guard = Umm {
-            i: 2
-        }
+        *guard = Umm { i: 2 }
     }
 }
 
-fn main() {
-}
+fn main() {}


### PR DESCRIPTION
#97334 has a lot of updates to test outputs that makes the PR larger than it needs to be. This PR pulls those changes out so we can keep the other one as simple as possible.

r? @jyn514 