### PR TITLE
reimplement `~const Trait` bounds via a fourth kind of generic param

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -612,6 +612,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 (
                     GenericArgKind::Lifetime(_)
                     | GenericArgKind::Type(_)
+                    | GenericArgKind::Effect(_)
                     | GenericArgKind::Const(_),
                     _,
                 ) => {

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -382,6 +382,7 @@ fn check_opaque_type_parameter_valid(
                 matches!(*lt, ty::ReEarlyBound(_) | ty::ReFree(_))
             }
             GenericArgKind::Const(ct) => matches!(ct.kind(), ty::ConstKind::Param(_)),
+            GenericArgKind::Effect(e) => matches!(e.val, ty::EffectValue::Param { .. }),
         };
 
         if arg_is_param {

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -169,7 +169,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
                 .type_must_outlive(origin, t1, r2, constraint_category);
             }
 
-            GenericArgKind::Const(_) => unreachable!(),
+            GenericArgKind::Effect(_) | GenericArgKind::Const(_) => unreachable!(),
         }
     }
 

--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -61,6 +61,13 @@ where
                 _ => c.super_visit_with(self),
             }
         }
+
+        fn visit_effect(&mut self, e: ty::Effect<'tcx>) -> ControlFlow<Self::BreakTy> {
+            match e.val {
+                ty::EffectValue::Param { .. } => ControlFlow::Break(FoundParam),
+                _ => e.super_visit_with(self),
+            }
+        }
     }
 
     let mut vis = UsedParamsNeedSubstVisitor { tcx };

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -808,7 +808,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                                 return;
                             }
                         }
-                        _ if !tcx.is_const_fn_raw(callee) => {
+                        _ if !self.tcx.effects() && !tcx.is_const_fn_raw(callee) => {
                             // At this point, it is only legal when the caller is in a trait
                             // marked with #[const_trait], and the callee is in the same trait.
                             let mut nonconst_call_permission = false;

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -344,9 +344,11 @@ impl<'mir, 'tcx> Checker<'mir, 'tcx> {
             let ty = match ty.unpack() {
                 GenericArgKind::Type(ty) => ty,
 
-                // No constraints on lifetimes or constants, except potentially
+                // No constraints on lifetimes, effects or constants, except potentially
                 // constants' types, but `walk` will get to them as well.
-                GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
+                GenericArgKind::Effect(_)
+                | GenericArgKind::Lifetime(_)
+                | GenericArgKind::Const(_) => continue,
             };
 
             match *ty.kind() {

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -157,8 +157,16 @@ impl Qualif for NeedsNonConstDrop {
             cx.tcx,
             ObligationCause::dummy_with_span(cx.body.span),
             cx.param_env,
-            ty::Binder::dummy(cx.tcx.at(cx.body.span).mk_trait_ref(LangItem::Destruct, [ty]))
-                .with_constness(ty::BoundConstness::ConstIfConst),
+            ty::Binder::dummy(cx.tcx.at(cx.body.span).mk_trait_ref_with_effect(
+                LangItem::Destruct,
+                [ty],
+                cx.def_id().to_def_id(),
+            ))
+            .with_constness(if cx.tcx.effects() {
+                ty::BoundConstness::NotConst
+            } else {
+                ty::BoundConstness::ConstIfConst
+            }),
         );
 
         let infcx = cx.tcx.infer_ctxt().build();

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -22,6 +22,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
     type Type = Self;
     type DynExistential = Self;
     type Const = Self;
+    type Effect = Self;
 
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
@@ -69,6 +70,10 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
 
     fn print_const(self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
         self.pretty_print_const(ct, false)
+    }
+
+    fn print_effect(self, _: ty::Effect<'tcx>) -> Result<Self::Effect, Self::Error> {
+        unimplemented!()
     }
 
     fn print_dyn_existential(

--- a/compiler/rustc_error_messages/locales/en-US/middle.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/middle.ftl
@@ -32,5 +32,5 @@ middle_strict_coherence_needs_negative_coherence =
     to use `strict_coherence` on this trait, the `with_negative_coherence` feature must be enabled
     .label = due to this attribute
 
-middle_const_not_used_in_type_alias =
-    const parameter `{$ct}` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+middle_param_not_used_in_type_alias =
+    parameter `{$param}` is part of concrete type but not used in parameter list for the `impl Trait` type alias

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1272,6 +1272,7 @@ impl HandlerInner {
     }
 
     // FIXME(eddyb) this should ideally take `diagnostic` by value.
+    #[track_caller]
     fn emit_diagnostic(&mut self, diagnostic: &mut Diagnostic) -> Option<ErrorGuaranteed> {
         // The `LintExpectationId` can be stable or unstable depending on when it was created.
         // Diagnostics created before the definition of `HirId`s are unstable and can not yet
@@ -1540,6 +1541,7 @@ impl HandlerInner {
         panic::panic_any(ExplicitBug);
     }
 
+    #[track_caller]
     fn emit_diag_at_span(&mut self, mut diag: Diagnostic, sp: impl Into<MultiSpan>) {
         self.emit_diagnostic(diag.set_span(sp));
     }
@@ -1653,6 +1655,7 @@ impl HandlerInner {
         self.warn_count += 1;
     }
 
+    #[track_caller]
     fn panic_if_treat_err_as_bug(&self) {
         if self.treat_err_as_bug() {
             match (

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -384,6 +384,8 @@ declare_features! (
     (active, doc_masked, "1.21.0", Some(44027), None),
     /// Allows `dyn* Trait` objects.
     (incomplete, dyn_star, "1.65.0", Some(102425), None),
+    // Uses generic effect parameters for ~const bounds
+    (active, effects, "1.62.0", Some(102090), None),
     /// Allows `X..Y` patterns.
     (active, exclusive_range_pattern, "1.11.0", Some(37854), None),
     /// Allows exhaustive pattern matching on types that contain uninhabited types.

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -264,6 +264,43 @@ impl DefKind {
             | DefKind::ExternCrate => false,
         }
     }
+
+    pub fn require_const(self) -> bool {
+        match self {
+            DefKind::Const
+            | DefKind::Static(_)
+            | DefKind::AssocConst
+            | DefKind::AnonConst
+            | DefKind::InlineConst => true,
+            DefKind::Fn
+            | DefKind::AssocFn
+            | DefKind::Ctor(..)
+            | DefKind::Closure
+            | DefKind::Generator
+            | DefKind::Mod
+            | DefKind::Struct
+            | DefKind::Union
+            | DefKind::Enum
+            | DefKind::Variant
+            | DefKind::Trait
+            | DefKind::TyAlias
+            | DefKind::ForeignTy
+            | DefKind::TraitAlias
+            | DefKind::AssocTy
+            | DefKind::Macro(..)
+            | DefKind::Use
+            | DefKind::ForeignMod
+            | DefKind::OpaqueTy
+            | DefKind::ImplTraitPlaceholder
+            | DefKind::Impl
+            | DefKind::Field
+            | DefKind::TyParam
+            | DefKind::ConstParam
+            | DefKind::LifetimeParam
+            | DefKind::GlobalAsm
+            | DefKind::ExternCrate => false,
+        }
+    }
 }
 
 /// The resolution of a path or export.

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -212,6 +212,7 @@ language_item_table! {
     Fn,                      kw::Fn,                   fn_trait,                   Target::Trait,          GenericRequirement::Exact(1);
     FnMut,                   sym::fn_mut,              fn_mut_trait,               Target::Trait,          GenericRequirement::Exact(1);
     FnOnce,                  sym::fn_once,             fn_once_trait,              Target::Trait,          GenericRequirement::Exact(1);
+    Callable,                sym::callable,            callable_trait,             Target::Trait,          GenericRequirement::Exact(1);
 
     FnOnceOutput,            sym::fn_once_output,      fn_once_output,             Target::AssocTy,        GenericRequirement::None;
 

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -319,6 +319,15 @@ impl<'tcx> TypeRelation<'tcx> for SimpleEqRelation<'tcx> {
         ty::relate::super_relate_consts(self, a, b)
     }
 
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        b: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        debug!("SimpleEqRelation::effects(a={:?}, b={:?})", a, b);
+        ty::relate::super_relate_effect(self, a, b)
+    }
+
     fn binders<T>(
         &mut self,
         a: ty::Binder<'tcx, T>,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1304,7 +1304,7 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
         | GenericParamDefKind::Const { has_default } => {
             has_default && def.index >= generics.parent_count as u32
         }
-        GenericParamDefKind::Lifetime => unreachable!(),
+        GenericParamDefKind::Effect { .. } | GenericParamDefKind::Lifetime => unreachable!(),
     };
 
     // Check that concrete defaults are well-formed. See test `type-check-defaults.rs`.
@@ -1346,8 +1346,8 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
                     }
                 }
             }
-            // Doesn't have defaults.
-            GenericParamDefKind::Lifetime => {}
+            // Don't have defaults.
+            GenericParamDefKind::Effect { .. } | GenericParamDefKind::Lifetime => {}
         }
     }
 
@@ -1361,8 +1361,8 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
     // First we build the defaulted substitution.
     let substs = InternalSubsts::for_item(tcx, def_id.to_def_id(), |param, _| {
         match param.kind {
-            GenericParamDefKind::Lifetime => {
-                // All regions are identity.
+            GenericParamDefKind::Effect { .. } | GenericParamDefKind::Lifetime => {
+                // All regions and effects are identity.
                 tcx.mk_param_from_def(param)
             }
 

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1425,6 +1425,13 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
                     }
                     c.super_visit_with(self)
                 }
+
+                fn visit_effect(&mut self, c: ty::Effect<'tcx>) -> ControlFlow<Self::BreakTy> {
+                    if let ty::EffectValue::Param { index } = c.val {
+                        self.params.insert(index);
+                    }
+                    c.super_visit_with(self)
+                }
             }
             let mut param_count = CountParams::default();
             let has_region = pred.visit_with(&mut param_count).is_break();

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -405,6 +405,15 @@ impl<'tcx> AstConv<'tcx> for ItemCtxt<'tcx> {
         self.tcx().const_error_with_message(ty, span, "bad placeholder constant")
     }
 
+    fn effect_infer(
+        &self,
+        kind: ty::EffectKind,
+        _: Option<&ty::GenericParamDef>,
+        span: Span,
+    ) -> ty::Effect<'tcx> {
+        span_bug!(span, "bad placeholder effect: {kind:?}")
+    }
+
     fn projected_ty_from_poly_trait_ref(
         &self,
         span: Span,

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -42,7 +42,7 @@ pub(super) fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredic
         // an obligation and instead be skipped. Otherwise we'd use
         // `tcx.def_span(def_id);`
 
-        let constness = if tcx.has_attr(def_id, sym::const_trait) {
+        let constness = if !tcx.effects() && tcx.has_attr(def_id, sym::const_trait) {
             ty::BoundConstness::ConstIfConst
         } else {
             ty::BoundConstness::NotConst

--- a/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
+++ b/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
@@ -93,6 +93,13 @@ impl<'tcx> TypeVisitor<'tcx> for ParameterCollector {
 
         c.super_visit_with(self)
     }
+
+    fn visit_effect(&mut self, e: ty::Effect<'tcx>) -> ControlFlow<Self::BreakTy> {
+        if let ty::EffectValue::Param { index } = e.val {
+            self.parameters.push(Parameter(index));
+        }
+        ControlFlow::CONTINUE
+    }
 }
 
 pub fn identify_constrained_generic_params<'tcx>(

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -147,6 +147,11 @@ fn enforce_impl_params_are_constrained(tcx: TyCtxt<'_>, impl_def_id: LocalDefId)
                     );
                 }
             }
+            ty::GenericParamDefKind::Effect { .. } => {
+                if !input_parameters.contains(&cgp::Parameter(param.index)) {
+                    report_unused_parameter(tcx, tcx.def_span(param.def_id), "effect", param.name);
+                }
+            }
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -97,9 +97,11 @@ fn insert_required_predicates_to_be_wf<'tcx>(
         let ty = match arg.unpack() {
             GenericArgKind::Type(ty) => ty,
 
-            // No predicates from lifetimes or constants, except potentially
+            // No predicates from lifetimes, effects or constants, except potentially
             // constants' types, but `walk` will get to them as well.
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
+            GenericArgKind::Effect(_) | GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => {
+                continue;
+            }
         };
 
         match *ty.kind() {

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -112,6 +112,10 @@ fn inferred_outlives_crate(tcx: TyCtxt<'_>, (): ()) -> CratePredicatesMap<'_> {
                             // Generic consts don't impose any constraints.
                             None
                         }
+                        GenericArgKind::Effect(_) => {
+                            // Effects don't impose any constraints.
+                            None
+                        }
                     }
                 },
             ));

--- a/compiler/rustc_hir_analysis/src/outlives/utils.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/utils.rs
@@ -145,6 +145,10 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
         GenericArgKind::Const(_) => {
             // Generic consts don't impose any constraints.
         }
+
+        GenericArgKind::Effect(_) => {
+            // Effect don't impose any constraints.
+        }
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -189,6 +189,8 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 GenericArgKind::Const(val) => {
                     self.add_constraints_from_const(current, val, variance_i)
                 }
+                // There are no constraints from effects
+                GenericArgKind::Effect(_) => {}
             }
         }
     }
@@ -350,6 +352,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 GenericArgKind::Const(val) => {
                     self.add_constraints_from_const(current, val, variance)
                 }
+                GenericArgKind::Effect(_) => {}
             }
         }
     }

--- a/compiler/rustc_hir_analysis/src/variance/mod.rs
+++ b/compiler/rustc_hir_analysis/src/variance/mod.rs
@@ -140,6 +140,7 @@ fn variance_of_opaque(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[ty::Varianc
                         variances[param.index as usize] = ty::Bivariant;
                     }
                     ty::GenericParamDefKind::Type { .. }
+                    | ty::GenericParamDefKind::Effect { .. }
                     | ty::GenericParamDefKind::Const { .. } => {}
                 }
             }

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -20,7 +20,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         base_ty: Ty<'tcx>,
     ) -> Option<InferOk<'tcx, MethodCallee<'tcx>>> {
-        self.try_overloaded_place_op(span, base_ty, &[], PlaceOp::Deref)
+        self.try_overloaded_place_op(span, base_ty, &[], PlaceOp::Deref, self.body_id)
     }
 
     /// Returns the adjustment steps.

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -44,7 +44,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         |InferOk { value: method, obligations: o }| {
                             obligations.extend(o);
                             if let ty::Ref(region, _, mutbl) = *method.sig.output().kind() {
-                                Some(OverloadedDeref { region, mutbl, span: autoderef.span() })
+                                Some(OverloadedDeref {
+                                    region,
+                                    mutbl,
+                                    span: autoderef.span(),
+                                    context: self.body_id.owner.to_def_id(),
+                                })
                             } else {
                                 None
                             }

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -246,6 +246,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 trait_def_id,
                 adjusted_ty,
                 opt_input_type.as_ref().map(slice::from_ref),
+                call_expr.hir_id,
             ) {
                 let method = self.register_infer_ok_obligations(ok);
                 let mut autoref = None;

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1042,7 +1042,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.infcx
                 .type_implements_trait(
                     self.tcx.lang_items().deref_mut_trait()?,
-                    [expr_ty],
+                    [expr_ty.into()].into_iter().chain(self.tcx.host_effect()),
                     self.param_env,
                 )
                 .may_apply()

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -278,6 +278,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 _ => t,
             },
+            e_op: |e| e,
         };
         let mut prev = eraser.fold_ty(ty);
         let mut prev_span = None;

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1246,6 +1246,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.fcx.var_for_def(self.span, param)
                         }
                     }
+                    GenericParamDefKind::Effect { .. } => self.fcx.var_for_def(self.span, param),
                 }
             }
         }

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -296,6 +296,7 @@ pub fn resolve_interior<'a, 'tcx>(
                 },
                 types: &mut |b| bug!("unexpected bound ty in binder: {b:?}"),
                 consts: &mut |b, ty| bug!("unexpected bound ct in binder: {b:?} {ty}"),
+                effects: &mut |b, kind| bug!("unexpected bound effect in binder: {b:?} {kind:?}"),
             },
         )
     } else {

--- a/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
+++ b/compiler/rustc_hir_typeck/src/generator_interior/mod.rs
@@ -306,8 +306,7 @@ pub fn resolve_interior<'a, 'tcx>(
     // Extract type components to build the witness type.
     let type_list = fcx.tcx.mk_type_list(type_causes.iter().map(|cause| cause.ty));
     let bound_vars = fcx.tcx.mk_bound_variable_kinds(bound_vars.iter());
-    let witness =
-        fcx.tcx.mk_generator_witness(ty::Binder::bind_with_vars(type_list, bound_vars.clone()));
+    let witness = fcx.tcx.mk_generator_witness(ty::Binder::bind_with_vars(type_list, bound_vars));
 
     drop(typeck_results);
     // Store the generator types and spans into the typeck results for this generator.

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -277,6 +277,7 @@ fn typeck_with_fallback<'tcx>(
         };
 
         fcx.type_inference_fallback();
+        fcx.effects_inference_fallback();
 
         // Even though coercion casts provide type hints, we check casts after fallback for
         // backwards compatibility. This makes fallback a stronger type hint than a cast coercion.
@@ -301,6 +302,8 @@ fn typeck_with_fallback<'tcx>(
             fcx.require_type_is_sized(ty, span, code);
         }
 
+        // Run effect fallback again as new effect variables may have been introduced
+        fcx.effects_inference_fallback();
         fcx.select_all_obligations_or_error();
 
         if let None = fcx.infcx.tainted_by_errors() {

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -459,17 +459,6 @@ fn fatally_break_rust(sess: &Session) {
     ));
 }
 
-fn has_expected_num_generic_args(
-    tcx: TyCtxt<'_>,
-    trait_did: Option<DefId>,
-    expected: usize,
-) -> bool {
-    trait_did.map_or(true, |trait_did| {
-        let generics = tcx.generics_of(trait_did);
-        generics.count() == expected + if generics.has_self { 1 } else { 0 }
-    })
-}
-
 pub fn provide(providers: &mut Providers) {
     method::provide(providers);
     *providers = Providers {

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -132,12 +132,19 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             );
         }
 
+        self.enforce_context_effects(
+            self.call_expr.hir_id,
+            self.span,
+            self.tcx.mk_fn_def(pick.item.def_id, all_substs),
+        );
+
         // Create the final `MethodCallee`.
         let callee = MethodCallee {
             def_id: pick.item.def_id,
             substs: all_substs,
             sig: method_sig.skip_binder(),
         };
+
         ConfirmResult { callee, illegal_sized_bound }
     }
 
@@ -154,7 +161,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         let mut autoderef = self.autoderef(self.call_expr.span, unadjusted_self_ty);
         let Some((ty, n)) = autoderef.nth(pick.autoderefs) else {
             return self.tcx.ty_error_with_message(
-                rustc_span::DUMMY_SP,
+                self.span,
                 &format!("failed autoderef {}", pick.autoderefs),
             );
         };

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -12,6 +12,7 @@ pub use self::MethodError::*;
 
 use crate::errors::OpMethodGenericParams;
 use crate::FnCtxt;
+use hir::HirId;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Applicability, Diagnostic};
 use rustc_hir as hir;
