### PR TITLE
Make `dyn*` casts into a coercion, allow `dyn*` upcasting

### DIFF
--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -38,7 +38,7 @@ use rustc_session::Session;
 use rustc_span::symbol::sym;
 use rustc_span::Symbol;
 use rustc_span::{DebuggerVisualizerFile, DebuggerVisualizerType};
-use rustc_target::abi::{Align, VariantIdx};
+use rustc_target::abi::{Align, Size, VariantIdx};
 
 use std::collections::BTreeSet;
 use std::convert::TryFrom;
@@ -150,7 +150,12 @@ pub fn unsized_info<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         (&ty::Array(_, len), &ty::Slice(_)) => {
             cx.const_usize(len.eval_usize(cx.tcx(), ty::ParamEnv::reveal_all()))
         }
-        (&ty::Dynamic(ref data_a, ..), &ty::Dynamic(ref data_b, ..)) => {
+        (
+            &ty::Dynamic(ref data_a, _, src_dyn_kind),
+            &ty::Dynamic(ref data_b, _, target_dyn_kind),
+        ) => {
+            assert_eq!(src_dyn_kind, target_dyn_kind);
+
             let old_info =
                 old_info.expect("unsized_info: missing old info for trait upcasting coercion");
             if data_a.principal_def_id() == data_b.principal_def_id() {
@@ -166,11 +171,7 @@ pub fn unsized_info<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             if let Some(entry_idx) = vptr_entry_idx {
                 let ptr_ty = cx.type_i8p();
                 let ptr_align = cx.tcx().data_layout.pointer_align.abi;
-                let vtable_ptr_ty = cx.scalar_pair_element_backend_type(
-                    cx.layout_of(cx.tcx().mk_mut_ptr(target)),
-                    1,
-                    true,
-                );
+                let vtable_ptr_ty = vtable_ptr_ty(cx, target, target_dyn_kind);
                 let llvtable = bx.pointercast(old_info, bx.type_ptr_to(ptr_ty));
                 let gep = bx.inbounds_gep(
                     ptr_ty,
@@ -186,16 +187,30 @@ pub fn unsized_info<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 old_info
             }
         }
-        (_, &ty::Dynamic(ref data, ..)) => {
-            let vtable_ptr_ty = cx.scalar_pair_element_backend_type(
-                cx.layout_of(cx.tcx().mk_mut_ptr(target)),
-                1,
-                true,
-            );
+        (_, &ty::Dynamic(ref data, _, target_dyn_kind)) => {
+            let vtable_ptr_ty = vtable_ptr_ty(cx, target, target_dyn_kind);
             cx.const_ptrcast(meth::get_vtable(cx, source, data.principal()), vtable_ptr_ty)
         }
         _ => bug!("unsized_info: invalid unsizing {:?} -> {:?}", source, target),
     }
+}
+
+// Returns the vtable pointer type of a `dyn` or `dyn*` type
+fn vtable_ptr_ty<'tcx, Cx: CodegenMethods<'tcx>>(
+    cx: &Cx,
+    target: Ty<'tcx>,
+    kind: ty::DynKind,
+) -> <Cx as BackendTypes>::Type {
+    cx.scalar_pair_element_backend_type(
+        cx.layout_of(match kind {
+            // vtable is the second field of `*mut dyn Trait`
+            ty::Dyn => cx.tcx().mk_mut_ptr(target),
+            // vtable is the second field of `dyn* Trait`
+            ty::DynStar => target,
+        }),
+        1,
+        true,
+    )
 }
 
 /// Coerces `src` to `dst_ty`. `src_ty` must be a pointer.
@@ -245,6 +260,26 @@ pub fn unsize_ptr<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         }
         _ => bug!("unsize_ptr: called on bad types"),
     }
