### PR TITLE
builtin_macros: Migrate diagnostic

### DIFF
--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -1,12 +1,13 @@
 mod context;
 
 use crate::edition_panic::use_panic_2021;
+use crate::errors::{self, ArgumentExpressionRequired};
 use rustc_ast::ptr::P;
 use rustc_ast::token;
 use rustc_ast::tokenstream::{DelimSpan, TokenStream};
 use rustc_ast::{Expr, ExprKind, MacArgs, MacCall, MacDelimiter, Path, PathSegment, UnOp};
 use rustc_ast_pretty::pprust;
-use rustc_errors::{Applicability, PResult};
+use rustc_errors::PResult;
 use rustc_expand::base::{DummyResult, ExtCtxt, MacEager, MacResult};
 use rustc_parse::parser::Parser;
 use rustc_span::symbol::{sym, Ident, Symbol};
@@ -113,9 +114,7 @@ fn parse_assert<'a>(cx: &mut ExtCtxt<'a>, sp: Span, stream: TokenStream) -> PRes
     let mut parser = cx.new_parser_from_tts(stream);
 
     if parser.token == token::Eof {
-        let mut err = cx.struct_span_err(sp, "macro requires a boolean expression as an argument");
-        err.span_label(sp, "boolean expression required");
-        return Err(err);
+        return Err(cx.create_err(errors::BooleanExpressionRequired { span: sp }));
     }
 
     let cond_expr = parser.parse_expr()?;
@@ -128,14 +127,7 @@ fn parse_assert<'a>(cx: &mut ExtCtxt<'a>, sp: Span, stream: TokenStream) -> PRes
     //
     // Emit an error about semicolon and suggest removing it.
     if parser.token == token::Semi {
-        let mut err = cx.struct_span_err(sp, "macro requires an expression as an argument");
-        err.span_suggestion(
-            parser.token.span,
-            "try removing semicolon",
-            "",
-            Applicability::MaybeIncorrect,
-        );
-        err.emit();
+        cx.emit_err(ArgumentExpressionRequired { span: sp });
 
         parser.bump();
     }
@@ -148,16 +140,7 @@ fn parse_assert<'a>(cx: &mut ExtCtxt<'a>, sp: Span, stream: TokenStream) -> PRes
     // Emit an error and suggest inserting a comma.
     let custom_message =
         if let token::Literal(token::Lit { kind: token::Str, .. }) = parser.token.kind {
-            let mut err = cx.struct_span_err(parser.token.span, "unexpected string literal");
-            let comma_span = parser.prev_token.span.shrink_to_hi();
-            err.span_suggestion_short(
-                comma_span,
-                "try adding a comma",
-                ", ",
-                Applicability::MaybeIncorrect,
-            );
-            err.emit();
-
+            cx.sess.emit_err(errors::UnexpectedStringLiteral { span: parser.token.span });
             parse_custom_message(&mut parser)
         } else if parser.eat(&token::Comma) {
             parse_custom_message(&mut parser)
@@ -174,5 +157,9 @@ fn parse_assert<'a>(cx: &mut ExtCtxt<'a>, sp: Span, stream: TokenStream) -> PRes
 
 fn parse_custom_message(parser: &mut Parser<'_>) -> Option<TokenStream> {
     let ts = parser.parse_tokens();
-    if !ts.is_empty() { Some(ts) } else { None }
+    if !ts.is_empty() {
+        Some(ts)
+    } else {
+        None
+    }
 }

--- a/compiler/rustc_builtin_macros/src/compile_error.rs
+++ b/compiler/rustc_builtin_macros/src/compile_error.rs
@@ -4,6 +4,8 @@ use rustc_ast::tokenstream::TokenStream;
 use rustc_expand::base::{self, *};
 use rustc_span::Span;
 
+use crate::errors::CompileError;
+
 pub fn expand_compile_error<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
@@ -13,7 +15,7 @@ pub fn expand_compile_error<'cx>(
         return DummyResult::any(sp);
     };
 
-    cx.span_err(sp, var.as_str());
+    cx.emit_err(CompileError { span: sp, msg: var.as_str().to_owned() });
 
     DummyResult::any(sp)
 }

--- a/compiler/rustc_builtin_macros/src/concat_bytes.rs
+++ b/compiler/rustc_builtin_macros/src/concat_bytes.rs
@@ -1,7 +1,13 @@
 use rustc_ast as ast;
 use rustc_ast::{ptr::P, tokenstream::TokenStream};
