### PR TITLE
Migrating rustc_infer to session diagnostics (part 3)

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -173,16 +173,15 @@ infer_msl_trait_note = this has an implicit `'static` lifetime requirement
 infer_msl_trait_sugg = consider relaxing the implicit `'static` requirement
 infer_suggest_add_let_for_letchains = consider adding `let`
 
-infer_explicit_lifetime_required = explicit lifetime required in {$ident_kind ->
-    [ident] the type of `{$simple_ident}`
-    *[param_type] parameter type
-}
+infer_explicit_lifetime_required_with_ident = explicit lifetime required in the type of `{$simple_ident}`
     .label = lifetime `{$named}` required
 
-infer_explicit_lifetime_required_sugg = add explicit lifetime `{$named}` to {$ident_kind ->
-    [ident] the type of `{$simple_ident}`
-    *[param_type] type
-}
+infer_explicit_lifetime_required_with_param_type = explicit lifetime required in parameter type
+    .label = lifetime `{$named}` required
+
+infer_explicit_lifetime_required_sugg_with_ident = add explicit lifetime `{$named}` to the type of `{$simple_ident}`
+
+infer_explicit_lifetime_required_sugg_with_param_type = add explicit lifetime `{$named}` to type
 
 infer_actual_impl_expl_expected_signature_two = {$leading_ellipsis ->
     [true] ...

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -233,15 +233,15 @@ infer_actual_impl_expl_expected_other_nothing = {$leading_ellipsis ->
     *[false] {""}
 }`{$ty_or_sig}` must implement `{$trait_path}`
 
-infer_actual_impl_expl_but_actually_implements_trait = ...but it actually implements `{$trait_path_2}`{$has_lifetime ->
+infer_actual_impl_expl_but_actually_implements_trait = ...but it actually implements `{$trait_path}`{$has_lifetime ->
     [true] , for some specific lifetime `'{$lifetime}`
     *[false] {""}
 }
-infer_actual_impl_expl_but_actually_implemented_for_ty = ...but `{$trait_path_2}` is actually implemented for the type `{$ty}`{$has_lifetime ->
+infer_actual_impl_expl_but_actually_implemented_for_ty = ...but `{$trait_path}` is actually implemented for the type `{$ty}`{$has_lifetime ->
     [true] , for some specific lifetime `'{$lifetime}`
     *[false] {""}
 }
-infer_actual_impl_expl_but_actually_ty_implements = ...but `{$ty}` actually implements `{$trait_path_2}`{$has_lifetime ->
+infer_actual_impl_expl_but_actually_ty_implements = ...but `{$ty}` actually implements `{$trait_path}`{$has_lifetime ->
     [true] , for some specific lifetime `'{$lifetime}`
     *[false] {""}
 }

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -221,3 +221,55 @@ infer_trait_impl_diff = `impl` item signature doesn't match `trait` item signatu
 infer_tid_rel_help = verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
 infer_tid_consider_borriwing = consider borrowing this type parameter in the trait
 infer_tid_param_help = the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
+
+infer_dtcs_has_lifetime_req_label = this has an implicit `'static` lifetime requirement
+infer_dtcs_introduces_requirement = calling this method introduces the `impl`'s 'static` requirement
+infer_dtcs_has_req_note = the used `impl` has a `'static` requirement
+infer_dtcs_suggestion = consider relaxing the implicit `'static` requirement
+
+infer_but_calling_introduces = {$has_param_name ->
+    [true] `{$param_name}`
+    *[false] `fn` parameter
+} has {$lifetime_kind ->
+    [named] lifetime `{lifetime}`
+    *[anon] an anonymous lifetime `'_`
+} but calling `{assoc_item}` introduces an implicit `'static` lifetime requirement
+    .label1 = {$has_lifetime ->
+        [named] lifetime `{lifetime}`
+        *[anon] an anonymous lifetime `'_`
+    }
+    .label2 = ...is used and required to live as long as `'static` here because of an implicit lifetime bound on the {$has_impl_path ->
+        [named] `impl` of `{$impl_path}`
+        *[anon] inherent `impl`
+    }
+
+infer_but_needs_to_satisfy = {$has_param_name ->
+    [true] `{$param_name}`
+    *[false] `fn` parameter
+} has {$has_lifetime ->
+    [named] lifetime `{lifetime}`
+    *[anon] an anonymous lifetime `'_`
+} but it needs to satisfy a `'static` lifetime requirement
+    .influencer = this data with {$has_lifetime ->
+        [named] lifetime `{lifetime}`
+        *[anon] an anonymous lifetime `'_`
+    }...
+    .require = {$spans_empty ->
+        *[true] ...is used and required to live as long as `'static` here
+        [false] ...and is required to live as long as `'static` here
+    }
+    .used_here = ...is used here...
+    .introduced_by_bound = 'static` lifetime requirement introduced by this bound
+
+infer_more_targeted = {$has_param_name ->
+    [true] `{$param_name}`
+    *[false] `fn` parameter
+} has {$has_lifetime ->
+    [named] lifetime `{lifetime}`
+    *[anon] an anonymous lifetime `'_`
+} but calling `{$ident}` introduces an implicit `'static` lifetime requirement
+
+infer_ril_introduced_here = `'static` requirement introduced here
+infer_ril_introduced_by = requirement introduced by this return type
+infer_ril_because_of = because of this returned expression
+infer_ril_static_introduced_by = "`'static` lifetime requirement introduced by the return type

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -258,7 +258,7 @@ infer_trait_impl_diff = `impl` item signature doesn't match `trait` item signatu
                {"   "}found `{$found}`
 
 infer_tid_rel_help = verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
-infer_tid_consider_borriwing = consider borrowing this type parameter in the trait
+infer_tid_consider_borrowing = consider borrowing this type parameter in the trait
 infer_tid_param_help = the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
 
 infer_dtcs_has_lifetime_req_label = this has an implicit `'static` lifetime requirement

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -183,3 +183,31 @@ infer_explicit_lifetime_required_sugg = add explicit lifetime `{$named}` to {$id
     [ident] the type of `{$simple_ident}`
     *[param_type] type
 }
+
+infer_actual_impl_expl_1 = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}{$kind ->
+    [signature] closure with signature `{$ty_or_sig}` must implement `{$trait_path}`
+    [passive] `{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`
+    *[other] `{$ty_or_sig}` must implement `{$trait_path}`
+}{$lt_kind ->
+    [two] , for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...
+    [any] , for any lifetime `'{$lifetime_1}`...
+    [some] , for some specific lifetime `'{lifetime_1}`...
+    *[nothing] {""}
+}
+
+infer_actual_impl_expl_2 = {$kind_2 ->
+    [implements_trait] ...but it actually implements `{$trait_path_2}`
+    [implemented_for_ty] ...but `{$trait_path_2}` is actually implemented for the type `{$ty}`
+    *[ty_implements] ...but `{$ty}` actually implements `{$trait_path_2}`
+}{$has_lifetime ->
+    [true] , for some specific lifetime `'{$lifetime}`
+    *[false] {""}
+}
+
+infer_trait_placeholder_mismatch = implementation of `{$trait_def_id}` is not general enough
+    .label_satisfy = doesn't satisfy where-clause
+    .label_where = due to a where-clause on `{$def_id}`...
+    .label_dup = implementation of `{$trait_def_id}` is not general enough

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -211,3 +211,13 @@ infer_trait_placeholder_mismatch = implementation of `{$trait_def_id}` is not ge
     .label_satisfy = doesn't satisfy where-clause
     .label_where = due to a where-clause on `{$def_id}`...
     .label_dup = implementation of `{$trait_def_id}` is not general enough
+
+infer_trait_impl_diff = `impl` item signature doesn't match `trait` item signature
+    .found = found `{$found}`
+    .expected = expected `{$expected}`
+    .expected_found = expected `{$expected}`
+               {"   "}found `{$found}`
+
+infer_tid_rel_help = verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
+infer_tid_consider_borriwing = consider borrowing this type parameter in the trait
+infer_tid_param_help = the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -184,25 +184,64 @@ infer_explicit_lifetime_required_sugg = add explicit lifetime `{$named}` to {$id
     *[param_type] type
 }
 
-infer_actual_impl_expl_expected = {$leading_ellipsis ->
+infer_actual_impl_expl_expected_signature_two = {$leading_ellipsis ->
     [true] ...
     *[false] {""}
-}{$kind ->
-    [signature] closure with signature `{$ty_or_sig}` must implement `{$trait_path}`
-    [passive] `{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`
-    *[other] `{$ty_or_sig}` must implement `{$trait_path}`
-}{$lt_kind ->
-    [two] , for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...
-    [any] , for any lifetime `'{$lifetime_1}`...
-    [some] , for some specific lifetime `'{lifetime_1}`...
-    *[nothing] {""}
-}
+}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...
+infer_actual_impl_expl_expected_signature_any = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for any lifetime `'{$lifetime_1}`...
+infer_actual_impl_expl_expected_signature_some = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for some specific lifetime `'{lifetime_1}`...
+infer_actual_impl_expl_expected_signature_nothing = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`
+infer_actual_impl_expl_expected_passive_two = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...
+infer_actual_impl_expl_expected_passive_any = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for any lifetime `'{$lifetime_1}`...
+infer_actual_impl_expl_expected_passive_some = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for some specific lifetime `'{lifetime_1}`...
+infer_actual_impl_expl_expected_passive_nothing = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`
+infer_actual_impl_expl_expected_other_two = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$ty_or_sig}` must implement `{$trait_path}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...
+infer_actual_impl_expl_expected_other_any = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$ty_or_sig}` must implement `{$trait_path}`, for any lifetime `'{$lifetime_1}`...
+infer_actual_impl_expl_expected_other_some = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$ty_or_sig}` must implement `{$trait_path}`, for some specific lifetime `'{lifetime_1}`...
+infer_actual_impl_expl_expected_other_nothing = {$leading_ellipsis ->
+    [true] ...
+    *[false] {""}
+}`{$ty_or_sig}` must implement `{$trait_path}`
 
-infer_actual_impl_expl_but_actually = {$kind_2 ->
-    [implements_trait] ...but it actually implements `{$trait_path_2}`
-    [implemented_for_ty] ...but `{$trait_path_2}` is actually implemented for the type `{$ty}`
-    *[ty_implements] ...but `{$ty}` actually implements `{$trait_path_2}`
-}{$has_lifetime ->
+infer_actual_impl_expl_but_actually_implements_trait = ...but it actually implements `{$trait_path_2}`{$has_lifetime ->
+    [true] , for some specific lifetime `'{$lifetime}`
+    *[false] {""}
+}
+infer_actual_impl_expl_but_actually_implemented_for_ty = ...but `{$trait_path_2}` is actually implemented for the type `{$ty}`{$has_lifetime ->
+    [true] , for some specific lifetime `'{$lifetime}`
+    *[false] {""}
+}
+infer_actual_impl_expl_but_actually_ty_implements = ...but `{$ty}` actually implements `{$trait_path_2}`{$has_lifetime ->
     [true] , for some specific lifetime `'{$lifetime}`
     *[false] {""}
 }

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -172,3 +172,14 @@ infer_msl_unmet_req = because this has an unmet lifetime requirement
 infer_msl_trait_note = this has an implicit `'static` lifetime requirement
 infer_msl_trait_sugg = consider relaxing the implicit `'static` requirement
 infer_suggest_add_let_for_letchains = consider adding `let`
+
+infer_explicit_lifetime_required = explicit lifetime required in {$ident_kind ->
+    [ident] the type of `{$simple_ident}`
+    *[param_type] parameter type
+}
+    .label = lifetime `{$named}` required
+
+infer_explicit_lifetime_required_sugg = add explicit lifetime `{$named}` to {$ident_kind ->
+    [ident] the type of `{$simple_ident}`
+    *[param_type] type
+}

--- a/compiler/rustc_error_messages/locales/en-US/infer.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/infer.ftl
@@ -184,7 +184,7 @@ infer_explicit_lifetime_required_sugg = add explicit lifetime `{$named}` to {$id
     *[param_type] type
 }
 
-infer_actual_impl_expl_1 = {$leading_ellipsis ->
+infer_actual_impl_expl_expected = {$leading_ellipsis ->
     [true] ...
     *[false] {""}
 }{$kind ->
@@ -198,7 +198,7 @@ infer_actual_impl_expl_1 = {$leading_ellipsis ->
     *[nothing] {""}
 }
 
-infer_actual_impl_expl_2 = {$kind_2 ->
+infer_actual_impl_expl_but_actually = {$kind_2 ->
     [implements_trait] ...but it actually implements `{$trait_path_2}`
     [implemented_for_ty] ...but `{$trait_path_2}` is actually implemented for the type `{$ty}`
     *[ty_implements] ...but `{$ty}` actually implements `{$trait_path_2}`

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -540,3 +540,44 @@ pub struct ExplicitLifetimeRequired<'a> {
     #[skip_arg]
     pub new_ty: Ty<'a>,
 }
+
+#[derive(SessionSubdiagnostic)]
+pub enum ActualImplExplNotes {
+    // Field names have to be different across all variants
+    #[note(infer::actual_impl_expl_1)]
+    NoteOne {
+        leading_ellipsis: bool,
+        kind: &'static str,
+        ty_or_sig: String,
+        trait_path: String,
+        lt_kind: &'static str,
+        lifetime_1: usize,
+        lifetime_2: usize,
+    },
+    #[note(infer::actual_impl_expl_2)]
+    NoteTwo {
+        kind_2: &'static str,
+        trait_path_2: String,
+        has_lifetime: bool,
+        lifetime: usize,
+        ty: String,
+    },
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(infer::trait_placeholder_mismatch)]
+pub struct TraitPlaceholderMismatch {
+    #[primary_span]
+    pub span: Span,
+    #[label(infer::label_satisfy)]
+    pub satisfy_span: Option<Span>,
+    #[label(infer::label_where)]
+    pub where_span: Option<Span>,
+    #[label(infer::label_dup)]
+    pub dup_span: Option<Span>,
+    pub def_id: String,
+    pub trait_def_id: String,
+
+    #[subdiagnostic]
+    pub actual_impl_expl_notes: Vec<ActualImplExplNotes>,
+}

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -581,3 +581,41 @@ pub struct TraitPlaceholderMismatch {
     #[subdiagnostic]
     pub actual_impl_expl_notes: Vec<ActualImplExplNotes>,
 }
+
+pub struct ConsiderBorrowingParamHelp {
+    pub spans: Vec<Span>,
+}
+
+impl AddSubdiagnostic for ConsiderBorrowingParamHelp {
+    fn add_to_diagnostic(self, diag: &mut rustc_errors::Diagnostic) {
+        let mut type_param_span: MultiSpan = self.spans.clone().into();
+        for &span in &self.spans {
+            type_param_span.push_span_label(span, fluent::infer::tid_consider_borriwing);
+        }
+        diag.span_help(type_param_span, fluent::infer::tid_param_help);
+    }
+}
+
+#[derive(SessionSubdiagnostic)]
+#[help(infer::tid_rel_help)]
+pub struct RelationshipHelp;
+
+#[derive(SessionDiagnostic)]
+#[diag(infer::trait_impl_diff)]
+pub struct TraitImplDiff {
+    #[primary_span]
+    #[label(infer::found)]
+    pub sp: Span,
+    #[label(infer::expected)]
+    pub trait_sp: Span,
+    #[note(infer::expected_found)]
+    pub note: (),
+    #[subdiagnostic]
+    pub param_help: ConsiderBorrowingParamHelp,
+    #[subdiagnostic]
+    // Seems like subdiagnostics are always pushed to the end, so this one
+    // also has to be a subdiagnostic to maintain order.
+    pub rel_help: Option<RelationshipHelp>,
+    pub expected: String,
+    pub found: String,
+}

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -357,8 +357,8 @@ impl AddToDiagnostic for LifetimeMismatchLabels {
 pub struct AddLifetimeParamsSuggestion<'a> {
     pub tcx: TyCtxt<'a>,
     pub sub: Region<'a>,
-    pub ty_sup: &'a Ty<'a>,
-    pub ty_sub: &'a Ty<'a>,
+    pub ty_sup: &'a hir::Ty<'a>,
+    pub ty_sub: &'a hir::Ty<'a>,
     pub add_note: bool,
 }
 
@@ -519,4 +519,24 @@ pub struct MismatchedStaticLifetime<'a> {
     pub does_not_outlive_static_from_impl: DoesNotOutliveStaticFromImpl,
     #[subdiagnostic]
     pub implicit_static_lifetimes: Vec<ImplicitStaticLifetimeSubdiag>,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(infer::explicit_lifetime_required, code = "E0621")]
+pub struct ExplicitLifetimeRequired<'a> {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub ident_kind: &'static str,
+    pub simple_ident: String,
+    pub named: String,
+
+    #[suggestion(
+        infer::explicit_lifetime_required_sugg,
+        code = "{new_ty}",
+        applicability = "unspecified"
+    )]
+    pub new_ty_span: Span,
+    #[skip_arg]
+    pub new_ty: Ty<'a>,
 }

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -777,7 +777,7 @@ pub struct TraitPlaceholderMismatch<'tcx> {
     pub def_id: String,
     pub trait_def_id: String,
 
-    #[subdiagnostic(eager)]
+    #[subdiagnostic]
     pub actual_impl_expl_notes: Vec<ActualImplExplNotes<'tcx>>,
 }
 

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -545,8 +545,8 @@ pub struct ExplicitLifetimeRequired<'a> {
 #[derive(Subdiagnostic)]
 pub enum ActualImplExplNotes {
     // Field names have to be different across all variants
-    #[note(infer::actual_impl_expl_1)]
-    NoteOne {
+    #[note(infer::actual_impl_expl_expected)]
+    Expected {
         leading_ellipsis: bool,
         kind: &'static str,
         ty_or_sig: String,
@@ -555,8 +555,8 @@ pub enum ActualImplExplNotes {
         lifetime_1: usize,
         lifetime_2: usize,
     },
-    #[note(infer::actual_impl_expl_2)]
-    NoteTwo {
+    #[note(infer::actual_impl_expl_but_actually)]
+    ButActually {
         kind_2: &'static str,
         trait_path_2: String,
         has_lifetime: bool,

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -4,9 +4,9 @@ use rustc_errors::{
     MultiSpan, SubdiagnosticMessage,
 };
 use rustc_hir as hir;
-use rustc_hir::{FnRetTy, Ty};
+use rustc_hir::FnRetTy;
 use rustc_macros::{Diagnostic, Subdiagnostic};
-use rustc_middle::ty::{Region, TyCtxt};
+use rustc_middle::ty::{Region, Ty, TyCtxt};
 use rustc_span::symbol::kw;
 use rustc_span::Symbol;
 use rustc_span::{symbol::Ident, BytePos, Span};
@@ -522,7 +522,7 @@ pub struct MismatchedStaticLifetime<'a> {
     pub implicit_static_lifetimes: Vec<ImplicitStaticLifetimeSubdiag>,
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(infer::explicit_lifetime_required, code = "E0621")]
 pub struct ExplicitLifetimeRequired<'a> {
     #[primary_span]
@@ -542,7 +542,7 @@ pub struct ExplicitLifetimeRequired<'a> {
     pub new_ty: Ty<'a>,
 }
 
-#[derive(SessionSubdiagnostic)]
+#[derive(Subdiagnostic)]
 pub enum ActualImplExplNotes {
     // Field names have to be different across all variants
     #[note(infer::actual_impl_expl_1)]
@@ -565,7 +565,7 @@ pub enum ActualImplExplNotes {
     },
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(infer::trait_placeholder_mismatch)]
 pub struct TraitPlaceholderMismatch {
     #[primary_span]
@@ -587,7 +587,7 @@ pub struct ConsiderBorrowingParamHelp {
     pub spans: Vec<Span>,
 }
 
-impl AddSubdiagnostic for ConsiderBorrowingParamHelp {
+impl AddToDiagnostic for ConsiderBorrowingParamHelp {
     fn add_to_diagnostic(self, diag: &mut rustc_errors::Diagnostic) {
         let mut type_param_span: MultiSpan = self.spans.clone().into();
         for &span in &self.spans {
@@ -597,11 +597,11 @@ impl AddSubdiagnostic for ConsiderBorrowingParamHelp {
     }
 }
 
-#[derive(SessionSubdiagnostic)]
+#[derive(Subdiagnostic)]
 #[help(infer::tid_rel_help)]
 pub struct RelationshipHelp;
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(infer::trait_impl_diff)]
 pub struct TraitImplDiff {
     #[primary_span]
@@ -626,7 +626,7 @@ pub struct DynTraitConstraintSuggestion {
     pub ident: Ident,
 }
 
-impl AddSubdiagnostic for DynTraitConstraintSuggestion {
+impl AddToDiagnostic for DynTraitConstraintSuggestion {
     fn add_to_diagnostic(self, diag: &mut rustc_errors::Diagnostic) {
         let mut multi_span: MultiSpan = vec![self.span].into();
         multi_span.push_span_label(self.span, fluent::infer::dtcs_has_lifetime_req_label);
@@ -641,7 +641,7 @@ impl AddSubdiagnostic for DynTraitConstraintSuggestion {
     }
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(infer::but_calling_introduces, code = "E0772")]
 pub struct ButCallingIntroduces {
     #[label(infer::label1)]
@@ -667,7 +667,7 @@ pub struct ReqIntroducedLocations {
     pub add_label: bool,
 }
 
-impl AddSubdiagnostic for ReqIntroducedLocations {
+impl AddToDiagnostic for ReqIntroducedLocations {
     fn add_to_diagnostic(mut self, diag: &mut rustc_errors::Diagnostic) {
         for sp in self.spans {
             self.span.push_span_label(sp, fluent::infer::ril_introduced_here);
@@ -685,7 +685,7 @@ pub struct MoreTargeted {
     pub ident: Symbol,
 }
 
-impl AddSubdiagnostic for MoreTargeted {
+impl AddToDiagnostic for MoreTargeted {
     fn add_to_diagnostic(self, diag: &mut rustc_errors::Diagnostic) {
         diag.code(rustc_errors::error_code!(E0772));
         diag.set_primary_message(fluent::infer::more_targeted);
@@ -693,7 +693,7 @@ impl AddSubdiagnostic for MoreTargeted {
     }
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(infer::but_needs_to_satisfy, code = "E0759")]
 pub struct ButNeedsToSatisfy {
     #[primary_span]

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -617,21 +617,16 @@ pub enum ActualImplExplNotes {
     #[note(infer::actual_impl_expl_expected_other_nothing)]
     ExpectedOtherNothing { leading_ellipsis: bool, ty_or_sig: String, trait_path: String },
     #[note(infer::actual_impl_expl_but_actually_implements_trait)]
-    ButActuallyImplementsTrait { trait_path_2: String, has_lifetime: bool, lifetime: usize },
+    ButActuallyImplementsTrait { trait_path: String, has_lifetime: bool, lifetime: usize },
     #[note(infer::actual_impl_expl_but_actually_implemented_for_ty)]
     ButActuallyImplementedForTy {
-        trait_path_2: String,
+        trait_path: String,
         has_lifetime: bool,
         lifetime: usize,
         ty: String,
     },
     #[note(infer::actual_impl_expl_but_actually_ty_implements)]
-    ButActuallyTyImplements {
-        trait_path_2: String,
-        has_lifetime: bool,
-        lifetime: usize,
-        ty: String,
-    },
+    ButActuallyTyImplements { trait_path: String, has_lifetime: bool, lifetime: usize, ty: String },
 }
 
 pub enum ActualImplExpectedKind {

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -523,7 +523,7 @@ pub struct MismatchedStaticLifetime<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::explicit_lifetime_required, code = "E0621")]
+#[diag(infer_explicit_lifetime_required, code = "E0621")]
 pub struct ExplicitLifetimeRequired<'a> {
     #[primary_span]
     #[label]
@@ -533,7 +533,7 @@ pub struct ExplicitLifetimeRequired<'a> {
     pub named: String,
 
     #[suggestion(
-        infer::explicit_lifetime_required_sugg,
+        infer_explicit_lifetime_required_sugg,
         code = "{new_ty}",
         applicability = "unspecified"
     )]
@@ -544,7 +544,7 @@ pub struct ExplicitLifetimeRequired<'a> {
 
 #[derive(Subdiagnostic)]
 pub enum ActualImplExplNotes {
-    #[note(infer::actual_impl_expl_expected_signature_two)]
+    #[note(infer_actual_impl_expl_expected_signature_two)]
     ExpectedSignatureTwo {
         leading_ellipsis: bool,
         ty_or_sig: String,
@@ -552,23 +552,23 @@ pub enum ActualImplExplNotes {
         lifetime_1: usize,
         lifetime_2: usize,
     },
-    #[note(infer::actual_impl_expl_expected_signature_any)]
+    #[note(infer_actual_impl_expl_expected_signature_any)]
     ExpectedSignatureAny {
         leading_ellipsis: bool,
         ty_or_sig: String,
         trait_path: String,
         lifetime_1: usize,
     },
-    #[note(infer::actual_impl_expl_expected_signature_some)]
+    #[note(infer_actual_impl_expl_expected_signature_some)]
     ExpectedSignatureSome {
         leading_ellipsis: bool,
         ty_or_sig: String,
         trait_path: String,
         lifetime_1: usize,
     },
-    #[note(infer::actual_impl_expl_expected_signature_nothing)]
+    #[note(infer_actual_impl_expl_expected_signature_nothing)]
     ExpectedSignatureNothing { leading_ellipsis: bool, ty_or_sig: String, trait_path: String },
-    #[note(infer::actual_impl_expl_expected_passive_two)]
+    #[note(infer_actual_impl_expl_expected_passive_two)]
     ExpectedPassiveTwo {
         leading_ellipsis: bool,
         ty_or_sig: String,
@@ -576,23 +576,23 @@ pub enum ActualImplExplNotes {
         lifetime_1: usize,
         lifetime_2: usize,
     },
-    #[note(infer::actual_impl_expl_expected_passive_any)]
+    #[note(infer_actual_impl_expl_expected_passive_any)]
     ExpectedPassiveAny {
         leading_ellipsis: bool,
         ty_or_sig: String,
         trait_path: String,
         lifetime_1: usize,
     },
-    #[note(infer::actual_impl_expl_expected_passive_some)]
+    #[note(infer_actual_impl_expl_expected_passive_some)]
     ExpectedPassiveSome {
         leading_ellipsis: bool,
         ty_or_sig: String,
         trait_path: String,
         lifetime_1: usize,
     },
-    #[note(infer::actual_impl_expl_expected_passive_nothing)]
+    #[note(infer_actual_impl_expl_expected_passive_nothing)]
     ExpectedPassiveNothing { leading_ellipsis: bool, ty_or_sig: String, trait_path: String },
-    #[note(infer::actual_impl_expl_expected_other_two)]
+    #[note(infer_actual_impl_expl_expected_other_two)]
     ExpectedOtherTwo {
         leading_ellipsis: bool,
         ty_or_sig: String,
@@ -600,32 +600,32 @@ pub enum ActualImplExplNotes {
         lifetime_1: usize,
         lifetime_2: usize,
     },
-    #[note(infer::actual_impl_expl_expected_other_any)]
+    #[note(infer_actual_impl_expl_expected_other_any)]
     ExpectedOtherAny {
         leading_ellipsis: bool,
         ty_or_sig: String,
         trait_path: String,
         lifetime_1: usize,
     },
-    #[note(infer::actual_impl_expl_expected_other_some)]
+    #[note(infer_actual_impl_expl_expected_other_some)]
     ExpectedOtherSome {
         leading_ellipsis: bool,
         ty_or_sig: String,
         trait_path: String,
         lifetime_1: usize,
     },
-    #[note(infer::actual_impl_expl_expected_other_nothing)]
+    #[note(infer_actual_impl_expl_expected_other_nothing)]
     ExpectedOtherNothing { leading_ellipsis: bool, ty_or_sig: String, trait_path: String },
-    #[note(infer::actual_impl_expl_but_actually_implements_trait)]
+    #[note(infer_actual_impl_expl_but_actually_implements_trait)]
     ButActuallyImplementsTrait { trait_path: String, has_lifetime: bool, lifetime: usize },
-    #[note(infer::actual_impl_expl_but_actually_implemented_for_ty)]
+    #[note(infer_actual_impl_expl_but_actually_implemented_for_ty)]
     ButActuallyImplementedForTy {
         trait_path: String,
         has_lifetime: bool,
         lifetime: usize,
         ty: String,
     },
-    #[note(infer::actual_impl_expl_but_actually_ty_implements)]
+    #[note(infer_actual_impl_expl_but_actually_ty_implements)]
     ButActuallyTyImplements { trait_path: String, has_lifetime: bool, lifetime: usize, ty: String },
 }
 
@@ -712,15 +712,15 @@ impl ActualImplExplNotes {
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::trait_placeholder_mismatch)]
+#[diag(infer_trait_placeholder_mismatch)]
 pub struct TraitPlaceholderMismatch {
     #[primary_span]
     pub span: Span,
-    #[label(infer::label_satisfy)]
+    #[label(label_satisfy)]
     pub satisfy_span: Option<Span>,
-    #[label(infer::label_where)]
+    #[label(label_where)]
     pub where_span: Option<Span>,
-    #[label(infer::label_dup)]
+    #[label(label_dup)]
     pub dup_span: Option<Span>,
     pub def_id: String,
     pub trait_def_id: String,
@@ -741,26 +741,26 @@ impl AddToDiagnostic for ConsiderBorrowingParamHelp {
         let mut type_param_span: MultiSpan = self.spans.clone().into();
         for &span in &self.spans {
             // Seems like we can't call f() here as Into<DiagnosticMessage> is required
-            type_param_span.push_span_label(span, fluent::infer::tid_consider_borrowing);
+            type_param_span.push_span_label(span, fluent::infer_tid_consider_borrowing);
         }
-        let msg = f(diag, fluent::infer::tid_param_help.into());
+        let msg = f(diag, fluent::infer_tid_param_help.into());
         diag.span_help(type_param_span, msg);
     }
 }
 
 #[derive(Subdiagnostic)]
-#[help(infer::tid_rel_help)]
+#[help(infer_tid_rel_help)]
 pub struct RelationshipHelp;
 
 #[derive(Diagnostic)]
-#[diag(infer::trait_impl_diff)]
+#[diag(infer_trait_impl_diff)]
 pub struct TraitImplDiff {
     #[primary_span]
-    #[label(infer::found)]
+    #[label(found)]
     pub sp: Span,
-    #[label(infer::expected)]
+    #[label(expected)]
     pub trait_sp: Span,
-    #[note(infer::expected_found)]
+    #[note(expected_found)]
     pub note: (),
     #[subdiagnostic]
     pub param_help: ConsiderBorrowingParamHelp,
@@ -783,11 +783,11 @@ impl AddToDiagnostic for DynTraitConstraintSuggestion {
         F: Fn(&mut Diagnostic, SubdiagnosticMessage) -> SubdiagnosticMessage,
     {
         let mut multi_span: MultiSpan = vec![self.span].into();
-        multi_span.push_span_label(self.span, fluent::infer::dtcs_has_lifetime_req_label);
-        multi_span.push_span_label(self.ident.span, fluent::infer::dtcs_introduces_requirement);
-        let msg = f(diag, fluent::infer::dtcs_has_req_note.into());
+        multi_span.push_span_label(self.span, fluent::infer_dtcs_has_lifetime_req_label);
+        multi_span.push_span_label(self.ident.span, fluent::infer_dtcs_introduces_requirement);
+        let msg = f(diag, fluent::infer_dtcs_has_req_note.into());
         diag.span_note(multi_span, msg);
-        let msg = f(diag, fluent::infer::dtcs_suggestion.into());
+        let msg = f(diag, fluent::infer_dtcs_suggestion.into());
         diag.span_suggestion_verbose(
             self.span.shrink_to_hi(),
             msg,
@@ -798,12 +798,12 @@ impl AddToDiagnostic for DynTraitConstraintSuggestion {
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::but_calling_introduces, code = "E0772")]
+#[diag(infer_but_calling_introduces, code = "E0772")]
 pub struct ButCallingIntroduces {
-    #[label(infer::label1)]
+    #[label(label1)]
     pub param_ty_span: Span,
     #[primary_span]
-    #[label(infer::label2)]
+    #[label(label2)]
     pub cause_span: Span,
 
     pub has_param_name: bool,
@@ -829,14 +829,14 @@ impl AddToDiagnostic for ReqIntroducedLocations {
         F: Fn(&mut Diagnostic, SubdiagnosticMessage) -> SubdiagnosticMessage,
     {
         for sp in self.spans {
-            self.span.push_span_label(sp, fluent::infer::ril_introduced_here);
+            self.span.push_span_label(sp, fluent::infer_ril_introduced_here);
         }
 
         if self.add_label {
-            self.span.push_span_label(self.fn_decl_span, fluent::infer::ril_introduced_by);
+            self.span.push_span_label(self.fn_decl_span, fluent::infer_ril_introduced_by);
         }
-        self.span.push_span_label(self.cause_span, fluent::infer::ril_because_of);
-        let msg = f(diag, fluent::infer::ril_static_introduced_by.into());
+        self.span.push_span_label(self.cause_span, fluent::infer_ril_because_of);
+        let msg = f(diag, fluent::infer_ril_static_introduced_by.into());
         diag.span_note(self.span, msg);
     }
 }
@@ -851,25 +851,25 @@ impl AddToDiagnostic for MoreTargeted {
         F: Fn(&mut Diagnostic, SubdiagnosticMessage) -> SubdiagnosticMessage,
     {
         diag.code(rustc_errors::error_code!(E0772));
-        diag.set_primary_message(fluent::infer::more_targeted);
+        diag.set_primary_message(fluent::infer_more_targeted);
         diag.set_arg("ident", self.ident);
     }
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::but_needs_to_satisfy, code = "E0759")]
+#[diag(infer_but_needs_to_satisfy, code = "E0759")]
 pub struct ButNeedsToSatisfy {
     #[primary_span]
     pub sp: Span,
-    #[label(infer::influencer)]
+    #[label(influencer)]
     pub influencer_point: Span,
-    #[label(infer::used_here)]
+    #[label(used_here)]
     pub spans: Vec<Span>,
-    #[label(infer::require)]
+    #[label(require)]
     pub require_span_as_label: Option<Span>,
-    #[note(infer::require)]
+    #[note(require)]
     pub require_span_as_note: Option<Span>,
-    #[note(infer::introduced_by_bound)]
+    #[note(introduced_by_bound)]
     pub bound: Option<Span>,
 
     #[subdiagnostic]

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -523,23 +523,38 @@ pub struct MismatchedStaticLifetime<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(infer_explicit_lifetime_required, code = "E0621")]
-pub struct ExplicitLifetimeRequired<'a> {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-    pub ident_kind: &'static str,
-    pub simple_ident: String,
-    pub named: String,
-
-    #[suggestion(
-        infer_explicit_lifetime_required_sugg,
-        code = "{new_ty}",
-        applicability = "unspecified"
-    )]
-    pub new_ty_span: Span,
-    #[skip_arg]
-    pub new_ty: Ty<'a>,
+pub enum ExplicitLifetimeRequired<'a> {
+    #[diag(infer_explicit_lifetime_required_with_ident, code = "E0621")]
+    WithIdent {
+        #[primary_span]
+        #[label]
+        span: Span,
+        simple_ident: Ident,
+        named: String,
+        #[suggestion(
+            infer_explicit_lifetime_required_sugg_with_ident,
+            code = "{new_ty}",
+            applicability = "unspecified"
+        )]
+        new_ty_span: Span,
+        #[skip_arg]
+        new_ty: Ty<'a>,
+    },
+    #[diag(infer_explicit_lifetime_required_with_param_type, code = "E0621")]
+    WithParamType {
+        #[primary_span]
+        #[label]
+        span: Span,
+        named: String,
+        #[suggestion(
+            infer_explicit_lifetime_required_sugg_with_param_type,
+            code = "{new_ty}",
+            applicability = "unspecified"
+        )]
+        new_ty_span: Span,
+        #[skip_arg]
+        new_ty: Ty<'a>,
+    },
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -544,25 +544,177 @@ pub struct ExplicitLifetimeRequired<'a> {
 
 #[derive(Subdiagnostic)]
 pub enum ActualImplExplNotes {
-    // Field names have to be different across all variants
-    #[note(infer::actual_impl_expl_expected)]
-    Expected {
+    // Field names have to be different across Expected* and ButActually variants
+    #[note(infer::actual_impl_expl_expected_signature_two)]
+    ExpectedSignatureTwo {
         leading_ellipsis: bool,
-        kind: &'static str,
         ty_or_sig: String,
         trait_path: String,
-        lt_kind: &'static str,
         lifetime_1: usize,
         lifetime_2: usize,
     },
-    #[note(infer::actual_impl_expl_but_actually)]
-    ButActually {
-        kind_2: &'static str,
+    #[note(infer::actual_impl_expl_expected_signature_any)]
+    ExpectedSignatureAny {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_signature_some)]
+    ExpectedSignatureSome {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_signature_nothing)]
+    ExpectedSignatureNothing { leading_ellipsis: bool, ty_or_sig: String, trait_path: String },
+    #[note(infer::actual_impl_expl_expected_passive_two)]
+    ExpectedPassiveTwo {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+        lifetime_2: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_passive_any)]
+    ExpectedPassiveAny {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_passive_some)]
+    ExpectedPassiveSome {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_passive_nothing)]
+    ExpectedPassiveNothing { leading_ellipsis: bool, ty_or_sig: String, trait_path: String },
+    #[note(infer::actual_impl_expl_expected_other_two)]
+    ExpectedOtherTwo {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+        lifetime_2: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_other_any)]
+    ExpectedOtherAny {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_other_some)]
+    ExpectedOtherSome {
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+    },
+    #[note(infer::actual_impl_expl_expected_other_nothing)]
+    ExpectedOtherNothing { leading_ellipsis: bool, ty_or_sig: String, trait_path: String },
+    #[note(infer::actual_impl_expl_but_actually_implements_trait)]
+    ButActuallyImplementsTrait { trait_path_2: String, has_lifetime: bool, lifetime: usize },
+    #[note(infer::actual_impl_expl_but_actually_implemented_for_ty)]
+    ButActuallyImplementedForTy {
         trait_path_2: String,
         has_lifetime: bool,
         lifetime: usize,
         ty: String,
     },
+    #[note(infer::actual_impl_expl_but_actually_ty_implements)]
+    ButActuallyTyImplements {
+        trait_path_2: String,
+        has_lifetime: bool,
+        lifetime: usize,
+        ty: String,
+    },
+}
+
+pub enum ActualImplExpectedKind {
+    Signature,
+    Passive,
+    Other,
+}
+
+pub enum ActualImplExpectedLifetimeKind {
+    Two,
+    Any,
+    Some,
+    Nothing,
+}
+
+impl ActualImplExplNotes {
+    pub fn new_expected(
+        kind: ActualImplExpectedKind,
+        lt_kind: ActualImplExpectedLifetimeKind,
+        leading_ellipsis: bool,
+        ty_or_sig: String,
+        trait_path: String,
+        lifetime_1: usize,
+        lifetime_2: usize,
+    ) -> Self {
+        match (kind, lt_kind) {
+            (ActualImplExpectedKind::Signature, ActualImplExpectedLifetimeKind::Two) => {
+                Self::ExpectedSignatureTwo {
+                    leading_ellipsis,
+                    ty_or_sig,
+                    trait_path,
+                    lifetime_1,
+                    lifetime_2,
+                }
+            }
+            (ActualImplExpectedKind::Signature, ActualImplExpectedLifetimeKind::Any) => {
+                Self::ExpectedSignatureAny { leading_ellipsis, ty_or_sig, trait_path, lifetime_1 }
+            }
+            (ActualImplExpectedKind::Signature, ActualImplExpectedLifetimeKind::Some) => {
+                Self::ExpectedSignatureSome { leading_ellipsis, ty_or_sig, trait_path, lifetime_1 }
+            }
+            (ActualImplExpectedKind::Signature, ActualImplExpectedLifetimeKind::Nothing) => {
+                Self::ExpectedSignatureNothing { leading_ellipsis, ty_or_sig, trait_path }
+            }
+            (ActualImplExpectedKind::Passive, ActualImplExpectedLifetimeKind::Two) => {
+                Self::ExpectedPassiveTwo {
+                    leading_ellipsis,
+                    ty_or_sig,
+                    trait_path,
+                    lifetime_1,
+                    lifetime_2,
+                }
+            }
+            (ActualImplExpectedKind::Passive, ActualImplExpectedLifetimeKind::Any) => {
+                Self::ExpectedPassiveAny { leading_ellipsis, ty_or_sig, trait_path, lifetime_1 }
+            }
+            (ActualImplExpectedKind::Passive, ActualImplExpectedLifetimeKind::Some) => {
+                Self::ExpectedPassiveSome { leading_ellipsis, ty_or_sig, trait_path, lifetime_1 }
+            }
+            (ActualImplExpectedKind::Passive, ActualImplExpectedLifetimeKind::Nothing) => {
+                Self::ExpectedPassiveNothing { leading_ellipsis, ty_or_sig, trait_path }
+            }
+            (ActualImplExpectedKind::Other, ActualImplExpectedLifetimeKind::Two) => {
+                Self::ExpectedOtherTwo {
+                    leading_ellipsis,
+                    ty_or_sig,
+                    trait_path,
+                    lifetime_1,
+                    lifetime_2,
+                }
+            }
+            (ActualImplExpectedKind::Other, ActualImplExpectedLifetimeKind::Any) => {
+                Self::ExpectedOtherAny { leading_ellipsis, ty_or_sig, trait_path, lifetime_1 }
+            }
+            (ActualImplExpectedKind::Other, ActualImplExpectedLifetimeKind::Some) => {
+                Self::ExpectedOtherSome { leading_ellipsis, ty_or_sig, trait_path, lifetime_1 }
+            }
+            (ActualImplExpectedKind::Other, ActualImplExpectedLifetimeKind::Nothing) => {
+                Self::ExpectedOtherNothing { leading_ellipsis, ty_or_sig, trait_path }
+            }
+        }
+    }
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
@@ -9,7 +9,7 @@ mod different_lifetimes;
 pub mod find_anon_type;
 mod mismatched_static_lifetime;
 mod named_anon_conflict;
-mod placeholder_error;
+pub(crate) mod placeholder_error;
 mod placeholder_relation;
 mod static_impl_trait;
 mod trait_impl_difference;

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -89,18 +89,17 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         {
             return None;
         }
-
-        let simple_ident = param.pat.simple_ident();
-        let (ident_kind, simple_ident) = match simple_ident {
-            Some(ident) => ("ident", ident.to_string()),
-            None => ("param_type", String::new()),
-        };
-
         let named = named.to_string();
-
-        let err =
-            ExplicitLifetimeRequired { span, ident_kind, simple_ident, named, new_ty_span, new_ty };
-        let err = self.tcx().sess.parse_sess.create_err(err);
-        Some(err)
+        let err = match param.pat.simple_ident() {
+            Some(simple_ident) => ExplicitLifetimeRequired::WithIdent {
+                span,
+                simple_ident,
+                named,
+                new_ty_span,
+                new_ty,
+            },
+            None => ExplicitLifetimeRequired::WithParamType { span, named, new_ty_span, new_ty },
+        };
+        Some(self.tcx().sess.parse_sess.create_err(err))
     }
 }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -405,8 +405,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             let mut self_ty = expected_trait_ref.map(|tr| tr.self_ty());
             self_ty.highlight.maybe_highlighting_region(vid, actual_has_vid);
 
-            if self_ty.value.is_closure()
-                && self.tcx().is_fn_trait(expected_trait_ref.value.def_id)
+            if self_ty.value.is_closure() && self.tcx().is_fn_trait(expected_trait_ref.value.def_id)
             {
                 let closure_sig = self_ty.map(|closure| {
                     if let ty::Closure(_, substs) = closure.kind() {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -333,7 +333,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             leading_ellipsis,
         );
 
-        let diag = TraitPlaceholderMismatch {
+        self.tcx().sess.create_err(TraitPlaceholderMismatch {
             span,
             satisfy_span,
             where_span,
@@ -341,9 +341,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             def_id,
             trait_def_id: self.tcx().def_path_str(trait_def_id),
             actual_impl_expl_notes,
-        };
-
-        self.tcx().sess.create_err(diag)
+        })
     }
 
     /// Add notes with details about the expected and actual trait refs, with attention to cases

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -451,7 +451,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             }
         };
 
-        let note_1 = ActualImplExplNotes::NoteOne {
+        let note_1 = ActualImplExplNotes::Expected {
             leading_ellipsis,
             kind,
             ty_or_sig,
@@ -483,7 +483,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
         let lifetime = actual_has_vid.unwrap_or_default();
 
         let note_2 =
-            ActualImplExplNotes::NoteTwo { kind_2, trait_path_2, ty, has_lifetime, lifetime };
+            ActualImplExplNotes::ButActually { kind_2, trait_path_2, ty, has_lifetime, lifetime };
 
         vec![note_1, note_2]
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -474,27 +474,22 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             None => true,
         };
 
-        let trait_path_2 = actual_trait_ref.map(|tr| tr.print_only_trait_path()).to_string();
+        let trait_path = actual_trait_ref.map(|tr| tr.print_only_trait_path()).to_string();
         let ty = actual_trait_ref.map(|tr| tr.self_ty()).to_string();
         let has_lifetime = actual_has_vid.is_some();
         let lifetime = actual_has_vid.unwrap_or_default();
 
         let note_2 = if same_self_type {
-            ActualImplExplNotes::ButActuallyImplementsTrait { trait_path_2, has_lifetime, lifetime }
+            ActualImplExplNotes::ButActuallyImplementsTrait { trait_path, has_lifetime, lifetime }
         } else if passive_voice {
             ActualImplExplNotes::ButActuallyImplementedForTy {
-                trait_path_2,
+                trait_path,
                 ty,
                 has_lifetime,
                 lifetime,
             }
         } else {
-            ActualImplExplNotes::ButActuallyTyImplements {
-                trait_path_2,
-                ty,
-                has_lifetime,
-                lifetime,
-            }
+            ActualImplExplNotes::ButActuallyTyImplements { trait_path, ty, has_lifetime, lifetime }
         };
 
         vec![note_1, note_2]

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -8,7 +8,7 @@ use crate::infer::error_reporting::nice_region_error::NiceRegionError;
 use crate::infer::lexical_region_resolve::RegionResolutionError;
 use crate::infer::{SubregionOrigin, TypeTrace};
 use crate::traits::{ObligationCauseCode, UnifyReceiverContext};
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::FxIndexSet;
 use rustc_errors::{AddToDiagnostic, Applicability, Diagnostic, ErrorGuaranteed, MultiSpan};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{walk_ty, Visitor};

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -63,7 +63,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                         AssocItemContainer::ImplContainer => (false, String::new()),
                     };
 
-                    let diag = ButCallingIntroduces {
+                    let mut err = self.tcx().sess.create_err(ButCallingIntroduces {
                         param_ty_span: param.param_ty_span,
                         cause_span: cause.span,
                         has_param_name: simple_ident.is_some(),
@@ -73,8 +73,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                         assoc_item: ctxt.assoc_item.name,
                         has_impl_path,
                         impl_path,
-                    };
-                    let mut err = self.tcx().sess.create_err(diag);
+                    });
                     if self.find_impl_on_dyn_trait(&mut err, param.param_ty, &ctxt) {
                         let reported = err.emit();
                         return Some(reported);

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -9,7 +9,7 @@ use crate::infer::lexical_region_resolve::RegionResolutionError;
 use crate::infer::{SubregionOrigin, TypeTrace};
 use crate::traits::{ObligationCauseCode, UnifyReceiverContext};
 use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::{AddSubdiagnostic, Applicability, Diagnostic, ErrorGuaranteed, MultiSpan};
+use rustc_errors::{AddToDiagnostic, Applicability, Diagnostic, ErrorGuaranteed, MultiSpan};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{walk_ty, Visitor};
 use rustc_hir::{self as hir, GenericBound, Item, ItemKind, Lifetime, LifetimeName, Node, TyKind};

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -1,11 +1,15 @@
 //! Error Reporting for static impl Traits.
 
+use crate::errors::{
+    ButCallingIntroduces, ButNeedsToSatisfy, DynTraitConstraintSuggestion, MoreTargeted,
+    ReqIntroducedLocations,
+};
 use crate::infer::error_reporting::nice_region_error::NiceRegionError;
 use crate::infer::lexical_region_resolve::RegionResolutionError;
 use crate::infer::{SubregionOrigin, TypeTrace};
 use crate::traits::{ObligationCauseCode, UnifyReceiverContext};
-use rustc_data_structures::fx::FxIndexSet;
-use rustc_errors::{struct_span_err, Applicability, Diagnostic, ErrorGuaranteed, MultiSpan};
+use rustc_data_structures::fx::FxHashSet;
+use rustc_errors::{AddSubdiagnostic, Applicability, Diagnostic, ErrorGuaranteed, MultiSpan};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{walk_ty, Visitor};
 use rustc_hir::{self as hir, GenericBound, Item, ItemKind, Lifetime, LifetimeName, Node, TyKind};
@@ -49,46 +53,33 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                     }
 
                     let param = self.find_param_with_region(*sup_r, *sub_r)?;
-                    let lifetime = if sup_r.has_name() {
-                        format!("lifetime `{}`", sup_r)
-                    } else {
-                        "an anonymous lifetime `'_`".to_string()
+                    let simple_ident = param.param.pat.simple_ident();
+
+                    let (has_impl_path, impl_path) = match ctxt.assoc_item.container {
+                        AssocItemContainer::TraitContainer => {
+                            let id = ctxt.assoc_item.container_id(tcx);
+                            (true, tcx.def_path_str(id))
+                        }
+                        AssocItemContainer::ImplContainer => (false, String::new()),
                     };
-                    let mut err = struct_span_err!(
-                        tcx.sess,
-                        cause.span,
-                        E0772,
-                        "{} has {} but calling `{}` introduces an implicit `'static` lifetime \
-                         requirement",
-                        param
-                            .param
-                            .pat
-                            .simple_ident()
-                            .map(|s| format!("`{}`", s))
-                            .unwrap_or_else(|| "`fn` parameter".to_string()),
-                        lifetime,
-                        ctxt.assoc_item.name,
-                    );
-                    err.span_label(param.param_ty_span, &format!("this data with {}...", lifetime));
-                    err.span_label(
-                        cause.span,
-                        &format!(
-                            "...is used and required to live as long as `'static` here \
-                             because of an implicit lifetime bound on the {}",
-                            match ctxt.assoc_item.container {
-                                AssocItemContainer::TraitContainer => {
-                                    let id = ctxt.assoc_item.container_id(tcx);
-                                    format!("`impl` of `{}`", tcx.def_path_str(id))
-                                }
-                                AssocItemContainer::ImplContainer => "inherent `impl`".to_string(),
-                            },
-                        ),
-                    );
+
+                    let diag = ButCallingIntroduces {
+                        param_ty_span: param.param_ty_span,
+                        cause_span: cause.span,
+                        has_param_name: simple_ident.is_some(),
+                        param_name: simple_ident.map(|x| x.to_string()).unwrap_or_default(),
+                        has_lifetime: sup_r.has_name(),
+                        lifetime: sup_r.to_string(),
+                        assoc_item: ctxt.assoc_item.name,
+                        has_impl_path,
+                        impl_path,
+                    };
+                    let mut err = self.tcx().sess.create_err(diag);
                     if self.find_impl_on_dyn_trait(&mut err, param.param_ty, &ctxt) {
                         let reported = err.emit();
                         return Some(reported);
                     } else {
-                        err.cancel();
+                        err.cancel()
                     }
                 }
                 return None;
@@ -104,25 +95,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let sp = var_origin.span();
         let return_sp = sub_origin.span();
         let param = self.find_param_with_region(*sup_r, *sub_r)?;
-        let (lifetime_name, lifetime) = if sup_r.has_name() {
-            (sup_r.to_string(), format!("lifetime `{}`", sup_r))
-        } else {
-            ("'_".to_owned(), "an anonymous lifetime `'_`".to_string())
-        };
-        let param_name = param
-            .param
-            .pat
-            .simple_ident()
-            .map(|s| format!("`{}`", s))
-            .unwrap_or_else(|| "`fn` parameter".to_string());
-        let mut err = struct_span_err!(
-            tcx.sess,
-            sp,
-            E0759,
-            "{} has {} but it needs to satisfy a `'static` lifetime requirement",
-            param_name,
-            lifetime,
-        );
+        let lifetime_name = if sup_r.has_name() { sup_r.to_string() } else { "'_".to_owned() };
 
         let (mention_influencer, influencer_point) =
             if sup_origin.span().overlaps(param.param_ty_span) {
@@ -141,7 +114,6 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             } else {
                 (!sup_origin.span().overlaps(return_sp), param.param_ty_span)
             };
-        err.span_label(influencer_point, &format!("this data with {}...", lifetime));
 
         debug!("try_report_static_impl_trait: param_info={:?}", param);
 
@@ -155,31 +127,19 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         spans.dedup_by_key(|span| (span.lo(), span.hi()));
 
         // We try to make the output have fewer overlapping spans if possible.
-        let require_msg = if spans.is_empty() {
-            "...is used and required to live as long as `'static` here"
-        } else {
-            "...and is required to live as long as `'static` here"
-        };
         let require_span =
             if sup_origin.span().overlaps(return_sp) { sup_origin.span() } else { return_sp };
 
-        for span in &spans {
-            err.span_label(*span, "...is used here...");
-        }
-
-        if spans.iter().any(|sp| sp.overlaps(return_sp) || *sp > return_sp) {
-            // If any of the "captured here" labels appears on the same line or after
-            // `require_span`, we put it on a note to ensure the text flows by appearing
-            // always at the end.
-            err.span_note(require_span, require_msg);
+        let spans_empty = spans.is_empty();
+        let require_as_note = spans.iter().any(|sp| sp.overlaps(return_sp) || *sp > return_sp);
+        let bound = if let SubregionOrigin::RelateParamBound(_, _, Some(bound)) = sub_origin {
+            Some(*bound)
         } else {
-            // We don't need a note, it's already at the end, it can be shown as a `span_label`.
-            err.span_label(require_span, require_msg);
-        }
+            None
+        };
 
-        if let SubregionOrigin::RelateParamBound(_, _, Some(bound)) = sub_origin {
-            err.span_note(*bound, "`'static` lifetime requirement introduced by this bound");
-        }
+        let mut subdiag = None;
+
         if let SubregionOrigin::Subtype(box TypeTrace { cause, .. }) = sub_origin {
             if let ObligationCauseCode::ReturnValue(hir_id)
             | ObligationCauseCode::BlockTailExpression(hir_id) = cause.code()
@@ -187,32 +147,49 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                 let parent_id = tcx.hir().get_parent_item(*hir_id);
                 if let Some(fn_decl) = tcx.hir().fn_decl_by_hir_id(parent_id.into()) {
                     let mut span: MultiSpan = fn_decl.output.span().into();
+                    let mut spans = Vec::new();
                     let mut add_label = true;
                     if let hir::FnRetTy::Return(ty) = fn_decl.output {
                         let mut v = StaticLifetimeVisitor(vec![], tcx.hir());
                         v.visit_ty(ty);
                         if !v.0.is_empty() {
                             span = v.0.clone().into();
-                            for sp in v.0 {
-                                span.push_span_label(sp, "`'static` requirement introduced here");
-                            }
+                            spans = v.0;
                             add_label = false;
                         }
                     }
-                    if add_label {
-                        span.push_span_label(
-                            fn_decl.output.span(),
-                            "requirement introduced by this return type",
-                        );
-                    }
-                    span.push_span_label(cause.span, "because of this returned expression");
-                    err.span_note(
+                    let fn_decl_span = fn_decl.output.span();
+
+                    subdiag = Some(ReqIntroducedLocations {
                         span,
-                        "`'static` lifetime requirement introduced by the return type",
-                    );
+                        spans,
+                        fn_decl_span,
+                        cause_span: cause.span,
+                        add_label,
+                    });
                 }
             }
         }
+
+        let diag = ButNeedsToSatisfy {
+            sp,
+            influencer_point,
+            spans: spans.clone(),
+            // If any of the "captured here" labels appears on the same line or after
+            // `require_span`, we put it on a note to ensure the text flows by appearing
+            // always at the end.
+            require_span_as_note: require_as_note.then_some(require_span),
+            // We don't need a note, it's already at the end, it can be shown as a `span_label`.
+            require_span_as_label: (!require_as_note).then_some(require_span),
+            req_introduces_loc: subdiag,
+
+            has_lifetime: sup_r.has_name(),
+            lifetime: sup_r.to_string(),
+            spans_empty,
+            bound,
+        };
+
+        let mut err = self.tcx().sess.create_err(diag);
 
         let fn_returns = tcx.return_type_impl_or_dyn_traits(anon_reg_sup.def_id);
 
@@ -247,12 +224,8 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         }
         if let (Some(ident), true) = (override_error_code, fn_returns.is_empty()) {
             // Provide a more targeted error code and description.
-            err.code(rustc_errors::error_code!(E0772));
-            err.set_primary_message(&format!(
-                "{} has {} but calling `{}` introduces an implicit `'static` lifetime \
-                requirement",
-                param_name, lifetime, ident,
-            ));
+            let retarget_subdiag = MoreTargeted { ident };
+            retarget_subdiag.add_to_diagnostic(&mut err);
         }
 
         let arg = match param.param.pat.simple_ident() {
@@ -513,21 +486,9 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             let mut traits = vec![];
             let mut hir_v = HirTraitObjectVisitor(&mut traits, *found_did);
             hir_v.visit_ty(&self_ty);
-            for span in &traits {
-                let mut multi_span: MultiSpan = vec![*span].into();
-                multi_span
-                    .push_span_label(*span, "this has an implicit `'static` lifetime requirement");
-                multi_span.push_span_label(
-                    ident.span,
-                    "calling this method introduces the `impl`'s 'static` requirement",
-                );
-                err.span_note(multi_span, "the used `impl` has a `'static` requirement");
-                err.span_suggestion_verbose(
-                    span.shrink_to_hi(),
-                    "consider relaxing the implicit `'static` requirement",
-                    " + '_",
-                    Applicability::MaybeIncorrect,
-                );
+            for &span in &traits {
+                let subdiag = DynTraitConstraintSuggestion { span, ident };
+                subdiag.add_to_diagnostic(err);
                 suggested = true;
             }
         }


### PR DESCRIPTION
@rustbot label +A-translation
r? rust-lang/diagnostics
cc https://github.com/rust-lang/rust/issues/100717

Seems like a part of static_impl_trait.rs emits suggestions in a loop, and note.rs needs to have two instances of the same subdiagnostic, so these will need to wait until we have eager translation/list support.
Other than that, there is only error_reporting/mod.rs left to migrate.