+}
+
+/// Coerces `src` to `dst_ty` which is guaranteed to be a `dyn*` type.
+pub fn cast_to_dyn_star<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+    bx: &mut Bx,
+    src: Bx::Value,
+    src_ty_and_layout: TyAndLayout<'tcx>,
+    dst_ty: Ty<'tcx>,
+    old_info: Option<Bx::Value>,
+) -> (Bx::Value, Bx::Value) {
+    debug!("unsize_ptr: {:?} => {:?}", src_ty_and_layout.ty, dst_ty);
+    assert!(matches!(dst_ty.kind(), ty::Dynamic(_, _, ty::DynStar)));
+    // FIXME(dyn-star): this is probably not the best way to check if this is
+    // a pointer, and really we should ensure that the value is a suitable
+    // pointer earlier in the compilation process.
+    let src = match src_ty_and_layout.pointee_info_at(bx.cx(), Size::ZERO) {
+        Some(_) => bx.ptrtoint(src, bx.cx().type_isize()),
+        None => bx.bitcast(src, bx.type_isize()),
+    };
+    (src, unsized_info(bx, src_ty_and_layout.ty, dst_ty, old_info))
 }
 
 /// Coerces `src`, which is a reference to a value of type `src_ty`,

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -270,8 +270,11 @@ pub fn cast_to_dyn_star<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     dst_ty: Ty<'tcx>,
     old_info: Option<Bx::Value>,
 ) -> (Bx::Value, Bx::Value) {
-    debug!("unsize_ptr: {:?} => {:?}", src_ty_and_layout.ty, dst_ty);
-    assert!(matches!(dst_ty.kind(), ty::Dynamic(_, _, ty::DynStar)));
+    debug!("cast_to_dyn_star: {:?} => {:?}", src_ty_and_layout.ty, dst_ty);
+    assert!(
+        matches!(dst_ty.kind(), ty::Dynamic(_, _, ty::DynStar)),
+        "destination type must be a dyn*"
+    );
     // FIXME(dyn-star): this is probably not the best way to check if this is
     // a pointer, and really we should ensure that the value is a suitable
     // pointer earlier in the compilation process.

--- a/compiler/rustc_hir_analysis/src/check/cast.rs
+++ b/compiler/rustc_hir_analysis/src/check/cast.rs
@@ -203,28 +203,8 @@ fn make_invalid_casting_error<'a, 'tcx>(
     )
 }
 
-pub enum CastCheckResult<'tcx> {
-    Ok,
-    Deferred(CastCheck<'tcx>),
-    Err(ErrorGuaranteed),
-}
-
-pub fn check_cast<'tcx>(
-    fcx: &FnCtxt<'_, 'tcx>,
-    expr: &'tcx hir::Expr<'tcx>,
-    expr_ty: Ty<'tcx>,
-    cast_ty: Ty<'tcx>,
-    cast_span: Span,
-    span: Span,
-) -> CastCheckResult<'tcx> {
-    match CastCheck::new(fcx, expr, expr_ty, cast_ty, cast_span, span) {
-        Ok(check) => CastCheckResult::Deferred(check),
-        Err(e) => CastCheckResult::Err(e),
-    }
-}
-
 impl<'a, 'tcx> CastCheck<'tcx> {