@@ -273,6 +274,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         trait_def_id: DefId,
         self_ty: Ty<'tcx>,
         opt_input_types: Option<&[Ty<'tcx>]>,
+        _hir_id: HirId,
     ) -> (traits::Obligation<'tcx, ty::Predicate<'tcx>>, &'tcx ty::List<ty::subst::GenericArg<'tcx>>)
     {
         // Construct a trait-reference `self_ty : Trait<input_tys>`
@@ -320,9 +322,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         trait_def_id: DefId,
         self_ty: Ty<'tcx>,
         opt_input_types: Option<&[Ty<'tcx>]>,
+        hir_id: HirId,
     ) -> Option<InferOk<'tcx, MethodCallee<'tcx>>> {
         let (obligation, substs) =
-            self.obligation_for_method(cause, trait_def_id, self_ty, opt_input_types);
+            self.obligation_for_method(cause, trait_def_id, self_ty, opt_input_types, hir_id);
         self.construct_obligation_for_trait(m_name, trait_def_id, obligation, substs)
     }
 

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -278,7 +278,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Construct a trait-reference `self_ty : Trait<input_tys>`
         let substs = InternalSubsts::for_item(self.tcx, trait_def_id, |param, _| {
             match param.kind {
-                GenericParamDefKind::Lifetime | GenericParamDefKind::Const { .. } => {}
+                GenericParamDefKind::Lifetime
+                | GenericParamDefKind::Const { .. }
+                | GenericParamDefKind::Effect { .. } => {}
                 GenericParamDefKind::Type { .. } => {
                     if param.index == 0 {
                         return self_ty.into();

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -21,7 +21,6 @@ use rustc_infer::infer::{
     type_variable::{TypeVariableOrigin, TypeVariableOriginKind},
     RegionVariableOrigin,
 };
-use rustc_middle::infer::unify_key::EffectVariableOrigin;
 use rustc_middle::infer::unify_key::EffectVariableOriginKind;
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc_middle::traits::util::supertraits;
@@ -1191,11 +1190,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 .into(),
                             GenericArgKind::Effect(e) => self
                                 .next_effect_var(
+                                    rustc_span::DUMMY_SP,
+                                    EffectVariableOriginKind::MiscVariable,
                                     e.kind,
-                                    EffectVariableOrigin {
-                                        span: rustc_span::DUMMY_SP,
-                                        kind: EffectVariableOriginKind::MiscVariable,
-                                    },
                                 )
                                 .into(),
                         }

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -21,6 +21,8 @@ use rustc_infer::infer::{
     type_variable::{TypeVariableOrigin, TypeVariableOriginKind},
     RegionVariableOrigin,
 };
+use rustc_middle::infer::unify_key::EffectVariableOrigin;
+use rustc_middle::infer::unify_key::EffectVariableOriginKind;
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc_middle::traits::util::supertraits;
 use rustc_middle::ty::fast_reject::DeepRejectCtxt;
@@ -1184,6 +1186,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     ConstVariableOrigin {
                                         span: rustc_span::DUMMY_SP,
                                         kind: ConstVariableOriginKind::MiscVariable,
+                                    },
+                                )
+                                .into(),
+                            GenericArgKind::Effect(e) => self
+                                .next_effect_var(
+                                    e.kind,
+                                    EffectVariableOrigin {
+                                        span: rustc_span::DUMMY_SP,
+                                        kind: EffectVariableOriginKind::MiscVariable,
                                     },
                                 )
                                 .into(),

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -1,7 +1,7 @@
 //! Code related to processing overloaded binary and unary operators.
 
 use super::method::MethodCallee;
-use super::{has_expected_num_generic_args, FnCtxt};
+use super::FnCtxt;
 use crate::Expectation;
 use rustc_ast as ast;
 use rustc_errors::{self, struct_span_err, Applicability, Diagnostic};
@@ -723,26 +723,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             "lookup_op_method(lhs_ty={:?}, op={:?}, opname={:?}, trait_did={:?})",
             lhs_ty, op, opname, trait_did
         );
-
-        // Catches cases like #83893, where a lang item is declared with the
-        // wrong number of generic arguments. Should have yielded an error
-        // elsewhere by now, but we have to catch it here so that we do not
-        // index `other_tys` out of bounds (if the lang item has too many
-        // generic arguments, `other_tys` is too short).
-        if !has_expected_num_generic_args(
-            self.tcx,
-            trait_did,
-            match op {
-                // Binary ops have a generic right-hand side, unary ops don't
-                Op::Binary(..) => 1,
-                Op::Unary(..) => 0,
-            },
-        ) {
-            self.tcx
-                .sess
-                .delay_span_bug(span, "operator didn't have the right number of generic args");
-            return Err(vec![]);
-        }
 
         let opname = Ident::with_dummy_span(opname);
         let input_types =

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -1,5 +1,5 @@
 use crate::method::MethodCallee;
-use crate::{has_expected_num_generic_args, FnCtxt, PlaceOp};
+use crate::{FnCtxt, PlaceOp};
 use rustc_ast as ast;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -209,20 +209,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PlaceOp::Index => (self.tcx.lang_items().index_trait(), sym::index),
         };
 
-        // If the lang item was declared incorrectly, stop here so that we don't
-        // run into an ICE (#83893). The error is reported where the lang item is
-        // declared.
-        if !has_expected_num_generic_args(
-            self.tcx,
-            imm_tr,
-            match op {
-                PlaceOp::Deref => 0,
-                PlaceOp::Index => 1,
-            },
-        ) {
-            return None;
-        }
-
         imm_tr.and_then(|trait_did| {
             self.lookup_method_in_trait(
                 self.misc(span),
@@ -247,20 +233,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PlaceOp::Deref => (self.tcx.lang_items().deref_mut_trait(), sym::deref_mut),
             PlaceOp::Index => (self.tcx.lang_items().index_mut_trait(), sym::index_mut),
         };
-
-        // If the lang item was declared incorrectly, stop here so that we don't
-        // run into an ICE (#83893). The error is reported where the lang item is
-        // declared.
-        if !has_expected_num_generic_args(
-            self.tcx,
-            mut_tr,
-            match op {
-                PlaceOp::Deref => 0,
-                PlaceOp::Index => 1,
-            },
-        ) {
-            return None;
-        }
 
         mut_tr.and_then(|trait_did| {
             self.lookup_method_in_trait(

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     {
                         let method = self.register_infer_ok_obligations(ok);
                         if let ty::Ref(region, _, mutbl) = *method.sig.output().kind() {
-                            *deref = OverloadedDeref { region, mutbl, span: deref.span };
+                            *deref = OverloadedDeref { region, mutbl, span: deref.span, context: self.body_id.owner.to_def_id() };
                         }
                         // If this is a union field, also throw an error for `DerefMut` of `ManuallyDrop` (see RFC 2514).
                         // This helps avoid accidental drops.

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -801,12 +801,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Resolver<'cx, 'tcx> {
     fn fold_effect(&mut self, e: ty::Effect<'tcx>) -> ty::Effect<'tcx> {
         match self.infcx.fully_resolve(e) {
             Ok(e) => e,
-            Err(_) => {
-                debug!("Resolver::fold_effect: input effect `{e:?}` not fully resolvable");
-                let err = self.report_error(e);
-                self.replaced_with_error = Some(err);
-                self.tcx().effect_error(e.kind)
-            }
+            Err(_) => bug!("Resolver::fold_effect: input effect `{e:?}` not fully resolvable"),
         }
     }
 }

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -797,6 +797,18 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Resolver<'cx, 'tcx> {
             }
         }
     }
+
+    fn fold_effect(&mut self, e: ty::Effect<'tcx>) -> ty::Effect<'tcx> {
+        match self.infcx.fully_resolve(e) {
+            Ok(e) => e,
+            Err(_) => {
+                debug!("Resolver::fold_effect: input effect `{e:?}` not fully resolvable");
+                let err = self.report_error(e);
+                self.replaced_with_error = Some(err);
+                self.tcx().effect_error(e.kind)
+            }
+        }
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -369,6 +369,21 @@ impl<'tcx> ToTrace<'tcx> for Const<'tcx> {
     }
 }
 
+impl<'tcx> ToTrace<'tcx> for ty::Effect<'tcx> {
+    fn to_trace(
+        _: TyCtxt<'tcx>,
+        cause: &ObligationCause<'tcx>,
+        a_is_expected: bool,
+        a: Self,
+        b: Self,
+    ) -> TypeTrace<'tcx> {
+        TypeTrace {
+            cause: cause.clone(),
+            values: Effects(ExpectedFound::new(a_is_expected, a.into(), b.into())),
+        }
+    }
+}
+
 impl<'tcx> ToTrace<'tcx> for ty::Term<'tcx> {
     fn to_trace(
         _: TyCtxt<'tcx>,

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -545,7 +545,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Canonicalizer<'cx, 'tcx> {
             }
             ty::EffectValue::Bound(debruijn, _) => {
                 if debruijn >= self.binder_index {
-                    bug!("escaping bound type during canonicalization")
+                    bug!("escaping bound effect during canonicalization")
                 } else {
                     return e;
                 }

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -478,6 +478,15 @@ impl<'tcx> InferCtxt<'tcx> {
                         opt_values[b] = Some(*original_value);
                     }
                 }
+                GenericArgKind::Effect(result_value) => {
+                    if let ty::EffectValue::Bound(debrujin, b) = result_value.val {
+                        // ...in which case we would set `canonical_vars[0]` to `Some(const X)`.
+
+                        // We only allow a `ty::INNERMOST` index in substitutions.
+                        assert_eq!(debrujin, ty::INNERMOST);
+                        opt_values[b] = Some(*original_value);
+                    }
+                }
             }
         }
 
@@ -582,6 +591,11 @@ impl<'tcx> InferCtxt<'tcx> {
                 // Consts cannot outlive one another, so we don't expect to
                 // encounter this branch.
                 span_bug!(cause.span, "unexpected const outlives {:?}", predicate);
+            }
+            GenericArgKind::Effect(..) => {
+                // Effects cannot outlive one another, so we don't expect to
+                // encounter this branch.
+                span_bug!(cause.span, "unexpected effect outlives {:?}", predicate);
             }
         };
         let predicate = predicate.0.rebind(atom);

--- a/compiler/rustc_infer/src/infer/canonical/substitute.rs
+++ b/compiler/rustc_infer/src/infer/canonical/substitute.rs
@@ -85,6 +85,12 @@ where
                 GenericArgKind::Const(ct) => ct,
                 c => bug!("{:?} is a const but value is {:?}", bound_ct, c),
             },
+            effects: &mut |bound_effect: ty::BoundVar, _| match var_values.var_values[bound_effect]
+                .unpack()
+            {
+                GenericArgKind::Effect(e) => e,
+                c => bug!("{:?} is an effect but value is {:?}", bound_effect, c),
+            },
         };
 
         tcx.replace_escaping_bound_vars_uncached(value, delegate)

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -174,6 +174,14 @@ impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
         self.fields.infcx.super_combine_consts(self, a, b)
     }
 
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        b: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        self.fields.infcx.super_combine_effect(self, a, b)
+    }
+
     fn binders<T>(
         &mut self,
         a: ty::Binder<'tcx, T>,

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -531,6 +531,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             type Type = !;
             type DynExistential = !;
             type Const = !;
+            type Effect = !;
 
             fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
                 self.tcx
@@ -552,6 +553,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
 
             fn print_const(self, _ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+                Err(NonTrivialPath)
+            }
+
+            fn print_effect(self, _: ty::Effect<'tcx>) -> Result<Self::Effect, Self::Error> {
                 Err(NonTrivialPath)
             }
 

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1583,6 +1583,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         (false, Mismatch::Fixed("trait"))
                     }
                     ValuePairs::Regions(_) => (false, Mismatch::Fixed("lifetime")),
+                    ValuePairs::Effects(_) => (false, Mismatch::Fixed("effect")),
                 };
                 let Some(vals) = self.values_str(values) else {
                     // Derived error. Cancel the emitter.
@@ -2025,6 +2026,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
     {
         match values {
             infer::Regions(exp_found) => self.expected_found_str(exp_found),
+            infer::Effects(exp_found) => self.expected_found_str(exp_found),
             infer::Terms(exp_found) => self.expected_found_str_term(exp_found),
             infer::TraitRefs(exp_found) => {
                 let pretty_exp_found = ty::error::ExpectedFound {

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1583,7 +1583,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         (false, Mismatch::Fixed("trait"))
                     }
                     ValuePairs::Regions(_) => (false, Mismatch::Fixed("lifetime")),
-                    ValuePairs::Effects(_) => (false, Mismatch::Fixed("effect")),
+                    ValuePairs::Effects(_) => (true, Mismatch::Fixed("effect")),
                 };
                 let Some(vals) = self.values_str(values) else {
                     // Derived error. Cancel the emitter.
@@ -2724,6 +2724,7 @@ impl<'tcx> ObligationCauseExt<'tcx> for ObligationCause<'tcx> {
                 TypeError::IntrinsicCast => {
                     Error0308("cannot coerce intrinsics to function pointers")
                 }
+                TypeError::EffectMismatch(_) => Error0308("mismatched effects"),
                 _ => Error0308("mismatched types"),
             },
         }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2609,6 +2609,16 @@ impl<'tcx> TypeRelation<'tcx> for SameTypeModuloInfer<'_, 'tcx> {
         // relation
         Ok(a)
     }
+
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        _b: ty::Effect<'tcx>,
+    ) -> relate::RelateResult<'tcx, ty::Effect<'tcx>> {
+        // FIXME(compiler-errors): This could at least do some first-order
+        // relation
+        Ok(a)
+    }
 }
 
 impl<'tcx> InferCtxt<'tcx> {

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -326,6 +326,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 }
             }
             GenericArgKind::Lifetime(_) => bug!("unexpected lifetime"),
+            GenericArgKind::Effect(_) => bug!("unexpected effect"),
         }
     }
 
@@ -481,6 +482,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 
                             match arg.unpack() {
                                 GenericArgKind::Lifetime(_) => bug!("unexpected lifetime"),
+                                GenericArgKind::Effect(_) => bug!("unexpected effect"),
                                 GenericArgKind::Type(_) => self
                                     .next_ty_var(TypeVariableOrigin {
                                         span: rustc_span::DUMMY_SP,
@@ -753,6 +755,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                     GenericArgKind::Lifetime(_) => 0, // erased
                     GenericArgKind::Type(ty) => self.ty_cost(ty),
                     GenericArgKind::Const(_) => 3, // some non-zero value
+                    GenericArgKind::Effect(_) => 3, // some non-zero value
                 }
             }
             fn ty_cost(self, ty: Ty<'tcx>) -> usize {
@@ -878,6 +881,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
             }
             match inner.unpack() {
                 GenericArgKind::Lifetime(_) => {}
+                GenericArgKind::Effect(_) => {}
                 GenericArgKind::Type(ty) => {
                     if matches!(
                         ty.kind(),

--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -95,6 +95,14 @@ impl<'tcx> TypeRelation<'tcx> for Glb<'_, '_, 'tcx> {
         self.fields.infcx.super_combine_consts(self, a, b)
     }
 
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        b: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        self.fields.infcx.super_combine_effect(self, a, b)
+    }
+
     fn binders<T>(
         &mut self,
         a: ty::Binder<'tcx, T>,

--- a/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
+++ b/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
@@ -97,6 +97,15 @@ impl<'tcx> InferCtxt<'tcx> {
                 self.tcx
                     .mk_const(ty::PlaceholderConst { universe: next_universe, name: bound_var }, ty)
             },
+            effects: &mut |bound_var: ty::BoundVar, kind| {
+                self.tcx.mk_effect(
+                    ty::EffectValue::Placeholder(ty::PlaceholderEffect {
+                        universe: next_universe,
+                        name: bound_var,
+                    }),
+                    kind,
+                )
+            },
         };
 
         debug!(?next_universe);

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -95,6 +95,14 @@ impl<'tcx> TypeRelation<'tcx> for Lub<'_, '_, 'tcx> {
         self.fields.infcx.super_combine_consts(self, a, b)
     }
 
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        b: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        self.fields.infcx.super_combine_effect(self, a, b)
+    }
+
     fn binders<T>(
         &mut self,
         a: ty::Binder<'tcx, T>,

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -106,6 +106,9 @@ pub struct InferCtxtInner<'tcx> {
     /// Map from const parameter variable to the kind of const it represents.
     const_unification_storage: ut::UnificationTableStorage<ty::ConstVid<'tcx>>,
 
+    /// Map from effect parameter variable to the kind of effect it represents.
+    effect_unification_storage: ut::UnificationTableStorage<ty::EffectVid<'tcx>>,
+
     /// Map from integral variable to the kind of integer it represents.
     int_unification_storage: ut::UnificationTableStorage<ty::IntVid>,
 
@@ -165,6 +168,7 @@ impl<'tcx> InferCtxtInner<'tcx> {
             type_variable_storage: type_variable::TypeVariableStorage::new(),
             undo_log: InferCtxtUndoLogs::default(),
             const_unification_storage: ut::UnificationTableStorage::new(),
+            effect_unification_storage: ut::UnificationTableStorage::new(),
             int_unification_storage: ut::UnificationTableStorage::new(),
             float_unification_storage: ut::UnificationTableStorage::new(),
             region_constraint_storage: Some(RegionConstraintStorage::new()),
@@ -230,6 +234,19 @@ impl<'tcx> InferCtxtInner<'tcx> {
         >,
     > {
         self.const_unification_storage.with_log(&mut self.undo_log)
+    }
+
+    #[inline]
+    fn effect_unification_table(
+        &mut self,
+    ) -> ut::UnificationTable<
+        ut::InPlace<
+            ty::EffectVid<'tcx>,
+            &mut ut::UnificationStorage<ty::EffectVid<'tcx>>,
+            &mut InferCtxtUndoLogs<'tcx>,
+        >,
+    > {
+        self.effect_unification_storage.with_log(&mut self.undo_log)
     }
 
     #[inline]

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -380,6 +380,7 @@ pub struct InferCtxt<'tcx> {
 pub enum ValuePairs<'tcx> {
     Regions(ExpectedFound<ty::Region<'tcx>>),
     Terms(ExpectedFound<ty::Term<'tcx>>),
+    Effects(ExpectedFound<ty::Effect<'tcx>>),
     TraitRefs(ExpectedFound<ty::TraitRef<'tcx>>),
     PolyTraitRefs(ExpectedFound<ty::PolyTraitRef<'tcx>>),
     Sigs(ExpectedFound<ty::FnSig<'tcx>>),
@@ -1491,6 +1492,16 @@ impl<'tcx> InferCtxt<'tcx> {
         match self.inner.borrow_mut().const_unification_table().probe_value(vid).val {
             ConstVariableValue::Known { value } => Ok(value),
             ConstVariableValue::Unknown { universe } => Err(universe),
+        }
+    }
+
+    pub fn probe_effect_var(
+        &self,
+        vid: ty::EffectVid<'tcx>,
+    ) -> Result<ty::Effect<'tcx>, ty::UniverseIndex> {
+        match self.inner.borrow_mut().effect_unification_table().probe_value(vid).val {
+            EffectVariableValue::Known { value } => Ok(value),
+            EffectVariableValue::Unknown { universe } => Err(universe),
         }
     }
 

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -360,7 +360,9 @@ impl<'tcx> InferCtxt<'tcx> {
                 .filter(|(i, _)| variances[*i] == ty::Variance::Invariant)
                 .filter_map(|(_, arg)| match arg.unpack() {
                     GenericArgKind::Lifetime(r) => Some(r),
-                    GenericArgKind::Type(_) | GenericArgKind::Const(_) => None,
+                    GenericArgKind::Type(_)
+                    | GenericArgKind::Const(_)
+                    | GenericArgKind::Effect(_) => None,
                 })
                 .chain(std::iter::once(self.tcx.lifetimes.re_static))
                 .collect(),

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -65,6 +65,7 @@ impl<'tcx> InferCtxt<'tcx> {
             tcx: self.tcx,
             lt_op: |lt| lt,
             ct_op: |ct| ct,
+            e_op: |e| e,
             ty_op: |ty| match *ty.kind() {
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. })
                     if replace_opaque_type(def_id) =>
@@ -595,6 +596,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 },
                 lt_op: |lt| lt,
                 ct_op: |ct| ct,
+                e_op: |e| e,
             });
 
             if let ty::PredicateKind::Clause(ty::Clause::Projection(projection)) =

--- a/compiler/rustc_infer/src/infer/outlives/components.rs
+++ b/compiler/rustc_infer/src/infer/outlives/components.rs
@@ -88,6 +88,7 @@ fn compute_components<'tcx>(
                             compute_components(tcx, ty, out, visited);
                         }
                         GenericArgKind::Lifetime(_) => {}
+                        GenericArgKind::Effect(_) => {}
                         GenericArgKind::Const(_) => {
                             compute_components_recursive(tcx, child, out, visited);
                         }
@@ -227,6 +228,8 @@ pub(super) fn compute_components_recursive<'tcx>(
             GenericArgKind::Const(_) => {
                 compute_components_recursive(tcx, child, out, visited);
             }
+            // Effects have no components
+            GenericArgKind::Effect(_) => {}
         }
     }
 }

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -521,6 +521,9 @@ where
                 GenericArgKind::Const(_) => {
                     // Const parameters don't impose constraints.
                 }
+                GenericArgKind::Effect(_) => {
+                    // Effect parameters don't impose constraints.
+                }
             }
         }
     }

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -210,6 +210,16 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
         }
     }
 
