### PR TITLE
Add note to clippy::non_expressive_names doc

### DIFF
--- a/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
+++ b/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
@@ -15,6 +15,10 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for names that are very similar and thus confusing.
     ///
+    /// Note: this lint looks for similar names throughout each
+    /// scope. To allow it, you need to allow it on the scope
+    /// level, not on the name that is reported.
+    ///
     /// ### Why is this bad?
     /// It's hard to distinguish between names that differ only
     /// by a single character.


### PR DESCRIPTION
Addresses confusion in rust-lang/rust-clippy#9514 by updating the lint docs.