### PR TITLE
rustdoc: clean up CSS for All Items and All Crates lists

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -294,16 +294,15 @@ impl AllTypes {
 
 impl AllTypes {
     fn print(self, f: &mut Buffer) {
-        fn print_entries(f: &mut Buffer, e: &FxHashSet<ItemEntry>, title: &str, class: &str) {
+        fn print_entries(f: &mut Buffer, e: &FxHashSet<ItemEntry>, title: &str) {
             if !e.is_empty() {
                 let mut e: Vec<&ItemEntry> = e.iter().collect();
                 e.sort();
                 write!(
                     f,
-                    "<h3 id=\"{}\">{}</h3><ul class=\"{} docblock\">",
+                    "<h3 id=\"{}\">{}</h3><ul class=\"all-items\">",
                     title.replace(' ', "-"), // IDs cannot contain whitespaces.
-                    title,
-                    class
+                    title
                 );
 
                 for s in e.iter() {
@@ -321,20 +320,20 @@ impl AllTypes {
         );
         // Note: print_entries does not escape the title, because we know the current set of titles
         // doesn't require escaping.
-        print_entries(f, &self.structs, "Structs", "structs");
-        print_entries(f, &self.enums, "Enums", "enums");
-        print_entries(f, &self.unions, "Unions", "unions");
-        print_entries(f, &self.primitives, "Primitives", "primitives");
-        print_entries(f, &self.traits, "Traits", "traits");
-        print_entries(f, &self.macros, "Macros", "macros");
-        print_entries(f, &self.attributes, "Attribute Macros", "attributes");
-        print_entries(f, &self.derives, "Derive Macros", "derives");
-        print_entries(f, &self.functions, "Functions", "functions");
-        print_entries(f, &self.typedefs, "Typedefs", "typedefs");
-        print_entries(f, &self.trait_aliases, "Trait Aliases", "trait-aliases");
-        print_entries(f, &self.opaque_tys, "Opaque Types", "opaque-types");
-        print_entries(f, &self.statics, "Statics", "statics");
-        print_entries(f, &self.constants, "Constants", "constants")
+        print_entries(f, &self.structs, "Structs");
+        print_entries(f, &self.enums, "Enums");
+        print_entries(f, &self.unions, "Unions");
+        print_entries(f, &self.primitives, "Primitives");
+        print_entries(f, &self.traits, "Traits");
+        print_entries(f, &self.macros, "Macros");
+        print_entries(f, &self.attributes, "Attribute Macros");
+        print_entries(f, &self.derives, "Derive Macros");
+        print_entries(f, &self.functions, "Functions");
+        print_entries(f, &self.typedefs, "Typedefs");
+        print_entries(f, &self.trait_aliases, "Trait Aliases");
+        print_entries(f, &self.opaque_tys, "Opaque Types");
+        print_entries(f, &self.statics, "Statics");
+        print_entries(f, &self.constants, "Constants");
     }
 }
 

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -519,12 +519,12 @@ if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
             let content = format!(
                 "<h1 class=\"fqn\">\
                      <span class=\"in-band\">List of all crates</span>\
-                </h1><ul class=\"crate mod\">{}</ul>",
+                </h1><ul class=\"all-items\">{}</ul>",
                 krates
                     .iter()
                     .map(|s| {
                         format!(
-                            "<li><a class=\"crate mod\" href=\"{}index.html\">{}</a></li>",
+                            "<li><a href=\"{}index.html\">{}</a></li>",
                             ensure_trailing_slash(s),
                             s
                         )

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -207,7 +207,6 @@ a.source,
 .out-of-band,
 span.since,
 details.rustdoc-toggle > summary::before,
-.content ul.crate a.crate,
 a.srclink,
 #help-button > button,
 details.rustdoc-toggle.top-doc > summary,
@@ -218,7 +217,7 @@ details.rustdoc-toggle.non-exhaustive > summary::before,
 .more-examples-toggle summary, .more-examples-toggle .hide-more,
 .example-links a,
 /* This selector is for the items listed in the "all items" page. */
-#main-content > ul.docblock > li > a {
+ul.all-items {
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
 }
 
@@ -788,6 +787,7 @@ h2.small-section-header > .anchor {
 	content: '§';
 }
 
+.all-items a:hover,
 .docblock a:not(.srclink):not(.test-arrow):not(.scrape-help):hover,
 .docblock-short a:not(.srclink):not(.test-arrow):not(.scrape-help):hover, .item-info a {
 	text-decoration: underline;
@@ -1517,10 +1517,7 @@ kbd {
 	cursor: default;
 }
 
-#main-content > ul {
-	padding-left: 10px;
-}
-#main-content > ul > li {
+ul.all-items > li {
 	list-style: none;
 }
 

--- a/src/test/rustdoc/index-page.rs
+++ b/src/test/rustdoc/index-page.rs
@@ -6,6 +6,6 @@
 
 // @has foo/../index.html
 // @has - '//span[@class="in-band"]' 'List of all crates'
-// @has - '//ul[@class="crate mod"]//a[@href="foo/index.html"]' 'foo'
-// @has - '//ul[@class="crate mod"]//a[@href="all_item_types/index.html"]' 'all_item_types'
+// @has - '//ul[@class="all-items"]//a[@href="foo/index.html"]' 'foo'
+// @has - '//ul[@class="all-items"]//a[@href="all_item_types/index.html"]' 'all_item_types'
 pub struct Foo;


### PR DESCRIPTION
This reduces the amount of CSS, and makes these two pages more consistent (which, necessarily, means changing them a bit).

# Before

![image](https://user-images.githubusercontent.com/1593513/190735035-c66b2664-3783-483c-9bc6-89f80e4a5490.png)

![image](https://user-images.githubusercontent.com/1593513/190735134-1d5df81d-58c5-4c86-b066-6dd3031ffc2e.png)

# After

![image](https://user-images.githubusercontent.com/1593513/190735261-fc3878bb-0cab-4c4e-a6da-b5f7abd06588.png)

![image](https://user-images.githubusercontent.com/1593513/190735389-935a7836-f2c0-4349-a7d0-7fe5378f6b9a.png)