+    #[instrument(skip(self), level = "debug")]
+    fn effects(
+        &mut self,
+        pattern: ty::Effect<'tcx>,
+        value: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        debug!("{}.effects({:?}, {:?})", self.tag(), pattern, value);
+        relate::super_relate_effect(self, pattern, value)
+    }
+
     fn binders<T>(
         &mut self,
         pattern: ty::Binder<'tcx, T>,

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -48,6 +48,15 @@ impl<'a, 'tcx> TypeFolder<'tcx> for OpportunisticVarResolver<'a, 'tcx> {
             ct.super_fold_with(self)
         }
     }
+
+    fn fold_effect(&mut self, e: ty::Effect<'tcx>) -> ty::Effect<'tcx> {
+        if !e.has_non_region_infer() {
+            e // micro-optimize -- if there is nothing in this effect that this fold affects...
+        } else {
+            let e = self.infcx.shallow_resolve(e);
+            e.super_fold_with(self)
+        }
+    }
 }
 
 /// The opportunistic region resolver opportunistically resolves regions
@@ -100,6 +109,14 @@ impl<'a, 'tcx> TypeFolder<'tcx> for OpportunisticRegionResolver<'a, 'tcx> {
             ct // micro-optimize -- if there is nothing in this const that this fold affects...
         } else {
             ct.super_fold_with(self)
+        }
+    }
+
+    fn fold_effect(&mut self, e: ty::Effect<'tcx>) -> ty::Effect<'tcx> {
+        if !e.has_infer_regions() {
+            e // micro-optimize -- if there is nothing in this effect that this fold affects...
+        } else {
+            e.super_fold_with(self)
         }
     }
 }

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -209,6 +209,18 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
         self.fields.infcx.super_combine_consts(self, a, b)
     }
 
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        b: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        match (a.val, b.val) {
+            // Any effect matches the rigid "off" effect. For example: `T: ~const Trait` implies `T: Trait`
+            (ty::EffectValue::Rigid { on: false }, _) => Ok(a),
+            _ => self.fields.infcx.super_combine_effect(self, a, b),
+        }
+    }
+
     fn binders<T>(
         &mut self,
         a: ty::Binder<'tcx, T>,

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -215,8 +215,8 @@ impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
         b: ty::Effect<'tcx>,
     ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
         match (a.val, b.val) {
-            // Any effect matches the rigid "off" effect. For example: `T: ~const Trait` implies `T: Trait`
-            (ty::EffectValue::Rigid { on: false }, _) => Ok(a),
+            // Any effect matches the rigid "on" effect. For example: `T: ~const Trait` (off) implies `T: Trait` (on)
+            (ty::EffectValue::Rigid { on: true }, _) => Ok(a),
             _ => self.fields.infcx.super_combine_effect(self, a, b),
         }
     }

--- a/compiler/rustc_infer/src/infer/undo_log.rs
+++ b/compiler/rustc_infer/src/infer/undo_log.rs
@@ -22,6 +22,7 @@ pub(crate) enum UndoLog<'tcx> {
     OpaqueTypes(OpaqueTypeKey<'tcx>, Option<OpaqueHiddenType<'tcx>>),
     TypeVariables(type_variable::UndoLog<'tcx>),
     ConstUnificationTable(sv::UndoLog<ut::Delegate<ty::ConstVid<'tcx>>>),
+    EffectUnificationTable(sv::UndoLog<ut::Delegate<ty::EffectVid<'tcx>>>),
     IntUnificationTable(sv::UndoLog<ut::Delegate<ty::IntVid>>),
     FloatUnificationTable(sv::UndoLog<ut::Delegate<ty::FloatVid>>),
     RegionConstraintCollector(region_constraints::UndoLog<'tcx>),
@@ -57,6 +58,7 @@ impl_from! {
     FloatUnificationTable(sv::UndoLog<ut::Delegate<ty::FloatVid>>),
 
     ConstUnificationTable(sv::UndoLog<ut::Delegate<ty::ConstVid<'tcx>>>),
+    EffectUnificationTable(sv::UndoLog<ut::Delegate<ty::EffectVid<'tcx>>>),
 
     RegionUnificationTable(sv::UndoLog<ut::Delegate<RegionVidKey<'tcx>>>),
     ProjectionCache(traits::UndoLog<'tcx>),
@@ -69,6 +71,7 @@ impl<'tcx> Rollback<UndoLog<'tcx>> for InferCtxtInner<'tcx> {
             UndoLog::OpaqueTypes(key, idx) => self.opaque_type_storage.remove(key, idx),
             UndoLog::TypeVariables(undo) => self.type_variable_storage.reverse(undo),
             UndoLog::ConstUnificationTable(undo) => self.const_unification_storage.reverse(undo),
+            UndoLog::EffectUnificationTable(undo) => self.effect_unification_storage.reverse(undo),
             UndoLog::IntUnificationTable(undo) => self.int_unification_storage.reverse(undo),
             UndoLog::FloatUnificationTable(undo) => self.float_unification_storage.reverse(undo),
             UndoLog::RegionConstraintCollector(undo) => {

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -1151,6 +1151,7 @@ impl<'tcx> LateContext<'tcx> {
             type Type = ();
             type DynExistential = ();
             type Const = ();
+            type Effect = ();
 
             fn tcx(&self) -> TyCtxt<'tcx> {
                 self.tcx
@@ -1172,6 +1173,10 @@ impl<'tcx> LateContext<'tcx> {
             }
 
             fn print_const(self, _ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+                Ok(())
+            }
+
+            fn print_effect(self, _: ty::Effect<'tcx>) -> Result<Self::Effect, Self::Error> {
                 Ok(())
             }
 

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -91,6 +91,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
                 ty_op: |ty| if ty == proj_ty { proj_term } else { ty },
                 lt_op: |lt| lt,
                 ct_op: |ct| ct,
+                e_op: |e| e,
             };
             // For example, in `impl Trait<Assoc = impl Send>`, for all of the bounds on `Assoc`,
             // e.g. `type Assoc: OtherTrait`, replace `<impl Trait as Trait>::Assoc: OtherTrait`

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -94,6 +94,7 @@ macro_rules! arena_types {
             [] tys: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::TyKind<'tcx>>,
             [] predicates: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::PredicateKind<'tcx>>,
             [] consts: rustc_middle::ty::ConstData<'tcx>,
+            [] effects: rustc_middle::ty::EffectData<'tcx>,
 
             // Note that this deliberately duplicates items in the `rustc_hir::arena`,
             // since we need to allocate this type on both the `rustc_hir` arena

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -66,9 +66,9 @@ pub(crate) struct StrictCoherenceNeedsNegativeCoherence {
 }
 
 #[derive(Diagnostic)]
-#[diag(middle_const_not_used_in_type_alias)]
-pub(super) struct ConstNotUsedTraitAlias {
-    pub ct: String,
+#[diag(middle_param_not_used_in_type_alias)]
+pub(super) struct ParamNotUsedTraitAlias {
+    pub param: String,
     #[primary_span]
     pub span: Span,
 }

--- a/compiler/rustc_middle/src/infer/canonical.rs
+++ b/compiler/rustc_middle/src/infer/canonical.rs
@@ -358,6 +358,12 @@ impl<'tcx> CanonicalVarValues<'tcx> {
                             ct.ty(),
                         )
                         .into(),
+                    GenericArgKind::Effect(e) => tcx
+                        .mk_effect(
+                            ty::EffectValue::Bound(ty::INNERMOST, ty::BoundVar::from_u32(i)),
+                            e.kind,
+                        )
+                        .into(),
                 })
                 .collect(),
         }

--- a/compiler/rustc_middle/src/infer/canonical.rs
+++ b/compiler/rustc_middle/src/infer/canonical.rs
@@ -117,6 +117,8 @@ impl<'tcx> CanonicalVarInfo<'tcx> {
             CanonicalVarKind::PlaceholderRegion(..) => false,
             CanonicalVarKind::Const(..) => true,
             CanonicalVarKind::PlaceholderConst(_, _) => false,
+            CanonicalVarKind::Effect(..) => true,
+            CanonicalVarKind::PlaceholderEffect(_, _) => false,
         }
     }
 }
@@ -146,6 +148,12 @@ pub enum CanonicalVarKind<'tcx> {
 
     /// A "placeholder" that represents "any const".
     PlaceholderConst(ty::PlaceholderConst<'tcx>, Ty<'tcx>),
+
+    /// Some kind of effect inference variable.
+    Effect(ty::UniverseIndex, ty::EffectKind),
+
+    /// A "placeholder" that represents "any effect".
+    PlaceholderEffect(ty::PlaceholderEffect, ty::EffectKind),
 }
 
 impl<'tcx> CanonicalVarKind<'tcx> {
@@ -161,6 +169,8 @@ impl<'tcx> CanonicalVarKind<'tcx> {
             CanonicalVarKind::PlaceholderRegion(placeholder) => placeholder.universe,
             CanonicalVarKind::Const(ui, _) => ui,
             CanonicalVarKind::PlaceholderConst(placeholder, _) => placeholder.universe,
+            CanonicalVarKind::Effect(ui, _) => ui,
+            CanonicalVarKind::PlaceholderEffect(placeholder, _) => placeholder.universe,
         }
     }
 }

--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -167,6 +167,7 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
 pub struct EffectVariableOrigin {
     pub kind: EffectVariableOriginKind,
     pub span: Span,
+    pub effect_kind: ty::EffectKind,
 }
 
 /// Reasons to create a effect inference variable

--- a/compiler/rustc_middle/src/traits/select.rs
+++ b/compiler/rustc_middle/src/traits/select.rs
@@ -164,7 +164,7 @@ pub enum SelectionCandidate<'tcx> {
     BuiltinUnsizeCandidate,
 
     /// Implementation of `const Destruct`, optionally from a custom `impl const Drop`.
-    ConstDestructCandidate(Option<DefId>),
+    ConstDestructCandidate(Option<DefId>, ty::Effect<'tcx>),
 }
 
 /// The result of trait evaluation. The order is important

--- a/compiler/rustc_middle/src/ty/_match.rs
+++ b/compiler/rustc_middle/src/ty/_match.rs
@@ -120,6 +120,20 @@ impl<'tcx> TypeRelation<'tcx> for Match<'tcx> {
         relate::super_relate_consts(self, a, b)
     }
 
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        b: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        debug!("{}.effects({:?}, {:?})", self.tag(), a, b);
+
+        if let ty::EffectValue::Infer(ty::InferEffect::Fresh(_)) = b.val {
+            return Ok(a);
+        }
+
+        ty::relate::super_relate_effect(self, a, b)
+    }
+
     fn binders<T>(
         &mut self,
         a: ty::Binder<'tcx, T>,

--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -1,4 +1,5 @@
 use crate::ty::{self, Ty, TyCtxt};
+use hir::def_id::DefId;
 use rustc_hir as hir;
 use rustc_hir::lang_items::LangItem;
 use rustc_macros::HashStable;
@@ -116,6 +117,8 @@ pub struct OverloadedDeref<'tcx> {
     /// The `Span` associated with the field access or method call
     /// that triggered this overloaded deref.
     pub span: Span,
+    /// The body that decides what effects are inferred.
+    pub context: DefId,
 }
 
 impl<'tcx> OverloadedDeref<'tcx> {
@@ -131,7 +134,10 @@ impl<'tcx> OverloadedDeref<'tcx> {
             .find(|m| m.kind == ty::AssocKind::Fn)
             .unwrap()
             .def_id;
-        tcx.mk_fn_def(method_def_id, [source])
+        tcx.mk_fn_def(
+            method_def_id,
+            tcx.mk_substs_trait_with_effect(trait_def_id, [source], self.context),
+        )
     }
 }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -139,6 +139,12 @@ impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for ty::Const<'tcx> {
     }
 }
 
+impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for ty::Effect<'tcx> {
+    fn encode(&self, e: &mut E) {
+        self.0.0.encode(e);
+    }
+}
+
 impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for ConstAllocation<'tcx> {
     fn encode(&self, e: &mut E) {
         self.inner().encode(e)
@@ -312,6 +318,12 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for ty::Const<'tcx> {
     fn decode(decoder: &mut D) -> Self {
         let consts: ty::ConstData<'tcx> = Decodable::decode(decoder);
         decoder.interner().mk_const(consts.kind, consts.ty)
+    }
+}
+
+impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for ty::Effect<'tcx> {
+    fn decode(decoder: &mut D) -> Self {
+        decoder.interner().mk_effect_internal(Decodable::decode(decoder))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/effect.rs
+++ b/compiler/rustc_middle/src/ty/effect.rs
@@ -74,6 +74,18 @@ pub enum EffectKind {
     Host,
 }
 
+impl<'tcx> From<InferEffect<'tcx>> for EffectValue<'tcx> {
+    fn from(infer: InferEffect<'tcx>) -> Self {
+        Self::Infer(infer)
+    }
+}
+
+impl<'tcx> From<EffectVid<'tcx>> for EffectValue<'tcx> {
+    fn from(infer: EffectVid<'tcx>) -> Self {
+        InferEffect::Var(infer).into()
+    }
+}
+
 /// An inference variable for an effect, for use in effect generics.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable, Hash, Lift)]
 #[derive(HashStable)]

--- a/compiler/rustc_middle/src/ty/effect.rs
+++ b/compiler/rustc_middle/src/ty/effect.rs
@@ -23,6 +23,12 @@ impl<'tcx> fmt::Debug for Effect<'tcx> {
     }
 }
 
+impl<'tcx> Effect<'tcx> {
+    pub fn is_e_infer(self) -> bool {
+        matches!(self.val, ty::EffectValue::Infer(_))
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, Debug, TyEncodable, TyDecodable)]
 pub struct EffectData<'tcx> {
     pub val: EffectValue<'tcx>,

