### PR TITLE
WIP: more enum layout optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4249,6 +4249,7 @@ dependencies = [
  "rustc_target",
  "rustc_trait_selection",
  "rustc_type_ir",
+ "smallvec",
  "tracing",
 ]
 

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3065,6 +3065,8 @@ mod size_asserts {
     static_assert_size!(PathSegment, 24);
     static_assert_size!(Stmt, 32);
     static_assert_size!(StmtKind, 16);
-    static_assert_size!(Ty, 96);
-    static_assert_size!(TyKind, 72);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(Ty, 88);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(TyKind, 64);
 }

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -944,6 +944,7 @@ pub enum ReprAttr {
     ReprSimd,
     ReprTransparent,
     ReprAlign(u32),
+    ReprFlag,
 }
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
@@ -998,6 +999,7 @@ pub fn parse_repr_attr(sess: &Session, attr: &Attribute) -> Vec<ReprAttr> {
                         recognised = true;
                         None
                     }
+                    sym::flag => Some(ReprFlag),
                     name => int_type_of_word(name).map(ReprInt),
                 };
 

--- a/compiler/rustc_codegen_cranelift/src/abi/comments.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/comments.rs
@@ -82,14 +82,8 @@ pub(super) fn add_local_place_comments<'tcx>(
         return;
     }
     let TyAndLayout { ty, layout } = place.layout();
