### PR TITLE
Tidy will not check coding style in bootstrap/target

### DIFF
--- a/src/tools/tidy/src/walk.rs
+++ b/src/tools/tidy/src/walk.rs
@@ -23,6 +23,7 @@ pub fn filter_dirs(path: &Path) -> bool {
         "src/doc/book",
         // Filter RLS output directories
         "target/rls",
+        "src/bootstrap/target",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
`bootstrap/target` may contains the files generated by `rust-analysis`, which we won't want to be checked.