### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,7 +28,6 @@ Libraries
 - [Implement network primitives with ideal Rust layout, not C system layout](https://github.com/rust-lang/rust/pull/78802/)
 - [Remove restrictions on compare-exchange memory ordering.](https://github.com/rust-lang/rust/pull/98383/)
 - You can now `write!` or `writeln!` into an `OsString`: [Implement `fmt::Write` for `OsString`](https://github.com/rust-lang/rust/pull/97915/)
-- [Enforce that layout size fits in isize in Layout](https://github.com/rust-lang/rust/pull/95295/)
 - [Make RwLockReadGuard covariant](https://github.com/rust-lang/rust/pull/96820/)
 - [Implement `FusedIterator` for `std::net::[Into]Incoming`](https://github.com/rust-lang/rust/pull/97300/)
 - [`impl<T: AsRawFd> AsRawFd for {Arc,Box}<T>`](https://github.com/rust-lang/rust/pull/97437/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -41,25 +41,6 @@ Libraries
 Stabilized APIs
 ---------------
 
-- [`ffi::CStr`](https://doc.rust-lang.org/stable/std/ffi/struct.CStr.html)
-- [`ffi::CString`](https://doc.rust-lang.org/stable/std/ffi/struct.CString.html)
-- [`ffi::FromBytesWithNulError`](https://doc.rust-lang.org/stable/std/ffi/struct.FromBytesWithNulError.html)
-- [`ffi::FromVecWithNulError`](https://doc.rust-lang.org/stable/std/ffi/struct.FromVecWithNulError.html)
-- [`ffi::IntoStringError`](https://doc.rust-lang.org/stable/std/ffi/struct.IntoStringError.html)
-- [`ffi::NulError`](https://doc.rust-lang.org/stable/std/ffi/struct.NulError.html)
-- [`ffi::c_char`](https://doc.rust-lang.org/stable/std/ffi/type.c_char.html)
-- [`ffi::c_double`](https://doc.rust-lang.org/stable/std/ffi/type.c_double.html)
-- [`ffi::c_float`](https://doc.rust-lang.org/stable/std/ffi/type.c_float.html)
-- [`ffi::c_int`](https://doc.rust-lang.org/stable/std/ffi/type.c_int.html)
-- [`ffi::c_long`](https://doc.rust-lang.org/stable/std/ffi/type.c_long.html)
-- [`ffi::c_longlong`](https://doc.rust-lang.org/stable/std/ffi/type.c_longlong.html)
-- [`ffi::c_schar`](https://doc.rust-lang.org/stable/std/ffi/type.c_schar.html)
-- [`ffi::c_short`](https://doc.rust-lang.org/stable/std/ffi/type.c_short.html)
-- [`ffi::c_uchar`](https://doc.rust-lang.org/stable/std/ffi/type.c_uchar.html)
-- [`ffi::c_uint`](https://doc.rust-lang.org/stable/std/ffi/type.c_uint.html)
-- [`ffi::c_ulong`](https://doc.rust-lang.org/stable/std/ffi/type.c_ulong.html)
-- [`ffi::c_ulonglong`](https://doc.rust-lang.org/stable/std/ffi/type.c_ulonglong.html)
-- [`ffi::c_ushort`](https://doc.rust-lang.org/stable/std/ffi/type.c_ushort.html)
 - [`future::IntoFuture`](https://doc.rust-lang.org/stable/std/future/trait.IntoFuture.html)
 - [`future::poll_fn`](https://doc.rust-lang.org/stable/std/future/fn.poll_fn.html)
 - [`task::ready!`](https://doc.rust-lang.org/stable/std/task/macro.ready.html)
@@ -79,6 +60,31 @@ Stabilized APIs
 - [`os::unix::process::CommandExt::process_group`](https://doc.rust-lang.org/stable/std/os/unix/process/trait.CommandExt.html#tymethod.process_group)
 - [`os::windows::fs::FileTypeExt::is_symlink_dir`](https://doc.rust-lang.org/stable/std/os/windows/fs/trait.FileTypeExt.html#tymethod.is_symlink_dir)
 - [`os::windows::fs::FileTypeExt::is_symlink_file`](https://doc.rust-lang.org/stable/std/os/windows/fs/trait.FileTypeExt.html#tymethod.is_symlink_file)
+
+These types were previously stable in `std::ffi`, but are now also available in `core` and `alloc`:
+
+- [`core::ffi::CStr`](https://doc.rust-lang.org/stable/core/ffi/struct.CStr.html)
+- [`core::ffi::FromBytesWithNulError`](https://doc.rust-lang.org/stable/core/ffi/struct.FromBytesWithNulError.html)
+- [`alloc::ffi::CString`](https://doc.rust-lang.org/stable/alloc/ffi/struct.CString.html)
+- [`alloc::ffi::FromVecWithNulError`](https://doc.rust-lang.org/stable/alloc/ffi/struct.FromVecWithNulError.html)
+- [`alloc::ffi::IntoStringError`](https://doc.rust-lang.org/stable/alloc/ffi/struct.IntoStringError.html)
+- [`alloc::ffi::NulError`](https://doc.rust-lang.org/stable/alloc/ffi/struct.NulError.html)
+
+These types were previously stable in `std::os::raw`, but are now also available in `core::ffi` and `std::ffi`:
+
+- [`ffi::c_char`](https://doc.rust-lang.org/stable/std/ffi/type.c_char.html)
+- [`ffi::c_double`](https://doc.rust-lang.org/stable/std/ffi/type.c_double.html)
+- [`ffi::c_float`](https://doc.rust-lang.org/stable/std/ffi/type.c_float.html)
+- [`ffi::c_int`](https://doc.rust-lang.org/stable/std/ffi/type.c_int.html)
+- [`ffi::c_long`](https://doc.rust-lang.org/stable/std/ffi/type.c_long.html)
+- [`ffi::c_longlong`](https://doc.rust-lang.org/stable/std/ffi/type.c_longlong.html)
+- [`ffi::c_schar`](https://doc.rust-lang.org/stable/std/ffi/type.c_schar.html)
+- [`ffi::c_short`](https://doc.rust-lang.org/stable/std/ffi/type.c_short.html)
+- [`ffi::c_uchar`](https://doc.rust-lang.org/stable/std/ffi/type.c_uchar.html)
+- [`ffi::c_uint`](https://doc.rust-lang.org/stable/std/ffi/type.c_uint.html)
+- [`ffi::c_ulong`](https://doc.rust-lang.org/stable/std/ffi/type.c_ulong.html)
+- [`ffi::c_ulonglong`](https://doc.rust-lang.org/stable/std/ffi/type.c_ulonglong.html)
+- [`ffi::c_ushort`](https://doc.rust-lang.org/stable/std/ffi/type.c_ushort.html)
 
 These APIs are now usable in const contexts:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -77,30 +77,24 @@ These APIs are now usable in const contexts:
 
 Cargo
 -----
-- Packages can now inherit settings from the workspace so that the settings
-  can be centralized in one place. See
+- [Packages can now inherit settings from the workspace so that the settings
+  can be centralized in one place.](https://github.com/rust-lang/cargo/pull/10859) See
   [`workspace.package`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-workspacepackage-table)
   and
   [`workspace.dependencies`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-workspacedependencies-table)
   for more details on how to define these common settings.
-  [#10859](https://github.com/rust-lang/cargo/pull/10859)
-- Cargo commands can now accept multiple `--target` flags to build for
-  multiple targets at once, and the
+- [Cargo commands can now accept multiple `--target` flags to build for
+  multiple targets at once](https://github.com/rust-lang/cargo/pull/10766), and the
   [`build.target`](https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildtarget)
   config option may now take an array of multiple targets.
-  [#10766](https://github.com/rust-lang/cargo/pull/10766)
-- The `--jobs` argument can now take a negative number to count backwards from
-  the max CPUs.
-  [#10844](https://github.com/rust-lang/cargo/pull/10844)
-- `cargo add` will now update `Cargo.lock`.
-  [#10902](https://github.com/rust-lang/cargo/pull/10902)
-- Added the
+- [The `--jobs` argument can now take a negative number to count backwards from
+  the max CPUs.](https://github.com/rust-lang/cargo/pull/10844)
+- [`cargo add` will now update `Cargo.lock`.](https://github.com/rust-lang/cargo/pull/10902)
+- [Added](https://github.com/rust-lang/cargo/pull/10838) the
   [`--crate-type`](https://doc.rust-lang.org/nightly/cargo/commands/cargo-rustc.html#option-cargo-rustc---crate-type)
   flag to `cargo rustc` to override the crate type.
-  [#10838](https://github.com/rust-lang/cargo/pull/10838)
-- Significantly improved the performance fetching git dependencies from GitHub
-  when using a hash in the `rev` field.
-  [#10079](https://github.com/rust-lang/cargo/pull/10079)
+- [Significantly improved the performance fetching git dependencies from GitHub
+  when using a hash in the `rev` field.](https://github.com/rust-lang/cargo/pull/10079)
 
 Misc
 ----

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,10 +15,7 @@ Compiler
 - [Only compile `#[used]` as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
 - [Add the `--diagnostic-width` compiler flag to define the terminal width.](https://github.com/rust-lang/rust/pull/95635/)
 - [Fix repr(align) enum handling](https://github.com/rust-lang/rust/pull/96814/)
-- [Suggest defining variable as mutable on `&mut _` type mismatch in pats](https://github.com/rust-lang/rust/pull/98431/)
-- [Emit warning when named arguments are used positionally in format](https://github.com/rust-lang/rust/pull/98580/)
 - [Add support for link-flavor `rust-lld` for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
-- [Do not mention private types from other crates as impl candidates](https://github.com/rust-lang/rust/pull/99091/)
 
 Libraries
 ---------

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ Version 1.64.0 (2022-09-22)
 Language
 --------
 - [make `const_err` show up in future breakage reports](https://github.com/rust-lang/rust/pull/97743/)
-- [allow unions with mutable references and tuples of allowed types](https://github.com/rust-lang/rust/pull/97995/)
+- [Unions with mutable references or tuples of allowed types are now allowed](https://github.com/rust-lang/rust/pull/97995/)
 - It is now considered valid to deallocate memory pointed to by a shared reference `&T` [if every byte in `T` is inside an `UnsafeCell`](https://github.com/rust-lang/rust/pull/98017/)
 - Unused tuple struct fields are now warned against in an allow-by-default lint, [`unused_tuple_struct_fields`](https://github.com/rust-lang/rust/pull/95977/), similar to the existing warning for unused struct fields. This lint will become warn-by-default in the future.
 
@@ -15,12 +15,12 @@ Compiler
 - [Add Nintendo Switch as tier 3 target](https://github.com/rust-lang/rust/pull/88991/)
   - Refer to Rust's [platform support page][platform-support-doc] for more
     information on Rust's tiered platform support.
-- [Only compile #[used] as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
-- [sess: stabilize `-Zterminal-width` as `--diagnostic-width`](https://github.com/rust-lang/rust/pull/95635/)
+- [Only compile `#[used]` as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
+- [Add the `--diagnostic-width` compiler flag to define the terminal width.](https://github.com/rust-lang/rust/pull/95635/)
 - [Fix repr(align) enum handling](https://github.com/rust-lang/rust/pull/96814/)
 - [Suggest defining variable as mutable on `&mut _` type mismatch in pats](https://github.com/rust-lang/rust/pull/98431/)
 - [Emit warning when named arguments are used positionally in format](https://github.com/rust-lang/rust/pull/98580/)
-- [Add support for link-flavor rust-lld for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
+- [Add support for link-flavor `rust-lld` for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
 - [Do not mention private types from other crates as impl candidates](https://github.com/rust-lang/rust/pull/99091/)
 
 Libraries
@@ -32,11 +32,11 @@ Libraries
 - [Make RwLockReadGuard covariant](https://github.com/rust-lang/rust/pull/96820/)
 - [Implement `FusedIterator` for `std::net::[Into]Incoming`](https://github.com/rust-lang/rust/pull/97300/)
 - [`impl<T: AsRawFd> AsRawFd for {Arc,Box}<T>`](https://github.com/rust-lang/rust/pull/97437/)
-- [ptr::copy and ptr::swap are doing untyped copies](https://github.com/rust-lang/rust/pull/97712/)
-- [Add assertion that `transmute_copy`'s U is not larger than T](https://github.com/rust-lang/rust/pull/98839/)
+- [`ptr::copy` and `ptr::swap` are doing untyped copies](https://github.com/rust-lang/rust/pull/97712/)
+- [Add assertion that `transmute_copy`'s U is not larger than `T`](https://github.com/rust-lang/rust/pull/98839/)
 - [A soundness bug in `BTreeMap` was fixed](https://github.com/rust-lang/rust/pull/99413/) that allowed data it was borrowing to be dropped before the container.
 - [Add cgroupv1 support to `available_parallelism`](https://github.com/rust-lang/rust/pull/97925/)
-- [mem::uninitialized: mitigate many incorrect uses of this function](https://github.com/rust-lang/rust/pull/99182/)
+- [Mitigate many incorrect uses of `mem::uninitialized`](https://github.com/rust-lang/rust/pull/99182/)
 
 Stabilized APIs
 ---------------
@@ -113,13 +113,13 @@ Cargo
 
 Misc
 ----
-- [Let rust-analyzer ship on stable, non-preview](https://github.com/rust-lang/rust/pull/98640/)
+- [The `rust-analyzer` rustup component is now available on the stable channel.](https://github.com/rust-lang/rust/pull/98640/)
 
 Compatibility Notes
 -------------------
 - The minimum required versions for all `-linux-gnu` targets are now at least kernel 3.2 and glibc 2.17, for targets that previously supported older versions: [Increase the minimum linux-gnu versions](https://github.com/rust-lang/rust/pull/95026/)
-- [Implement network primitives with ideal Rust layout, not C system layout](https://github.com/rust-lang/rust/pull/78802/)
-- [Add assertion that `transmute_copy`'s U is not larger than T](https://github.com/rust-lang/rust/pull/98839/)
+- [Network primitives are now implemented with the ideal Rust layout, not the C system layout](https://github.com/rust-lang/rust/pull/78802/). This can cause problems when transmuting the types.
+- [Add assertion that `transmute_copy`'s `U` is not larger than `T`](https://github.com/rust-lang/rust/pull/98839/)
 - [A soundness bug in `BTreeMap` was fixed](https://github.com/rust-lang/rust/pull/99413/) that allowed data it was borrowing to be dropped before the container.
 - [The Drop behavior of C-like enums cast to ints has changed](https://github.com/rust-lang/rust/pull/96862/). These are already discouraged by a compiler warning.
 - [Relate late-bound closure lifetimes to parent fn in NLL](https://github.com/rust-lang/rust/pull/98835/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,6 @@ Compiler
     information on Rust's tiered platform support.
 - [Only compile `#[used]` as llvm.compiler.used for ELF targets](https://github.com/rust-lang/rust/pull/93718/)
 - [Add the `--diagnostic-width` compiler flag to define the terminal width.](https://github.com/rust-lang/rust/pull/95635/)
-- [Fix repr(align) enum handling](https://github.com/rust-lang/rust/pull/96814/)
 - [Add support for link-flavor `rust-lld` for iOS, tvOS and watchOS](https://github.com/rust-lang/rust/pull/98771/)
 
 Libraries

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,15 +3,12 @@ Version 1.64.0 (2022-09-22)
 
 Language
 --------
-- [make `const_err` show up in future breakage reports](https://github.com/rust-lang/rust/pull/97743/)
 - [Unions with mutable references or tuples of allowed types are now allowed](https://github.com/rust-lang/rust/pull/97995/)
 - It is now considered valid to deallocate memory pointed to by a shared reference `&T` [if every byte in `T` is inside an `UnsafeCell`](https://github.com/rust-lang/rust/pull/98017/)
 - Unused tuple struct fields are now warned against in an allow-by-default lint, [`unused_tuple_struct_fields`](https://github.com/rust-lang/rust/pull/95977/), similar to the existing warning for unused struct fields. This lint will become warn-by-default in the future.
 
 Compiler
 --------
-- The minimum required versions for all `-linux-gnu` targets are now at least kernel 3.2 and glibc 2.17, for targets that previously supported older versions: [Increase the minimum linux-gnu versions](https://github.com/rust-lang/rust/pull/95026/)
-- [Keep unstable target features for asm feature checking](https://github.com/rust-lang/rust/pull/99155/)
 - [Add Nintendo Switch as tier 3 target](https://github.com/rust-lang/rust/pull/88991/)
   - Refer to Rust's [platform support page][platform-support-doc] for more
     information on Rust's tiered platform support.
@@ -25,7 +22,6 @@ Compiler
 
 Libraries
 ---------
-- [Implement network primitives with ideal Rust layout, not C system layout](https://github.com/rust-lang/rust/pull/78802/)
 - [Remove restrictions on compare-exchange memory ordering.](https://github.com/rust-lang/rust/pull/98383/)
 - You can now `write!` or `writeln!` into an `OsString`: [Implement `fmt::Write` for `OsString`](https://github.com/rust-lang/rust/pull/97915/)
 - [Enforce that layout size fits in isize in Layout](https://github.com/rust-lang/rust/pull/95295/)
@@ -33,8 +29,6 @@ Libraries
 - [Implement `FusedIterator` for `std::net::[Into]Incoming`](https://github.com/rust-lang/rust/pull/97300/)
 - [`impl<T: AsRawFd> AsRawFd for {Arc,Box}<T>`](https://github.com/rust-lang/rust/pull/97437/)
 - [`ptr::copy` and `ptr::swap` are doing untyped copies](https://github.com/rust-lang/rust/pull/97712/)
-- [Add assertion that `transmute_copy`'s U is not larger than `T`](https://github.com/rust-lang/rust/pull/98839/)
-- [A soundness bug in `BTreeMap` was fixed](https://github.com/rust-lang/rust/pull/99413/) that allowed data it was borrowing to be dropped before the container.
 - [Add cgroupv1 support to `available_parallelism`](https://github.com/rust-lang/rust/pull/97925/)
 - [Mitigate many incorrect uses of `mem::uninitialized`](https://github.com/rust-lang/rust/pull/99182/)
 

--- a/compiler/rustc_middle/src/middle/resolve_lifetime.rs
+++ b/compiler/rustc_middle/src/middle/resolve_lifetime.rs
@@ -2,7 +2,7 @@
 
 use crate::ty;
 
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::ItemLocalId;
 use rustc_macros::HashStable;
@@ -50,11 +50,6 @@ pub struct ResolveLifetimes {
     /// Maps from every use of a named (not anonymous) lifetime to a
     /// `Region` describing how that region is bound
     pub defs: FxHashMap<LocalDefId, FxHashMap<ItemLocalId, Region>>,
-
-    /// Set of lifetime def ids that are late-bound; a region can
-    /// be late-bound if (a) it does NOT appear in a where-clause and
-    /// (b) it DOES appear in the arguments.
-    pub late_bound: FxHashMap<LocalDefId, FxHashSet<LocalDefId>>,
 
     pub late_bound_vars: FxHashMap<LocalDefId, FxHashMap<ItemLocalId, Vec<ty::BoundVariableKind>>>,
 }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -3129,6 +3129,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: DefId) -> CodegenFnAttrs {
                         E0535,
                         "invalid argument"
                     )
+                    .help("valid inline arguments are `always` and `never`")
                     .emit();
 
                     InlineAttr::None

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -109,6 +109,7 @@
 #![feature(core_intrinsics)]
 #![feature(const_eval_select)]
 #![feature(const_pin)]
+#![feature(const_waker)]
 #![feature(cstr_from_bytes_until_nul)]
 #![feature(dispatch_from_dyn)]
 #![cfg_attr(not(bootstrap), feature(error_generic_member_access))]

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1021,15 +1021,18 @@ impl<T: ?Sized> RefCell<T> {
 
     /// Returns a mutable reference to the underlying data.
     ///
-    /// This call borrows `RefCell` mutably (at compile-time) so there is no
-    /// need for dynamic checks.
+    /// Since this method borrows `RefCell` mutably, it is statically guaranteed
+    /// that no borrows to the underlying data exist. The dynamic checks inherent
+    /// in [`borrow_mut`] and most other methods of `RefCell` are therefor
+    /// unnecessary.
     ///
-    /// However be cautious: this method expects `self` to be mutable, which is
-    /// generally not the case when using a `RefCell`. Take a look at the
-    /// [`borrow_mut`] method instead if `self` isn't mutable.
+    /// This method can only be called if `RefCell` can be mutably borrowed,
+    /// which in general is only the case directly after the `RefCell` has
+    /// been created. In these situations, skipping the aforementioned dynamic
+    /// borrowing checks may yield better ergonomics and runtime-performance.
     ///
-    /// Also, please be aware that this method is only for special circumstances and is usually
-    /// not what you want. In case of doubt, use [`borrow_mut`] instead.
+    /// In most situations where `RefCell` is used, it can't be borrowed mutably.
+    /// Use [`borrow_mut`] to get mutable access to the underlying data then.
     ///
     /// [`borrow_mut`]: RefCell::borrow_mut()
     ///

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -145,6 +145,7 @@
 #![feature(const_default_impls)]
 #![feature(const_unicode_case_lookup)]
 #![feature(const_unsafecell_get_mut)]
+#![feature(const_waker)]
 #![feature(core_panic)]
 #![feature(duration_consts_float)]
 #![feature(maybe_uninit_uninit_array)]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -186,7 +186,7 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Create a new `Context` from a [`&Waker`](Waker).
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "none")]
+    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[must_use]
     #[inline]
     pub const fn from_waker(waker: &'a Waker) -> Self {
@@ -195,7 +195,7 @@ impl<'a> Context<'a> {
 
     /// Returns a reference to the [`Waker`] for the current task.
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "none")]
+    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[must_use]
     #[inline]
     pub const fn waker(&self) -> &'a Waker {
@@ -313,7 +313,7 @@ impl Waker {
     #[inline]
     #[must_use]
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "none")]
+    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     pub const unsafe fn from_raw(waker: RawWaker) -> Waker {
         Waker { waker }
     }

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -186,17 +186,19 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Create a new `Context` from a [`&Waker`](Waker).
     #[stable(feature = "futures_api", since = "1.36.0")]
+    #[rustc_const_unstable(feature = "const_waker", issue = "none")]
     #[must_use]
     #[inline]
-    pub fn from_waker(waker: &'a Waker) -> Self {
+    pub const fn from_waker(waker: &'a Waker) -> Self {
         Context { waker, _marker: PhantomData }
     }
 
     /// Returns a reference to the [`Waker`] for the current task.
     #[stable(feature = "futures_api", since = "1.36.0")]
+    #[rustc_const_unstable(feature = "const_waker", issue = "none")]
     #[must_use]
     #[inline]
-    pub fn waker(&self) -> &'a Waker {
+    pub const fn waker(&self) -> &'a Waker {
         &self.waker
     }
 }
@@ -311,7 +313,8 @@ impl Waker {
     #[inline]
     #[must_use]
     #[stable(feature = "futures_api", since = "1.36.0")]
-    pub unsafe fn from_raw(waker: RawWaker) -> Waker {
+    #[rustc_const_unstable(feature = "const_waker", issue = "none")]
+    pub const unsafe fn from_raw(waker: RawWaker) -> Waker {
         Waker { waker }
     }
 

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -74,6 +74,7 @@
 #![feature(iterator_try_reduce)]
 #![feature(const_mut_refs)]
 #![feature(const_pin)]
+#![feature(const_waker)]
 #![feature(never_type)]
 #![feature(unwrap_infallible)]
 #![feature(pointer_byte_offsets)]

--- a/library/core/tests/task.rs
+++ b/library/core/tests/task.rs
@@ -1,4 +1,4 @@
-use core::task::Poll;
+use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 #[test]
 fn poll_const() {
@@ -11,4 +11,19 @@ fn poll_const() {
 
     const IS_PENDING: bool = POLL.is_pending();
     assert!(IS_PENDING);
+}
+
+#[test]
+fn waker_const() {
+    const VOID_TABLE: RawWakerVTable = RawWakerVTable::new(|_| VOID_WAKER, |_| {}, |_| {}, |_| {});
+
+    const VOID_WAKER: RawWaker = RawWaker::new(&(), &VOID_TABLE);
+
+    static WAKER: Waker = unsafe { Waker::from_raw(VOID_WAKER) };
+
+    static CONTEXT: Context<'static> = Context::from_waker(&WAKER);
+
+    static WAKER_REF: &'static Waker = CONTEXT.waker();
+
+    WAKER_REF.wake_by_ref();
 }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -315,6 +315,7 @@
 #![feature(strict_provenance)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(const_maybe_uninit_uninit_array)]
+#![feature(const_waker)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1152,10 +1152,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 1rem;
 }
 
-td.summary-column {
-	width: 100%;
-}
-
 .summary {
 	padding-right: 0px;
 }

--- a/src/test/ui/invalid/invalid-inline.rs
+++ b/src/test/ui/invalid/invalid-inline.rs
@@ -1,19 +1,14 @@
 #![allow(dead_code)]
 
-#[inline(please_no)] //~ ERROR invalid argument
+#[inline(please,no)] //~ ERROR expected one argument
 fn a() {
 }
 
-#[inline(please,no)] //~ ERROR expected one argument
-fn b() {
-}
-
 #[inline()] //~ ERROR expected one argument
-fn c() {
+fn b() {
 }
 
 fn main() {
     a();
     b();
-    c();
 }

--- a/src/test/ui/invalid/invalid-inline.stderr
+++ b/src/test/ui/invalid/invalid-inline.stderr
@@ -1,22 +1,15 @@
-error[E0535]: invalid argument
-  --> $DIR/invalid-inline.rs:3:10
-   |
-LL | #[inline(please_no)]
-   |          ^^^^^^^^^
-
 error[E0534]: expected one argument
-  --> $DIR/invalid-inline.rs:7:1
+  --> $DIR/invalid-inline.rs:3:1
    |
 LL | #[inline(please,no)]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0534]: expected one argument
-  --> $DIR/invalid-inline.rs:11:1
+  --> $DIR/invalid-inline.rs:7:1
    |
 LL | #[inline()]
    | ^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0534, E0535.
-For more information about an error, try `rustc --explain E0534`.
+For more information about this error, try `rustc --explain E0534`.

--- a/src/test/ui/lexer/lex-emoji-identifiers.rs
+++ b/src/test/ui/lexer/lex-emoji-identifiers.rs
@@ -1,0 +1,17 @@
+fn invalid_emoji_usages() {
+    let arrow↔️ = "basic emoji"; //~ ERROR: identifiers cannot contain emoji
+    // FIXME
+    let planet🪐 = "basic emoji"; //~ ERROR: unknown start of token
+    // FIXME
+    let wireless🛜 = "basic emoji"; //~ ERROR: unknown start of token
+    // FIXME
+    let key1️⃣ = "keycap sequence"; //~ ERROR: unknown start of token
+                                    //~^ WARN: identifier contains uncommon Unicode codepoints
+    let flag🇺🇳 = "flag sequence"; //~ ERROR: identifiers cannot contain emoji
+    let wales🏴 = "tag sequence"; //~ ERROR: identifiers cannot contain emoji
+    let folded🙏🏿 = "modifier sequence"; //~ ERROR: identifiers cannot contain emoji
+}
+
+fn main() {
+    invalid_emoji_usages();
+}

--- a/src/test/ui/lexer/lex-emoji-identifiers.stderr
+++ b/src/test/ui/lexer/lex-emoji-identifiers.stderr
@@ -1,0 +1,52 @@
+error: unknown start of token: \u{1fa90}
+  --> $DIR/lex-emoji-identifiers.rs:4:15
+   |
+LL |     let planet🪐 = "basic emoji";
+   |               ^^
+
+error: unknown start of token: \u{1f6dc}
+  --> $DIR/lex-emoji-identifiers.rs:6:17
+   |
+LL |     let wireless🛜 = "basic emoji";
+   |                 ^^
+
+error: unknown start of token: \u{20e3}
+  --> $DIR/lex-emoji-identifiers.rs:8:14
+   |
+LL |     let key1️⃣ = "keycap sequence";
+   |             ^
+
+error: identifiers cannot contain emoji: `arrow↔️`
+  --> $DIR/lex-emoji-identifiers.rs:2:9
+   |
+LL |     let arrow↔️ = "basic emoji";
+   |         ^^^^^^
+
+error: identifiers cannot contain emoji: `flag🇺🇳`
+  --> $DIR/lex-emoji-identifiers.rs:10:9
+   |
+LL |     let flag🇺🇳 = "flag sequence";
+   |         ^^^^^^
+
+error: identifiers cannot contain emoji: `wales🏴`
+  --> $DIR/lex-emoji-identifiers.rs:11:9
+   |
+LL |     let wales🏴 = "tag sequence";
+   |         ^^^^^^^
+
+error: identifiers cannot contain emoji: `folded🙏🏿`
+  --> $DIR/lex-emoji-identifiers.rs:12:9
+   |
+LL |     let folded🙏🏿 = "modifier sequence";
+   |         ^^^^^^^^^^
+
+warning: identifier contains uncommon Unicode codepoints
+  --> $DIR/lex-emoji-identifiers.rs:8:9
+   |
+LL |     let key1️⃣ = "keycap sequence";
+   |         ^^^^
+   |
+   = note: `#[warn(uncommon_codepoints)]` on by default
+
+error: aborting due to 7 previous errors; 1 warning emitted
+

--- a/src/test/ui/span/E0535.stderr
+++ b/src/test/ui/span/E0535.stderr
@@ -3,6 +3,8 @@ error[E0535]: invalid argument
    |
 LL | #[inline(unknown)]
    |          ^^^^^^^
+   |
+   = help: valid inline arguments are `always` and `never`
 
 error: aborting due to previous error
 

--- a/src/tools/tidy/src/walk.rs
+++ b/src/tools/tidy/src/walk.rs
@@ -21,6 +21,12 @@ pub fn filter_dirs(path: &Path) -> bool {
         "src/tools/rust-installer",
         "src/tools/rustfmt",
         "src/doc/book",
+        "src/doc/edition-guide",
+        "src/doc/embedded-book",
+        "src/doc/nomicon",
+        "src/doc/rust-by-example",
+        "src/doc/rustc-dev-guide",
+        "src/doc/reference",
         // Filter RLS output directories
         "target/rls",
         "src/bootstrap/target",


### PR DESCRIPTION
Successful merges:

 - #101389 (Tone down explanation on RefCell::get_mut)
 - #101798 (Make `from_waker`, `waker` and `from_raw` unstably `const`)
 - #101881 (Remove an unused struct field `late_bound`)
 - #101904 (Add help for invalid inline argument)
 - #101966 (Add unit test for identifier Unicode emoji diagnostics)
 - #101979 (Update release notes for 1.64)
 - #101985 (interpret: expose generate_stacktrace without full InterpCx)
 - #102004 (Try to clarify what's new in 1.64.0 ffi types)
 - #102005 (rustdoc: remove unused CSS `td.summary-column`)
 - #102017 (Add all submodules to the list of directories tidy skips)
 - #102019 (Remove backed off PRs from relnotes)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101389,101798,101881,101904,101966,101979,101985,102004,102005,102017,102019)
<!-- homu-ignore:end -->