### PR TITLE
Adding ignore fuchsia tests for Backtrace, ErrorKind cases

### DIFF
--- a/src/test/ui/backtrace.rs
+++ b/src/test/ui/backtrace.rs
@@ -4,6 +4,7 @@
 // ignore-openbsd no support for libbacktrace without filename
 // ignore-sgx no processes
 // ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
+// ignore-fuchsia Backtraces not symbolized
 // compile-flags:-g
 // compile-flags:-Cstrip=none
 

--- a/src/test/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
+++ b/src/test/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:22:5
+thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:23:5
 stack backtrace:
    0: std::panicking::begin_panic
    1: issue_47429_short_backtraces::main

--- a/src/test/ui/panics/issue-47429-short-backtraces.rs
+++ b/src/test/ui/panics/issue-47429-short-backtraces.rs
@@ -12,6 +12,7 @@
 // ignore-wasm no panic or subprocess support
 // ignore-emscripten no panic or subprocess support
 // ignore-sgx no subprocess support
+// ignore-fuchsia Backtraces not symbolized
 
 // NOTE(eddyb) output differs between symbol mangling schemes
 // revisions: legacy v0

--- a/src/test/ui/panics/issue-47429-short-backtraces.v0.run.stderr
+++ b/src/test/ui/panics/issue-47429-short-backtraces.v0.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:22:5
+thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:23:5
 stack backtrace:
    0: std::panicking::begin_panic::<&str>
    1: issue_47429_short_backtraces::main

--- a/src/test/ui/panics/runtime-switch.legacy.run.stderr
+++ b/src/test/ui/panics/runtime-switch.legacy.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:25:5
+thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:26:5
 stack backtrace:
    0: std::panicking::begin_panic
    1: runtime_switch::main

--- a/src/test/ui/panics/runtime-switch.rs
+++ b/src/test/ui/panics/runtime-switch.rs
@@ -12,6 +12,7 @@
 // ignore-wasm no panic or subprocess support
 // ignore-emscripten no panic or subprocess support
 // ignore-sgx no subprocess support
+// ignore-fuchsia Backtrace not symbolized
 
 // NOTE(eddyb) output differs between symbol mangling schemes
 // revisions: legacy v0

--- a/src/test/ui/panics/runtime-switch.v0.run.stderr
+++ b/src/test/ui/panics/runtime-switch.v0.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:25:5
+thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:26:5
 stack backtrace:
    0: std::panicking::begin_panic::<&str>
    1: runtime_switch::main

--- a/src/test/ui/process/process-spawn-nonexistent.rs
+++ b/src/test/ui/process/process-spawn-nonexistent.rs
@@ -1,6 +1,7 @@
 // run-pass
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-fuchsia ErrorKind not translated
 
 use std::io::ErrorKind;
 use std::process::Command;

--- a/src/test/ui/runtime/backtrace-debuginfo.rs
+++ b/src/test/ui/runtime/backtrace-debuginfo.rs
@@ -12,6 +12,7 @@
 // ignore-pretty issue #37195
 // ignore-emscripten spawning processes is not supported
 // ignore-sgx no processes
+// ignore-fuchsia Backtrace not symbolized, trace different line alignment
 
 use std::env;
 

--- a/src/test/ui/std-backtrace.rs
+++ b/src/test/ui/std-backtrace.rs
@@ -4,6 +4,7 @@
 // ignore-openbsd no support for libbacktrace without filename
 // ignore-sgx no processes
 // ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
+// ignore-fuchsia Backtraces not symbolized
 // compile-flags:-g
 // compile-flags:-Cstrip=none
 


### PR DESCRIPTION
Tests where Backtrace parses are required (invalid since Fuchsia backtraces are not symbolized), and test where ErrorKind is not properly translated from a Fuchsia-style to Unix-style error code

cc. @djkoloski 

r? @tmandry 