### PR TITLE
Clippy pre beta branch fix

### DIFF
--- a/src/tools/clippy/clippy_lints/src/lib.register_all.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.register_all.rs
@@ -344,7 +344,6 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(unnecessary_owned_empty_strings::UNNECESSARY_OWNED_EMPTY_STRINGS),
     LintId::of(unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME),
     LintId::of(unused_io_amount::UNUSED_IO_AMOUNT),
-    LintId::of(unused_peekable::UNUSED_PEEKABLE),
     LintId::of(unused_unit::UNUSED_UNIT),
     LintId::of(unwrap::PANICKING_UNWRAP),
     LintId::of(unwrap::UNNECESSARY_UNWRAP),

--- a/src/tools/clippy/clippy_lints/src/lib.register_nursery.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.register_nursery.rs
@@ -31,6 +31,7 @@ store.register_group(true, "clippy::nursery", Some("clippy_nursery"), vec![
     LintId::of(suspicious_operation_groupings::SUSPICIOUS_OPERATION_GROUPINGS),
     LintId::of(trailing_empty_array::TRAILING_EMPTY_ARRAY),
     LintId::of(transmute::TRANSMUTE_UNDEFINED_REPR),
+    LintId::of(unused_peekable::UNUSED_PEEKABLE),
     LintId::of(unused_rounding::UNUSED_ROUNDING),
     LintId::of(use_self::USE_SELF),
 ])

--- a/src/tools/clippy/clippy_lints/src/lib.register_suspicious.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.register_suspicious.rs
@@ -35,6 +35,5 @@ store.register_group(true, "clippy::suspicious", Some("clippy_suspicious"), vec!
     LintId::of(suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL),
     LintId::of(suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL),
     LintId::of(swap_ptr_to_ref::SWAP_PTR_TO_REF),
-    LintId::of(unused_peekable::UNUSED_PEEKABLE),
     LintId::of(write::POSITIONAL_NAMED_FORMAT_PARAMETERS),
 ])

--- a/src/tools/clippy/clippy_lints/src/unused_peekable.rs
+++ b/src/tools/clippy/clippy_lints/src/unused_peekable.rs
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.64.0"]
     pub UNUSED_PEEKABLE,
-    suspicious,
+    nursery,
     "creating a peekable iterator without using any of its methods"
 }
 


### PR DESCRIPTION
Before beta is branched on Friday, I want to move the `unused_peekable` lint  that was added in this release cycle (1.65) to `nursery`. This lint was already reported twice (https://github.com/rust-lang/rust-clippy/issues/9456, https://github.com/rust-lang/rust-clippy/issues/9462) in a short time, so it is probably a good idea to fix it before it hits beta and then stable.

r? @Manishearth 