-use rustc_errors::Applicability;
 use rustc_expand::base::{self, DummyResult};
+
+use crate::errors::{
+    BooleanLiteralsConcatenate, ByteLiteralExpected, CharacterLiteralsConcatenate,
+    DoublyNestedArrayConcatenate, FloatLiteralsConcatenate, InvalidNumericLiteral,
+    InvalidRepeatCount, NumericLiteralsConcatenate, OutOfBoundNumericLiteral, Snippet,
+    StringLiteralsConcatenate,
+};
 
 /// Emits errors for literal expressions that are invalid inside and outside of an array.
 fn invalid_type_err(cx: &mut base::ExtCtxt<'_>, expr: &P<rustc_ast::Expr>, is_nested: bool) {
@@ -10,60 +16,49 @@ fn invalid_type_err(cx: &mut base::ExtCtxt<'_>, expr: &P<rustc_ast::Expr>, is_ne
     };
     match lit.kind {
         ast::LitKind::Char(_) => {
-            let mut err = cx.struct_span_err(expr.span, "cannot concatenate character literals");
-            if let Ok(snippet) = cx.sess.source_map().span_to_snippet(expr.span) {
-                err.span_suggestion(
-                    expr.span,
-                    "try using a byte character",
-                    format!("b{}", snippet),
-                    Applicability::MachineApplicable,
-                )
-                .emit();
-            }
+            let sub = cx
+                .sess
+                .source_map()
+                .span_to_snippet(expr.span)
+                .ok()
+                .map(|s| Snippet::ByteCharacter { span: expr.span, snippet: s });
+            cx.emit_err(CharacterLiteralsConcatenate { span: expr.span, sub });
         }
         ast::LitKind::Str(_, _) => {
-            let mut err = cx.struct_span_err(expr.span, "cannot concatenate string literals");
             // suggestion would be invalid if we are nested
-            if !is_nested {
-                if let Ok(snippet) = cx.sess.source_map().span_to_snippet(expr.span) {
-                    err.span_suggestion(
-                        expr.span,
-                        "try using a byte string",
-                        format!("b{}", snippet),
-                        Applicability::MachineApplicable,
-                    );
-                }
-            }
-            err.emit();
+            let sub = if !is_nested {
+                cx.sess
+                    .source_map()
+                    .span_to_snippet(expr.span)
+                    .ok()
+                    .map(|s| Snippet::ByteString { span: expr.span, snippet: s })
+            } else {
+                None
+            };
+            cx.emit_err(StringLiteralsConcatenate { span: expr.span, sub });
         }
         ast::LitKind::Float(_, _) => {
-            cx.span_err(expr.span, "cannot concatenate float literals");
+            cx.emit_err(FloatLiteralsConcatenate { span: expr.span });
         }
         ast::LitKind::Bool(_) => {
-            cx.span_err(expr.span, "cannot concatenate boolean literals");
+            cx.emit_err(BooleanLiteralsConcatenate { span: expr.span });
         }
         ast::LitKind::Err => {}
         ast::LitKind::Int(_, _) if !is_nested => {
-            let mut err = cx.struct_span_err(expr.span, "cannot concatenate numeric literals");
-            if let Ok(snippet) = cx.sess.source_map().span_to_snippet(expr.span) {
-                err.span_suggestion(
-                    expr.span,
-                    "try wrapping the number in an array",
-                    format!("[{}]", snippet),
-                    Applicability::MachineApplicable,
-                );
-            }
-            err.emit();
+            let sub = cx.sess.source_map().span_to_snippet(expr.span).ok().map(|s| {
+                Snippet::WrappingNumberInArray { span: expr.span, snippet: format!("[{}]", s) }
+            });
+            cx.emit_err(NumericLiteralsConcatenate { span: expr.span, sub });
         }
         ast::LitKind::Int(
             val,
             ast::LitIntType::Unsuffixed | ast::LitIntType::Unsigned(ast::UintTy::U8),
         ) => {
             assert!(val > u8::MAX.into()); // must be an error
-            cx.span_err(expr.span, "numeric literal is out of bounds");
+            cx.emit_err(OutOfBoundNumericLiteral { span: expr.span });
         }
         ast::LitKind::Int(_, _) => {
-            cx.span_err(expr.span, "numeric literal is not a `u8`");
+            cx.emit_err(InvalidNumericLiteral { span: expr.span });
         }
         _ => unreachable!(),
     }
@@ -78,7 +73,11 @@ fn handle_array_element(
     match expr.kind {
         ast::ExprKind::Array(_) | ast::ExprKind::Repeat(_, _) => {
             if !*has_errors {
-                cx.span_err(expr.span, "cannot concatenate doubly nested array");
+                cx.emit_err(DoublyNestedArrayConcatenate {
+                    span: expr.span,
+                    note: None,
+                    help: None,
+                });
             }
             *has_errors = true;
             None
@@ -92,10 +91,11 @@ fn handle_array_element(
             ast::LitKind::Byte(val) => Some(val),
             ast::LitKind::ByteStr(_) => {
                 if !*has_errors {
-                    cx.struct_span_err(expr.span, "cannot concatenate doubly nested array")
-                        .note("byte strings are treated as arrays of bytes")
-                        .help("try flattening the array")
-                        .emit();
+                    cx.emit_err(DoublyNestedArrayConcatenate {
+                        span: expr.span,
+                        note: Some(()),
+                        help: Some(()),
+                    });
                 }
                 *has_errors = true;
                 None
@@ -150,7 +150,7 @@ pub fn expand_concat_bytes(
                         }
                     }
                 } else {
-                    cx.span_err(count.value.span, "repeat count is not a positive number");
+                    cx.emit_err(InvalidRepeatCount { span: count.value.span });
                 }
             }
             ast::ExprKind::Lit(ref lit) => match lit.kind {
@@ -176,9 +176,7 @@ pub fn expand_concat_bytes(
         }
     }
     if !missing_literals.is_empty() {
-        let mut err = cx.struct_span_err(missing_literals.clone(), "expected a byte literal");
-        err.note("only byte literals (like `b\"foo\"`, `b's'`, and `[3, 4, 5]`) can be passed to `concat_bytes!()`");
-        err.emit();
+        cx.emit_err(ByteLiteralExpected { spans: missing_literals.clone() });
         return base::MacEager::expr(DummyResult::raw_expr(sp, true));
     } else if has_errors {
         return base::MacEager::expr(DummyResult::raw_expr(sp, true));

--- a/compiler/rustc_builtin_macros/src/concat_idents.rs
+++ b/compiler/rustc_builtin_macros/src/concat_idents.rs
@@ -6,13 +6,15 @@ use rustc_expand::base::{self, *};
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::Span;
 
+use crate::errors::{CommaExpected, IdentArgsRequired, MissingArguments};
+
 pub fn expand_concat_idents<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
 ) -> Box<dyn base::MacResult + 'cx> {
     if tts.is_empty() {
-        cx.span_err(sp, "concat_idents! takes 1 or more arguments");
+        cx.emit_err(MissingArguments { span: sp });
         return DummyResult::any(sp);
     }
 
@@ -22,7 +24,7 @@ pub fn expand_concat_idents<'cx>(
             match e {
                 TokenTree::Token(Token { kind: token::Comma, .. }, _) => {}
                 _ => {
-                    cx.span_err(sp, "concat_idents! expecting comma");
+                    cx.emit_err(CommaExpected { span: sp });
                     return DummyResult::any(sp);
                 }
             }
@@ -34,7 +36,7 @@ pub fn expand_concat_idents<'cx>(
                 }
             }
 
-            cx.span_err(sp, "concat_idents! requires ident args");
+            cx.emit_err(IdentArgsRequired { span: sp });
             return DummyResult::any(sp);
         }
     }

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -163,6 +163,7 @@ pub use StaticFields::*;
 pub use SubstructureFields::*;
 
 use crate::deriving;
