### PR TITLE
Enforce "joined()" and "joined_with_noop()" test

### DIFF
--- a/src/test/ui/async-await/async-fn-size-uninit-locals.rs
+++ b/src/test/ui/async-await/async-fn-size-uninit-locals.rs
@@ -67,9 +67,7 @@ async fn joined() {
     let c = Big::new();
 
     fut().await;
-    noop();
     joiner = Joiner { a: Some(a), b: Some(b), c: Some(c) };
-    noop();
 }
 
 async fn joined_with_noop() {
@@ -97,7 +95,7 @@ async fn join_retval() -> Joiner {
 fn main() {
     assert_eq!(2, std::mem::size_of_val(&single()));
     assert_eq!(3, std::mem::size_of_val(&single_with_noop()));
-    assert_eq!(3078, std::mem::size_of_val(&joined()));
+    assert_eq!(3074, std::mem::size_of_val(&joined()));
     assert_eq!(3078, std::mem::size_of_val(&joined_with_noop()));
     assert_eq!(3074, std::mem::size_of_val(&join_retval()));
 }


### PR DESCRIPTION
Several similar tests come in the form of `joined()` and `joined_with_noop()`. In this test, the `joined()` has two calls to a noop, making it functionally equivalent to `joined_with_noop()`. This doesn't seem intended, and this PR removes those calls and changes the memory size to reflect the change

For my education, why do tests with `noop()` calls sometimes have `noop()` contributing to the size, while others do not? E.g. https://github.com/rust-lang/rust/blob/master/src/test/ui/async-await/async-fn-size-moved-locals.rs#L115 and https://github.com/rust-lang/rust/blob/master/src/test/ui/async-await/async-fn-size-moved-locals.rs#L116 have no size difference, whereas https://github.com/rust-lang/rust/blob/master/src/test/ui/async-await/async-fn-size-moved-locals.rs#L113 and https://github.com/rust-lang/rust/blob/master/src/test/ui/async-await/async-fn-size-moved-locals.rs#L114 have a size difference. Thank you!