### PR TITLE
Don't add rustdoc's CSS to other doc pages

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -383,15 +383,9 @@ impl Step for Standalone {
             }
 
             if filename == "not_found.md" {
-                cmd.arg("--markdown-css")
-                    .arg(format!("https://doc.rust-lang.org/rustdoc{}.css", &builder.version))
-                    .arg("--markdown-css")
-                    .arg("https://doc.rust-lang.org/rust.css");
+                cmd.arg("--markdown-css").arg("https://doc.rust-lang.org/rust.css");
             } else {
-                cmd.arg("--markdown-css")
-                    .arg(format!("rustdoc{}.css", &builder.version))
-                    .arg("--markdown-css")
-                    .arg("rust.css");
+                cmd.arg("--markdown-css").arg("rust.css");
             }
             builder.run(&mut cmd);
         }


### PR DESCRIPTION
This was originally added so those doc pages could use the same font files, but it turns out to be fragile. And those doc pages are just stubs that link to other pages, so they don't need fancy fonts.

Before:

![Screenshot from 2022-09-16 16-45-44](https://user-images.githubusercontent.com/220205/190831650-b626ee66-046a-4b71-8e57-dd06872359db.png)

After:

![Screenshot from 2022-09-16 16-52-06](https://user-images.githubusercontent.com/220205/190831657-f7d10a3f-d8c0-48a3-b30d-666db5a50563.png)

Demo of all affected pages:

https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/complement-design-faq.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/complement-lang-faq.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/complement-project-faq.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/grammar.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-crates.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-error-handling.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-ffi.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-macros.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-ownership.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-plugins.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-pointers.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-strings.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-tasks.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-testing.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/guide-unsafe.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/index.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/intro.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/not_found.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/reference.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/rustdoc.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/rust.html
https://rustdoc.crud.net/jsha/aux-pages-no-rustdoc-css/tutorial.html

Prior art: https://github.com/rust-lang/rust/pull/86663