--- a/compiler/rustc_middle/src/ty/effect.rs
+++ b/compiler/rustc_middle/src/ty/effect.rs
@@ -19,7 +19,7 @@ impl<'tcx> std::ops::Deref for Effect<'tcx> {
 
 impl<'tcx> fmt::Debug for Effect<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.0.fmt(f)
+        fmt::Display::fmt(self, f)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/effect.rs
+++ b/compiler/rustc_middle/src/ty/effect.rs
@@ -30,6 +30,7 @@ pub struct EffectData<'tcx> {
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, Debug, TyEncodable, TyDecodable)]
+#[derive(Copy)]
 pub enum EffectValue<'tcx> {
     Rigid {
         on: bool,
@@ -52,7 +53,7 @@ pub enum EffectValue<'tcx> {
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, Debug, TyEncodable, TyDecodable)]
-#[derive(Copy)]
+#[derive(Copy, TypeFoldable, TypeVisitable)]
 pub enum EffectKind {
     /// The opposite of `const`. This effect enables access to `static` variables, the file system,
     /// threads, networking, ...

--- a/compiler/rustc_middle/src/ty/effect.rs
+++ b/compiler/rustc_middle/src/ty/effect.rs
@@ -1,0 +1,80 @@
+use super::Placeholder;
+use crate::ty;
+use rustc_data_structures::intern::Interned;
+use rustc_errors::ErrorGuaranteed;
+use rustc_macros::HashStable;
+use std::{fmt, marker::PhantomData};
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable)]
+#[rustc_pass_by_value]
+pub struct Effect<'tcx>(pub Interned<'tcx, EffectData<'tcx>>);
+
+impl<'tcx> std::ops::Deref for Effect<'tcx> {
+    type Target = EffectData<'tcx>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.0
+    }
+}
+
+impl<'tcx> fmt::Debug for Effect<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.0.fmt(f)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, Debug, TyEncodable, TyDecodable)]
+pub struct EffectData<'tcx> {
+    pub val: EffectValue<'tcx>,
+    pub kind: EffectKind,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, Debug, TyEncodable, TyDecodable)]
+pub enum EffectValue<'tcx> {
+    Rigid {
+        on: bool,
+    },
+    /// Effect is forwarded from parent generics
+    Param {
+        index: u32,
+    },
+    /// Only used during type inference to decide on one of `On`/`Off`/`Param`
+    Infer(InferEffect<'tcx>),
+
+    /// Bound effect variable, used only when preparing a trait query.
+    Bound(ty::DebruijnIndex, ty::BoundVar),
+
+    /// A placeholder effect - universally quantified higher-ranked effect.
+    Placeholder(PlaceholderEffect),
+
+    /// An error occurred.
+    Err(ErrorGuaranteed),
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, Debug, TyEncodable, TyDecodable)]
+#[derive(Copy)]
+pub enum EffectKind {
+    /// The opposite of `const`. This effect enables access to `static` variables, the file system,
+    /// threads, networking, ...
+    Host,
+}
+
+/// An inference variable for an effect, for use in effect generics.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable, Hash)]
+#[derive(HashStable)]
+pub enum InferEffect<'tcx> {
+    /// Infer the value of the const.
+    Var(EffectVid<'tcx>),
+    /// A fresh effect variable. See `infer::freshen` for more details.
+    Fresh(u32),
+}
+
+/// An **effect** **v**ariable **ID**.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(HashStable, TyEncodable, TyDecodable)]
+pub struct EffectVid<'tcx> {
+    pub index: u32,
+    pub phantom: PhantomData<&'tcx ()>,
+}
+
+pub type PlaceholderEffect = Placeholder<ty::BoundVar>;

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -71,6 +71,7 @@ pub enum TypeError<'tcx> {
     ProjectionMismatched(ExpectedFound<DefId>),
     ExistentialMismatch(ExpectedFound<&'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>>),
     ConstMismatch(ExpectedFound<ty::Const<'tcx>>),
+    EffectMismatch(ExpectedFound<ty::Effect<'tcx>>),
 
     IntrinsicCast,
     /// Safe `#[target_feature]` functions are not assignable to safe function pointers.
@@ -228,6 +229,9 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
             ConstMismatch(ref values) => {
                 write!(f, "expected `{}`, found `{}`", values.expected, values.found)
             }
+            EffectMismatch(ref values) => {
+                write!(f, "expected `{:?}`, found `{:?}`", values.expected, values.found)
+            }
             IntrinsicCast => write!(f, "cannot coerce intrinsics to function pointers"),
             TargetFeatureCast(_) => write!(
                 f,
@@ -244,7 +248,7 @@ impl<'tcx> TypeError<'tcx> {
             CyclicTy(_) | CyclicConst(_) | UnsafetyMismatch(_) | ConstnessMismatch(_)
             | PolarityMismatch(_) | Mismatch | AbiMismatch(_) | FixedArraySize(_)
             | ArgumentSorts(..) | Sorts(_) | IntMismatch(_) | FloatMismatch(_)
-            | VariadicMismatch(_) | TargetFeatureCast(_) => false,
+            | VariadicMismatch(_) | TargetFeatureCast(_) | EffectMismatch(_) => false,
 
             Mutability
             | ArgumentMutability(_)

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -177,6 +177,9 @@ impl DeepRejectCtxt {
             (GenericArgKind::Const(obl), GenericArgKind::Const(imp)) => {
                 self.consts_may_unify(obl, imp)
             }
+            (GenericArgKind::Effect(obl), GenericArgKind::Effect(imp)) => {
+                self.effects_may_unify(obl, imp)
+            }
             _ => bug!("kind mismatch: {obligation_arg} {impl_arg}"),
         }
     }

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -78,6 +78,9 @@ impl FlagComputation {
                 ty::BoundVariableKind::Const => {
                     computation.flags |= TypeFlags::HAS_CT_LATE_BOUND;
                 }
+                ty::BoundVariableKind::Effect => {
+                    computation.flags |= TypeFlags::HAS_EFFECT_LATE_BOUND;
+                }
             }
         }
 

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -400,6 +400,7 @@ impl FlagComputation {
                 GenericArgKind::Type(ty) => self.add_ty(ty),
                 GenericArgKind::Lifetime(lt) => self.add_region(lt),
                 GenericArgKind::Const(ct) => self.add_const(ct),
+                GenericArgKind::Effect(e) => self.add_effect(e),
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -162,6 +162,10 @@ pub trait FallibleTypeFolder<'tcx>: Sized {
         c.try_super_fold_with(self)
     }
 
+    fn try_fold_effect(&mut self, e: ty::Effect<'tcx>) -> Result<ty::Effect<'tcx>, Self::Error> {
+        e.try_super_fold_with(self)
+    }
+
     fn try_fold_predicate(
         &mut self,
         p: ty::Predicate<'tcx>,

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -271,6 +271,22 @@ impl<'tcx> Generics {
         }
     }
 
+    /// Returns the `GenericParamDef` associated with the effect param (if any).
+    pub fn effect_param(
+        &'tcx self,
+        effect_kind: ty::EffectKind,
+        tcx: TyCtxt<'tcx>,
+    ) -> Option<&GenericParamDef> {
+        self.params
+            .iter()
+            .rev()
+            .find(|pred| match pred.kind {
+                GenericParamDefKind::Effect { kind } => kind == effect_kind,
+                _ => false,
+            })
+            .or_else(|| tcx.generics_of(self.parent?).effect_param(effect_kind, tcx))
+    }
+
     /// Returns `true` if `params` has `impl Trait`.
     pub fn has_impl_trait(&'tcx self) -> bool {
         self.params.iter().any(|param| {

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -97,6 +97,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::GenericArgKin
                 0xF5u8.hash_stable(hcx, hasher);
                 lt.hash_stable(hcx, hasher);
             }
+            ty::subst::GenericArgKind::Effect(e) => e.hash_stable(hcx, hasher),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -338,6 +338,9 @@ impl<'tcx> Instance<'tcx> {
             ty::GenericParamDefKind::Const { .. } => {
                 bug!("Instance::mono: {:?} has const parameters", def_id)
             }
+            ty::GenericParamDefKind::Effect { .. } => {
+                bug!("Instance::mono: {:?} has effect parameters", def_id)
+            }
         });
 
         Instance::new(def_id, substs)

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -86,6 +86,9 @@ pub use self::context::{
     tls, CtxtInterners, DeducedParamAttrs, FreeRegionInfo, GlobalCtxt, Lift, OnDiskCache, TyCtxt,
     TyCtxtFeed,
 };
+pub use self::effect::{
+    Effect, EffectData, EffectKind, EffectValue, EffectVid, InferEffect, PlaceholderEffect,
+};
 pub use self::instance::{Instance, InstanceDef, ShortInstance};
 pub use self::list::List;
 pub use self::parameterized::ParameterizedOverTcx;
@@ -136,6 +139,7 @@ mod closure;
 mod consts;
 mod context;
 mod diagnostics;
+mod effect;
 mod erase_regions;
 mod generics;
 mod impls_ty;

--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -214,6 +214,10 @@ impl<'tcx> TypeFolder<'tcx> for NormalizeAfterErasingRegionsFolder<'tcx> {
     fn fold_const(&mut self, c: ty::Const<'tcx>) -> ty::Const<'tcx> {
         self.normalize_generic_arg_after_erasing_regions(c.into()).expect_const()
     }
+
+    fn fold_effect(&mut self, e: ty::Effect<'tcx>) -> ty::Effect<'tcx> {
+        self.normalize_generic_arg_after_erasing_regions(e.into()).expect_effect()
+    }
 }
 
 struct TryNormalizeAfterErasingRegionsFolder<'tcx> {

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -36,6 +36,7 @@ pub trait Printer<'tcx>: Sized {
     type Type;
     type DynExistential;
     type Const;
+    type Effect;
 
     fn tcx<'a>(&'a self) -> TyCtxt<'tcx>;
 
@@ -67,6 +68,7 @@ pub trait Printer<'tcx>: Sized {
     ) -> Result<Self::DynExistential, Self::Error>;
 
     fn print_const(self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error>;
+    fn print_effect(self, ct: ty::Effect<'tcx>) -> Result<Self::Effect, Self::Error>;
 
     fn path_crate(self, cnum: CrateNum) -> Result<Self::Path, Self::Error>;
 
@@ -327,5 +329,13 @@ pub fn describe_as_module(def_id: LocalDefId, tcx: TyCtxt<'_>) -> String {
         "top-level module".to_string()
     } else {
         format!("module `{}`", tcx.def_path_str(def_id.to_def_id()))
+    }
+}
+
+impl<'tcx, P: Printer<'tcx>> Print<'tcx, P> for ty::Effect<'tcx> {
+    type Output = P::Effect;
+    type Error = P::Error;
+    fn print(&self, cx: P) -> Result<Self::Output, Self::Error> {
+        cx.print_effect(*self)
     }
 }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2769,6 +2769,7 @@ define_print_and_forward_display! {
         if let ty::BoundConstness::ConstIfConst = self.constness && cx.tcx().features().const_trait_impl {
             p!("~const ");
         }
+
         p!(print(self.trait_ref.print_only_trait_path()))
     }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2837,6 +2837,7 @@ define_print_and_forward_display! {
             GenericArgKind::Lifetime(lt) => p!(print(lt)),
             GenericArgKind::Type(ty) => p!(print(ty)),
             GenericArgKind::Const(ct) => p!(print(ct)),
+            GenericArgKind::Effect(e) => p!(print(e)),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -852,6 +852,9 @@ impl<'tcx> Relate<'tcx> for GenericArg<'tcx> {
             (GenericArgKind::Const(a_ct), GenericArgKind::Const(b_ct)) => {
                 Ok(relation.relate(a_ct, b_ct)?.into())
             }
+            (GenericArgKind::Effect(a), GenericArgKind::Effect(b)) => {
+                Ok(relation.relate(a, b)?.into())
+            }
             (GenericArgKind::Lifetime(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
@@ -859,6 +862,9 @@ impl<'tcx> Relate<'tcx> for GenericArg<'tcx> {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
             (GenericArgKind::Const(unpacked), x) => {
+                bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
+            }
+            (GenericArgKind::Effect(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
         }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -930,6 +930,7 @@ pub enum BoundVariableKind {
     Ty(BoundTyKind),
     Region(BoundRegionKind),
     Const,
+    Effect,
 }
 
 impl BoundVariableKind {
@@ -951,6 +952,13 @@ impl BoundVariableKind {
         match self {
             BoundVariableKind::Const => (),
             _ => bug!("expected a const, but found another kind"),
+        }
+    }
+
+    pub fn expect_effect(self) {
+        match self {
+            BoundVariableKind::Effect => (),
+            _ => bug!("expected a effect, but found another kind"),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -833,7 +833,6 @@ impl<'a, 'tcx> TypeFolder<'tcx> for SubstFolder<'a, 'tcx> {
     }
 
     fn fold_effect(&mut self, e: ty::Effect<'tcx>) -> ty::Effect<'tcx> {
-        // FIXME(keyword_generics): handle other effects
         if let ty::EffectValue::Param { index } = e.val {
             self.effect_for_param(index, e)
         } else {

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -431,6 +431,16 @@ impl<'tcx> InternalSubsts<'tcx> {
 
     #[inline]
     #[track_caller]
+    pub fn effect_at(&self, i: usize) -> ty::Effect<'tcx> {
+        if let GenericArgKind::Effect(e) = self[i].unpack() {
+            e
+        } else {
+            bug!("expected effect for param #{} in {:?}", i, self);
+        }
+    }
+
+    #[inline]
+    #[track_caller]
     pub fn type_at(&self, i: usize) -> Ty<'tcx> {
         if let GenericArgKind::Type(ty) = self[i].unpack() {
             ty

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -668,6 +668,15 @@ impl<'tcx> CanonicalUserType<'tcx> {
                             }
                             _ => false,
                         },
+
+                        GenericArgKind::Effect(e) => match e.val {
+                            ty::EffectValue::Bound(debruijn, b) => {
+                                // We only allow a `ty::INNERMOST` index in substitutions.
+                                assert_eq!(debruijn, ty::INNERMOST);
+                                cvar == b
+                            }
+                            _ => false,
+                        },
                     }
                 })
             }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -448,6 +448,11 @@ impl<'tcx> TyCtxt<'tcx> {
                         // Error: not a const param
                         _ => false,
                     },
+                    GenericArgKind::Effect(e) => match e.val {
+                        ty::EffectValue::Param { .. } => true,
+                        // Error: not an effect param
+                        _ => false,
+                    },
                 }
             })
             .map(|(item_param, _)| item_param)
@@ -490,6 +495,14 @@ impl<'tcx> TyCtxt<'tcx> {
                         }
                     }
                     _ => return Err(NotUniqueParam::NotParam(c.into())),
+                },
+                GenericArgKind::Effect(e) => match e.val {
+                    ty::EffectValue::Param { index } => {
+                        if !seen.insert(index) {
+                            return Err(NotUniqueParam::DuplicateParam(arg));
+                        }
+                    }
+                    _ => return Err(NotUniqueParam::NotParam(arg)),
                 },
             }
         }

--- a/compiler/rustc_middle/src/ty/visit.rs
+++ b/compiler/rustc_middle/src/ty/visit.rs
@@ -133,6 +133,7 @@ pub trait TypeVisitable<'tcx>: fmt::Debug + Clone {
         self.has_type_flags(
             TypeFlags::HAS_RE_PLACEHOLDER
                 | TypeFlags::HAS_TY_PLACEHOLDER
+                | TypeFlags::HAS_EFFECT_PLACEHOLDER
                 | TypeFlags::HAS_CT_PLACEHOLDER,
         )
     }

--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -203,6 +203,7 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
             }
         },
         GenericArgKind::Lifetime(_) => {}
+        GenericArgKind::Effect(_) => {}
         GenericArgKind::Const(parent_ct) => {
             stack.push(parent_ct.ty().into());
             match parent_ct.kind() {

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -248,6 +248,7 @@ impl<'tcx> ConstToPat<'tcx> {
                 ty::subst::GenericArgKind::Lifetime(_) => false,
                 ty::subst::GenericArgKind::Type(t) => t.is_fn_ptr(),
                 ty::subst::GenericArgKind::Const(_) => false,
+                ty::subst::GenericArgKind::Effect(_) => false,
             })
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -226,13 +226,14 @@ impl<'tcx> ConstToPat<'tcx> {
         // using `PartialEq::eq` in this scenario in the past.)
         let partial_eq_trait_id =
             self.tcx().require_lang_item(hir::LangItem::PartialEq, Some(self.span));
+        let arg = ty::GenericArg::from(ty);
         let obligation: PredicateObligation<'_> = predicate_for_trait_def(
             self.tcx(),
             self.param_env,
             ObligationCause::misc(self.span, self.id),
             partial_eq_trait_id,
             0,
-            [ty, ty],
+            [arg, arg].into_iter().chain(self.tcx().host_effect()),
         );
         // FIXME: should this call a `predicate_must_hold` variant instead?
 

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -962,6 +962,13 @@ where
         let tcx = self.tcx();
         let unit_temp = Place::from(self.new_temp(tcx.mk_unit()));
         let free_func = tcx.require_lang_item(LangItem::BoxFree, Some(self.source_info.span));
+
+        let substs = if tcx.effects() {
+            tcx.mk_substs(substs.iter().chain(tcx.host_effect()))
+        } else {
+            substs
+        };
+
         let args = adt
             .variant(VariantIdx::new(0))
             .fields

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -614,6 +614,11 @@ where
         let drop_trait = tcx.require_lang_item(LangItem::Drop, None);
         let drop_fn = tcx.associated_item_def_ids(drop_trait)[0];
         let ty = self.place_ty(self.place);
+        let substs = tcx.mk_substs_trait_with_effect(
+            drop_trait,
+            [ty],
+            self.elaborator.body().source.def_id(),
+        );
 
         let ref_ty =
             tcx.mk_ref(tcx.lifetimes.re_erased, ty::TypeAndMut { ty, mutbl: hir::Mutability::Mut });
@@ -631,12 +636,7 @@ where
             )],
             terminator: Some(Terminator {
                 kind: TerminatorKind::Call {
-                    func: Operand::function_handle(
-                        tcx,
-                        drop_fn,
-                        [ty.into()],
-                        self.source_info.span,
-                    ),
+                    func: Operand::function_handle(tcx, drop_fn, substs, self.source_info.span),
                     args: vec![Operand::Move(Place::from(ref_place))],
                     destination: unit_temp,
                     target: Some(succ),

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -624,6 +624,7 @@ fn check_type_length_limit<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) {
         .filter(|arg| match arg.unpack() {
             GenericArgKind::Type(_) | GenericArgKind::Const(_) => true,
             GenericArgKind::Lifetime(_) => false,
+            GenericArgKind::Effect(_) => false,
         })
         .count();
     debug!(" => type length={}", type_length);

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1369,6 +1369,7 @@ fn create_mono_items_for_default_impls<'tcx>(
                         InternalSubsts::for_item(tcx, method.def_id, |param, _| match param.kind {
                             GenericParamDefKind::Lifetime => tcx.lifetimes.re_erased.into(),
                             GenericParamDefKind::Type { .. }
+                            | GenericParamDefKind::Effect { .. }
                             | GenericParamDefKind::Const { .. } => {
                                 trait_ref.substs[param.index as usize]
                             }

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -830,6 +830,7 @@ impl ReachEverythingInTheInterfaceVisitor<'_, '_> {
         for param in &self.ev.tcx.generics_of(self.item_def_id).params {
             match param.kind {
                 GenericParamDefKind::Lifetime => {}
+                GenericParamDefKind::Effect { .. } => {}
                 GenericParamDefKind::Type { has_default, .. } => {
                     if has_default {
                         self.visit(self.ev.tcx.type_of(param.def_id));
@@ -1735,6 +1736,7 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
         for param in &self.tcx.generics_of(self.item_def_id).params {
             match param.kind {
                 GenericParamDefKind::Lifetime => {}
+                GenericParamDefKind::Effect { .. } => {}
                 GenericParamDefKind::Type { has_default, .. } => {
                     if has_default {
                         self.visit(self.tcx.type_of(param.def_id));

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -642,6 +642,7 @@ symbols! {
         dyn_trait,
         e,
         edition_panic,
+        effects,
         eh_catch_typeinfo,
         eh_personality,
         emit_enum,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -441,6 +441,7 @@ symbols! {
         call,
         call_mut,
         call_once,
+        callable,
         caller_location,
         capture_disjoint_fields,
         cause,

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -203,6 +203,7 @@ impl<'tcx> Printer<'tcx> for &mut SymbolPrinter<'tcx> {
     type Type = Self;
     type DynExistential = Self;
     type Const = Self;
+    type Effect = Self;
 
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
@@ -271,6 +272,11 @@ impl<'tcx> Printer<'tcx> for &mut SymbolPrinter<'tcx> {
             }
             _ => self.write_str("_")?,
         }
+        Ok(self)
+    }
+
+    fn print_effect(self, _: ty::Effect<'tcx>) -> Result<Self::Effect, Self::Error> {
+        self.write_str("_")?;
         Ok(self)
     }
 

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -844,6 +844,9 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
                     self.push("K");
                     self = c.print(self)?;
                 }
+                GenericArgKind::Effect(e) => {
+                    self = e.print(self)?;
+                }
             }
         }
         self.push("E");

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -244,6 +244,7 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
     type Type = Self;
     type DynExistential = Self;
     type Const = Self;
+    type Effect = Self;
 
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
@@ -562,6 +563,10 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
 
         self.push("E");
         Ok(self)
+    }
+
+    fn print_effect(self, _: ty::Effect<'tcx>) -> Result<Self::Effect, Self::Error> {
+        unimplemented!()
     }
 
     fn print_const(mut self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/method_chain.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/method_chain.rs
@@ -53,6 +53,14 @@ impl<'a, 'tcx> TypeRelation<'tcx> for CollectAllMismatches<'a, 'tcx> {
         Ok(a)
     }
 
+    fn effects(
+        &mut self,
+        a: ty::Effect<'tcx>,
+        _b: ty::Effect<'tcx>,
+    ) -> RelateResult<'tcx, ty::Effect<'tcx>> {
+        Ok(a)
+    }
+
     fn tys(&mut self, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, Ty<'tcx>> {
         self.infcx.probe(|_| {
             if a.is_ty_infer() || b.is_ty_infer() {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -191,9 +191,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
             for param in generics.params.iter() {
                 let value = match param.kind {
-                    GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
-                        substs[param.index as usize].to_string()
-                    }
+                    GenericParamDefKind::Effect { .. }
+                    | GenericParamDefKind::Type { .. }
+                    | GenericParamDefKind::Const { .. } => substs[param.index as usize].to_string(),
                     GenericParamDefKind::Lifetime => continue,
                 };
                 let name = param.name;
@@ -609,10 +609,14 @@ impl<'tcx> OnUnimplementedFormatString {
             .iter()
             .filter_map(|param| {
                 let value = match param.kind {
-                    GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
+                    GenericParamDefKind::Effect { .. }
+                    | GenericParamDefKind::Type { .. }
+                    | GenericParamDefKind::Const { .. } => {
                         trait_ref.substs[param.index as usize].to_string()
                     }
-                    GenericParamDefKind::Lifetime => return None,
+                    GenericParamDefKind::Lifetime => {
+                        return None;
+                    }
                 };
                 let name = param.name;
                 Some((name, value))

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3553,7 +3553,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             return prev_ty.into();
                         }
                     }
-                    ty::GenericParamDefKind::Lifetime | ty::GenericParamDefKind::Const { .. } => {}
+                    ty::GenericParamDefKind::Effect { .. }
+                    | ty::GenericParamDefKind::Lifetime
+                    | ty::GenericParamDefKind::Const { .. } => {}
                 }
                 self.var_for_def(span, param)
             });

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -142,7 +142,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'tcx>(
 }
 
 #[instrument(level = "debug", skip(infcx, param_env, span, pred), ret)]
-fn pred_known_to_hold_modulo_regions<'tcx>(
+pub fn pred_known_to_hold_modulo_regions<'tcx>(
     infcx: &InferCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     pred: impl ToPredicate<'tcx> + TypeVisitable<'tcx>,

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1907,6 +1907,7 @@ fn confirm_generator_candidate<'cx, 'tcx>(
         tcx,
         gen_def_id,
         obligation.predicate.self_ty(),
+        obligation.predicate.substs[2..].to_vec(),
         gen_sig,
     )
     .map_bound(|(trait_ref, yield_ty, return_ty)| {
@@ -2078,6 +2079,7 @@ fn confirm_callable_candidate<'cx, 'tcx>(
         tcx,
         fn_once_def_id,
         obligation.predicate.self_ty(),
+        obligation.predicate.substs[2..].to_owned(),
         fn_sig,
         flag,
     )
@@ -2242,6 +2244,8 @@ fn check_substs_compatible<'tcx>(
                 (ty::GenericParamDefKind::Type { .. }, ty::GenericArgKind::Type(_))
                 | (ty::GenericParamDefKind::Lifetime, ty::GenericArgKind::Lifetime(_))
                 | (ty::GenericParamDefKind::Const { .. }, ty::GenericArgKind::Const(_)) => {}
+                (ty::GenericParamDefKind::Effect { kind, .. }, ty::GenericArgKind::Effect(e))
+                    if e.kind == *kind => {}
                 _ => return false,
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -66,7 +66,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
         let mut _orig_values = OriginalQueryValues::default();
 
         let param_env = match obligation.predicate.kind().skip_binder() {
-            ty::PredicateKind::Clause(ty::Clause::Trait(pred)) => {
+            ty::PredicateKind::Clause(ty::Clause::Trait(pred)) if !self.tcx.effects() => {
                 // we ignore the value set to it.
                 let mut _constness = pred.constness;
                 obligation

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -158,6 +158,17 @@ impl<'tcx> TypeVisitor<'tcx> for MaxEscapingBoundVarVisitor {
             _ => ct.super_visit_with(self),
         }
     }
+
+    fn visit_effect(&mut self, e: ty::Effect<'tcx>) -> ControlFlow<Self::BreakTy> {
+        match e.val {
+            ty::EffectValue::Bound(debruijn, _) if debruijn >= self.outer_index => {
+                self.escaping =
+                    self.escaping.max(debruijn.as_usize() - self.outer_index.as_usize());
+                ControlFlow::CONTINUE
+            }
+            _ => e.super_visit_with(self),
+        }
+    }
 }
 
 struct QueryNormalizer<'cx, 'tcx> {

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -309,7 +309,7 @@ impl<'cx, 'tcx> FallibleTypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
 
                 let tcx = self.infcx.tcx;
                 let infcx = self.infcx;
-                let (data, mapped_regions, mapped_types, mapped_consts) =
+                let (data, mapped_regions, mapped_types, mapped_consts, mapped_effects) =
                     BoundVarReplacer::replace_bound_vars(infcx, &mut self.universes, data);
                 let data = data.try_fold_with(self)?;
 
@@ -349,6 +349,7 @@ impl<'cx, 'tcx> FallibleTypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
                     mapped_regions,
                     mapped_types,
                     mapped_consts,
+                    mapped_effects,
                     &self.universes,
                     result.normalized_ty,
                 );

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -564,6 +564,18 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 )
                                 .into()
                             }
+                            GenericParamDefKind::Effect { kind } => {
+                                let bound_var = ty::BoundVariableKind::Effect;
+                                bound_vars.push(bound_var);
+                                tcx.mk_effect(
+                                    ty::EffectValue::Bound(
+                                        ty::INNERMOST,
+                                        ty::BoundVar::from_usize(bound_vars.len() - 1),
+                                    ),
+                                    kind,
+                                )
+                                .into()
+                            }
                         });
                         let bound_vars = tcx.mk_bound_variable_kinds(bound_vars.into_iter());
                         let assoc_ty_substs = tcx.intern_substs(&substs);

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -1075,6 +1075,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     // Lifetimes aren't allowed to change during unsizing.
                     GenericArgKind::Lifetime(_) => None,
 
+                    // Effects aren't allowed to change during unsizing.
+                    GenericArgKind::Effect(_) => None,
+
                     GenericArgKind::Const(ct) => match ct.kind() {
                         ty::ConstKind::Param(p) => Some(p.index),
                         _ => None,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2357,6 +2357,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     ty_op: |_| err,
                     lt_op: |l| l,
                     ct_op: |c| c,
+                    e_op: |e| e,
                 });
                 Normalized { value, obligations: vec![] }
             }

--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -244,6 +244,7 @@ fn vtable_entries<'tcx>(
                         InternalSubsts::for_item(tcx, def_id, |param, _| match param.kind {
                             GenericParamDefKind::Lifetime => tcx.lifetimes.re_erased.into(),
                             GenericParamDefKind::Type { .. }
+                            | GenericParamDefKind::Effect { .. }
                             | GenericParamDefKind::Const { .. } => {
                                 trait_ref.substs[param.index as usize]
                             }

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -56,6 +56,9 @@ pub fn obligations<'tcx>(
         }
         // There is nothing we have to do for lifetimes.
         GenericArgKind::Lifetime(..) => return Some(Vec::new()),
+
+        // There is nothing we have to do for effects.
+        GenericArgKind::Effect(..) => return Some(Vec::new()),
     };
 
     let mut wf = WfPredicates {
@@ -447,6 +450,9 @@ impl<'tcx> WfPredicates<'tcx> {
                 // No WF constraints for lifetimes being present, any outlives
                 // obligations are handled by the parent (e.g. `ty::Ref`).
                 GenericArgKind::Lifetime(_) => continue,
+
+                // No WF constraints for effects being present
+                GenericArgKind::Effect(_) => continue,
 
                 GenericArgKind::Const(ct) => {
                     match ct.kind() {

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -762,6 +762,9 @@ fn binders_for<'tcx>(
             ty::subst::GenericArgKind::Const(c) => {
                 chalk_ir::VariableKind::Const(c.ty().lower_into(interner))
             }
+            ty::subst::GenericArgKind::Effect(_e) => {
+                unimplemented!()
+            }
         }),
     )
 }

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -745,6 +745,10 @@ fn bound_vars_for_item(tcx: TyCtxt<'_>, def_id: DefId) -> SubstsRef<'_> {
                 tcx.type_of(param.def_id),
             )
             .into(),
+
+        ty::GenericParamDefKind::Effect { kind } => tcx
+            .mk_effect(ty::EffectValue::Bound(ty::INNERMOST, ty::BoundVar::from(param.index)), kind)
+            .into(),
     })
 }
 

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -192,6 +192,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>> for ty::Predi
                     chalk_ir::GoalData::All(chalk_ir::Goals::empty(interner))
                 }
                 GenericArgKind::Lifetime(lt) => bug!("unexpected well formed predicate: {:?}", lt),
+                GenericArgKind::Effect(e) => bug!("unexpected well formed predicate: {:?}", e),
             },
 
             ty::PredicateKind::ObjectSafe(t) => chalk_ir::GoalData::DomainGoal(
@@ -579,6 +580,9 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GenericArg<RustInterner<'tcx>>> for Generic
             }
             ty::subst::GenericArgKind::Const(c) => {
                 chalk_ir::GenericArgData::Const(c.lower_into(interner))
+            }
+            ty::subst::GenericArgKind::Effect(_e) => {
+                unimplemented!()
             }
         }
         .intern(interner)

--- a/compiler/rustc_traits/src/chalk/mod.rs
+++ b/compiler/rustc_traits/src/chalk/mod.rs
@@ -77,6 +77,8 @@ pub(crate) fn evaluate_goal<'tcx>(
                     ),
                     CanonicalVarKind::Const(_ui, _ty) => unimplemented!(),
                     CanonicalVarKind::PlaceholderConst(_pc, _ty) => unimplemented!(),
