### PR TITLE
🥅 [diagnostic] Add better diagnostic for Result types

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2172,6 +2172,23 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                 }
                             }
                         }
+                        (expected_type, ty::Adt(found_type, _)) => {
+                            let is_found_result = self.tcx.is_diagnostic_item(sym::Result, found_type.did());
+                            let is_expected_result = match expected_type {
+                                ty::Adt(idk, _) => self.tcx.is_diagnostic_item(sym::Result, idk.did()),
+                                _ => false
+                            };
+                            if is_found_result && !is_expected_result {
+                                if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span) {
+                                    err.span_suggestion(
+                                        span,
+                                        "Either change the return type or use `unwrap`",
+                                        format!("{}.unwrap()", code),
+                                        Applicability::MaybeIncorrect,
+                                    );
+                                }
+                            }
+                        }
                         _ => {}
                     }
                 }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2179,6 +2179,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                 _ => false
                             };
                             if is_found_result && !is_expected_result {
+                                let is_found_type_same_as_expected_result_ok = match expected_type {
+                                    Result::Ok(ok) => ok == found_type.did()
+                                };
+                                if !is_found_type_same_as_expected_result_ok {}
                                 if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span) {
                                     err.span_suggestion(
                                         span,

--- a/src/test/ui/issues/issue-101998/issue-101998.rs
+++ b/src/test/ui/issues/issue-101998/issue-101998.rs
@@ -1,0 +1,6 @@
+fn parse_num(num: String) -> i32 {
+    num.parse()
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn main(){}

--- a/src/test/ui/issues/issue-101998/issue-101998.rs
+++ b/src/test/ui/issues/issue-101998/issue-101998.rs
@@ -1,6 +1,18 @@
+// will suggest better error when the expression type is the same as `Ok`
 fn parse_num(num: String) -> i32 {
-    num.parse()
+    result_i32_error() // specific Result error message
     //~^ ERROR mismatched types [E0308]
 }
+
+fn result_i32_error() -> Result<i32, std::num::ParseIntError> {
+    Ok(42)
+}
+
+// will continue using generic error when the expression type is different than `Ok`
+fn foo(num: String) -> String {
+    result_i32_error() // generic error message
+    //~^ ERROR mismatched types [E0308]
+}
+
 
 fn main(){}

--- a/src/test/ui/issues/issue-101998/issue-101998.stderr
+++ b/src/test/ui/issues/issue-101998/issue-101998.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-101998.rs:2:5
+   |
+LL | fn parse_num(num: String) -> i32 {
+   |                              --- expected `i32` because of return type
+LL |     num.parse()
+   |     ^^^^^^^^^^^
+   |     |
+   |     expected `i32`, found enum `Result`
+   |     help: Either change the return type or use `unwrap`: `num.parse().unwrap()`
+   |
+   = note: expected type `i32`
+              found enum `Result<_, _>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-101998/issue-101998.stderr
+++ b/src/test/ui/issues/issue-101998/issue-101998.stderr
@@ -1,17 +1,28 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-101998.rs:2:5
+  --> $DIR/issue-101998.rs:3:5
    |
 LL | fn parse_num(num: String) -> i32 {
    |                              --- expected `i32` because of return type
-LL |     num.parse()
-   |     ^^^^^^^^^^^
+LL |     result_i32_error() // specific Result error message
+   |     ^^^^^^^^^^^^^^^^^^
    |     |
    |     expected `i32`, found enum `Result`
-   |     help: Either change the return type or use `unwrap`: `num.parse().unwrap()`
+   |     help: Either change the return type or use `unwrap`: `result_i32_error().unwrap()`
    |
    = note: expected type `i32`
-              found enum `Result<_, _>`
+              found enum `Result<i32, ParseIntError>`
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/issue-101998.rs:13:5
+   |
+LL | fn foo(num: String) -> String {
+   |                        ------ expected `String` because of return type
+LL |     result_i32_error() // generic error message
+   |     ^^^^^^^^^^^^^^^^^^ expected struct `String`, found enum `Result`
+   |
+   = note: expected struct `String`
+                found enum `Result<i32, ParseIntError>`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/abridged.stderr
+++ b/src/test/ui/mismatched_types/abridged.stderr
@@ -15,7 +15,10 @@ error[E0308]: mismatched types
 LL | fn a2() -> Foo {
    |            --- expected `Foo` because of return type
 LL |     Ok(Foo { bar: 1})
-   |     ^^^^^^^^^^^^^^^^^ expected struct `Foo`, found enum `Result`
+   |     ^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected struct `Foo`, found enum `Result`
+   |     help: Either change the return type or use `unwrap`: `Ok(Foo { bar: 1}).unwrap()`
    |
    = note: expected struct `Foo`
                 found enum `Result<Foo, _>`


### PR DESCRIPTION
## TODO
- [x] test
- [ ] Figure out what to do for non-return types.  Such as 
```rs
fn bar() {
    let i: i32 = result_i32_error() // generic
    //~^ ERROR mismatched types [E0308]
}
```
the current error message "change return type to" doesn't make sense in this context.

## Questions for reviewer 
1. Instead of just suggesting "change return type to `Result`" I would like to suggest "change return type to `Result<i32, std::num::ParseIntError>.  How would I do that?
2.  I'm struggling with another edge case: non-fn return types.

For example: All my tests like 

```rs
// will suggest better error when the expression type is the same as `Ok`
fn parse_num(num: String) -> i32 {
    result_i32_error(), // "Either change the return type or use `unwrap`.  `result_i32_error().unwrap()`"
    //~^ ERROR mismatched types [E0308]
}

fn result_i32_error() -> Result<i32, std::num::ParseIntError> {
    Ok(42)
}
```
look good.  But consider a case like 

```rs
fn bar() -> Result<i32, std::num::ParseIntError>  {
    let i: i32 = result_i32_error(); // "Either change the return type or use `unwrap`.  `result_i32_error().unwrap()`"
    //~^ ERROR mismatched types [E0308]
    i
}
```
note that it still mentions "change the return type" while of course that doesn't apply here since it's a variable.

I would like to have different diagnostics for each of these cases.  For example, maybe if it's a variable assignment I'd rather suggest `?` instead of changing the return type.  This is more complicated, and I'd rather do this in another commit.  For this commit I want to _just_ focus on return types

**Question**: in my code, how would I check that is is only for return types (I would do other cases in a follow-up commit)?

Closes #101998