### PR TITLE
[Beta] Clippy: Fix hang in `vec_init_then_push`

### DIFF
--- a/src/tools/clippy/clippy_lints/src/vec_init_then_push.rs
+++ b/src/tools/clippy/clippy_lints/src/vec_init_then_push.rs
@@ -86,7 +86,7 @@ impl VecPushSearcher {
                 },
                 ExprKind::Unary(UnOp::Deref, _) | ExprKind::Index(..) if !needs_mut => {
                     let mut last_place = parent;
-                    while let Some(parent) = get_parent_expr(cx, parent) {
+                    while let Some(parent) = get_parent_expr(cx, last_place) {
                         if matches!(parent.kind, ExprKind::Unary(UnOp::Deref, _) | ExprKind::Field(..))
                             || matches!(parent.kind, ExprKind::Index(e, _) if e.hir_id == last_place.hir_id)
                         {

--- a/src/tools/clippy/tests/ui/vec_init_then_push.rs
+++ b/src/tools/clippy/tests/ui/vec_init_then_push.rs
@@ -104,3 +104,9 @@ fn _cond_push_with_large_start(x: bool) -> Vec<u32> {
 
     v2
 }
+
+fn f() {
+    let mut v = Vec::new();
+    v.push((0i32, 0i32));
+    let y = v[0].0.abs();
+}

--- a/src/tools/clippy/tests/ui/vec_init_then_push.stderr
+++ b/src/tools/clippy/tests/ui/vec_init_then_push.stderr
@@ -62,5 +62,12 @@ LL | |     v2.push(1);
 LL | |     v2.push(0);
    | |_______________^ help: consider using the `vec![]` macro: `let mut v2 = vec![..];`
 
-error: aborting due to 7 previous errors
+error: calls to `push` immediately after creation
+  --> $DIR/vec_init_then_push.rs:109:5
+   |
+LL | /     let mut v = Vec::new();
+LL | |     v.push((0i32, 0i32));
+   | |_________________________^ help: consider using the `vec![]` macro: `let v = vec![..];`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Small Clippy ICE/hang fix backport before beta gets branched. We'd like to get this into stable ASAP. This fix is already in `master` as 15859323ea4.