### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -280,7 +280,7 @@ impl<'tcx, Prov: Provenance> PlaceTy<'tcx, Prov> {
 
     #[inline(always)]
     #[cfg_attr(debug_assertions, track_caller)] // only in debug builds due to perf (see #98980)
-    pub fn assert_mem_place(self) -> MPlaceTy<'tcx, Prov> {
+    pub fn assert_mem_place(&self) -> MPlaceTy<'tcx, Prov> {
         self.try_as_mplace().unwrap()
     }
 }

--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -129,7 +129,7 @@ impl<'tcx> UnifyKey for ty::ConstVid<'tcx> {
 }
 
 impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
-    type Error = (ty::Const<'tcx>, ty::Const<'tcx>);
+    type Error = NoError;
 
     fn unify_values(&value1: &Self, &value2: &Self) -> Result<Self, Self::Error> {
         Ok(match (value1.val, value2.val) {

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -384,14 +384,7 @@ impl DeepRejectCtxt {
             // they might unify with any value.
             ty::ConstKind::Unevaluated(_) | ty::ConstKind::Error(_) => true,
             ty::ConstKind::Value(obl) => match k {
-                ty::ConstKind::Value(imp) => {
-                    // FIXME(valtrees): Once we have valtrees, we can just
-                    // compare them directly here.
-                    match (obl.try_to_scalar_int(), imp.try_to_scalar_int()) {
-                        (Some(obl), Some(imp)) => obl == imp,
-                        _ => true,
-                    }
-                }
+                ty::ConstKind::Value(imp) => obl == imp,
                 _ => true,
             },
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -35,8 +35,8 @@ pub(crate) fn target_from_impl_item<'tcx>(
     match impl_item.kind {
         hir::ImplItemKind::Const(..) => Target::AssocConst,
         hir::ImplItemKind::Fn(..) => {
-            let parent_hir_id = tcx.hir().get_parent_item(impl_item.hir_id());
-            let containing_item = tcx.hir().expect_item(parent_hir_id);
+            let parent_def_id = tcx.hir().get_parent_item(impl_item.hir_id());
+            let containing_item = tcx.hir().expect_item(parent_def_id);
             let containing_impl_is_for_trait = match &containing_item.kind {
                 hir::ItemKind::Impl(impl_) => impl_.of_trait.is_some(),
                 _ => bug!("parent of an ImplItem must be an Impl"),
@@ -640,8 +640,8 @@ impl CheckAttrVisitor<'_> {
         let span = meta.span();
         if let Some(location) = match target {
             Target::AssocTy => {
-                let parent_hir_id = self.tcx.hir().get_parent_item(hir_id);
-                let containing_item = self.tcx.hir().expect_item(parent_hir_id);
+                let parent_def_id = self.tcx.hir().get_parent_item(hir_id);
+                let containing_item = self.tcx.hir().expect_item(parent_def_id);
                 if Target::from_item(containing_item) == Target::Impl {
                     Some("type alias in implementation block")
                 } else {
@@ -649,8 +649,8 @@ impl CheckAttrVisitor<'_> {
                 }
             }
             Target::AssocConst => {
-                let parent_hir_id = self.tcx.hir().get_parent_item(hir_id);
-                let containing_item = self.tcx.hir().expect_item(parent_hir_id);
+                let parent_def_id = self.tcx.hir().get_parent_item(hir_id);
+                let containing_item = self.tcx.hir().expect_item(parent_def_id);
                 // We can't link to trait impl's consts.
                 let err = "associated constant in trait implementation block";
                 match containing_item.kind {

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -95,7 +95,8 @@ pub enum ControlFlow<B, C = ()> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-impl<B, C> ops::Try for ControlFlow<B, C> {
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
+impl<B, C> const ops::Try for ControlFlow<B, C> {
     type Output = C;
     type Residual = ControlFlow<B, convert::Infallible>;
 
@@ -114,7 +115,8 @@ impl<B, C> ops::Try for ControlFlow<B, C> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-impl<B, C> ops::FromResidual for ControlFlow<B, C> {
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
+impl<B, C> const ops::FromResidual for ControlFlow<B, C> {
     #[inline]
     fn from_residual(residual: ControlFlow<B, convert::Infallible>) -> Self {
         match residual {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -239,8 +239,8 @@ struct AllTypes {
     opaque_tys: FxHashSet<ItemEntry>,
     statics: FxHashSet<ItemEntry>,
     constants: FxHashSet<ItemEntry>,
-    attributes: FxHashSet<ItemEntry>,
-    derives: FxHashSet<ItemEntry>,
+    attribute_macros: FxHashSet<ItemEntry>,
+    derive_macros: FxHashSet<ItemEntry>,
     trait_aliases: FxHashSet<ItemEntry>,
 }
 
@@ -259,8 +259,8 @@ impl AllTypes {
             opaque_tys: new_set(100),
             statics: new_set(100),
             constants: new_set(100),
-            attributes: new_set(100),
-            derives: new_set(100),
+            attribute_macros: new_set(100),
+            derive_macros: new_set(100),
             trait_aliases: new_set(100),
         }
     }
@@ -283,8 +283,10 @@ impl AllTypes {
                 ItemType::OpaqueTy => self.opaque_tys.insert(ItemEntry::new(new_url, name)),
                 ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
                 ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
-                ItemType::ProcAttribute => self.attributes.insert(ItemEntry::new(new_url, name)),
-                ItemType::ProcDerive => self.derives.insert(ItemEntry::new(new_url, name)),
+                ItemType::ProcAttribute => {
+                    self.attribute_macros.insert(ItemEntry::new(new_url, name))
+                }
+                ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(new_url, name)),
                 ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
                 _ => true,
             };
@@ -327,10 +329,10 @@ impl AllTypes {
         if !self.constants.is_empty() {
             sections.insert(ItemSection::Constants);
         }
-        if !self.attributes.is_empty() {
+        if !self.attribute_macros.is_empty() {
             sections.insert(ItemSection::AttributeMacros);
         }
-        if !self.derives.is_empty() {
+        if !self.derive_macros.is_empty() {
             sections.insert(ItemSection::DeriveMacros);
         }
         if !self.trait_aliases.is_empty() {
@@ -373,8 +375,8 @@ impl AllTypes {
         print_entries(f, &self.primitives, ItemSection::PrimitiveTypes);
         print_entries(f, &self.traits, ItemSection::Traits);
         print_entries(f, &self.macros, ItemSection::Macros);
-        print_entries(f, &self.attributes, ItemSection::AttributeMacros);
-        print_entries(f, &self.derives, ItemSection::DeriveMacros);
+        print_entries(f, &self.attribute_macros, ItemSection::AttributeMacros);
+        print_entries(f, &self.derive_macros, ItemSection::DeriveMacros);
         print_entries(f, &self.functions, ItemSection::Functions);
         print_entries(f, &self.typedefs, ItemSection::TypeDefinitions);
         print_entries(f, &self.trait_aliases, ItemSection::TraitAliases);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -522,10 +522,6 @@ img {
 	width: 100px;
 }
 
-.location:empty {
-	border: none;
-}
-
 .block ul, .block li {
 	padding: 0;
 	margin: 0;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -749,7 +749,6 @@ pre, .rustdoc.source .example-wrap {
 }
 
 .content .item-info {
-	position: relative;
 	margin-left: 24px;
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -577,13 +577,9 @@ h2.location a {
 }
 
 .rustdoc .example-wrap {
-	display: inline-flex;
+	display: flex;
 	margin-bottom: 10px;
-}
-
-.example-wrap {
 	position: relative;
-	width: 100%;
 }
 
 .example-wrap > pre.line-number {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -697,20 +697,39 @@ function loadCss(cssFileName) {
         }
     }());
 
+    window.rustdoc_add_line_numbers_to_examples = () => {
+        onEachLazy(document.getElementsByClassName("rust-example-rendered"), x => {
+            const parent = x.parentNode;
+            const line_numbers = parent.querySelectorAll(".line-number");
+            if (line_numbers.length > 0) {
+                return;
+            }
+            const count = x.textContent.split("\n").length;
+            const elems = [];
+            for (let i = 0; i < count; ++i) {
+                elems.push(i + 1);
+            }
+            const node = document.createElement("pre");
+            addClass(node, "line-number");
+            node.innerHTML = elems.join("\n");
+            parent.insertBefore(node, x);
+        });
+    };
+
+    window.rustdoc_remove_line_numbers_from_examples = () => {
+        onEachLazy(document.getElementsByClassName("rust-example-rendered"), x => {
+            const parent = x.parentNode;
+            const line_numbers = parent.querySelectorAll(".line-number");
+            for (const node of line_numbers) {
+                parent.removeChild(node);
+            }
+        });
+    };
+
     (function() {
         // To avoid checking on "rustdoc-line-numbers" value on every loop...
         if (getSettingValue("line-numbers") === "true") {
-            onEachLazy(document.getElementsByClassName("rust-example-rendered"), x => {
-                const count = x.textContent.split("\n").length;
-                const elems = [];
-                for (let i = 0; i < count; ++i) {
-                    elems.push(i + 1);
-                }
-                const node = document.createElement("pre");
-                addClass(node, "line-number");
-                node.innerHTML = elems.join("\n");
-                x.parentNode.insertBefore(node, x);
-            });
+            window.rustdoc_add_line_numbers_to_examples();
         }
     }());
 

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -19,6 +19,13 @@
                 updateSystemTheme();
                 updateLightAndDark();
                 break;
+            case "line-numbers":
+                if (value === true) {
+                    window.rustdoc_add_line_numbers_to_examples();
+                } else {
+                    window.rustdoc_remove_line_numbers_from_examples();
+                }
+                break;
         }
     }
 

--- a/src/test/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/src/test/rustdoc-gui/docblock-code-block-line-number.goml
@@ -20,3 +20,20 @@ assert-css: ("pre.line-number", {
 })
 // The first code block has two lines so let's check its `<pre>` elements lists both of them.
 assert-text: ("pre.line-number", "1\n2")
+
+// Now, try changing the setting dynamically. We'll turn it off, using the settings menu,
+// and make sure it goes away.
+
+// First, open the settings menu.
+click: "#settings-menu"
+wait-for: "#settings"
+assert-css: ("#settings", {"display": "block"})
+
+// Then, click the toggle button.
+click: "input#line-numbers + .slider"
+wait-for: 100 // wait-for-false does not exist
+assert-false: "pre.line-number"
+
+// Finally, turn it on again.
+click: "input#line-numbers + .slider"
+wait-for: "pre.line-number"

--- a/src/test/rustdoc-gui/source-anchor-scroll.goml
+++ b/src/test/rustdoc-gui/source-anchor-scroll.goml
@@ -10,7 +10,7 @@ assert-property: ("html", {"scrollTop": "0"})
 click: '//a[text() = "barbar"]'
 assert-property: ("html", {"scrollTop": "125"})
 click: '//a[text() = "bar"]'
-assert-property: ("html", {"scrollTop": "166"})
+assert-property: ("html", {"scrollTop": "156"})
 click: '//a[text() = "sub_fn"]'
 assert-property: ("html", {"scrollTop": "53"})
 

--- a/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
+++ b/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
@@ -15,6 +15,10 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for names that are very similar and thus confusing.
     ///
+    /// Note: this lint looks for similar names throughout each
+    /// scope. To allow it, you need to allow it on the scope
+    /// level, not on the name that is reported.
+    ///
     /// ### Why is this bad?
     /// It's hard to distinguish between names that differ only
     /// by a single character.


### PR DESCRIPTION
Successful merges:

 - #102113 (OpTy: fix a method taking self rather than &self)
 - #102118 (rustdoc: clean up line numbers on code examples)
 - #102123 (Add note to clippy::non_expressive_names doc)
 - #102125 (rustdoc: remove no-op CSS `.content .item-info { position: relative }`)
 - #102127 (Use appropriate variable names)
 - #102128 (Const unification is already infallible, remove the error handling logic)
 - #102133 (Use valtrees for comparison)
 - #102135 (Improve some AllTypes fields name)
 - #102144 (Extend const_convert with const {FormResidual, Try} for ControlFlow.)
 - #102147 (rustdoc: remove no-op CSS `.location:empty { border: none }`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102113,102118,102123,102125,102127,102128,102133,102135,102144,102147)
<!-- homu-ignore:end -->