+use crate::errors::{CannotBeDerivedUnions, UnallowedDerive};
 use rustc_ast::ptr::P;
 use rustc_ast::{
     self as ast, BindingAnnotation, ByRef, EnumDef, Expr, Generics, Mutability, PatKind,
@@ -391,7 +392,7 @@ fn find_type_parameters(
         }
 
         fn visit_mac_call(&mut self, mac: &ast::MacCall) {
-            self.cx.span_err(mac.span(), "`derive` cannot be used on items with type macros");
+            self.cx.emit_err(UnallowedDerive { span: mac.span() });
         }
     }
 
@@ -478,7 +479,7 @@ impl<'a> TraitDef<'a> {
                                 always_copy,
                             )
                         } else {
-                            cx.span_err(mitem.span, "this trait cannot be derived for unions");
+                            cx.emit_err(CannotBeDerivedUnions { span: mitem.span });
                             return;
                         }
                     }

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1,0 +1,218 @@
+use rustc_macros::SessionDiagnostic;
+use rustc_span::{Span, Symbol};
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_args_after_clobber_abi)]
+pub(crate) struct AsmArgsAfterClobberAbi {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    #[label(builtin_macros::abi_label)]
+    pub(crate) abi_span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_args_after_options)]
+pub(crate) struct AsmArgsAfterOptions {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    #[label(builtin_macros::previous_options_label)]
+    pub(crate) options_spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_args_named_after_explicit_register)]
+pub(crate) struct AsmArgsNamedAfterExplicitRegister {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    #[label(builtin_macros::register_label)]
+    pub(crate) register_spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_args_positional_after_named_or_explicit_register)]
+pub(crate) struct AsmArgsPositionalAfterNamedOrExplicitRegister {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    #[label(builtin_macros::named_label)]
+    pub(crate) named_spans: Vec<Span>,
+    #[label(builtin_macros::register_label)]
+    pub(crate) register_spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_cannot_be_used_with)]
+pub(crate) struct AsmCannotBeUsedWith {
+    pub(crate) left: &'static str,
+    pub(crate) right: &'static str,
+    #[primary_span]
+    pub(crate) spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_clobber_abi_after_options)]
+pub(crate) struct AsmClobberAbiAfterOptions {
+    #[primary_span]
+    pub(crate) span: Span,
+    #[label(builtin_macros::options_label)]
+    pub(crate) options_spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_clobber_abi_needs_an_abi)]
+pub(crate) struct AsmClobberAbiNeedsAnAbi {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_clobber_abi_needs_explicit_registers)]
+pub(crate) struct AsmClobberAbiNeedsExplicitRegisters {
+    #[primary_span]
+    #[label]
+    pub(crate) spans: Vec<Span>,
+    #[label(builtin_macros::abi_label)]
+    pub(crate) abi_spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_duplicate_argument)]
+pub(crate) struct AsmDuplicateArgument {
+    pub(crate) name: Symbol,
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    #[label(builtin_macros::previously_label)]
+    pub(crate) prev_span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_duplicate_option)]
+pub(crate) struct AsmDuplicateOption {
+    pub(crate) symbol: Symbol,
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    // TODO: This should be a `tool_only_span_suggestion`
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub(crate) full_span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_expected_operand_options_or_template_string)]
+pub(crate) struct AsmExpectedOperandOptionsOrTemplateString {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_expected_operand_clobber_abi_options_or_template_string)]
+pub(crate) struct AsmExpectedOperandClobberAbiOptionsOrTemplateString {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_expected_path_arg_to_sym)]
+pub(crate) struct AsmExpectedPathArgToSym {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_expected_register_class_or_explicit_register)]
+pub(crate) struct AsmExpectedRegisterClassOrExplicitRegister {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_expected_string_literal)]
+pub(crate) struct AsmExpectedStringLiteral {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_expected_token_comma)]
+pub(crate) struct AsmExpectedTokenComma {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_explicit_register_arg_with_name)]
+pub(crate) struct AsmExplicitRegisterArgWithName {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_no_argument_named)]
+pub(crate) struct AsmNoArgumentNamed {
+    pub(crate) name: String,
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_option_must_be_combined_with_either)]
+pub(crate) struct AsmOptionMustBeCombinedWithEither {
+    pub(crate) option: &'static str,
+    pub(crate) left: &'static str,
+    pub(crate) right: &'static str,
+    #[primary_span]
+    pub(crate) spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_option_noreturn_with_outputs)]
+pub(crate) struct AsmOptionNoreturnWithOutputs {
+    #[primary_span]
+    pub(crate) spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_option_pure_needs_one_output)]
+pub(crate) struct AsmOptionPureNeedsOneOutput {
+    #[primary_span]
+    pub(crate) spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_options_mutually_exclusive)]
+pub(crate) struct AsmOptionsMutuallyExclusive {
+    pub(crate) left: &'static str,
+    pub(crate) right: &'static str,
+    #[primary_span]
+    pub(crate) spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_requires_template_string_arg)]
+pub(crate) struct AsmRequiresTemplateStringArg {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_template_modifier_single_char)]
+pub(crate) struct AsmTemplateModifierSingleChar {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::asm_underscore_for_input_operands)]
+pub(crate) struct AsmUnderscoreForInputOperands {
+    #[primary_span]
+    pub(crate) span: Span,
+}

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1,5 +1,6 @@
-use rustc_macros::SessionDiagnostic;
-use rustc_span::{Span, Symbol};
+use rustc_errors::{fluent, AddSubdiagnostic, Applicability, Diagnostic};
+use rustc_macros::{SessionDiagnostic, SessionSubdiagnostic};
+use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(SessionDiagnostic)]
 #[diag(builtin_macros::asm_args_after_clobber_abi)]
