### PR TITLE
Prevent usage of .stab elements to create scrollable areas in doc blocks

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1102,6 +1102,12 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	margin-right: 0.3rem;
 }
 
+/* This is to prevent the `.stab` elements to overflow the .docblock elements. */
+.docblock .stab {
+	padding: 0 0.125em;
+	margin-bottom: 0;
+}
+
 /* Black one-pixel outline around emoji shapes */
 .emoji {
 	text-shadow:

--- a/src/test/rustdoc-gui/check-stab-in-docblock.goml
+++ b/src/test/rustdoc-gui/check-stab-in-docblock.goml
@@ -1,0 +1,21 @@
+// This test checks that using `.stab` attributes in `.docblock` elements doesn't
+// create scrollable paragraphs.
+goto: file://|DOC_PATH|/test_docs/index.html
+// Needs the text to be display to check for scrollable content.
+show-text: true
+size: (786, 600)
+// Confirms that there 3 paragraphs.
+assert-count: (".top-doc .docblock p", 3)
+// Checking that there is no scrollable content.
+assert-property: (
+    ".top-doc .docblock p:nth-of-type(1)",
+    {"scrollHeight": "120", "clientHeight": "120", "scrollWidth": "502", "clientWidth": "502"},
+)
+assert-property: (
+    ".top-doc .docblock p:nth-of-type(2)",
+    {"scrollHeight": "48", "clientHeight": "48", "scrollWidth": "502", "clientWidth": "502"},
+)
+assert-property: (
+    ".top-doc .docblock p:nth-of-type(3)",
+    {"scrollHeight": "48", "clientHeight": "48", "scrollWidth": "502", "clientWidth": "502"},
+)

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -6,6 +6,24 @@
 #![feature(rustdoc_internals)]
 #![feature(doc_cfg)]
 
+/*!
+Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy
+this crate even more!
+Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy
+this crate even more!
+Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy
+this crate even more!
+
+Also, stop using `bar` as it's <span class="stab deprecated" title="">deprecated</span>.
+Also, stop using `bar` as it's <span class="stab deprecated" title="">deprecated</span>.
+Also, stop using `bar` as it's <span class="stab deprecated" title="">deprecated</span>.
+
+Finally, you can use `quz` only on <span class="stab portability"><code>Unix or x86-64</code>
+</span>.
+Finally, you can use `quz` only on <span class="stab portability"><code>Unix or x86-64</code>
+</span>.
+*/
+
 use std::convert::AsRef;
 use std::fmt;
 


### PR DESCRIPTION
Fixes #101874.

You can test it online [here](https://rustdoc.crud.net/imperio/stab-in-doblocks/foo/index.html).

r? @notriddle 