### PR TITLE
refactor: use grep -E/-F instead of fgrep/egrep

### DIFF
--- a/src/etc/cat-and-grep.sh
+++ b/src/etc/cat-and-grep.sh
@@ -26,7 +26,7 @@ Options:
     -i      Case insensitive search.
 '
 
-GREPPER=fgrep
+GREPPER=grep
 INVERT=0
 GREPFLAGS='q'
 while getopts ':vieh' OPTION; do
@@ -39,7 +39,7 @@ while getopts ':vieh' OPTION; do
             GREPFLAGS="i$GREPFLAGS"
             ;;
         e)
-            GREPPER=egrep
+            GREPFLAGS="E$GREPFLAGS"
             ;;
         h)
             echo "$USAGE"
@@ -50,6 +50,15 @@ while getopts ':vieh' OPTION; do
             ;;
     esac
 done
+
+# an utility function to check if a string contains a substring
+stringContain() { [ -z "$1" ] || { [ -z "${2##*$1*}" ] && [ -n "$2" ];};}
+
+if ! stringContain 'E' "$GREPFLAGS"
+then
+    # use F flag if there is not an E flag
+    GREPFLAGS="F$GREPFLAGS"
+fi
 
 shift $((OPTIND - 1))
 

--- a/src/etc/cat-and-grep.sh
+++ b/src/etc/cat-and-grep.sh
@@ -51,10 +51,7 @@ while getopts ':vieh' OPTION; do
     esac
 done
 
-# an utility function to check if a string contains a substring
-stringContain() { [ -z "$1" ] || { [ -z "${2##*$1*}" ] && [ -n "$2" ];};}
-
-if ! stringContain 'E' "$GREPFLAGS"
+if ! echo "$GREPFLAGS" | grep -q E
 then
     # use F flag if there is not an E flag
     GREPFLAGS="F$GREPFLAGS"


### PR DESCRIPTION
`egrep` and `fgrep` are obsolescent now. This PR updates  all `egrep` and `fgrep` commands to `grep -E` and `grep -F`.

Running egrep/fgrep command with grep v3.8 will output the following warning to stderr:

```
egrep: warning: egrep is obsolescent; using grep -E
```

- https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep
- https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html