### PR TITLE
Return the custom error instead of its cause in `io::Error::{cause,source}`

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -951,7 +951,7 @@ impl error::Error for Error {
             ErrorData::Os(..) => None,
             ErrorData::Simple(..) => None,
             ErrorData::SimpleMessage(..) => None,
-            ErrorData::Custom(c) => c.error.cause(),
+            ErrorData::Custom(c) => Some(&*c.error),
         }
     }
 
@@ -960,7 +960,7 @@ impl error::Error for Error {
             ErrorData::Os(..) => None,
             ErrorData::Simple(..) => None,
             ErrorData::SimpleMessage(..) => None,
-            ErrorData::Custom(c) => c.error.source(),
+            ErrorData::Custom(c) => Some(&*c.error),
         }
     }
 }


### PR DESCRIPTION
Fixes #101817

One note about this that I realize now, is that this will result in an error that formats the same being hit twice in the cause chain. So I'm unsure this is actually desirable.