### PR TITLE
Add examples to `bool::then` and `bool::then_some`

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -58,6 +58,7 @@ impl bool {
     ///
     /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
+    /// assert_eq!(a, 1);
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,16 +18,16 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
     /// let mut function_with_side_effects = || { a += 1; };
-    /// 
+    ///
     /// true.then_some(function_with_side_effects());
     /// false.then_some(function_with_side_effects());
-    /// 
-    /// // `a` is incremented twice because the value passed to `then_some` is 
-    /// // evaluated eagerly. 
+    ///
+    /// // `a` is incremented twice because the value passed to `then_some` is
+    /// // evaluated eagerly.
     /// assert_eq!(a, 2);
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
@@ -49,14 +49,14 @@ impl bool {
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
-    /// 
+    ///
     /// true.then(|| { a += 1; });
     /// false.then(|| { a += 1; });
-    /// 
-    /// // `a` is incremented once because the closure is evaluated lazily by 
+    ///
+    /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,6 +18,18 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// let mut function_with_side_effects = || { a += 1; };
+    /// 
+    /// true.then_some(function_with_side_effects());
+    /// false.then_some(function_with_side_effects());
+    /// 
+    /// // `a` is incremented twice because the value passed to `then_some` is 
+    /// // evaluated eagerly. 
+    /// assert_eq!(a, 2);
+    /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]
     #[inline]
@@ -36,6 +48,16 @@ impl bool {
     /// ```
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
+    /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// 
+    /// true.then(|| { a += 1; });
+    /// false.then(|| { a += 1; });
+    /// 
+    /// // `a` is incremented once because the closure is evaluated lazily by 
+    /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]


### PR DESCRIPTION
Added examples to `bool::then` and `bool::then_some` to show the distinction between the eager evaluation of `bool::then_some` and the lazy evaluation of `bool::then`. 