### PR TITLE
Simplify TLS key creation on Windows

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -251,6 +251,7 @@
 #![feature(doc_notable_trait)]
 #![feature(dropck_eyepatch)]
 #![feature(exhaustive_patterns)]
+#![feature(inline_const)]
 #![feature(intra_doc_pointers)]
 #![cfg_attr(bootstrap, feature(label_break_value))]
 #![feature(lang_items)]

--- a/library/std/src/sys/sgx/thread_local_key.rs
+++ b/library/std/src/sys/sgx/thread_local_key.rs
@@ -21,8 +21,3 @@ pub unsafe fn get(key: Key) -> *mut u8 {
 pub unsafe fn destroy(key: Key) {
     Tls::destroy(AbiKey::from_usize(key))
 }
-
-#[inline]
-pub fn requires_synchronized_create() -> bool {
-    false
-}

--- a/library/std/src/sys/solid/thread_local_key.rs
+++ b/library/std/src/sys/solid/thread_local_key.rs
@@ -19,8 +19,3 @@ pub unsafe fn get(_key: Key) -> *mut u8 {
 pub unsafe fn destroy(_key: Key) {
     panic!("should not be used on the solid target");
 }
-
-#[inline]
-pub fn requires_synchronized_create() -> bool {
-    panic!("should not be used on the solid target");
-}

--- a/library/std/src/sys/unix/thread_local_key.rs
+++ b/library/std/src/sys/unix/thread_local_key.rs
@@ -6,8 +6,28 @@ pub type Key = libc::pthread_key_t;
 
 #[inline]
 pub unsafe fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
+    let dtor = mem::transmute(dtor);
     let mut key = 0;
-    assert_eq!(libc::pthread_key_create(&mut key, mem::transmute(dtor)), 0);
+    let r = libc::pthread_key_create(&mut key, dtor);
+    assert_eq!(r, 0);
+
+    // POSIX allows the key created here to be 0, but `StaticKey` relies
+    // on using 0 as a sentinel value to check who won the race to set the
+    // shared TLS key. As far as I know, there is no guaranteed value that
+    // cannot be returned as a posix_key_create key, so there is no value
+    // we can initialize the inner key with to prove that it has not yet
+    // been set. Therefore, we use this small trick to ensure the returned
+    // key is not zero.
+    if key == 0 {
+        let mut new = 0;
+        // Only check the creation result after deleting the old key to avoid
+        // leaking it.
+        let r_c = libc::pthread_key_create(&mut new, dtor);
+        let r_d = libc::pthread_key_delete(key);
+        assert_eq!(r_c, 0);
+        debug_assert_eq!(r_d, 0);
+        key = new;
+    }
     key
 }
 
@@ -26,9 +46,4 @@ pub unsafe fn get(key: Key) -> *mut u8 {
 pub unsafe fn destroy(key: Key) {
     let r = libc::pthread_key_delete(key);
     debug_assert_eq!(r, 0);
-}
-
-#[inline]
-pub fn requires_synchronized_create() -> bool {
-    false
 }

--- a/library/std/src/sys/unsupported/thread_local_key.rs
+++ b/library/std/src/sys/unsupported/thread_local_key.rs
@@ -19,8 +19,3 @@ pub unsafe fn get(_key: Key) -> *mut u8 {
 pub unsafe fn destroy(_key: Key) {
     panic!("should not be used on this target");
 }
-
-#[inline]
-pub fn requires_synchronized_create() -> bool {
-    panic!("should not be used on this target");
-}

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -959,6 +959,7 @@ extern "system" {
     pub fn TlsAlloc() -> DWORD;
     pub fn TlsGetValue(dwTlsIndex: DWORD) -> LPVOID;
     pub fn TlsSetValue(dwTlsIndex: DWORD, lpTlsvalue: LPVOID) -> BOOL;
+    pub fn TlsFree(dwTlsIndex: DWORD) -> BOOL;
     pub fn GetLastError() -> DWORD;
     pub fn QueryPerformanceFrequency(lpFrequency: *mut LARGE_INTEGER) -> BOOL;
     pub fn QueryPerformanceCounter(lpPerformanceCount: *mut LARGE_INTEGER) -> BOOL;


### PR DESCRIPTION
By using a static array instead of a linked list for the storage of destructor function, the creation of new keys does not need to be synchronized. Also, running destructors should be a bit faster because of cache locality (using an atomic counter to store the maximum index of destructors avoids having to iterate over the whole array, assuming keys are mostly dense). This optimization comes at the cost of a minor runtime memory increase, however.

Using a fixed-size array is possible since [the total number of TLS keys is capped at 1088](https://learn.microsoft.com/en-us/windows/win32/procthread/thread-local-storage). Since [TLS keys are always numbers less than 1088](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlssetvalue), we can just use the value of the key to index into the array.

@rustbot label +O-windows-gnu