### PR TITLE
Add missing space between notable trait tooltip and where clause

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -371,7 +371,7 @@ pub(crate) fn print_where_clause<'a, 'tcx: 'a>(
                     format!("<br><span class=\"where\">where{where_preds}</span>")
                 } else {
                     let mut clause = br_with_padding;
-                    clause.truncate(clause.len() - 5 * "&nbsp;".len());
+                    clause.truncate(clause.len() - 4 * "&nbsp;".len());
                     write!(clause, "<span class=\"where\">where{where_preds}</span>")?;
                     clause
                 }

--- a/src/test/rustdoc/where.SWhere_TraitWhere_item-decl.html
+++ b/src/test/rustdoc/where.SWhere_TraitWhere_item-decl.html
@@ -1,3 +1,8 @@
 <div class="item-decl"><pre class="rust trait"><code>pub trait TraitWhere {
-    type <a href="#associatedtype.Item" class="associatedtype">Item</a>&lt;'a&gt;<br />&#160;&#160;&#160;<span class="where">where<br />&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Self: 'a</span>;
+    type <a href="#associatedtype.Item" class="associatedtype">Item</a>&lt;'a&gt;<br />&#160;&#160;&#160;&#160;<span class="where">where<br />&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Self: 'a</span>;
+
+    fn <a href="#method.func" class="fnname">func</a>(self)<br />&#160;&#160;&#160;&#160;<span class="where">where<br />&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Self: <a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a></span>,
+    { ... }
+<span class="item-spacer" />    fn <a href="#method.lines" class="fnname">lines</a>(self) -&gt; <a class="struct" href="{{channel}}/std/io/struct.Lines.html" title="struct std::io::Lines">Lines</a>&lt;Self&gt;<br />&#160;&#160;&#160;&#160;<span class="where">where<br />&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Self: <a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a></span>,
+    { ... }
 }</code></pre></div>

--- a/src/test/rustdoc/where.rs
+++ b/src/test/rustdoc/where.rs
@@ -1,5 +1,7 @@
 #![crate_name = "foo"]
 
+use std::io::Lines;
+
 pub trait MyTrait { fn dummy(&self) { } }
 
 // @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>(_)where A: MyTrait"
@@ -29,6 +31,16 @@ where
 // @snapshot SWhere_TraitWhere_item-decl - '//div[@class="item-decl"]'
 pub trait TraitWhere {
     type Item<'a> where Self: 'a;
+
+    fn func(self)
+    where
+        Self: Sized
+    {}
+
+    fn lines(self) -> Lines<Self>
+    where
+        Self: Sized,
+    { todo!() }
 }
 
 // @has foo/struct.Echo.html '//*[@class="impl has-srclink"]//h3[@class="code-header in-band"]' \


### PR DESCRIPTION
This PR add a missing space between the notable trait tooltip and the where clause.

The issue can be seeing on the [BufRead](https://doc.rust-lang.org/nightly/std/io/trait.BufRead.html) page.

Added a simple snapshot regression test in `src/test/rustdoc/where.rs`.

Before:
![image](https://user-images.githubusercontent.com/3616612/191566999-2f80e138-29c9-4f66-8bed-07781cbd9783.png)

After:
![image](https://user-images.githubusercontent.com/3616612/191567025-0ed3f7d4-7cec-4788-901f-5980fc241daa.png)

r? @GuillaumeGomez