-    let rustc_target::abi::LayoutS {
-        size,
-        align,
-        abi: _,
-        variants: _,
-        fields: _,
-        largest_niche: _,
-    } = layout.0.0;
+    let rustc_target::abi::LayoutS { size, align, abi: _, variants: _, fields: _, niches: _ } =
+        layout.0.0;
 
     let (kind, extra) = match *place.inner() {
         CPlaceInner::Var(place_local, var) => {

--- a/compiler/rustc_codegen_cranelift/src/discriminant.rs
+++ b/compiler/rustc_codegen_cranelift/src/discriminant.rs
@@ -42,7 +42,8 @@ pub(crate) fn codegen_set_discriminant<'tcx>(
         Variants::Multiple {
             tag: _,
             tag_field,
-            tag_encoding: TagEncoding::Niche { untagged_variant, ref niche_variants, niche_start },
+            tag_encoding:
+                TagEncoding::Niche { untagged_variant, ref niche_variants, niche_start, .. },
             variants: _,
         } => {
             if variant_index != untagged_variant {
@@ -113,7 +114,7 @@ pub(crate) fn codegen_get_discriminant<'tcx>(
             let res = CValue::by_val(val, dest_layout);
             dest.write_cvalue(fx, res);
         }
-        TagEncoding::Niche { untagged_variant, ref niche_variants, niche_start } => {
+        TagEncoding::Niche { untagged_variant, ref niche_variants, niche_start, .. } => {
             // Rebase from niche values to discriminants, and check
             // whether the result is in range for the niche variants.
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
@@ -430,32 +430,34 @@ fn compute_discriminant_value<'ll, 'tcx>(
             enum_type_and_layout.ty.discriminant_for_variant(cx.tcx, variant_index).unwrap().val,
         ),
         &Variants::Multiple {
-            tag_encoding: TagEncoding::Niche { ref niche_variants, niche_start, untagged_variant },
-            tag,
+            //tag_encoding: TagEncoding::Niche { ref niche_variants, niche_start, untagged_variant, .. },
+            //tag,
             ..
         } => {
-            if variant_index == untagged_variant {
-                let valid_range = enum_type_and_layout
-                    .for_variant(cx, variant_index)
-                    .largest_niche
-                    .as_ref()
-                    .unwrap()
-                    .valid_range;
+            // YYY
+            DiscrResult::Range(0, 1)
+            //if variant_index == untagged_variant {
+            //    let valid_range = enum_type_and_layout
+            //        .for_variant(cx, variant_index)
+            //        .largest_niche
+            //        .as_ref()
+            //        .unwrap()
+            //        .valid_range;
 
-                let min = valid_range.start.min(valid_range.end);
-                let min = tag.size(cx).truncate(min);
+            //    let min = valid_range.start.min(valid_range.end);
+            //    let min = tag.size(cx).truncate(min);
 
-                let max = valid_range.start.max(valid_range.end);
-                let max = tag.size(cx).truncate(max);
+            //    let max = valid_range.start.max(valid_range.end);
+            //    let max = tag.size(cx).truncate(max);
 
-                DiscrResult::Range(min, max)
-            } else {
-                let value = (variant_index.as_u32() as u128)
-                    .wrapping_sub(niche_variants.start().as_u32() as u128)
-                    .wrapping_add(niche_start);
-                let value = tag.size(cx).truncate(value);
-                DiscrResult::Value(value)
-            }
+            //    DiscrResult::Range(min, max)
+            //} else {
+            //    let value = (variant_index.as_u32() as u128)
+            //        .wrapping_sub(niche_variants.start().as_u32() as u128)
+            //        .wrapping_add(niche_start);
+            //    let value = tag.size(cx).truncate(value);
+            //    DiscrResult::Value(value)
+            //}
         }
     }
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3520,8 +3520,10 @@ mod size_asserts {
     static_assert_size!(Expr<'_>, 64);
     static_assert_size!(ExprKind<'_>, 48);
     static_assert_size!(FnDecl<'_>, 40);
-    static_assert_size!(ForeignItem<'_>, 72);
-    static_assert_size!(ForeignItemKind<'_>, 40);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(ForeignItem<'_>, 64);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(ForeignItemKind<'_>, 32);
     static_assert_size!(GenericArg<'_>, 24);
     static_assert_size!(GenericBound<'_>, 48);
     static_assert_size!(Generics<'_>, 56);
@@ -3540,8 +3542,10 @@ mod size_asserts {
     static_assert_size!(Res, 12);
     static_assert_size!(Stmt<'_>, 32);
     static_assert_size!(StmtKind<'_>, 16);
-    static_assert_size!(TraitItem<'_>, 88);
-    static_assert_size!(TraitItemKind<'_>, 48);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(TraitItem<'_>, 80);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(TraitItemKind<'_>, 40);
     static_assert_size!(Ty<'_>, 48);
     static_assert_size!(TyKind<'_>, 32);
 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1942,11 +1942,12 @@ bitflags! {
         const IS_C               = 1 << 0;
         const IS_SIMD            = 1 << 1;
         const IS_TRANSPARENT     = 1 << 2;
+        const USE_FLAG           = 1 << 3;
         // Internal only for now. If true, don't reorder fields.
-        const IS_LINEAR          = 1 << 3;
+        const IS_LINEAR          = 1 << 4;
         // If true, the type's layout can be randomized using
         // the seed stored in `ReprOptions.layout_seed`
-        const RANDOMIZE_LAYOUT   = 1 << 4;
+        const RANDOMIZE_LAYOUT   = 1 << 5;
         // Any of these flags being set prevent field reordering optimisation.
         const IS_UNOPTIMISABLE   = ReprFlags::IS_C.bits
                                  | ReprFlags::IS_SIMD.bits
@@ -2004,6 +2005,7 @@ impl ReprOptions {
                     }
                     attr::ReprTransparent => ReprFlags::IS_TRANSPARENT,
                     attr::ReprSimd => ReprFlags::IS_SIMD,
+                    attr::ReprFlag => ReprFlags::USE_FLAG,
                     attr::ReprInt(i) => {
                         size = Some(i);
                         ReprFlags::empty()
@@ -2048,6 +2050,11 @@ impl ReprOptions {
     #[inline]
     pub fn transparent(&self) -> bool {
         self.flags.contains(ReprFlags::IS_TRANSPARENT)
+    }
+
+    #[inline]
+    pub fn use_flag(&self) -> bool {
+        self.flags.contains(ReprFlags::USE_FLAG)
     }
 
     #[inline]

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1651,6 +1651,12 @@ impl CheckAttrVisitor<'_> {
                         _ => ("a", "struct, enum, or union"),
                     }
                 }
+                sym::flag => {
+                    match target {
+                        Target::Enum => continue,
+                        _ => ("an", "enum"),
+                    }
+                }
                 sym::i8
                 | sym::u8
                 | sym::i16

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -723,6 +723,7 @@ symbols! {
         file_macro,
         fill,
         finish,
+        flag,
         flags,
         float,
         float_to_int_unchecked,

--- a/compiler/rustc_ty_utils/Cargo.toml
+++ b/compiler/rustc_ty_utils/Cargo.toml
@@ -19,3 +19,4 @@ rustc_target = { path = "../rustc_target" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_type_ir = { path = "../rustc_type_ir" }
 rustc_index = { path = "../rustc_index" }
+smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -15,16 +15,19 @@ error: layout_of(E) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I32,
+                           false,
+                       ),
+                       valid_range: 0..=0,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -49,7 +52,7 @@ error: layout_of(E) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -73,7 +76,7 @@ error: layout_of(E) = Layout {
                                2,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -120,7 +123,7 @@ error: layout_of(S) = Layout {
                    2,
                ],
            },
-           largest_niche: None,
+           niches: [],
            variants: Single {
                index: 0,
            },
@@ -142,7 +145,7 @@ error: layout_of(U) = Layout {
            fields: Union(
                2,
            ),
-           largest_niche: None,
+           niches: [],
            variants: Single {
                index: 0,
            },
@@ -182,16 +185,19 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I32,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -233,7 +239,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -268,7 +274,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -297,7 +303,7 @@ error: layout_of(i32) = Layout {
                },
            ),
            fields: Primitive,
-           largest_niche: None,
+           niches: [],
            variants: Single {
                index: 0,
            },

--- a/src/test/ui/layout/hexagon-enum.stderr
+++ b/src/test/ui/layout/hexagon-enum.stderr
@@ -21,16 +21,19 @@ error: layout_of(A) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=0,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -55,7 +58,7 @@ error: layout_of(A) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -91,16 +94,19 @@ error: layout_of(B) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 255..=255,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 255..=255,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -125,7 +131,7 @@ error: layout_of(B) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -161,16 +167,19 @@ error: layout_of(C) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: 256..=256,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I16,
+                           false,
+                       ),
+                       valid_range: 256..=256,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -195,7 +204,7 @@ error: layout_of(C) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -231,16 +240,19 @@ error: layout_of(P) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 268435456..=268435456,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I32,
+                           false,
+                       ),
+                       valid_range: 268435456..=268435456,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -265,7 +277,7 @@ error: layout_of(P) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -301,16 +313,19 @@ error: layout_of(T) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 2164260864..=2164260864,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I32,
+                           true,
+                       ),
+                       valid_range: 2164260864..=2164260864,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -335,7 +350,7 @@ error: layout_of(T) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },

--- a/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -27,16 +27,19 @@ error: layout_of(MissingPayloadField) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -77,7 +80,7 @@ error: layout_of(MissingPayloadField) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -95,7 +98,7 @@ error: layout_of(MissingPayloadField) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -138,16 +141,19 @@ error: layout_of(CommonPayloadField) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -189,7 +195,7 @@ error: layout_of(CommonPayloadField) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -224,7 +230,7 @@ error: layout_of(CommonPayloadField) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -266,16 +272,19 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -316,7 +325,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -350,7 +359,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -392,16 +401,19 @@ error: layout_of(NicheFirst) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=4,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=4,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -414,6 +426,7 @@ error: layout_of(NicheFirst) = Layout {
                    untagged_variant: 0,
                    niche_variants: 1..=2,
                    niche_start: 3,
+                   flag: None,
                },
                tag_field: 0,
                variants: [
@@ -449,16 +462,7 @@ error: layout_of(NicheFirst) = Layout {
                                1,
                            ],
                        },
-                       largest_niche: Some(
-                           Niche {
-                               offset: Size(0 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=2,
-                           },
-                       ),
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -476,7 +480,7 @@ error: layout_of(NicheFirst) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -494,7 +498,7 @@ error: layout_of(NicheFirst) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 2,
                        },
@@ -536,16 +540,19 @@ error: layout_of(NicheSecond) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(1 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=4,
+                   data: NicheData {
+                       offset: Size(1 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=4,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -558,6 +565,7 @@ error: layout_of(NicheSecond) = Layout {
                    untagged_variant: 0,
                    niche_variants: 1..=2,
                    niche_start: 3,
+                   flag: None,
                },
                tag_field: 0,
                variants: [
@@ -593,16 +601,7 @@ error: layout_of(NicheSecond) = Layout {
                                1,
                            ],
                        },
-                       largest_niche: Some(
-                           Niche {
-                               offset: Size(1 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=2,
-                           },
-                       ),
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -620,7 +619,7 @@ error: layout_of(NicheSecond) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -638,7 +637,7 @@ error: layout_of(NicheSecond) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 2,
                        },

--- a/src/test/ui/layout/issue-96185-overaligned-enum.stderr
+++ b/src/test/ui/layout/issue-96185-overaligned-enum.stderr
@@ -15,16 +15,19 @@ error: layout_of(Aligned1) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -49,7 +52,7 @@ error: layout_of(Aligned1) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -67,7 +70,7 @@ error: layout_of(Aligned1) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -103,16 +106,19 @@ error: layout_of(Aligned2) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -137,7 +143,7 @@ error: layout_of(Aligned2) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -155,7 +161,7 @@ error: layout_of(Aligned2) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },

--- a/src/test/ui/layout/thumb-enum.stderr
+++ b/src/test/ui/layout/thumb-enum.stderr
@@ -21,16 +21,19 @@ error: layout_of(A) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=0,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -55,7 +58,7 @@ error: layout_of(A) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -91,16 +94,19 @@ error: layout_of(B) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 255..=255,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 255..=255,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -125,7 +131,7 @@ error: layout_of(B) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -161,16 +167,19 @@ error: layout_of(C) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: 256..=256,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I16,
+                           false,
+                       ),
+                       valid_range: 256..=256,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -195,7 +204,7 @@ error: layout_of(C) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -231,16 +240,19 @@ error: layout_of(P) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 268435456..=268435456,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I32,
+                           false,
+                       ),
+                       valid_range: 268435456..=268435456,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -265,7 +277,7 @@ error: layout_of(P) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -301,16 +313,19 @@ error: layout_of(T) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 2164260864..=2164260864,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I32,
+                           true,
+                       ),
+                       valid_range: 2164260864..=2164260864,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -335,7 +350,7 @@ error: layout_of(T) = Layout {
                            offsets: [],
                            memory_index: [],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },

--- a/src/test/ui/layout/zero-sized-array-enum-niche.stderr
+++ b/src/test/ui/layout/zero-sized-array-enum-niche.stderr
@@ -15,16 +15,19 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -53,7 +56,7 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -75,16 +78,19 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: Some(
+                       niches: [
                            Niche {
-                               offset: Size(1 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
+                               data: NicheData {
+                                   offset: Size(1 bytes),
+                                   value: Int(
+                                       I8,
+                                       false,
+                                   ),
+                                   valid_range: 0..=1,
+                               },
+                               flag: None,
                            },
-                       ),
+                       ],
                        variants: Single {
                            index: 1,
                        },
@@ -114,16 +120,19 @@ error: layout_of(MultipleAlignments) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=2,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=2,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -152,7 +161,7 @@ error: layout_of(MultipleAlignments) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -174,7 +183,7 @@ error: layout_of(MultipleAlignments) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },
@@ -196,16 +205,19 @@ error: layout_of(MultipleAlignments) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: Some(
+                       niches: [
                            Niche {
-                               offset: Size(1 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
+                               data: NicheData {
+                                   offset: Size(1 bytes),
+                                   value: Int(
+                                       I8,
+                                       false,
+                                   ),
+                                   valid_range: 0..=1,
+                               },
+                               flag: None,
                            },
-                       ),
+                       ],
                        variants: Single {
                            index: 2,
                        },
@@ -235,16 +247,19 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I8,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -273,7 +288,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -295,16 +310,19 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                                0,
                            ],
                        },
-                       largest_niche: Some(
+                       niches: [
                            Niche {
-                               offset: Size(1 bytes),
-                               value: Int(
-                                   I16,
-                                   false,
-                               ),
-                               valid_range: 1..=65535,
+                               data: NicheData {
+                                   offset: Size(1 bytes),
+                                   value: Int(
+                                       I16,
+                                       false,
+                                   ),
+                                   valid_range: 1..=65535,
+                               },
+                               flag: None,
                            },
-                       ),
+                       ],
                        variants: Single {
                            index: 1,
                        },
@@ -334,16 +352,19 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                    0,
                ],
            },
-           largest_niche: Some(
+           niches: [
                Niche {
-                   offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: 0..=1,
+                   data: NicheData {
+                       offset: Size(0 bytes),
+                       value: Int(
+                           I16,
+                           false,
+                       ),
+                       valid_range: 0..=1,
+                   },
+                   flag: None,
                },
-           ),
+           ],
            variants: Multiple {
                tag: Initialized {
                    value: Int(
@@ -356,6 +377,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                    untagged_variant: 1,
                    niche_variants: 0..=0,
                    niche_start: 1,
+                   flag: None,
                },
                tag_field: 0,
                variants: [
@@ -376,7 +398,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: None,
+                       niches: [],
                        variants: Single {
                            index: 0,
                        },
@@ -398,16 +420,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                                0,
                            ],
                        },
-                       largest_niche: Some(
-                           Niche {
-                               offset: Size(0 bytes),
-                               value: Int(
-                                   I16,
-                                   false,
-                               ),
-                               valid_range: 0..=0,
-                           },
-                       ),
+                       niches: [],
                        variants: Single {
                            index: 1,
                        },

--- a/src/test/ui/print_type_sizes/padding.stdout
+++ b/src/test/ui/print_type_sizes/padding.stdout
@@ -1,21 +1,17 @@
-print-type-size type: `E1`: 12 bytes, alignment: 4 bytes
-print-type-size     discriminant: 1 bytes
-print-type-size     variant `B`: 11 bytes
-print-type-size         padding: 3 bytes
-print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
-print-type-size     variant `A`: 7 bytes
-print-type-size         field `.1`: 1 bytes
-print-type-size         padding: 2 bytes
-print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
-print-type-size type: `E2`: 12 bytes, alignment: 4 bytes
-print-type-size     discriminant: 1 bytes
-print-type-size     variant `B`: 11 bytes
-print-type-size         padding: 3 bytes
-print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
-print-type-size     variant `A`: 7 bytes
-print-type-size         field `.0`: 1 bytes
-print-type-size         padding: 2 bytes
-print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
+print-type-size type: `E1`: 8 bytes, alignment: 4 bytes
+print-type-size     variant `B`: 8 bytes
+print-type-size         field `.0`: 8 bytes
+print-type-size     variant `A`: 6 bytes
+print-type-size         field `.0`: 4 bytes
+print-type-size         padding: 1 bytes
+print-type-size         field `.1`: 1 bytes, alignment: 1 bytes
+print-type-size type: `E2`: 8 bytes, alignment: 4 bytes
+print-type-size     variant `B`: 8 bytes
+print-type-size         field `.0`: 8 bytes
+print-type-size     variant `A`: 6 bytes
+print-type-size         field `.1`: 4 bytes
+print-type-size         padding: 1 bytes
+print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
 print-type-size type: `S`: 8 bytes, alignment: 4 bytes
 print-type-size     field `.g`: 4 bytes
 print-type-size     field `.a`: 1 bytes

--- a/src/test/ui/stats/hir-stats.stderr
+++ b/src/test/ui/stats/hir-stats.stderr
@@ -2,118 +2,118 @@ ast-stats-1 PRE EXPANSION AST STATS
 ast-stats-1 Name                Accumulated Size         Count     Item Size
 ast-stats-1 ----------------------------------------------------------------
 ast-stats-1 ExprField                 48 ( 0.6%)             1            48
+ast-stats-1 GenericArgs               56 ( 0.7%)             1            56
+ast-stats-1 - AngleBracketed            56 ( 0.7%)             1
 ast-stats-1 Crate                     56 ( 0.7%)             1            56
 ast-stats-1 Attribute                 64 ( 0.8%)             2            32
 ast-stats-1 - Normal                    32 ( 0.4%)             1
 ast-stats-1 - DocComment                32 ( 0.4%)             1
-ast-stats-1 GenericArgs               64 ( 0.8%)             1            64
-ast-stats-1 - AngleBracketed            64 ( 0.8%)             1
+ast-stats-1 WherePredicate            64 ( 0.8%)             1            64
+ast-stats-1 - BoundPredicate            64 ( 0.8%)             1
 ast-stats-1 Local                     72 ( 0.9%)             1            72
-ast-stats-1 WherePredicate            72 ( 0.9%)             1            72
-ast-stats-1 - BoundPredicate            72 ( 0.9%)             1
-ast-stats-1 Arm                       96 ( 1.1%)             2            48
-ast-stats-1 ForeignItem               96 ( 1.1%)             1            96
-ast-stats-1 - Fn                        96 ( 1.1%)             1
+ast-stats-1 Arm                       96 ( 1.2%)             2            48
+ast-stats-1 ForeignItem               96 ( 1.2%)             1            96
+ast-stats-1 - Fn                        96 ( 1.2%)             1
 ast-stats-1 FieldDef                 160 ( 1.9%)             2            80
 ast-stats-1 Stmt                     160 ( 1.9%)             5            32
 ast-stats-1 - Local                     32 ( 0.4%)             1
 ast-stats-1 - MacCall                   32 ( 0.4%)             1
-ast-stats-1 - Expr                      96 ( 1.1%)             3
+ast-stats-1 - Expr                      96 ( 1.2%)             3
 ast-stats-1 Param                    160 ( 1.9%)             4            40
 ast-stats-1 FnDecl                   200 ( 2.4%)             5            40
 ast-stats-1 Variant                  240 ( 2.9%)             2           120
-ast-stats-1 Block                    288 ( 3.4%)             6            48
+ast-stats-1 Block                    288 ( 3.5%)             6            48
 ast-stats-1 GenericBound             352 ( 4.2%)             4            88
 ast-stats-1 - Trait                    352 ( 4.2%)             4
-ast-stats-1 AssocItem                416 ( 4.9%)             4           104
+ast-stats-1 AssocItem                416 ( 5.0%)             4           104
 ast-stats-1 - TyAlias                  208 ( 2.5%)             2
 ast-stats-1 - Fn                       208 ( 2.5%)             2
-ast-stats-1 GenericParam             480 ( 5.7%)             5            96
-ast-stats-1 PathSegment              720 ( 8.6%)            30            24
-ast-stats-1 Expr                     832 ( 9.9%)             8           104
-ast-stats-1 - Path                     104 ( 1.2%)             1
-ast-stats-1 - Match                    104 ( 1.2%)             1
-ast-stats-1 - Struct                   104 ( 1.2%)             1
+ast-stats-1 GenericParam             480 ( 5.8%)             5            96
+ast-stats-1 PathSegment              720 ( 8.7%)            30            24
+ast-stats-1 Expr                     832 (10.0%)             8           104
+ast-stats-1 - Path                     104 ( 1.3%)             1
+ast-stats-1 - Match                    104 ( 1.3%)             1
+ast-stats-1 - Struct                   104 ( 1.3%)             1
 ast-stats-1 - Lit                      208 ( 2.5%)             2
-ast-stats-1 - Block                    312 ( 3.7%)             3
-ast-stats-1 Pat                      840 (10.0%)             7           120
+ast-stats-1 - Block                    312 ( 3.8%)             3
+ast-stats-1 Pat                      840 (10.1%)             7           120
 ast-stats-1 - Struct                   120 ( 1.4%)             1
 ast-stats-1 - Wild                     120 ( 1.4%)             1
-ast-stats-1 - Ident                    600 ( 7.1%)             5
-ast-stats-1 Ty                     1_344 (16.0%)            14            96
-ast-stats-1 - Rptr                      96 ( 1.1%)             1
-ast-stats-1 - Ptr                       96 ( 1.1%)             1
-ast-stats-1 - ImplicitSelf             192 ( 2.3%)             2
-ast-stats-1 - Path                     960 (11.4%)            10
-ast-stats-1 Item                   1_656 (19.7%)             9           184
+ast-stats-1 - Ident                    600 ( 7.2%)             5
+ast-stats-1 Ty                     1_232 (14.9%)            14            88
+ast-stats-1 - Rptr                      88 ( 1.1%)             1
+ast-stats-1 - Ptr                       88 ( 1.1%)             1
+ast-stats-1 - ImplicitSelf             176 ( 2.1%)             2
+ast-stats-1 - Path                     880 (10.6%)            10
+ast-stats-1 Item                   1_656 (20.0%)             9           184
 ast-stats-1 - Trait                    184 ( 2.2%)             1
 ast-stats-1 - Enum                     184 ( 2.2%)             1
 ast-stats-1 - ForeignMod               184 ( 2.2%)             1
 ast-stats-1 - Impl                     184 ( 2.2%)             1
 ast-stats-1 - Fn                       368 ( 4.4%)             2
-ast-stats-1 - Use                      552 ( 6.6%)             3
+ast-stats-1 - Use                      552 ( 6.7%)             3
 ast-stats-1 ----------------------------------------------------------------
-ast-stats-1 Total                  8_416
+ast-stats-1 Total                  8_288
 ast-stats-1
 ast-stats-2 POST EXPANSION AST STATS
 ast-stats-2 Name                Accumulated Size         Count     Item Size
 ast-stats-2 ----------------------------------------------------------------
 ast-stats-2 ExprField                 48 ( 0.5%)             1            48
+ast-stats-2 GenericArgs               56 ( 0.6%)             1            56
+ast-stats-2 - AngleBracketed            56 ( 0.6%)             1
 ast-stats-2 Crate                     56 ( 0.6%)             1            56
-ast-stats-2 GenericArgs               64 ( 0.7%)             1            64
-ast-stats-2 - AngleBracketed            64 ( 0.7%)             1
+ast-stats-2 WherePredicate            64 ( 0.7%)             1            64
+ast-stats-2 - BoundPredicate            64 ( 0.7%)             1
 ast-stats-2 Local                     72 ( 0.8%)             1            72
-ast-stats-2 WherePredicate            72 ( 0.8%)             1            72
-ast-stats-2 - BoundPredicate            72 ( 0.8%)             1
-ast-stats-2 Arm                       96 ( 1.0%)             2            48
-ast-stats-2 ForeignItem               96 ( 1.0%)             1            96
-ast-stats-2 - Fn                        96 ( 1.0%)             1
+ast-stats-2 Arm                       96 ( 1.1%)             2            48
+ast-stats-2 ForeignItem               96 ( 1.1%)             1            96
+ast-stats-2 - Fn                        96 ( 1.1%)             1
 ast-stats-2 InlineAsm                120 ( 1.3%)             1           120
 ast-stats-2 Attribute                128 ( 1.4%)             4            32
-ast-stats-2 - DocComment                32 ( 0.3%)             1
-ast-stats-2 - Normal                    96 ( 1.0%)             3
-ast-stats-2 FieldDef                 160 ( 1.7%)             2            80
-ast-stats-2 Stmt                     160 ( 1.7%)             5            32
-ast-stats-2 - Local                     32 ( 0.3%)             1
-ast-stats-2 - Semi                      32 ( 0.3%)             1
-ast-stats-2 - Expr                      96 ( 1.0%)             3
-ast-stats-2 Param                    160 ( 1.7%)             4            40
+ast-stats-2 - DocComment                32 ( 0.4%)             1
+ast-stats-2 - Normal                    96 ( 1.1%)             3
+ast-stats-2 FieldDef                 160 ( 1.8%)             2            80
+ast-stats-2 Stmt                     160 ( 1.8%)             5            32
+ast-stats-2 - Local                     32 ( 0.4%)             1
+ast-stats-2 - Semi                      32 ( 0.4%)             1
+ast-stats-2 - Expr                      96 ( 1.1%)             3
+ast-stats-2 Param                    160 ( 1.8%)             4            40
 ast-stats-2 FnDecl                   200 ( 2.2%)             5            40
-ast-stats-2 Variant                  240 ( 2.6%)             2           120
-ast-stats-2 Block                    288 ( 3.1%)             6            48
-ast-stats-2 GenericBound             352 ( 3.8%)             4            88
-ast-stats-2 - Trait                    352 ( 3.8%)             4
-ast-stats-2 AssocItem                416 ( 4.5%)             4           104
+ast-stats-2 Variant                  240 ( 2.7%)             2           120
+ast-stats-2 Block                    288 ( 3.2%)             6            48
+ast-stats-2 GenericBound             352 ( 3.9%)             4            88
+ast-stats-2 - Trait                    352 ( 3.9%)             4
+ast-stats-2 AssocItem                416 ( 4.6%)             4           104
 ast-stats-2 - TyAlias                  208 ( 2.3%)             2
 ast-stats-2 - Fn                       208 ( 2.3%)             2
-ast-stats-2 GenericParam             480 ( 5.2%)             5            96
-ast-stats-2 PathSegment              792 ( 8.7%)            33            24
-ast-stats-2 Pat                      840 ( 9.2%)             7           120
+ast-stats-2 GenericParam             480 ( 5.3%)             5            96
+ast-stats-2 PathSegment              792 ( 8.8%)            33            24
+ast-stats-2 Pat                      840 ( 9.3%)             7           120
 ast-stats-2 - Struct                   120 ( 1.3%)             1
 ast-stats-2 - Wild                     120 ( 1.3%)             1
-ast-stats-2 - Ident                    600 ( 6.6%)             5
-ast-stats-2 Expr                     936 (10.2%)             9           104
-ast-stats-2 - Path                     104 ( 1.1%)             1
-ast-stats-2 - Match                    104 ( 1.1%)             1
-ast-stats-2 - Struct                   104 ( 1.1%)             1
-ast-stats-2 - InlineAsm                104 ( 1.1%)             1
+ast-stats-2 - Ident                    600 ( 6.7%)             5
+ast-stats-2 Expr                     936 (10.4%)             9           104
+ast-stats-2 - Path                     104 ( 1.2%)             1
+ast-stats-2 - Match                    104 ( 1.2%)             1
+ast-stats-2 - Struct                   104 ( 1.2%)             1
+ast-stats-2 - InlineAsm                104 ( 1.2%)             1
 ast-stats-2 - Lit                      208 ( 2.3%)             2
-ast-stats-2 - Block                    312 ( 3.4%)             3
-ast-stats-2 Ty                     1_344 (14.7%)            14            96
-ast-stats-2 - Rptr                      96 ( 1.0%)             1
-ast-stats-2 - Ptr                       96 ( 1.0%)             1
-ast-stats-2 - ImplicitSelf             192 ( 2.1%)             2
-ast-stats-2 - Path                     960 (10.5%)            10
-ast-stats-2 Item                   2_024 (22.1%)            11           184
+ast-stats-2 - Block                    312 ( 3.5%)             3
+ast-stats-2 Ty                     1_232 (13.7%)            14            88
+ast-stats-2 - Rptr                      88 ( 1.0%)             1
+ast-stats-2 - Ptr                       88 ( 1.0%)             1
+ast-stats-2 - ImplicitSelf             176 ( 2.0%)             2
+ast-stats-2 - Path                     880 ( 9.8%)            10
+ast-stats-2 Item                   2_024 (22.4%)            11           184
 ast-stats-2 - Trait                    184 ( 2.0%)             1
 ast-stats-2 - Enum                     184 ( 2.0%)             1
 ast-stats-2 - ExternCrate              184 ( 2.0%)             1
 ast-stats-2 - ForeignMod               184 ( 2.0%)             1
 ast-stats-2 - Impl                     184 ( 2.0%)             1
-ast-stats-2 - Fn                       368 ( 4.0%)             2
-ast-stats-2 - Use                      736 ( 8.0%)             4
+ast-stats-2 - Fn                       368 ( 4.1%)             2
+ast-stats-2 - Use                      736 ( 8.2%)             4
 ast-stats-2 ----------------------------------------------------------------
-ast-stats-2 Total                  9_144
+ast-stats-2 Total                  9_016
 ast-stats-2
 hir-stats HIR STATS
 hir-stats Name                Accumulated Size         Count     Item Size
@@ -139,31 +139,31 @@ hir-stats - Semi                      32 ( 0.4%)             1
 hir-stats - Expr                      32 ( 0.4%)             1
 hir-stats FnDecl                   120 ( 1.3%)             3            40
 hir-stats Attribute                128 ( 1.4%)             4            32
+hir-stats Variant                  144 ( 1.6%)             2            72
 hir-stats GenericArgs              144 ( 1.6%)             3            48
-hir-stats Variant                  160 ( 1.8%)             2            80
 hir-stats GenericBound             192 ( 2.1%)             4            48
 hir-stats - Trait                    192 ( 2.1%)             4
 hir-stats WherePredicate           192 ( 2.1%)             3            64
 hir-stats - BoundPredicate           192 ( 2.1%)             3
 hir-stats Block                    288 ( 3.2%)             6            48
-hir-stats Pat                      360 ( 3.9%)             5            72
+hir-stats GenericParam             360 ( 4.0%)             5            72
+hir-stats Pat                      360 ( 4.0%)             5            72
 hir-stats - Wild                      72 ( 0.8%)             1
 hir-stats - Struct                    72 ( 0.8%)             1
 hir-stats - Binding                  216 ( 2.4%)             3
-hir-stats GenericParam             400 ( 4.4%)             5            80
-hir-stats Generics                 560 ( 6.1%)            10            56
+hir-stats Generics                 560 ( 6.2%)            10            56
 hir-stats Ty                       720 ( 7.9%)            15            48
 hir-stats - Ptr                       48 ( 0.5%)             1
 hir-stats - Rptr                      48 ( 0.5%)             1
-hir-stats - Path                     624 ( 6.8%)            13
-hir-stats Expr                     768 ( 8.4%)            12            64
+hir-stats - Path                     624 ( 6.9%)            13
+hir-stats Expr                     768 ( 8.5%)            12            64
 hir-stats - Path                      64 ( 0.7%)             1
 hir-stats - Struct                    64 ( 0.7%)             1
 hir-stats - Match                     64 ( 0.7%)             1
 hir-stats - InlineAsm                 64 ( 0.7%)             1
 hir-stats - Lit                      128 ( 1.4%)             2
 hir-stats - Block                    384 ( 4.2%)             6
-hir-stats Item                     960 (10.5%)            12            80
+hir-stats Item                     960 (10.6%)            12            80
 hir-stats - Trait                     80 ( 0.9%)             1
 hir-stats - Enum                      80 ( 0.9%)             1
 hir-stats - ExternCrate               80 ( 0.9%)             1
@@ -171,8 +171,8 @@ hir-stats - ForeignMod                80 ( 0.9%)             1
 hir-stats - Impl                      80 ( 0.9%)             1
 hir-stats - Fn                       160 ( 1.8%)             2
 hir-stats - Use                      400 ( 4.4%)             5
-hir-stats Path                   1_280 (14.0%)            32            40
-hir-stats PathSegment            1_920 (21.0%)            40            48
+hir-stats Path                   1_280 (14.1%)            32            40
+hir-stats PathSegment            1_920 (21.2%)            40            48
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  9_128
+hir-stats Total                  9_072
 hir-stats

--- a/src/test/ui/structs-enums/type-sizes.rs
+++ b/src/test/ui/structs-enums/type-sizes.rs
@@ -5,7 +5,7 @@
 #![feature(never_type)]
 
 use std::mem::size_of;
-use std::num::NonZeroU8;
+use std::num::{NonZeroU64, NonZeroU8};
 
 struct t {a: u8, b: i8}
 struct u {a: u8, b: i8, c: u8}
@@ -168,6 +168,45 @@ pub enum EnumManyVariant<X> {
     _F0, _F1, _F2, _F3, _F4, _F5, _F6, _F7, _F8, _F9, _FA, _FB, _FC, _FD, _FE, _FF,
 }
 
+pub enum EnumContainingAnother<X> {
+    A(X),
+
+    // 0x100 niche variants.
+    _00, _01, _02, _03, _04, _05, _06, _07, _08, _09, _0A, _0B, _0C, _0D, _0E, _0F,
+    _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _1A, _1B, _1C, _1D, _1E, _1F,
+    _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _2A, _2B, _2C, _2D, _2E, _2F,
+    _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _3A, _3B, _3C, _3D, _3E, _3F,
+    _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _4A, _4B, _4C, _4D, _4E, _4F,
+    _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _5A, _5B, _5C, _5D, _5E, _5F,
+    _60, _61, _62, _63, _64, _65, _66, _67, _68, _69, _6A, _6B, _6C, _6D, _6E, _6F,
+    _70, _71, _72, _73, _74, _75, _76, _77, _78, _79, _7A, _7B, _7C, _7D, _7E, _7F,
+    _80, _81, _82, _83, _84, _85, _86, _87, _88, _89, _8A, _8B, _8C, _8D, _8E, _8F,
+    _90, _91, _92, _93, _94, _95, _96, _97, _98, _99, _9A, _9B, _9C, _9D, _9E, _9F,
+    _A0, _A1, _A2, _A3, _A4, _A5, _A6, _A7, _A8, _A9, _AA, _AB, _AC, _AD, _AE, _AF,
+    _B0, _B1, _B2, _B3, _B4, _B5, _B6, _B7, _B8, _B9, _BA, _BB, _BC, _BD, _BE, _BF,
+    _C0, _C1, _C2, _C3, _C4, _C5, _C6, _C7, _C8, _C9, _CA, _CB, _CC, _CD, _CE, _CF,
+    _D0, _D1, _D2, _D3, _D4, _D5, _D6, _D7, _D8, _D9, _DA, _DB, _DC, _DD, _DE, _DF,
+    _E0, _E1, _E2, _E3, _E4, _E5, _E6, _E7, _E8, _E9, _EA, _EB, _EC, _ED, _EE, _EF,
+    _F0, _F1, _F2, _F3, _F4, _F5, _F6, _F7, _F8, _F9, _FA, _FB, _FC, _FD, _FE, _FF,
+}
+
+#[repr(flag)]
+enum Provenance {
+    Concrete {
+        alloc_id: NonZeroU64,
+        sb: NonZeroU64,
+    },
+    Wildcard,
+}
+
+enum ProvenanceNoFlag {
+    Concrete {
+        alloc_id: NonZeroU64,
+        sb: NonZeroU64,
+    },
+    Wildcard,
+}
+
 pub fn main() {
     assert_eq!(size_of::<u8>(), 1 as usize);
     assert_eq!(size_of::<u32>(), 4 as usize);
@@ -249,4 +288,18 @@ pub fn main() {
     assert_eq!(size_of::<EnumManyVariant<Option<NicheU16>>>(), 4);
     assert_eq!(size_of::<EnumManyVariant<Option2<NicheU16,u8>>>(), 6);
     assert_eq!(size_of::<EnumManyVariant<Option<(NicheU16,u8)>>>(), 6);
+
+    // Check for using a flag with a niche - a bool on its own can't
+    // accommodate 256 variants.
+    assert_eq!(size_of::<EnumManyVariant<bool>>(), 2);
+    assert_eq!(size_of::<EnumContainingAnother<EnumManyVariant<bool>>>(), 2);
+    assert_eq!(size_of::<EnumContainingAnother<EnumContainingAnother<EnumManyVariant<bool>>>>(), 2);
+
+    assert_eq!(size_of::<Provenance>(), 16);
+    assert_eq!(size_of::<Option<Provenance>>(), 16);
+    assert_eq!(size_of::<Option<Option<Provenance>>>(), 16);
+
+    assert_eq!(size_of::<ProvenanceNoFlag>(), 16);
+    assert_eq!(size_of::<Option<ProvenanceNoFlag>>(), 24);
+    assert_eq!(size_of::<Option<Option<ProvenanceNoFlag>>>(), 24);
 }


### PR DESCRIPTION
Work in progress, but it works. 

In addition to addressing #101567, also keep around multiple niches rather than just the largest one, and for tagged variants possibly move fields around the niche rather than just putting the whole variant before or after.

Things that aren't right at the moment:

- [ ] I haven't fixed cranelift codegen
- [ ] I'm just emitting bogus debuginfo in `rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs`
- [X] Contrary to my comment in #101567, I only look at existing niches when creating a `Flag`, even though any field will do
- [ ] Keeping a `Vec` of niches rather than just the largest one likely has a significant negative effect on performance, but I've done no performance testing
- [ ] Comments should be updated/added to explain what's going on with `Flag`
- [ ] The current sorting of niches in the presence of `Flag` probably makes no sense
- [ ] There probably should be some `repr` to force an `enum` to use a `Flag`. Right now an enum like the one given in the issue:
```
pub enum Provenance {
    Concrete {
        alloc_id: NonZeroU64,
        sb: NonZeroU64,
    },
    Wildcard,
}
```
will just use a regular niche, which means `Option<Provenance>` won't be able to use a flag. 