+                    CanonicalVarKind::Effect(_ui, _effect_kind) => unimplemented!(),
+                    CanonicalVarKind::PlaceholderEffect(_pc, _effect_kind) => unimplemented!(),
                 }),
             ),
             value: obligation.value.lower_into(interner),

--- a/compiler/rustc_traits/src/implied_outlives_bounds.rs
+++ b/compiler/rustc_traits/src/implied_outlives_bounds.rs
@@ -133,6 +133,7 @@ fn compute_implied_outlives_bounds<'tcx>(
                 push_outlives_components(tcx, ty_a, &mut components);
                 implied_bounds_from_components(r_b, components)
             }
+            ty::GenericArgKind::Effect(_) => unreachable!(),
             ty::GenericArgKind::Const(_) => unreachable!(),
         })
         .collect();

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -326,6 +326,9 @@ fn well_formed_types_in_env(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::List<Predica
 
             // FIXME(eddyb) support const generics in Chalk
             GenericArgKind::Const(_) => None,
+
+            // FIXME(oli-obk) support effects in Chalk
+            GenericArgKind::Effect(_) => None,
         }
     });
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -177,6 +177,7 @@ bitflags! {
 
         const NEEDS_SUBST                 = TypeFlags::HAS_TY_PARAM.bits
                                           | TypeFlags::HAS_RE_PARAM.bits
+                                          | TypeFlags::HAS_EFFECT_PARAM.bits
                                           | TypeFlags::HAS_CT_PARAM.bits;
 
         /// Does this have `Infer`?
@@ -190,6 +191,7 @@ bitflags! {
         /// inference is required.
         const NEEDS_INFER                 = TypeFlags::HAS_TY_INFER.bits
                                           | TypeFlags::HAS_RE_INFER.bits
+                                          | TypeFlags::HAS_EFFECT_INFER.bits
                                           | TypeFlags::HAS_CT_INFER.bits;
 
         /// Does this have `Placeholder`?
@@ -207,10 +209,13 @@ bitflags! {
         /// that are local to a particular fn
         const HAS_FREE_LOCAL_NAMES        = TypeFlags::HAS_TY_PARAM.bits
                                           | TypeFlags::HAS_CT_PARAM.bits
+                                          | TypeFlags::HAS_EFFECT_PARAM.bits
                                           | TypeFlags::HAS_TY_INFER.bits
                                           | TypeFlags::HAS_CT_INFER.bits
+                                          | TypeFlags::HAS_EFFECT_INFER.bits
                                           | TypeFlags::HAS_TY_PLACEHOLDER.bits
                                           | TypeFlags::HAS_CT_PLACEHOLDER.bits
+                                          | TypeFlags::HAS_EFFECT_PLACEHOLDER.bits
                                           // We consider 'freshened' types and constants
                                           // to depend on a particular fn.
                                           // The freshening process throws away information,
@@ -220,6 +225,7 @@ bitflags! {
                                           // which is different from how types/const are freshened.
                                           | TypeFlags::HAS_TY_FRESH.bits
                                           | TypeFlags::HAS_CT_FRESH.bits
+                                          | TypeFlags::HAS_EFFECT_FRESH.bits
                                           | TypeFlags::HAS_FREE_LOCAL_REGIONS.bits;
 
         /// Does this have `Projection`?
@@ -265,6 +271,18 @@ bitflags! {
 
         /// Does this value have `InferConst::Fresh`?
         const HAS_CT_FRESH                = 1 << 21;
+
+        /// Does this have `Effect::Param`?
+        const HAS_EFFECT_PARAM            = 1 << 22;
+
+        /// Does this have `InferEffect::Fresh`?
+        const HAS_EFFECT_FRESH            = 1 << 23;
+
+        /// Does this have `InferEffect::Var`?
+        const HAS_EFFECT_INFER            = 1 << 24;
+
+        /// Does this have `Effect::Placeholder`?
+        const HAS_EFFECT_PLACEHOLDER      = 1 << 25;
     }
 }
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -283,6 +283,9 @@ bitflags! {
 
         /// Does this have `Effect::Placeholder`?
         const HAS_EFFECT_PLACEHOLDER      = 1 << 25;
+
+        /// Does this have any `Effect::Bound` consts?
+        const HAS_EFFECT_LATE_BOUND           = 1 << 26;
     }
 }
 

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -376,9 +376,8 @@ impl Layout {
     /// # assert_eq!(repr_c(&[u64, u32, u16, u32]), Ok((s, vec![0, 8, 12, 16])));
     /// ```
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
-    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub const fn extend(&self, next: Self) -> Result<(Self, usize), LayoutError> {
+    pub fn extend(&self, next: Self) -> Result<(Self, usize), LayoutError> {
         let new_align = cmp::max(self.align, next.align);
         let pad = self.padding_needed_for(next.align());
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -354,7 +354,7 @@ where
     type Output = <[T] as Index<I>>::Output;
 
     #[inline]
-    fn index(&self, index: I) -> &Self::Output {
+    fn index(&self, index: I) -> &<[T] as Index<I>>::Output {
         Index::index(self as &[T], index)
     }
 }
@@ -366,7 +366,7 @@ where
     [T]: ~const IndexMut<I>,
 {
     #[inline]
-    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+    fn index_mut(&mut self, index: I) -> &mut <[T] as Index<I>>::Output {
         IndexMut::index_mut(self as &mut [T], index)
     }
 }

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -280,7 +280,8 @@ pub macro PartialEq($item:item) {
 #[doc(alias = "!=")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Eq"]
-pub trait Eq: PartialEq<Self> {
+#[const_trait]
+pub trait Eq: ~const PartialEq<Self> {
     // this method is used solely by #[deriving] to assert
     // that every component of a type implements #[deriving]
     // itself, the current deriving infrastructure means doing this
@@ -601,8 +602,7 @@ impl Ordering {
 pub struct Reverse<T>(#[stable(feature = "reverse_cmp_key", since = "1.19.0")] pub T);
 
 #[stable(feature = "reverse_cmp_key", since = "1.19.0")]
-#[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
-impl<T: ~const PartialOrd> const PartialOrd for Reverse<T> {
+impl<T: PartialOrd> PartialOrd for Reverse<T> {
     #[inline]
     fn partial_cmp(&self, other: &Reverse<T>) -> Option<Ordering> {
         other.0.partial_cmp(&self.0)
@@ -761,7 +761,7 @@ impl<T: Clone> Clone for Reverse<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Ord"]
 #[const_trait]
-pub trait Ord: Eq + PartialOrd<Self> {
+pub trait Ord: Eq + ~const PartialOrd<Self> {
     /// This method returns an [`Ordering`] between `self` and `other`.
     ///
     /// By convention, `self.cmp(&other)` returns the ordering matching the expression
@@ -1051,7 +1051,7 @@ pub macro Ord($item:item) {
 )]
 #[const_trait]
 #[rustc_diagnostic_item = "PartialOrd"]
-pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+pub trait PartialOrd<Rhs: ?Sized = Self>: ~const PartialEq<Rhs> {
     /// This method returns an ordering between `self` and `other` values if one exists.
     ///
     /// # Examples

--- a/library/core/src/const_closure.rs
+++ b/library/core/src/const_closure.rs
@@ -61,7 +61,7 @@ macro_rules! impl_fn_mut_tuple {
         impl<'a, $($var,)* ClosureArguments: Tuple, Function, ClosureReturnValue> const
             FnMut<ClosureArguments> for ConstFnMutClosure<($(&'a mut $var),*), Function>
         where
-            Function: ~const Fn(($(&mut $var),*), ClosureArguments)-> ClosureReturnValue,
+            Function: ~const Fn(($(&mut $var),*), ClosureArguments)-> ClosureReturnValue+ ~const Destruct,
         {
             extern "rust-call" fn call_mut(&mut self, args: ClosureArguments) -> Self::Output {
                 #[allow(non_snake_case)]

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -171,7 +171,7 @@ impl<T: ?Sized> const Deref for &mut T {
 #[doc(alias = "*")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[const_trait]
-pub trait DerefMut: Deref {
+pub trait DerefMut: ~const Deref {
     /// Mutably dereferences the value.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn deref_mut(&mut self) -> &mut Self::Target;

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -73,7 +73,7 @@ use crate::marker::Tuple;
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
 #[const_trait]
-pub trait Fn<Args: Tuple>: FnMut<Args> {
+pub trait Fn<Args: Tuple>: ~const FnMut<Args> {
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
     extern "rust-call" fn call(&self, args: Args) -> Self::Output;
@@ -160,7 +160,7 @@ pub trait Fn<Args: Tuple>: FnMut<Args> {
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
 #[const_trait]
-pub trait FnMut<Args: Tuple>: FnOnce<Args> {
+pub trait FnMut<Args: Tuple>: ~const FnOnce<Args> {
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -239,6 +239,25 @@ pub trait FnMut<Args: Tuple>: ~const FnOnce<Args> {
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
 #[const_trait]
+#[cfg(not(bootstrap))]
+pub trait FnOnce<Args: Tuple>: Callable<Args> {
+    /// The returned type after the call operator is used.
+    #[lang = "fn_once_output"]
+    #[stable(feature = "fn_once_output", since = "1.12.0")]
+    type Output;
+
+    /// Performs the call operation.
+    #[unstable(feature = "fn_traits", issue = "29625")]
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+#[cfg(bootstrap)]
+#[const_trait]
+#[lang = "fn_once"]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_paren_sugar]
+#[fundamental] // so that regex can rely that `&str: !FnMut`
+/// Nope
 pub trait FnOnce<Args: Tuple> {
     /// The returned type after the call operator is used.
     #[lang = "fn_once_output"]
@@ -249,6 +268,14 @@ pub trait FnOnce<Args: Tuple> {
     #[unstable(feature = "fn_traits", issue = "29625")]
     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
 }
+
+#[cfg(not(bootstrap))]
+#[const_trait]
+#[lang = "callable"]
+#[unstable(feature = "fn_traits", issue = "29625")]
+/// This is an internal trait that, in contrast to `FnOnce` is also implemented
+/// for unsafe functions and intrinsics.
+pub trait Callable<Args: Tuple> {}
 
 mod impls {
     use crate::marker::Tuple;

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -209,3 +209,7 @@ pub use self::unsize::DispatchFromDyn;
 
 #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
 pub use self::control_flow::ControlFlow;
+
+#[unstable(feature = "fn_traits", issue = "29625")]
+#[cfg(not(bootstrap))]
+pub use self::function::Callable;

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -362,7 +362,8 @@ where
 pub trait Residual<O> {
     /// The "return" type of this meta-function.
     #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
-    type TryType: ~const Try<Output = O, Residual = Self>;
+    // const-hack: only ~const Try should be required
+    type TryType: ~const Try<Output = O, Residual = Self> + Try<Output = O, Residual = Self>;
 }
 
 #[unstable(feature = "pub_crate_should_not_need_unstable_attr", issue = "none")]

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -663,7 +663,11 @@ impl<P: Deref> Pin<P> {
     /// ruled out by the contract of `Pin::new_unchecked`.
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub fn as_ref(&self) -> Pin<&P::Target> {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    pub const fn as_ref(&self) -> Pin<&P::Target>
+    where
+        P: ~const Deref,
+    {
         // SAFETY: see documentation on this function
         unsafe { Pin::new_unchecked(&*self.pointer) }
     }
@@ -720,7 +724,11 @@ impl<P: DerefMut> Pin<P> {
     /// ```
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub fn as_mut(&mut self) -> Pin<&mut P::Target> {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    pub const fn as_mut(&mut self) -> Pin<&mut P::Target>
+    where
+        P: ~const DerefMut,
+    {
         // SAFETY: see documentation on this function
         unsafe { Pin::new_unchecked(&mut *self.pointer) }
     }
@@ -955,7 +963,8 @@ impl<T: ?Sized> Pin<&'static mut T> {
 }
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<P: Deref> Deref for Pin<P> {
+#[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+impl<P: ~const Deref> const Deref for Pin<P> {
     type Target = P::Target;
     fn deref(&self) -> &P::Target {
         Pin::get_ref(Pin::as_ref(self))
@@ -963,7 +972,8 @@ impl<P: Deref> Deref for Pin<P> {
 }
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<P: DerefMut<Target: Unpin>> DerefMut for Pin<P> {
+#[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+impl<P: ~const DerefMut<Target: Unpin>> const DerefMut for Pin<P> {
     fn deref_mut(&mut self) -> &mut P::Target {
         Pin::get_mut(Pin::as_mut(self))
     }

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -170,7 +170,7 @@ impl From<Alignment> for usize {
 
 #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-impl const cmp::Ord for Alignment {
+impl cmp::Ord for Alignment {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.as_nonzero().get().cmp(&other.as_nonzero().get())
@@ -179,7 +179,7 @@ impl const cmp::Ord for Alignment {
 
 #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-impl const cmp::PartialOrd for Alignment {
+impl cmp::PartialOrd for Alignment {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -645,6 +645,7 @@ where
                     }
                 }
                 GenericParamDefKind::Lifetime { .. } => {}
+                GenericParamDefKind::Effect { .. } => {}
                 GenericParamDefKind::Const { ref mut default, .. } => {
                     // We never want something like `impl<const N: usize = 10>`
                     default.take();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -511,6 +511,9 @@ fn clean_generic_param_def<'tcx>(
                 },
             },
         ),
+        ty::GenericParamDefKind::Effect { .. } => {
+            (def.name, GenericParamDefKind::Effect { did: def.def_id })
+        }
     };
 
     GenericParamDef { name, kind }
@@ -609,6 +612,7 @@ pub(crate) fn clean_generics<'tcx>(
                     cx.impl_trait_bounds.insert(did.into(), bounds.clone());
                 }
                 GenericParamDefKind::Const { .. } => unreachable!(),
+                GenericParamDefKind::Effect { .. } => unreachable!(),
             }
             param
         })
@@ -688,7 +692,9 @@ pub(crate) fn clean_generics<'tcx>(
                     }
                 }
             }
-            GenericParamDefKind::Type { .. } | GenericParamDefKind::Const { .. } => {
+            GenericParamDefKind::Type { .. }
+            | GenericParamDefKind::Effect { .. }
+            | GenericParamDefKind::Const { .. } => {
                 // nothing to do here.
             }
         }
@@ -745,6 +751,7 @@ fn clean_ty_generics<'tcx>(
                 Some(clean_generic_param_def(param, cx))
             }
             ty::GenericParamDefKind::Const { .. } => Some(clean_generic_param_def(param, cx)),
+            ty::GenericParamDefKind::Effect { .. } => None,
         })
         .collect::<ThinVec<GenericParamDef>>();
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1424,6 +1424,7 @@ pub(crate) enum GenericParamDefKind {
     Lifetime { outlives: Vec<Lifetime> },
     Type { did: DefId, bounds: Vec<GenericBound>, default: Option<Box<Type>>, synthetic: bool },
     Const { did: DefId, ty: Box<Type>, default: Option<Box<String>> },
+    Effect { did: DefId },
 }
 
 impl GenericParamDefKind {
@@ -1445,7 +1446,9 @@ impl GenericParamDef {
 
     pub(crate) fn is_synthetic_type_param(&self) -> bool {
         match self.kind {
-            GenericParamDefKind::Lifetime { .. } | GenericParamDefKind::Const { .. } => false,
+            GenericParamDefKind::Lifetime { .. }
+            | GenericParamDefKind::Const { .. }
+            | GenericParamDefKind::Effect { .. } => false,
             GenericParamDefKind::Type { synthetic, .. } => synthetic,
         }
     }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -101,6 +101,8 @@ pub(crate) fn substs_to_args<'tcx>(
         GenericArgKind::Const(ct) => {
             Some(GenericArg::Const(Box::new(clean_middle_const(kind.rebind(ct), cx))))
         }
+        // FIXME(oli-obk,keyword-generics): teach rustdoc about effects
+        GenericArgKind::Effect(_) => None,
     }));
     ret_val
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -239,6 +239,15 @@ impl clean::GenericParamDef {
 
                 Ok(())
             }
+            clean::GenericParamDefKind::Effect { .. } => {
+                if f.alternate() {
+                    write!(f, "effect {}", self.name)?;
+                } else {
+                    write!(f, "effect {}:&nbsp;", self.name)?;
+                }
+
+                Ok(())
+            }
         })
     }
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -424,6 +424,7 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
                 type_: (*ty).into_tcx(tcx),
                 default: default.map(|x| *x),
             },
+            Effect { did: _ } => GenericParamDefKind::Effect,
         }
     }
 }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -480,6 +480,7 @@ pub enum GenericParamDefKind {
         type_: Type,
         default: Option<String>,
     },
+    Effect,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/test/ui/const-generics/const_trait_fn-issue-88433.rs
+++ b/src/test/ui/const-generics/const_trait_fn-issue-88433.rs
@@ -1,6 +1,7 @@
 // build-pass
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Func<T> {

--- a/src/test/ui/const-generics/issues/issue-98629.rs
+++ b/src/test/ui/const-generics/issues/issue-98629.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Trait {

--- a/src/test/ui/const-generics/issues/issue-98629.stderr
+++ b/src/test/ui/const-generics/issues/issue-98629.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `N`
-  --> $DIR/issue-98629.rs:8:1
+  --> $DIR/issue-98629.rs:9:1
    |
 LL |     const N: usize;
    |     -------------- `N` from trait

--- a/src/test/ui/consts/const-call.rs
+++ b/src/test/ui/consts/const-call.rs
@@ -1,8 +1,10 @@
+#![feature(effects)]
+
 fn f(x: usize) -> usize {
     x
 }
 
 fn main() {
     let _ = [0; f(2)];
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR cannot call non-const fn `f` in constant expressions
 }

--- a/src/test/ui/consts/const-call.stderr
+++ b/src/test/ui/consts/const-call.stderr
@@ -1,11 +1,8 @@
-error[E0015]: cannot call non-const fn `f` in constants
-  --> $DIR/const-call.rs:6:17
+error: cannot call non-const fn `f` in constant expressions
+  --> $DIR/const-call.rs:8:17
    |
 LL |     let _ = [0; f(2)];
    |                 ^^^^
-   |
-   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/consts/const-tuple-struct.rs
+++ b/src/test/ui/consts/const-tuple-struct.rs
@@ -1,5 +1,7 @@
 // run-pass
 
+#![feature(effects)]
+
 struct Bar(isize, isize);
 
 static X: Bar = Bar(1, 2);

--- a/src/test/ui/consts/const_let_assign3.rs
+++ b/src/test/ui/consts/const_let_assign3.rs
@@ -1,3 +1,5 @@
+#![feature(effects)]
+
 struct S {
     state: u32,
 }

--- a/src/test/ui/consts/const_let_assign3.stderr
+++ b/src/test/ui/consts/const_let_assign3.stderr
@@ -1,5 +1,5 @@
 error[E0658]: mutable references are not allowed in constant functions
-  --> $DIR/const_let_assign3.rs:6:18
+  --> $DIR/const_let_assign3.rs:8:18
    |
 LL |     const fn foo(&mut self, x: u32) {
    |                  ^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     const fn foo(&mut self, x: u32) {
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: mutable references are not allowed in constants
-  --> $DIR/const_let_assign3.rs:14:5
+  --> $DIR/const_let_assign3.rs:16:5
    |
 LL |     s.foo(3);
    |     ^^^^^^^^
@@ -17,7 +17,7 @@ LL |     s.foo(3);
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: mutable references are not allowed in constants
-  --> $DIR/const_let_assign3.rs:20:13
+  --> $DIR/const_let_assign3.rs:22:13
    |
 LL |     let y = &mut x;
    |             ^^^^^^

--- a/src/test/ui/consts/const_method_call.rs
+++ b/src/test/ui/consts/const_method_call.rs
@@ -1,0 +1,14 @@
+#![feature(effects)]
+
+// check-pass
+// compile-flags: --crate-type lib
+
+pub struct ManuallyDrop<T: ?Sized> {
+    value: T,
+}
+
+impl<T> ManuallyDrop<T> {
+    pub const fn new(value: T) -> ManuallyDrop<T> {
+        ManuallyDrop { value }
+    }
+}

--- a/src/test/ui/consts/issue-25826.stderr
+++ b/src/test/ui/consts/issue-25826.stderr
@@ -1,11 +1,11 @@
-error[E0277]: can't compare `*const ()` with `*const ()` in const contexts
+error[E0277]: can't compare `*const ()` with `_` in const contexts
   --> $DIR/issue-25826.rs:3:52
    |
 LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };
-   |                                                    ^ no implementation for `*const () < *const ()` and `*const () > *const ()`
+   |                                                    ^ no implementation for `*const () < _` and `*const () > _`
    |
-   = help: the trait `~const PartialOrd` is not implemented for `*const ()`
-note: the trait `PartialOrd` is implemented for `*const ()`, but that implementation is not `const`
+   = help: the trait `~const PartialOrd<_>` is not implemented for `*const ()`
+note: the trait `PartialOrd<_>` is implemented for `*const ()`, but that implementation is not `const`
   --> $DIR/issue-25826.rs:3:52
    |
 LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };

--- a/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.rs
@@ -1,3 +1,5 @@
+#![feature(effects)]
+
 const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe { &*x } }
 //~^ dereferencing raw mutable pointers in constant functions
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
@@ -1,5 +1,5 @@
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
-  --> $DIR/min_const_fn_unsafe_bad.rs:1:77
+  --> $DIR/min_const_fn_unsafe_bad.rs:3:77
    |
 LL | const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe { &*x } }
    |                                                                             ^^^
@@ -8,7 +8,7 @@ LL | const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe {
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
-  --> $DIR/min_const_fn_unsafe_bad.rs:4:70
+  --> $DIR/min_const_fn_unsafe_bad.rs:6:70
    |
 LL | const unsafe fn bad_const_unsafe_deref_raw(x: *mut usize) -> usize { *x }
    |                                                                      ^^
@@ -17,7 +17,7 @@ LL | const unsafe fn bad_const_unsafe_deref_raw(x: *mut usize) -> usize { *x }
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
-  --> $DIR/min_const_fn_unsafe_bad.rs:7:83
+  --> $DIR/min_const_fn_unsafe_bad.rs:9:83
    |
 LL | const unsafe fn bad_const_unsafe_deref_raw_ref(x: *mut usize) -> &'static usize { &*x }
    |                                                                                   ^^^

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.rs
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.rs
@@ -1,5 +1,7 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
 
+#![feature(effects)]
+
 // A test demonstrating that we prevent calling non-const fn during CTFE.
 
 fn foo() {}

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -1,5 +1,5 @@
 error[E0080]: could not evaluate static initializer
-  --> $DIR/non_const_fn.rs:7:16
+  --> $DIR/non_const_fn.rs:9:16
    |
 LL | static C: () = foo();
    |                ^^^^^ calling non-const function `foo`
@@ -7,7 +7,7 @@ LL | static C: () = foo();
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/non_const_fn.rs:7:16
+  --> $DIR/non_const_fn.rs:9:16
    |
 LL | static C: () = foo();
    |                ^^^^^

--- a/src/test/ui/consts/operator_traits.rs
+++ b/src/test/ui/consts/operator_traits.rs
@@ -1,0 +1,493 @@
+#![crate_type = "lib"]
+#![feature(no_core, lang_items, unboxed_closures, auto_traits, intrinsics, rustc_attrs)]
+#![feature(fundamental)]
+#![feature(const_trait_impl, effects, const_mut_refs)]
+#![no_std]
+#![no_core]
+
+// check-pass
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "add"]
+#[const_trait]
+trait Add<Rhs = Self> {
+    type Output;
+
+    fn add(self, rhs: Rhs) -> Self::Output;
+}
+
+impl const Add for i32 {
+    type Output = i32;
+    fn add(self, rhs: i32) -> i32 {
+        loop {}
+    }
+}
+
+fn foo() {
+    let x = 42_i32 + 43_i32;
+}
+
+const fn bar() {
+    let x = 42_i32 + 43_i32;
+}
+
+
+#[lang = "Try"]
+#[const_trait]
+trait Try: ~const FromResidual {
+    type Output;
+    type Residual;
+
+    #[lang = "from_output"]
+    fn from_output(output: Self::Output) -> Self;
+
+    #[lang = "branch"]
+    fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+}
+
+#[const_trait]
+trait FromResidual<R = <Self as Try>::Residual> {
+    #[lang = "from_residual"]
+    fn from_residual(residual: R) -> Self;
+}
+
+enum ControlFlow<B, C = ()> {
+    #[lang = "Continue"]
+    Continue(C),
+    #[lang = "Break"]
+    Break(B),
+}
+
+#[const_trait]
+#[lang = "fn"]
+#[rustc_paren_sugar]
+trait Fn<Args: Tuple>: ~const FnMut<Args> {
+    extern "rust-call" fn call(&self, args: Args) -> Self::Output;
+}
+
+#[const_trait]
+#[lang = "fn_mut"]
+#[rustc_paren_sugar]
+trait FnMut<Args: Tuple>: ~const FnOnce<Args> {
+    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
+}
+
+#[const_trait]
+#[lang = "fn_once"]
+#[rustc_paren_sugar]
+trait FnOnce<Args: Tuple> {
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+struct ConstFnMutClosure<CapturedData, Function> {
+    data: CapturedData,
+    func: Function,
+}
+
+#[lang = "tuple_trait"]
+pub trait Tuple {}
+
+macro_rules! impl_fn_mut_tuple {
+    ($($var:ident)*) => {
+        impl<'a, $($var,)* ClosureArguments: Tuple, Function, ClosureReturnValue> const
+            FnOnce<ClosureArguments> for ConstFnMutClosure<($(&'a mut $var),*), Function>
+        where
+            Function: ~const Fn(($(&mut $var),*), ClosureArguments) -> ClosureReturnValue,
+            Function: ~const Destruct,
+        {
+            type Output = ClosureReturnValue;
+
+            extern "rust-call" fn call_once(mut self, args: ClosureArguments) -> Self::Output {
+            self.call_mut(args)
+            }
+        }
+        impl<'a, $($var,)* ClosureArguments: Tuple, Function, ClosureReturnValue> const
+            FnMut<ClosureArguments> for ConstFnMutClosure<($(&'a mut $var),*), Function>
+        where
+            Function: ~const Fn(($(&mut $var),*), ClosureArguments)-> ClosureReturnValue,
+            Function: ~const Destruct,
+        {
+            extern "rust-call" fn call_mut(&mut self, args: ClosureArguments) -> Self::Output {
+                #[allow(non_snake_case)]
+                let ($($var),*) = &mut self.data;
+                (self.func)(($($var),*), args)
+            }
+        }
+    };
+}
+impl_fn_mut_tuple!(A);
+//impl_fn_mut_tuple!(A B);
+//impl_fn_mut_tuple!(A B C);
+//impl_fn_mut_tuple!(A B C D);
+//impl_fn_mut_tuple!(A B C D E);
+
+#[lang = "receiver"]
+trait Receiver {}
+
+impl<T: ?Sized> Receiver for &T {}
+
+impl<T: ?Sized> Receiver for &mut T {}
+
+#[lang = "destruct"]
+#[const_trait]
+trait Destruct {}
+
+#[lang = "freeze"]
+unsafe auto trait Freeze {}
+
+#[lang = "drop"]
+#[const_trait]
+trait Drop {
+    fn drop(&mut self);
+}
+
+#[const_trait]
+trait Residual<O> {
+    type TryType: ~const Try<Output = O, Residual = Self> + Try<Output = O, Residual = Self>;
+}
+
+const fn size_of<T>() -> usize {
+    42
+}
+
+impl Copy for u8 {}
+
+impl usize {
+    #[rustc_allow_incoherent_impl]
+    const fn repeat_u8(x: u8) -> usize {
+        usize::from_ne_bytes([x; size_of::<usize>()])
+    }
+    #[rustc_allow_incoherent_impl]
+    const fn from_ne_bytes(bytes: [u8; size_of::<Self>()]) -> Self {
+        loop {}
+    }
+}
+
+#[rustc_do_not_const_check] // hooked by const-eval
+const fn panic_display() {
+    panic_fmt();
+}
+
+fn panic_fmt() {}
+
+#[lang = "index"]
+#[const_trait]
+trait Index<Idx: ?Sized> {
+    type Output: ?Sized;
+
+    fn index(&self, index: Idx) -> &Self::Output;
+}
+
+
+#[const_trait]
+unsafe trait SliceIndex<T: ?Sized> {
+    type Output: ?Sized;
+    fn index(self, slice: &T) -> &Self::Output;
+}
+
+impl<T, I> const Index<I> for [T]
+where
+    I: ~const SliceIndex<[T]>,
+{
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &I::Output {
+        index.index(self)
+    }
+}
+
+impl<T, I, const N: usize> const Index<I> for [T; N]
+where
+    [T]: ~const Index<I>,
+{
+    type Output = <[T] as Index<I>>::Output;
+
+    #[inline]
+    // FIXME: make `Self::Output` act like `<Self as ~const Index<I>>::Output`
+    fn index(&self, index: I) -> &<[T] as Index<I>>::Output {
+        Index::index(self as &[T], index)
+    }
+}
+
+#[lang = "unsize"]
+trait Unsize<T: ?Sized> {
+}
+
+#[lang = "coerce_unsized"]
+trait CoerceUnsized<T: ?Sized> {
+}
+
+impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
+
+
+#[lang = "deref"]
+#[const_trait]
+trait Deref {
+    #[lang = "deref_target"]
+    type Target: ?Sized;
+
+    fn deref(&self) -> &Self::Target;
+}
+
+
+impl<T: ?Sized> const Deref for &T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *self
+    }
+}
+
+impl<T: ?Sized> const Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *self
+    }
+}
+
+enum Option<T> {
+    #[lang = "None"]
+    None,
+    #[lang = "Some"]
+    Some(T),
+}
+
+impl<T> Option<T> {
+    const fn as_ref(&self) -> Option<&T> {
+        match *self {
+            Some(ref x) => Some(x),
+            None => None,
+        }
+    }
+
+    const fn as_mut(&mut self) -> Option<&mut T> {
+        match *self {
+            Some(ref mut x) => Some(x),
+            None => None,
+        }
+    }
+}
+
+use Option::*;
+
+const fn as_deref<T>(opt: &Option<T>) -> Option<&T::Target>
+where
+    T: ~const Deref,
+{
+    match opt {
+        Option::Some(t) => Option::Some(t.deref()),
+        Option::None => Option::None,
+    }
+}
+
+#[const_trait]
+trait Into<T>: Sized {
+    fn into(self) -> T;
+}
+
+#[const_trait]
+trait From<T>: Sized {
+    #[lang = "from"]
+    fn from(value: T) -> Self;
+}
+
+impl<T, U> const Into<U> for T
+where
+    U: ~const From<T>,
+{
+    fn into(self) -> U {
+        U::from(self)
+    }
+}
+
+impl<T> const From<T> for T {
+    fn from(t: T) -> T {
+        t
+    }
+}
+
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+use Result::*;
+
+fn from_str(s: &str) -> Result<bool, ()> {
+    match s {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(()),
+    }
+}
+
+#[lang = "eq"]
+#[const_trait]
+trait PartialEq<Rhs: ?Sized = Self> {
+    fn eq(&self, other: &Rhs) -> bool;
+    fn ne(&self, other: &Rhs) -> bool {
+        !self.eq(other)
+    }
+}
+
+impl PartialEq for str {
+    fn eq(&self, other: &str) -> bool {
+        loop {}
+    }
+}
+
+
+#[lang = "not"]
+#[const_trait]
+trait Not {
+    type Output;
+    fn not(self) -> Self::Output;
+}
+
+impl const Not for bool {
+    type Output = bool;
+    fn not(self) -> bool {
+        !self
+    }
+}
+
+impl Copy for bool {}
+impl<'a> Copy for &'a str {}
+
+#[lang = "pin"]
+#[fundamental]
+#[repr(transparent)]
+struct Pin<P> {
+    pointer: P,
+}
+
+impl<P> Pin<P> {
+    #[lang = "new_unchecked"]
+    const unsafe fn new_unchecked(pointer: P) -> Pin<P> {
+        Pin { pointer }
+    }
+}
+
+impl<'a, T: ?Sized> Pin<&'a T> {
+    const fn get_ref(self) -> &'a T {
+        self.pointer
+    }
+}
+
+impl<P: Deref> Pin<P> {
+    const fn as_ref(&self) -> Pin<&P::Target>
+    where
+        P: ~const Deref,
+    {
+        unsafe { Pin::new_unchecked(&*self.pointer) }
+    }
+}
+
+impl<'a, T: ?Sized> Pin<&'a mut T> {
+    const unsafe fn get_unchecked_mut(self) -> &'a mut T {
+        self.pointer
+    }
+}
+
+impl<T> Option<T> {
+    const fn as_pin_ref(self: Pin<&Self>) -> Option<Pin<&T>> {
+        match Pin::get_ref(self).as_ref() {
+            Some(x) => unsafe { Some(Pin::new_unchecked(x)) },
+            None => None,
+        }
+    }
+
+    const fn as_pin_mut(self: Pin<&mut Self>) -> Option<Pin<&mut T>> {
+        unsafe {
+            match Pin::get_unchecked_mut(self).as_mut() {
+                Some(x) => Some(Pin::new_unchecked(x)),
+                None => None,
+            }
+        }
+    }
+}
+
+impl<P: ~const Deref> const Deref for Pin<P> {
+    type Target = P::Target;
+    fn deref(&self) -> &P::Target {
+        Pin::get_ref(Pin::as_ref(self))
+    }
+}
+
+impl<T> const Deref for Option<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        loop {}
+    }
+}
+
+impl<P: Receiver> Receiver for Pin<P> {}
+
+impl<T: Clone> Clone for RefCell<T> {
+    fn clone(&self) -> RefCell<T> {
+        RefCell::new(self.borrow().clone())
+    }
+}
+
+struct RefCell<T: ?Sized> {
+    borrow: UnsafeCell<()>,
+    value: UnsafeCell<T>,
+}
+impl<T> RefCell<T> {
+    const fn new(value: T) -> RefCell<T> {
+        loop {}
+    }
+}
+impl<T: ?Sized> RefCell<T> {
+    fn borrow(&self) -> Ref<'_, T> {
+        loop {}
+    }
+}
+
+#[lang = "unsafe_cell"]
+#[repr(transparent)]
+struct UnsafeCell<T: ?Sized> {
+    value: T,
+}
+
+struct Ref<'b, T: ?Sized + 'b> {
+    value: *const T,
+    borrow: &'b UnsafeCell<()>,
+}
+
+impl<T: ?Sized> Deref for Ref<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        loop {}
+    }
+}
+
+#[lang = "clone"]
+#[rustc_trivial_field_reads]
+#[const_trait]
+trait Clone: Sized {
+    fn clone(&self) -> Self;
+    fn clone_from(&mut self, source: &Self)
+    where
+        Self: ~const Destruct,
+    {
+        *self = source.clone()
+    }
+}
+
+#[lang = "structural_peq"]
+trait StructuralPartialEq {}
+
+#[lang = "structural_teq"]
+trait StructuralEq {}
+
+const fn drop<T: ~const Destruct>(_: T) {}

--- a/src/test/ui/consts/operator_traits.rs
+++ b/src/test/ui/consts/operator_traits.rs
@@ -79,11 +79,15 @@ trait FnMut<Args: Tuple>: ~const FnOnce<Args> {
 #[const_trait]
 #[lang = "fn_once"]
 #[rustc_paren_sugar]
-trait FnOnce<Args: Tuple> {
+trait FnOnce<Args: Tuple>: Callable<Args> {
     type Output;
 
     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
 }
+
+#[const_trait]
+#[lang = "callable"]
+trait Callable<Args: Tuple> {}
 
 struct ConstFnMutClosure<CapturedData, Function> {
     data: CapturedData,

--- a/src/test/ui/keyword_generics/const_trait.rs
+++ b/src/test/ui/keyword_generics/const_trait.rs
@@ -1,0 +1,94 @@
+#![feature(const_trait_impl)]
+#![feature(effects)]
+#![feature(inline_const)]
+
+#[const_trait]
+trait Foo {
+    type AssocTy;
+    fn bar();
+}
+
+struct A;
+impl Foo for A {
+    type AssocTy = ();
+    fn bar() {
+        println!("");
+    }
+}
+
+struct B;
+impl const Foo for B {
+    type AssocTy = i32;
+    fn bar() {}
+}
+
+const C: <A as Foo>::AssocTy = ();
+const D: <B as Foo>::AssocTy = 42;
+
+const FOO: () = {
+    A::bar(); //~ ERROR: cannot call
+    B::bar();
+    foo();
+    moo::<A>();
+    moo::<B>();
+    boo::<A>(); //~ ERROR: cannot call
+    boo::<B>();
+};
+
+static BAR: () = {
+    A::bar(); //~ ERROR: cannot call
+    B::bar();
+    foo();
+    moo::<A>();
+    moo::<B>();
+    boo::<A>(); //~ ERROR: cannot call
+    boo::<B>();
+};
+
+const fn foo() {
+    A::bar(); //~ ERROR: cannot call
+    B::bar();
+    moo::<A>();
+    moo::<B>();
+    boo::<A>(); //~ ERROR: cannot call
+    boo::<B>();
+}
+
+const fn moo<T: Foo>() {
+    T::bar(); //~ ERROR: cannot call
+}
+
+const fn boo<T: ~const Foo>() {
+    T::bar();
+}
+
+fn main() {
+    A::bar();
+    B::bar();
+    foo();
+    moo::<A>();
+    moo::<B>();
+    boo::<A>();
+    boo::<B>();
+
+    const {
+        A::bar(); //~ ERROR: cannot call
+        B::bar();
+        foo();
+        moo::<A>();
+        moo::<B>();
+        boo::<A>(); //~ ERROR: cannot call
+        boo::<B>();
+    };
+
+    [(); {
+        A::bar(); //~ ERROR: cannot call
+        B::bar();
+        foo();
+        moo::<A>();
+        moo::<B>();
+        boo::<A>(); //~ ERROR: cannot call
+        boo::<B>();
+        0
+    }];
+}

--- a/src/test/ui/keyword_generics/const_trait.stderr
+++ b/src/test/ui/keyword_generics/const_trait.stderr
@@ -1,0 +1,120 @@
+error: cannot call `<A as Foo>::bar` because it is not `const`
+  --> $DIR/const_trait.rs:29:5
+   |
+LL | const FOO: () = {
+   |       --- required because of this
+LL |     A::bar();
+   |     ^^^^^^^^
+
+error: cannot call `boo::<A>` because it is not `const`
+  --> $DIR/const_trait.rs:34:5
+   |
+LL | const FOO: () = {
+   |       --- required because of this
+...
+LL |     boo::<A>();
+   |     ^^^^^^^^^^
+
+error: cannot call `<A as Foo>::bar` because it is not `const`
+  --> $DIR/const_trait.rs:39:5
+   |
+LL | static BAR: () = {
+   |        --- required because of this
+LL |     A::bar();
+   |     ^^^^^^^^
+
+error: cannot call `boo::<A>` because it is not `const`
+  --> $DIR/const_trait.rs:44:5
+   |
+LL | static BAR: () = {
+   |        --- required because of this
+...
+LL |     boo::<A>();
+   |     ^^^^^^^^^^
+
+error: cannot call `<A as Foo>::bar` because it is not `const`
+  --> $DIR/const_trait.rs:49:5
+   |
+LL | const fn foo() {
+   |          --- required because of this
+LL |     A::bar();
+   |     ^^^^^^^^
+
+error: cannot call `boo::<A>` because it is not `const`
+  --> $DIR/const_trait.rs:53:5
+   |
+LL | const fn foo() {
+   |          --- required because of this
+...
+LL |     boo::<A>();
+   |     ^^^^^^^^^^
+
+error: cannot call `<T as Foo>::bar` because it is not `const`
+  --> $DIR/const_trait.rs:58:5
+   |
+LL | const fn moo<T: Foo>() {
+   |          --- required because of this
+LL |     T::bar();
+   |     ^^^^^^^^
+
+error: cannot call `<A as Foo>::bar` because it is not `const`
+  --> $DIR/const_trait.rs:75:9
+   |
+LL |       const {
+   |  ___________-
+LL | |         A::bar();
+   | |         ^^^^^^^^
+LL | |         B::bar();
+LL | |         foo();
+...  |
+LL | |         boo::<B>();
+LL | |     };
+   | |_____- required because of this
+
+error: cannot call `boo::<A>` because it is not `const`
+  --> $DIR/const_trait.rs:80:9
+   |
+LL |       const {
+   |  ___________-
+LL | |         A::bar();
+LL | |         B::bar();
+LL | |         foo();
+...  |
+LL | |         boo::<A>();
+   | |         ^^^^^^^^^^
+LL | |         boo::<B>();
+LL | |     };
+   | |_____- required because of this
+
+error: cannot call `<A as Foo>::bar` because it is not `const`
+  --> $DIR/const_trait.rs:85:9
+   |
+LL |       [(); {
+   |  __________-
+LL | |         A::bar();
+   | |         ^^^^^^^^
+LL | |         B::bar();
+LL | |         foo();
+...  |
+LL | |         0
+LL | |     }];
+   | |_____- required because of this
+
+error: cannot call `boo::<A>` because it is not `const`
+  --> $DIR/const_trait.rs:90:9
+   |
+LL |       [(); {
+   |  __________-
+LL | |         A::bar();
+LL | |         B::bar();
+LL | |         foo();
+...  |
+LL | |         boo::<A>();
+   | |         ^^^^^^^^^^
+LL | |         boo::<B>();
+LL | |         0
+LL | |     }];
+   | |_____- required because of this
+
+error: aborting due to 11 previous errors
+

--- a/src/test/ui/keyword_generics/effects_are_not_user_visible_generic_params.rs
+++ b/src/test/ui/keyword_generics/effects_are_not_user_visible_generic_params.rs
@@ -1,0 +1,18 @@
+#![feature(const_trait_impl)]
+#![feature(effects)]
+#![feature(inline_const)]
+
+#[const_trait]
+trait Foo {
+    fn bar(&self);
+}
+
+fn foo<T: Foo<()>>() {}
+//~^ ERROR this trait takes 0 generic arguments but 1 generic argument was supplied
+
+fn bar(x: &dyn Foo) {
+    x.bar();
+}
+
+fn main() {
+}

--- a/src/test/ui/keyword_generics/effects_are_not_user_visible_generic_params.stderr
+++ b/src/test/ui/keyword_generics/effects_are_not_user_visible_generic_params.stderr
@@ -1,0 +1,17 @@
+error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/effects_are_not_user_visible_generic_params.rs:10:11
+   |
+LL | fn foo<T: Foo<()>>() {}
+   |           ^^^---- help: remove these generics
+   |           |
+   |           expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/effects_are_not_user_visible_generic_params.rs:6:7
+   |
+LL | trait Foo {
+   |       ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/keyword_generics/feature-gate-effects.rs
+++ b/src/test/ui/keyword_generics/feature-gate-effects.rs
@@ -1,0 +1,7 @@
+// This is a fake feature gate test. There is currently no way
+// to fail a test only with the feature gate missing.
+// FIXME(effects): make this an actual test once effects enable more code to compile
+
+fn main() {
+    "just fail this test" //~ ERROR mismatched types
+}

--- a/src/test/ui/keyword_generics/feature-gate-effects.stderr
+++ b/src/test/ui/keyword_generics/feature-gate-effects.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/feature-gate-effects.rs:6:5
+   |
+LL | fn main() {
+   |           - expected `()` because of default return type
+LL |     "just fail this test"
+   |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `&str`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/keyword_generics/other_const_fn.rs
+++ b/src/test/ui/keyword_generics/other_const_fn.rs
@@ -1,0 +1,13 @@
+#![feature(effects)]
+
+// check-pass
+
+fn main() {}
+
+const fn f() {
+    g();
+    let x = g;
+    x();
+}
+
+const fn g() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/assoc-type-const-bound-usage.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/assoc-type-const-bound-usage.rs
@@ -1,5 +1,6 @@
+#![feature(const_trait_impl, effects)]
+
 // check-pass
-#![feature(const_trait_impl)]
 
 #[const_trait]
 trait Foo {

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait A {

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
@@ -1,11 +1,11 @@
 error: attribute should be applied to a trait
-  --> $DIR/attr-misuse.rs:9:1
+  --> $DIR/attr-misuse.rs:10:1
    |
 LL | #[const_trait]
    | ^^^^^^^^^^^^^^
 
 error: attribute should be applied to a trait
-  --> $DIR/attr-misuse.rs:5:5
+  --> $DIR/attr-misuse.rs:6:5
    |
 LL |     #[const_trait]
    |     ^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
@@ -1,4 +1,4 @@
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, effects)]
 
 #[const_trait]
 pub trait MyTrait {

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/staged-api.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/staged-api.rs
@@ -1,4 +1,4 @@
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, effects)]
 #![feature(staged_api)]
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 pub trait Plus {

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
@@ -1,14 +1,10 @@
-error[E0277]: the trait bound `u32: ~const Plus` is not satisfied
-  --> $DIR/call-const-trait-method-fail.rs:25:7
+error[E0277]: the trait bound `u32: Plus` is not satisfied
+  --> $DIR/call-const-trait-method-fail.rs:26:7
    |
 LL |     a.plus(b)
-   |       ^^^^ the trait `~const Plus` is not implemented for `u32`
+   |       ^^^^ the trait `Plus` is not implemented for `u32`
    |
-note: the trait `Plus` is implemented for `u32`, but that implementation is not `const`
-  --> $DIR/call-const-trait-method-fail.rs:25:7
-   |
-LL |     a.plus(b)
-   |       ^^^^
+   = help: the trait `Plus` is implemented for `u32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst-bound.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst-bound.rs
@@ -1,5 +1,7 @@
 // check-pass
 
+#![feature(effects)]
+
 struct S;
 
 impl PartialEq for S {

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
@@ -1,4 +1,4 @@
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, effects)]
 
 struct S;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
@@ -6,11 +6,7 @@ LL | pub const EQ: bool = equals_self(&S);
    |                      |
    |                      required by a bound introduced by this call
    |
-note: the trait `Foo` is implemented for `S`, but that implementation is not `const`
-  --> $DIR/call-generic-method-nonconst.rs:23:34
-   |
-LL | pub const EQ: bool = equals_self(&S);
-   |                                  ^^
+   = help: the trait `Foo` is implemented for `S`
 note: required by a bound in `equals_self`
   --> $DIR/call-generic-method-nonconst.rs:16:25
    |

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait ConstDefaultFn: Sized {

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -1,14 +1,10 @@
-error[E0277]: the trait bound `NonConstImpl: ~const ConstDefaultFn` is not satisfied
-  --> $DIR/const-default-method-bodies.rs:24:18
+error[E0277]: the trait bound `NonConstImpl: ConstDefaultFn` is not satisfied
+  --> $DIR/const-default-method-bodies.rs:25:18
    |
 LL |     NonConstImpl.a();
-   |                  ^ the trait `~const ConstDefaultFn` is not implemented for `NonConstImpl`
+   |                  ^ the trait `ConstDefaultFn` is not implemented for `NonConstImpl`
    |
-note: the trait `ConstDefaultFn` is implemented for `NonConstImpl`, but that implementation is not `const`
-  --> $DIR/const-default-method-bodies.rs:24:5
-   |
-LL |     NonConstImpl.a();
-   |     ^^^^^^^^^^^^
+   = help: the trait `ConstDefaultFn` is implemented for `NonConstImpl`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 struct Foo;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-norecover.rs:5:7
+  --> $DIR/const-impl-norecover.rs:6:7
    |
 LL | const impl Foo {
    |       ^^^^ expected identifier, found keyword

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Foo {}

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-recovery.rs:6:7
+  --> $DIR/const-impl-recovery.rs:7:7
    |
 LL | const impl Foo for i32 {}
    |       ^^^^ expected identifier, found keyword
@@ -11,7 +11,7 @@ LL + impl const Foo for i32 {}
    |
 
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-recovery.rs:11:7
+  --> $DIR/const-impl-recovery.rs:12:7
    |
 LL | const impl<T: Foo> Bar for T {}
    |       ^^^^ expected identifier, found keyword

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-requires-const-trait.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-requires-const-trait.rs
@@ -1,7 +1,7 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 pub trait A {}
-//~^ HELP: mark `A` as const
 
 impl const A for () {}
 //~^ ERROR: const `impl` for trait `A` which is not marked with `#[const_trait]`

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
@@ -3,7 +3,7 @@ error: const `impl` for trait `A` which is not marked with `#[const_trait]`
    |
 LL | pub trait A {}
    | - help: mark `A` as const: `#[const_trait]`
-...
+LL |
 LL | impl const A for () {}
    |            ^
    |

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-default-method-body-is-const.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-default-method-body-is-const.rs
@@ -4,6 +4,7 @@
 // check-pass
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 // aux-build: cross-crate.rs
 extern crate cross_crate;

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gatednc.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gatednc.stderr
@@ -1,14 +1,10 @@
-error[E0277]: the trait bound `cross_crate::NonConst: ~const cross_crate::MyTrait` is not satisfied
+error[E0277]: the trait bound `cross_crate::NonConst: cross_crate::MyTrait` is not satisfied
   --> $DIR/cross-crate.rs:17:14
    |
 LL |     NonConst.func();
-   |              ^^^^ the trait `~const cross_crate::MyTrait` is not implemented for `cross_crate::NonConst`
+   |              ^^^^ the trait `cross_crate::MyTrait` is not implemented for `cross_crate::NonConst`
    |
-note: the trait `cross_crate::MyTrait` is implemented for `cross_crate::NonConst`, but that implementation is not `const`
-  --> $DIR/cross-crate.rs:17:5
-   |
-LL |     NonConst.func();
-   |     ^^^^^^^^
+   = help: the trait `cross_crate::MyTrait` is implemented for `cross_crate::NonConst`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
@@ -1,6 +1,6 @@
 // revisions: stock gated stocknc gatednc
 // [gated] check-pass
-#![cfg_attr(any(gated, gatednc), feature(const_trait_impl))]
+#![cfg_attr(any(gated, gatednc), feature(const_trait_impl, effects))]
 
 // aux-build: cross-crate.rs
 extern crate cross_crate;

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-body-checking.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-body-checking.rs
@@ -1,4 +1,4 @@
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, effects)]
 
 #[const_trait]
 trait Tr {}
@@ -10,7 +10,7 @@ const fn foo<T>() where T: ~const Tr {}
 pub trait Foo {
     fn foo() {
         foo::<()>();
-        //~^ ERROR the trait bound `(): ~const Tr` is not satisfied
+        //~^ ERROR cannot call
     }
 }
 

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-body-checking.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-body-checking.stderr
@@ -1,20 +1,10 @@
-error[E0277]: the trait bound `(): ~const Tr` is not satisfied
-  --> $DIR/default-method-body-is-const-body-checking.rs:12:15
+error: cannot call `foo::<()>` because it is not `const`
+  --> $DIR/default-method-body-is-const-body-checking.rs:12:9
    |
+LL |     fn foo() {
+   |        --- required because of this
 LL |         foo::<()>();
-   |               ^^ the trait `~const Tr` is not implemented for `()`
-   |
-note: the trait `Tr` is implemented for `()`, but that implementation is not `const`
-  --> $DIR/default-method-body-is-const-body-checking.rs:12:15
-   |
-LL |         foo::<()>();
-   |               ^^
-note: required by a bound in `foo`
-  --> $DIR/default-method-body-is-const-body-checking.rs:7:28
-   |
-LL | const fn foo<T>() where T: ~const Tr {}
-   |                            ^^^^^^^^^ required by this bound in `foo`
+   |         ^^^^^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 pub trait Tr {

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
@@ -1,14 +1,10 @@
-error[E0277]: the trait bound `(): ~const Tr` is not satisfied
-  --> $DIR/default-method-body-is-const-same-trait-ck.rs:8:12
+error[E0277]: the trait bound `(): Tr` is not satisfied
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:9:12
    |
 LL |         ().a()
-   |            ^ the trait `~const Tr` is not implemented for `()`
+   |            ^ the trait `Tr` is not implemented for `()`
    |
-note: the trait `Tr` is implemented for `()`, but that implementation is not `const`
-  --> $DIR/default-method-body-is-const-same-trait-ck.rs:8:9
-   |
-LL |         ().a()
-   |         ^^
+   = help: the trait `Tr` is implemented for `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-with-staged-api.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-with-staged-api.rs
@@ -7,6 +7,7 @@
 
 #![feature(staged_api)]
 #![feature(const_trait_impl)]
+#![feature(effects)]
 #![stable(since = "1", feature = "foo")]
 
 #[const_trait]

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-tilde-const-trait.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-tilde-const-trait.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 struct S;
 trait T {}

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-tilde-const-trait.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-tilde-const-trait.stderr
@@ -1,5 +1,5 @@
 error: expected a trait, found type
-  --> $DIR/impl-tilde-const-trait.rs:6:6
+  --> $DIR/impl-tilde-const-trait.rs:7:6
    |
 LL | impl ~const T for S {}
    |      ^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Tr {

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `req`
-  --> $DIR/impl-with-default-fn-fail.rs:12:1
+  --> $DIR/impl-with-default-fn-fail.rs:13:1
    |
 LL |     fn req(&self);
    |     -------------- `req` from trait

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
@@ -1,6 +1,7 @@
 // check-pass
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Tr {

--- a/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.rs
@@ -1,13 +1,16 @@
 #![feature(const_trait_impl)]
 #![allow(bare_trait_objects)]
+#![feature(effects)]
 
 struct S;
 trait T {}
 
 impl const S {}
 //~^ ERROR inherent impls cannot be `const`
+//~| ERROR `host` is not constrained
 
 impl const T {}
 //~^ ERROR inherent impls cannot be `const`
+//~| ERROR `host` is not constrained
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
@@ -1,5 +1,5 @@
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:7:12
+  --> $DIR/inherent-impl.rs:8:12
    |
 LL | impl const S {}
    |      ----- ^ inherent impl for this type
@@ -9,7 +9,7 @@ LL | impl const S {}
    = note: only trait implementations may be annotated with `const`
 
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:10:12
+  --> $DIR/inherent-impl.rs:12:12
    |
 LL | impl const T {}
    |      ----- ^ inherent impl for this type
@@ -18,5 +18,18 @@ LL | impl const T {}
    |
    = note: only trait implementations may be annotated with `const`
 
-error: aborting due to 2 previous errors
+error[E0207]: the effect parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/inherent-impl.rs:8:1
+   |
+LL | impl const S {}
+   | ^^^^^^^^^^^^ unconstrained effect parameter
 
+error[E0207]: the effect parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/inherent-impl.rs:12:1
+   |
+LL | impl const T {}
+   | ^^^^^^^^^^^^ unconstrained effect parameter
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/src/test/ui/rfc-2632-const-trait-impl/intrinsics.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/intrinsics.rs
@@ -1,0 +1,10 @@
+#![feature(effects)]
+#![feature(core_intrinsics)]
+
+// check-pass
+
+const fn foo() -> usize {
+    std::intrinsics::size_of::<i32>()
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-100222.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-100222.rs
@@ -1,19 +1,34 @@
 // revisions: nn ny yn yy
 // check-pass
 #![feature(const_trait_impl, associated_type_defaults, const_mut_refs)]
+#![feature(effects)]
 
 #[cfg_attr(any(yn, yy), const_trait)]
 pub trait Index {
     type Output;
 }
 
-#[cfg_attr(any(ny, yy), const_trait)]
-pub trait IndexMut where Self: Index {
+#[cfg(yy)]
+#[const_trait]
+pub trait IndexMut: ~const Index {
     const C: <Self as Index>::Output;
     type Assoc = <Self as Index>::Output;
     fn foo(&mut self, x: <Self as Index>::Output) -> <Self as Index>::Output;
 }
 
+#[cfg(not(yy))]
+#[cfg_attr(ny, const_trait)]
+pub trait IndexMut: Index {
+    const C: <Self as Index>::Output;
+    type Assoc = <Self as Index>::Output;
+    fn foo(&mut self, x: <Self as Index>::Output) -> <Self as Index>::Output;
+}
+
+#[cfg(yy)]
+// FIXME: once we have `<Type as ~const Index>` syntax, remove this impl
+// and merge the `IndexMut` declarations to only use the one without a `~const Index` bound.
+impl const Index for () { type Output = (); }
+#[cfg(not(yy))]
 impl Index for () { type Output = (); }
 
 #[cfg(not(any(nn, yn)))]

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-88155.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-88155.rs
@@ -1,4 +1,4 @@
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, effects)]
 
 pub trait A {
     fn assoc() -> bool;
@@ -6,8 +6,7 @@ pub trait A {
 
 pub const fn foo<T: A>() -> bool {
     T::assoc()
-    //~^ ERROR the trait bound
-    //~| ERROR cannot call non-const fn
+    //~^ ERROR cannot call non-const fn `<T as A>::assoc` in functions
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
@@ -1,24 +1,8 @@
-error[E0277]: the trait bound `T: ~const A` is not satisfied
-  --> $DIR/issue-88155.rs:8:5
-   |
-LL |     T::assoc()
-   |     ^^^^^^^^^^ the trait `~const A` is not implemented for `T`
-   |
-note: the trait `A` is implemented for `T`, but that implementation is not `const`
+error: cannot call non-const fn `<T as A>::assoc` in functions
   --> $DIR/issue-88155.rs:8:5
    |
 LL |     T::assoc()
    |     ^^^^^^^^^^
 
-error[E0015]: cannot call non-const fn `<T as A>::assoc` in constant functions
-  --> $DIR/issue-88155.rs:8:5
-   |
-LL |     T::assoc()
-   |     ^^^^^^^^^^
-   |
-   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0015, E0277.
-For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/specializing-constness-2.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/specializing-constness-2.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl, min_specialization, rustc_attrs)]
+#![feature(effects)]
 
 #[rustc_specialization_trait]
 #[const_trait]
@@ -17,7 +18,7 @@ impl<T: Default> A for T {
     }
 }
 
-impl<T: Default + ~const Sup> const A for T {
+impl<T: Default + ~const Sup> const A for T { //~ ERROR: conflicting impl
     fn a() -> u32 {
         3
     }
@@ -25,7 +26,6 @@ impl<T: Default + ~const Sup> const A for T {
 
 const fn generic<T: Default>() {
     <T as A>::a();
-    //~^ ERROR: the trait bound `T: ~const Sup` is not satisfied
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/specializing-constness-2.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/specializing-constness-2.stderr
@@ -1,19 +1,12 @@
-error[E0277]: the trait bound `T: ~const Sup` is not satisfied
-  --> $DIR/specializing-constness-2.rs:27:5
+error[E0119]: conflicting implementations of trait `A`
+  --> $DIR/specializing-constness-2.rs:21:1
    |
-LL |     <T as A>::a();
-   |     ^^^^^^^^^^^^^ the trait `~const Sup` is not implemented for `T`
-   |
-note: required for `T` to implement `~const A`
-  --> $DIR/specializing-constness-2.rs:20:37
-   |
+LL | impl<T: Default> A for T {
+   | ------------------------ first implementation here
+...
 LL | impl<T: Default + ~const Sup> const A for T {
-   |                                     ^     ^
-help: consider further restricting this bound
-   |
-LL | const fn generic<T: Default + ~const Sup>() {
-   |                             ++++++++++++
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/rfc-2632-const-trait-impl/staged-api.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/staged-api.rs
@@ -1,7 +1,7 @@
 // revisions: stable unstable
 
 #![cfg_attr(unstable, feature(unstable))] // The feature from the ./auxiliary/staged-api.rs file.
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, effects)]
 #![feature(staged_api)]
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.rs
@@ -1,4 +1,4 @@
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, effects)]
 
 // revisions: yy yn ny nn
 
@@ -13,7 +13,7 @@ trait Bar: ~const Foo {}
 
 const fn foo<T: Bar>(x: &T) {
     x.a();
-    //[yn,yy]~^ ERROR the trait bound
+    //[yn,yy]~^ ERROR cannot call
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
@@ -1,19 +1,10 @@
-error[E0277]: the trait bound `T: ~const Foo` is not satisfied
+error: cannot call `<T as Foo>::a` because it is not `const`
   --> $DIR/super-traits-fail-2.rs:15:7
    |
+LL | const fn foo<T: Bar>(x: &T) {
+   |          --- required because of this
 LL |     x.a();
-   |       ^ the trait `~const Foo` is not implemented for `T`
-   |
-note: the trait `Foo` is implemented for `T`, but that implementation is not `const`
-  --> $DIR/super-traits-fail-2.rs:15:5
-   |
-LL |     x.a();
-   |     ^
-help: consider further restricting this bound
-   |
-LL | const fn foo<T: Bar + ~const Foo>(x: &T) {
-   |                     ++++++++++++
+   |       ^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
@@ -1,19 +1,10 @@
-error[E0277]: the trait bound `T: ~const Foo` is not satisfied
+error: cannot call `<T as Foo>::a` because it is not `const`
   --> $DIR/super-traits-fail-2.rs:15:7
    |
+LL | const fn foo<T: Bar>(x: &T) {
+   |          --- required because of this
 LL |     x.a();
-   |       ^ the trait `~const Foo` is not implemented for `T`
-   |
-note: the trait `Foo` is implemented for `T`, but that implementation is not `const`
-  --> $DIR/super-traits-fail-2.rs:15:5
-   |
-LL |     x.a();
-   |     ^
-help: consider further restricting this bound
-   |
-LL | const fn foo<T: Bar + ~const Foo>(x: &T) {
-   |                     ++++++++++++
+   |       ^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Foo {

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.stderr
@@ -1,19 +1,10 @@
-error[E0277]: the trait bound `S: ~const Foo` is not satisfied
-  --> $DIR/super-traits-fail.rs:15:12
+error[E0277]: the trait bound `S: Foo` is not satisfied
+  --> $DIR/super-traits-fail.rs:16:12
    |
 LL | impl const Bar for S {}
-   |            ^^^ the trait `~const Foo` is not implemented for `S`
+   |            ^^^ the trait `Foo` is not implemented for `S`
    |
-note: the trait `Foo` is implemented for `S`, but that implementation is not `const`
-  --> $DIR/super-traits-fail.rs:15:12
-   |
-LL | impl const Bar for S {}
-   |            ^^^
-note: required by a bound in `Bar`
-  --> $DIR/super-traits-fail.rs:8:12
-   |
-LL | trait Bar: ~const Foo {}
-   |            ^^^^^^^^^^ required by this bound in `Bar`
+   = help: the trait `Foo` is implemented for `S`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits.rs
@@ -1,5 +1,6 @@
 // check-pass
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Foo {

--- a/src/test/ui/rfc-2632-const-trait-impl/syntax.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/syntax.rs
@@ -3,6 +3,7 @@
 
 #![feature(const_trait_bound_opt_out)]
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 // For now, this parses since an error does not occur until AST lowering.
 impl ~const T {}

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
@@ -1,5 +1,6 @@
 #![feature(const_trait_impl)]
 #![feature(associated_type_bounds)]
+#![feature(effects)]
 
 struct TildeQuestion<T: ~const ?Sized>(std::marker::PhantomData<T>);
 //~^ ERROR `~const` and `?` are mutually exclusive

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -1,5 +1,5 @@
 error: `~const` and `?` are mutually exclusive
-  --> $DIR/tilde-const-invalid-places.rs:4:25
+  --> $DIR/tilde-const-invalid-places.rs:5:25
    |
 LL | struct TildeQuestion<T: ~const ?Sized>(std::marker::PhantomData<T>);
    |                         ^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-const-syntax.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-const-syntax.rs
@@ -2,6 +2,7 @@
 // check-pass
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 struct S<
     T: ~const ?for<'a> Tr<'a> + 'static + ~const std::ops::Add,

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-twice.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-twice.rs
@@ -1,6 +1,7 @@
 // compile-flags: -Z parse-only
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 struct S<T: ~const ~const Tr>;
 //~^ ERROR expected identifier, found `~`

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-twice.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-twice.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found `~`
-  --> $DIR/tilde-twice.rs:5:20
+  --> $DIR/tilde-twice.rs:6:20
    |
 LL | struct S<T: ~const ~const Tr>;
    |                    ^ expected identifier

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-const.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-const.rs
@@ -3,6 +3,7 @@
 // (`rustc_const_eval` instead of `rustc_hir_analysis`) Therefore one file as a
 // test is not enough.
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Bar {}

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-const.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-const.stderr
@@ -1,34 +1,34 @@
-error[E0277]: the trait bound `T: ~const Bar` is not satisfied
-  --> $DIR/trait-where-clause-const.rs:19:5
+error[E0277]: the trait bound `T: Bar` is not satisfied
+  --> $DIR/trait-where-clause-const.rs:20:5
    |
 LL |     T::b();
-   |     ^^^^^^ the trait `~const Bar` is not implemented for `T`
+   |     ^^^^ the trait `Bar` is not implemented for `T`
    |
-note: the trait `Bar` is implemented for `T`, but that implementation is not `const`
-  --> $DIR/trait-where-clause-const.rs:19:5
+note: required by a bound in `Foo::b`
+  --> $DIR/trait-where-clause-const.rs:14:24
    |
-LL |     T::b();
-   |     ^^^^^^
+LL |     fn b() where Self: ~const Bar;
+   |                        ^^^^^^^^^^ required by this bound in `Foo::b`
 help: consider further restricting this bound
    |
-LL | const fn test1<T: ~const Foo + Bar + ~const Bar>() {
-   |                                    ++++++++++++
+LL | const fn test1<T: ~const Foo + Bar + Bar>() {
+   |                                    +++++
 
-error[E0277]: the trait bound `T: ~const Bar` is not satisfied
-  --> $DIR/trait-where-clause-const.rs:21:5
+error[E0277]: the trait bound `T: Bar` is not satisfied
+  --> $DIR/trait-where-clause-const.rs:22:12
    |
 LL |     T::c::<T>();
-   |     ^^^^^^^^^^^ the trait `~const Bar` is not implemented for `T`
+   |            ^ the trait `Bar` is not implemented for `T`
    |
-note: the trait `Bar` is implemented for `T`, but that implementation is not `const`
-  --> $DIR/trait-where-clause-const.rs:21:5
+note: required by a bound in `Foo::c`
+  --> $DIR/trait-where-clause-const.rs:15:13
    |
-LL |     T::c::<T>();
-   |     ^^^^^^^^^^^
+LL |     fn c<T: ~const Bar>();
+   |             ^^^^^^^^^^ required by this bound in `Foo::c`
 help: consider further restricting this bound
    |
-LL | const fn test1<T: ~const Foo + Bar + ~const Bar>() {
-   |                                    ++++++++++++
+LL | const fn test1<T: ~const Foo + Bar + Bar>() {
+   |                                    +++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-run.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-run.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Bar {

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-self-referential.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-self-referential.rs
@@ -1,6 +1,7 @@
 // check-pass
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Foo {

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 #[const_trait]
 trait Bar {}

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `T: Bar` is not satisfied
-  --> $DIR/trait-where-clause.rs:14:5
+  --> $DIR/trait-where-clause.rs:15:5
    |
 LL |     T::b();
    |     ^^^^ the trait `Bar` is not implemented for `T`
    |
 note: required by a bound in `Foo::b`
-  --> $DIR/trait-where-clause.rs:8:24
+  --> $DIR/trait-where-clause.rs:9:24
    |
 LL |     fn b() where Self: ~const Bar;
    |                        ^^^^^^^^^^ required by this bound in `Foo::b`
@@ -15,13 +15,13 @@ LL | fn test1<T: Foo + Bar>() {
    |                 +++++
 
 error[E0277]: the trait bound `T: Bar` is not satisfied
-  --> $DIR/trait-where-clause.rs:16:12
+  --> $DIR/trait-where-clause.rs:17:12
    |
 LL |     T::c::<T>();
    |            ^ the trait `Bar` is not implemented for `T`
    |
 note: required by a bound in `Foo::c`
-  --> $DIR/trait-where-clause.rs:9:13
+  --> $DIR/trait-where-clause.rs:10:13
    |
 LL |     fn c<T: ~const Bar>();
    |             ^^^^^^^^^^ required by this bound in `Foo::c`

--- a/src/test/ui/rfc-2632-const-trait-impl/without-tilde.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/without-tilde.rs
@@ -1,6 +1,7 @@
 // compile-flags: -Z parse-only
 
 #![feature(const_trait_impl)]
+#![feature(effects)]
 
 struct S<T: const Tr>;
 //~^ ERROR const bounds must start with `~`

--- a/src/test/ui/rfc-2632-const-trait-impl/without-tilde.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/without-tilde.stderr
@@ -1,5 +1,5 @@
 error: const bounds must start with `~`
-  --> $DIR/without-tilde.rs:5:13
+  --> $DIR/without-tilde.rs:6:13
    |
 LL | struct S<T: const Tr>;
    |             -^^^^

--- a/src/test/ui/static/static-vec-repeat-not-constant.rs
+++ b/src/test/ui/static/static-vec-repeat-not-constant.rs
@@ -1,6 +1,6 @@
 fn foo() -> isize { 23 }
 
 static a: [isize; 2] = [foo(); 2];
-//~^ ERROR: E0015
+//~^ ERROR: cannot call non-const fn `foo` in statics [E0015]
 
 fn main() {}

--- a/src/tools/clippy/clippy_lints/src/let_underscore.rs
+++ b/src/tools/clippy/clippy_lints/src/let_underscore.rs
@@ -107,7 +107,7 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
             let init_ty = cx.typeck_results().expr_ty(init);
             let contains_sync_guard = init_ty.walk().any(|inner| match inner.unpack() {
                 GenericArgKind::Type(inner_ty) => SYNC_GUARD_PATHS.iter().any(|path| match_type(cx, inner_ty, path)),
-                GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+                GenericArgKind::Effect(_) | GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
             });
             if contains_sync_guard {
                 span_lint_and_help(

--- a/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
+++ b/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
@@ -212,6 +212,7 @@ fn ty_allowed_with_raw_pointer_heuristic<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'t
                 substs.iter().all(|generic_arg| match generic_arg.unpack() {
                     GenericArgKind::Type(ty) => ty_allowed_with_raw_pointer_heuristic(cx, ty, send_trait),
                     // Lifetimes and const generics are not solid part of ADT and ignored
+                    GenericArgKind::Effect(_) |
                     GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => true,
                 })
             } else {

--- a/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
+++ b/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
@@ -388,6 +388,7 @@ fn has_matching_substs(kind: FnKind, substs: SubstsRef<'_>) -> bool {
             GenericArgKind::Lifetime(_) => true,
             GenericArgKind::Type(ty) => matches!(*ty.kind(), ty::Param(ty) if ty.index as usize == idx),
             GenericArgKind::Const(c) => matches!(c.kind(), ConstKind::Param(c) if c.index as usize == idx),
+            GenericArgKind::Effect(e) => matches!(e.val, ty::EffectValue::Param { index } if index as usize == idx),
         }),
         #[allow(trivial_casts)]
         FnKind::ImplTraitFn(expected_substs) => substs as *const _ as usize == expected_substs,

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -75,6 +75,7 @@ fn check_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span) -> McfResult {
 
             // No constraints on lifetimes or constants, except potentially
             // constants' types, but `walk` will get to them as well.
+            GenericArgKind::Effect(_) |
             GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
         };
 

--- a/src/tools/clippy/clippy_utils/src/ty.rs
+++ b/src/tools/clippy/clippy_utils/src/ty.rs
@@ -59,6 +59,7 @@ pub fn can_partially_move_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool
 pub fn contains_adt_constructor<'tcx>(ty: Ty<'tcx>, adt: AdtDef<'tcx>) -> bool {
     ty.walk().any(|inner| match inner.unpack() {
         GenericArgKind::Type(inner_ty) => inner_ty.ty_adt_def() == Some(adt),
+        GenericArgKind::Effect(_) |
         GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
     })
 }
@@ -121,7 +122,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
 
                 false
             },
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+            GenericArgKind::Lifetime(_) | GenericArgKind::Effect(_) | GenericArgKind::Const(_) => false,
         })
     }
 

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -316,6 +316,7 @@ impl<'a> Validator<'a> {
             rustdoc_json_types::GenericParamDefKind::Const { type_, default: _ } => {
                 self.check_type(type_)
             }
+            rustdoc_json_types::GenericParamDefKind::Effect {} => {}
         }
     }
 


### PR DESCRIPTION
r? @lcnr

tracking issue: #102090