### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2088,15 +2088,15 @@ pub enum InlineAsmRegOrRegClass {
 bitflags::bitflags! {
     #[derive(Encodable, Decodable, HashStable_Generic)]
     pub struct InlineAsmOptions: u16 {
-        const PURE = 1 << 0;
-        const NOMEM = 1 << 1;
-        const READONLY = 1 << 2;
+        const PURE            = 1 << 0;
+        const NOMEM           = 1 << 1;
+        const READONLY        = 1 << 2;
         const PRESERVES_FLAGS = 1 << 3;
-        const NORETURN = 1 << 4;
-        const NOSTACK = 1 << 5;
-        const ATT_SYNTAX = 1 << 6;
-        const RAW = 1 << 7;
-        const MAY_UNWIND = 1 << 8;
+        const NORETURN        = 1 << 4;
+        const NOSTACK         = 1 << 5;
+        const ATT_SYNTAX      = 1 << 6;
+        const RAW             = 1 << 7;
+        const MAY_UNWIND      = 1 << 8;
     }
 }
 

--- a/compiler/rustc_ast/src/util/parser.rs
+++ b/compiler/rustc_ast/src/util/parser.rs
@@ -297,11 +297,11 @@ impl ExprPrecedence {
         match self {
             ExprPrecedence::Closure => PREC_CLOSURE,
 
-            ExprPrecedence::Break |
-            ExprPrecedence::Continue |
-            ExprPrecedence::Ret |
-            ExprPrecedence::Yield |
-            ExprPrecedence::Yeet => PREC_JUMP,
+            ExprPrecedence::Break
+            | ExprPrecedence::Continue
+            | ExprPrecedence::Ret
+            | ExprPrecedence::Yield
+            | ExprPrecedence::Yeet => PREC_JUMP,
 
             // `Range` claims to have higher precedence than `Assign`, but `x .. x = x` fails to
             // parse, instead of parsing as `(x .. x) = x`.  Giving `Range` a lower precedence
@@ -318,43 +318,43 @@ impl ExprPrecedence {
             ExprPrecedence::AssignOp => AssocOp::Assign.precedence() as i8,
 
             // Unary, prefix
-            ExprPrecedence::Box |
-            ExprPrecedence::AddrOf |
+            ExprPrecedence::Box
+            | ExprPrecedence::AddrOf
             // Here `let pats = expr` has `let pats =` as a "unary" prefix of `expr`.
             // However, this is not exactly right. When `let _ = a` is the LHS of a binop we
             // need parens sometimes. E.g. we can print `(let _ = a) && b` as `let _ = a && b`
             // but we need to print `(let _ = a) < b` as-is with parens.
-            ExprPrecedence::Let |
-            ExprPrecedence::Unary => PREC_PREFIX,
+            | ExprPrecedence::Let
+            | ExprPrecedence::Unary => PREC_PREFIX,
 
             // Unary, postfix
-            ExprPrecedence::Await |
-            ExprPrecedence::Call |
-            ExprPrecedence::MethodCall |
-            ExprPrecedence::Field |
-            ExprPrecedence::Index |
-            ExprPrecedence::Try |
-            ExprPrecedence::InlineAsm |
-            ExprPrecedence::Mac => PREC_POSTFIX,
+            ExprPrecedence::Await
+            | ExprPrecedence::Call
+            | ExprPrecedence::MethodCall
+            | ExprPrecedence::Field
+            | ExprPrecedence::Index
+            | ExprPrecedence::Try
+            | ExprPrecedence::InlineAsm
+            | ExprPrecedence::Mac => PREC_POSTFIX,
 
             // Never need parens
-            ExprPrecedence::Array |
-            ExprPrecedence::Repeat |
-            ExprPrecedence::Tup |
-            ExprPrecedence::Lit |
-            ExprPrecedence::Path |
-            ExprPrecedence::Paren |
-            ExprPrecedence::If |
-            ExprPrecedence::While |
-            ExprPrecedence::ForLoop |
-            ExprPrecedence::Loop |
-            ExprPrecedence::Match |
-            ExprPrecedence::ConstBlock |
-            ExprPrecedence::Block |
-            ExprPrecedence::TryBlock |
-            ExprPrecedence::Async |
-            ExprPrecedence::Struct |
-            ExprPrecedence::Err => PREC_PAREN,
+            ExprPrecedence::Array
+            | ExprPrecedence::Repeat
+            | ExprPrecedence::Tup
+            | ExprPrecedence::Lit
+            | ExprPrecedence::Path
+            | ExprPrecedence::Paren
+            | ExprPrecedence::If
+            | ExprPrecedence::While
+            | ExprPrecedence::ForLoop
+            | ExprPrecedence::Loop
+            | ExprPrecedence::Match
+            | ExprPrecedence::ConstBlock
+            | ExprPrecedence::Block
+            | ExprPrecedence::TryBlock
+            | ExprPrecedence::Async
+            | ExprPrecedence::Struct
+            | ExprPrecedence::Err => PREC_PAREN,
         }
     }
 }

