### PR TITLE
Update stdarch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,10 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+dependencies = [
+ "compiler_builtins",
+ "rustc-std-workspace-core",
+]
 
 [[package]]
 name = "chalk-derive"
@@ -4603,7 +4607,7 @@ version = "0.0.0"
 dependencies = [
  "addr2line 0.16.0",
  "alloc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "compiler_builtins",
  "core",
  "dlmalloc",
@@ -4627,7 +4631,7 @@ dependencies = [
 name = "std_detect"
 version = "0.1.5"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "compiler_builtins",
  "libc",
  "rustc-std-workspace-alloc",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["dylib", "rlib"]
 
 [dependencies]
 alloc = { path = "../alloc" }
-cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
+cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }


### PR DESCRIPTION
This pulls in the following changes:

- [Use simd_bitmask intrinsic in a couple of places](https://github.com/rust-lang/stdarch/commit/9f0928782b051edb6add78e9310472abface1e5c)
- [Remove simd_shuffle<n> usage in favor of simd_shuffle](https://github.com/rust-lang/stdarch/commit/3fd17e46079dbb5b99888dbcfdd232f2c023dff5)
- [Remove late specifiers in __cpuid_count](https://github.com/rust-lang/stdarch/commit/f1db941633e6e12bf62093cf0458bcbd7031c663)
  - Helps with #101346
- [Use mov and xchg instead of movl(q) and xchgl(q)](https://github.com/rust-lang/stdarch/commit/3049a31937e4f7353e1dea2f6dc558b02451bb13)
- [Bump cfg-if dependency to 1.0](https://github.com/rust-lang/stdarch/commit/f305cc83e7036f250a2a437021552526d1398cb4)
- [Fix documentation of __m256bh and __m512bh structs](https://github.com/rust-lang/stdarch/commit/699c093a42283c07e9763b4c19439a900ae2d321)

r? @Amanieu 

