### PR TITLE
Fix a typo “pararmeter” in error message

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -173,7 +173,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                 span,
                 span_label: match res {
                     Res::Def(kind, def_id) if kind == DefKind::TyParam => {
-                        self.def_span(def_id).map(|span| (span, "found this type pararmeter"))
+                        self.def_span(def_id).map(|span| (span, "found this type parameter"))
                     }
                     _ => None,
                 },

--- a/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
@@ -4,7 +4,7 @@ error[E0423]: expected value, found type parameter `T`
 LL | impl<T> Bar<T> for [u8; T] {}
    |      -                  ^ not a value
    |      |
-   |      found this type pararmeter
+   |      found this type parameter
 
 error[E0599]: the function or associated item `foo` exists for struct `Foo<_>`, but its trait bounds were not satisfied
   --> $DIR/issue-69654.rs:17:10

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -2,7 +2,7 @@ error[E0574]: expected struct, variant or union type, found type parameter `T`
   --> $DIR/lexical-scopes.rs:3:13
    |
 LL | fn f<T>() {
-   |      - found this type pararmeter
+   |      - found this type parameter
 LL |     let t = T { i: 0 };
    |             ^ not a struct, variant or union type
 

--- a/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
+++ b/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
@@ -2,7 +2,7 @@ error[E0574]: expected struct, variant or union type, found type parameter `Baz`
   --> $DIR/point-at-type-parameter-shadowing-another-type.rs:16:13
    |
 LL | impl<Baz> Foo<Baz> for Bar {
-   |      --- found this type pararmeter
+   |      --- found this type parameter
 ...
 LL |             Baz { num } => num,
    |             ^^^ not a struct, variant or union type

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -4,7 +4,7 @@ error[E0404]: expected trait, found type parameter `Add`
 LL | impl<T: Clone, Add> Add for Foo<T> {
    |                ---  ^^^ not a trait
    |                |
-   |                found this type pararmeter
+   |                found this type parameter
    |
 help: consider importing this trait instead
    |


### PR DESCRIPTION
Issue reported on IRLO: https://internals.rust-lang.org/t/fixing-a-typo/17427