### PR TITLE
Adding needs-unwind to nicer-assert-messages compiler ui tests

### DIFF
--- a/src/test/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
+++ b/src/test/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
@@ -2,6 +2,7 @@
 // ignore-tidy-linelength
 // only-x86_64
 // run-pass
+// needs-unwind Asserting on contents of error message
 
 #![allow(path_statements, unused_allocation)]
 #![feature(box_syntax, core_intrinsics, generic_assert, generic_assert_internals)]

--- a/src/test/ui/macros/rfc-2011-nicer-assert-messages/all-not-available-cases.rs
+++ b/src/test/ui/macros/rfc-2011-nicer-assert-messages/all-not-available-cases.rs
@@ -2,6 +2,7 @@
 // ignore-tidy-linelength
 // only-x86_64
 // run-pass
+// needs-unwind Asserting on contents of error message
 
 #![feature(core_intrinsics, generic_assert, generic_assert_internals)]
 

--- a/src/test/ui/macros/rfc-2011-nicer-assert-messages/assert-without-captures-does-not-create-unnecessary-code.rs
+++ b/src/test/ui/macros/rfc-2011-nicer-assert-messages/assert-without-captures-does-not-create-unnecessary-code.rs
@@ -1,6 +1,7 @@
 // aux-build:common.rs
 // only-x86_64
 // run-pass
+// needs-unwind Asserting on contents of error message
 
 #![feature(core_intrinsics, generic_assert, generic_assert_internals)]
 


### PR DESCRIPTION
Tests where unwind is required for asserting on contents of error message

cc. @djkoloski

r? @tmandry