### PR TITLE
Adding ignore fuchsia tests for signal interpretation cases

### DIFF
--- a/src/test/ui/abi/segfault-no-out-of-stack.rs
+++ b/src/test/ui/abi/segfault-no-out-of-stack.rs
@@ -3,6 +3,7 @@
 #![allow(unused_imports)]
 // ignore-emscripten can't run commands
 // ignore-sgx no processes
+// ignore-fuchsia must translate zircon signal to SIGSEGV/SIGBUS, FIXME (#58590)
 #![feature(rustc_private)]
 
 extern crate libc;

--- a/src/test/ui/abi/stack-probes-lto.rs
+++ b/src/test/ui/abi/stack-probes-lto.rs
@@ -12,6 +12,7 @@
 // ignore-sgx no processes
 // ignore-musl FIXME #31506
 // ignore-pretty
+// ignore-fuchsia no exception handler registered for segfault
 // compile-flags: -C lto
 // no-prefer-dynamic
 

--- a/src/test/ui/abi/stack-probes.rs
+++ b/src/test/ui/abi/stack-probes.rs
@@ -10,6 +10,7 @@
 // ignore-wasm
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-fuchsia no exception handler registered for segfault
 
 use std::env;
 use std::mem::MaybeUninit;

--- a/src/test/ui/process/signal-exit-status.rs
+++ b/src/test/ui/process/signal-exit-status.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-windows
+// ignore-fuchsia code returned as ZX_TASK_RETCODE_EXCEPTION_KILL, FIXME (#58590)
 
 use std::env;
 use std::process::Command;

--- a/src/test/ui/runtime/out-of-stack.rs
+++ b/src/test/ui/runtime/out-of-stack.rs
@@ -5,6 +5,7 @@
 // ignore-android: FIXME (#20004)
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-fuchsia must translate zircon signal to SIGABRT, FIXME (#58590)
 
 #![feature(core_intrinsics)]
 #![feature(rustc_private)]


### PR DESCRIPTION
Tests where Signal interpreting is required. Since Fuchsia currently does not return signals of type `libc::SIGSEGV` etc., instead, use generalized `!status.success()` case.

cc. @djkoloski

r? @tmandry