### PR TITLE
emit diagnostic suggestion for error when if let used with enum varia…

### DIFF
--- a/compiler/rustc_span/src/span_encoding.rs
+++ b/compiler/rustc_span/src/span_encoding.rs
@@ -149,6 +149,10 @@ impl Span {
             with_span_interner(|interner| interner.spans[index as usize].ctxt)
         }
     }
+
+    pub fn get_base_or_index(self) -> u32 {
+        self.base_or_index
+    }
 }
 
 #[derive(Default)]

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1661,6 +1661,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                 err,
                 true,
                 false,
+                false,
             );
             self.note_obligation_cause(&mut diag, obligation);
             diag.emit();

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -405,6 +405,7 @@ fn compare_predicate_entailment<'tcx>(
                 terr,
                 false,
                 false,
+                false,
             );
 
             return Err(diag.emit());
@@ -518,6 +519,7 @@ pub fn collect_trait_impl_trait_tys<'tcx>(
                         found: impl_return_ty.into(),
                     })),
                     terr,
+                    false,
                     false,
                     false,
                 );
@@ -1387,6 +1389,7 @@ pub(crate) fn compare_const_impl<'tcx>(
                     found: impl_ty.into(),
                 })),
                 terr,
+                false,
                 false,
                 false,
             );

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -848,6 +848,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 e,
                                 false,
                                 true,
+                                false,
                             );
                         }
                     }

--- a/src/test/ui/type/issue-101208.rs
+++ b/src/test/ui/type/issue-101208.rs
@@ -1,0 +1,10 @@
+enum E {
+    One(i32, i32)
+}
+fn main() {
+    let var = E::One;
+    if let E::One(var1, var2) = var {
+    //~^ ERROR 0308
+        println!("{var1} {var2}");
+    }
+}

--- a/src/test/ui/type/issue-101208.stderr
+++ b/src/test/ui/type/issue-101208.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-101208.rs:6:12
+   |
+LL |     if let E::One(var1, var2) = var {
+   |            ^^^^^^^^^^^^^^^^^^   --- this expression has type `fn(i32, i32) -> E {E::One}`
+   |            |
+   |            expected fn item, found enum `E`
+   |
+   = note: expected fn item `fn(i32, i32) -> E {E::One}`
+                 found enum `E`
+help: use parentheses to instantiate this tuple variant
+   |
+LL |     if let E::One(var1, var2) = var(_,_) {
+   |                                    +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
…nt without being initialized

compare the span base id to get the correct expression and add suggestion to it
	modified:   compiler/rustc_infer/src/infer/error_reporting/mod.rs
	modified:   compiler/rustc_span/src/span_encoding.rs
	modified:   compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
	modified:   compiler/rustc_typeck/src/check/compare_method.rs
	modified:   compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
	new file:   src/test/ui/type/issue-101208.rs
	new file:   src/test/ui/type/issue-101208.stderr