### PR TITLE
Remove backed off PRs from relnotes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,7 +28,6 @@ Libraries
 - [Implement network primitives with ideal Rust layout, not C system layout](https://github.com/rust-lang/rust/pull/78802/)
 - [Remove restrictions on compare-exchange memory ordering.](https://github.com/rust-lang/rust/pull/98383/)
 - You can now `write!` or `writeln!` into an `OsString`: [Implement `fmt::Write` for `OsString`](https://github.com/rust-lang/rust/pull/97915/)
-- [Enforce that layout size fits in isize in Layout](https://github.com/rust-lang/rust/pull/95295/)
 - [Make RwLockReadGuard covariant](https://github.com/rust-lang/rust/pull/96820/)
 - [Implement `FusedIterator` for `std::net::[Into]Incoming`](https://github.com/rust-lang/rust/pull/97300/)
 - [`impl<T: AsRawFd> AsRawFd for {Arc,Box}<T>`](https://github.com/rust-lang/rust/pull/97437/)


### PR DESCRIPTION
Backport of https://github.com/rust-lang/rust/pull/102018/commits/7358a9b03e5d22ea4d74d89cb00d3985fc89c773 to master.