### PR TITLE
rustdoc: remove redundant `.location a { font-weight: 500 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -533,10 +533,6 @@ img {
 	border: none;
 }
 
-.location a:first-of-type {
-	font-weight: 500;
-}
-
 .block ul, .block li {
 	padding: 0;
 	margin: 0;


### PR DESCRIPTION
The `class="location"` element is an h2, either in the sidebar or in the mobile header. Either way, it already has `font-weight: 500`, which the link inside will inherit.

The original version of this rule was added in 9e82fc7ef9b6c8a344dd27583990b02a661af78c. At that time, the location header was rendered as a paragraph with the full path:

https://github.com/rust-lang/rust/blob/9e82fc7ef9b6c8a344dd27583990b02a661af78c/src/librustdoc/html/render.rs#L2080

Nowadays, it's rendered as a true header, with only the name of the item, and the full path is included in a separate `fqn` header:

https://github.com/rust-lang/rust/blob/98ad6a5519651af36e246c0335c964dd52c554ba/src/librustdoc/html/render/mod.rs#L1797