--- a/compiler/rustc_error_messages/locales/en-US/symbol_mangling.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/symbol_mangling.ftl
@@ -1,7 +1,1 @@
-symbol_mangling_invalid_symbol_name = symbol-name({$mangled_formatted})
-
-symbol_mangling_invalid_trait_item = demangling({$demangling_formatted})
-
-symbol_mangling_alt_invalid_trait_item = demangling-alt({$alt_demangling_formatted})
-
-symbol_mangling_invalid_def_path = def-path({$def_path})
+symbol_mangling_test_output = {$kind}({$content})

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -139,11 +139,10 @@ impl LifetimeName {
         match self {
             LifetimeName::ImplicitObjectLifetimeDefault | LifetimeName::Infer => true,
 
-            // It might seem surprising that `Fresh` counts as
-            // *not* elided -- but this is because, as far as the code
-            // in the compiler is concerned -- `Fresh` variants act
-            // equivalently to "some fresh name". They correspond to
-            // early-bound regions on an impl, in other words.
+            // It might seem surprising that `Fresh` counts as not *elided*
+            // -- but this is because, as far as the code in the compiler is
+            // concerned -- `Fresh` variants act equivalently to "some fresh name".
+            // They correspond to early-bound regions on an impl, in other words.
             LifetimeName::Error | LifetimeName::Param(..) | LifetimeName::Static => false,
         }
     }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1666,7 +1666,8 @@ impl CheckAttrVisitor<'_> {
                         E0552,
                         "unrecognized representation hint"
                     )
-                    .help("valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`")
+                    .help("valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, \
+                          `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`")
                     .emit();
 
                     continue;

--- a/compiler/rustc_symbol_mangling/src/errors.rs
+++ b/compiler/rustc_symbol_mangling/src/errors.rs
@@ -1,36 +1,34 @@
 //! Errors emitted by symbol_mangling.
 
+use rustc_errors::{DiagnosticArgValue, IntoDiagnosticArg};
 use rustc_macros::SessionDiagnostic;
 use rustc_span::Span;
 
 #[derive(SessionDiagnostic)]
