### PR TITLE
Improve handing of env vars during bootstrap process

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -732,9 +732,19 @@ class RustBuild(object):
             (os.pathsep + env["LIBRARY_PATH"]) \
             if "LIBRARY_PATH" in env else ""
 
+        # Export Stage0 snapshot compiler related env variables
+        build_section = "target.{}".format(self.build)
+        host_triple_sanitized = self.build.replace("-", "_")
+        var_data = {
+            "CC": "cc", "CXX": "cxx", "LD": "linker", "AR": "ar", "RANLIB": "ranlib"
+        }
+        for var_name, toml_key in var_data.items():
+            toml_val = self.get_toml(toml_key, build_section)
+            if toml_val != None:
+                env["{}_{}".format(var_name, host_triple_sanitized)] = toml_val
+
         # preserve existing RUSTFLAGS
         env.setdefault("RUSTFLAGS", "")
-        build_section = "target.{}".format(self.build)
         target_features = []
         if self.get_toml("crt-static", build_section) == "true":
             target_features += ["+crt-static"]
@@ -742,9 +752,6 @@ class RustBuild(object):
             target_features += ["-crt-static"]
         if target_features:
             env["RUSTFLAGS"] += " -C target-feature=" + (",".join(target_features))
-        target_linker = self.get_toml("linker", build_section)
-        if target_linker is not None:
-            env["RUSTFLAGS"] += " -C linker=" + target_linker
         env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
         env["RUSTFLAGS"] += " -Wsemicolon_in_expressions_from_macros"
         if self.get_toml("deny-warnings", "rust") != "false":

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1940,25 +1940,26 @@ impl<'a> Builder<'a> {
                     _ => s.display().to_string(),
                 }
             };
+            let triple_underscored = target.triple.replace("-", "_");
             let cc = ccacheify(&self.cc(target));
-            cargo.env(format!("CC_{}", target.triple), &cc);
+            cargo.env(format!("CC_{}", triple_underscored), &cc);
 
             let cflags = self.cflags(target, GitRepo::Rustc, CLang::C).join(" ");
-            cargo.env(format!("CFLAGS_{}", target.triple), &cflags);
+            cargo.env(format!("CFLAGS_{}", triple_underscored), &cflags);
 
             if let Some(ar) = self.ar(target) {
                 let ranlib = format!("{} s", ar.display());
                 cargo
-                    .env(format!("AR_{}", target.triple), ar)
-                    .env(format!("RANLIB_{}", target.triple), ranlib);
+                    .env(format!("AR_{}", triple_underscored), ar)
+                    .env(format!("RANLIB_{}", triple_underscored), ranlib);
             }
 
             if let Ok(cxx) = self.cxx(target) {
                 let cxx = ccacheify(&cxx);
                 let cxxflags = self.cflags(target, GitRepo::Rustc, CLang::Cxx).join(" ");
                 cargo
-                    .env(format!("CXX_{}", target.triple), &cxx)
-                    .env(format!("CXXFLAGS_{}", target.triple), cxxflags);
+                    .env(format!("CXX_{}", triple_underscored), &cxx)
+                    .env(format!("CXXFLAGS_{}", triple_underscored), cxxflags);
             }
         }
 


### PR DESCRIPTION
This CL modifies the handing of env vars during the bootstrap process in two ways:
1. Replaces '-' characters with '_' characters in target names to increase compatibility with different shells
2. Passes Stage0 snapshot compiler related env vars to early invocations of Cargo