### PR TITLE
doc: fix redirected link in `/index.html`

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -101,7 +101,7 @@ accomplishing various tasks.
 
 Many of Rust's errors come with error codes, and you can request extended
 diagnostics from the compiler on those errors. You can also [read them
-here](error-index.html), if you prefer to read them that way.
+here](error_codes/index.html), if you prefer to read them that way.
 
 # Master Rust
 


### PR DESCRIPTION
Fallout from #101166