### PR TITLE
Relax `Sized` bound on `Fn` traits

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1936,21 +1936,30 @@ impl<I: FusedIterator + ?Sized, A: Allocator> FusedIterator for Box<I, A> {}
 impl<Args, F: FnOnce<Args> + ?Sized, A: Allocator> FnOnce<Args> for Box<F, A> {
     type Output = <F as FnOnce<Args>>::Output;
 
-    extern "rust-call" fn call_once(self, args: Args) -> Self::Output {
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output
+    where
+        <F as FnOnce<Args>>::Output: Sized,
+    {
         <F as FnOnce<Args>>::call_once(*self, args)
     }
 }
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
 impl<Args, F: FnMut<Args> + ?Sized, A: Allocator> FnMut<Args> for Box<F, A> {
-    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output {
+    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output
+    where
+        <F as FnOnce<Args>>::Output: Sized,
+    {
         <F as FnMut<Args>>::call_mut(self, args)
     }
 }
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
 impl<Args, F: Fn<Args> + ?Sized, A: Allocator> Fn<Args> for Box<F, A> {
-    extern "rust-call" fn call(&self, args: Args) -> Self::Output {
+    extern "rust-call" fn call(&self, args: Args) -> Self::Output
+    where
+        <F as FnOnce<Args>>::Output: Sized,
+    {
         <F as Fn<Args>>::call(self, args)
     }
 }

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -74,7 +74,9 @@
 pub trait Fn<Args>: FnMut<Args> {
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
-    extern "rust-call" fn call(&self, args: Args) -> Self::Output;
+    extern "rust-call" fn call(&self, args: Args) -> Self::Output
+    where
+        Self::Output: Sized;
 }
 
 /// The version of the call operator that takes a mutable receiver.
@@ -161,7 +163,9 @@ pub trait Fn<Args>: FnMut<Args> {
 pub trait FnMut<Args>: FnOnce<Args> {
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
-    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
+    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output
+    where
+        Self::Output: Sized;
 }
 
 /// The version of the call operator that takes a by-value receiver.
@@ -241,11 +245,13 @@ pub trait FnOnce<Args> {
     /// The returned type after the call operator is used.
     #[lang = "fn_once_output"]
     #[stable(feature = "fn_once_output", since = "1.12.0")]
-    type Output;
+    type Output: ?Sized;
 
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
-    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output
+    where
+        Self::Output: Sized;
 }
 
 mod impls {
@@ -255,7 +261,10 @@ mod impls {
     where
         F: ~const Fn<A>,
     {
-        extern "rust-call" fn call(&self, args: A) -> F::Output {
+        extern "rust-call" fn call(&self, args: A) -> F::Output
+        where
+            F::Output: Sized,
+        {
             (**self).call(args)
         }
     }
@@ -266,7 +275,10 @@ mod impls {
     where
         F: ~const Fn<A>,
     {
-        extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
+        extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output
+        where
+            F::Output: Sized,
+        {
             (**self).call(args)
         }
     }
@@ -279,7 +291,10 @@ mod impls {
     {
         type Output = F::Output;
 
-        extern "rust-call" fn call_once(self, args: A) -> F::Output {
+        extern "rust-call" fn call_once(self, args: A) -> F::Output
+        where
+            F::Output: Sized,
+        {
             (*self).call(args)
         }
     }
@@ -290,7 +305,10 @@ mod impls {
     where
         F: ~const FnMut<A>,
     {
-        extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
+        extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output
+        where
+            F::Output: Sized,
+        {
             (*self).call_mut(args)
         }
     }
@@ -302,7 +320,10 @@ mod impls {
         F: ~const FnMut<A>,
     {
         type Output = F::Output;
-        extern "rust-call" fn call_once(self, args: A) -> F::Output {
+        extern "rust-call" fn call_once(self, args: A) -> F::Output
+        where
+            F::Output: Sized,
+        {
             (*self).call_mut(args)
         }
     }


### PR DESCRIPTION
An experiment to see what this does with perf...

r? @ghost
