### PR TITLE
Use rebind instead of dummy binder in `SameTypeModuloInfer` relation

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2765,7 +2765,7 @@ impl<'tcx> TypeRelation<'tcx> for SameTypeModuloInfer<'_, 'tcx> {
     where
         T: relate::Relate<'tcx>,
     {
-        Ok(ty::Binder::dummy(self.relate(a.skip_binder(), b.skip_binder())?))
+        Ok(a.rebind(self.relate(a.skip_binder(), b.skip_binder())?))
     }
 
     fn consts(

--- a/src/test/ui/suggestions/issue-101984.rs
+++ b/src/test/ui/suggestions/issue-101984.rs
@@ -1,0 +1,27 @@
+use std::marker::PhantomData;
+
+type Component = fn(&());
+
+struct Wrapper {
+    router: Router<(Component, Box<Self>)>,
+}
+
+struct Match<C>(PhantomData<C>);
+
+struct Router<T>(PhantomData<T>);
+
+impl<T> Router<T> {
+    pub fn at(&self) -> Result<Match<&T>, ()> {
+        todo!()
+    }
+}
+
+impl Wrapper {
+    fn at(&self, path: &str) -> Result<(Component, Box<Self>), ()> {
+        let (cmp, router) = self.router.at()?;
+        //~^ ERROR mismatched types
+        todo!()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-101984.stderr
+++ b/src/test/ui/suggestions/issue-101984.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-101984.rs:21:13
+   |
+LL |         let (cmp, router) = self.router.at()?;
+   |             ^^^^^^^^^^^^^   ----------------- this expression has type `Match<&(for<'r> fn(&'r ()), Box<Wrapper>)>`
+   |             |
+   |             expected struct `Match`, found tuple
+   |
+   = note: expected struct `Match<&(for<'r> fn(&'r ()), Box<Wrapper>)>`
+               found tuple `(_, _)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Lazy binder usage (sorry, my fault) + assertion in `Binder::dummy`

Fixes #101984