### PR TITLE
Avoid duplicating StorageLive in let-else

### DIFF
--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -232,7 +232,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         pattern,
                         UserTypeProjections::none(),
                         &mut |this, _, _, _, node, span, _, _| {
-                            this.storage_live_binding(block, node, span, OutsideGuard, false);
+                            this.storage_live_binding(block, node, span, OutsideGuard, true);
+                            this.schedule_drop_for_binding(node, span, OutsideGuard);
                         },
                     );
                     let failure = unpack!(

--- a/src/test/mir-opt/issue-101867.rs
+++ b/src/test/mir-opt/issue-101867.rs
@@ -1,4 +1,4 @@
-#![feature(let_else)]
+#![cfg_attr(bootstrap, feature(let_else))]
 
 // EMIT_MIR issue_101867.main.mir_map.0.mir
 fn main() {

--- a/src/test/mir-opt/issue-101867.rs
+++ b/src/test/mir-opt/issue-101867.rs
@@ -1,0 +1,9 @@
+#![feature(let_else)]
+
+// EMIT_MIR issue_101867.main.mir_map.0.mir
+fn main() {
+    let x: Option<u8> = Some(1);
+    let Some(y) = x else {
+        panic!();
+    };
+}

--- a/src/test/mir-opt/issue_101867.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_101867.main.mir_map.0.mir
@@ -1,0 +1,75 @@
+// MIR for `main` 0 mir_map
+
+| User Type Annotations
+| 0: user_ty: Canonical { max_universe: U0, variables: [], value: Ty(std::option::Option<u8>) }, span: $DIR/issue-101867.rs:5:12: 5:22, inferred_ty: std::option::Option<u8>
+| 1: user_ty: Canonical { max_universe: U0, variables: [], value: Ty(std::option::Option<u8>) }, span: $DIR/issue-101867.rs:5:12: 5:22, inferred_ty: std::option::Option<u8>
+|
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/issue-101867.rs:+0:11: +0:11
+    let _1: std::option::Option<u8> as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 0 at $DIR/issue-101867.rs:+1:9: +1:10
+    let mut _2: !;                       // in scope 0 at $DIR/issue-101867.rs:+2:26: +4:6
+    let _3: ();                          // in scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
+    let mut _4: !;                       // in scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
+    let mut _6: isize;                   // in scope 0 at $DIR/issue-101867.rs:+2:9: +2:16
+    scope 1 {
+        debug x => _1;                   // in scope 1 at $DIR/issue-101867.rs:+1:9: +1:10
+        let _5: u8;                      // in scope 1 at $DIR/issue-101867.rs:+2:14: +2:15
+        scope 2 {
+            debug y => _5;               // in scope 2 at $DIR/issue-101867.rs:+2:14: +2:15
+        }
+    }
+
+    bb0: {
+        StorageLive(_1);                 // scope 0 at $DIR/issue-101867.rs:+1:9: +1:10
+        _1 = Option::<u8>::Some(const 1_u8); // scope 0 at $DIR/issue-101867.rs:+1:25: +1:32
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/issue-101867.rs:+1:9: +1:10
+        AscribeUserType(_1, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/issue-101867.rs:+1:12: +1:22
+        StorageLive(_5);                 // scope 1 at $DIR/issue-101867.rs:+2:14: +2:15
+        FakeRead(ForMatchedPlace(None), _1); // scope 1 at $DIR/issue-101867.rs:+2:19: +2:20
+        _6 = discriminant(_1);           // scope 1 at $DIR/issue-101867.rs:+2:19: +2:20
+        switchInt(move _6) -> [1_isize: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-101867.rs:+2:9: +2:16
+    }
+
+    bb1: {
+        StorageLive(_3);                 // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
+        StorageLive(_4);                 // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
+        _4 = begin_panic::<&str>(const "explicit panic") -> bb7; // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/std/src/panic.rs:LL:COL
+                                         // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(<ZST>) }
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/std/src/panic.rs:LL:COL
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
+    }
+
+    bb2: {
+        StorageDead(_4);                 // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
+        StorageDead(_3);                 // scope 1 at $DIR/issue-101867.rs:+3:16: +3:17
+        unreachable;                     // scope 1 at $DIR/issue-101867.rs:+2:26: +4:6
+    }
+
+    bb3: {
+        goto -> bb6;                     // scope 1 at $DIR/issue-101867.rs:+2:19: +2:20
+    }
+
+    bb4: {
+        falseEdge -> [real: bb5, imaginary: bb3]; // scope 1 at $DIR/issue-101867.rs:+2:9: +2:16
+    }
+
+    bb5: {
+        _5 = ((_1 as Some).0: u8);       // scope 1 at $DIR/issue-101867.rs:+2:14: +2:15
+        _0 = const ();                   // scope 0 at $DIR/issue-101867.rs:+0:11: +5:2
+        StorageDead(_5);                 // scope 1 at $DIR/issue-101867.rs:+5:1: +5:2
+        StorageDead(_1);                 // scope 0 at $DIR/issue-101867.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/issue-101867.rs:+5:2: +5:2
+    }
+
+    bb6: {
+        StorageDead(_5);                 // scope 1 at $DIR/issue-101867.rs:+5:1: +5:2
+        goto -> bb1;                     // scope 0 at $DIR/issue-101867.rs:+0:11: +5:2
+    }
+
+    bb7 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-101867.rs:+0:1: +5:2
+    }
+}

--- a/src/test/ui/let-else/const-fn.rs
+++ b/src/test/ui/let-else/const-fn.rs
@@ -1,0 +1,19 @@
+// run-pass
+// issue #101932
+
+#![cfg_attr(bootstrap, feature(let_else))]
+
+const fn foo(a: Option<i32>) -> i32 {
+    let Some(a) = a else {
+        return 42
+    };
+
+    a + 1
+}
+
+fn main() {
+    const A: i32 = foo(None);
+    const B: i32 = foo(Some(1));
+
+    println!("{} {}", A, B);
+}


### PR DESCRIPTION
cc @est31 

Fix #101867
Fix #101932

#101410 introduced directives to activate storages of bindings in let-else earlier. However, since it is using the machinery of `match` and friends for pattern matching and binding, those storages are activated for the second time. This PR adjusts this behavior and avoid the duplicated activation for let-else statements.