### PR TITLE
rustdoc: remove no-op CSS `.block { padding: 0 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -498,9 +498,6 @@ img {
 	font-weight: 500;
 }
 
-.block {
-	padding: 0;
-}
 .block ul, .block li {
 	padding: 0;
 	margin: 0;


### PR DESCRIPTION
This rule was changed in 8fb1250aba8135679463351a3813c04ae45bf311 from the original version that had a non-zero padding. It's not needed, because it's not overriding anything that would've given `.block` a padding.