### PR TITLE
Make `core::iter::Fuse` fuse all iterators

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1543,10 +1543,6 @@ pub trait Iterator {
     /// [`Some(T)`] again. `fuse()` adapts an iterator, ensuring that after a
     /// [`None`] is given, it will always return [`None`] forever.
     ///
-    /// Note that the [`Fuse`] wrapper is a no-op on iterators that implement
-    /// the [`FusedIterator`] trait. `fuse()` may therefore behave incorrectly
-    /// if the [`FusedIterator`] trait is improperly implemented.
-    ///
     /// [`Some(T)`]: Some
     /// [`FusedIterator`]: crate::iter::FusedIterator
     ///

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -3,17 +3,15 @@ use crate::iter::Step;
 /// An iterator that always continues to yield `None` when exhausted.
 ///
 /// Calling next on a fused iterator that has returned `None` once is guaranteed
-/// to return [`None`] again. This trait should be implemented by all iterators
-/// that behave this way because it allows optimizing [`Iterator::fuse()`].
+/// to return [`None`] again.
 ///
 /// Note: In general, you should not use `FusedIterator` in generic bounds if
 /// you need a fused iterator. Instead, you should just call [`Iterator::fuse()`]
-/// on the iterator. If the iterator is already fused, the additional [`Fuse`]
+/// on the iterator. If the iterator is already a [`Fuse`], the additional [`Fuse`]
 /// wrapper will be a no-op with no performance penalty.
 ///
 /// [`Fuse`]: crate::iter::Fuse
 #[stable(feature = "fused", since = "1.26.0")]
-#[rustc_unsafe_specialization_marker]
 pub trait FusedIterator: Iterator {}
 
 #[stable(feature = "fused", since = "1.26.0")]


### PR DESCRIPTION
This keeps the specialization for `Fuse<Fuse<...>>` specifically, to avoid one of the branches.

Per comments in the stabilization PR, this is not considered a breaking change.