### PR TITLE
Fix spurious error when a `Drop` local has an assignment in a loop

### DIFF
--- a/compiler/rustc_borrowck/src/def_use.rs
+++ b/compiler/rustc_borrowck/src/def_use.rs
@@ -7,6 +7,10 @@ pub enum DefUse {
     Def,
     Use,
     Drop,
+    /// This is only created for a `DropAndReplace` terminator.
+    /// It needs special handling because represents a `Drop` immediately followed
+    /// by a `Def`, at the same MIR location.
+    DropAndDef,
 }
 
 pub fn categorize(context: PlaceContext) -> Option<DefUse> {
@@ -30,6 +34,8 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
         // values that come before them.
         PlaceContext::NonUse(NonUseContext::StorageLive) |
         PlaceContext::NonUse(NonUseContext::StorageDead) => Some(DefUse::Def),
+
+        PlaceContext::MutatingUse(MutatingUseContext::DropAndReplace) => Some(DefUse::DropAndDef),
 
         ///////////////////////////////////////////////////////////////////////////
         // REGULAR USES

--- a/compiler/rustc_borrowck/src/diagnostics/find_use.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/find_use.rs
@@ -121,6 +121,10 @@ impl<'cx, 'tcx> Visitor<'tcx> for DefUseVisitor<'cx, 'tcx> {
                 Some(DefUse::Def) => Some(DefUseResult::Def),
                 Some(DefUse::Use) => Some(DefUseResult::UseLive { local }),
                 Some(DefUse::Drop) => Some(DefUseResult::UseDrop { local }),
+                // This makes some diagnostics nicer - we want to indicate
+                // that a variable is being kept alive because it can be accessed
+                // by this drop.
+                Some(DefUse::DropAndDef) => Some(DefUseResult::UseDrop { local }),
                 None => None,
             };
         }

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -211,6 +211,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
 
             PlaceContext::MutatingUse(
                 MutatingUseContext::Store
+                | MutatingUseContext::DropAndReplace
                 | MutatingUseContext::Deinit
                 | MutatingUseContext::SetDiscriminant
                 | MutatingUseContext::AsmOutput

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -504,7 +504,7 @@ macro_rules! make_mir_visitor {
                     } => {
                         self.visit_place(
                             place,
-                            PlaceContext::MutatingUse(MutatingUseContext::Drop),
+                            PlaceContext::MutatingUse(MutatingUseContext::DropAndReplace),
                             location
                         );
                         self.visit_operand(value, location);
@@ -1267,6 +1267,8 @@ pub enum MutatingUseContext {
     Yield,
     /// Being dropped.
     Drop,
+    /// A `DropAndReplace` terminator
+    DropAndReplace,
     /// Mutable borrow.
     Borrow,
     /// AddressOf for *mut pointer.

--- a/compiler/rustc_mir_dataflow/src/impls/liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/liveness.rs
@@ -206,6 +206,13 @@ impl DefUse {
             | PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection) => {
                 unreachable!("A projection could be a def or a use and must be handled separately")
             }
+
+            PlaceContext::MutatingUse(MutatingUseContext::DropAndReplace) => {
+                unreachable!(
+                    "DropAndReplace terminators should have been removed by drop elaboration: place {:?}",
+                    place
+                )
+            }
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -932,6 +932,7 @@ impl Visitor<'_> for CanConstProp {
             // whether they'd be fine right now.
             MutatingUse(MutatingUseContext::Yield)
             | MutatingUse(MutatingUseContext::Drop)
+            | MutatingUse(MutatingUseContext::DropAndReplace)
             | MutatingUse(MutatingUseContext::Retag)
             // These can't ever be propagated under any scheme, as we can't reason about indirect
             // mutation.

--- a/src/test/ui/borrowck/drop-in-loop.rs
+++ b/src/test/ui/borrowck/drop-in-loop.rs
@@ -1,0 +1,24 @@
+// A version of `issue-70919-drop-in-loop`, but without
+// the necessary `drop` call.
+//
+// This should fail to compile, since the `Drop` impl
+// for `WrapperWithDrop` could observe the changed
+// `base` value.
+
+struct WrapperWithDrop<'a>(&'a mut bool);
+impl<'a> Drop for WrapperWithDrop<'a> {
+    fn drop(&mut self) {
+    }
+}
+
+fn drop_in_loop() {
+    let mut base = true;
+    let mut wrapper = WrapperWithDrop(&mut base);
+    loop {
+        base = false; //~ ERROR: cannot assign to `base`
+        wrapper = WrapperWithDrop(&mut base);
+    }
+}
+
+fn main() {
+}

--- a/src/test/ui/borrowck/drop-in-loop.stderr
+++ b/src/test/ui/borrowck/drop-in-loop.stderr
@@ -1,0 +1,14 @@
+error[E0506]: cannot assign to `base` because it is borrowed
+  --> $DIR/drop-in-loop.rs:18:9
+   |
+LL |     let mut wrapper = WrapperWithDrop(&mut base);
+   |                                       --------- borrow of `base` occurs here
+LL |     loop {
+LL |         base = false;
+   |         ^^^^^^^^^^^^ assignment to borrowed `base` occurs here
+LL |         wrapper = WrapperWithDrop(&mut base);
+   |         ------- borrow might be used here, when `wrapper` is dropped and runs the `Drop` code for type `WrapperWithDrop`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/src/test/ui/borrowck/issue-70919-drop-in-loop.rs
+++ b/src/test/ui/borrowck/issue-70919-drop-in-loop.rs
@@ -1,0 +1,25 @@
+// Regression test for issue #70919
+// Tests that we don't emit a spurious "borrow might be used" error
+// when we have an explicit `drop` in a loop
+
+// check-pass
+
+struct WrapperWithDrop<'a>(&'a mut bool);
+impl<'a> Drop for WrapperWithDrop<'a> {
+    fn drop(&mut self) {
+    }
+}
+
+fn drop_in_loop() {
+    let mut base = true;
+    let mut wrapper = WrapperWithDrop(&mut base);
+    loop {
+        drop(wrapper);
+
+        base = false;
+        wrapper = WrapperWithDrop(&mut base);
+    }
+}
+
+fn main() {
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/70919

`DropAndReplace` terminators are special - unlike all other terminators, they perform two distinct actions (a drop and a store) to the same `Place`. This complicates various analysis passes that we do, which expect at most one of 'Drop'/'Def'/'Use' for a local at a given MIR location.

Previously, we categorized a `DropAndReplace` terminator's `Local` access as `MutatingUseContext::Drop`. As a result, livness computation would not consider the `DropAndReplace` as a store ('Def') of a local. The "use live" set would end up being too large (a use would be seen to extend back to an earlier store, rather than the closure `DropAndReplace`).

We now explicitly propagate information about `DropAndReplace` terminators via new enum variants `MutatingUseContext:DropAndReplace` and `DefUse::DropAndReplace`. We use this information in liveness computation to record *both* a Drop and a Def. This prevents creating an extra-large "use live" set, while ensuring that te local is still considered "drop live" at the required locations.