### PR TITLE
Set 'exec-env:RUST_BACKTRACE=0' in const-eval-select tests

### DIFF
--- a/src/test/ui/intrinsics/const-eval-select-backtrace-std.rs
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace-std.rs
@@ -1,6 +1,7 @@
 // See issue #100696.
 // run-fail
 // check-run-results
+// exec-env:RUST_BACKTRACE=0
 fn main() {
     &""[1..];
 }

--- a/src/test/ui/intrinsics/const-eval-select-backtrace-std.run.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace-std.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'byte index 1 is out of bounds of ``', $DIR/const-eval-select-backtrace-std.rs:5:6
+thread 'main' panicked at 'byte index 1 is out of bounds of ``', $DIR/const-eval-select-backtrace-std.rs:6:6
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/intrinsics/const-eval-select-backtrace.rs
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace.rs
@@ -2,6 +2,7 @@
 // See issue #100696.
 // run-fail
 // check-run-results
+// exec-env:RUST_BACKTRACE=0
 
 #[track_caller]
 fn uhoh() {

--- a/src/test/ui/intrinsics/const-eval-select-backtrace.run.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'Aaah!', $DIR/const-eval-select-backtrace.rs:16:9
+thread 'main' panicked at 'Aaah!', $DIR/const-eval-select-backtrace.rs:17:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
This allows the tests to pass even if the user has RUST_BACKTRACE set when running 'x.py'