### PR TITLE
rustdoc: clean up `#toggle-all-docs`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -305,6 +305,9 @@ button#toggle-all-docs {
 	background: none;
 	border: none;
 	cursor: pointer;
+	/* iOS button gradient: https://stackoverflow.com/q/5438567 */
+	-webkit-appearance: none;
+	opacity: 1;
 }
 
 /* end tweaks for normalize.css 8 */

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -163,9 +163,6 @@ h1.fqn {
 	padding-bottom: 6px;
 	margin-bottom: 15px;
 }
-#toggle-all-docs {
-	text-decoration: none;
-}
 /* The only headings that get underlines are:
 	 Markdown-generated headings within the top-doc
 	 Rustdoc-generated h2 section headings (e.g. "Implementations", "Required Methods", etc)
@@ -209,7 +206,7 @@ ul.all-items {
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
 }
 
-a#toggle-all-docs,
+#toggle-all-docs,
 a.anchor,
 .small-section-header a,
 #source-sidebar a,
@@ -301,6 +298,13 @@ summary {
 button {
 	/* Buttons on Safari have different default padding than other platforms. Make them the same. */
 	padding: 1px 6px;
+}
+
+button#toggle-all-docs {
+	padding: 0;
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 
 /* end tweaks for normalize.css 8 */

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -21,8 +21,8 @@
                 <a class="srclink" href="{{href|safe}}">source</a> · {# -#}
             {%- else -%}
         {%- endmatch -%}
-        <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs"> {#- -#}
-            [<span class="inner">&#x2212;</span>] {#- -#}
-        </a> {#- -#}
+        <button id="toggle-all-docs" title="collapse all docs"> {#- -#}
+            [<span>&#x2212;</span>] {#- -#}
+        </button> {#- -#}
     </span> {#- -#}
 </div> {#- -#}


### PR DESCRIPTION
This change converts the element from an `<a>` link to a button. It's pretty much directly trading slightly more CSS for slightly less HTML, and it's also semantically correct (so you don't get a broken "bookmark" option when you right click on it).

While doing this, I also got rid of the unnecessary `class="inner"` attribute on the inner span. There was a style targeting `.collapse-toggle > .inner`, but no CSS ever targeted the `#toggle-all-docs > .inner`.

Preview: https://notriddle.com/notriddle-rustdoc-test/button-toggle-all-docs/index.html