-    fn new(
+    pub fn new(
         fcx: &FnCtxt<'a, 'tcx>,
         expr: &'tcx hir::Expr<'tcx>,
         expr_ty: Ty<'tcx>,

--- a/compiler/rustc_hir_analysis/src/check/cast.rs
+++ b/compiler/rustc_hir_analysis/src/check/cast.rs
@@ -35,13 +35,12 @@ use crate::type_error_struct;
 use hir::def_id::LOCAL_CRATE;
 use rustc_errors::{struct_span_err, Applicability, DelayDm, DiagnosticBuilder, ErrorGuaranteed};
 use rustc_hir as hir;
-use rustc_infer::traits::{Obligation, ObligationCause, ObligationCauseCode};
 use rustc_middle::mir::Mutability;
 use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::cast::{CastKind, CastTy};
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::subst::SubstsRef;
-use rustc_middle::ty::{self, Binder, Ty, TypeAndMut, TypeVisitable, VariantDef};
+use rustc_middle::ty::{self, Ty, TypeAndMut, TypeVisitable, VariantDef};
 use rustc_session::lint;
 use rustc_session::Session;
 use rustc_span::symbol::sym;
@@ -218,58 +217,10 @@ pub fn check_cast<'tcx>(
     cast_span: Span,
     span: Span,
 ) -> CastCheckResult<'tcx> {
-    if cast_ty.is_dyn_star() {
-        check_dyn_star_cast(fcx, expr, expr_ty, cast_ty)
-    } else {
-        match CastCheck::new(fcx, expr, expr_ty, cast_ty, cast_span, span) {
-            Ok(check) => CastCheckResult::Deferred(check),
-            Err(e) => CastCheckResult::Err(e),
-        }
+    match CastCheck::new(fcx, expr, expr_ty, cast_ty, cast_span, span) {
+        Ok(check) => CastCheckResult::Deferred(check),
+        Err(e) => CastCheckResult::Err(e),
     }
-}
-
-fn check_dyn_star_cast<'tcx>(
-    fcx: &FnCtxt<'_, 'tcx>,
-    expr: &'tcx hir::Expr<'tcx>,
-    expr_ty: Ty<'tcx>,
-    cast_ty: Ty<'tcx>,
-) -> CastCheckResult<'tcx> {
-    // Find the bounds in the dyn*. For eaxmple, if we have
-    //
-    //    let x = 22_usize as dyn* (Clone + Debug + 'static)
-    //
-    // this would return `existential_predicates = [?Self: Clone, ?Self: Debug]` and `region = 'static`.
-    let (existential_predicates, region) = match cast_ty.kind() {
-        ty::Dynamic(predicates, region, ty::DynStar) => (predicates, region),
-        _ => panic!("Invalid dyn* cast_ty"),
-    };
-
-    let cause = ObligationCause::new(
-        expr.span,
-        fcx.body_id,
-        // FIXME(dyn-star): Use a better obligation cause code
-        ObligationCauseCode::MiscObligation,
-    );
-
-    // For each existential predicate (e.g., `?Self: Clone`) substitute
-    // the type of the expression (e.g., `usize` in our example above)
-    // and then require that the resulting predicate (e.g., `usize: Clone`)
-    // holds (it does).
-    for existential_predicate in existential_predicates.iter() {
-        let predicate = existential_predicate.with_self_ty(fcx.tcx, expr_ty);
-        fcx.register_predicate(Obligation::new(cause.clone(), fcx.param_env, predicate));
-    }
-
-    // Enforce the region bound `'static` (e.g., `usize: 'static`, in our example).
-    fcx.register_predicate(Obligation::new(
-        cause,
-        fcx.param_env,
-        fcx.tcx.mk_predicate(Binder::dummy(ty::PredicateKind::TypeOutlives(
-            ty::OutlivesPredicate(expr_ty, *region),
-        ))),
-    ));
-
-    CastCheckResult::Ok
 }
 
 impl<'a, 'tcx> CastCheck<'tcx> {
@@ -934,11 +885,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
 
             (Int(_) | Float, Int(_) | Float) => Ok(CastKind::NumericCast),
 
-            // FIXME(dyn-star): this needs more conditions...
-            (_, DynStar) => Ok(CastKind::DynStarCast),
-
-            // FIXME(dyn-star): do we want to allow dyn* upcasting or other casts?
-            (DynStar, _) => Err(CastError::IllegalCast),
+            (_, DynStar) | (DynStar, _) => bug!("should be handled by `try_coerce`"),
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/check/coercion.rs
+++ b/compiler/rustc_hir_analysis/src/check/coercion.rs
@@ -764,8 +764,16 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         {
             if a_data.principal_def_id() == b_data.principal_def_id() {
                 return self.unify_and(a, b, |_| vec![]);
-            } else {
-                bug!("dyn* trait upcasting is not supported");
+            } else if !self.tcx().features().trait_upcasting {
+                let mut err = feature_err(
+                    &self.tcx.sess.parse_sess,
+                    sym::trait_upcasting,
+                    self.cause.span,
+                    &format!(
+                        "cannot cast `{a}` to `{b}`, trait upcasting coercion is experimental"
+                    ),
+                );
+                err.emit();
             }
         }
 

