### PR TITLE
Impl AsRef, Borrow for Ref, RefMut

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1346,7 +1346,7 @@ impl<T: ?Sized> Deref for Ref<'_, T> {
 impl<T: ?Sized> crate::convert::AsRef<T> for Ref<'_, T> {
     #[inline]
     fn as_ref(&self) -> &T {
-        &self
+        self
     }
 }
 
@@ -1354,7 +1354,7 @@ impl<T: ?Sized> crate::convert::AsRef<T> for Ref<'_, T> {
 impl<T: ?Sized> crate::borrow::Borrow<T> for Ref<'_, T> {
     #[inline]
     fn borrow(&self) -> &T {
-        &self
+        self
     }
 }
 
@@ -1753,7 +1753,15 @@ impl<T: ?Sized> DerefMut for RefMut<'_, T> {
 impl<T: ?Sized> crate::convert::AsRef<T> for RefMut<'_, T> {
     #[inline]
     fn as_ref(&self) -> &T {
-        &self
+        self
+    }
+}
+
+#[stable(feature = "borrow_ref", since = "1.65.0")]
+impl<T: ?Sized> crate::convert::AsMut<T> for RefMut<'_, T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut T {
+        self
     }
 }
 
@@ -1761,7 +1769,15 @@ impl<T: ?Sized> crate::convert::AsRef<T> for RefMut<'_, T> {
 impl<T: ?Sized> crate::borrow::Borrow<T> for RefMut<'_, T> {
     #[inline]
     fn borrow(&self) -> &T {
-        &self
+        self
+    }
+}
+
+#[stable(feature = "borrow_ref", since = "1.65.0")]
+impl<T: ?Sized> crate::borrow::BorrowMut<T> for RefMut<'_, T> {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut T {
+        self
     }
 }
 

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1342,6 +1342,22 @@ impl<T: ?Sized> Deref for Ref<'_, T> {
     }
 }
 
+#[stable(feature = "borrow_ref", since = "1.65.0")]
+impl<T: ?Sized> crate::convert::AsRef<T> for Ref<'_, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        &self
+    }
+}
+
+#[stable(feature = "borrow_ref", since = "1.65.0")]
+impl<T: ?Sized> crate::borrow::Borrow<T> for Ref<'_, T> {
+    #[inline]
+    fn borrow(&self) -> &T {
+        &self
+    }
+}
+
 impl<'b, T: ?Sized> Ref<'b, T> {
     /// Copies a `Ref`.
     ///
@@ -1730,6 +1746,22 @@ impl<T: ?Sized> DerefMut for RefMut<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         // SAFETY: the value is accessible as long as we hold our borrow.
         unsafe { self.value.as_mut() }
+    }
+}
+
+#[stable(feature = "borrow_ref", since = "1.65.0")]
+impl<T: ?Sized> crate::convert::AsRef<T> for RefMut<'_, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        &self
+    }
+}
+
+#[stable(feature = "borrow_ref", since = "1.65.0")]
+impl<T: ?Sized> crate::borrow::Borrow<T> for RefMut<'_, T> {
+    #[inline]
+    fn borrow(&self) -> &T {
+        &self
     }
 }
 


### PR DESCRIPTION
**Summary:** Implement `AsRef`, `Borrow` for `std::cell::Ref`, `RefMut`.

Sorry if I didn't exactly follow a guide. This is too small to need an RFC?

I'm not certain about the `#[stable]` attrs, but it seems there's little choice in the matter (given that one can't have unstable impls of existing traits).

# Motivation

Why? Because we can. This is what `AsRef` and `Borrow` are for? (More generally: *any* impl of `Deref` should impl `AsRef` too?)

Further motivation:
```rust
trait Foo<T: ?Sized> {
    type Ref<'b>: std::borrow::Borrow<T>;
    fn borrow(&self) -> Self::Ref<'_>;
}

struct MyCell(std::cell::RefCell<String>);
impl Foo<str> for MyCell {
    type Ref<'b> = std::cell::Ref<'b>; // avoids the need to construct a new type here
    fn borrow(&self) -> Self::Ref<'_> {
        std::cell::Ref::map(self.0.borrow(), String::as_str)
    }
}
```

ACP: https://github.com/rust-lang/libs-team/issues/215
