### PR TITLE
Unify "all items" page's sidebar with other pages

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -341,15 +341,15 @@ impl AllTypes {
     }
 
     fn print(self, f: &mut Buffer) {
-        fn print_entries(f: &mut Buffer, e: &FxHashSet<ItemEntry>, title: &str) {
+        fn print_entries(f: &mut Buffer, e: &FxHashSet<ItemEntry>, kind: ItemSection) {
             if !e.is_empty() {
                 let mut e: Vec<&ItemEntry> = e.iter().collect();
                 e.sort();
                 write!(
                     f,
-                    "<h3 id=\"{}\">{}</h3><ul class=\"all-items\">",
-                    title.replace(' ', "-"), // IDs cannot contain whitespaces.
-                    title
+                    "<h3 id=\"{id}\">{title}</h3><ul class=\"all-items\">",
+                    id = kind.id(),
+                    title = kind.name(),
                 );
 
                 for s in e.iter() {
@@ -367,20 +367,20 @@ impl AllTypes {
         );
         // Note: print_entries does not escape the title, because we know the current set of titles
         // doesn't require escaping.
-        print_entries(f, &self.structs, "Structs");
-        print_entries(f, &self.enums, "Enums");
-        print_entries(f, &self.unions, "Unions");
-        print_entries(f, &self.primitives, "Primitives");
-        print_entries(f, &self.traits, "Traits");
-        print_entries(f, &self.macros, "Macros");
-        print_entries(f, &self.attributes, "Attribute Macros");
-        print_entries(f, &self.derives, "Derive Macros");
-        print_entries(f, &self.functions, "Functions");
-        print_entries(f, &self.typedefs, "Typedefs");
-        print_entries(f, &self.trait_aliases, "Trait Aliases");
-        print_entries(f, &self.opaque_tys, "Opaque Types");
-        print_entries(f, &self.statics, "Statics");
-        print_entries(f, &self.constants, "Constants");
+        print_entries(f, &self.structs, ItemSection::Structs);
+        print_entries(f, &self.enums, ItemSection::Enums);
+        print_entries(f, &self.unions, ItemSection::Unions);
+        print_entries(f, &self.primitives, ItemSection::PrimitiveTypes);
+        print_entries(f, &self.traits, ItemSection::Traits);
+        print_entries(f, &self.macros, ItemSection::Macros);
+        print_entries(f, &self.attributes, ItemSection::AttributeMacros);
+        print_entries(f, &self.derives, ItemSection::DeriveMacros);
+        print_entries(f, &self.functions, ItemSection::Functions);
+        print_entries(f, &self.typedefs, ItemSection::TypeDefinitions);
+        print_entries(f, &self.trait_aliases, ItemSection::TraitAliases);
+        print_entries(f, &self.opaque_tys, ItemSection::OpaqueTypes);
+        print_entries(f, &self.statics, ItemSection::Statics);
+        print_entries(f, &self.constants, ItemSection::Constants);
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -290,9 +290,56 @@ impl AllTypes {
             };
         }
     }
-}
 
-impl AllTypes {
+    fn item_sections(&self) -> FxHashSet<ItemSection> {
+        let mut sections = FxHashSet::default();
+
+        if !self.structs.is_empty() {
+            sections.insert(ItemSection::Structs);
+        }
+        if !self.enums.is_empty() {
+            sections.insert(ItemSection::Enums);
+        }
+        if !self.unions.is_empty() {
+            sections.insert(ItemSection::Unions);
+        }
+        if !self.primitives.is_empty() {
+            sections.insert(ItemSection::PrimitiveTypes);
+        }
+        if !self.traits.is_empty() {
+            sections.insert(ItemSection::Traits);
+        }
+        if !self.macros.is_empty() {
+            sections.insert(ItemSection::Macros);
+        }
+        if !self.functions.is_empty() {
+            sections.insert(ItemSection::Functions);
+        }
+        if !self.typedefs.is_empty() {
+            sections.insert(ItemSection::TypeDefinitions);
+        }
+        if !self.opaque_tys.is_empty() {
+            sections.insert(ItemSection::OpaqueTypes);
+        }
+        if !self.statics.is_empty() {
+            sections.insert(ItemSection::Statics);
+        }
+        if !self.constants.is_empty() {
+            sections.insert(ItemSection::Constants);
+        }
+        if !self.attributes.is_empty() {
+            sections.insert(ItemSection::AttributeMacros);
+        }
+        if !self.derives.is_empty() {
+            sections.insert(ItemSection::DeriveMacros);
+        }
+        if !self.trait_aliases.is_empty() {
+            sections.insert(ItemSection::TraitAliases);
+        }
+
+        sections
+    }
+
     fn print(self, f: &mut Buffer) {
         fn print_entries(f: &mut Buffer, e: &FxHashSet<ItemEntry>, title: &str) {
             if !e.is_empty() {
@@ -2468,7 +2515,7 @@ fn sidebar_enum(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, e: &clean:
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-enum ItemSection {
+pub(crate) enum ItemSection {
     Reexports,
     PrimitiveTypes,
     Modules,
@@ -2620,25 +2667,11 @@ fn item_ty_to_section(ty: ItemType) -> ItemSection {
     }
 }
 
-fn sidebar_module(buf: &mut Buffer, items: &[clean::Item]) {
+pub(crate) fn sidebar_module_like(buf: &mut Buffer, item_sections_in_use: FxHashSet<ItemSection>) {
     use std::fmt::Write as _;
 
     let mut sidebar = String::new();
 
-    let item_sections_in_use: FxHashSet<_> = items
-        .iter()
-        .filter(|it| {
-            !it.is_stripped()
-                && it
-                    .name
-                    .or_else(|| {
-                        if let clean::ImportItem(ref i) = *it.kind &&
-                            let clean::ImportKind::Simple(s) = i.kind { Some(s) } else { None }
-                    })
-                    .is_some()
-        })
-        .map(|it| item_ty_to_section(it.type_()))
-        .collect();
     for &sec in ItemSection::ALL.iter().filter(|sec| item_sections_in_use.contains(sec)) {
         let _ = write!(sidebar, "<li><a href=\"#{}\">{}</a></li>", sec.id(), sec.name());
     }
@@ -2654,6 +2687,25 @@ fn sidebar_module(buf: &mut Buffer, items: &[clean::Item]) {
             sidebar
         );
     }
+}
+
+fn sidebar_module(buf: &mut Buffer, items: &[clean::Item]) {
+    let item_sections_in_use: FxHashSet<_> = items
+        .iter()
+        .filter(|it| {
+            !it.is_stripped()
+                && it
+                    .name
+                    .or_else(|| {
+                        if let clean::ImportItem(ref i) = *it.kind &&
+                            let clean::ImportKind::Simple(s) = i.kind { Some(s) } else { None }
+                    })
+                    .is_some()
+        })
+        .map(|it| item_ty_to_section(it.type_()))
+        .collect();
+
+    sidebar_module_like(buf, item_sections_in_use);
 }
 
 fn sidebar_foreign_type(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item) {

--- a/src/test/rustdoc/sidebar-all-page.rs
+++ b/src/test/rustdoc/sidebar-all-page.rs
@@ -1,0 +1,35 @@
+#![crate_name = "foo"]
+
+#![feature(rustdoc_internals)]
+
+// @has 'foo/all.html'
+// @has - '//*[@class="sidebar-elems"]//li' 'Structs'
+// @has - '//*[@class="sidebar-elems"]//li' 'Enums'
+// @has - '//*[@class="sidebar-elems"]//li' 'Unions'
+// @has - '//*[@class="sidebar-elems"]//li' 'Functions'
+// @has - '//*[@class="sidebar-elems"]//li' 'Traits'
+// @has - '//*[@class="sidebar-elems"]//li' 'Macros'
+// @has - '//*[@class="sidebar-elems"]//li' 'Type Definitions'
+// @has - '//*[@class="sidebar-elems"]//li' 'Constants'
+// @has - '//*[@class="sidebar-elems"]//li' 'Statics'
+// @has - '//*[@class="sidebar-elems"]//li' 'Primitive Types'
+
+pub struct Foo;
+pub enum Enum {
+    A,
+}
+pub union Bar {
+    a: u8,
+    b: u16,
+}
+pub fn foo() {}
+pub trait Trait {}
+#[macro_export]
+macro_rules! foo {
+    () => {}
+}
+pub type Type = u8;
+pub const FOO: u8 = 0;
+pub static BAR: u8 = 0;
+#[doc(primitive = "u8")]
+mod u8 {}


### PR DESCRIPTION
Currently, the "all types" page's sidebar doesn't list the different categories of type available. This PR fixes it.

Before:

![Screenshot from 2022-09-20 17-11-15](https://user-images.githubusercontent.com/3050060/191296348-95d8771d-a887-432e-96bd-d5284d87d743.png)

After:

![Screenshot from 2022-09-20 17-11-09](https://user-images.githubusercontent.com/3050060/191296344-8e7318a3-eb51-4037-ae94-7ae2115363ce.png)

r? @notriddle 

