### PR TITLE
Allow more `!Copy` impls

### DIFF
--- a/src/test/ui/coherence/coherence-negative-impls-copy-bad.rs
+++ b/src/test/ui/coherence/coherence-negative-impls-copy-bad.rs
@@ -1,0 +1,11 @@
+#![feature(negative_impls)]
+#![crate_type = "lib"]
+
+impl !Copy for str {}
+//~^ ERROR only traits defined in the current crate can be implemented
+
+impl !Copy for fn() {}
+//~^ ERROR only traits defined in the current crate can be implemented
+
+impl !Copy for () {}
+//~^ ERROR only traits defined in the current crate can be implemented

--- a/src/test/ui/coherence/coherence-negative-impls-copy-bad.stderr
+++ b/src/test/ui/coherence/coherence-negative-impls-copy-bad.stderr
@@ -1,0 +1,36 @@
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-negative-impls-copy-bad.rs:4:1
+   |
+LL | impl !Copy for str {}
+   | ^^^^^^^^^^^^^^^---
+   | |              |
+   | |              `str` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-negative-impls-copy-bad.rs:7:1
+   |
+LL | impl !Copy for fn() {}
+   | ^^^^^^^^^^^^^^^----
+   | |              |
+   | |              `fn()` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-negative-impls-copy-bad.rs:10:1
+   |
+LL | impl !Copy for () {}
+   | ^^^^^^^^^^^^^^^--
+   | |              |
+   | |              this is not defined in the current crate because tuples are always foreign
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0117`.

--- a/src/test/ui/coherence/coherence-negative-impls-copy.rs
+++ b/src/test/ui/coherence/coherence-negative-impls-copy.rs
@@ -1,0 +1,29 @@
+// check-pass
+// regression test for issue #101836
+
+#![feature(negative_impls, extern_types)]
+#![crate_type = "lib"]
+
+struct NonCopy;
+struct NeverCopy(NonCopy);
+
+impl !Copy for NeverCopy {}
+
+
+struct WithDrop;
+impl Drop for WithDrop { fn drop(&mut self) {} }
+
+impl !Copy for WithDrop {}
+
+
+struct Type;
+trait Trait {}
+extern {
+    type ExternType;
+}
+
+impl !Copy for &mut Type {}
+
+impl !Copy for dyn Trait {}
+
+impl !Copy for ExternType {}

--- a/src/test/ui/coherence/deep-bad-copy-reason.stderr
+++ b/src/test/ui/coherence/deep-bad-copy-reason.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/deep-bad-copy-reason.rs:33:15
+  --> $DIR/deep-bad-copy-reason.rs:33:24
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
    |                          ------------------------ this field does not implement `Copy`
 ...
 LL | impl<'tcx, T> Copy for List<'tcx, T> {}
-   |               ^^^^
+   |                        ^^^^^^^^^^^^^
    |
 note: the `Copy` impl for `Interned<'tcx, ListS<T>>` requires that `OpaqueListContents: Sized`
   --> $DIR/deep-bad-copy-reason.rs:23:26

--- a/src/test/ui/opt-in-copy.stderr
+++ b/src/test/ui/opt-in-copy.stderr
@@ -1,20 +1,20 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/opt-in-copy.rs:7:6
+  --> $DIR/opt-in-copy.rs:7:15
    |
 LL |     but_i_cant: CantCopyThis,
    |     ------------------------ this field does not implement `Copy`
 ...
 LL | impl Copy for IWantToCopyThis {}
-   |      ^^^^
+   |               ^^^^^^^^^^^^^^^
 
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/opt-in-copy.rs:19:6
+  --> $DIR/opt-in-copy.rs:19:15
    |
 LL |     ButICant(CantCopyThisEither),
    |              ------------------ this field does not implement `Copy`
 ...
 LL | impl Copy for IWantToCopyThisToo {}
-   |      ^^^^
+   |               ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/E0204.stderr
+++ b/src/test/ui/span/E0204.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/E0204.rs:5:6
+  --> $DIR/E0204.rs:5:15
    |
 LL |     foo: Vec<u32>,
    |     ------------- this field does not implement `Copy`
 ...
 LL | impl Copy for Foo { }
-   |      ^^^^
+   |               ^^^
 
 error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/E0204.rs:7:10
@@ -19,13 +19,13 @@ LL |     ty: &'a mut bool,
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/E0204.rs:17:6
+  --> $DIR/E0204.rs:17:15
    |
 LL |     Bar { x: Vec<u32> },
    |           ----------- this field does not implement `Copy`
 ...
 LL | impl Copy for EFoo { }
-   |      ^^^^
+   |               ^^^^
 
 error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/E0204.rs:19:10

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:16:9
+  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:16:18
    |
 LL | struct Wrapper<T>(T);
    |                   - this field does not implement `Copy`
 ...
 LL | impl<S> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
-   |         ^^^^
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the `Copy` impl for `OnlyCopyIfDisplay<S>` requires that `S: std::fmt::Display`
   --> $DIR/missing-bound-in-manual-copy-impl-2.rs:4:19

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/missing-bound-in-manual-copy-impl.rs:6:9
+  --> $DIR/missing-bound-in-manual-copy-impl.rs:6:18
    |
 LL | struct Wrapper<T>(T);
    |                   - this field does not implement `Copy`
 LL |
 LL | impl<S> Copy for Wrapper<S> {}
-   |         ^^^^
+   |                  ^^^^^^^^^^
    |
 help: consider restricting type parameter `S`
    |

--- a/src/test/ui/traits/copy-impl-cannot-normalize.stderr
+++ b/src/test/ui/traits/copy-impl-cannot-normalize.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: TraitFoo` is not satisfied
-  --> $DIR/copy-impl-cannot-normalize.rs:22:1
+  --> $DIR/copy-impl-cannot-normalize.rs:22:18
    |
 LL | impl<T> Copy for Foo<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `TraitFoo` is not implemented for `T`
+   |                  ^^^^^^ the trait `TraitFoo` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/union/union-copy.stderr
+++ b/src/test/ui/union/union-copy.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/union-copy.rs:12:6
+  --> $DIR/union-copy.rs:12:15
    |
 LL |     a: std::mem::ManuallyDrop<String>
    |     --------------------------------- this field does not implement `Copy`
 ...
 LL | impl Copy for W {}
-   |      ^^^^
+   |               ^
    |
 note: the `Copy` impl for `ManuallyDrop<String>` requires that `String: Copy`
   --> $DIR/union-copy.rs:8:8


### PR DESCRIPTION
You can already implement `!Copy` for a lot of types (with `#![feature(negative_impls)]`). However, before this PR you could not implement `!Copy` for ADTs whose fields don't implement `Copy` which didn't make any sense. Further, you couldn't implement `!Copy` for types impl'ing `Drop` (equally nonsensical).

@rustbot label T-types F-negative_impls
Fixes #101836.

r? types