### PR TITLE
Extend list of targets that support dyanmic linking for llvm tools

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1307,10 +1307,6 @@ impl Build {
         self.package_vers(&self.version)
     }
 
-    fn llvm_link_tools_dynamically(&self, target: TargetSelection) -> bool {
-        target.contains("linux-gnu") || target.contains("apple-darwin")
-    }
-
     /// Returns the `version` string associated with this compiler for Rust
     /// itself.
     ///

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -423,12 +423,7 @@ impl Step for Llvm {
         // which saves both memory during parallel links and overall disk space
         // for the tools. We don't do this on every platform as it doesn't work
         // equally well everywhere.
-        //
-        // If we're not linking rustc to a dynamic LLVM, though, then don't link
-        // tools to it.
-        let llvm_link_shared =
-            builder.llvm_link_tools_dynamically(target) && builder.llvm_link_shared();
-        if llvm_link_shared {
+        if builder.llvm_link_shared() {
             cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 
@@ -553,7 +548,7 @@ impl Step for Llvm {
         // libLLVM.dylib will be built. However, llvm-config will still look
         // for a versioned path like libLLVM-14.dylib. Manually create a symbolic
         // link to make llvm-config happy.
-        if llvm_link_shared && target.contains("apple-darwin") {
+        if builder.llvm_link_shared() && target.contains("apple-darwin") {
             let mut cmd = Command::new(&build_llvm_config);
             let version = output(cmd.arg("--version"));
             let major = version.split('.').next().unwrap();

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -286,7 +286,7 @@ jobs:
 
           - name: x86_64-gnu-llvm-13
             <<: *job-linux-xl
-            
+
           - name: x86_64-gnu-tools
             env:
               CI_ONLY_WHEN_SUBMODULES_CHANGED: 1


### PR DESCRIPTION
This commit adds `linux-musl` to the list of targets that support dynamic linking for the LLVM tools.