### PR TITLE
Avoid panicking on missing fallback

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -543,8 +543,18 @@ impl Builder {
             for (substr, fallback_target) in fallback {
                 if target_name.contains(substr) {
                     let t = Target::from_compressed_tar(self, &tarball_name!(fallback_target));
-                    // Fallbacks must always be available.
-                    assert!(t.available);
+                    // Fallbacks should typically be available on 'production' builds
+                    // but may not be available for try builds, which only build one target by
+                    // default. Ideally we'd gate this being a hard error on whether we're in a
+                    // production build or not, but it's not information that's readily available
+                    // here.
+                    if !t.available {
+                        eprintln!(
+                            "{:?} not available for fallback",
+                            tarball_name!(fallback_target)
+                        );
+                        continue;
+                    }
                     return t;
                 }
             }


### PR DESCRIPTION
This just prints a message but continues on if a fallback is missing, which can happen when we're building a partial set of builders and producing a dev-static build from it (e.g., when no Apple builder runs at all).

Probably the more extensive fix is to allow the build-manifest invoker to specify the expected set of targets & hosts, but that's a far more extensive change. The main risk from this is that we accidentally start falling back to linux docs across all platforms without noticing. I'm not sure that we can do much about that though at this time.

cc @ehuss since IIRC you participated in adding this system

This comes up when building a test nightly from a try build, e.g., https://github.com/rust-lang/rust/pull/101855#issuecomment-1250123298. For now I'm going to manually cherry pick this onto that PR for testing purposes.