### PR TITLE
Allow using vendoring when running bootstrap from outside the source root

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -771,7 +771,8 @@ class RustBuild(object):
         elif color == "never":
             args.append("--color=never")
 
-        run(args, env=env, verbose=self.verbose)
+        # Run this from the source directory so cargo finds .cargo/config
+        run(args, env=env, verbose=self.verbose, cwd=self.rust_root)
 
     def build_triple(self):
         """Build triple as in LLVM

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1325,6 +1325,9 @@ impl<'a> Builder<'a> {
     ) -> Cargo {
         let mut cargo = Command::new(&self.initial_cargo);
         let out_dir = self.stage_out(compiler, mode);
+        // Run cargo from the source root so it can find .cargo/config.
+        // This matters when using vendoring and the working directory is outside the repository.
+        cargo.current_dir(&self.src);
 
         // Codegen backends are not yet tracked by -Zbinary-dep-depinfo,
         // so we need to explicitly clear out if they've been updated.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/100364.