### PR TITLE
rustdoc: remove no-op CSS `.content > .methods > .method`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -728,9 +728,6 @@ pre, .rustdoc.source .example-wrap {
 	padding: 0;
 }
 
-.content > .methods > .method {
-	position: relative;
-}
 /* Shift "where ..." part of method or fn definition down a line */
 .content .method .where,
 .content .fn .where,

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -729,7 +729,6 @@ pre, .rustdoc.source .example-wrap {
 }
 
 .content > .methods > .method {
-	font-size: 1rem;
 	position: relative;
 }
 /* Shift "where ..." part of method or fn definition down a line */


### PR DESCRIPTION
# `font-size: 1rem`

This rule was added in 22dad4b0440b184568956c10f2cbedabf763065a, back when the `method` class was attached to headers instead of DIVs that wrap headers.

Old method rendering:

https://github.com/rust-lang/rust/blob/a96247bcac385671757034bd928c13097fd2ce76/src/librustdoc/html/render.rs#L2062

Current method rendering:

https://github.com/rust-lang/rust/blob/432abd86f231c908f6df3cdd779e83f35084be90/src/librustdoc/html/render/print_item.rs#L721

# `position: relative`

This rule was added in 88fe6dfa31a1bee49090dc72c537c5cd7bd632f4 to assist in position the hide/show togges on methods. This is no longer needed, because these toggles are no longer implemented as absolutely positioned links nested inside headers.
