### PR TITLE
Remove `ast::Lit::kind`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1691,10 +1691,6 @@ pub enum StrStyle {
 pub struct Lit {
     /// The original literal token as written in source code.
     pub token_lit: token::Lit,
-    /// The "semantic" representation of the literal lowered from the original tokens.
-    /// Strings are unescaped, hexadecimal forms are eliminated, etc.
-    /// FIXME: Remove this and only create the semantic representation during lowering to HIR.
-    pub kind: LitKind,
     pub span: Span,
 }
 
@@ -1717,11 +1713,7 @@ impl StrLit {
             StrStyle::Cooked => token::Str,
             StrStyle::Raw(n) => token::StrRaw(n),
         };
-        Lit {
-            token_lit: token::Lit::new(token_kind, self.symbol, self.suffix),
-            span: self.span,
-            kind: LitKind::Str(self.symbol_unescaped, self.style),
-        }
+        Lit { token_lit: token::Lit::new(token_kind, self.symbol, self.suffix), span: self.span }
     }
 }
 
@@ -1778,20 +1770,9 @@ impl LitKind {
         matches!(self, LitKind::Str(..))
     }
 
-    /// Returns `true` if this literal is byte literal string.
-    pub fn is_bytestr(&self) -> bool {
-        matches!(self, LitKind::ByteStr(_))
-    }
-
     /// Returns `true` if this is a numeric literal.
     pub fn is_numeric(&self) -> bool {
         matches!(self, LitKind::Int(..) | LitKind::Float(..))
-    }
-
-    /// Returns `true` if this literal has no suffix.
-    /// Note: this will return true for literals with prefixes such as raw strings and byte strings.
-    pub fn is_unsuffixed(&self) -> bool {
-        !self.is_suffixed()
     }
 
     /// Returns `true` if this literal has a suffix.
@@ -3056,7 +3037,7 @@ mod size_asserts {
     static_assert_size!(Impl, 200);
     static_assert_size!(Item, 184);
     static_assert_size!(ItemKind, 112);
-    static_assert_size!(Lit, 48);
+    static_assert_size!(Lit, 20);
     static_assert_size!(LitKind, 24);
     static_assert_size!(Local, 72);
     static_assert_size!(Param, 40);

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -80,6 +80,28 @@ pub struct Lit {
     pub suffix: Option<Symbol>,
 }
 
+impl Lit {
+    pub fn is_bool_true(&self) -> bool {
+        matches!(self.kind, LitKind::Bool) && self.symbol == kw::True
+    }
+
+    /// Returns `true` if this literal is a string.
+    pub fn is_str(&self) -> bool {
+        matches!(self.kind, LitKind::Str | LitKind::StrRaw(_))
+    }
+
+    /// Returns `true` if this literal is byte literal string.
+    pub fn is_bytestr(&self) -> bool {
+        matches!(self.kind, LitKind::ByteStr | LitKind::ByteStrRaw(_))
+    }
+
+    /// Returns `true` if this literal has no suffix.
+    /// Note: this will return true for literals with prefixes such as raw strings and byte strings.
+    pub fn is_unsuffixed(&self) -> bool {
+        self.suffix.is_none()
+    }
+}
+
 impl fmt::Display for Lit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Lit { kind, symbol, suffix } = *self;

--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -281,11 +281,13 @@ fn filtered_float_lit(
     })
 }
 
+#[inline]
 fn float_lit(symbol: Symbol, suffix: Option<Symbol>) -> Result<LitKind, LitError> {
     debug!("float_lit: {:?}, {:?}", symbol, suffix);
     filtered_float_lit(strip_underscores(symbol), suffix, 10)
 }
 
