### PR TITLE
Constify impl Fn* &(mut) Fn*

### DIFF
--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -250,7 +250,7 @@ pub trait FnOnce<Args> {
 
 mod impls {
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "101803")]
     impl<A, F: ?Sized> const Fn<A> for &F
     where
         F: ~const Fn<A>,
@@ -261,7 +261,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "101803")]
     impl<A, F: ?Sized> const FnMut<A> for &F
     where
         F: ~const Fn<A>,
@@ -272,7 +272,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "101803")]
     impl<A, F: ?Sized> const FnOnce<A> for &F
     where
         F: ~const Fn<A>,
@@ -285,7 +285,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "101803")]
     impl<A, F: ?Sized> const FnMut<A> for &mut F
     where
         F: ~const FnMut<A>,
@@ -296,7 +296,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "101803")]
     impl<A, F: ?Sized> const FnOnce<A> for &mut F
     where
         F: ~const FnMut<A>,

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -250,9 +250,10 @@ pub trait FnOnce<Args> {
 
 mod impls {
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A, F: ?Sized> Fn<A> for &F
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    impl<A, F: ?Sized> const Fn<A> for &F
     where
-        F: Fn<A>,
+        F: ~const Fn<A>,
     {
         extern "rust-call" fn call(&self, args: A) -> F::Output {
             (**self).call(args)
@@ -260,9 +261,10 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A, F: ?Sized> FnMut<A> for &F
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    impl<A, F: ?Sized> const FnMut<A> for &F
     where
-        F: Fn<A>,
+        F: ~const Fn<A>,
     {
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (**self).call(args)
@@ -270,9 +272,10 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A, F: ?Sized> FnOnce<A> for &F
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    impl<A, F: ?Sized> const FnOnce<A> for &F
     where
-        F: Fn<A>,
+        F: ~const Fn<A>,
     {
         type Output = F::Output;
 
@@ -282,9 +285,10 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A, F: ?Sized> FnMut<A> for &mut F
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    impl<A, F: ?Sized> const FnMut<A> for &mut F
     where
-        F: FnMut<A>,
+        F: ~const FnMut<A>,
     {
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (*self).call_mut(args)
@@ -292,9 +296,10 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A, F: ?Sized> FnOnce<A> for &mut F
+    #[rustc_const_unstable(feature = "const_fn_trait_ref_impls", issue = "none")]
+    impl<A, F: ?Sized> const FnOnce<A> for &mut F
     where
-        F: FnMut<A>,
+        F: ~const FnMut<A>,
     {
         type Output = F::Output;
         extern "rust-call" fn call_once(self, args: A) -> F::Output {


### PR DESCRIPTION
Tracking Issue: [101803](https://github.com/rust-lang/rust/issues/101803)

Feature gate: `#![feature(const_fn_trait_ref_impls)]`

This feature allows using references to Fn* Items as Fn* Items themself in a const context.
