### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -77,30 +77,24 @@ These APIs are now usable in const contexts:
 
 Cargo
 -----
-- Packages can now inherit settings from the workspace so that the settings
-  can be centralized in one place. See
+- [Packages can now inherit settings from the workspace so that the settings
+  can be centralized in one place.](https://github.com/rust-lang/cargo/pull/10859) See
   [`workspace.package`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-workspacepackage-table)
   and
   [`workspace.dependencies`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-workspacedependencies-table)
   for more details on how to define these common settings.
-  [#10859](https://github.com/rust-lang/cargo/pull/10859)
-- Cargo commands can now accept multiple `--target` flags to build for
-  multiple targets at once, and the
+- [Cargo commands can now accept multiple `--target` flags to build for
+  multiple targets at once](https://github.com/rust-lang/cargo/pull/10766), and the
   [`build.target`](https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildtarget)
   config option may now take an array of multiple targets.
-  [#10766](https://github.com/rust-lang/cargo/pull/10766)
-- The `--jobs` argument can now take a negative number to count backwards from
-  the max CPUs.
-  [#10844](https://github.com/rust-lang/cargo/pull/10844)
-- `cargo add` will now update `Cargo.lock`.
-  [#10902](https://github.com/rust-lang/cargo/pull/10902)
-- Added the
+- [The `--jobs` argument can now take a negative number to count backwards from
+  the max CPUs.](https://github.com/rust-lang/cargo/pull/10844)
+- [`cargo add` will now update `Cargo.lock`.](https://github.com/rust-lang/cargo/pull/10902)
+- [Added](https://github.com/rust-lang/cargo/pull/10838) the
   [`--crate-type`](https://doc.rust-lang.org/nightly/cargo/commands/cargo-rustc.html#option-cargo-rustc---crate-type)
   flag to `cargo rustc` to override the crate type.
-  [#10838](https://github.com/rust-lang/cargo/pull/10838)
-- Significantly improved the performance fetching git dependencies from GitHub
-  when using a hash in the `rev` field.
-  [#10079](https://github.com/rust-lang/cargo/pull/10079)
+- [Significantly improved the performance fetching git dependencies from GitHub
+  when using a hash in the `rev` field.](https://github.com/rust-lang/cargo/pull/10079)
 
 Misc
 ----

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,10 +15,7 @@ Compiler
 - [Only compile `#[used]` as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
 - [Add the `--diagnostic-width` compiler flag to define the terminal width.](https://github.com/rust-lang/rust/pull/95635/)
 - [Fix repr(align) enum handling](https://github.com/rust-lang/rust/pull/96814/)
-- [Suggest defining variable as mutable on `&mut _` type mismatch in pats](https://github.com/rust-lang/rust/pull/98431/)
-- [Emit warning when named arguments are used positionally in format](https://github.com/rust-lang/rust/pull/98580/)
 - [Add support for link-flavor `rust-lld` for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
-- [Do not mention private types from other crates as impl candidates](https://github.com/rust-lang/rust/pull/99091/)
 
 Libraries
 ---------

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ Version 1.64.0 (2022-09-22)
 Language
 --------
 - [make `const_err` show up in future breakage reports](https://github.com/rust-lang/rust/pull/97743/)
-- [allow unions with mutable references and tuples of allowed types](https://github.com/rust-lang/rust/pull/97995/)
+- [Unions with mutable references or tuples of allowed types are now allowed](https://github.com/rust-lang/rust/pull/97995/)
 - It is now considered valid to deallocate memory pointed to by a shared reference `&T` [if every byte in `T` is inside an `UnsafeCell`](https://github.com/rust-lang/rust/pull/98017/)
 - Unused tuple struct fields are now warned against in an allow-by-default lint, [`unused_tuple_struct_fields`](https://github.com/rust-lang/rust/pull/95977/), similar to the existing warning for unused struct fields. This lint will become warn-by-default in the future.
 
@@ -15,12 +15,12 @@ Compiler
 - [Add Nintendo Switch as tier 3 target](https://github.com/rust-lang/rust/pull/88991/)
   - Refer to Rust's [platform support page][platform-support-doc] for more
     information on Rust's tiered platform support.
-- [Only compile #[used] as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
-- [sess: stabilize `-Zterminal-width` as `--diagnostic-width`](https://github.com/rust-lang/rust/pull/95635/)
+- [Only compile `#[used]` as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
+- [Add the `--diagnostic-width` compiler flag to define the terminal width.](https://github.com/rust-lang/rust/pull/95635/)
 - [Fix repr(align) enum handling](https://github.com/rust-lang/rust/pull/96814/)
 - [Suggest defining variable as mutable on `&mut _` type mismatch in pats](https://github.com/rust-lang/rust/pull/98431/)
 - [Emit warning when named arguments are used positionally in format](https://github.com/rust-lang/rust/pull/98580/)
-- [Add support for link-flavor rust-lld for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
+- [Add support for link-flavor `rust-lld` for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
 - [Do not mention private types from other crates as impl candidates](https://github.com/rust-lang/rust/pull/99091/)
 
 Libraries
@@ -32,11 +32,11 @@ Libraries
 - [Make RwLockReadGuard covariant](https://github.com/rust-lang/rust/pull/96820/)
 - [Implement `FusedIterator` for `std::net::[Into]Incoming`](https://github.com/rust-lang/rust/pull/97300/)
 - [`impl<T: AsRawFd> AsRawFd for {Arc,Box}<T>`](https://github.com/rust-lang/rust/pull/97437/)
-- [ptr::copy and ptr::swap are doing untyped copies](https://github.com/rust-lang/rust/pull/97712/)
-- [Add assertion that `transmute_copy`'s U is not larger than T](https://github.com/rust-lang/rust/pull/98839/)
+- [`ptr::copy` and `ptr::swap` are doing untyped copies](https://github.com/rust-lang/rust/pull/97712/)
+- [Add assertion that `transmute_copy`'s U is not larger than `T`](https://github.com/rust-lang/rust/pull/98839/)
 - [A soundness bug in `BTreeMap` was fixed](https://github.com/rust-lang/rust/pull/99413/) that allowed data it was borrowing to be dropped before the container.
 - [Add cgroupv1 support to `available_parallelism`](https://github.com/rust-lang/rust/pull/97925/)
-- [mem::uninitialized: mitigate many incorrect uses of this function](https://github.com/rust-lang/rust/pull/99182/)
+- [Mitigate many incorrect uses of `mem::uninitialized`](https://github.com/rust-lang/rust/pull/99182/)
 
 Stabilized APIs
 ---------------
@@ -113,13 +113,13 @@ Cargo
 
 Misc
 ----
-- [Let rust-analyzer ship on stable, non-preview](https://github.com/rust-lang/rust/pull/98640/)
+- [The `rust-analyzer` rustup component is now available on the stable channel.](https://github.com/rust-lang/rust/pull/98640/)
 
 Compatibility Notes
 -------------------
 - The minimum required versions for all `-linux-gnu` targets are now at least kernel 3.2 and glibc 2.17, for targets that previously supported older versions: [Increase the minimum linux-gnu versions](https://github.com/rust-lang/rust/pull/95026/)
-- [Implement network primitives with ideal Rust layout, not C system layout](https://github.com/rust-lang/rust/pull/78802/)
-- [Add assertion that `transmute_copy`'s U is not larger than T](https://github.com/rust-lang/rust/pull/98839/)
+- [Network primitives are now implemented with the ideal Rust layout, not the C system layout](https://github.com/rust-lang/rust/pull/78802/). This can cause problems when transmuting the types.
+- [Add assertion that `transmute_copy`'s `U` is not larger than `T`](https://github.com/rust-lang/rust/pull/98839/)
 - [A soundness bug in `BTreeMap` was fixed](https://github.com/rust-lang/rust/pull/99413/) that allowed data it was borrowing to be dropped before the container.
 - [The Drop behavior of C-like enums cast to ints has changed](https://github.com/rust-lang/rust/pull/96862/). These are already discouraged by a compiler warning.
 - [Relate late-bound closure lifetimes to parent fn in NLL](https://github.com/rust-lang/rust/pull/98835/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,6 @@ Compiler
     information on Rust's tiered platform support.
 - [Only compile `#[used]` as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
 - [Add the `--diagnostic-width` compiler flag to define the terminal width.](https://github.com/rust-lang/rust/pull/95635/)
-- [Fix repr(align) enum handling](https://github.com/rust-lang/rust/pull/96814/)
 - [Add support for link-flavor `rust-lld` for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
 
 Libraries

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,15 +3,12 @@ Version 1.64.0 (2022-09-22)
 
 Language
 --------
-- [make `const_err` show up in future breakage reports](https://github.com/rust-lang/rust/pull/97743/)
 - [Unions with mutable references or tuples of allowed types are now allowed](https://github.com/rust-lang/rust/pull/97995/)
 - It is now considered valid to deallocate memory pointed to by a shared reference `&T` [if every byte in `T` is inside an `UnsafeCell`](https://github.com/rust-lang/rust/pull/98017/)
 - Unused tuple struct fields are now warned against in an allow-by-default lint, [`unused_tuple_struct_fields`](https://github.com/rust-lang/rust/pull/95977/), similar to the existing warning for unused struct fields. This lint will become warn-by-default in the future.
 
 Compiler
 --------
-- The minimum required versions for all `-linux-gnu` targets are now at least kernel 3.2 and glibc 2.17, for targets that previously supported older versions: [Increase the minimum linux-gnu versions](https://github.com/rust-lang/rust/pull/95026/)
-- [Keep unstable target features for asm feature checking](https://github.com/rust-lang/rust/pull/99155/)
 - [Add Nintendo Switch as tier 3 target](https://github.com/rust-lang/rust/pull/88991/)
   - Refer to Rust's [platform support page][platform-support-doc] for more
     information on Rust's tiered platform support.
@@ -25,7 +22,6 @@ Compiler
 
 Libraries
 ---------
-- [Implement network primitives with ideal Rust layout, not C system layout](https://github.com/rust-lang/rust/pull/78802/)
 - [Remove restrictions on compare-exchange memory ordering.](https://github.com/rust-lang/rust/pull/98383/)
 - You can now `write!` or `writeln!` into an `OsString`: [Implement `fmt::Write` for `OsString`](https://github.com/rust-lang/rust/pull/97915/)
 - [Enforce that layout size fits in isize in Layout](https://github.com/rust-lang/rust/pull/95295/)
@@ -33,8 +29,6 @@ Libraries
 - [Implement `FusedIterator` for `std::net::[Into]Incoming`](https://github.com/rust-lang/rust/pull/97300/)
 - [`impl<T: AsRawFd> AsRawFd for {Arc,Box}<T>`](https://github.com/rust-lang/rust/pull/97437/)
 - [`ptr::copy` and `ptr::swap` are doing untyped copies](https://github.com/rust-lang/rust/pull/97712/)
-- [Add assertion that `transmute_copy`'s U is not larger than `T`](https://github.com/rust-lang/rust/pull/98839/)
-- [A soundness bug in `BTreeMap` was fixed](https://github.com/rust-lang/rust/pull/99413/) that allowed data it was borrowing to be dropped before the container.
 - [Add cgroupv1 support to `available_parallelism`](https://github.com/rust-lang/rust/pull/97925/)
 - [Mitigate many incorrect uses of `mem::uninitialized`](https://github.com/rust-lang/rust/pull/99182/)
 

--- a/compiler/rustc_middle/src/middle/resolve_lifetime.rs
+++ b/compiler/rustc_middle/src/middle/resolve_lifetime.rs
@@ -2,7 +2,7 @@
 
 use crate::ty;
 
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::ItemLocalId;
 use rustc_macros::HashStable;
@@ -50,11 +50,6 @@ pub struct ResolveLifetimes {
     /// Maps from every use of a named (not anonymous) lifetime to a
     /// `Region` describing how that region is bound
     pub defs: FxHashMap<LocalDefId, FxHashMap<ItemLocalId, Region>>,
-
-    /// Set of lifetime def ids that are late-bound; a region can
-    /// be late-bound if (a) it does NOT appear in a where-clause and
-    /// (b) it DOES appear in the arguments.
-    pub late_bound: FxHashMap<LocalDefId, FxHashSet<LocalDefId>>,
 
     pub late_bound_vars: FxHashMap<LocalDefId, FxHashMap<ItemLocalId, Vec<ty::BoundVariableKind>>>,
 }

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1021,15 +1021,18 @@ impl<T: ?Sized> RefCell<T> {
 
     /// Returns a mutable reference to the underlying data.
     ///
-    /// This call borrows `RefCell` mutably (at compile-time) so there is no
-    /// need for dynamic checks.
+    /// Since this method borrows `RefCell` mutably, it is statically guaranteed
+    /// that no borrows to the underlying data exist. The dynamic checks inherent
+    /// in [`borrow_mut`] and most other methods of `RefCell` are therefor
+    /// unnecessary.
     ///
-    /// However be cautious: this method expects `self` to be mutable, which is
-    /// generally not the case when using a `RefCell`. Take a look at the
-    /// [`borrow_mut`] method instead if `self` isn't mutable.
+    /// This method can only be called if `RefCell` can be mutably borrowed,
+    /// which in general is only the case directly after the `RefCell` has
+    /// been created. In these situations, skipping the aforementioned dynamic
+    /// borrowing checks may yield better ergonomics and runtime-performance.
     ///
-    /// Also, please be aware that this method is only for special circumstances and is usually
-    /// not what you want. In case of doubt, use [`borrow_mut`] instead.
+    /// In most situations where `RefCell` is used, it can't be borrowed mutably.
+    /// Use [`borrow_mut`] to get mutable access to the underlying data then.
     ///
     /// [`borrow_mut`]: RefCell::borrow_mut()
     ///

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1152,10 +1152,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 1rem;
 }
 
-td.summary-column {
-	width: 100%;
-}
-
 .summary {
 	padding-right: 0px;
 }

--- a/src/test/ui/lexer/lex-emoji-identifiers.rs
+++ b/src/test/ui/lexer/lex-emoji-identifiers.rs
@@ -1,0 +1,17 @@
+fn invalid_emoji_usages() {
+    let arrow↔️ = "basic emoji"; //~ ERROR: identifiers cannot contain emoji
+    // FIXME
+    let planet🪐 = "basic emoji"; //~ ERROR: unknown start of token
+    // FIXME
+    let wireless🛜 = "basic emoji"; //~ ERROR: unknown start of token
+    // FIXME
+    let key1️⃣ = "keycap sequence"; //~ ERROR: unknown start of token
+                                    //~^ WARN: identifier contains uncommon Unicode codepoints
+    let flag🇺🇳 = "flag sequence"; //~ ERROR: identifiers cannot contain emoji
+    let wales🏴 = "tag sequence"; //~ ERROR: identifiers cannot contain emoji
+    let folded🙏🏿 = "modifier sequence"; //~ ERROR: identifiers cannot contain emoji
+}
+
+fn main() {
+    invalid_emoji_usages();
+}

--- a/src/test/ui/lexer/lex-emoji-identifiers.stderr
+++ b/src/test/ui/lexer/lex-emoji-identifiers.stderr
@@ -1,0 +1,52 @@
+error: unknown start of token: \u{1fa90}
+  --> $DIR/lex-emoji-identifiers.rs:4:15
+   |
+LL |     let planet🪐 = "basic emoji";
+   |               ^^
+
+error: unknown start of token: \u{1f6dc}
+  --> $DIR/lex-emoji-identifiers.rs:6:17
+   |
+LL |     let wireless🛜 = "basic emoji";
+   |                 ^^
+
+error: unknown start of token: \u{20e3}
+  --> $DIR/lex-emoji-identifiers.rs:8:14
+   |
+LL |     let key1️⃣ = "keycap sequence";
+   |             ^
+
+error: identifiers cannot contain emoji: `arrow↔️`
+  --> $DIR/lex-emoji-identifiers.rs:2:9
+   |
+LL |     let arrow↔️ = "basic emoji";
+   |         ^^^^^^
+
+error: identifiers cannot contain emoji: `flag🇺🇳`
+  --> $DIR/lex-emoji-identifiers.rs:10:9
+   |
+LL |     let flag🇺🇳 = "flag sequence";
+   |         ^^^^^^
+
+error: identifiers cannot contain emoji: `wales🏴`
+  --> $DIR/lex-emoji-identifiers.rs:11:9
+   |
+LL |     let wales🏴 = "tag sequence";
+   |         ^^^^^^^
+
+error: identifiers cannot contain emoji: `folded🙏🏿`
+  --> $DIR/lex-emoji-identifiers.rs:12:9
+   |
+LL |     let folded🙏🏿 = "modifier sequence";
+   |         ^^^^^^^^^^
+
+warning: identifier contains uncommon Unicode codepoints
+  --> $DIR/lex-emoji-identifiers.rs:8:9
+   |
+LL |     let key1️⃣ = "keycap sequence";
+   |         ^^^^
+   |
+   = note: `#[warn(uncommon_codepoints)]` on by default
+
+error: aborting due to 7 previous errors; 1 warning emitted
+


### PR DESCRIPTION
Successful merges:

 - #101389 (Tone down explanation on RefCell::get_mut)
 - #101881 (Remove an unused struct field `late_bound`)
 - #101966 (Add unit test for identifier Unicode emoji diagnostics)
 - #101979 (Update release notes for 1.64)
 - #102005 (rustdoc: remove unused CSS `td.summary-column`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101389,101881,101966,101979,102005)
<!-- homu-ignore:end -->