@@ -97,7 +98,7 @@ pub(crate) struct AsmDuplicateOption {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
-    // TODO: This should be a `tool_only_span_suggestion`
+    // FIXME: This should be a `tool_only_span_suggestion`
     #[suggestion(code = "", applicability = "machine-applicable")]
     pub(crate) full_span: Span,
 }
@@ -215,4 +216,405 @@ pub(crate) struct AsmTemplateModifierSingleChar {
 pub(crate) struct AsmUnderscoreForInputOperands {
     #[primary_span]
     pub(crate) span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::boolean_expression_required)]
+pub struct BooleanExpressionRequired {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::unexpected_string_literal)]
+pub struct UnexpectedStringLiteral {
+    #[primary_span]
+    #[suggestion_short(code = ", ", applicability = "maybe-incorrect")]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::argument_expression_required)]
+pub struct ArgumentExpressionRequired {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::not_specified)]
+pub struct NotSpecified {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::multiple_paths_specified)]
+pub struct MultiplePathsSpecified {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::unallowed_literal_path)]
+pub struct UnallowedLiteralPath {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::unaccepted_arguments)]
+pub struct UnacceptedArguments {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::nondeterministic_access)]
+pub struct NondeterministicAccess {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::compile_error)]
+pub struct CompileError {
+    #[primary_span]
+    pub span: Span,
+    pub msg: String,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::byte_string_literal_concatenate)]
+pub struct ByteStringLiteralConcatenate {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::missing_literal)]
+#[note]
+pub struct MissingLiteral {
+    #[primary_span]
+    pub span: Span,
+}
+
+pub enum Snippet {
+    ByteCharacter { span: Span, snippet: String },
+    ByteString { span: Span, snippet: String },
+    WrappingNumberInArray { span: Span, snippet: String },
+}
+
+impl AddSubdiagnostic for Snippet {
+    fn add_to_diagnostic(self, diag: &mut Diagnostic) {
+        match self {
+            Self::ByteCharacter { span, snippet } => {
+                diag.span_suggestion(
+                    span,
+                    fluent::builtin_macros::use_byte_character,
+                    snippet,
+                    Applicability::MachineApplicable,
+                );
+            }
+            Self::ByteString { span, snippet } => {
+                diag.span_suggestion(
+                    span,
+                    fluent::builtin_macros::use_byte_string,
+                    snippet,
+                    Applicability::MachineApplicable,
+                );
+            }
+            Self::WrappingNumberInArray { span, snippet } => {
+                diag.span_suggestion(
+                    span,
+                    fluent::builtin_macros::wrap_number_in_array,
+                    snippet,
+                    Applicability::MachineApplicable,
+                );
+            }
+        }
+    }
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::character_literals_concatenate)]
+pub struct CharacterLiteralsConcatenate {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: Option<Snippet>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::string_literals_concatenate)]
+pub struct StringLiteralsConcatenate {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: Option<Snippet>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::float_literals_concatenate)]
+pub struct FloatLiteralsConcatenate {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::boolean_literals_concatenate)]
+pub struct BooleanLiteralsConcatenate {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::numeric_literals_concatenate)]
+pub struct NumericLiteralsConcatenate {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sub: Option<Snippet>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::out_of_bound_numeric_literal)]
+pub struct OutOfBoundNumericLiteral {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::invalid_numeric_literal)]
+pub struct InvalidNumericLiteral {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::doubly_nested_array_concatenate)]
+pub struct DoublyNestedArrayConcatenate {
+    #[primary_span]
+    pub span: Span,
+    #[note]
+    pub note: Option<()>,
+    #[help]
+    pub help: Option<()>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::invalid_repeat_count)]
+pub struct InvalidRepeatCount {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[note]
+#[diag(builtin_macros::byte_literal_expected)]
+pub struct ByteLiteralExpected {
+    #[primary_span]
+    pub spans: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::missing_arguments)]
+pub struct MissingArguments {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::comma_expected)]
+pub struct CommaExpected {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::ident_args_required)]
+pub struct IdentArgsRequired {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::not_applicable_derive, code = "E0774")]
+pub struct NotApplicableDerive {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[label(builtin_macros::item_label)]
+    pub item_span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::trait_path_expected, code = "E0777")]
+pub struct TraitPathExpected<'a> {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub help_msg: &'a str,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::path_rejected)]
+pub struct PathRejected<'a> {
+    #[primary_span]
+    #[label]
+    #[suggestion(code = "", applicability = "machine-applicable")]
+    pub span: Span,
+    pub title: &'a str,
+    pub action: &'a str,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::no_default)]
+pub struct NoDefault {
+    #[primary_span]
+    pub span: Span,
+    // FIXME: This should be a `tool_only_span_suggestion`
+    #[subdiagnostic]
+    pub suggestions: Vec<NoDefaultSuggestion>,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[suggestion(
+    builtin_macros::variant_suggestion,
+    code = "#[default] {ident}",
+    applicability = "maybe-incorrect"
+)]
+pub struct NoDefaultSuggestion {
+    #[primary_span]
+    pub span: Span,
+    pub ident: Ident,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::multiple_declared_defaults)]
+pub struct MultipleDeclaredDefaults {
+    #[primary_span]
+    pub span: Span,
+    #[label(builtin_macros::multiple_declared_defaults_first)]
+    pub first: Span,
+    #[label(builtin_macros::multiple_declared_defaults_additional)]
+    pub variants: Vec<Span>,
+    // FIXME: This should be a `tool_only_multipart_suggestion`
+    #[subdiagnostic]
+    pub suggestions: Vec<MultipleDeclaredDefaultsSuggestion>,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[multipart_suggestion(builtin_macros::variant_suggestion, applicability = "maybe-incorrect")]
+pub struct MultipleDeclaredDefaultsSuggestion {
+    #[suggestion_part(code = "")]
+    pub span: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::default_not_allowed)]
+pub struct DefaultNotAllowed {
+    #[primary_span]
+    pub span: Span,
+    #[help]
+    pub help: Option<()>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::default_non_exhaustive)]
+pub struct DefaultNonExhaustive {
+    #[primary_span]
+    pub span: Span,
+    #[label(builtin_macros::default_non_exhaustive_instruction)]
+    pub non_exhustive_attr: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::multiple_default_attributes)]
+pub struct MultipleDefaultAttributes<'a> {
+    #[primary_span]
+    pub span: Span,
+    #[label(builtin_macros::multiple_default_attributes_first)]
+    pub first: Span,
+    #[label(builtin_macros::multiple_default_attributes_rest)]
+    pub rest: Span,
+    #[help(builtin_macros::multiple_default_attributes_suggestion_text)]
+    pub help: Vec<Span>,
+    pub suggestion_text: &'a str,
+    // FIXME: This should be a `tool_only_multipart_suggestion`
+    #[subdiagnostic]
+    pub suggestions: MultipleDefaultAttributesSuggestions,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[multipart_suggestion(
+    builtin_macros::multiple_default_attributes_suggestion_text,
+    applicability = "machine-applicable"
+)]
+pub struct MultipleDefaultAttributesSuggestions {
+    #[suggestion_part(code = "")]
+    pub span: Vec<Span>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::default_not_accept_value)]
+pub struct DefaultNotAcceptValue {
+    #[primary_span]
+    #[suggestion_hidden(code = "#[default]", applicability = "maybe-incorrect")]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::unallowed_derive)]
+pub struct UnallowedDerive {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::cannot_be_derived_unions)]
+pub struct CannotBeDerivedUnions {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::empty_argument)]
+pub struct EmptyArgument {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::env_expand_error)]
+pub struct EnvExpandError<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub msg: &'a str,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::format_string_argument_required)]
+pub struct FormatStringArgumentRequired {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::duplicated_argument)]
+pub struct DuplicatedArgument {
+    #[primary_span]
+    pub span: Span,
+    #[label(builtin_macros::multiple_default_attributes_first)]
+    pub prev_span: Span,
+    pub ident: Ident,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(builtin_macros::invalid_positional_arguments)]
+pub struct InvalidPositionalArguments {
+    #[primary_span]
+    pub span: Span,
+    #[label(builtin_macros::invalid_positional_arguments_names)]
+    pub names: Vec<Span>,
 }

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -37,6 +37,7 @@ mod derive;
 mod deriving;
 mod edition_panic;
 mod env;
