### PR TITLE
rustdoc: remove no-op CSS `h1-4 { color: --main-color }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -222,7 +222,6 @@ details.rustdoc-toggle.non-exhaustive > summary::before,
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
 }
 
-h1, h2, h3, h4,
 a#toggle-all-docs,
 a.anchor,
 .small-section-header a,


### PR DESCRIPTION
Headers already inherit the font color they need from their parents.

This rule dates back to earlier versions of the rustdoc theme, where headers and body had different text colors.

https://github.com/rust-lang/rust/blob/68c15be8b5a28297ae58ea030adf49f265e41127/src/librustdoc/html/static/main.css#L72-L98

Nowadays, since the two have exactly the same color (specified by the `--main-color` variable), this rule does nothing.