-#[diag(symbol_mangling::invalid_symbol_name)]
-pub struct InvalidSymbolName {
+#[diag(symbol_mangling::test_output)]
+pub struct TestOutput {
     #[primary_span]
     pub span: Span,
-    pub mangled_formatted: String,
+    pub kind: Kind,
+    pub content: String,
 }
 
-#[derive(SessionDiagnostic)]
-#[diag(symbol_mangling::invalid_trait_item)]
-pub struct InvalidTraitItem {
-    #[primary_span]
-    pub span: Span,
-    pub demangling_formatted: String,
+pub enum Kind {
+    SymbolName,
+    Demangling,
+    DemanglingAlt,
+    DefPath,
 }
 
-#[derive(SessionDiagnostic)]
-#[diag(symbol_mangling::alt_invalid_trait_item)]
-pub struct AltInvalidTraitItem {
-    #[primary_span]
-    pub span: Span,
-    pub alt_demangling_formatted: String,
-}
-
-#[derive(SessionDiagnostic)]
-#[diag(symbol_mangling::invalid_def_path)]
-pub struct InvalidDefPath {
-    #[primary_span]
-    pub span: Span,
-    pub def_path: String,
+impl IntoDiagnosticArg for Kind {
+    fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
+        let kind = match self {
+            Kind::SymbolName => "symbol-name",
+            Kind::Demangling => "demangling",
+            Kind::DemanglingAlt => "demangling-alt",
+            Kind::DefPath => "def-path",
+        }
+        .into();
+        DiagnosticArgValue::Str(kind)
+    }
 }

--- a/compiler/rustc_symbol_mangling/src/test.rs
+++ b/compiler/rustc_symbol_mangling/src/test.rs
@@ -4,7 +4,7 @@
 //! def-path. This is used for unit testing the code that generates
 //! paths etc in all kinds of annoying scenarios.
 
-use crate::errors::{AltInvalidTraitItem, InvalidDefPath, InvalidSymbolName, InvalidTraitItem};
+use crate::errors::{Kind, TestOutput};
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{subst::InternalSubsts, Instance, TyCtxt};
@@ -60,26 +60,30 @@ impl SymbolNamesTest<'_> {
                 tcx.erase_regions(InternalSubsts::identity_for_item(tcx, def_id)),
             );
             let mangled = tcx.symbol_name(instance);
-            tcx.sess.emit_err(InvalidSymbolName {
+            tcx.sess.emit_err(TestOutput {
                 span: attr.span,
-                mangled_formatted: format!("{mangled}"),
+                kind: Kind::SymbolName,
+                content: format!("{mangled}"),
             });
             if let Ok(demangling) = rustc_demangle::try_demangle(mangled.name) {
-                tcx.sess.emit_err(InvalidTraitItem {
+                tcx.sess.emit_err(TestOutput {
                     span: attr.span,
-                    demangling_formatted: format!("{demangling}"),
+                    kind: Kind::Demangling,
+                    content: format!("{demangling}"),
                 });
-                tcx.sess.emit_err(AltInvalidTraitItem {
+                tcx.sess.emit_err(TestOutput {
                     span: attr.span,
-                    alt_demangling_formatted: format!("{:#}", demangling),
+                    kind: Kind::DemanglingAlt,
+                    content: format!("{:#}", demangling),
                 });
             }
         }
 
         for attr in tcx.get_attrs(def_id.to_def_id(), DEF_PATH) {
-            tcx.sess.emit_err(InvalidDefPath {
+            tcx.sess.emit_err(TestOutput {
                 span: attr.span,
-                def_path: with_no_trimmed_paths!(tcx.def_path_str(def_id.to_def_id())),
+                kind: Kind::DefPath,
+                content: with_no_trimmed_paths!(tcx.def_path_str(def_id.to_def_id())),
             });
         }
     }

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -139,10 +139,8 @@ fn main() {
         // Cargo doesn't pass RUSTFLAGS to proc_macros:
         // https://github.com/rust-lang/cargo/issues/4423
         // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.
-        // We also declare that the flag is expected, which is mainly needed for
-        // later stages so that they don't warn about #[cfg(bootstrap)],
-        // but enabling it for stage 0 too lets any warnings, if they occur,
-        // occur more early on, e.g. about #[cfg(bootstrap = "foo")].
+        // We also declare that the flag is expected, which we need to do to not
+        // get warnings about it being unexpected.
         if stage == "0" {
             cmd.arg("--cfg=bootstrap");
         }

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -11,6 +11,7 @@ include!("../dylib_util.rs");
 
 fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
+    let stage = env::var("RUSTC_STAGE").expect("RUSTC_STAGE was not set");
     let rustdoc = env::var_os("RUSTDOC_REAL").expect("RUSTDOC_REAL was not set");
     let libdir = env::var_os("RUSTDOC_LIBDIR").expect("RUSTDOC_LIBDIR was not set");
     let sysroot = env::var_os("RUSTC_SYSROOT").expect("RUSTC_SYSROOT was not set");
@@ -62,6 +63,16 @@ fn main() {
             cmd.arg("-Clink-arg=-Wl,--threads=1");
         }
     }
+    // Cargo doesn't pass RUSTDOCFLAGS to proc_macros:
+    // https://github.com/rust-lang/cargo/issues/4423
+    // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.
+    // We also declare that the flag is expected, which we need to do to not
+    // get warnings about it being unexpected.
+    if stage == "0" {
+        cmd.arg("--cfg=bootstrap");
+    }
+    cmd.arg("-Zunstable-options");
+    cmd.arg("--check-cfg=values(bootstrap)");
 
     if verbose > 1 {
         eprintln!(

--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -42,6 +42,11 @@ authoritative if this occurs. Instead of pinging individual members, use
 1. [Testing](#testing)
     1. [Running unit tests](#running-unit-tests)
     1. [Running the compiler test suite](#running-the-compiler-test-suite)
+1. [Debugging](#debugging)
+    1. [`zxdb`](#zxdb)
+    1. [Attaching `zxdb`](#attaching-zxdb)
+    1. [Using `zxdb`](#using-zxdb)
+    1. [Displaying source code in `zxdb`](#displaying-source-code-in-zxdb)
 
 ## Requirements
 
@@ -136,7 +141,7 @@ These options configure the following:
 
 * `-Lnative=${SDK_PATH}/arch/${ARCH}/lib`: Link against Fuchsia libraries from
   the SDK
-* `-Lnative=${SDK_PATH}/arch/${ARCH}/sysroot/lib`: Link against Fuchsia kernel
+* `-Lnative=${SDK_PATH}/arch/${ARCH}/sysroot/lib`: Link against Fuchsia sysroot
   libraries from the SDK
 
 In total, our new project will look like:
@@ -253,7 +258,7 @@ the following options:
   platform of your choice
 * `-Lnative ${SDK_PATH}/arch/${ARCH}/lib`: Link against Fuchsia libraries from
   the SDK
-* `-Lnative ${SDK_PATH}/arch/${ARCH}/sysroot/lib`: Link against Fuchsia kernel
+* `-Lnative ${SDK_PATH}/arch/${ARCH}/sysroot/lib`: Link against Fuchsia sysroot
   libraries from the SDK
 
 Putting it all together:
@@ -638,6 +643,130 @@ available on the [Fuchsia devsite].
 Running the Rust test suite on Fuchsia is [not currently supported], but work is
 underway to enable it.
 
+## Debugging
+
+### `zxdb`
+
+Debugging components running on a Fuchsia emulator can be done using the
+console-mode debugger: [zxdb]. We will demonstrate attaching necessary symbol
+paths to debug our `hello-fuchsia` component.
+
+### Attaching `zxdb`
+
+In a separate terminal, issue the following command from our `hello_fuchsia`
+directory to launch `zxdb`:
+
+**In separate terminal**
+```sh
+${SDK_PATH}/tools/${ARCH}/ffx debug connect -- \
+    --symbol-path target/x86_64-fuchsia/debug
+```
+
+* `--symbol-path` gets required symbol paths, which are
+necessary for stepping through your program.
+
+The "[displaying source code in `zxdb`](#displaying-source-code-in-zxdb)" section describes how you can
+display Rust and/or Fuchsia source code in your debugging session.
+
+### Using `zxdb`
+
+Once launched, you will be presented with the window:
+
+```sh
+Connecting (use "disconnect" to cancel)...
+Connected successfully.
+👉 To get started, try "status" or "help".
+[zxdb]
+```
+
+To attach to our program, we can run:
+
+```sh
+[zxdb] attach hello_fuchsia
+```
+
+**Expected output**
+```sh
+Waiting for process matching "hello_fuchsia".
+Type "filter" to see the current filters.
+```
+
+Next, we can create a breakpoint at main using "b main":
+
+```sh
+[zxdb] b main
+```
+
+**Expected output**
+```sh
+Created Breakpoint 1 @ main
+```
+
+Finally, we can re-run the "hello_fuchsia" component from our original
+terminal:
+
+```sh
+${SDK_PATH}/tools/${ARCH}/ffx component run \
+    --recreate \
+    fuchsia-pkg://hello-fuchsia/hello_fuchsia_manifest#meta/hello_fuchsia.cm
+```
+
+Once our component is running, our `zxdb` window will stop execution
+in our main as desired:
+
+**Expected output**
+```txt
+Breakpoint 1 now matching 1 addrs for main
+🛑 on bp 1 hello_fuchsia::main() • main.rs:2
+   1 fn main() {
+ ▶ 2     println!("Hello Fuchsia!");
+   3 }
+   4
+[zxdb]
+```
+
+`zxdb` has similar commands to other debuggers like [gdb].
+To list the available commands, run "help" in the
+`zxdb` window or visit [the zxdb documentation].
+
+```sh
+[zxdb] help
+```
+
+**Expected output**
+```sh
+Help!
+
+  Type "help <command>" for command-specific help.
+
+Other help topics (see "help <topic>")
+...
+```
+
+### Displaying source code in `zxdb`
+
+By default, the debugger will not be able to display
+source code while debugging. For our user code, we displayed
+source code by pointing our debugger to our debug binary via
+the `--symbol-path` arg. To display library source code in
+the debugger, you must provide paths to the source using
+`--build-dir`. For example, to display the Rust and Fuchsia
+source code:
+
+```sh
+${SDK_PATH}/tools/${ARCH}/ffx debug connect -- \
+    --symbol-path target/x86_64-fuchsia/debug \
+    --build-dir ${RUST_SRC_PATH}/rust \
+    --build-dir ${FUCHSIA_SRC_PATH}/fuchsia/out/default
+```
+
+ * `--build-dir` links against source code paths, which
+ are not strictly necessary for debugging, but is a nice-to-have
+ for displaying source code in `zxdb`.
+
+ Linking to a Fuchsia checkout can help with debugging Fuchsia libraries,
+ such as [fdio].
+
 [Fuchsia team]: https://team-api.infra.rust-lang.org/v1/teams/fuchsia.json
 [Fuchsia]: https://fuchsia.dev/
 [source tree]: https://fuchsia.dev/fuchsia-src/get-started/learn/build
@@ -648,3 +777,7 @@ underway to enable it.
 [reference for the file format]: https://fuchsia.dev/reference/cml
 [Fuchsia devsite]: https://fuchsia.dev/reference/cml
 [not currently supported]: https://fxbug.dev/105393
+[zxdb]: https://fuchsia.dev/fuchsia-src/development/debugger
+[gdb]: https://www.sourceware.org/gdb/
+[the zxdb documentation]: https://fuchsia.dev/fuchsia-src/development/debugger
+[fdio]: https://cs.opensource.google/fuchsia/fuchsia/+/main:sdk/lib/fdio/

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -346,7 +346,6 @@ img {
 }
 
 .source .content {
-	max-width: none;
 	overflow: visible;
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -348,7 +348,6 @@ img {
 .source .content {
 	max-width: none;
 	overflow: visible;
-	margin-left: 0px;
 }
 
 .sub-container {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -119,9 +119,6 @@ pre, .rustdoc.source .example-wrap {
 .content span.traitalias, .content a.traitalias { color: #39AFD7; }
 .content span.keyword, .content a.keyword { color: #39AFD7; }
 
-.content span.externcrate, .content span.mod, .content a.mod {
-	color: #39AFD7;
-}
 .content span.struct, .content a.struct {
 	color: #ffa0a5;
 }
@@ -131,20 +128,12 @@ pre, .rustdoc.source .example-wrap {
 .content span.trait, .content a.trait {
 	color: #39AFD7;
 }
-.content span.type, .content a.type {
-	color: #39AFD7;
-}
 .content span.type,
 .content a.type,
 .block a.current.type { color: #39AFD7; }
-.content span.associatedtype,
-.content a.associatedtype,
-.block a.current.associatedtype { color: #39AFD7; }
-.content span.fn, .content a.fn, .content span.method,
-.content a.method, .content span.tymethod,
-.content a.tymethod, .content .fnname {
-	color: #fdd687;
-}
+.content span.associatedtype, .content a.associatedtype { color: #39AFD7; }
+.content span.fn, .content a.fn,
+.content .fnname { color: #fdd687; }
 .content span.attr, .content a.attr, .content span.derive,
 .content a.derive, .content span.macro, .content a.macro {
 	color: #a37acc;
@@ -152,7 +141,6 @@ pre, .rustdoc.source .example-wrap {
 
 .sidebar a { color: #53b1db; }
 .sidebar a.current.type { color: #53b1db; }
-.sidebar a.current.associatedtype { color: #53b1db; }
 
 pre.rust .comment { color: #788797; }
 pre.rust .doccomment { color: #a1ac88; }
@@ -290,24 +278,19 @@ individually rather than as a group) */
 /* FIXME: these rules should be at the bottom of the file but currently must be
 above the `@media (max-width: 700px)` rules due to a bug in the css checker */
 /* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
-.content span.attr,.content a.attr,.block a.current.attr,.content span.derive,.content a.derive,
-.block a.current.derive,.content span.macro,.content a.macro,.block a.current.macro {}
+.content span.attr, .content a.attr, .block a.current.attr,
+.content span.derive,.content a.derive, .block a.current.derive,
+.content span.macro,.content a.macro,.block a.current.macro {}
 .content span.struct,.content a.struct,.block a.current.struct {}
-#titles>button:hover,#titles>button.selected {}
-.content span.typedef,.content a.typedef,.block a.current.typedef {}
-.content span.union,.content a.union,.block a.current.union {}
+#titles > button:hover, #titles > button.selected {}
+.content span.union, .content a.union, .block a.current.union {}
 pre.rust .lifetime {}
-.stab.unstable {}
-h2,
-h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod) {}
-.content span.enum,.content a.enum,.block a.current.enum {}
-.content span.constant,.content a.constant,.block a.current.constant,.content span.static,
+.content span.enum, .content a.enum, .block a.current.enum {}
+.content span.constant, .content a.constant, .block a.current.constant, .content span.static,
 .content a.static, .block a.current.static {}
-.content span.keyword,.content a.keyword,.block a.current.keyword {}
+.content span.keyword, .content a.keyword, .block a.current.keyword {}
 .content span.traitalias,.content a.traitalias,.block a.current.traitalias {}
-.content span.fn,.content a.fn,.block a.current.fn,.content span.method,.content a.method,
-.block a.current.method,.content span.tymethod,.content a.tymethod,.block a.current.tymethod,
-.content .fnname {}
+.content span.fn,.content a.fn,.block a.current.fn, .content .fnname {}
 pre.rust .kw {}
 pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
 .content span.foreigntype,.content a.foreigntype,.block a.current.foreigntype {}
@@ -315,7 +298,6 @@ pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
 .content a.attr,.content a.derive,.content a.macro {}
 .stab.portability {}
 .content span.primitive,.content a.primitive,.block a.current.primitive {}
-.content span.externcrate,.content span.mod,.content a.mod,.block a.current.mod {}
 pre.rust .kw-2,pre.rust .prelude-ty {}
 .content span.trait,.content a.trait,.block a.current.trait {}
 
@@ -353,13 +335,9 @@ a.result-keyword:focus {}
 .sidebar a.current.constant
 .sidebar a.current.static {}
 .sidebar a.current.primitive {}
-.sidebar a.current.externcrate
-.sidebar a.current.mod {}
 .sidebar a.current.trait {}
 .sidebar a.current.traitalias {}
-.sidebar a.current.fn,
-.sidebar a.current.method,
-.sidebar a.current.tymethod {}
+.sidebar a.current.fn {}
 .sidebar a.current.keyword {}
 
 kbd {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -118,7 +118,9 @@ pre, .rustdoc.source .example-wrap {
 .content span.primitive, .content a.primitive { color: #ffa0a5; }
 .content span.traitalias, .content a.traitalias { color: #39AFD7; }
 .content span.keyword, .content a.keyword { color: #39AFD7; }
-
+.content span.mod, .content a.mod {
+	color: #39AFD7;
+}
 .content span.struct, .content a.struct {
 	color: #ffa0a5;
 }
@@ -128,9 +130,7 @@ pre, .rustdoc.source .example-wrap {
 .content span.trait, .content a.trait {
 	color: #39AFD7;
 }
-.content span.type,
-.content a.type,
-.block a.current.type { color: #39AFD7; }
+.content span.type, .content a.type { color: #39AFD7; }
 .content span.associatedtype, .content a.associatedtype { color: #39AFD7; }
 .content span.fn, .content a.fn,
 .content .fnname { color: #fdd687; }
@@ -278,28 +278,29 @@ individually rather than as a group) */
 /* FIXME: these rules should be at the bottom of the file but currently must be
 above the `@media (max-width: 700px)` rules due to a bug in the css checker */
 /* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
-.content span.attr, .content a.attr, .block a.current.attr,
-.content span.derive,.content a.derive, .block a.current.derive,
-.content span.macro,.content a.macro,.block a.current.macro {}
-.content span.struct,.content a.struct,.block a.current.struct {}
+.content span.attr, .content a.attr,
+.content span.derive,.content a.derive,
+.content span.macro,.content a.macro {}
+.content span.struct,.content a.struct {}
 #titles > button:hover, #titles > button.selected {}
-.content span.union, .content a.union, .block a.current.union {}
+.content span.union, .content a.union {}
 pre.rust .lifetime {}
-.content span.enum, .content a.enum, .block a.current.enum {}
-.content span.constant, .content a.constant, .block a.current.constant, .content span.static,
-.content a.static, .block a.current.static {}
-.content span.keyword, .content a.keyword, .block a.current.keyword {}
-.content span.traitalias,.content a.traitalias,.block a.current.traitalias {}
-.content span.fn,.content a.fn,.block a.current.fn, .content .fnname {}
+.content span.enum, .content a.enum {}
+.content span.constant, .content a.constant,
+.content span.static, .content a.static {}
+.content span.keyword, .content a.keyword {}
+.content span.traitalias,.content a.traitalias {}
+.content span.fn,.content a.fn,
+.content .fnname {}
 pre.rust .kw {}
 pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
-.content span.foreigntype,.content a.foreigntype,.block a.current.foreigntype {}
+.content span.foreigntype,.content a.foreigntype {}
 .stab.deprecated {}
 .content a.attr,.content a.derive,.content a.macro {}
 .stab.portability {}
-.content span.primitive,.content a.primitive,.block a.current.primitive {}
+.content span.primitive,.content a.primitive {}
 pre.rust .kw-2,pre.rust .prelude-ty {}
-.content span.trait,.content a.trait,.block a.current.trait {}
+.content span.trait,.content a.trait {}
 
 .search-results a:focus span {}
 a.result-trait:focus {}

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -278,29 +278,11 @@ individually rather than as a group) */
 /* FIXME: these rules should be at the bottom of the file but currently must be
 above the `@media (max-width: 700px)` rules due to a bug in the css checker */
 /* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
-.content span.attr, .content a.attr,
-.content span.derive,.content a.derive,
-.content span.macro,.content a.macro {}
-.content span.struct,.content a.struct {}
-#titles > button:hover, #titles > button.selected {}
-.content span.union, .content a.union {}
 pre.rust .lifetime {}
-.content span.enum, .content a.enum {}
-.content span.constant, .content a.constant,
-.content span.static, .content a.static {}
-.content span.keyword, .content a.keyword {}
-.content span.traitalias,.content a.traitalias {}
-.content span.fn,.content a.fn,
-.content .fnname {}
 pre.rust .kw {}
-pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute {}
-.content span.foreigntype,.content a.foreigntype {}
-.stab.deprecated {}
-.content a.attr,.content a.derive,.content a.macro {}
-.stab.portability {}
-.content span.primitive,.content a.primitive {}
-pre.rust .kw-2,pre.rust .prelude-ty {}
-.content span.trait,.content a.trait {}
+#titles > button:hover, #titles > button.selected {}
+pre.rust .self, pre.rust .bool-val, pre.rust .prelude-val, pre.rust .attribute {}
+pre.rust .kw-2, pre.rust .prelude-ty {}
 
 .search-results a:focus span {}
 a.result-trait:focus {}

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -86,9 +86,7 @@ a.result-keyword:focus { background-color: #884719; }
 .content span.enum, .content a.enum, .block a.current.enum { color: #2dbfb8; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #2dbfb8; }
-.content span.associatedtype,
-.content a.associatedtype,
-.block a.current.associatedtype { color: #D2991D; }
+.content span.associatedtype, .content a.associatedtype { color: #D2991D; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #2dbfb8; }
 .content span.attr, .content a.attr, .block a.current.attr,
 .content span.derive, .content a.derive, .block a.current.derive,
@@ -97,21 +95,16 @@ a.result-keyword:focus { background-color: #884719; }
 .content span.constant, .content a.constant, .block a.current.constant,
 .content span.static, .content a.static, .block a.current.static { color: #D2991D; }
 .content span.primitive, .content a.primitive, .block a.current.primitive { color: #2dbfb8; }
-.content span.externcrate,
-.content span.mod, .content a.mod, .block a.current.mod { color: #D2991D; }
 .content span.trait, .content a.trait, .block a.current.trait { color: #b78cf2; }
 .content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #b78cf2; }
 .content span.fn, .content a.fn, .block a.current.fn,
-.content span.method, .content a.method, .block a.current.method,
-.content span.tymethod, .content a.tymethod, .block a.current.tymethod,
-.content .fnname{ color: #2BAB63; }
+.content .fnname { color: #2BAB63; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #D2991D; }
 
 .sidebar a { color: #fdbf35; }
 .sidebar a.current.enum { color: #12ece2; }
 .sidebar a.current.struct { color: #12ece2; }
 .sidebar a.current.type { color: #12ece2; }
-.sidebar a.current.associatedtype { color: #fdbf35; }
 .sidebar a.current.foreigntype { color: #12ece2; }
 .sidebar a.current.attr,
 .sidebar a.current.derive,
@@ -120,13 +113,9 @@ a.result-keyword:focus { background-color: #884719; }
 .sidebar a.current.constant
 .sidebar a.current.static { color: #fdbf35; }
 .sidebar a.current.primitive { color: #12ece2; }
-.sidebar a.current.externcrate
-.sidebar a.current.mod { color: #fdbf35; }
 .sidebar a.current.trait { color: #cca7ff; }
 .sidebar a.current.traitalias { color: #cca7ff; }
-.sidebar a.current.fn,
-.sidebar a.current.method,
-.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.fn { color: #32d479; }
 .sidebar a.current.keyword { color: #fdbf35; }
 
 pre.rust .comment { color: #8d8d8b; }

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -83,23 +83,24 @@ a.result-keyword:focus { background-color: #884719; }
 
 .content .item-info::before { color: #ccc; }
 
-.content span.enum, .content a.enum, .block a.current.enum { color: #2dbfb8; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
-.content span.type, .content a.type, .block a.current.type { color: #2dbfb8; }
+.content span.enum, .content a.enum { color: #2dbfb8; }
+.content span.struct, .content a.struct { color: #2dbfb8; }
+.content span.type, .content a.type { color: #2dbfb8; }
 .content span.associatedtype, .content a.associatedtype { color: #D2991D; }
-.content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #2dbfb8; }
-.content span.attr, .content a.attr, .block a.current.attr,
-.content span.derive, .content a.derive, .block a.current.derive,
-.content span.macro, .content a.macro, .block a.current.macro { color: #09bd00; }
-.content span.union, .content a.union, .block a.current.union { color: #2dbfb8; }
-.content span.constant, .content a.constant, .block a.current.constant,
-.content span.static, .content a.static, .block a.current.static { color: #D2991D; }
-.content span.primitive, .content a.primitive, .block a.current.primitive { color: #2dbfb8; }
-.content span.trait, .content a.trait, .block a.current.trait { color: #b78cf2; }
-.content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #b78cf2; }
-.content span.fn, .content a.fn, .block a.current.fn,
+.content span.foreigntype, .content a.foreigntype { color: #2dbfb8; }
+.content span.attr, .content a.attr,
+.content span.derive, .content a.derive,
+.content span.macro, .content a.macro { color: #09bd00; }
+.content span.union, .content a.union { color: #2dbfb8; }
+.content span.constant, .content a.constant,
+.content span.static, .content a.static { color: #D2991D; }
+.content span.primitive, .content a.primitive { color: #2dbfb8; }
+.content span.mod, .content a.mod { color: #D2991D; }
+.content span.trait, .content a.trait { color: #b78cf2; }
+.content span.traitalias, .content a.traitalias { color: #b78cf2; }
+.content span.fn, .content a.fn,
 .content .fnname { color: #2BAB63; }
-.content span.keyword, .content a.keyword, .block a.current.keyword { color: #D2991D; }
+.content span.keyword, .content a.keyword { color: #D2991D; }
 
 .sidebar a { color: #fdbf35; }
 .sidebar a.current.enum { color: #12ece2; }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -82,23 +82,24 @@ a.result-keyword:focus { background-color: #afc6e4; }
 
 .content .item-info::before { color: #ccc; }
 
-.content span.enum, .content a.enum, .block a.current.enum { color: #AD378A; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #AD378A; }
-.content span.type, .content a.type, .block a.current.type { color:  #AD378A; }
+.content span.enum, .content a.enum { color: #AD378A; }
+.content span.struct, .content a.struct { color: #AD378A; }
+.content span.type, .content a.type { color:  #AD378A; }
 .content span.associatedtype, .content a.associatedtype { color: #3873AD; }
-.content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #3873AD; }
-.content span.attr, .content a.attr, .block a.current.attr,
-.content span.derive, .content a.derive, .block a.current.derive,
-.content span.macro, .content a.macro, .block a.current.macro { color: #068000; }
-.content span.union, .content a.union, .block a.current.union { color: #AD378A; }
-.content span.constant, .content a.constant, .block a.current.constant,
-.content span.static, .content a.static, .block a.current.static { color: #3873AD; }
-.content span.primitive, .content a.primitive, .block a.current.primitive { color: #AD378A; }
-.content span.trait, .content a.trait, .block a.current.trait { color: #6E4FC9; }
-.content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #5137AD; }
-.content span.fn, .content a.fn, .block a.current.fn,
+.content span.foreigntype, .content a.foreigntype { color: #3873AD; }
+.content span.attr, .content a.attr,
+.content span.derive, .content a.derive,
+.content span.macro, .content a.macro { color: #068000; }
+.content span.union, .content a.union { color: #AD378A; }
+.content span.constant, .content a.constant,
+.content span.static, .content a.static { color: #3873AD; }
+.content span.primitive, .content a.primitive { color: #AD378A; }
+.content span.mod, .content a.mod { color: #3873AD; }
+.content span.trait, .content a.trait { color: #6E4FC9; }
+.content span.traitalias, .content a.traitalias { color: #5137AD; }
+.content span.fn, .content a.fn,
 .content .fnname { color: #AD7C37; }
-.content span.keyword, .content a.keyword, .block a.current.keyword { color: #3873AD; }
+.content span.keyword, .content a.keyword { color: #3873AD; }
 
 .sidebar a { color: #356da4; }
 .sidebar a.current.enum { color: #a63283; }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -85,10 +85,8 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .content span.enum, .content a.enum, .block a.current.enum { color: #AD378A; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #AD378A; }
 .content span.type, .content a.type, .block a.current.type { color:  #AD378A; }
+.content span.associatedtype, .content a.associatedtype { color: #3873AD; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #3873AD; }
-.content span.associatedtype,
-.content a.associatedtype,
-.block a.current.associatedtype { color: #3873AD; }
 .content span.attr, .content a.attr, .block a.current.attr,
 .content span.derive, .content a.derive, .block a.current.derive,
 .content span.macro, .content a.macro, .block a.current.macro { color: #068000; }
@@ -96,13 +94,9 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .content span.constant, .content a.constant, .block a.current.constant,
 .content span.static, .content a.static, .block a.current.static { color: #3873AD; }
 .content span.primitive, .content a.primitive, .block a.current.primitive { color: #AD378A; }
-.content span.externcrate,
-.content span.mod, .content a.mod, .block a.current.mod { color: #3873AD; }
 .content span.trait, .content a.trait, .block a.current.trait { color: #6E4FC9; }
 .content span.traitalias, .content a.traitalias, .block a.current.traitalias { color: #5137AD; }
 .content span.fn, .content a.fn, .block a.current.fn,
-.content span.method, .content a.method, .block a.current.method,
-.content span.tymethod, .content a.tymethod, .block a.current.tymethod,
 .content .fnname { color: #AD7C37; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #3873AD; }
 
@@ -110,7 +104,6 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .sidebar a.current.enum { color: #a63283; }
 .sidebar a.current.struct { color: #a63283; }
 .sidebar a.current.type { color: #a63283; }
-.sidebar a.current.associatedtype { color: #356da4; }
 .sidebar a.current.foreigntype { color: #356da4; }
 .sidebar a.current.attr,
 .sidebar a.current.derive,
@@ -119,13 +112,9 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .sidebar a.current.constant
 .sidebar a.current.static { color: #356da4; }
 .sidebar a.current.primitive { color: #a63283; }
-.sidebar a.current.externcrate
-.sidebar a.current.mod { color: #356da4; }
 .sidebar a.current.trait { color: #6849c3; }
 .sidebar a.current.traitalias { color: #4b349e; }
-.sidebar a.current.fn,
-.sidebar a.current.method,
-.sidebar a.current.tymethod { color: #a67736; }
+.sidebar a.current.fn { color: #a67736; }
 .sidebar a.current.keyword { color: #356da4; }
 
 a {

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -542,7 +542,7 @@ pub enum Term {
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "kind", content = "inner")]
 pub enum Type {
-    /// Structs and enums
+    /// Structs, enums, and unions
     ResolvedPath(Path),
     DynTrait(DynTrait),
     /// Parameterized types

--- a/src/test/rustdoc-json/unions/union.rs
+++ b/src/test/rustdoc-json/unions/union.rs
@@ -1,7 +1,15 @@
 // @has "$.index[*][?(@.name=='Union')].visibility" \"public\"
 // @has "$.index[*][?(@.name=='Union')].kind" \"union\"
 // @!has "$.index[*][?(@.name=='Union')].inner.struct_type"
+// @set Union = "$.index[*][?(@.name=='Union')].id"
 pub union Union {
     int: i32,
     float: f32,
+}
+
+
+// @is "$.index[*][?(@.name=='make_int_union')].inner.decl.output.kind" '"resolved_path"'
+// @is "$.index[*][?(@.name=='make_int_union')].inner.decl.output.inner.id" $Union
+pub fn make_int_union(int: i32) -> Union {
+    Union { int }
 }

--- a/src/test/ui/asm/x86_64/may_unwind.rs
+++ b/src/test/ui/asm/x86_64/may_unwind.rs
@@ -1,6 +1,7 @@
 // only-x86_64
 // run-pass
 // needs-asm-support
+// needs-unwind
 
 #![feature(asm_sym, asm_unwind)]
 

--- a/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
+++ b/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
@@ -2,6 +2,7 @@
 // error-pattern:diverging_fn called
 // error-pattern:0 dropped
 // ignore-emscripten no processes
+// needs-unwind this test checks that a destructor is called after panicking
 
 struct Droppable(u8);
 impl Drop for Droppable {

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-1.rs:6:1
+  --> $DIR/invalid-punct-ident-1.rs:7:1
    |
 LL | invalid_punct!();
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-2.rs:6:1
+  --> $DIR/invalid-punct-ident-2.rs:7:1
    |
 LL | invalid_ident!();
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-3.rs:6:1
+  --> $DIR/invalid-punct-ident-3.rs:7:1
    |
 LL | invalid_raw_ident!();
    | ^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
@@ -1,5 +1,5 @@
 error: unexpected closing delimiter: `)`
-  --> $DIR/invalid-punct-ident-4.rs:6:1
+  --> $DIR/invalid-punct-ident-4.rs:7:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^ unexpected closing delimiter
@@ -7,13 +7,13 @@ LL | lexer_failure!();
    = note: this error originates in the macro `lexer_failure` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-4.rs:6:1
+  --> $DIR/invalid-punct-ident-4.rs:7:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-punct-ident-4.rs:11:33
+  --> $DIR/invalid-punct-ident-4.rs:12:33
    |
 LL |     let _recovery_witness: () = 0;
    |                            --   ^ expected `()`, found integer

--- a/src/test/ui/proc-macro/issue-36935.rs
+++ b/src/test/ui/proc-macro/issue-36935.rs
@@ -1,4 +1,5 @@
 // aux-build:test-macros.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate test_macros;

--- a/src/test/ui/proc-macro/issue-36935.stderr
+++ b/src/test/ui/proc-macro/issue-36935.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Baz` is defined multiple times
-  --> $DIR/issue-36935.rs:7:1
+  --> $DIR/issue-36935.rs:8:1
    |
 LL | struct Baz {
    | ^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | struct Baz {
    = note: `Baz` must be defined only once in the type namespace of this module
 
 error: proc-macro derive panicked
-  --> $DIR/issue-36935.rs:6:20
+  --> $DIR/issue-36935.rs:7:20
    |
 LL | #[derive(Identity, Panic)]
    |                    ^^^^^

--- a/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.rs
+++ b/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.rs
@@ -1,5 +1,6 @@
 // aux-build:proc-macro-panic.rs
 // edition:2018
+// needs-unwind proc macro panics to report errors
 
 // Regression test for issue #76270
 // Tests that we don't print an ICE message when a panic

--- a/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.stderr
+++ b/src/test/ui/proc-macro/issue-76270-panic-in-libproc-macro.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/issue-76270-panic-in-libproc-macro.rs:10:1
+  --> $DIR/issue-76270-panic-in-libproc-macro.rs:11:1
    |
 LL | proc_macro_panic::panic_in_libproc_macro!();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/load-panic-backtrace.rs
+++ b/src/test/ui/proc-macro/load-panic-backtrace.rs
@@ -3,6 +3,7 @@
 // rustc-env:RUST_BACKTRACE=0
 // normalize-stderr-test "thread '.*' panicked " -> ""
 // normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate test_macros;

--- a/src/test/ui/proc-macro/load-panic-backtrace.stderr
+++ b/src/test/ui/proc-macro/load-panic-backtrace.stderr
@@ -1,6 +1,6 @@
 at 'panic-derive', $DIR/auxiliary/test-macros.rs:43:5
 error: proc-macro derive panicked
-  --> $DIR/load-panic-backtrace.rs:10:10
+  --> $DIR/load-panic-backtrace.rs:11:10
    |
 LL | #[derive(Panic)]
    |          ^^^^^

--- a/src/test/ui/proc-macro/load-panic.rs
+++ b/src/test/ui/proc-macro/load-panic.rs
@@ -1,4 +1,5 @@
 // aux-build:test-macros.rs
+// needs-unwind proc macro panics to report errors
 
 #[macro_use]
 extern crate test_macros;

--- a/src/test/ui/proc-macro/load-panic.stderr
+++ b/src/test/ui/proc-macro/load-panic.stderr
@@ -1,5 +1,5 @@
 error: proc-macro derive panicked
-  --> $DIR/load-panic.rs:6:10
+  --> $DIR/load-panic.rs:7:10
    |
 LL | #[derive(Panic)]
    |          ^^^^^


### PR DESCRIPTION
Successful merges:

 - #101340 (Adding Fuchsia zxdb debugging walkthrough to docs)
 - #101741 (Adding needs-unwind arg to applicable compiler ui tests)
 - #101782 (Update `symbol_mangling` diagnostics migration)
 - #101878 (More simple formatting)
 - #101898 (Remove some unused CSS rules)
 - #101911 (rustdoc: remove no-op CSS on `.source .content`)
 - #101914 (rustdoc-json-types: Document that ResolvedPath can also be a union)
 - #101921 (Pass --cfg=bootstrap for rustdoc for proc_macro crates)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101340,101741,101782,101878,101898,101911,101914,101921)
<!-- homu-ignore:end -->