+mod errors;
 mod format;
 mod format_foreign;
 mod global_allocator;

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -13,6 +13,8 @@
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_quote)]
 #![recursion_limit = "256"]
+#![deny(rustc::untranslatable_diagnostic)]
+#![deny(rustc::diagnostic_outside_of_impl)]
 
 extern crate proc_macro;
 

--- a/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
@@ -1,3 +1,91 @@
+builtin_macros_asm_args_after_clobber_abi =
+    arguments are not allowed after clobber_abi
+    .label = argument
+    .abi_label = clobber_abi
+
+builtin_macros_asm_args_after_options =
+    arguments are not allowed after options
+    .label = argument
+    .previous_options_label = previous options
+
+builtin_macros_asm_args_named_after_explicit_register =
+    named arguments cannot follow explicit register arguments
+    .label = named argument
+    .register_label = explicit register argument
+
+builtin_macros_asm_args_positional_after_named_or_explicit_register =
+    positional arguments cannot follow named arguments or explicit register arguments
+    .label = positional argument
+    .named_label = named argument
+    .register_label = explicit register argument
+
+builtin_macros_asm_cannot_be_used_with = `{$left}` cannot be used with `{$right}`
+
+builtin_macros_asm_clobber_abi_after_options =
+    clobber_abi is not allowed after options
+    .options_label = options
+
+builtin_macros_asm_clobber_abi_needs_an_abi =
+    at least one abi must be provided as an argument to `clobber_abi`
+
+builtin_macros_asm_clobber_abi_needs_explicit_registers =
+    asm with `clobber_abi` must specify explicit registers for outputs
+    .label = generic outputs
+    .abi_label = clobber_abi
+
+builtin_macros_asm_duplicate_argument =
+    duplicate argument named `{$name}`
+    .label = duplicate argument
+    .previously_label = previously here
+
+builtin_macros_asm_duplicate_option =
+    the `{$symbol}` option was already provided
+    .label = this option was already provided
+    .suggestion = remove this option
+
+builtin_macros_asm_expected_operand_options_or_template_string =
+    expected operand, options, or additional template string
+    .label = expected operand, options, or additional template string
+
+builtin_macros_asm_expected_operand_clobber_abi_options_or_template_string =
+    expected operand, clobber_abi, options, or additional template string
+    .label = expected operand, clobber_abi, options, or additional template string
+
+builtin_macros_asm_expected_path_arg_to_sym = expected a path for argument to `sym`
+
+builtin_macros_asm_expected_register_class_or_explicit_register =
+    expected register class or explicit register
+
+builtin_macros_asm_expected_string_literal =
+    expected string literal
+    .label = not a string literal
+
+builtin_macros_asm_expected_token_comma =
+    expected token: `,`
+    .label = expected `,`
+
+builtin_macros_asm_explicit_register_arg_with_name = explicit register arguments cannot have names
+
+builtin_macros_asm_no_argument_named = there is no argument named `{$name}`
+
+builtin_macros_asm_option_must_be_combined_with_either =
+    the `{$option}` option must be combined with either `{$left}` or `{$right}`
+
+builtin_macros_asm_option_noreturn_with_outputs =
+    asm outputs are not allowed with the `noreturn` option
+
+builtin_macros_asm_option_pure_needs_one_output =
+    asm with the `pure` option must have at least one output
+
+builtin_macros_asm_options_mutually_exclusive =
+    the `{$left}` and `${right}` options are mutually exclusive
+
+builtin_macros_asm_requires_template_string_arg = requires at least a template string argument
+
+builtin_macros_asm_template_modifier_single_char = asm template modifier must be a single character
+
+builtin_macros_asm_underscore_for_input_operands = _ cannot be used for input operands
+
 builtin_macros_requires_cfg_pattern =
     macro requires a cfg-pattern as an argument
     .label = cfg-pattern required

