### PR TITLE
rustdoc: remove no-op CSS `.location:empty { border: none }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -522,10 +522,6 @@ img {
 	width: 100px;
 }
 
-.location:empty {
-	border: none;
-}
-
 .block ul, .block li {
 	padding: 0;
 	margin: 0;


### PR DESCRIPTION
This rule was added in 2bb2a2975f25e8ba7a372898e7e112f1cec5db01 to remove a border placed around the location when it's empty. That rule was removed in 6a5f8b1aef1417d7dc85b5d0a229d2db1930eb7c, so this rule does nothing.