### PR TITLE
Only register `Sized` in `fn` pointer confirmation if return is not trivially `Sized`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -638,15 +638,17 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             output_ty,
             &mut nested,
         );
-        let tr = ty::Binder::dummy(ty::TraitRef::new(
-            self.tcx().require_lang_item(LangItem::Sized, None),
-            self.tcx().mk_substs_trait(output_ty, &[]),
-        ));
-        nested.push(Obligation::new(
-            cause,
-            obligation.param_env,
-            tr.to_poly_trait_predicate().to_predicate(self.tcx()),
-        ));
+        if !output_ty.is_trivially_sized(self.tcx()) {
+            let tr = ty::Binder::dummy(ty::TraitRef::new(
+                self.tcx().require_lang_item(LangItem::Sized, None),
+                self.tcx().mk_substs_trait(output_ty, &[]),
+            ));
+            nested.push(Obligation::new(
+                cause,
+                obligation.param_env,
+                tr.to_poly_trait_predicate().to_predicate(self.tcx()),
+            ));
+        }
 
         Ok(ImplSourceFnPointerData { fn_ty: self_ty, nested })
     }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -638,7 +638,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             output_ty,
             &mut nested,
         );
-        if !output_ty.is_trivially_sized(self.tcx()) {
+        if self_ty.is_fn_ptr() && !output_ty.is_trivially_sized(self.tcx()) {
             let tr = ty::Binder::dummy(ty::TraitRef::new(
                 self.tcx().require_lang_item(LangItem::Sized, None),
                 self.tcx().mk_substs_trait(output_ty, &[]),


### PR DESCRIPTION
r? @ghost

cc https://github.com/rust-lang/rust/pull/100096#issuecomment-1253410870