### PR TITLE
Tell rustc about unused bits in Span.

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3040,19 +3040,19 @@ mod size_asserts {
     use super::*;
     use rustc_data_structures::static_assert_size;
     // tidy-alphabetical-start
-    static_assert_size!(AssocItem, 104);
-    static_assert_size!(AssocItemKind, 32);
+    static_assert_size!(AssocItem, 96);
+    static_assert_size!(AssocItemKind, 24);
     static_assert_size!(Attribute, 32);
     static_assert_size!(Block, 48);
     static_assert_size!(Expr, 104);
     static_assert_size!(ExprKind, 72);
-    static_assert_size!(Fn, 184);
+    static_assert_size!(Fn, 168);
     static_assert_size!(ForeignItem, 96);
     static_assert_size!(ForeignItemKind, 24);
     static_assert_size!(GenericArg, 24);
     static_assert_size!(GenericBound, 88);
     static_assert_size!(Generics, 72);
-    static_assert_size!(Impl, 200);
+    static_assert_size!(Impl, 184);
     static_assert_size!(Item, 184);
     static_assert_size!(ItemKind, 112);
     static_assert_size!(Lit, 48);
@@ -3065,7 +3065,7 @@ mod size_asserts {
     static_assert_size!(PatKind, 96);
     static_assert_size!(Stmt, 32);
     static_assert_size!(StmtKind, 16);
-    static_assert_size!(Ty, 96);
-    static_assert_size!(TyKind, 72);
+    static_assert_size!(Ty, 88);
+    static_assert_size!(TyKind, 64);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3517,20 +3517,20 @@ mod size_asserts {
     // tidy-alphabetical-start
     static_assert_size!(Block<'_>, 48);
     static_assert_size!(Body<'_>, 32);
-    static_assert_size!(Expr<'_>, 64);
-    static_assert_size!(ExprKind<'_>, 48);
+    static_assert_size!(Expr<'_>, 56);
+    static_assert_size!(ExprKind<'_>, 40);
     static_assert_size!(FnDecl<'_>, 40);
     static_assert_size!(ForeignItem<'_>, 72);
     static_assert_size!(ForeignItemKind<'_>, 40);
     static_assert_size!(GenericArg<'_>, 24);
     static_assert_size!(GenericBound<'_>, 48);
     static_assert_size!(Generics<'_>, 56);
-    static_assert_size!(Impl<'_>, 80);
+    static_assert_size!(Impl<'_>, 72);
     static_assert_size!(ImplItem<'_>, 80);
     static_assert_size!(ImplItemKind<'_>, 32);
     static_assert_size!(Item<'_>, 80);
     static_assert_size!(ItemKind<'_>, 48);
-    static_assert_size!(Local<'_>, 64);
+    static_assert_size!(Local<'_>, 56);
     static_assert_size!(Param<'_>, 32);
     static_assert_size!(Pat<'_>, 72);
     static_assert_size!(Path<'_>, 40);
@@ -3540,8 +3540,8 @@ mod size_asserts {
     static_assert_size!(Res, 12);
     static_assert_size!(Stmt<'_>, 32);
     static_assert_size!(StmtKind<'_>, 16);
-    static_assert_size!(TraitItem<'_>, 88);
-    static_assert_size!(TraitItemKind<'_>, 48);
+    static_assert_size!(TraitItem<'_>, 80);
+    static_assert_size!(TraitItemKind<'_>, 40);
     static_assert_size!(Ty<'_>, 48);
     static_assert_size!(TyKind<'_>, 32);
     // tidy-alphabetical-end

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -156,7 +156,7 @@ pub struct Parser<'a> {
 // This type is used a lot, e.g. it's cloned when matching many declarative macro rules. Make sure
 // it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Parser<'_>, 328);
+rustc_data_structures::static_assert_size!(Parser<'_>, 320);
 
 /// Stores span information about a closure.
 #[derive(Clone)]

--- a/src/test/ui/stats/hir-stats.stderr
+++ b/src/test/ui/stats/hir-stats.stderr
@@ -6,114 +6,114 @@ ast-stats-1 Crate                     56 ( 0.7%)             1            56
 ast-stats-1 Attribute                 64 ( 0.8%)             2            32
 ast-stats-1 - Normal                    32 ( 0.4%)             1
 ast-stats-1 - DocComment                32 ( 0.4%)             1
+ast-stats-1 WherePredicate            64 ( 0.8%)             1            64
+ast-stats-1 - BoundPredicate            64 ( 0.8%)             1
 ast-stats-1 GenericArgs               64 ( 0.8%)             1            64
 ast-stats-1 - AngleBracketed            64 ( 0.8%)             1
 ast-stats-1 Local                     72 ( 0.9%)             1            72
-ast-stats-1 WherePredicate            72 ( 0.9%)             1            72
-ast-stats-1 - BoundPredicate            72 ( 0.9%)             1
-ast-stats-1 Arm                       96 ( 1.1%)             2            48
-ast-stats-1 ForeignItem               96 ( 1.1%)             1            96
-ast-stats-1 - Fn                        96 ( 1.1%)             1
+ast-stats-1 Arm                       96 ( 1.2%)             2            48
+ast-stats-1 ForeignItem               96 ( 1.2%)             1            96
+ast-stats-1 - Fn                        96 ( 1.2%)             1
 ast-stats-1 FieldDef                 160 ( 1.9%)             2            80
 ast-stats-1 Stmt                     160 ( 1.9%)             5            32
 ast-stats-1 - Local                     32 ( 0.4%)             1
 ast-stats-1 - MacCall                   32 ( 0.4%)             1
-ast-stats-1 - Expr                      96 ( 1.1%)             3
+ast-stats-1 - Expr                      96 ( 1.2%)             3
 ast-stats-1 Param                    160 ( 1.9%)             4            40
 ast-stats-1 FnDecl                   200 ( 2.4%)             5            40
 ast-stats-1 Variant                  240 ( 2.9%)             2           120
-ast-stats-1 Block                    288 ( 3.4%)             6            48
-ast-stats-1 GenericBound             352 ( 4.2%)             4            88
-ast-stats-1 - Trait                    352 ( 4.2%)             4
-ast-stats-1 AssocItem                416 ( 4.9%)             4           104
-ast-stats-1 - Type                     208 ( 2.5%)             2
-ast-stats-1 - Fn                       208 ( 2.5%)             2
-ast-stats-1 GenericParam             480 ( 5.7%)             5            96
-ast-stats-1 PathSegment              720 ( 8.6%)            30            24
-ast-stats-1 Expr                     832 ( 9.9%)             8           104
-ast-stats-1 - Path                     104 ( 1.2%)             1
-ast-stats-1 - Match                    104 ( 1.2%)             1
-ast-stats-1 - Struct                   104 ( 1.2%)             1
+ast-stats-1 Block                    288 ( 3.5%)             6            48
+ast-stats-1 GenericBound             352 ( 4.3%)             4            88
+ast-stats-1 - Trait                    352 ( 4.3%)             4
+ast-stats-1 AssocItem                384 ( 4.6%)             4            96
+ast-stats-1 - Type                     192 ( 2.3%)             2
+ast-stats-1 - Fn                       192 ( 2.3%)             2
+ast-stats-1 GenericParam             480 ( 5.8%)             5            96
+ast-stats-1 PathSegment              720 ( 8.7%)            30            24
+ast-stats-1 Expr                     832 (10.1%)             8           104
+ast-stats-1 - Path                     104 ( 1.3%)             1
+ast-stats-1 - Match                    104 ( 1.3%)             1
+ast-stats-1 - Struct                   104 ( 1.3%)             1
 ast-stats-1 - Lit                      208 ( 2.5%)             2
-ast-stats-1 - Block                    312 ( 3.7%)             3
-ast-stats-1 Pat                      840 (10.0%)             7           120
-ast-stats-1 - Struct                   120 ( 1.4%)             1
-ast-stats-1 - Wild                     120 ( 1.4%)             1
-ast-stats-1 - Ident                    600 ( 7.1%)             5
-ast-stats-1 Ty                     1_344 (16.0%)            14            96
-ast-stats-1 - Rptr                      96 ( 1.1%)             1
-ast-stats-1 - Ptr                       96 ( 1.1%)             1
-ast-stats-1 - ImplicitSelf             192 ( 2.3%)             2
-ast-stats-1 - Path                     960 (11.4%)            10
-ast-stats-1 Item                   1_656 (19.7%)             9           184
+ast-stats-1 - Block                    312 ( 3.8%)             3
+ast-stats-1 Pat                      840 (10.2%)             7           120
+ast-stats-1 - Struct                   120 ( 1.5%)             1
+ast-stats-1 - Wild                     120 ( 1.5%)             1
+ast-stats-1 - Ident                    600 ( 7.3%)             5
+ast-stats-1 Ty                     1_232 (14.9%)            14            88
+ast-stats-1 - Rptr                      88 ( 1.1%)             1
+ast-stats-1 - Ptr                       88 ( 1.1%)             1
+ast-stats-1 - ImplicitSelf             176 ( 2.1%)             2
+ast-stats-1 - Path                     880 (10.6%)            10
+ast-stats-1 Item                   1_656 (20.0%)             9           184
 ast-stats-1 - Trait                    184 ( 2.2%)             1
 ast-stats-1 - Enum                     184 ( 2.2%)             1
 ast-stats-1 - ForeignMod               184 ( 2.2%)             1
 ast-stats-1 - Impl                     184 ( 2.2%)             1
-ast-stats-1 - Fn                       368 ( 4.4%)             2
-ast-stats-1 - Use                      552 ( 6.6%)             3
+ast-stats-1 - Fn                       368 ( 4.5%)             2
+ast-stats-1 - Use                      552 ( 6.7%)             3
 ast-stats-1 ----------------------------------------------------------------
-ast-stats-1 Total                  8_416
+ast-stats-1 Total                  8_264
 ast-stats-1
 ast-stats-2 POST EXPANSION AST STATS
 ast-stats-2 Name                Accumulated Size         Count     Item Size
 ast-stats-2 ----------------------------------------------------------------
 ast-stats-2 ExprField                 48 ( 0.5%)             1            48
 ast-stats-2 Crate                     56 ( 0.6%)             1            56
+ast-stats-2 WherePredicate            64 ( 0.7%)             1            64
+ast-stats-2 - BoundPredicate            64 ( 0.7%)             1
 ast-stats-2 GenericArgs               64 ( 0.7%)             1            64
 ast-stats-2 - AngleBracketed            64 ( 0.7%)             1
 ast-stats-2 Local                     72 ( 0.8%)             1            72
-ast-stats-2 WherePredicate            72 ( 0.8%)             1            72
-ast-stats-2 - BoundPredicate            72 ( 0.8%)             1
-ast-stats-2 Arm                       96 ( 1.0%)             2            48
-ast-stats-2 ForeignItem               96 ( 1.0%)             1            96
-ast-stats-2 - Fn                        96 ( 1.0%)             1
+ast-stats-2 Arm                       96 ( 1.1%)             2            48
+ast-stats-2 ForeignItem               96 ( 1.1%)             1            96
+ast-stats-2 - Fn                        96 ( 1.1%)             1
 ast-stats-2 InlineAsm                120 ( 1.3%)             1           120
 ast-stats-2 Attribute                128 ( 1.4%)             4            32
-ast-stats-2 - DocComment                32 ( 0.3%)             1
-ast-stats-2 - Normal                    96 ( 1.0%)             3
-ast-stats-2 FieldDef                 160 ( 1.7%)             2            80
-ast-stats-2 Stmt                     160 ( 1.7%)             5            32
-ast-stats-2 - Local                     32 ( 0.3%)             1
-ast-stats-2 - Semi                      32 ( 0.3%)             1
-ast-stats-2 - Expr                      96 ( 1.0%)             3
-ast-stats-2 Param                    160 ( 1.7%)             4            40
+ast-stats-2 - DocComment                32 ( 0.4%)             1
+ast-stats-2 - Normal                    96 ( 1.1%)             3
+ast-stats-2 FieldDef                 160 ( 1.8%)             2            80
+ast-stats-2 Stmt                     160 ( 1.8%)             5            32
+ast-stats-2 - Local                     32 ( 0.4%)             1
+ast-stats-2 - Semi                      32 ( 0.4%)             1
+ast-stats-2 - Expr                      96 ( 1.1%)             3
+ast-stats-2 Param                    160 ( 1.8%)             4            40
 ast-stats-2 FnDecl                   200 ( 2.2%)             5            40
-ast-stats-2 Variant                  240 ( 2.6%)             2           120
-ast-stats-2 Block                    288 ( 3.1%)             6            48
-ast-stats-2 GenericBound             352 ( 3.8%)             4            88
-ast-stats-2 - Trait                    352 ( 3.8%)             4
-ast-stats-2 AssocItem                416 ( 4.5%)             4           104
-ast-stats-2 - Type                     208 ( 2.3%)             2
-ast-stats-2 - Fn                       208 ( 2.3%)             2
-ast-stats-2 GenericParam             480 ( 5.2%)             5            96
-ast-stats-2 PathSegment              792 ( 8.7%)            33            24
-ast-stats-2 Pat                      840 ( 9.2%)             7           120
+ast-stats-2 Variant                  240 ( 2.7%)             2           120
+ast-stats-2 Block                    288 ( 3.2%)             6            48
+ast-stats-2 GenericBound             352 ( 3.9%)             4            88
+ast-stats-2 - Trait                    352 ( 3.9%)             4
+ast-stats-2 AssocItem                384 ( 4.3%)             4            96
+ast-stats-2 - Type                     192 ( 2.1%)             2
+ast-stats-2 - Fn                       192 ( 2.1%)             2
+ast-stats-2 GenericParam             480 ( 5.3%)             5            96
+ast-stats-2 PathSegment              792 ( 8.8%)            33            24
+ast-stats-2 Pat                      840 ( 9.3%)             7           120
 ast-stats-2 - Struct                   120 ( 1.3%)             1
 ast-stats-2 - Wild                     120 ( 1.3%)             1
-ast-stats-2 - Ident                    600 ( 6.6%)             5
-ast-stats-2 Expr                     936 (10.2%)             9           104
-ast-stats-2 - Path                     104 ( 1.1%)             1
-ast-stats-2 - Match                    104 ( 1.1%)             1
-ast-stats-2 - Struct                   104 ( 1.1%)             1
-ast-stats-2 - InlineAsm                104 ( 1.1%)             1
+ast-stats-2 - Ident                    600 ( 6.7%)             5
+ast-stats-2 Expr                     936 (10.4%)             9           104
+ast-stats-2 - Path                     104 ( 1.2%)             1
+ast-stats-2 - Match                    104 ( 1.2%)             1
+ast-stats-2 - Struct                   104 ( 1.2%)             1
+ast-stats-2 - InlineAsm                104 ( 1.2%)             1
 ast-stats-2 - Lit                      208 ( 2.3%)             2
-ast-stats-2 - Block                    312 ( 3.4%)             3
-ast-stats-2 Ty                     1_344 (14.7%)            14            96
-ast-stats-2 - Rptr                      96 ( 1.0%)             1
-ast-stats-2 - Ptr                       96 ( 1.0%)             1
-ast-stats-2 - ImplicitSelf             192 ( 2.1%)             2
-ast-stats-2 - Path                     960 (10.5%)            10
-ast-stats-2 Item                   2_024 (22.1%)            11           184
+ast-stats-2 - Block                    312 ( 3.5%)             3
+ast-stats-2 Ty                     1_232 (13.7%)            14            88
+ast-stats-2 - Rptr                      88 ( 1.0%)             1
+ast-stats-2 - Ptr                       88 ( 1.0%)             1
+ast-stats-2 - ImplicitSelf             176 ( 2.0%)             2
+ast-stats-2 - Path                     880 ( 9.8%)            10
+ast-stats-2 Item                   2_024 (22.5%)            11           184
 ast-stats-2 - Trait                    184 ( 2.0%)             1
 ast-stats-2 - Enum                     184 ( 2.0%)             1
 ast-stats-2 - ExternCrate              184 ( 2.0%)             1
 ast-stats-2 - ForeignMod               184 ( 2.0%)             1
 ast-stats-2 - Impl                     184 ( 2.0%)             1
-ast-stats-2 - Fn                       368 ( 4.0%)             2
-ast-stats-2 - Use                      736 ( 8.0%)             4
+ast-stats-2 - Fn                       368 ( 4.1%)             2
+ast-stats-2 - Use                      736 ( 8.2%)             4
 ast-stats-2 ----------------------------------------------------------------
-ast-stats-2 Total                  9_144
+ast-stats-2 Total                  8_992
 ast-stats-2
 hir-stats HIR STATS
 hir-stats Name                Accumulated Size         Count     Item Size
@@ -122,8 +122,8 @@ hir-stats ForeignItemRef            24 ( 0.3%)             1            24
 hir-stats Lifetime                  32 ( 0.4%)             1            32
 hir-stats Mod                       32 ( 0.4%)             1            32
 hir-stats ExprField                 40 ( 0.4%)             1            40
+hir-stats Local                     56 ( 0.6%)             1            56
 hir-stats TraitItemRef              56 ( 0.6%)             2            28
-hir-stats Local                     64 ( 0.7%)             1            64
 hir-stats Param                     64 ( 0.7%)             2            32
 hir-stats InlineAsm                 72 ( 0.8%)             1            72
 hir-stats ImplItemRef               72 ( 0.8%)             2            36
@@ -146,33 +146,33 @@ hir-stats - Trait                    192 ( 2.1%)             4
 hir-stats WherePredicate           192 ( 2.1%)             3            64
 hir-stats - BoundPredicate           192 ( 2.1%)             3
 hir-stats Block                    288 ( 3.2%)             6            48
-hir-stats Pat                      360 ( 3.9%)             5            72
+hir-stats GenericParam             360 ( 4.0%)             5            72
+hir-stats Pat                      360 ( 4.0%)             5            72
 hir-stats - Wild                      72 ( 0.8%)             1
 hir-stats - Struct                    72 ( 0.8%)             1
 hir-stats - Binding                  216 ( 2.4%)             3
-hir-stats GenericParam             400 ( 4.4%)             5            80
-hir-stats Generics                 560 ( 6.1%)            10            56
-hir-stats Ty                       720 ( 7.9%)            15            48
+hir-stats Generics                 560 ( 6.2%)            10            56
+hir-stats Expr                     672 ( 7.5%)            12            56
+hir-stats - Path                      56 ( 0.6%)             1
+hir-stats - Struct                    56 ( 0.6%)             1
+hir-stats - Match                     56 ( 0.6%)             1
+hir-stats - InlineAsm                 56 ( 0.6%)             1
+hir-stats - Lit                      112 ( 1.2%)             2
+hir-stats - Block                    336 ( 3.7%)             6
+hir-stats Ty                       720 ( 8.0%)            15            48
 hir-stats - Ptr                       48 ( 0.5%)             1
 hir-stats - Rptr                      48 ( 0.5%)             1
-hir-stats - Path                     624 ( 6.8%)            13
-hir-stats Expr                     768 ( 8.4%)            12            64
-hir-stats - Path                      64 ( 0.7%)             1
-hir-stats - Struct                    64 ( 0.7%)             1
-hir-stats - Match                     64 ( 0.7%)             1
-hir-stats - InlineAsm                 64 ( 0.7%)             1
-hir-stats - Lit                      128 ( 1.4%)             2
-hir-stats - Block                    384 ( 4.2%)             6
-hir-stats Item                     960 (10.5%)            12            80
+hir-stats - Path                     624 ( 6.9%)            13
+hir-stats Item                     960 (10.7%)            12            80
 hir-stats - Trait                     80 ( 0.9%)             1
 hir-stats - Enum                      80 ( 0.9%)             1
 hir-stats - ExternCrate               80 ( 0.9%)             1
 hir-stats - ForeignMod                80 ( 0.9%)             1
 hir-stats - Impl                      80 ( 0.9%)             1
 hir-stats - Fn                       160 ( 1.8%)             2
-hir-stats - Use                      400 ( 4.4%)             5
-hir-stats Path                   1_280 (14.0%)            32            40
-hir-stats PathSegment            1_920 (21.0%)            40            48
+hir-stats - Use                      400 ( 4.5%)             5
+hir-stats Path                   1_280 (14.2%)            32            40
+hir-stats PathSegment            1_920 (21.4%)            40            48
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  9_128
+hir-stats Total                  8_984
 hir-stats


### PR DESCRIPTION
This shrinks the size of `Option<Span>` and similar types, which shrinks several AST and HIR nodes. The most important of these are `hir::Expr` and `ast::Ty`.

This change was first attempted in #93747 where it had little effect. But the improved niche-filling implemented by #94075 means this change now has a much bigger effect.

r? @cjgillot 