### PR TITLE
Remove some unused CSS rules

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -119,9 +119,6 @@ pre, .rustdoc.source .example-wrap {
 .content span.traitalias, .content a.traitalias { color: #39AFD7; }
 .content span.keyword, .content a.keyword { color: #39AFD7; }
 
-.content span.externcrate, .content span.mod, .content a.mod {
-	color: #39AFD7;
-}
 .content span.struct, .content a.struct {
 	color: #ffa0a5;
 }
@@ -131,20 +128,12 @@ pre, .rustdoc.source .example-wrap {
 .content span.trait, .content a.trait {
 	color: #39AFD7;
 }
-.content span.type, .content a.type {
-	color: #39AFD7;
-}
 .content span.type,
 .content a.type,
 .block a.current.type { color: #39AFD7; }
-.content span.associatedtype,
-.content a.associatedtype,
-.block a.current.associatedtype { color: #39AFD7; }
-.content span.fn, .content a.fn, .content span.method,
-.content a.method, .content span.tymethod,
-.content a.tymethod, .content .fnname {
-	color: #fdd687;
-}
+.content span.associatedtype, .content a.associatedtype { color: #39AFD7; }
+.content span.fn, .content a.fn,
+.content .fnname { color: #fdd687; }
 .content span.attr, .content a.attr, .content span.derive,
 .content a.derive, .content span.macro, .content a.macro {
 	color: #a37acc;
@@ -152,7 +141,6 @@ pre, .rustdoc.source .example-wrap {
 
 .sidebar a { color: #53b1db; }
 .sidebar a.current.type { color: #53b1db; }
-.sidebar a.current.associatedtype { color: #53b1db; }
 
 pre.rust .comment { color: #788797; }
 pre.rust .doccomment { color: #a1ac88; }
@@ -290,24 +278,19 @@ individually rather than as a group) */
 /* FIXME: these rules should be at the bottom of the file but currently must be
 above the `@media (max-width: 700px)` rules due to a bug in the css checker */
 /* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
-.content span.attr,.content a.attr,.block a.current.attr,.content span.derive,.content a.derive,
-.block a.current.derive,.content span.macro,.content a.macro,.block a.current.macro {}
+.content span.attr, .content a.attr, .block a.current.attr,
+.content span.derive,.content a.derive, .block a.current.derive,
+.content span.macro,.content a.macro,.block a.current.macro {}
 .content span.struct,.content a.struct,.block a.current.struct {}
-#titles>button:hover,#titles>button.selected {}
-.content span.typedef,.content a.typedef,.block a.current.typedef {}
-.content span.union,.content a.union,.block a.current.union {}
+#titles > button:hover, #titles > button.selected {}
+.content span.union, .content a.union, .block a.current.union {}
 pre.rust .lifetime {}
-.stab.unstable {}
-h2,
-h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod) {}
-.content span.enum,.content a.enum,.block a.current.enum {}
-.content span.constant,.content a.constant,.block a.current.constant,.content span.static,
+.content span.enum, .content a.enum, .block a.current.enum {}
+.content span.constant, .content a.constant, .block a.current.constant, .content span.static,
 .content a.static, .block a.current.static {}
-.content span.keyword,.content a.keyword,.block a.current.keyword {}
+.content span.keyword, .content a.keyword, .block a.current.keyword {}
 .content span.traitalias,.content a.traitalias,.block a.current.traitalias {}
-.content span.fn,.content a.fn,.block a.current.fn,.content span.method,.content a.method,
-.block a.current.method,.content span.tymethod,.content a.tymethod,.block a.current.tymethod,
-.content .fnname {}
+.content span.fn,.content a.fn,.block a.current.fn, .content .fnname {}
 pre.rust .kw {}
 pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
 .content span.foreigntype,.content a.foreigntype,.block a.current.foreigntype {}
@@ -315,7 +298,6 @@ pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
 .content a.attr,.content a.derive,.content a.macro {}
 .stab.portability {}
 .content span.primitive,.content a.primitive,.block a.current.primitive {}
-.content span.externcrate,.content span.mod,.content a.mod,.block a.current.mod {}
 pre.rust .kw-2,pre.rust .prelude-ty {}
 .content span.trait,.content a.trait,.block a.current.trait {}
 
@@ -353,13 +335,9 @@ a.result-keyword:focus {}
 .sidebar a.current.constant
 .sidebar a.current.static {}
 .sidebar a.current.primitive {}
-.sidebar a.current.externcrate
-.sidebar a.current.mod {}
 .sidebar a.current.trait {}
 .sidebar a.current.traitalias {}
-.sidebar a.current.fn,
-.sidebar a.current.method,
-.sidebar a.current.tymethod {}
+.sidebar a.current.fn {}
 .sidebar a.current.keyword {}
 
 kbd {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -118,7 +118,9 @@ pre, .rustdoc.source .example-wrap {
 .content span.primitive, .content a.primitive { color: #ffa0a5; }
 .content span.traitalias, .content a.traitalias { color: #39AFD7; }
 .content span.keyword, .content a.keyword { color: #39AFD7; }
-
+.content span.mod, .content a.mod {
+	color: #39AFD7;
+}
 .content span.struct, .content a.struct {
 	color: #ffa0a5;
 }
@@ -128,9 +130,7 @@ pre, .rustdoc.source .example-wrap {
 .content span.trait, .content a.trait {
 	color: #39AFD7;
 }
-.content span.type,
-.content a.type,
-.block a.current.type { color: #39AFD7; }
+.content span.type, .content a.type { color: #39AFD7; }
 .content span.associatedtype, .content a.associatedtype { color: #39AFD7; }
 .content span.fn, .content a.fn,
 .content .fnname { color: #fdd687; }
@@ -278,28 +278,29 @@ individually rather than as a group) */
 /* FIXME: these rules should be at the bottom of the file but currently must be
 above the `@media (max-width: 700px)` rules due to a bug in the css checker */
 /* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
-.content span.attr, .content a.attr, .block a.current.attr,
-.content span.derive,.content a.derive, .block a.current.derive,
-.content span.macro,.content a.macro,.block a.current.macro {}
-.content span.struct,.content a.struct,.block a.current.struct {}
+.content span.attr, .content a.attr,
+.content span.derive,.content a.derive,
+.content span.macro,.content a.macro {}
+.content span.struct,.content a.struct {}
 #titles > button:hover, #titles > button.selected {}
-.content span.union, .content a.union, .block a.current.union {}
+.content span.union, .content a.union {}
 pre.rust .lifetime {}
-.content span.enum, .content a.enum, .block a.current.enum {}
-.content span.constant, .content a.constant, .block a.current.constant, .content span.static,
-.content a.static, .block a.current.static {}
-.content span.keyword, .content a.keyword, .block a.current.keyword {}
-.content span.traitalias,.content a.traitalias,.block a.current.traitalias {}
-.content span.fn,.content a.fn,.block a.current.fn, .content .fnname {}
+.content span.enum, .content a.enum {}
+.content span.constant, .content a.constant,
+.content span.static, .content a.static {}
+.content span.keyword, .content a.keyword {}
+.content span.traitalias,.content a.traitalias {}
+.content span.fn,.content a.fn,
+.content .fnname {}
 pre.rust .kw {}
 pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
-.content span.foreigntype,.content a.foreigntype,.block a.current.foreigntype {}
+.content span.foreigntype,.content a.foreigntype {}
 .stab.deprecated {}
 .content a.attr,.content a.derive,.content a.macro {}
 .stab.portability {}
-.content span.primitive,.content a.primitive,.block a.current.primitive {}
+.content span.primitive,.content a.primitive {}
 pre.rust .kw-2,pre.rust .prelude-ty {}
-.content span.trait,.content a.trait,.block a.current.trait {}
+.content span.trait,.content a.trait {}
 
 .search-results a:focus span {}
 a.result-trait:focus {}

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -278,29 +278,11 @@ individually rather than as a group) */
 /* FIXME: these rules should be at the bottom of the file but currently must be
 above the `@media (max-width: 700px)` rules due to a bug in the css checker */
 /* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
-.content span.attr, .content a.attr,
-.content span.derive,.content a.derive,
-.content span.macro,.content a.macro {}
-.content span.struct,.content a.struct {}
-#titles > button:hover, #titles > button.selected {}
-.content span.union, .content a.union {}
 pre.rust .lifetime {}
-.content span.enum, .content a.enum {}
-.content span.constant, .content a.constant,
-.content span.static, .content a.static {}
-.content span.keyword, .content a.keyword {}
-.content span.traitalias,.content a.traitalias {}
-.content span.fn,.content a.fn,
-.content .fnname {}
 pre.rust .kw {}
-pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
-.content span.foreigntype,.content a.foreigntype {}
-.stab.deprecated {}
-.content a.attr,.content a.derive,.content a.macro {}
-.stab.portability {}
-.content span.primitive,.content a.primitive {}
-pre.rust .kw-2,pre.rust .prelude-ty {}
-.content span.trait,.content a.trait {}
+#titles > button:hover, #titles > button.selected {}
+pre.rust .self, pre.rust .bool-val, pre.rust .prelude-val, pre.rust .attribute {}
+pre.rust .kw-2, pre.rust .prelude-ty {}
 
 .search-results a:focus span {}
 a.result-trait:focus {}

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -86,9 +86,7 @@ a.result-keyword:focus { background-color: #884719; }
 .content span.enum, .content a.enum, .block a.current.enum { color: #2dbfb8; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #2dbfb8; }
-.content span.associatedtype,
-.content a.associatedtype,
-.block a.current.associatedtype { color: #D2991D; }
+.content span.associatedtype, .content a.associatedtype { color: #D2991D; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #2dbfb8; }
 .content span.attr, .content a.attr, .block a.current.attr,
 .content span.derive, .content a.derive, .block a.current.derive,
@@ -97,21 +95,16 @@ a.result-keyword:focus { background-color: #884719; }
 .content span.constant, .content a.constant, .block a.current.constant,
 .content span.static, .content a.static, .block a.current.static { color: #D2991D; }
 .content span.primitive, .content a.primitive, .block a.current.primitive { color: #2dbfb8; }
-.content span.externcrate,
-.content span.mod, .content a.mod, .block a.current.mod { color: #D2991D; }
 .content span.trait, .content a.trait, .block a.current.trait { color: #b78cf2; }
 .content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #b78cf2; }
 .content span.fn, .content a.fn, .block a.current.fn,
-.content span.method, .content a.method, .block a.current.method,
-.content span.tymethod, .content a.tymethod, .block a.current.tymethod,
-.content .fnname{ color: #2BAB63; }
+.content .fnname { color: #2BAB63; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #D2991D; }
 
 .sidebar a { color: #fdbf35; }
 .sidebar a.current.enum { color: #12ece2; }
 .sidebar a.current.struct { color: #12ece2; }
 .sidebar a.current.type { color: #12ece2; }
-.sidebar a.current.associatedtype { color: #fdbf35; }
 .sidebar a.current.foreigntype { color: #12ece2; }
 .sidebar a.current.attr,
 .sidebar a.current.derive,
@@ -120,13 +113,9 @@ a.result-keyword:focus { background-color: #884719; }
 .sidebar a.current.constant
 .sidebar a.current.static { color: #fdbf35; }
 .sidebar a.current.primitive { color: #12ece2; }
-.sidebar a.current.externcrate
-.sidebar a.current.mod { color: #fdbf35; }
 .sidebar a.current.trait { color: #cca7ff; }
 .sidebar a.current.traitalias { color: #cca7ff; }
-.sidebar a.current.fn,
-.sidebar a.current.method,
-.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.fn { color: #32d479; }
 .sidebar a.current.keyword { color: #fdbf35; }
 
 pre.rust .comment { color: #8d8d8b; }

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -83,23 +83,24 @@ a.result-keyword:focus { background-color: #884719; }
 
 .content .item-info::before { color: #ccc; }
 
-.content span.enum, .content a.enum, .block a.current.enum { color: #2dbfb8; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
-.content span.type, .content a.type, .block a.current.type { color: #2dbfb8; }
+.content span.enum, .content a.enum { color: #2dbfb8; }
+.content span.struct, .content a.struct { color: #2dbfb8; }
+.content span.type, .content a.type { color: #2dbfb8; }
 .content span.associatedtype, .content a.associatedtype { color: #D2991D; }
-.content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #2dbfb8; }
-.content span.attr, .content a.attr, .block a.current.attr,
-.content span.derive, .content a.derive, .block a.current.derive,
-.content span.macro, .content a.macro, .block a.current.macro { color: #09bd00; }
-.content span.union, .content a.union, .block a.current.union { color: #2dbfb8; }
-.content span.constant, .content a.constant, .block a.current.constant,
-.content span.static, .content a.static, .block a.current.static { color: #D2991D; }
-.content span.primitive, .content a.primitive, .block a.current.primitive { color: #2dbfb8; }
-.content span.trait, .content a.trait, .block a.current.trait { color: #b78cf2; }
-.content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #b78cf2; }
-.content span.fn, .content a.fn, .block a.current.fn,
+.content span.foreigntype, .content a.foreigntype { color: #2dbfb8; }
+.content span.attr, .content a.attr,
+.content span.derive, .content a.derive,
+.content span.macro, .content a.macro { color: #09bd00; }
+.content span.union, .content a.union { color: #2dbfb8; }
+.content span.constant, .content a.constant,
+.content span.static, .content a.static { color: #D2991D; }
+.content span.primitive, .content a.primitive { color: #2dbfb8; }
+.content span.mod, .content a.mod { color: #D2991D; }
+.content span.trait, .content a.trait { color: #b78cf2; }
+.content span.traitalias, .content a.traitalias { color: #b78cf2; }
+.content span.fn, .content a.fn,
 .content .fnname { color: #2BAB63; }
-.content span.keyword, .content a.keyword, .block a.current.keyword { color: #D2991D; }
+.content span.keyword, .content a.keyword { color: #D2991D; }
 
 .sidebar a { color: #fdbf35; }
 .sidebar a.current.enum { color: #12ece2; }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -82,23 +82,24 @@ a.result-keyword:focus { background-color: #afc6e4; }
 
 .content .item-info::before { color: #ccc; }
 
-.content span.enum, .content a.enum, .block a.current.enum { color: #AD378A; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #AD378A; }
-.content span.type, .content a.type, .block a.current.type { color:  #AD378A; }
+.content span.enum, .content a.enum { color: #AD378A; }
+.content span.struct, .content a.struct { color: #AD378A; }
+.content span.type, .content a.type { color:  #AD378A; }
 .content span.associatedtype, .content a.associatedtype { color: #3873AD; }
-.content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #3873AD; }
-.content span.attr, .content a.attr, .block a.current.attr,
-.content span.derive, .content a.derive, .block a.current.derive,
-.content span.macro, .content a.macro, .block a.current.macro { color: #068000; }
-.content span.union, .content a.union, .block a.current.union { color: #AD378A; }
-.content span.constant, .content a.constant, .block a.current.constant,
-.content span.static, .content a.static, .block a.current.static { color: #3873AD; }
-.content span.primitive, .content a.primitive, .block a.current.primitive { color: #AD378A; }
-.content span.trait, .content a.trait, .block a.current.trait { color: #6E4FC9; }
-.content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #5137AD; }
-.content span.fn, .content a.fn, .block a.current.fn,
+.content span.foreigntype, .content a.foreigntype { color: #3873AD; }
+.content span.attr, .content a.attr,
+.content span.derive, .content a.derive,
+.content span.macro, .content a.macro { color: #068000; }
+.content span.union, .content a.union { color: #AD378A; }
+.content span.constant, .content a.constant,
+.content span.static, .content a.static { color: #3873AD; }
+.content span.primitive, .content a.primitive { color: #AD378A; }
+.content span.mod, .content a.mod { color: #3873AD; }
+.content span.trait, .content a.trait { color: #6E4FC9; }
+.content span.traitalias, .content a.traitalias { color: #5137AD; }
+.content span.fn, .content a.fn,
 .content .fnname { color: #AD7C37; }
-.content span.keyword, .content a.keyword, .block a.current.keyword { color: #3873AD; }
+.content span.keyword, .content a.keyword { color: #3873AD; }
 
 .sidebar a { color: #356da4; }
 .sidebar a.current.enum { color: #a63283; }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -85,10 +85,8 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .content span.enum, .content a.enum, .block a.current.enum { color: #AD378A; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #AD378A; }
 .content span.type, .content a.type, .block a.current.type { color:  #AD378A; }
+.content span.associatedtype, .content a.associatedtype { color: #3873AD; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #3873AD; }
-.content span.associatedtype,
-.content a.associatedtype,
-.block a.current.associatedtype { color: #3873AD; }
 .content span.attr, .content a.attr, .block a.current.attr,
 .content span.derive, .content a.derive, .block a.current.derive,
 .content span.macro, .content a.macro, .block a.current.macro { color: #068000; }
@@ -96,13 +94,9 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .content span.constant, .content a.constant, .block a.current.constant,
 .content span.static, .content a.static, .block a.current.static { color: #3873AD; }
 .content span.primitive, .content a.primitive, .block a.current.primitive { color: #AD378A; }
-.content span.externcrate,
-.content span.mod, .content a.mod, .block a.current.mod { color: #3873AD; }
 .content span.trait, .content a.trait, .block a.current.trait { color: #6E4FC9; }
 .content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #5137AD; }
 .content span.fn, .content a.fn, .block a.current.fn,
-.content span.method, .content a.method, .block a.current.method,
-.content span.tymethod, .content a.tymethod, .block a.current.tymethod,
 .content .fnname { color: #AD7C37; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #3873AD; }
 
@@ -110,7 +104,6 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .sidebar a.current.enum { color: #a63283; }
 .sidebar a.current.struct { color: #a63283; }
 .sidebar a.current.type { color: #a63283; }
-.sidebar a.current.associatedtype { color: #356da4; }
 .sidebar a.current.foreigntype { color: #356da4; }
 .sidebar a.current.attr,
 .sidebar a.current.derive,
@@ -119,13 +112,9 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .sidebar a.current.constant
 .sidebar a.current.static { color: #356da4; }
 .sidebar a.current.primitive { color: #a63283; }
-.sidebar a.current.externcrate
-.sidebar a.current.mod { color: #356da4; }
 .sidebar a.current.trait { color: #6849c3; }
 .sidebar a.current.traitalias { color: #4b349e; }
-.sidebar a.current.fn,
-.sidebar a.current.method,
-.sidebar a.current.tymethod { color: #a67736; }
+.sidebar a.current.fn { color: #a67736; }
 .sidebar a.current.keyword { color: #356da4; }
 
 a {


### PR DESCRIPTION
Since we now have list of items for the ones on the page, we don't need the CSS rules anymore in the sidebar (`.sidebar a`). As for the `.content` ones, they are used to highlight the items in the page (for definitions and others). Surprisingly enough, `method` and `tymethod` are all replaced with `fnname`.

I also used this opportunity to remove these rules in `ayu.css`:

```css
.stab.unstable {}
h2,
h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod) {}
```
 
In the second commit, I removed the `.block a.current*` CSS rules as they're overridden by `.sidebar a.current*` CSS rules.

In the third commit I removed unneeded empty rules (that were there to satisfy the `--check-theme` option).

cc @jsha
r? @notriddle 