--- a/compiler/rustc_hir_analysis/src/check/coercion.rs
+++ b/compiler/rustc_hir_analysis/src/check/coercion.rs
@@ -216,6 +216,9 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             ty::Ref(r_b, _, mutbl_b) => {
                 return self.coerce_borrowed_pointer(a, b, r_b, mutbl_b);
             }
+            ty::Dynamic(predicates, region, ty::DynStar) if self.tcx.features().dyn_star => {
+                return self.coerce_dyn_star(a, b, predicates, region);
+            }
             _ => {}
         }
 
@@ -743,6 +746,53 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         }
 
         Ok(coercion)
+    }
+
+    fn coerce_dyn_star(
+        &self,
+        a: Ty<'tcx>,
+        b: Ty<'tcx>,
+        predicates: &'tcx ty::List<ty::Binder<'tcx, ty::ExistentialPredicate<'tcx>>>,
+        b_region: ty::Region<'tcx>,
+    ) -> CoerceResult<'tcx> {
+        if !self.tcx.features().dyn_star {
+            return Err(TypeError::Mismatch);
+        }
+
+        if let ty::Dynamic(a_data, _, _) = a.kind()
+            && let ty::Dynamic(b_data, _, _) = b.kind()
+        {
+            if a_data.principal_def_id() == b_data.principal_def_id() {
+                return self.unify_and(a, b, |_| vec![]);
+            } else {
+                bug!("dyn* trait upcasting is not supported");
+            }
+        }
+
+        let obligations = predicates
+            .iter()
+            .map(|predicate| {
+                // For each existential predicate (e.g., `?Self: Clone`) substitute
+                // the type of the expression (e.g., `usize` in our example above)
+                // and then require that the resulting predicate (e.g., `usize: Clone`)
+                // holds (it does).
+                let predicate = predicate.with_self_ty(self.tcx, a);
+                Obligation::new(self.cause.clone(), self.param_env, predicate)
+            })
+            // Enforce the region bound `'static` (e.g., `usize: 'static`, in our example).
+            .chain([Obligation::new(
+                self.cause.clone(),
+                self.param_env,
+                self.tcx.mk_predicate(ty::Binder::dummy(ty::PredicateKind::TypeOutlives(
+                    ty::OutlivesPredicate(a, b_region),
+                ))),
+            )])
+            .collect();
+
+        Ok(InferOk {
+            value: (vec![Adjustment { kind: Adjust::DynStar, target: b }], b),
+            obligations,
+        })
     }
 
     fn coerce_from_safe_fn<F, G>(

--- a/compiler/rustc_hir_analysis/src/check/coercion.rs
+++ b/compiler/rustc_hir_analysis/src/check/coercion.rs
@@ -777,6 +777,8 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             }
         }
 
+        // Check the obligations of the cast -- for example, when casting
+        // `usize` to `dyn* Clone + 'static`:
         let obligations = predicates
             .iter()
             .map(|predicate| {
@@ -787,7 +789,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 let predicate = predicate.with_self_ty(self.tcx, a);
                 Obligation::new(self.cause.clone(), self.param_env, predicate)
             })
