### PR TITLE
Add a codegen test for `slice::from_ptr_range`

### DIFF
--- a/src/test/codegen/slice_as_from_ptr_range.rs
+++ b/src/test/codegen/slice_as_from_ptr_range.rs
@@ -1,0 +1,23 @@
+// compile-flags: -O
+// only-64bit (because we're using [ui]size)
+// ignore-debug (because the assertions get in the way)
+// min-llvm-version: 15.0 (because this is a relatively new instcombine)
+
+#![crate_type = "lib"]
+#![feature(slice_from_ptr_range)]
+
+// This is intentionally using a non-power-of-two array length,
+// as that's where the optimization differences show up
+
+// CHECK-LABEL: @flatten_via_ptr_range
+#[no_mangle]
+pub fn flatten_via_ptr_range(slice_of_arrays: &[[i32; 13]]) -> &[i32] {
+    // CHECK-NOT: lshr
+    // CHECK-NOT: udiv
+    // CHECK: mul nuw nsw i64 %{{.+}}, 13
+    // CHECK-NOT: lshr
+    // CHECK-NOT: udiv
+    let r = slice_of_arrays.as_ptr_range();
+    let r = r.start.cast()..r.end.cast();
+    unsafe { core::slice::from_ptr_range(r) }
+}


### PR DESCRIPTION
I noticed back in #95579 that this didn't optimize as well as it should.

It's better now, after #95837 changed the code in `from_ptr_range` and https://github.com/llvm/llvm-project/issues/54824 was fixed in LLVM 15.

So here's a test to keep it generating the good version.