### PR TITLE
Add doc aliases on Sized trait

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -81,6 +81,7 @@ impl<T: ?Sized> !Send for *mut T {}
 /// ```
 ///
 /// [trait object]: ../../book/ch17-02-trait-objects.html
+#[doc(alias = "?", alias = "?Sized")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sized"]
 #[rustc_on_unimplemented(


### PR DESCRIPTION
Fixes #101267.

It adds both `?` and `?Sized` doc aliases for the `Sized` trait.

Some screenshots of the result:

![Screenshot from 2022-09-21 16-19-55](https://user-images.githubusercontent.com/3050060/191529854-65a79b75-6c20-4fd4-88c2-56d617d1acff.png)
![Screenshot from 2022-09-21 16-20-04](https://user-images.githubusercontent.com/3050060/191529857-2d11b477-5c5d-4080-9382-0b07950fd7f6.png)