+#[inline]
 fn integer_lit(symbol: Symbol, suffix: Option<Symbol>) -> Result<LitKind, LitError> {
     debug!("integer_lit: {:?}, {:?}", symbol, suffix);
     let symbol = strip_underscores(symbol);

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -2,6 +2,61 @@ use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic, Diagnost
 use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
 use rustc_span::{symbol::Ident, Span, Symbol};
 
+#[derive(SessionDiagnostic)]
+#[diag(parser::invalid_int_literal_width)]
+#[help]
+pub(crate) struct InvalidIntLiteralWidth {
+    #[primary_span]
+    pub span: Span,
+    pub width: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(parser::invalid_num_literal_base_prefix)]
+#[note]
+pub(crate) struct InvalidNumLiteralBasePrefix {
+    #[primary_span]
+    #[suggestion(applicability = "maybe-incorrect", code = "{fixed}")]
+    pub span: Span,
+    pub fixed: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(parser::invalid_num_literal_suffix)]
+#[help]
+pub(crate) struct InvalidNumLiteralSuffix {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub suffix: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(parser::invalid_float_literal_width)]
+#[help]
+pub(crate) struct InvalidFloatLiteralWidth {
+    #[primary_span]
+    pub span: Span,
+    pub width: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(parser::invalid_float_literal_suffix)]
+#[help]
+pub(crate) struct InvalidFloatLiteralSuffix {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub suffix: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(parser::int_literal_too_large)]
+pub(crate) struct IntLiteralTooLarge {
+    #[primary_span]
+    pub span: Span,
+}
+
 #[derive(SessionDiagnostic, Clone, Copy)]
 #[diag(ast_lowering::generic_type_with_parentheses, code = "E0214")]
 pub struct GenericTypeWithParentheses {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -952,7 +952,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 } else {
                     Lit {
                         token_lit: token::Lit::new(token::LitKind::Err, kw::Empty, None),
-                        kind: LitKind::Err,
                         span: DUMMY_SP,
                     }
                 };

--- a/compiler/rustc_attr/src/lib.rs
+++ b/compiler/rustc_attr/src/lib.rs
@@ -4,6 +4,7 @@
 //! The goal is to move the definition of `MetaItem` and things that don't need to be in `syntax`
 //! to this crate.
 
+#![feature(if_let_guard)]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(let_else))]
 #![deny(rustc::untranslatable_diagnostic)]

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -306,12 +306,12 @@ pub(crate) enum IncorrectReprFormatGenericCause<'a> {
 }
 
 impl<'a> IncorrectReprFormatGenericCause<'a> {
-    pub fn from_lit_kind(span: Span, kind: &ast::LitKind, name: &'a str) -> Option<Self> {
+    pub fn from_lit_kind(span: Span, kind: Option<ast::LitKind>, name: &'a str) -> Option<Self> {
         match kind {
-            ast::LitKind::Int(int, ast::LitIntType::Unsuffixed) => {
-                Some(Self::Int { span, name, int: *int })
+            Some(ast::LitKind::Int(int, ast::LitIntType::Unsuffixed)) => {
+                Some(Self::Int { span, name, int })
             }
-            ast::LitKind::Str(symbol, _) => Some(Self::Symbol { span, name, symbol: *symbol }),
+            Some(ast::LitKind::Str(symbol, _)) => Some(Self::Symbol { span, name, symbol }),
             _ => None,
         }
     }

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -172,7 +172,7 @@ pub fn parse_asm_args<'a>(
             // If it can't possibly expand to a string, provide diagnostics here to include other
             // things it could have been.
             match template.kind {
-                ast::ExprKind::Lit(ast::Lit { kind: ast::LitKind::Str(..), .. }) => {}
+                ast::ExprKind::Lit(ast::Lit { token_lit, .. }) if token_lit.is_str() => {}
                 ast::ExprKind::MacCall(..) => {}
                 _ => {
                     let errstr = if is_global_asm {

--- a/compiler/rustc_builtin_macros/src/concat_bytes.rs
+++ b/compiler/rustc_builtin_macros/src/concat_bytes.rs
@@ -4,16 +4,13 @@ use rustc_errors::Applicability;
 use rustc_expand::base::{self, DummyResult};
 
 /// Emits errors for literal expressions that are invalid inside and outside of an array.
-fn invalid_type_err(cx: &mut base::ExtCtxt<'_>, expr: &P<rustc_ast::Expr>, is_nested: bool) {
-    let ast::ExprKind::Lit(lit) = &expr.kind else {
-        unreachable!();
-    };
-    match lit.kind {
-        ast::LitKind::Char(_) => {
-            let mut err = cx.struct_span_err(expr.span, "cannot concatenate character literals");
-            if let Ok(snippet) = cx.sess.source_map().span_to_snippet(expr.span) {
+fn invalid_type_err(cx: &mut base::ExtCtxt<'_>, lit: &ast::Lit, is_nested: bool) {
+    match ast::LitKind::from_token_lit(lit.token_lit) {
+        Ok(ast::LitKind::Char(_)) => {
+            let mut err = cx.struct_span_err(lit.span, "cannot concatenate character literals");
+            if let Ok(snippet) = cx.sess.source_map().span_to_snippet(lit.span) {
                 err.span_suggestion(
-                    expr.span,
+                    lit.span,
                     "try using a byte character",
                     format!("b{}", snippet),
                     Applicability::MachineApplicable,
@@ -21,13 +18,13 @@ fn invalid_type_err(cx: &mut base::ExtCtxt<'_>, expr: &P<rustc_ast::Expr>, is_ne
                 .emit();
             }
         }
-        ast::LitKind::Str(_, _) => {
-            let mut err = cx.struct_span_err(expr.span, "cannot concatenate string literals");
+        Ok(ast::LitKind::Str(_, _)) => {
+            let mut err = cx.struct_span_err(lit.span, "cannot concatenate string literals");
             // suggestion would be invalid if we are nested
             if !is_nested {
-                if let Ok(snippet) = cx.sess.source_map().span_to_snippet(expr.span) {
+                if let Ok(snippet) = cx.sess.source_map().span_to_snippet(lit.span) {
                     err.span_suggestion(
-                        expr.span,
+                        lit.span,
                         "try using a byte string",
                         format!("b{}", snippet),
                         Applicability::MachineApplicable,
@@ -36,18 +33,18 @@ fn invalid_type_err(cx: &mut base::ExtCtxt<'_>, expr: &P<rustc_ast::Expr>, is_ne
             }
             err.emit();
         }
-        ast::LitKind::Float(_, _) => {
-            cx.span_err(expr.span, "cannot concatenate float literals");
+        Ok(ast::LitKind::Float(_, _)) => {
+            cx.span_err(lit.span, "cannot concatenate float literals");
         }
-        ast::LitKind::Bool(_) => {
-            cx.span_err(expr.span, "cannot concatenate boolean literals");
+        Ok(ast::LitKind::Bool(_)) => {
+            cx.span_err(lit.span, "cannot concatenate boolean literals");
         }
-        ast::LitKind::Err => {}
-        ast::LitKind::Int(_, _) if !is_nested => {
-            let mut err = cx.struct_span_err(expr.span, "cannot concatenate numeric literals");
-            if let Ok(snippet) = cx.sess.source_map().span_to_snippet(expr.span) {
+        Ok(ast::LitKind::Err) => {}
+        Ok(ast::LitKind::Int(_, _)) if !is_nested => {
+            let mut err = cx.struct_span_err(lit.span, "cannot concatenate numeric literals");
+            if let Ok(snippet) = cx.sess.source_map().span_to_snippet(lit.span) {
                 err.span_suggestion(
-                    expr.span,
+                    lit.span,
                     "try wrapping the number in an array",
                     format!("[{}]", snippet),
                     Applicability::MachineApplicable,
@@ -55,17 +52,20 @@ fn invalid_type_err(cx: &mut base::ExtCtxt<'_>, expr: &P<rustc_ast::Expr>, is_ne
             }
             err.emit();
         }
-        ast::LitKind::Int(
+        Ok(ast::LitKind::Int(
             val,
             ast::LitIntType::Unsuffixed | ast::LitIntType::Unsigned(ast::UintTy::U8),
-        ) => {
+        )) => {
             assert!(val > u8::MAX.into()); // must be an error
-            cx.span_err(expr.span, "numeric literal is out of bounds");
+            cx.span_err(lit.span, "numeric literal is out of bounds");
         }
-        ast::LitKind::Int(_, _) => {
-            cx.span_err(expr.span, "numeric literal is not a `u8`");
+        Ok(ast::LitKind::Int(_, _)) => {
+            cx.span_err(lit.span, "numeric literal is not a `u8`");
         }
-        _ => unreachable!(),
+        Ok(ast::LitKind::Byte(_) | ast::LitKind::ByteStr(_)) => unreachable!(),
+        Err(_) => {
+            cx.span_err(lit.span, "cannot concatenate invalid literals");
+        }
     }
 }
 
@@ -83,14 +83,14 @@ fn handle_array_element(
             *has_errors = true;
             None
         }
-        ast::ExprKind::Lit(ref lit) => match lit.kind {
-            ast::LitKind::Int(
+        ast::ExprKind::Lit(ref lit) => match ast::LitKind::from_token_lit(lit.token_lit) {
+            Ok(ast::LitKind::Int(
                 val,
                 ast::LitIntType::Unsuffixed | ast::LitIntType::Unsigned(ast::UintTy::U8),
-            ) if val <= u8::MAX.into() => Some(val as u8),
+            )) if val <= u8::MAX.into() => Some(val as u8),
 
-            ast::LitKind::Byte(val) => Some(val),
-            ast::LitKind::ByteStr(_) => {
+            Ok(ast::LitKind::Byte(val)) => Some(val),
+            Ok(ast::LitKind::ByteStr(_)) => {
                 if !*has_errors {
                     cx.struct_span_err(expr.span, "cannot concatenate doubly nested array")
                         .note("byte strings are treated as arrays of bytes")
@@ -102,7 +102,7 @@ fn handle_array_element(
             }
             _ => {
                 if !*has_errors {
-                    invalid_type_err(cx, expr, true);
+                    invalid_type_err(cx, lit, true);
                 }
                 *has_errors = true;
                 None
@@ -138,9 +138,9 @@ pub fn expand_concat_bytes(
                 }
             }
             ast::ExprKind::Repeat(ref expr, ref count) => {
-                if let ast::ExprKind::Lit(ast::Lit {
-                    kind: ast::LitKind::Int(count_val, _), ..
-                }) = count.value.kind
+                if let ast::ExprKind::Lit(lit) = &count.value.kind
+                && let Ok(ast::LitKind::Int(count_val, _)) =
+                    ast::LitKind::from_token_lit(lit.token_lit)
                 {
                     if let Some(elem) =
                         handle_array_element(cx, &mut has_errors, &mut missing_literals, expr)
@@ -153,16 +153,16 @@ pub fn expand_concat_bytes(
                     cx.span_err(count.value.span, "repeat count is not a positive number");
                 }
             }
-            ast::ExprKind::Lit(ref lit) => match lit.kind {
-                ast::LitKind::Byte(val) => {
+            ast::ExprKind::Lit(ref lit) => match ast::LitKind::from_token_lit(lit.token_lit) {
+                Ok(ast::LitKind::Byte(val)) => {
                     accumulator.push(val);
                 }
-                ast::LitKind::ByteStr(ref bytes) => {
+                Ok(ast::LitKind::ByteStr(ref bytes)) => {
                     accumulator.extend_from_slice(&bytes);
                 }
                 _ => {
                     if !has_errors {
-                        invalid_type_err(cx, &e, false);
+                        invalid_type_err(cx, lit, false);
                     }
                     has_errors = true;
                 }

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1222,9 +1222,9 @@ pub fn expr_to_spanned_string<'a>(
     let expr = cx.expander().fully_expand_fragment(AstFragment::Expr(expr)).make_expr();
 
     Err(match expr.kind {
-        ast::ExprKind::Lit(ref l) => match l.kind {
-            ast::LitKind::Str(s, style) => return Ok((s, style, expr.span)),
-            ast::LitKind::ByteStr(_) => {
+        ast::ExprKind::Lit(ref l) => match ast::LitKind::from_token_lit(l.token_lit) {
+            Ok(ast::LitKind::Str(s, style)) => return Ok((s, style, expr.span)),
+            Ok(ast::LitKind::ByteStr(_)) => {
                 let mut err = cx.struct_span_err(l.span, err_msg);
                 err.span_suggestion(
                     expr.span.shrink_to_lo(),
@@ -1234,7 +1234,8 @@ pub fn expr_to_spanned_string<'a>(
                 );
                 Some((err, true))
             }
-            ast::LitKind::Err => None,
+            Ok(ast::LitKind::Err) => None,
+            Err(_) => None,
             _ => Some((cx.struct_span_err(l.span, err_msg), false)),
         },
         ast::ExprKind::Err => None,

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -330,7 +330,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     fn expr_lit(&self, span: Span, lit_kind: ast::LitKind) -> P<ast::Expr> {
-        let lit = ast::Lit::from_lit_kind(lit_kind, span);
+        let lit = ast::Lit { token_lit: lit_kind.to_token_lit(), span };
         self.expr(span, ast::ExprKind::Lit(lit))
     }
 

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -109,7 +109,7 @@ pub fn parse_cfgspecs(cfgspecs: Vec<String>) -> FxHashSet<(String, Option<String
                             }
                             match &meta_item.kind {
                                 MetaItemKind::List(..) => {}
-                                MetaItemKind::NameValue(lit) if !lit.kind.is_str() => {
+                                MetaItemKind::NameValue(lit) if !lit.token_lit.is_str() => {
                                     error!("argument value must be a string");
                                 }
                                 MetaItemKind::NameValue(..) | MetaItemKind::Word => {
@@ -190,8 +190,9 @@ pub fn parse_check_cfg(specs: Vec<String>) -> CheckCfg {
                                             .or_insert_with(|| FxHashSet::default());
 
                                         for val in values {
-                                            if let Some(LitKind::Str(s, _)) =
-                                                val.literal().map(|lit| &lit.kind)
+                                            if let Some(Ok(LitKind::Str(s, _))) = val
+                                                .literal()
+                                                .map(|lit| LitKind::from_token_lit(lit.token_lit))
                                             {
                                                 ident_values.insert(s.to_string());
                                             } else {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -100,7 +100,7 @@ impl EarlyLintPass for WhileTrue {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
         if let ast::ExprKind::While(cond, _, label) = &e.kind {
             if let ast::ExprKind::Lit(ref lit) = pierce_parens(cond).kind {
-                if let ast::LitKind::Bool(true) = lit.kind {
+                if lit.token_lit.is_bool_true() {
                     if !lit.span.from_expansion() {
                         let condition_span = e.span.with_hi(cond.span.hi());
                         cx.struct_span_lint(WHILE_TRUE, condition_span, |lint| {

--- a/compiler/rustc_lint/src/hidden_unicode_codepoints.rs
+++ b/compiler/rustc_lint/src/hidden_unicode_codepoints.rs
@@ -120,16 +120,16 @@ impl EarlyLintPass for HiddenUnicodeCodepoints {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
         // byte strings are already handled well enough by `EscapeError::NonAsciiCharInByteString`
         let (text, span, padding) = match &expr.kind {
-            ast::ExprKind::Lit(ast::Lit { token_lit, kind, span }) => {
+            ast::ExprKind::Lit(ast::Lit { token_lit, span, .. }) => {
                 let text = token_lit.symbol;
                 if !contains_text_flow_control_chars(text.as_str()) {
                     return;
                 }
-                let padding = match kind {
+                let padding = match token_lit.kind {
                     // account for `"` or `'`
-                    ast::LitKind::Str(_, ast::StrStyle::Cooked) | ast::LitKind::Char(_) => 1,
+                    ast::token::LitKind::Str | ast::token::LitKind::Char => 1,
                     // account for `r###"`
-                    ast::LitKind::Str(_, ast::StrStyle::Raw(val)) => *val as u32 + 2,
+                    ast::token::LitKind::StrRaw(n) => n as u32 + 2,
                     _ => return,
                 };
                 (text, span, padding)

--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -462,7 +462,8 @@ impl LateLintPass<'_> for BadOptAccess {
                 let Some(items) = attr.meta_item_list()  &&
                 let Some(item) = items.first()  &&
                 let Some(literal) = item.literal()  &&
-                let ast::LitKind::Str(val, _) = literal.kind
+                let Ok(ast::LitKind::Str(val, _)) =
+                    ast::LitKind::from_token_lit(literal.token_lit)
             {
                 cx.struct_span_lint(BAD_OPT_ACCESS, expr.span, |lint| {
                     lint.build(val.as_str()).emit(); }

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -593,7 +593,9 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
                     ast::MetaItemKind::Word => {} // actual lint names handled later
                     ast::MetaItemKind::NameValue(ref name_value) => {
                         if item.path == sym::reason {
-                            if let ast::LitKind::Str(rationale, _) = name_value.kind {
+                            if let Ok(ast::LitKind::Str(rationale, _)) =
+                                ast::LitKind::from_token_lit(name_value.token_lit)
+                            {
                                 if !self.sess.features_untracked().lint_reasons {
                                     feature_err(
                                         &self.sess.parse_sess,

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -340,7 +340,9 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
                 .and_then(|attr| attr.meta())
                 .and_then(|meta| {
                     meta.name_value_literal().and_then(|lit| {
-                        if let ast::LitKind::Str(name, ..) = lit.kind {
+                        if let Ok(ast::LitKind::Str(name, ..)) =
+                            ast::LitKind::from_token_lit(lit.token_lit)
+                        {
                             // Discard the double quotes surrounding the literal.
                             let sp = cx
                                 .sess()

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1198,13 +1198,9 @@ impl<'tcx> TyCtxt<'tcx> {
                 return Bound::Unbounded;
             };
             debug!("layout_scalar_valid_range: attr={:?}", attr);
-            if let Some(
-                &[
-                    ast::NestedMetaItem::Literal(ast::Lit {
-                        kind: ast::LitKind::Int(a, _), ..
-                    }),
-                ],
-            ) = attr.meta_item_list().as_deref()
+            if let Some(&[ast::NestedMetaItem::Literal(ast::Lit { token_lit, .. })]) =
+                attr.meta_item_list().as_deref()
+            && let Ok(ast::LitKind::Int(a, _)) = ast::LitKind::from_token_lit(token_lit)
             {
                 Bound::Included(a)
             } else {

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -336,7 +336,7 @@ impl<'a> Parser<'a> {
         let lit = self.parse_lit()?;
         debug!("checking if {:?} is unusuffixed", lit);
 
-        if !lit.kind.is_unsuffixed() {
+        if lit.token_lit.suffix.is_some() {
             self.struct_span_err(lit.span, "suffixed literals are not allowed in attributes")
                 .help(
                     "instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), \

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -500,61 +500,6 @@ pub(crate) struct FloatLiteralRequiresIntegerPart {
 }
 
 #[derive(SessionDiagnostic)]
-#[diag(parser::invalid_int_literal_width)]
-#[help]
-pub(crate) struct InvalidIntLiteralWidth {
-    #[primary_span]
-    pub span: Span,
-    pub width: String,
-}
-
-#[derive(SessionDiagnostic)]
-#[diag(parser::invalid_num_literal_base_prefix)]
-#[note]
-pub(crate) struct InvalidNumLiteralBasePrefix {
-    #[primary_span]
-    #[suggestion(applicability = "maybe-incorrect", code = "{fixed}")]
-    pub span: Span,
-    pub fixed: String,
-}
-
-#[derive(SessionDiagnostic)]
-#[diag(parser::invalid_num_literal_suffix)]
-#[help]
-pub(crate) struct InvalidNumLiteralSuffix {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-    pub suffix: String,
-}
-
-#[derive(SessionDiagnostic)]
-#[diag(parser::invalid_float_literal_width)]
-#[help]
-pub(crate) struct InvalidFloatLiteralWidth {
-    #[primary_span]
-    pub span: Span,
-    pub width: String,
-}
-
-#[derive(SessionDiagnostic)]
-#[diag(parser::invalid_float_literal_suffix)]
-#[help]
-pub(crate) struct InvalidFloatLiteralSuffix {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-    pub suffix: String,
-}
-
-#[derive(SessionDiagnostic)]
-#[diag(parser::int_literal_too_large)]
-pub(crate) struct IntLiteralTooLarge {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(SessionDiagnostic)]
 #[diag(parser::missing_semicolon_before_array)]
 pub(crate) struct MissingSemicolonBeforeArray {
     #[primary_span]

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1381,8 +1381,8 @@ impl<'a> Parser<'a> {
     fn parse_abi(&mut self) -> Option<StrLit> {
         match self.parse_str_lit() {
             Ok(str_lit) => Some(str_lit),
-            Err(Some(lit)) => match lit.kind {
-                ast::LitKind::Err => None,
+            Err(Some(lit)) => match lit.token_lit.kind {
+                token::LitKind::Err => None,
                 _ => {
                     self.struct_span_err(lit.span, "non-string ABI literal")
                         .span_suggestion(

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -50,7 +50,7 @@ pub fn parse_meta<'a>(sess: &'a ParseSess, attr: &Attribute) -> PResult<'a, Meta
             }
             MacArgs::Eq(_, MacArgsEq::Ast(expr)) => {
                 if let ast::ExprKind::Lit(lit) = &expr.kind {
-                    if !lit.kind.is_unsuffixed() {
+                    if lit.token_lit.suffix.is_some() {
                         let mut err = sess.span_diagnostic.struct_span_err(
                             lit.span,
                             "suffixed literals are not allowed in attributes",
@@ -101,7 +101,7 @@ fn is_attr_template_compatible(template: &AttributeTemplate, meta: &ast::MetaIte
     match meta {
         MetaItemKind::Word => template.word,
         MetaItemKind::List(..) => template.list.is_some(),
-        MetaItemKind::NameValue(lit) if lit.kind.is_str() => template.name_value_str.is_some(),
+        MetaItemKind::NameValue(lit) if lit.token_lit.is_str() => template.name_value_str.is_some(),
         MetaItemKind::NameValue(..) => false,
     }
 }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1960,8 +1960,8 @@ impl<'a> Resolver<'a> {
                     .find(|a| a.has_name(sym::rustc_legacy_const_generics))?;
                 let mut ret = Vec::new();
                 for meta in attr.meta_item_list()? {
-                    match meta.literal()?.kind {
-                        LitKind::Int(a, _) => ret.push(a as usize),
+                    match LitKind::from_token_lit(meta.literal()?.token_lit) {
+                        Ok(LitKind::Int(a, _)) => ret.push(a as usize),
                         _ => panic!("invalid arg index"),
                     }
                 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -857,8 +857,8 @@ fn clean_fn_decl_legacy_const_generics(func: &mut Function, attrs: &[ast::Attrib
         .filter_map(|a| a.meta_item_list())
     {
         for (pos, literal) in meta_item_list.iter().filter_map(|meta| meta.literal()).enumerate() {
-            match literal.kind {
-                ast::LitKind::Int(a, _) => {
+            match ast::LitKind::from_token_lit(literal.token_lit) {
+                Ok(ast::LitKind::Int(a, _)) => {
                     let gen = func.generics.params.remove(0);
                     if let GenericParamDef { name, kind: GenericParamDefKind::Const { ty, .. } } =
                         gen

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1268,8 +1268,8 @@ impl Attributes {
         for attr in self.other_attrs.lists(sym::doc).filter(|a| a.has_name(sym::alias)) {
             if let Some(values) = attr.meta_item_list() {
                 for l in values {
-                    match l.literal().unwrap().kind {
-                        ast::LitKind::Str(s, _) => {
+                    match ast::LitKind::from_token_lit(l.literal().unwrap().token_lit) {
+                        Ok(ast::LitKind::Str(s, _)) => {
                             aliases.insert(s);
                         }
                         _ => unreachable!(),

--- a/src/test/ui/codemap_tests/unicode_2.stderr
+++ b/src/test/ui/codemap_tests/unicode_2.stderr
@@ -1,3 +1,9 @@
+error[E0425]: cannot find value `a̐é` in this scope
+  --> $DIR/unicode_2.rs:4:13
+   |
+LL |     let _ = a̐é;
+   |             ^^ not found in this scope
+
 error: invalid width `7` for integer literal
   --> $DIR/unicode_2.rs:2:25
    |
@@ -13,12 +19,6 @@ LL |     let _ = ("아あ", 1i42);
    |                      ^^^^
    |
    = help: valid widths are 8, 16, 32, 64 and 128
-
-error[E0425]: cannot find value `a̐é` in this scope
-  --> $DIR/unicode_2.rs:4:13
-   |
-LL |     let _ = a̐é;
-   |             ^^ not found in this scope
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/extenv/issue-55897.rs
+++ b/src/test/ui/extenv/issue-55897.rs
@@ -14,7 +14,7 @@ mod nonexistent_env {
 
 mod erroneous_literal {
     include!(concat!("NON_EXISTENT"suffix, "/data.rs"));
-    //~^ ERROR suffixes on a string literal are invalid
+    //~^ ERROR cannot concatenate an invalid literal
 }
 
 fn main() {}

--- a/src/test/ui/extenv/issue-55897.stderr
+++ b/src/test/ui/extenv/issue-55897.stderr
@@ -6,11 +6,11 @@ LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    |
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: suffixes on a string literal are invalid
+error: cannot concatenate an invalid literal
   --> $DIR/issue-55897.rs:16:22
    |
 LL |     include!(concat!("NON_EXISTENT"suffix, "/data.rs"));
-   |                      ^^^^^^^^^^^^^^^^^^^^ invalid suffix `suffix`
+   |                      ^^^^^^^^^^^^^^^^^^^^
 
 error[E0432]: unresolved import `prelude`
   --> $DIR/issue-55897.rs:1:5

--- a/src/test/ui/lowering/literals.rs
+++ b/src/test/ui/lowering/literals.rs
@@ -6,29 +6,32 @@
 #![feature(concat_bytes)]
 
 #[repr(align(340282366920938463463374607431768211456))]
-//~^ ERROR integer literal is too large
+//~^ ERROR invalid `repr(align)` attribute: not an unsuffixed integer [E0589]
+//~^^ ERROR invalid `repr(align)` attribute: not an unsuffixed integer [E0589]
 struct S1(u32);
 
-#[repr(align(4u7))] //~ ERROR invalid width `7` for integer literal
+#[repr(align(4u7))]
+//~^ ERROR suffixed literals are not allowed in attributes
+//~^^ ERROR invalid `repr(align)` attribute: not an unsuffixed integer [E0589]
+//~^^^ ERROR invalid `repr(align)` attribute: not an unsuffixed integer [E0589]
 struct S2(u32);
 
 #[doc = "documentation"suffix]
-//~^ ERROR suffixes on a string literal are invalid
-//~^^ ERROR attribute must be of the form
-//~^^^ WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+//~^ ERROR suffixed literals are not allowed in attributes
 struct D;
 
-#[doc(alias = 0u7)] //~ ERROR invalid width `7` for integer literal
+#[doc(alias = 0u7)]
+//~^ ERROR doc alias attribute expects a string `#[doc(alias = "a")]` or a list of strings `#[doc(alias("a", "b"))]`
+//~^^ ERROR suffixed literals are not allowed in attributes
 struct E;
 
 fn main() {
     println!(concat!(
-        "abc"suffix, //~ ERROR suffixes on a string literal are invalid
-        "blah"foo, //~ ERROR suffixes on a string literal are invalid
-        3u33, //~ ERROR invalid width `33` for integer literal
+        "abc"suffix, //~ ERROR cannot concatenate an invalid literal
+        "blah"foo, //~ ERROR cannot concatenate an invalid literal
+        3u33, //~ ERROR cannot concatenate an invalid literal
     ));
 
     let x = concat_bytes!("foo"blah, 3u33);
-    //~^ ERROR suffixes on a string literal are invalid
-    //~^^ ERROR invalid width `33` for integer literal
+    //~^ ERROR cannot concatenate invalid literals
 }

--- a/src/test/ui/lowering/literals.rs
+++ b/src/test/ui/lowering/literals.rs
@@ -1,0 +1,34 @@
+// check-fail
+
+// A variety of code features that require the value of a literal prior to AST
+// lowering.
+
+#![feature(concat_bytes)]
+
+#[repr(align(340282366920938463463374607431768211456))]
+//~^ ERROR integer literal is too large
+struct S1(u32);
+
+#[repr(align(4u7))] //~ ERROR invalid width `7` for integer literal
+struct S2(u32);
+
+#[doc = "documentation"suffix]
+//~^ ERROR suffixes on a string literal are invalid
+//~^^ ERROR attribute must be of the form
+//~^^^ WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+struct D;
+
+#[doc(alias = 0u7)] //~ ERROR invalid width `7` for integer literal
+struct E;
+
+fn main() {
+    println!(concat!(
+        "abc"suffix, //~ ERROR suffixes on a string literal are invalid
+        "blah"foo, //~ ERROR suffixes on a string literal are invalid
+        3u33, //~ ERROR invalid width `33` for integer literal
+    ));
+
+    let x = concat_bytes!("foo"blah, 3u33);
+    //~^ ERROR suffixes on a string literal are invalid
+    //~^^ ERROR invalid width `33` for integer literal
+}

--- a/src/test/ui/lowering/literals.stderr
+++ b/src/test/ui/lowering/literals.stderr
@@ -1,0 +1,74 @@
+error: suffixes on a string literal are invalid
+  --> $DIR/literals.rs:15:9
+   |
+LL | #[doc = "documentation"suffix]
+   |         ^^^^^^^^^^^^^^^^^^^^^ invalid suffix `suffix`
+
+error: suffixes on a string literal are invalid
+  --> $DIR/literals.rs:26:9
+   |
+LL |         "abc"suffix,
+   |         ^^^^^^^^^^^ invalid suffix `suffix`
+
+error: suffixes on a string literal are invalid
+  --> $DIR/literals.rs:27:9
+   |
+LL |         "blah"foo,
+   |         ^^^^^^^^^ invalid suffix `foo`
+
+error: invalid width `33` for integer literal
+  --> $DIR/literals.rs:28:9
+   |
+LL |         3u33,
+   |         ^^^^
+   |
+   = help: valid widths are 8, 16, 32, 64 and 128
+
+error: suffixes on a string literal are invalid
+  --> $DIR/literals.rs:31:27
+   |
+LL |     let x = concat_bytes!("foo"blah, 3u33);
+   |                           ^^^^^^^^^ invalid suffix `blah`
+
+error: invalid width `33` for integer literal
+  --> $DIR/literals.rs:31:38
+   |
+LL |     let x = concat_bytes!("foo"blah, 3u33);
+   |                                      ^^^^
+   |
+   = help: valid widths are 8, 16, 32, 64 and 128
+
+error: integer literal is too large
+  --> $DIR/literals.rs:8:14
+   |
+LL | #[repr(align(340282366920938463463374607431768211456))]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid width `7` for integer literal
+  --> $DIR/literals.rs:12:14
+   |
+LL | #[repr(align(4u7))]
+   |              ^^^
+   |
+   = help: valid widths are 8, 16, 32, 64 and 128
+
+error: invalid width `7` for integer literal
+  --> $DIR/literals.rs:21:15
+   |
+LL | #[doc(alias = 0u7)]
+   |               ^^^
+   |
+   = help: valid widths are 8, 16, 32, 64 and 128
+
+error: attribute must be of the form `#[doc(hidden|inline|...)]` or `#[doc = "string"]`
+  --> $DIR/literals.rs:15:1
+   |
+LL | #[doc = "documentation"suffix]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+error: aborting due to 10 previous errors
+

--- a/src/test/ui/lowering/literals.stderr
+++ b/src/test/ui/lowering/literals.stderr
@@ -1,74 +1,81 @@
-error: suffixes on a string literal are invalid
-  --> $DIR/literals.rs:15:9
-   |
-LL | #[doc = "documentation"suffix]
-   |         ^^^^^^^^^^^^^^^^^^^^^ invalid suffix `suffix`
-
-error: suffixes on a string literal are invalid
-  --> $DIR/literals.rs:26:9
+error: cannot concatenate an invalid literal
+  --> $DIR/literals.rs:30:9
    |
 LL |         "abc"suffix,
-   |         ^^^^^^^^^^^ invalid suffix `suffix`
+   |         ^^^^^^^^^^^
 
-error: suffixes on a string literal are invalid
-  --> $DIR/literals.rs:27:9
+error: cannot concatenate an invalid literal
+  --> $DIR/literals.rs:31:9
    |
 LL |         "blah"foo,
-   |         ^^^^^^^^^ invalid suffix `foo`
+   |         ^^^^^^^^^
 
-error: invalid width `33` for integer literal
-  --> $DIR/literals.rs:28:9
+error: cannot concatenate an invalid literal
+  --> $DIR/literals.rs:32:9
    |
 LL |         3u33,
    |         ^^^^
-   |
-   = help: valid widths are 8, 16, 32, 64 and 128
 
-error: suffixes on a string literal are invalid
-  --> $DIR/literals.rs:31:27
+error: cannot concatenate invalid literals
+  --> $DIR/literals.rs:35:27
    |
 LL |     let x = concat_bytes!("foo"blah, 3u33);
-   |                           ^^^^^^^^^ invalid suffix `blah`
+   |                           ^^^^^^^^^
 
-error: invalid width `33` for integer literal
-  --> $DIR/literals.rs:31:38
-   |
-LL |     let x = concat_bytes!("foo"blah, 3u33);
-   |                                      ^^^^
-   |
-   = help: valid widths are 8, 16, 32, 64 and 128
-
-error: integer literal is too large
-  --> $DIR/literals.rs:8:14
-   |
-LL | #[repr(align(340282366920938463463374607431768211456))]
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: invalid width `7` for integer literal
-  --> $DIR/literals.rs:12:14
+error: suffixed literals are not allowed in attributes
+  --> $DIR/literals.rs:13:14
    |
 LL | #[repr(align(4u7))]
    |              ^^^
    |
-   = help: valid widths are 8, 16, 32, 64 and 128
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
-error: invalid width `7` for integer literal
-  --> $DIR/literals.rs:21:15
+error: suffixed literals are not allowed in attributes
+  --> $DIR/literals.rs:19:9
+   |
+LL | #[doc = "documentation"suffix]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
+
+error: suffixed literals are not allowed in attributes
+  --> $DIR/literals.rs:23:15
    |
 LL | #[doc(alias = 0u7)]
    |               ^^^
    |
-   = help: valid widths are 8, 16, 32, 64 and 128
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
-error: attribute must be of the form `#[doc(hidden|inline|...)]` or `#[doc = "string"]`
-  --> $DIR/literals.rs:15:1
+error[E0589]: invalid `repr(align)` attribute: not an unsuffixed integer
+  --> $DIR/literals.rs:8:8
    |
-LL | #[doc = "documentation"suffix]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[repr(align(340282366920938463463374607431768211456))]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0589]: invalid `repr(align)` attribute: not an unsuffixed integer
+  --> $DIR/literals.rs:13:8
    |
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+LL | #[repr(align(4u7))]
+   |        ^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error: doc alias attribute expects a string `#[doc(alias = "a")]` or a list of strings `#[doc(alias("a", "b"))]`
+  --> $DIR/literals.rs:23:7
+   |
+LL | #[doc(alias = 0u7)]
+   |       ^^^^^^^^^^^
 
+error[E0589]: invalid `repr(align)` attribute: not an unsuffixed integer
+  --> $DIR/literals.rs:8:8
+   |
+LL | #[repr(align(340282366920938463463374607431768211456))]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0589]: invalid `repr(align)` attribute: not an unsuffixed integer
+  --> $DIR/literals.rs:13:8
+   |
+LL | #[repr(align(4u7))]
+   |        ^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0589`.

--- a/src/test/ui/parser/bad-lit-suffixes.rs
+++ b/src/test/ui/parser/bad-lit-suffixes.rs
@@ -1,9 +1,9 @@
 extern
-    "C"suffix //~ ERROR suffixes on a string literal are invalid
+    "C"suffix //~ ERROR non-string ABI literal
     fn foo() {}
 
 extern
-    "C"suffix //~ ERROR suffixes on a string literal are invalid
+    "C"suffix //~ ERROR non-string ABI literal
 {}
 
 fn main() {

--- a/src/test/ui/parser/bad-lit-suffixes.stderr
+++ b/src/test/ui/parser/bad-lit-suffixes.stderr
@@ -1,14 +1,14 @@
-error: suffixes on a string literal are invalid
+error: non-string ABI literal
   --> $DIR/bad-lit-suffixes.rs:2:5
    |
 LL |     "C"suffix
-   |     ^^^^^^^^^ invalid suffix `suffix`
+   |     ^^^^^^^^^ help: specify the ABI with a string literal: `"C"`
 
-error: suffixes on a string literal are invalid
+error: non-string ABI literal
   --> $DIR/bad-lit-suffixes.rs:6:5
    |
 LL |     "C"suffix
-   |     ^^^^^^^^^ invalid suffix `suffix`
+   |     ^^^^^^^^^ help: specify the ABI with a string literal: `"C"`
 
 error: suffixes on a string literal are invalid
   --> $DIR/bad-lit-suffixes.rs:10:5

--- a/src/tools/clippy/clippy_lints/src/almost_complete_letter_range.rs
+++ b/src/tools/clippy/clippy_lints/src/almost_complete_letter_range.rs
@@ -75,9 +75,18 @@ fn check_range(cx: &EarlyContext<'_>, span: Span, start: &Expr, end: &Expr, sugg
     if let ExprKind::Lit(start_lit) = &start.peel_parens().kind
         && let ExprKind::Lit(end_lit) = &end.peel_parens().kind
         && matches!(
-            (&start_lit.kind, &end_lit.kind),
-            (LitKind::Byte(b'a') | LitKind::Char('a'), LitKind::Byte(b'z') | LitKind::Char('z'))
-            | (LitKind::Byte(b'A') | LitKind::Char('A'), LitKind::Byte(b'Z') | LitKind::Char('Z'))
+            (
+                LitKind::from_token_lit(start_lit.token_lit),
+                LitKind::from_token_lit(end_lit.token_lit),
+            ),
+            (
+                Ok(LitKind::Byte(b'a') | LitKind::Char('a')),
+                Ok(LitKind::Byte(b'z') | LitKind::Char('z'))
+            )
+            | (
+                Ok(LitKind::Byte(b'A') | LitKind::Char('A')),
+                Ok(LitKind::Byte(b'Z') | LitKind::Char('Z')),
+            )
         )
     {
         span_lint_and_then(

--- a/src/tools/clippy/clippy_lints/src/attrs.rs
+++ b/src/tools/clippy/clippy_lints/src/attrs.rs
@@ -552,7 +552,7 @@ fn check_attrs(cx: &LateContext<'_>, span: Span, name: Symbol, attrs: &[Attribut
 }
 
 fn check_semver(cx: &LateContext<'_>, span: Span, lit: &Lit) {
-    if let LitKind::Str(is, _) = lit.kind {
+    if let Ok(LitKind::Str(is, _)) = LitKind::from_token_lit(lit.token_lit) {
         if Version::parse(is.as_str()).is_ok() {
             return;
         }

--- a/src/tools/clippy/clippy_lints/src/int_plus_one.rs
+++ b/src/tools/clippy/clippy_lints/src/int_plus_one.rs
@@ -53,7 +53,7 @@ enum Side {
 impl IntPlusOne {
     #[expect(clippy::cast_sign_loss)]
     fn check_lit(lit: &Lit, target_value: i128) -> bool {
-        if let LitKind::Int(value, ..) = lit.kind {
+        if let Ok(LitKind::Int(value, ..)) = LitKind::from_token_lit(lit.token_lit) {
             return value == (target_value as u128);
         }
         false

--- a/src/tools/clippy/clippy_lints/src/literal_representation.rs
+++ b/src/tools/clippy/clippy_lints/src/literal_representation.rs
@@ -472,7 +472,7 @@ impl DecimalLiteralRepresentation {
     fn check_lit(self, cx: &EarlyContext<'_>, lit: &Lit) {
         // Lint integral literals.
         if_chain! {
-            if let LitKind::Int(val, _) = lit.kind;
+            if let Ok(LitKind::Int(val, _)) = LitKind::from_token_lit(lit.token_lit);
             if let Some(src) = snippet_opt(cx, lit.span);
             if let Some(num_lit) = NumericLiteral::from_lit(&src, lit);
             if num_lit.radix == Radix::Decimal;

--- a/src/tools/clippy/clippy_lints/src/misc_early/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/misc_early/mod.rs
@@ -394,7 +394,8 @@ impl MiscEarlyLints {
             _ => return,
         };
 
-        if let LitKind::Int(value, lit_int_type) = lit.kind {
+        let lit_kind = LitKind::from_token_lit(lit.token_lit);
+        if let Ok(LitKind::Int(value, lit_int_type)) = lit_kind {
             let suffix = match lit_int_type {
                 LitIntType::Signed(ty) => ty.name_str(),
                 LitIntType::Unsigned(ty) => ty.name_str(),
@@ -408,7 +409,7 @@ impl MiscEarlyLints {
             } else if value != 0 && lit_snip.starts_with('0') {
                 zero_prefixed_literal::check(cx, lit, &lit_snip);
             }
-        } else if let LitKind::Float(_, LitFloatType::Suffixed(float_ty)) = lit.kind {
+        } else if let Ok(LitKind::Float(_, LitFloatType::Suffixed(float_ty))) = lit_kind {
             let suffix = float_ty.name_str();
             literal_suffix::check(cx, lit, &lit_snip, suffix, "float");
         }

--- a/src/tools/clippy/clippy_lints/src/precedence.rs
+++ b/src/tools/clippy/clippy_lints/src/precedence.rs
@@ -1,7 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_applicability;
 use if_chain::if_chain;
-use rustc_ast::ast::{BinOpKind, Expr, ExprKind, LitKind, UnOp};
+use rustc_ast::ast::{BinOpKind, Expr, ExprKind, UnOp};
+use rustc_ast::token;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -120,7 +121,7 @@ impl EarlyLintPass for Precedence {
             if_chain! {
                 if !all_odd;
                 if let ExprKind::Lit(lit) = &arg.kind;
-                if let LitKind::Int(..) | LitKind::Float(..) = &lit.kind;
+                if let token::LitKind::Integer | token::LitKind::Float = lit.token_lit.kind;
                 then {
                     let mut applicability = Applicability::MachineApplicable;
                     span_lint_and_sugg(

--- a/src/tools/clippy/clippy_lints/src/unused_rounding.rs
+++ b/src/tools/clippy/clippy_lints/src/unused_rounding.rs
@@ -34,7 +34,7 @@ fn is_useless_rounding(expr: &Expr) -> Option<(&str, String)> {
         && let method_name = name_ident.ident.name.as_str()
         && (method_name == "ceil" || method_name == "round" || method_name == "floor")
         && let ExprKind::Lit(spanned) = &receiver.kind
-        && let LitKind::Float(symbol, ty) = spanned.kind {
+        && let Ok(LitKind::Float(symbol, ty)) = LitKind::from_token_lit(spanned.token_lit) {
             let f = symbol.as_str().parse::<f64>().unwrap();
             let f_str = symbol.to_string() + if let LitFloatType::Suffixed(ty) = ty {
                 ty.name_str()

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -152,7 +152,7 @@ pub fn eq_expr(l: &Expr, r: &Expr) -> bool {
         },
         (Binary(lo, ll, lr), Binary(ro, rl, rr)) => lo.node == ro.node && eq_expr(ll, rl) && eq_expr(lr, rr),
         (Unary(lo, l), Unary(ro, r)) => mem::discriminant(lo) == mem::discriminant(ro) && eq_expr(l, r),
-        (Lit(l), Lit(r)) => l.kind == r.kind,
+        (Lit(l), Lit(r)) => l.token_lit == r.token_lit,
         (Cast(l, lt), Cast(r, rt)) | (Type(l, lt), Type(r, rt)) => eq_expr(l, r) && eq_ty(lt, rt),
         (Let(lp, le, _), Let(rp, re, _)) => eq_pat(lp, rp) && eq_expr(le, re),
         (If(lc, lt, le), If(rc, rt, re)) => eq_expr(lc, rc) && eq_block(lt, rt) && eq_expr_opt(le, re),
@@ -706,7 +706,7 @@ pub fn eq_mac_args(l: &MacArgs, r: &MacArgs) -> bool {
         (Empty, Empty) => true,
         (Delimited(_, ld, lts), Delimited(_, rd, rts)) => ld == rd && lts.eq_unspanned(rts),
         (Eq(_, MacArgsEq::Ast(le)), Eq(_, MacArgsEq::Ast(re))) => eq_expr(le, re),
-        (Eq(_, MacArgsEq::Hir(ll)), Eq(_, MacArgsEq::Hir(rl))) => ll.kind == rl.kind,
+        (Eq(_, MacArgsEq::Hir(ll)), Eq(_, MacArgsEq::Hir(rl))) => ll.token_lit == rl.token_lit,
         _ => false,
     }
 }

--- a/src/tools/clippy/clippy_utils/src/numeric_literal.rs
+++ b/src/tools/clippy/clippy_utils/src/numeric_literal.rs
@@ -47,7 +47,8 @@ pub struct NumericLiteral<'a> {
 
 impl<'a> NumericLiteral<'a> {
     pub fn from_lit(src: &'a str, lit: &Lit) -> Option<NumericLiteral<'a>> {
-        NumericLiteral::from_lit_kind(src, &lit.kind)
+        let lit_kind = LitKind::from_token_lit(lit.token_lit).ok()?;
+        NumericLiteral::from_lit_kind(src, &lit_kind)
     }
 
     pub fn from_lit_kind(src: &'a str, lit_kind: &LitKind) -> Option<NumericLiteral<'a>> {

--- a/src/tools/rustfmt/src/modules/visitor.rs
+++ b/src/tools/rustfmt/src/modules/visitor.rs
@@ -85,24 +85,21 @@ impl PathVisitor {
 
 impl<'ast> MetaVisitor<'ast> for PathVisitor {
     fn visit_meta_name_value(&mut self, meta_item: &'ast ast::MetaItem, lit: &'ast ast::Lit) {
-        if meta_item.has_name(Symbol::intern("path")) && lit.kind.is_str() {
+        if meta_item.has_name(Symbol::intern("path")) && lit.token_lit.is_str() {
             self.paths.push(lit_to_str(lit));
         }
     }
 }
 
-#[cfg(not(windows))]
 fn lit_to_str(lit: &ast::Lit) -> String {
-    match lit.kind {
-        ast::LitKind::Str(symbol, ..) => symbol.to_string(),
-        _ => unreachable!(),
-    }
-}
-
-#[cfg(windows)]
-fn lit_to_str(lit: &ast::Lit) -> String {
-    match lit.kind {
-        ast::LitKind::Str(symbol, ..) => symbol.as_str().replace("/", "\\"),
+    match ast::LitKind::from_token_lit(lit.token_lit) {
+        Ok(ast::LitKind::Str(symbol, ..)) => {
+            if cfg!(windows) {
+                symbol.as_str().replace("/", "\\")
+            } else {
+                symbol.to_string()
+            }
+        }
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
This is an alternative to the "Remove `token::Lit` from `ast::Lit` commit in #101562.

r? @petrochenkov 