-            // Enforce the region bound `'static` (e.g., `usize: 'static`, in our example).
+            // Enforce the region bound (e.g., `usize: 'static`, in our example).
             .chain([Obligation::new(
                 self.cause.clone(),
                 self.param_env,

--- a/compiler/rustc_hir_analysis/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_analysis/src/expr_use_visitor.rs
@@ -583,7 +583,9 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
         for adjustment in adjustments {
             debug!("walk_adjustment expr={:?} adj={:?}", expr, adjustment);
             match adjustment.kind {
-                adjustment::Adjust::NeverToAny | adjustment::Adjust::Pointer(_) => {
+                adjustment::Adjust::NeverToAny
+                | adjustment::Adjust::Pointer(_)
+                | adjustment::Adjust::DynStar => {
                     // Creating a closure/fn-pointer or unsizing consumes
                     // the input and stores it into the resulting rvalue.
                     self.delegate_consume(&place_with_id, place_with_id.hir_id);

--- a/compiler/rustc_hir_analysis/src/mem_categorization.rs
+++ b/compiler/rustc_hir_analysis/src/mem_categorization.rs
@@ -292,7 +292,8 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
 
             adjustment::Adjust::NeverToAny
             | adjustment::Adjust::Pointer(_)
-            | adjustment::Adjust::Borrow(_) => {
+            | adjustment::Adjust::Borrow(_)
+            | adjustment::Adjust::DynStar => {
                 // Result is an rvalue.
                 Ok(self.cat_rvalue(expr.hir_id, expr.span, target))
             }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1824,7 +1824,6 @@ impl<'tcx> Rvalue<'tcx> {
             // While the model is undecided, we should be conservative. See
             // <https://www.ralfj.de/blog/2022/04/11/provenance-exposed.html>
             Rvalue::Cast(CastKind::PointerExposeAddress, _, _) => false,
-            Rvalue::Cast(CastKind::DynStar, _, _) => false,
 
             Rvalue::Use(_)
             | Rvalue::CopyForDeref(_)
@@ -1841,7 +1840,8 @@ impl<'tcx> Rvalue<'tcx> {
                 | CastKind::FnPtrToPtr
                 | CastKind::PtrToPtr
                 | CastKind::Pointer(_)
-                | CastKind::PointerFromExposedAddress,
+                | CastKind::PointerFromExposedAddress
+                | CastKind::DynStar,
                 _,
                 _,
             )

--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -101,6 +101,9 @@ pub enum Adjust<'tcx> {
     Borrow(AutoBorrow<'tcx>),
 
     Pointer(PointerCast),
+
+    /// Cast into a dyn* object.
+    DynStar,
 }
 
 /// An overloaded autoderef step, representing a `Deref(Mut)::deref(_mut)`

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -159,6 +159,7 @@ impl<'tcx> Cx<'tcx> {
             Adjust::Borrow(AutoBorrow::RawPtr(mutability)) => {
                 ExprKind::AddressOf { mutability, arg: self.thir.exprs.push(expr) }
             }
+            Adjust::DynStar => ExprKind::Cast { source: self.thir.exprs.push(expr) },
         };
 
         Expr { temp_lifetime, ty: adjustment.target, span, kind }

--- a/src/test/ui/dyn-star/auxiliary/dyn-star-foreign.rs
+++ b/src/test/ui/dyn-star/auxiliary/dyn-star-foreign.rs
@@ -1,0 +1,10 @@
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+use std::fmt::Display;
+
+pub fn require_dyn_star_display(_: dyn* Display) {}
+
+fn works_locally() {
+    require_dyn_star_display(1usize);
+}

--- a/src/test/ui/dyn-star/const.rs
+++ b/src/test/ui/dyn-star/const.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 fn make_dyn_star() {
     let i = 42usize;
-    let dyn_i: dyn* Debug = i as dyn* Debug;
+    let dyn_i: dyn* Debug = i;
 }
 
 fn main() {

--- a/src/test/ui/dyn-star/drop.rs
+++ b/src/test/ui/dyn-star/drop.rs
@@ -15,7 +15,7 @@ impl Drop for Foo {
 }
 
 fn make_dyn_star(i: Foo) {
-    let _dyn_i: dyn* Debug = i as dyn* Debug;
+    let _dyn_i: dyn* Debug = i;
 }
 
 fn main() {

--- a/src/test/ui/dyn-star/error.rs
+++ b/src/test/ui/dyn-star/error.rs
@@ -7,7 +7,7 @@ trait Foo {}
 
 fn make_dyn_star() {
     let i = 42;
-    let dyn_i: dyn* Foo = i as dyn* Foo; //~ ERROR trait bound `{integer}: Foo` is not satisfied
+    let dyn_i: dyn* Foo = i; //~ ERROR trait bound `{integer}: Foo` is not satisfied
 }
 
 fn main() {}

--- a/src/test/ui/dyn-star/error.stderr
+++ b/src/test/ui/dyn-star/error.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `{integer}: Foo` is not satisfied
   --> $DIR/error.rs:10:27
    |
-LL |     let dyn_i: dyn* Foo = i as dyn* Foo;
+LL |     let dyn_i: dyn* Foo = i;
    |                           ^ the trait `Foo` is not implemented for `{integer}`
 
 error: aborting due to previous error

--- a/src/test/ui/dyn-star/make-dyn-star.rs
+++ b/src/test/ui/dyn-star/make-dyn-star.rs
@@ -8,6 +8,11 @@ fn make_dyn_star(i: usize) {
     let _dyn_i: dyn* Debug = i;
 }
 
+fn make_dyn_star_explicit(i: usize) {
+    let _dyn_i: dyn* Debug = i as dyn* Debug;
+}
+
 fn main() {
     make_dyn_star(42);
+    make_dyn_star_explicit(42);
 }

--- a/src/test/ui/dyn-star/make-dyn-star.rs
+++ b/src/test/ui/dyn-star/make-dyn-star.rs
@@ -5,7 +5,7 @@
 use std::fmt::Debug;
 
 fn make_dyn_star(i: usize) {
-    let _dyn_i: dyn* Debug = i as dyn* Debug;
+    let _dyn_i: dyn* Debug = i;
 }
 
 fn main() {

--- a/src/test/ui/dyn-star/method.rs
+++ b/src/test/ui/dyn-star/method.rs
@@ -1,4 +1,5 @@
 // run-pass
+
 #![feature(dyn_star)]
 #![allow(incomplete_features)]
 
@@ -17,7 +18,7 @@ fn invoke_dyn_star(i: dyn* Foo) -> usize {
 }
 
 fn make_and_invoke_dyn_star(i: usize) -> usize {
-    let dyn_i: dyn* Foo = i as dyn* Foo;
+    let dyn_i: dyn* Foo = i;
     invoke_dyn_star(dyn_i)
 }
 

--- a/src/test/ui/dyn-star/no-implicit-dyn-star.rs
+++ b/src/test/ui/dyn-star/no-implicit-dyn-star.rs
@@ -1,0 +1,8 @@
+// aux-build:dyn-star-foreign.rs
+
+extern crate dyn_star_foreign;
+
+fn main() {
+    dyn_star_foreign::require_dyn_star_display(1usize);
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/dyn-star/no-implicit-dyn-star.stderr
+++ b/src/test/ui/dyn-star/no-implicit-dyn-star.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/no-implicit-dyn-star.rs:6:48
+   |
+LL |     dyn_star_foreign::require_dyn_star_display(1usize);
+   |     ------------------------------------------ ^^^^^^ expected trait object `dyn std::fmt::Display`, found `usize`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected trait object `(dyn* std::fmt::Display + 'static)`
+                      found type `usize`
+note: function defined here
+  --> $DIR/auxiliary/dyn-star-foreign.rs:6:8
+   |
+LL | pub fn require_dyn_star_display(_: dyn* Display) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/dyn-star/upcast.rs
+++ b/src/test/ui/dyn-star/upcast.rs
@@ -1,0 +1,33 @@
+// run-pass
+
+#![feature(dyn_star, trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait Foo: Bar {
+    fn hello(&self);
+}
+
+trait Bar {
+    fn world(&self);
+}
+
+struct W(usize);
+
+impl Foo for W {
+    fn hello(&self) {
+        println!("hello!");
+    }
+}
+
+impl Bar for W {
+    fn world(&self) {
+        println!("world!");
+    }
+}
+
+fn main() {
+    let w: dyn* Foo = W(0);
+    w.hello();
+    let w: dyn* Bar = w;
+    w.world();
+}


### PR DESCRIPTION
I know that `dyn*` is likely not going to be a feature exposed to surface Rust, but this makes it slightly more ergonomic to write tests for these types anyways. ... and this was just fun to implement anyways.

1. Make `dyn*` into a coercion instead of a cast
2. Enable `dyn*` upcasting since we basically get it for free
3. Simplify some of the cast checking code since we're using the coercion path now

r? @eholk but feel free to reassign
cc @nikomatsakis and @tmandry who might care about making `dyn*` casts into a coercion