### PR TITLE
Pass --cfg=bootstrap for rustdoc for proc_macro crates

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -139,10 +139,8 @@ fn main() {
         // Cargo doesn't pass RUSTFLAGS to proc_macros:
         // https://github.com/rust-lang/cargo/issues/4423
         // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.
-        // We also declare that the flag is expected, which is mainly needed for
-        // later stages so that they don't warn about #[cfg(bootstrap)],
-        // but enabling it for stage 0 too lets any warnings, if they occur,
-        // occur more early on, e.g. about #[cfg(bootstrap = "foo")].
+        // We also declare that the flag is expected, which we need to do to not
+        // get warnings about it being unexpected.
         if stage == "0" {
             cmd.arg("--cfg=bootstrap");
         }

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -11,6 +11,7 @@ include!("../dylib_util.rs");
 
 fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
+    let stage = env::var("RUSTC_STAGE").expect("RUSTC_STAGE was not set");
     let rustdoc = env::var_os("RUSTDOC_REAL").expect("RUSTDOC_REAL was not set");
     let libdir = env::var_os("RUSTDOC_LIBDIR").expect("RUSTDOC_LIBDIR was not set");
     let sysroot = env::var_os("RUSTC_SYSROOT").expect("RUSTC_SYSROOT was not set");
@@ -62,6 +63,16 @@ fn main() {
             cmd.arg("-Clink-arg=-Wl,--threads=1");
         }
     }
+    // Cargo doesn't pass RUSTDOCFLAGS to proc_macros:
+    // https://github.com/rust-lang/cargo/issues/4423
+    // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.
+    // We also declare that the flag is expected, which we need to do to not
+    // get warnings about it being unexpected.
+    if stage == "0" {
+        cmd.arg("--cfg=bootstrap");
+    }
+    cmd.arg("-Zunstable-options");
+    cmd.arg("--check-cfg=values(bootstrap)");
 
     if verbose > 1 {
         eprintln!(


### PR DESCRIPTION
This PR does three things:

* First, it passes --cfg=bootstrap on stage 0 for rustdoc invocations on proc_macro crates. This mirrors what we do already for rustc invocations of those, and is needed because cargo doesn't respect RUSTFLAGS or RUSTDOCFLAGS when confronted with a proc macro.
* Second, it marks the bootstrap config variable as expected. This is needed both on later stages where it's not set, but also on stage 0, where it is set.
* Third, it adjusts the comment in the rustc wrapper to better reflect the reason why we set the bootstrap variable as
  expected: due to recent changes, setting it as expected
  is also required even if the cfg variable is passed: ebf4cc361e0d0f11a25b42372bd629953365d17e .