### PR TITLE
Add help for invalid inline argument

### DIFF
--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -3129,6 +3129,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
                         E0535,
                         "invalid argument"
                     )
+                    .help("valid inline arguments are `always` and `never`")
                     .emit();
 
                     InlineAttr::None

--- a/src/test/ui/invalid/invalid-inline.rs
+++ b/src/test/ui/invalid/invalid-inline.rs
@@ -1,19 +1,14 @@
 #![allow(dead_code)]
 
-#[inline(please_no)] //~ ERROR invalid argument
+#[inline(please,no)] //~ ERROR expected one argument
 fn a() {
 }
 
-#[inline(please,no)] //~ ERROR expected one argument
-fn b() {
-}
-
 #[inline()] //~ ERROR expected one argument
-fn c() {
+fn b() {
 }
 
 fn main() {
     a();
     b();
-    c();
 }

--- a/src/test/ui/invalid/invalid-inline.stderr
+++ b/src/test/ui/invalid/invalid-inline.stderr
@@ -1,22 +1,15 @@
-error[E0535]: invalid argument
-  --> $DIR/invalid-inline.rs:3:10
-   |
-LL | #[inline(please_no)]
-   |          ^^^^^^^^^
-
 error[E0534]: expected one argument
-  --> $DIR/invalid-inline.rs:7:1
+  --> $DIR/invalid-inline.rs:3:1
    |
 LL | #[inline(please,no)]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0534]: expected one argument
-  --> $DIR/invalid-inline.rs:11:1
+  --> $DIR/invalid-inline.rs:7:1
    |
 LL | #[inline()]
    | ^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0534, E0535.
-For more information about an error, try `rustc --explain E0534`.
+For more information about this error, try `rustc --explain E0534`.

--- a/src/test/ui/span/E0535.stderr
+++ b/src/test/ui/span/E0535.stderr
@@ -3,6 +3,8 @@ error[E0535]: invalid argument
    |
 LL | #[inline(unknown)]
    |          ^^^^^^^
+   |
+   = help: valid inline arguments are `always` and `never`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #101712

Removed 1 part of the test as its identical with another one. Do let me know if this is undesirable, so I can revert those changes.