### PR TITLE
rustdoc: remove no-op CSS on `.source .content`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -346,7 +346,6 @@ img {
 }
 
 .source .content {
-	max-width: none;
 	overflow: visible;
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -348,7 +348,6 @@ img {
 .source .content {
 	max-width: none;
 	overflow: visible;
-	margin-left: 0px;
 }
 
 .sub-container {


### PR DESCRIPTION
# `margin-left: 0`

This rule originated in 7669f04fb0ddc3d71a1fb44dc1c5c00a6564ae99, to override the default, massive left margin that content used to accommodate the sidebar:

https://github.com/rust-lang/rust/blob/7669f04fb0ddc3d71a1fb44dc1c5c00a6564ae99/src/librustdoc/html/static/main.css#L307-L309

This massive left margin doesn't exist any more. It was replaced with a flexbox-based sidebar layout in 135281ed1525db15edd8ebd092aa10aa40df2386.

# `max-width: none`

This rule originated in 7669f04fb0ddc3d71a1fb44dc1c5c00a6564ae99, to override the default, limited line-width that makes sense for prose, but doesn't make sense for code (which typically uses hard-wrapped lines):

https://github.com/rust-lang/rust/blob/7669f04fb0ddc3d71a1fb44dc1c5c00a6564ae99/src/librustdoc/html/static/main.css#L153

This line width limiter isn't applied to the `<div class="content">` node any more. It's been moved to a separate wrapper `<div>` that used to be called `main-inner` (in 135281ed1525db15edd8ebd092aa10aa40df2386) but is now called `width-limiter` (since d7528e2157762fadb9665518fd1e4dee6d6a2809).