### PR TITLE
Add tools to sysroot after build.

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -93,14 +93,14 @@ fn test_intersection() {
     let set = PathSet::Set(
         ["library/core", "library/alloc", "library/std"].into_iter().map(TaskPath::parse).collect(),
     );
-    let mut command_paths =
+    let command_paths =
         vec![Path::new("library/core"), Path::new("library/alloc"), Path::new("library/stdarch")];
-    let subset = set.intersection_removing_matches(&mut command_paths, None);
+    let (subset, matched_paths) = set.intersection_with_matches(&command_paths, None);
     assert_eq!(
         subset,
         PathSet::Set(["library/core", "library/alloc"].into_iter().map(TaskPath::parse).collect())
     );
-    assert_eq!(command_paths, vec![Path::new("library/stdarch")]);
+    assert_eq!(matched_paths, vec![Path::new("library/alloc"), Path::new("library/core")]);
 }
 
 #[test]


### PR DESCRIPTION
As the title suggest, this makes bootstrap add tools to sysroot after building them. This allows the tools to be used with rustup, e.g.
```shell
; x b rustfmt
; rustfmt +stage1 ./t.rs
```

Resolves #97762
Resolves #81431

-----

r? @jyn514 

I copied the implementation from the same thing with rustdoc ([link](https://github.com/rust-lang/rust/blob/503e19d01e941b88bf6d5b28e9108d046abcfa2d/src/bootstrap/tool.rs#L567-L576)), however there are some questions/problems:

1. [ ] Q: Do we need `miri` in the sysroot? It seems like the only way to run miri is throw `cargo-miri`...
2. [ ] Q: Do we need _both_ `cargo-clippy` and `clippy-driver` in the sysroot?
3. [ ] P: when building any tool, all other tools are deleted for some reason that I can't seem to grasp
     ```shell
     ; x b cargo-miri
     ; ls build/x86_64-unknown-linux-gnu/stage1/bin
     cargo-miri  rustc
     ; x b rustfmt
     ; ls build/x86_64-unknown-linux-gnu/stage1/bin
     rustc  rustfmt
     ; x b clippy
     ; ls build/x86_64-unknown-linux-gnu/stage1/bin
     clippy-driver  rustc
     ```