### PR TITLE
Add all submodules to the list of directories tidy skips

### DIFF
--- a/src/tools/tidy/src/walk.rs
+++ b/src/tools/tidy/src/walk.rs
@@ -21,6 +21,12 @@ pub fn filter_dirs(path: &Path) -> bool {
         "src/tools/rust-installer",
         "src/tools/rustfmt",
         "src/doc/book",
+        "src/doc/edition-guide",
+        "src/doc/embedded-book",
+        "src/doc/nomicon",
+        "src/doc/rust-by-example",
+        "src/doc/rustc-dev-guide",
+        "src/doc/reference",
         // Filter RLS output directories
         "target/rls",
         "src/bootstrap/target",


### PR DESCRIPTION
Tidy contains a blacklist of directories that it is not visiting. This list is also used by the `replace-version-placeholder` tool added by #100591 , to determine the directories to do its replacement from. Generally, tidy does not check submodules, but this is not done consistently for all submodules. This PR adds the submodules that were previously missing, so that the `replace-version-placeholder` tool does not attempt to change content of the books. This was needed because `rustc-dev-guide` contains the placeholder, leading to #102014.

Fixes #102014