### PR TITLE
Suggest to use . instead of :: when accessing a method of an object

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -470,6 +470,7 @@ pub enum StashKey {
     /// Maybe there was a typo where a comma was forgotten before
     /// FRU syntax
     MaybeFruTypo,
+    CallAssocMethod,
 }
 
 fn default_track_diagnostic(_: &Diagnostic) {}

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -528,6 +528,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.resolve_ty_and_res_fully_qualified_call(qpath, expr.hir_id, expr.span);
         let ty = match res {
             Res::Err => {
+                self.suggest_assoc_method_call(segs);
                 let e =
                     self.tcx.sess.delay_span_bug(qpath.span(), "`Res::Err` but no error emitted");
                 self.set_tainted_by_errors(e);

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1840,13 +1840,16 @@ impl<'a> Resolver<'a> {
 
             (format!("use of undeclared type `{}`", ident), suggestion)
         } else {
-            let suggestion = if ident.name == sym::alloc {
-                Some((
+            let mut suggestion = None;
+            if ident.name == sym::alloc {
+                suggestion = Some((
                     vec![],
                     String::from("add `extern crate alloc` to use the `alloc` crate"),
                     Applicability::MaybeIncorrect,
                 ))
-            } else {
+            }
+
+            suggestion = suggestion.or_else(|| {
                 self.find_similarly_named_module_or_crate(ident.name, &parent_scope.module).map(
                     |sugg| {
                         (
@@ -1856,7 +1859,7 @@ impl<'a> Resolver<'a> {
                         )
                     },
                 )
-            };
+            });
             (format!("use of undeclared crate or module `{}`", ident), suggestion)
         }
     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3364,13 +3364,13 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             // Before we start looking for candidates, we have to get our hands
             // on the type user is trying to perform invocation on; basically:
             // we're transforming `HashMap::new` into just `HashMap`.
-            let path = match path.split_last() {
+            let prefix_path = match path.split_last() {
                 Some((_, path)) if !path.is_empty() => path,
                 _ => return Some(parent_err),
             };
 
             let (mut err, candidates) =
-                this.smart_resolve_report_errors(path, path_span, PathSource::Type, None);
+                this.smart_resolve_report_errors(prefix_path, path_span, PathSource::Type, None);
 
             // There are two different error messages user might receive at
             // this point:
@@ -3414,11 +3414,23 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
 
             if this.should_report_errs() {
                 if candidates.is_empty() {
-                    // When there is no suggested imports, we can just emit the error
-                    // and suggestions immediately. Note that we bypass the usually error
-                    // reporting routine (ie via `self.r.report_error`) because we need
-                    // to post-process the `ResolutionError` above.
-                    err.emit();
+                    if path.len() == 2 && prefix_path.len() == 1 {
+                        // Delay to check whether methond name is an associated function or not
+                        // ```
+                        // let foo = Foo {};
+                        // foo::bar(); // possibly suggest to foo.bar();
+                        //```
+                        err.stash(
+                            prefix_path[0].ident.span,
+                            rustc_errors::StashKey::CallAssocMethod,
+                        );
+                    } else {
+                        // When there is no suggested imports, we can just emit the error
+                        // and suggestions immediately. Note that we bypass the usually error
+                        // reporting routine (ie via `self.r.report_error`) because we need
+                        // to post-process the `ResolutionError` above.
+                        err.emit();
+                    }
                 } else {
                     // If there are suggested imports, the error reporting is delayed
                     this.r.use_injections.push(UseError {
@@ -3427,7 +3439,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                         def_id,
                         instead: false,
                         suggestion: None,
-                        path: path.into(),
+                        path: prefix_path.into(),
                         is_call: source.is_call(),
                     });
                 }

--- a/src/test/ui/resolve/bad-module.stderr
+++ b/src/test/ui/resolve/bad-module.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `thing`
-  --> $DIR/bad-module.rs:2:15
-   |
-LL |     let foo = thing::len(Vec::new());
-   |               ^^^^^ use of undeclared crate or module `thing`
-
 error[E0433]: failed to resolve: use of undeclared crate or module `foo`
   --> $DIR/bad-module.rs:5:15
    |
 LL |     let foo = foo::bar::baz();
    |               ^^^ use of undeclared crate or module `foo`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `thing`
+  --> $DIR/bad-module.rs:2:15
+   |
+LL |     let foo = thing::len(Vec::new());
+   |               ^^^^^ use of undeclared crate or module `thing`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-101749-2.rs
+++ b/src/test/ui/resolve/issue-101749-2.rs
@@ -1,0 +1,16 @@
+struct Rectangle {
+    width: i32,
+    height: i32,
+}
+impl Rectangle {
+    fn new(width: i32, height: i32) -> Self {
+        Self { width, height }
+    }
+}
+
+fn main() {
+    let rect = Rectangle::new(3, 4);
+    // `area` is not implemented for `Rectangle`, so this should not suggest
+    let _ = rect::area();
+    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+}

--- a/src/test/ui/resolve/issue-101749-2.stderr
+++ b/src/test/ui/resolve/issue-101749-2.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `rect`
+  --> $DIR/issue-101749-2.rs:14:13
+   |
+LL |     let _ = rect::area();
+   |             ^^^^ use of undeclared crate or module `rect`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/resolve/issue-101749.fixed
+++ b/src/test/ui/resolve/issue-101749.fixed
@@ -1,0 +1,19 @@
+// run-rustfix
+struct Rectangle {
+    width: i32,
+    height: i32,
+}
+impl Rectangle {
+    fn new(width: i32, height: i32) -> Self {
+        Self { width, height }
+    }
+    fn area(&self) -> i32 {
+        self.height * self.width
+    }
+}
+
+fn main() {
+    let rect = Rectangle::new(3, 4);
+    let _ = rect.area();
+    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+}

--- a/src/test/ui/resolve/issue-101749.rs
+++ b/src/test/ui/resolve/issue-101749.rs
@@ -1,0 +1,19 @@
+// run-rustfix
+struct Rectangle {
+    width: i32,
+    height: i32,
+}
+impl Rectangle {
+    fn new(width: i32, height: i32) -> Self {
+        Self { width, height }
+    }
+    fn area(&self) -> i32 {
+        self.height * self.width
+    }
+}
+
+fn main() {
+    let rect = Rectangle::new(3, 4);
+    let _ = rect::area();
+    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+}

--- a/src/test/ui/resolve/issue-101749.stderr
+++ b/src/test/ui/resolve/issue-101749.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `rect`
+  --> $DIR/issue-101749.rs:17:13
+   |
+LL |     let _ = rect::area();
+   |             ^^^^ use of undeclared crate or module `rect`
+   |
+help: you may have meant to call an instance method
+   |
+LL |     let _ = rect.area();
+   |                 ~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/resolve/issue-24968.stderr
+++ b/src/test/ui/resolve/issue-24968.stderr
@@ -1,15 +1,3 @@
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
-  --> $DIR/issue-24968.rs:21:19
-   |
-LL | const FOO2: u32 = Self::bar();
-   |                   ^^^^ `Self` is only available in impls, traits, and type definitions
-
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
-  --> $DIR/issue-24968.rs:27:22
-   |
-LL | static FOO_S2: u32 = Self::bar();
-   |                      ^^^^ `Self` is only available in impls, traits, and type definitions
-
 error[E0411]: cannot find type `Self` in this scope
   --> $DIR/issue-24968.rs:3:11
    |
@@ -50,6 +38,18 @@ LL | static FOO_S: Self = 0;
    |        -----  ^^^^ `Self` is only available in impls, traits, and type definitions
    |        |
    |        `Self` not allowed in a static item
+
+error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+  --> $DIR/issue-24968.rs:21:19
+   |
+LL | const FOO2: u32 = Self::bar();
+   |                   ^^^^ `Self` is only available in impls, traits, and type definitions
+
+error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+  --> $DIR/issue-24968.rs:27:22
+   |
+LL | static FOO_S2: u32 = Self::bar();
+   |                      ^^^^ `Self` is only available in impls, traits, and type definitions
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/resolve/typo-suggestion-mistyped-in-path.stderr
+++ b/src/test/ui/resolve/typo-suggestion-mistyped-in-path.stderr
@@ -1,3 +1,24 @@
+error[E0433]: failed to resolve: could not find `Struc` in `module`
+  --> $DIR/typo-suggestion-mistyped-in-path.rs:35:13
+   |
+LL |     module::Struc::foo();
+   |             ^^^^^
+   |             |
+   |             could not find `Struc` in `module`
+   |             help: a struct with a similar name exists: `Struct`
+
+error[E0599]: no function or associated item named `fob` found for struct `Struct` in the current scope
+  --> $DIR/typo-suggestion-mistyped-in-path.rs:23:13
+   |
+LL | struct Struct;
+   | ------------- function or associated item `fob` not found for this struct
+...
+LL |     Struct::fob();
+   |             ^^^
+   |             |
+   |             function or associated item not found in `Struct`
+   |             help: there is an associated function with a similar name: `foo`
+
 error[E0433]: failed to resolve: use of undeclared type `Struc`
   --> $DIR/typo-suggestion-mistyped-in-path.rs:27:5
    |
@@ -18,15 +39,6 @@ help: there is a crate or module with a similar name
 LL |     module::foo();
    |     ~~~~~~
 
-error[E0433]: failed to resolve: could not find `Struc` in `module`
-  --> $DIR/typo-suggestion-mistyped-in-path.rs:35:13
-   |
-LL |     module::Struc::foo();
-   |             ^^^^^
-   |             |
-   |             could not find `Struc` in `module`
-   |             help: a struct with a similar name exists: `Struct`
-
 error[E0433]: failed to resolve: use of undeclared type `Trai`
   --> $DIR/typo-suggestion-mistyped-in-path.rs:39:5
    |
@@ -35,18 +47,6 @@ LL |     Trai::foo();
    |     |
    |     use of undeclared type `Trai`
    |     help: a trait with a similar name exists: `Trait`
-
-error[E0599]: no function or associated item named `fob` found for struct `Struct` in the current scope
-  --> $DIR/typo-suggestion-mistyped-in-path.rs:23:13
-   |
-LL | struct Struct;
-   | ------------- function or associated item `fob` not found for this struct
-...
-LL |     Struct::fob();
-   |             ^^^
-   |             |
-   |             function or associated item not found in `Struct`
-   |             help: there is an associated function with a similar name: `foo`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/resolve/use_suggestion.stderr
+++ b/src/test/ui/resolve/use_suggestion.stderr
@@ -1,9 +1,3 @@
-error[E0433]: failed to resolve: use of undeclared type `GooMap`
-  --> $DIR/use_suggestion.rs:3:14
-   |
-LL |     let x2 = GooMap::new();
-   |              ^^^^^^ use of undeclared type `GooMap`
-
 error[E0433]: failed to resolve: use of undeclared type `HashMap`
   --> $DIR/use_suggestion.rs:2:14
    |
@@ -31,6 +25,12 @@ error[E0412]: cannot find type `GooMap` in this scope
    |
 LL |     let y2: GooMap;
    |             ^^^^^^ not found in this scope
+
+error[E0433]: failed to resolve: use of undeclared type `GooMap`
+  --> $DIR/use_suggestion.rs:3:14
+   |
+LL |     let x2 = GooMap::new();
+   |              ^^^^^^ use of undeclared type `GooMap`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/crate-or-module-typo.stderr
+++ b/src/test/ui/suggestions/crate-or-module-typo.stderr
@@ -20,12 +20,6 @@ help: there is a crate or module with a similar name
 LL | use bar::bar;
    |     ~~~
 
-error[E0433]: failed to resolve: use of undeclared crate or module `bar`
-  --> $DIR/crate-or-module-typo.rs:6:20
-   |
-LL |     pub fn bar() { bar::baz(); }
-   |                    ^^^ use of undeclared crate or module `bar`
-
 error[E0433]: failed to resolve: use of undeclared crate or module `st`
   --> $DIR/crate-or-module-typo.rs:14:10
    |
@@ -36,6 +30,12 @@ help: there is a crate or module with a similar name
    |
 LL |     bar: std::cell::Cell<bool>
    |          ~~~
+
+error[E0433]: failed to resolve: use of undeclared crate or module `bar`
+  --> $DIR/crate-or-module-typo.rs:6:20
+   |
+LL |     pub fn bar() { bar::baz(); }
+   |                    ^^^ use of undeclared crate or module `bar`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes #101749
Fixes #101542