### PR TITLE
rustdoc: remove unused CSS `td.summary-column`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1152,10 +1152,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 1rem;
 }
 
-td.summary-column {
-	width: 100%;
-}
-
 .summary {
 	padding-right: 0px;
 }


### PR DESCRIPTION
It was added in 2a1bad70dd9bc99d8db54964108b42da8f4e9fbd to go with this module summary function:

https://github.com/rust-lang/rust/blob/2a1bad70dd9bc99d8db54964108b42da8f4e9fbd/src/librustdoc/html/format.rs#L767-L780

The corresponding HTML was removed in 0a46933c4d81573e78ce16cd215ba155a3114fce.