### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4886,9 +4886,18 @@ checksum = "29738eedb4388d9ea620eeab9384884fc3f06f586a2eddb56bedc5885126c7c1"
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -5176,24 +5185,24 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-script"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098ec66172ce21cd55f8bcc786ee209dd20e04eff70acfca30cb79924d173ae9"
+checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
 
 [[package]]
 name = "unicode-security"
-version = "0.0.5"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d87c28edc5b263377e448d6cdcb935c06b95413d8013ba6fae470558ccab18f"
+checksum = "9ef5756b3097992b934b06608c69f48448a0fbe804bb1e72b982f6d7983e9e63"
 dependencies = [
  "unicode-normalization",
  "unicode-script",
@@ -5201,15 +5210,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -5218,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unicode_categories"

--- a/compiler/rustc_lint/Cargo.toml
+++ b/compiler/rustc_lint/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tracing = "0.1"
-unicode-security = "0.0.5"
+unicode-security = "0.1.0"
 rustc_middle = { path = "../rustc_middle" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_attr = { path = "../rustc_attr" }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -383,15 +383,9 @@ impl Step for Standalone {
             }
 
             if filename == "not_found.md" {
-                cmd.arg("--markdown-css")
-                    .arg(format!("https://doc.rust-lang.org/rustdoc{}.css", &builder.version))
-                    .arg("--markdown-css")
-                    .arg("https://doc.rust-lang.org/rust.css");
+                cmd.arg("--markdown-css").arg("https://doc.rust-lang.org/rust.css");
             } else {
-                cmd.arg("--markdown-css")
-                    .arg(format!("rustdoc{}.css", &builder.version))
-                    .arg("--markdown-css")
-                    .arg("rust.css");
+                cmd.arg("--markdown-css").arg("rust.css");
             }
             builder.run(&mut cmd);
         }

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -32,6 +32,7 @@
     - [*-unknown-openbsd](platform-support/openbsd.md)
     - [\*-unknown-uefi](platform-support/unknown-uefi.md)
     - [wasm64-unknown-unknown](platform-support/wasm64-unknown-unknown.md)
+    - [x86_64-fortanix-unknown-sgx](platform-support/x86_64-fortanix-unknown-sgx.md)
     - [x86_64-unknown-none](platform-support/x86_64-unknown-none.md)
 - [Targets](targets/index.md)
     - [Built-in Targets](targets/built-in.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -174,7 +174,7 @@ target | std | notes
 `wasm32-unknown-unknown` | ✓ | WebAssembly
 `wasm32-wasi` | ✓ | WebAssembly with WASI
 `x86_64-apple-ios` | ✓ | 64-bit x86 iOS
-`x86_64-fortanix-unknown-sgx` | ✓ | [Fortanix ABI] for 64-bit Intel SGX
+[`x86_64-fortanix-unknown-sgx`](platform-support/x86_64-fortanix-unknown-sgx.md) | ✓ | [Fortanix ABI] for 64-bit Intel SGX
 `x86_64-fuchsia` | ✓ | 64-bit Fuchsia
 `x86_64-linux-android` | ✓ | 64-bit x86 Android
 `x86_64-pc-solaris` | ✓ | 64-bit Solaris 10/11, illumos

--- a/src/doc/rustc/src/platform-support/x86_64-fortanix-unknown-sgx.md
+++ b/src/doc/rustc/src/platform-support/x86_64-fortanix-unknown-sgx.md
@@ -1,0 +1,72 @@
+# `x86_64-fortanix-unknown-sgx`
+
+**Tier: 2**
+
+Secure enclaves using [Intel Software Guard Extensions
+(SGX)](https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/overview.html)
+based on the ABI defined by Fortanix for the [Enclave Development Platform
+(EDP)](https://edp.fortanix.com/).
+
+## Target maintainers
+
+The [EDP team](mailto:edp.maintainers@fortanix.com) at Fortanix.
+
+- Jethro Beekman [@jethrogb](https://github.com/jethrogb)
+- Raoul Strackx [@raoulstrackx](https://github.com/raoulstrackx)
+- Mohsen Zohrevandi [@mzohreva](https://github.com/mzohreva)
+
+## Requirements
+
+The target supports `std` with a default allocator. Only cross compilation is
+supported.
+
+Binaries support all CPUs that include Intel SGX. Only 64-bit mode is supported.
+
+Not all `std` features are supported, see [Using Rust's
+std](https://edp.fortanix.com/docs/concepts/rust-std/) for details.
+
+The `extern "C"` calling convention is the System V AMD64 ABI.
+
+The supported ABI is the
+[fortanix-sgx-abi](https://edp.fortanix.com/docs/api/fortanix_sgx_abi/index.html).
+
+The compiler output is ELF, but the native format for the platform is the SGX
+stream (SGXS) format. A converter like
+[ftxsgx-elf2sgxs](https://crates.io/crates/fortanix-sgx-tools) is needed.
+
+Programs in SGXS format adhering to the Fortanix SGX ABI can be run with any
+compatible runner, such as
+[ftxsgx-runner](https://crates.io/crates/fortanix-sgx-tools).
+
+See the [EDP installation
+guide](https://edp.fortanix.com/docs/installation/guide/) for recommendations
+on how to setup a development and runtime environment.
+
+## Building the target
+
+As a tier 2 target, the target is built by the Rust project.
+
+You can configure rustbuild like so:
+
+```toml
+[build]
+build-stage = 1
+target = ["x86_64-fortanix-unknown-sgx"]
+```
+
+## Building Rust programs
+
+Standard build flows using `cargo` or `rustc` should work.
+
+## Testing
+
+The Rust test suite as well as custom unit and integration tests will run on
+hardware that has Intel SGX enabled if a cargo runner is configured correctly,
+see the requirements section.
+
+## Cross-compilation toolchains and C code
+
+C code is not generally supported, as there is no libc. C code compiled for
+x86-64 in freestanding mode using the System V AMD64 ABI may work. The
+[rs-libc](https://crates.io/crates/rs-libc) crate contains a subset of libc
+that's known to work with this target.

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -533,10 +533,6 @@ img {
 	border: none;
 }
 
-.location a:first-of-type {
-	font-weight: 500;
-}
-
 .block ul, .block li {
 	padding: 0;
 	margin: 0;

--- a/src/tools/error_index_generator/error-index.css
+++ b/src/tools/error_index_generator/error-index.css
@@ -27,10 +27,11 @@ pre .tooltip::before {
 	content: " ";
 	position: absolute;
 	top: 50%;
-	left: 16px;
+	left: 2px;
 	margin-top: -5px;
 	border-width: 5px;
 	border-style: solid;
+	height: 0px;
 }
 
 pre .tooltip:hover::before, pre .tooltip:hover::after {

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -215,6 +215,7 @@ impl Checker {
                 || url.starts_with("ftp:")
                 || url.starts_with("irc:")
                 || url.starts_with("data:")
+                || url.starts_with("mailto:")
             {
                 report.links_ignored_external += 1;
                 return;

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -20,6 +20,7 @@ const LICENSES: &[&str] = &[
     "Unlicense OR MIT",
     "0BSD OR MIT OR Apache-2.0", // adler license
     "Zlib OR Apache-2.0 OR MIT", // tinyvec
+    "MIT OR Apache-2.0 OR Zlib", // tinyvec_macros
     "MIT OR Zlib OR Apache-2.0", // miniz_oxide
 ];
 
@@ -218,6 +219,7 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "time",
     "tinystr",
     "tinyvec",
+    "tinyvec_macros",
     "thin-vec",
     "tracing",
     "tracing-attributes",


### PR DESCRIPTION
Successful merges:

 - #101151 (Document x86_64-fortanix-unknown-sgx platform)
 - #101912 (Update `unicode-rs` crates to Unicode 15)
 - #101923 (Don't add rustdoc's CSS to other doc pages)
 - #101953 (Fix tooltip display for error codes)
 - #101954 (rustdoc: remove redundant `.location a { font-weight: 500 }`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101151,101912,101923,101953,101954)
<!-- homu-ignore:end -->