### PR TITLE
add note for `layout_of` when query depth overflows

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/query_system.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/query_system.ftl
@@ -23,3 +23,5 @@ query_system_cycle_recursive_trait_alias = trait aliases cannot be recursive
 query_system_cycle_which_requires = ...which requires {$desc}...
 
 query_system_query_overflow = queries overflow the depth limit!
+
+query_system_layout_of_depth = Query depth increased by {$depth} when {$desc}!

--- a/compiler/rustc_error_messages/locales/en-US/query_system.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/query_system.ftl
@@ -23,5 +23,6 @@ query_system_cycle_recursive_trait_alias = trait aliases cannot be recursive
 query_system_cycle_which_requires = ...which requires {$desc}...
 
 query_system_query_overflow = queries overflow the depth limit!
+    .help = consider increasing the recursion limit by adding a `#![recursion_limit = "{$suggested_limit}"]` attribute to your crate (`{$crate_name}`)
 
-query_system_layout_of_depth = Query depth increased by {$depth} when {$desc}!
+query_system_layout_of_depth = query depth increased by {$depth} when {$desc}

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -109,7 +109,7 @@ impl QueryContext for QueryCtxt<'_> {
         // when accessing the `ImplicitCtxt`.
         tls::with_related_context(**self, move |current_icx| {
             if depth_limit && !self.recursion_limit().value_within_limit(current_icx.query_depth) {
-                self.depth_limit_error();
+                self.depth_limit_error(token);
             }
 
             // Update the `ImplicitCtxt` to point to our new query job.

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -1,5 +1,6 @@
 use rustc_errors::AddSubdiagnostic;
-use rustc_span::Span;
+use rustc_session::Limit;
+use rustc_span::{Span, Symbol};
 
 pub struct CycleStack {
     pub span: Span,
@@ -76,17 +77,20 @@ pub struct IncrementCompilation {
 }
 
 #[derive(SessionDiagnostic)]
+#[help]
 #[diag(query_system::query_overflow)]
 pub struct QueryOverflow {
+    #[primary_span]
+    pub span: Option<Span>,
     #[subdiagnostic]
     pub layout_of_depth: Option<LayoutOfDepth>,
+    pub suggested_limit: Limit,
+    pub crate_name: Symbol,
 }
 
 #[derive(SessionSubdiagnostic)]
 #[note(query_system::layout_of_depth)]
 pub struct LayoutOfDepth {
-    #[primary_span]
-    pub span: Span,
     pub desc: String,
     pub depth: usize,
 }

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -77,4 +77,16 @@ pub struct IncrementCompilation {
 
 #[derive(SessionDiagnostic)]
 #[diag(query_system::query_overflow)]
-pub struct QueryOverflow;
+pub struct QueryOverflow {
+    #[subdiagnostic]
+    pub layout_of_depth: Option<LayoutOfDepth>,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[note(query_system::layout_of_depth)]
+pub struct LayoutOfDepth {
+    #[primary_span]
+    pub span: Span,
+    pub desc: String,
+    pub depth: usize,
+}

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -23,4 +23,6 @@ pub mod query;
 mod values;
 
 pub use error::HandleCycleError;
+pub use error::LayoutOfDepth;
+pub use error::QueryOverflow;
 pub use values::Value;

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -160,10 +160,7 @@ impl QueryJobId {
 
     #[cold]
     #[inline(never)]
-    pub(super) fn try_find_layout_root(
-        &self,
-        query_map: QueryMap,
-    ) -> Option<(QueryJobInfo, usize)> {
+    pub fn try_find_layout_root(&self, query_map: QueryMap) -> Option<(QueryJobInfo, usize)> {
         let mut last_layout = None;
         let mut current_id = Some(*self);
         let mut depth = 0;

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -59,6 +59,7 @@ impl QueryJobId {
     }
 }
 
+#[derive(Clone)]
 pub struct QueryJobInfo {
     pub query: QueryStackFrame,
     pub job: QueryJob,
@@ -116,10 +117,10 @@ impl QueryJob {
     }
 }
 
-#[cfg(not(parallel_compiler))]
 impl QueryJobId {
     #[cold]
     #[inline(never)]
+    #[cfg(not(parallel_compiler))]
     pub(super) fn find_cycle_in_stack(
         &self,
         query_map: QueryMap,
@@ -155,6 +156,27 @@ impl QueryJobId {
         }
 
         panic!("did not find a cycle")
+    }
+
+    #[cold]
+    #[inline(never)]
+    pub(super) fn try_find_layout_root(
+        &self,
+        query_map: QueryMap,
+    ) -> Option<(QueryJobInfo, usize)> {
+        let mut last_layout = None;
+        let mut current_id = Some(*self);
+        let mut depth = 0;
+
+        while let Some(id) = current_id {
+            let info = query_map.get(&id).unwrap();
+            if info.query.name == "layout_of" {
+                depth += 1;
+                last_layout = Some((info.clone(), depth));
+            }
+            current_id = info.job.parent;
+        }
+        last_layout
     }
 }
 

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -14,7 +14,7 @@ pub use self::caches::{
 mod config;
 pub use self::config::{QueryConfig, QueryDescription, QueryVTable};
 
-use crate::dep_graph::{DepContext, DepNodeIndex, HasDepContext, SerializedDepNodeIndex};
+use crate::dep_graph::{DepNodeIndex, HasDepContext, SerializedDepNodeIndex};
 use rustc_data_structures::sync::Lock;
 use rustc_errors::Diagnostic;
 use rustc_hir::def::DefKind;
@@ -123,18 +123,5 @@ pub trait QueryContext: HasDepContext {
         compute: impl FnOnce() -> R,
     ) -> R;
 
-    fn depth_limit_error(&self, job: QueryJobId) {
-        let sess = self.dep_context().sess();
-        let mut layout_of_depth = None;
-        if let Some(map) = self.try_collect_active_jobs() {
-            if let Some((info, depth)) = job.try_find_layout_root(map) {
-                layout_of_depth = Some(crate::error::LayoutOfDepth {
-                    span: info.job.span,
-                    desc: info.query.description,
-                    depth,
-                });
-            }
-        }
-        sess.emit_fatal(crate::error::QueryOverflow { layout_of_depth });
-    }
+    fn depth_limit_error(&self, job: QueryJobId);
 }

--- a/src/test/ui/query-system/query_depth.rs
+++ b/src/test/ui/query-system/query_depth.rs
@@ -1,0 +1,31 @@
+// build-fail
+
+#![recursion_limit = "64"]
+type Byte = Option<Option<Option<Option< Option<Option<Option<Option<
+    Option<Option<Option<Option< Option<Option<Option<Option<
+        Option<Option<Option<Option< Option<Option<Option<Option<
+            Option<Option<Option<Option< Option<Option<Option<Option<
+                Option<Option<Option<Option< Option<Option<Option<Option<
+                    Option<Option<Option<Option< Option<Option<Option<Option<
+                        Option<Option<Option<Option< Option<Option<Option<Option<
+                            Option<Option<Option<Option< Option<Option<Option<Option<
+                                Option<Option<Option<Option< Option<Option<Option<Option<
+                                    Option<Option<Option<Option< Option<Option<Option<Option<
+                                        Option<Option<Option<Option< Option<Option<Option<Option<
+                                            Box<String>
+                                        >>>> >>>>
+                                    >>>> >>>>
+                                >>>> >>>>
+                            >>>> >>>>
+                        >>>> >>>>
+                    >>>> >>>>
+                >>>> >>>>
+            >>>> >>>>
+        >>>> >>>>
+    >>>> >>>>
+>>>> >>>>;
+
+fn main() {
+//~^ ERROR: queries overflow the depth limit!
+    println!("{}", std::mem::size_of::<Byte>());
+}

--- a/src/test/ui/query-system/query_depth.stderr
+++ b/src/test/ui/query-system/query_depth.stderr
@@ -1,0 +1,11 @@
+error: queries overflow the depth limit!
+  --> $DIR/query_depth.rs:28:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "128"]` attribute to your crate (`query_depth`)
+   = note: query depth increased by 66 when computing layout of `core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<alloc::boxed::Box<alloc::string::String>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #101747
Added `try_find_layout_root` function to add a note for `layout_of` when query depth overflows. This would make the error in #101747 look like this:
```
error: queries overflow the depth limit!
   |
note: Query depth increased by 66 when computing layout of `core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<alloc::boxed::Box<alloc::string::String>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`!
  --> D:\rust-backup\parallel_rust\query_depth.rs:40:1
   |
40 | fn main() {
   | ^^^^^^^^^

error: aborting due to previous error
```

cc @semicoleon 