--- a/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
@@ -91,3 +91,138 @@ builtin_macros_requires_cfg_pattern =
     .label = cfg-pattern required
 
 builtin_macros_expected_one_cfg_pattern = expected 1 cfg-pattern
+
+builtin_macros_boolean_expression_required =
+    macro requires a boolean expression as an argument
+    .label = boolean expression required
+
+builtin_macros_unexpected_string_literal = unexpected string literal
+    .suggestion = try adding a comma
+
+builtin_macros_argument_expression_required =
+    macro requires an expression as an argument
+    .suggestion = try removing semicolon
+
+builtin_macros_not_specified =
+    `cfg_accessible` path is not specified
+
+builtin_macros_multiple_paths_specified =
+    multiple `cfg_accessible` paths are specified
+
+builtin_macros_unallowed_literal_path =
+    `cfg_accessible` path cannot be a literal
+
+builtin_macros_unaccepted_arguments =
+    `cfg_accessible` path cannot accept arguments
+
+builtin_macros_nondeterministic_access =
+    cannot determine whether the path is accessible or not
+
+builtin_macros_compile_error = {$msg}
+
+builtin_macros_byte_string_literal_concatenate =
+    cannot concatenate a byte string literal
+
+builtin_macros_missing_literal = expected a literal
+    .note = only literals (like `\"foo\"`, `42` and `3.14`) can be passed to `concat!()`
+
+builtin_macros_character_literals_concatenate = cannot concatenate character literals
+
+builtin_macros_string_literals_concatenate = cannot concatenate string literals
+
+builtin_macros_use_byte_character = try using a byte character
+
+builtin_macros_use_byte_string = try using a byte string
+
+builtin_macros_float_literals_concatenate = cannot concatenate float literals
+
+builtin_macros_boolean_literals_concatenate = cannot concatenate boolean literals
+
+builtin_macros_wrap_number_in_array = try wrapping the number in an array
+
+builtin_macros_numeric_literals_concatenate = cannot concatenate numeric literals
+
+builtin_macros_out_of_bound_numeric_literal = numeric literal is out of bounds
+
+builtin_macros_invalid_numeric_literal = numeric literal is not a `u8`
+
+builtin_macros_doubly_nested_array_concatenate = cannot concatenate doubly nested array
+    .note = byte strings are treated as arrays of bytes
+    .help = try flattening the array
+
+builtin_macros_invalid_repeat_count = repeat count is not a positive number
+
+builtin_macros_byte_literal_expected = expected a byte literal
+    .note = only byte literals (like `b\"foo\"`, `b's'`, and `[3, 4, 5]`) can be passed to `concat_bytes!()`
+
+builtin_macros_missing_arguments = concat_idents! takes 1 or more arguments
+
+builtin_macros_comma_expected = concat_idents! expecting comma
+
+builtin_macros_ident_args_required = concat_idents! requires ident args
+
+builtin_macros_not_applicable_derive =
+    `derive` may only be applied to `struct`s, `enum`s and `union`s
+    .label = not applicable here
+    .item_label = not a `struct`, `enum` or `union`
+
+builtin_macros_trait_path_expected =
+    expected path to a trait, found literal
+    .label = not a trait
+    .help = {$help_msg}
+
+builtin_macros_path_rejected = {$title}
+    .suggestion = {$action}
+
+builtin_macros_no_default = no default declared
+    .help = make a unit variant default by placing `#[default]` above it
+
+builtin_macros_variant_suggestion = make `{$ident}` default
+
+builtin_macros_multiple_declared_defaults_first = = first default
+
+builtin_macros_multiple_declared_defaults_additional = additional default
+
+builtin_macros_multiple_declared_defaults = multiple declared defaults
+    .note = only one variant can be default
+
+builtin_macros_default_not_allowed =
+    the `#[default]` attribute may only be used on unit enum variants
+    .help = consider a manual implementation of `Default`
+
+builtin_macros_default_non_exhaustive = default variant must be exhaustive
+    .help = consider a manual implementation of `Default`
+
+builtin_macros_default_non_exhaustive_instruction = declared `#[non_exhaustive]` here
+
+builtin_macros_multiple_default_attributes_first = `#[default]` used here
+
+builtin_macros_multiple_default_attributes_rest = `#[default]` used again here
+
+builtin_macros_multiple_default_attributes_suggestion_text = {$suggestion_text}
+
+builtin_macros_multiple_default_attributes = multiple `#[default]` attributes
+    .note = only one `#[default]` attribute is needed
+
+builtin_macros_default_not_accept_value = `#[default]` attribute does not accept a value
+    .suggestion = try using `#[default]`
+
+builtin_macros_unallowed_derive = `derive` cannot be used on items with type macros
+
+builtin_macros_cannot_be_derived_unions = this trait cannot be derived for unions
+
+builtin_macros_empty_argument = env! takes 1 or 2 arguments
+
+builtin_macros_env_expand_error = {$msg}
+
+builtin_macros_format_string_argument_required = requires at least a format string argument
+
+builtin_macros_duplicated_argument = duplicate argument named `{$ident}`
+    .label = duplicate argument
+
+builtin_macros_duplicated_argument_prev = previously here
+
+builtin_macros_invalid_positional_arguments = positional arguments cannot follow named arguments
+    .label = positional arguments must be before named arguments
+
+builtin_macros_invalid_positional_arguments_names = named argument


### PR DESCRIPTION
* Migrate the `rustc_biltin_macros` crate's diagnostic to translatable diagnostic structs.