### PR TITLE
Add test for #101743

### DIFF
--- a/src/test/rustdoc/issue-101743-bold-tag.rs
+++ b/src/test/rustdoc/issue-101743-bold-tag.rs
@@ -1,0 +1,19 @@
+// Regression test for https://github.com/rust-lang/rust/issues/101743
+
+#![crate_name="foo"]
+
+pub type Word = usize;
+pub struct Repr<const B: usize>([i32; B]);
+pub struct IBig(usize);
+
+pub const fn base_as_ibig<const B: Word>() -> IBig {
+    IBig(B)
+}
+
+impl<const B: Word> Repr<B> {
+    // If we change back to rendering the value of consts, check this doesn't add
+    // a <b> tag, but escapes correctly
+
+    // @has foo/struct.Repr.html '//section[@id="associatedconstant.BASE"]/h4' '= _'
+    pub const BASE: IBig = base_as_ibig::<B>();
+}


### PR DESCRIPTION
The issue was closes as we stopped rendering `const`s like this, but if we move back to doing that, make sure we don't accidently generate tags