### PR TITLE
rustdoc: remove unused CSS `.non-exhaustive { margin-bottom }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1522,10 +1522,6 @@ kbd {
 	list-style: none;
 }
 
-.non-exhaustive {
-	margin-bottom: 1em;
-}
-
 details.dir-entry {
 	padding-left: 4px;
 }


### PR DESCRIPTION
This selector was added in 959a13d53e27ca92b59798e6c6737f8249d59a2e to target a `<div class="non-exhaustive">`. With 4edcf6147912e7e4c1f13208d830c3c25e544a8c, the non-exhaustive indicator was changed to a `<details>`, and a separate selector targetting `details.non-exhaustive` was added for it, but the old selector was never removed.