### PR TITLE
Allow full relro on powerpc64-unknown-linux-gnu

### DIFF
--- a/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
@@ -1,15 +1,11 @@
 use crate::abi::Endian;
-use crate::spec::{LinkerFlavor, RelroLevel, Target, TargetOptions};
+use crate::spec::{LinkerFlavor, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
     base.cpu = "ppc64".into();
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m64"]);
     base.max_atomic_width = Some(64);
-
-    // ld.so in at least RHEL6 on ppc64 has a bug related to BIND_NOW, so only enable partial RELRO
-    // for now. https://github.com/rust-lang/rust/pull/43170#issuecomment-315411474
-    base.relro_level = RelroLevel::Partial;
 
     Target {
         llvm_target: "powerpc64-unknown-linux-gnu".into(),


### PR DESCRIPTION
This was previously limited to partial relro, citing issues on RHEL6,
but that's no longer a supported platform since #95026. We have long
been enabling full relro in RHEL7's own Rust builds for ppc64, without
trouble, so it should be fine to drop this workaround.
