### PR TITLE
Migrated the rustc_passes annotation without effect diagnostic infrastructure

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -268,3 +268,6 @@ passes_link_ordinal = attribute should be applied to a foreign function or stati
 
 passes_collapse_debuginfo = `collapse_debuginfo` attribute should be applied to macro definitions
     .label = not a macro definition
+
+passes_deprecated_annotation_has_no_effect = this `#[deprecated]` annotation has no effect
+    .suggestion = remove the unnecessary deprecation attribute

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -658,3 +658,10 @@ pub struct CollapseDebuginfo {
     #[label]
     pub defn_span: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(passes::deprecated_annotation_has_no_effect)]
+pub struct DeprecatedAnnotationHasNoEffect {
+    #[suggestion(applicability = "machine-applicable", code = "")]
+    pub span: Span,
+}


### PR DESCRIPTION
Small change to move the validation for annotations to the new diagnostic infrastructure.