### PR TITLE
rustdoc: remove no-op CSS `.content .item-info { position: relative }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -749,7 +749,6 @@ pre, .rustdoc.source .example-wrap {
 }
 
 .content .item-info {
-	position: relative;
 	margin-left: 24px;
 }
 


### PR DESCRIPTION
This rule was added to help position the marker line in 110e7270ab7b0700ce714b8b1c7e509195dea2c4, which was a `position: absolute` pseudo-element that relied on its parent to put it in the right spot. (it was changed from a line to an arrow in 1ffb9cf8d75e6f8b9aa27a25c7bc56c7bb3a1c43, then a different arrow in ae3a53ff58cec7aca1dfd17479fca44b7f91491f).

The arrow was removed in 73d0f7c7b68784f1db0a1f53855c20d118a7e8b0, so the `relative` position is no longer necessary.