### PR TITLE
Adding ignore fuchsia tests for execvp (pre_exec)

### DIFF
--- a/src/test/ui/command/command-pre-exec.rs
+++ b/src/test/ui/command/command-pre-exec.rs
@@ -6,6 +6,7 @@
 // ignore-windows - this is a unix-specific test
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-fuchsia no execvp syscall
 #![feature(process_exec, rustc_private)]
 
 extern crate libc;


### PR DESCRIPTION
Adding ignore fuchsia tests for pre_exec, which calls execvp

cc. @djkoloski

r? @tmandry