### PR TITLE
rustdoc: remove no-op CSS `h1-6 { border-bottom-color }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -141,10 +141,6 @@ h1, h2, h3, h4 {
 h1.fqn {
 	margin: 0;
 	padding: 0;
-	border-bottom-color: var(--headings-border-bottom-color);
-}
-h2, h3, h4 {
-	border-bottom-color: var(--headings-border-bottom-color);
 }
 .main-heading {
 	display: flex;
@@ -662,9 +658,6 @@ h2.location a {
 
 .docblock h5 { font-size: 1rem; }
 .docblock h6 { font-size: 0.875rem; }
-.docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5, .docblock h6 {
-	border-bottom-color: var(--headings-border-bottom-color);
-}
 
 .docblock {
 	margin-left: 24px;

--- a/src/test/rustdoc-gui/docblock-details.goml
+++ b/src/test/rustdoc-gui/docblock-details.goml
@@ -14,7 +14,7 @@ assert-css: (
 // We now check that the `<summary>` doesn't have a bottom border and has the correct display.
 assert-css: (
     ".top-doc .docblock summary h4",
-    {"border-bottom": "0px none rgb(210, 210, 210)"},
+    {"border-bottom-width": "0px"},
 )
 // This allows to ensure that summary is on one line only!
 assert-property: (".top-doc .docblock summary h4", {"offsetHeight": "33"})

--- a/src/test/rustdoc-gui/headings.goml
+++ b/src/test/rustdoc-gui/headings.goml
@@ -168,19 +168,19 @@ assert-css: (
 )
 assert-css: (
     ".top-doc .docblock h5",
-    {"color": "rgb(0, 0, 0)", "border-bottom": "0px none rgb(221, 221, 221)"},
+    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h4",
-    {"color": "rgb(0, 0, 0)", "border-bottom": "0px none rgb(221, 221, 221)"},
+    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h5",
-    {"color": "rgb(0, 0, 0)", "border-bottom": "0px none rgb(221, 221, 221)"},
+    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h6",
-    {"color": "rgb(0, 0, 0)", "border-bottom": "0px none rgb(221, 221, 221)"},
+    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
 )
 
 local-storage: {"rustdoc-theme": "dark"}
@@ -199,19 +199,19 @@ assert-css: (
 )
 assert-css: (
     ".top-doc .docblock h5",
-    {"color": "rgb(221, 221, 221)", "border-bottom": "0px none rgb(210, 210, 210)"},
+    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h4",
-    {"color": "rgb(221, 221, 221)", "border-bottom": "0px none rgb(210, 210, 210)"},
+    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h5",
-    {"color": "rgb(221, 221, 221)", "border-bottom": "0px none rgb(210, 210, 210)"},
+    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h6",
-    {"color": "rgb(221, 221, 221)", "border-bottom": "0px none rgb(210, 210, 210)"},
+    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
 )
 
 local-storage: {"rustdoc-theme": "ayu"}
@@ -230,19 +230,19 @@ assert-css: (
 )
 assert-css: (
     ".top-doc .docblock h5",
-    {"color": "rgb(197, 197, 197)", "border-bottom": "0px none rgb(92, 103, 115)"},
+    {"color": "rgb(197, 197, 197)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h4",
-    {"color": "rgb(255, 255, 255)", "border-bottom": "0px none rgb(92, 103, 115)"},
+    {"color": "rgb(255, 255, 255)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h5",
-    {"color": "rgb(197, 197, 197)", "border-bottom": "0px none rgb(92, 103, 115)"},
+    {"color": "rgb(197, 197, 197)", "border-bottom-width": "0px"},
 )
 assert-css: (
     "#implementations-list .docblock h6",
-    {"color": "rgb(197, 197, 197)", "border-bottom": "0px none rgb(92, 103, 115)"},
+    {"color": "rgb(197, 197, 197)", "border-bottom-width": "0px"},
 )
 
 local-storage: {"rustdoc-theme": "light"}


### PR DESCRIPTION
For this rule to have an actual effect, the border-bottom width needs specified, elsewhere, without also specifying the color. This doesn't happen. Ever since 88b137d5fe0cbe28dab4f9af61045c726f831872, every spot where headers get a border assigned to them also assigns the color.

Preview: https://notriddle.com/notriddle-rustdoc-test/border-bottom/rustc_monomorphize/collector/index.html