### PR TITLE
rustdoc: remove unnecessary `max-width` on headers

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -674,7 +674,6 @@ h2.location a {
 }
 
 .method > .code-header, .trait-impl > .code-header {
-	max-width: calc(100% - 41px);
 	display: block;
 }
 

--- a/src/test/rustdoc-gui/notable-trait.goml
+++ b/src/test/rustdoc-gui/notable-trait.goml
@@ -83,7 +83,7 @@ assert-position: (
 )
 
 // Checking on very small mobile. The `i` should be on its own line.
-size: (410, 600)
+size: (365, 600)
 compare-elements-position-false: (
     "//*[@id='method.create_an_iterator_from_read']//a[text()='NotableStructWithLongName']",
     "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",


### PR DESCRIPTION
This code was added in 003b2bc1c65251ec2fc80b78ed91c43fb35402ec to prevent these headers from overlapping `.out-of-band` side items. That stopped being a problem when 3f92ff34b5a2fe8dd1a32aa27d437519e63782f0 switched rustdoc over to using `float`, rather than `position: absolute`, to implement this.