### PR TITLE
Make the `normalize-overflow` rustdoc test actually do something

### DIFF
--- a/src/test/rustdoc-ui/normalize-overflow.rs
+++ b/src/test/rustdoc-ui/normalize-overflow.rs
@@ -1,3 +1,5 @@
 // aux-crate:overflow=overflow.rs
 // check-pass
 // Regression test for <https://github.com/rust-lang/rust/issues/79506>.
+
+extern crate overflow;


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/88679, rustdoc doesn't load crates eagerly. Add an explicit `extern crate` item to make sure the crate is loaded and the bug reproduces.
You can verify this fix by adding `// compile-flags: -Znormalize-docs` and running the test to make sure it gives an error.