### PR TITLE
rustdoc: remove no-op rule `a { background: transparent }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -766,7 +766,6 @@ nav.sub form { display: inline; }
 
 a {
 	text-decoration: none;
-	background: transparent;
 }
 
 .small-section-header {


### PR DESCRIPTION
The background is transparent by default.

It was added in 5a01dbe67b43660bf1df96074f34a635aad50e56 to work around a bug in the JavaScript syntax highlighting engine that rustdoc used at the time.