### PR TITLE
[crater experiment] Turn on debug assertions

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -77,6 +77,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
+      --set rust.debug=true \
       --set rust.jemalloc \
       --set rust.use-lld=true
 ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \


### PR DESCRIPTION
The standard library has a lot more debug assertions since https://github.com/rust-lang/rust/pull/92686 which also found and fixed some UB in the compiler using them. It has been suggested that as a follow-up to trying out the LLVM assertions in https://github.com/rust-lang/rust/pull/101591, we try out the Rust assertions.

I think this would only need a check run.