### PR TITLE
Distribute rust-docs-json via rustup.

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -98,29 +98,23 @@ impl Step for JsonDocs {
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let default = run.builder.config.docs;
-        run.alias("rust-json-docs").default_condition(default)
+        run.alias("rust-docs-json").default_condition(default)
     }
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(JsonDocs { host: run.target });
     }
 
-    /// Builds the `rust-json-docs` installer component.
+    /// Builds the `rust-docs-json` installer component.
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
-        // This prevents JSON docs from being built for "dist" or "install"
-        // on the stable/beta channels. The JSON format is not stable yet and
-        // should not be included in stable/beta toolchains.
-        if !builder.build.unstable_features() {
-            return None;
-        }
-
         let host = self.host;
         builder.ensure(crate::doc::JsonStd { stage: builder.top_stage, target: host });
 
         let dest = "share/doc/rust/json";
 
-        let mut tarball = Tarball::new(builder, "rust-json-docs", &host.triple);
+        let mut tarball = Tarball::new(builder, "rust-docs-json", &host.triple);
         tarball.set_product_name("Rust Documentation In JSON Format");
+        tarball.is_preview(true);
         tarball.add_bulk_dir(&builder.json_doc_out(host), dest);
         Some(tarball.generate())
     }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -184,7 +184,7 @@ static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"
 
 static MINGW: &[&str] = &["i686-pc-windows-gnu", "x86_64-pc-windows-gnu"];
 
-static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview"];
+static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview", "rust-docs-json-preview"];
 
 macro_rules! t {
     ($e:expr) => {
@@ -318,6 +318,7 @@ impl Builder {
         package!("rust-mingw", MINGW);
         package!("rust-std", TARGETS);
         self.package("rust-docs", &mut manifest.pkg, HOSTS, DOCS_FALLBACK);
+        self.package("rust-docs-json-preview", &mut manifest.pkg, HOSTS, DOCS_FALLBACK);
         package!("rust-src", &["*"]);
         package!("rls-preview", HOSTS);
         package!("rust-analyzer-preview", HOSTS);
@@ -403,6 +404,7 @@ impl Builder {
         rename("rustfmt", "rustfmt-preview");
         rename("clippy", "clippy-preview");
         rename("miri", "miri-preview");
+        rename("rust-docs-json", "rust-docs-json-preview");
         rename("rust-analyzer", "rust-analyzer-preview");
     }
 
@@ -459,6 +461,7 @@ impl Builder {
             host_component("rustfmt-preview"),
             host_component("llvm-tools-preview"),
             host_component("rust-analysis"),
+            host_component("rust-docs-json"),
         ]);
 
         extensions.extend(


### PR DESCRIPTION
I am not 100% sure on how to treat `rust-json-docs` in `target_host_combination`. I went along with a similar strategy to the one used for `rust-docs`, but looking for guidance there.