### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -268,3 +268,6 @@ passes_link_ordinal = attribute should be applied to a foreign function or stati
 
 passes_collapse_debuginfo = `collapse_debuginfo` attribute should be applied to macro definitions
     .label = not a macro definition
+
+passes_deprecated_annotation_has_no_effect = this `#[deprecated]` annotation has no effect
+    .suggestion = remove the unnecessary deprecation attribute

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -312,6 +312,8 @@ declare_features! (
     (active, associated_type_defaults, "1.2.0", Some(29661), None),
     /// Allows `async || body` closures.
     (active, async_closure, "1.37.0", Some(62290), None),
+    /// Alows async functions to be declared, implemented, and used in traits.
+    (incomplete, async_fn_in_trait, "CURRENT_RUSTC_VERSION", Some(91611), None),
     /// Allows `extern "C-unwind" fn` to enable unwinding across ABI boundaries.
     (active, c_unwind, "1.52.0", Some(74990), None),
     /// Allows using C-variadics.

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1779,11 +1779,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                         .tcx
                                         .parent_module_from_def_id(defid.expect_local())
                                         .to_def_id();
-                                    let module_name =
-                                        self.tcx.def_path(module).to_string_no_crate_verbose();
-                                    format!(
-                                        "{name} is defined in module {module_name} of the current crate"
-                                    )
+                                    let module_name = self.tcx.def_path(module).to_string_no_crate_verbose();
+                                    format!("{name} is defined in module `crate{module_name}` of the current crate")
                                 } else if defid.is_local() {
                                     format!("{name} is defined in the current crate")
                                 } else {

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,6 +20,8 @@
 #![cfg_attr(bootstrap, feature(label_break_value))]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(let_else))]
+#![feature(let_else)]
+#![feature(if_let_guard)]
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(try_blocks)]

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,7 +20,6 @@
 #![cfg_attr(bootstrap, feature(label_break_value))]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(let_else))]
-#![feature(let_else)]
 #![feature(if_let_guard)]
 #![feature(min_specialization)]
 #![feature(never_type)]

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -19,7 +19,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_index::vec::Idx;
 use rustc_macros::HashStable;
-use rustc_span::symbol::{kw, Symbol};
+use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_target::abi::VariantIdx;
 use rustc_target::spec::abi;
 use std::borrow::Cow;
@@ -2272,6 +2272,35 @@ impl<'tcx> Ty<'tcx> {
             ty::Bound(..) | ty::Placeholder(..) => {
                 bug!("`is_trivially_pure_clone_copy` applied to unexpected type: {:?}", self);
             }
+        }
+    }
+
+    // If `self` is a primitive, return its [`Symbol`].
+    pub fn primitive_symbol(self) -> Option<Symbol> {
+        match self.kind() {
+            ty::Bool => Some(sym::bool),
+            ty::Char => Some(sym::char),
+            ty::Float(f) => match f {
+                ty::FloatTy::F32 => Some(sym::f32),
+                ty::FloatTy::F64 => Some(sym::f64),
+            },
+            ty::Int(f) => match f {
+                ty::IntTy::Isize => Some(sym::isize),
+                ty::IntTy::I8 => Some(sym::i8),
+                ty::IntTy::I16 => Some(sym::i16),
+                ty::IntTy::I32 => Some(sym::i32),
+                ty::IntTy::I64 => Some(sym::i64),
+                ty::IntTy::I128 => Some(sym::i128),
+            },
+            ty::Uint(f) => match f {
+                ty::UintTy::Usize => Some(sym::usize),
+                ty::UintTy::U8 => Some(sym::u8),
+                ty::UintTy::U16 => Some(sym::u16),
+                ty::UintTy::U32 => Some(sym::u32),
+                ty::UintTy::U64 => Some(sym::u64),
+                ty::UintTy::U128 => Some(sym::u128),
+            },
+            _ => None,
         }
     }
 }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -658,3 +658,10 @@ pub struct CollapseDebuginfo {
     #[label]
     pub defn_span: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(passes::deprecated_annotation_has_no_effect)]
+pub struct DeprecatedAnnotationHasNoEffect {
+    #[suggestion(applicability = "machine-applicable", code = "")]
+    pub span: Span,
+}

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -396,6 +396,7 @@ symbols! {
         assume_init,
         async_await,
         async_closure,
+        async_fn_in_trait,
         atomic,
         atomic_mod,
         atomics,

--- a/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
@@ -1,15 +1,11 @@
 use crate::abi::Endian;
-use crate::spec::{LinkerFlavor, RelroLevel, Target, TargetOptions};
+use crate::spec::{LinkerFlavor, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
     base.cpu = "ppc64".into();
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m64"]);
     base.max_atomic_width = Some(64);
-
-    // ld.so in at least RHEL6 on ppc64 has a bug related to BIND_NOW, so only enable partial RELRO
-    // for now. https://github.com/rust-lang/rust/pull/43170#issuecomment-315411474
-    base.relro_level = RelroLevel::Partial;
 
     Target {
         llvm_target: "powerpc64-unknown-linux-gnu".into(),

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -98,29 +98,23 @@ impl Step for JsonDocs {
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let default = run.builder.config.docs;
-        run.alias("rust-json-docs").default_condition(default)
+        run.alias("rust-docs-json").default_condition(default)
     }
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(JsonDocs { host: run.target });
     }
 
-    /// Builds the `rust-json-docs` installer component.
+    /// Builds the `rust-docs-json` installer component.
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
-        // This prevents JSON docs from being built for "dist" or "install"
-        // on the stable/beta channels. The JSON format is not stable yet and
-        // should not be included in stable/beta toolchains.
-        if !builder.build.unstable_features() {
-            return None;
-        }
-
         let host = self.host;
         builder.ensure(crate::doc::JsonStd { stage: builder.top_stage, target: host });
 
         let dest = "share/doc/rust/json";
 
-        let mut tarball = Tarball::new(builder, "rust-json-docs", &host.triple);
+        let mut tarball = Tarball::new(builder, "rust-docs-json", &host.triple);
         tarball.set_product_name("Rust Documentation In JSON Format");
+        tarball.is_preview(true);
         tarball.add_bulk_dir(&builder.json_doc_out(host), dest);
         Some(tarball.generate())
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -674,7 +674,6 @@ h2.location a {
 }
 
 .method > .code-header, .trait-impl > .code-header {
-	max-width: calc(100% - 41px);
 	display: block;
 }
 

--- a/src/test/rustdoc-gui/notable-trait.goml
+++ b/src/test/rustdoc-gui/notable-trait.goml
@@ -83,7 +83,7 @@ assert-position: (
 )
 
 // Checking on very small mobile. The `i` should be on its own line.
-size: (410, 600)
+size: (365, 600)
 compare-elements-position-false: (
     "//*[@id='method.create_an_iterator_from_read']//a[text()='NotableStructWithLongName']",
     "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",

--- a/src/test/ui/async-await/async-fn-size-moved-locals.rs
+++ b/src/test/ui/async-await/async-fn-size-moved-locals.rs
@@ -7,7 +7,6 @@
 //
 // See issue #59123 for a full explanation.
 
-// ignore-emscripten (sizes don't match)
 // needs-unwind Size of Futures change on panic=abort
 // run-pass
 

--- a/src/test/ui/async-await/async-trait-fn.stderr
+++ b/src/test/ui/async-await/async-trait-fn.stderr
@@ -9,7 +9,7 @@ LL |     async fn foo() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/async-trait-fn.rs:5:5
@@ -22,7 +22,7 @@ LL |     async fn bar(&self) {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/async-trait-fn.rs:7:5
@@ -35,7 +35,7 @@ LL |     async fn baz() {
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
   --> $DIR/async-trait-fn.rs:3:20

--- a/src/test/ui/async-await/edition-deny-async-fns-2015.stderr
+++ b/src/test/ui/async-await/edition-deny-async-fns-2015.stderr
@@ -90,7 +90,7 @@ LL |     async fn foo() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
   --> $DIR/edition-deny-async-fns-2015.rs:18:20

--- a/src/test/ui/async-await/feature-gate-async_fn_in_trait.rs
+++ b/src/test/ui/async-await/feature-gate-async_fn_in_trait.rs
@@ -1,0 +1,25 @@
+// edition:2021
+
+// RPITIT is not enough to allow use of async functions
+#![allow(incomplete_features)]
+#![feature(return_position_impl_trait_in_trait)]
+
+trait T {
+    async fn foo(); //~ ERROR functions in traits cannot be declared `async`
+}
+
+// Both return_position_impl_trait_in_trait and async_fn_in_trait are required for this (see also
+// feature-gate-return_position_impl_trait_in_trait.rs)
+trait T2 {
+    async fn foo() -> impl Sized; //~ ERROR functions in traits cannot be declared `async`
+}
+
+trait T3 {
+    fn foo() -> impl std::future::Future<Output = ()>;
+}
+
+impl T3 for () {
+    async fn foo() {} //~ ERROR functions in traits cannot be declared `async`
+}
+
+fn main() {}

--- a/src/test/ui/async-await/feature-gate-async_fn_in_trait.stderr
+++ b/src/test/ui/async-await/feature-gate-async_fn_in_trait.stderr
@@ -1,0 +1,42 @@
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/feature-gate-async_fn_in_trait.rs:8:5
+   |
+LL |     async fn foo();
+   |     -----^^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/feature-gate-async_fn_in_trait.rs:14:5
+   |
+LL |     async fn foo() -> impl Sized;
+   |     -----^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/feature-gate-async_fn_in_trait.rs:22:5
+   |
+LL |     async fn foo() {}
+   |     -----^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0706`.

--- a/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
+++ b/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
@@ -6,7 +6,6 @@
 // error-pattern: thread 'main' panicked at '`async fn` resumed after panicking'
 // edition:2018
 // ignore-wasm no panic or subprocess support
-// ignore-emscripten no panic or subprocess support
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/async-await/issues/issue-95307.stderr
+++ b/src/test/ui/async-await/issues/issue-95307.stderr
@@ -9,7 +9,7 @@ LL |     async fn new() -> [u8; _];
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error: in expressions, `_` can only be used on the left-hand side of an assignment
   --> $DIR/issue-95307.rs:7:28

--- a/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
+++ b/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
@@ -3,7 +3,6 @@
 // Check that partially moved from function parameters are dropped after the
 // named bindings that move from them.
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::{panic, cell::RefCell};
 

--- a/src/test/ui/builtin-clone-unwind.rs
+++ b/src/test/ui/builtin-clone-unwind.rs
@@ -3,7 +3,6 @@
 
 #![allow(unused_variables)]
 #![allow(unused_imports)]
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // Test that builtin implementations of `Clone` cleanup everything
 // in case of unwinding.

--- a/src/test/ui/catch-unwind-bang.rs
+++ b/src/test/ui/catch-unwind-bang.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 fn worker() -> ! {
     panic!()

--- a/src/test/ui/cfg/cfg-panic.rs
+++ b/src/test/ui/cfg/cfg-panic.rs
@@ -1,9 +1,6 @@
 // build-pass
 // compile-flags: -C panic=unwind
 // needs-unwind
-// ignore-emscripten no panic_unwind implementation
-// ignore-wasm32     no panic_unwind implementation
-// ignore-wasm64     no panic_unwind implementation
 
 
 #[cfg(panic = "abort")]

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -3,7 +3,6 @@
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-// ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -3,7 +3,6 @@
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-// ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,5 +1,5 @@
 error: changes to closure capture in Rust 2021 will affect which traits the closure implements
-  --> $DIR/mir_calls_to_shims.rs:21:38
+  --> $DIR/mir_calls_to_shims.rs:20:38
    |
 LL |     let result = panic::catch_unwind(move || {
    |                                      ^^^^^^^

--- a/src/test/ui/drop/dynamic-drop-async.rs
+++ b/src/test/ui/drop/dynamic-drop-async.rs
@@ -6,7 +6,6 @@
 // run-pass
 // needs-unwind
 // edition:2018
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(unused)]
 

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/drop/repeat-drop.rs
+++ b/src/test/ui/drop/repeat-drop.rs
@@ -1,8 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare no unwinding panic
-// ignore-avr no unwinding panic
-// ignore-nvptx64 no unwinding panic
 
 static mut CHECK: usize = 0;
 

--- a/src/test/ui/extern-flag/empty-extern-arg.rs
+++ b/src/test/ui/extern-flag/empty-extern-arg.rs
@@ -1,6 +1,5 @@
 // compile-flags: --extern std=
 // error-pattern: extern location for std does not exist
 // needs-unwind since it affects the error output
-// ignore-emscripten compiled with panic=abort, personality not required
 
 fn main() {}

--- a/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
+++ b/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 
 // rust-lang/rust#64655: with panic=unwind, a panic from a subroutine

--- a/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
+++ b/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 
 // rust-lang/rust#64655: with panic=unwind, a panic from a subroutine

--- a/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.rs
+++ b/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.rs
@@ -1,5 +1,18 @@
+// edition:2021
+
+// async_fn_in_trait is not enough to allow use of RPITIT
+#![allow(incomplete_features)]
+#![feature(async_fn_in_trait)]
+
 trait Foo {
     fn bar() -> impl Sized; //~ ERROR `impl Trait` only allowed in function and inherent method return types, not in trait method return
+    fn baz() -> Box<impl std::fmt::Display>; //~ ERROR `impl Trait` only allowed in function and inherent method return types, not in trait method return
+}
+
+// Both return_position_impl_trait_in_trait and async_fn_in_trait are required for this (see also
+// feature-gate-async_fn_in_trait.rs)
+trait AsyncFoo {
+    async fn bar() -> impl Sized; //~ ERROR `impl Trait` only allowed in function and inherent method return types, not in trait method return
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
+++ b/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
@@ -1,5 +1,5 @@
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
-  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:2:17
+  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:8:17
    |
 LL |     fn bar() -> impl Sized;
    |                 ^^^^^^^^^^
@@ -7,6 +7,24 @@ LL |     fn bar() -> impl Sized;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:9:21
+   |
+LL |     fn baz() -> Box<impl std::fmt::Display>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:15:23
+   |
+LL |     async fn bar() -> impl Sized;
+   |                       ^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -7,12 +7,12 @@ LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
    |
    = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
-note: enum `x::Foo` is defined in module ::x of the current crate
+note: enum `x::Foo` is defined in module `crate::x` of the current crate
   --> $DIR/fully-qualified-type-name2.rs:4:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^
-note: enum `y::Foo` is defined in module ::y of the current crate
+note: enum `y::Foo` is defined in module `crate::y` of the current crate
   --> $DIR/fully-qualified-type-name2.rs:8:5
    |
 LL |     pub enum Foo { }

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -7,12 +7,12 @@ LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
    |
    = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
-note: enum `x::Foo` is defined in the current crate.
+note: enum `x::Foo` is defined in module ::x of the current crate
   --> $DIR/fully-qualified-type-name2.rs:4:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^
-note: enum `y::Foo` is defined in the current crate.
+note: enum `y::Foo` is defined in module ::y of the current crate
   --> $DIR/fully-qualified-type-name2.rs:8:5
    |
 LL |     pub enum Foo { }

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -5,6 +5,18 @@ LL | fn bar(x: x::Foo) -> y::Foo {
    |                      ------ expected `y::Foo` because of return type
 LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
+   |
+   = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
+note: enum `x::Foo` is defined in the current crate.
+  --> $DIR/fully-qualified-type-name2.rs:4:5
+   |
+LL |     pub enum Foo { }
+   |     ^^^^^^^^^^^^
+note: enum `y::Foo` is defined in the current crate.
+  --> $DIR/fully-qualified-type-name2.rs:8:5
+   |
+LL |     pub enum Foo { }
+   |     ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/generator/panic-drops-resume.rs
+++ b/src/test/ui/generator/panic-drops-resume.rs
@@ -2,8 +2,6 @@
 
 // run-pass
 // needs-unwind
-// ignore-wasm       no unwind support
-// ignore-emscripten no unwind support
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/panic-drops.rs
+++ b/src/test/ui/generator/panic-drops.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/panic-safe.rs
+++ b/src/test/ui/generator/panic-safe.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/resume-after-return.rs
+++ b/src/test/ui/generator/resume-after-return.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/intrinsics/const-eval-select-backtrace-std.rs
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace-std.rs
@@ -1,6 +1,7 @@
 // See issue #100696.
 // run-fail
 // check-run-results
+// exec-env:RUST_BACKTRACE=0
 fn main() {
     &""[1..];
 }

--- a/src/test/ui/intrinsics/const-eval-select-backtrace-std.run.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace-std.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'byte index 1 is out of bounds of ``', $DIR/const-eval-select-backtrace-std.rs:5:6
+thread 'main' panicked at 'byte index 1 is out of bounds of ``', $DIR/const-eval-select-backtrace-std.rs:6:6
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/intrinsics/const-eval-select-backtrace.rs
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace.rs
@@ -2,6 +2,7 @@
 // See issue #100696.
 // run-fail
 // check-run-results
+// exec-env:RUST_BACKTRACE=0
 
 #[track_caller]
 fn uhoh() {

--- a/src/test/ui/intrinsics/const-eval-select-backtrace.run.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'Aaah!', $DIR/const-eval-select-backtrace.rs:16:9
+thread 'main' panicked at 'Aaah!', $DIR/const-eval-select-backtrace.rs:17:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // revisions: mir thir strict
 // [thir]compile-flags: -Zthir-unsafeck
 // [strict]compile-flags: -Zstrict-init-checks

--- a/src/test/ui/issues/issue-14875.rs
+++ b/src/test/ui/issues/issue-14875.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // Check that values are not leaked when a dtor panics (#14875)
 

--- a/src/test/ui/issues/issue-29948.rs
+++ b/src/test/ui/issues/issue-29948.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;
 

--- a/src/test/ui/issues/issue-43853.rs
+++ b/src/test/ui/issues/issue-43853.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;
 

--- a/src/test/ui/issues/issue-46519.rs
+++ b/src/test/ui/issues/issue-46519.rs
@@ -2,7 +2,6 @@
 // compile-flags:--test -O
 
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #[test]
 #[should_panic(expected = "creating inhabited type")]

--- a/src/test/ui/issues/issue-56943.stderr
+++ b/src/test/ui/issues/issue-56943.stderr
@@ -5,6 +5,18 @@ LL |     let _: issue_56943::S = issue_56943::S2;
    |            --------------   ^^^^^^^^^^^^^^^ expected struct `S`, found struct `S2`
    |            |
    |            expected due to this
+   |
+   = note: struct `S2` and struct `S` have similar names, but are actually distinct types
+note: struct `S2` is defined in crate `issue_56943`.
+  --> $DIR/auxiliary/issue-56943.rs:2:9
+   |
+LL | mod m { pub struct S; }
+   |         ^^^^^^^^^^^^
+note: struct `S` is defined in crate `issue_56943`.
+  --> $DIR/auxiliary/issue-56943.rs:1:1
+   |
+LL | pub struct S;
+   | ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-56943.stderr
+++ b/src/test/ui/issues/issue-56943.stderr
@@ -5,18 +5,6 @@ LL |     let _: issue_56943::S = issue_56943::S2;
    |            --------------   ^^^^^^^^^^^^^^^ expected struct `S`, found struct `S2`
    |            |
    |            expected due to this
-   |
-   = note: struct `S2` and struct `S` have similar names, but are actually distinct types
-note: struct `S2` is defined in crate `issue_56943`.
-  --> $DIR/auxiliary/issue-56943.rs:2:9
-   |
-LL | mod m { pub struct S; }
-   |         ^^^^^^^^^^^^
-note: struct `S` is defined in crate `issue_56943`.
-  --> $DIR/auxiliary/issue-56943.rs:1:1
-   |
-LL | pub struct S;
-   | ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/iterators/iter-count-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;

--- a/src/test/ui/iterators/iter-position-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;

--- a/src/test/ui/iterators/iter-step-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-step-overflow-debug.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 
 use std::panic;

--- a/src/test/ui/iterators/iter-sum-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-debug.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 
 use std::panic;

--- a/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C overflow-checks
 
 use std::panic;

--- a/src/test/ui/macros/macro-comma-behavior-rpass.rs
+++ b/src/test/ui/macros/macro-comma-behavior-rpass.rs
@@ -14,7 +14,6 @@
 // compile-flags: --test -C debug_assertions=yes
 // revisions: std core
 
-// ignore-wasm32-bare compiled with panic=abort by default
 #![cfg_attr(core, no_std)]
 
 #[cfg(core)]

--- a/src/test/ui/mir/mir_calls_to_shims.rs
+++ b/src/test/ui/mir/mir_calls_to_shims.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(fn_traits)]
 #![feature(never_type)]

--- a/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
+++ b/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
@@ -1,7 +1,6 @@
 // run-fail
 // error-pattern:diverging_fn called
 // error-pattern:0 dropped
-// ignore-emscripten no processes
 // needs-unwind this test checks that a destructor is called after panicking
 
 struct Droppable(u8);

--- a/src/test/ui/mir/mir_drop_order.rs
+++ b/src/test/ui/mir/mir_drop_order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::cell::RefCell;
 use std::panic;

--- a/src/test/ui/mir/mir_drop_panics.rs
+++ b/src/test/ui/mir/mir_drop_panics.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // error-pattern:panic 1
 // error-pattern:drop 2
-// ignore-emscripten no processes
 
 struct Droppable(u32);
 impl Drop for Droppable {

--- a/src/test/ui/mir/mir_let_chains_drop_order.rs
+++ b/src/test/ui/mir/mir_let_chains_drop_order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // See `mir_drop_order.rs` for more information
 

--- a/src/test/ui/mismatched_types/show_module.rs
+++ b/src/test/ui/mismatched_types/show_module.rs
@@ -1,0 +1,18 @@
+pub mod blah{
+    pub mod baz{
+        pub struct Foo;
+    }
+}
+
+pub mod meh{
+    pub struct Foo;
+}
+
+pub type Foo = blah::baz::Foo;
+
+fn foo() -> Foo {
+    meh::Foo
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn main(){}

--- a/src/test/ui/mismatched_types/show_module.rs
+++ b/src/test/ui/mismatched_types/show_module.rs
@@ -1,10 +1,10 @@
-pub mod blah{
-    pub mod baz{
+pub mod blah {
+    pub mod baz {
         pub struct Foo;
     }
 }
 
-pub mod meh{
+pub mod meh {
     pub struct Foo;
 }
 
@@ -15,4 +15,4 @@ fn foo() -> Foo {
     //~^ ERROR mismatched types [E0308]
 }
 
-fn main(){}
+fn main() {}

--- a/src/test/ui/mismatched_types/show_module.stderr
+++ b/src/test/ui/mismatched_types/show_module.stderr
@@ -7,12 +7,12 @@ LL |     meh::Foo
    |     ^^^^^^^^ expected struct `baz::Foo`, found struct `meh::Foo`
    |
    = note: struct `meh::Foo` and struct `baz::Foo` have similar names, but are actually distinct types
-note: struct `meh::Foo` is defined in module ::meh of the current crate
+note: struct `meh::Foo` is defined in module `crate::meh` of the current crate
   --> $DIR/show_module.rs:8:5
    |
 LL |     pub struct Foo;
    |     ^^^^^^^^^^^^^^
-note: struct `baz::Foo` is defined in module ::blah::baz of the current crate
+note: struct `baz::Foo` is defined in module `crate::blah::baz` of the current crate
   --> $DIR/show_module.rs:3:9
    |
 LL |         pub struct Foo;

--- a/src/test/ui/mismatched_types/show_module.stderr
+++ b/src/test/ui/mismatched_types/show_module.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/show_module.rs:14:5
+   |
+LL | fn foo() -> Foo {
+   |             --- expected `baz::Foo` because of return type
+LL |     meh::Foo
+   |     ^^^^^^^^ expected struct `baz::Foo`, found struct `meh::Foo`
+   |
+   = note: struct `meh::Foo` and struct `baz::Foo` have similar names, but are actually distinct types
+note: struct `meh::Foo` is defined in module ::meh of the current crate
+  --> $DIR/show_module.rs:8:5
+   |
+LL |     pub struct Foo;
+   |     ^^^^^^^^^^^^^^
+note: struct `baz::Foo` is defined in module ::blah::baz of the current crate
+  --> $DIR/show_module.rs:3:9
+   |
+LL |         pub struct Foo;
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/similar_paths.rs
+++ b/src/test/ui/mismatched_types/similar_paths.rs
@@ -1,11 +1,11 @@
-enum Option<T>{
+enum Option<T> {
     Some(T),
     None,
 }
 
-pub fn foo() -> Option<u8>{
+pub fn foo() -> Option<u8> {
     Some(42_u8)
     //~^ ERROR mismatched types [E0308]
 }
 
-fn main(){}
+fn main() {}

--- a/src/test/ui/mismatched_types/similar_paths.rs
+++ b/src/test/ui/mismatched_types/similar_paths.rs
@@ -1,0 +1,11 @@
+enum Option<T>{
+    Some(T),
+    None,
+}
+
+pub fn foo() -> Option<u8>{
+    Some(42_u8)
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn main(){}

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/similar_paths.rs:7:5
+   |
+LL | pub fn foo() -> Option<u8>{
+   |                 ---------- expected `Option<u8>` because of return type
+LL |     Some(42_u8)
+   |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
+   |
+   = note: enum `std::option::Option` and enum `Option` have similar names, but are actually distinct types
+note: enum `std::option::Option` is defined in the standard library.
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL | pub enum Option<T> {
+   | ^^^^^^^^^^^^^^^^^^
+note: enum `Option` is defined in the current crate.
+  --> $DIR/similar_paths.rs:1:1
+   |
+LL | enum Option<T>{
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -7,12 +7,12 @@ LL |     Some(42_u8)
    |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
    |
    = note: enum `std::option::Option` and enum `Option` have similar names, but are actually distinct types
-note: enum `std::option::Option` is defined in the standard library.
+note: enum `std::option::Option` is defined in crate `core`
   --> $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {
    | ^^^^^^^^^^^^^^^^^^
-note: enum `Option` is defined in the current crate.
+note: enum `Option` is defined in the current crate
   --> $DIR/similar_paths.rs:1:1
    |
 LL | enum Option<T>{

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
   --> $DIR/similar_paths.rs:7:5
    |
-LL | pub fn foo() -> Option<u8>{
+LL | pub fn foo() -> Option<u8> {
    |                 ---------- expected `Option<u8>` because of return type
 LL |     Some(42_u8)
    |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
@@ -15,7 +15,7 @@ LL | pub enum Option<T> {
 note: enum `Option` is defined in the current crate
   --> $DIR/similar_paths.rs:1:1
    |
-LL | enum Option<T>{
+LL | enum Option<T> {
    | ^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/mismatched_types/similar_paths_primitive.rs
+++ b/src/test/ui/mismatched_types/similar_paths_primitive.rs
@@ -1,0 +1,10 @@
+#![allow(non_camel_case_types)]
+
+struct bool;
+
+fn foo(_: bool) {}
+
+fn main() {
+    foo(true);
+    //~^ ERROR mismatched types [E0308]
+}

--- a/src/test/ui/mismatched_types/similar_paths_primitive.stderr
+++ b/src/test/ui/mismatched_types/similar_paths_primitive.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/similar_paths_primitive.rs:8:9
+   |
+LL |     foo(true);
+   |     --- ^^^^ expected struct `bool`, found `bool`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: bool and struct `bool` have similar names, but are actually distinct types
+   = note: bool is a primitive defined by the language
+note: struct `bool` is defined in the current crate
+  --> $DIR/similar_paths_primitive.rs:3:1
+   |
+LL | struct bool;
+   | ^^^^^^^^^^^
+note: function defined here
+  --> $DIR/similar_paths_primitive.rs:5:4
+   |
+LL | fn foo(_: bool) {}
+   |    ^^^ -------
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
+++ b/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // compile-flags: -C debug_assertions=yes
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten dies with an LLVM error
 
 use std::panic;

--- a/src/test/ui/panic-handler/weak-lang-item.rs
+++ b/src/test/ui/panic-handler/weak-lang-item.rs
@@ -2,7 +2,6 @@
 // error-pattern: `#[panic_handler]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // needs-unwind since it affects the error output
-// ignore-emscripten compiled with panic=abort, personality not required
 
 #![no_std]
 

--- a/src/test/ui/panic-handler/weak-lang-item.stderr
+++ b/src/test/ui/panic-handler/weak-lang-item.stderr
@@ -1,5 +1,5 @@
 error[E0259]: the name `core` is defined multiple times
-  --> $DIR/weak-lang-item.rs:9:1
+  --> $DIR/weak-lang-item.rs:8:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ `core` reimported here

--- a/src/test/ui/panic-runtime/need-abort-got-unwind.rs
+++ b/src/test/ui/panic-runtime/need-abort-got-unwind.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // error-pattern:is incompatible with this crate's strategy of `unwind`
 // aux-build:needs-abort.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 extern crate needs_abort;
 

--- a/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
+++ b/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
@@ -6,7 +6,6 @@
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
 // error-pattern: is not compiled with this crate's panic strategy `unwind`
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-runtime/want-unwind-got-abort.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort.rs
@@ -3,7 +3,6 @@
 // error-pattern:is not compiled with this crate's panic strategy `unwind`
 // aux-build:panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
@@ -4,7 +4,6 @@
 // aux-build:panic-runtime-abort.rs
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-while-printing.rs
+++ b/src/test/ui/panic-while-printing.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-emscripten no subprocess support
 
 #![feature(internal_output_capture)]
 

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -147,7 +147,7 @@ LL |         async fn ft1();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/fn-header-semantic-fail.rs:21:9
@@ -160,7 +160,7 @@ LL |         const async unsafe extern "C" fn ft5();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/fn-header-semantic-fail.rs:29:9
@@ -173,7 +173,7 @@ LL |         async fn ft1() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/fn-header-semantic-fail.rs:33:9
@@ -186,7 +186,7 @@ LL |         const async unsafe extern "C" fn ft5() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0391]: cycle detected when computing type of `main::ff5::{opaque#0}`
   --> $DIR/fn-header-semantic-fail.rs:12:44

--- a/src/test/ui/privacy/reachable-unnameable-items.rs
+++ b/src/test/ui/privacy/reachable-unnameable-items.rs
@@ -1,5 +1,4 @@
 // run-pass
-// ignore-wasm32-bare compiled with panic=abort by default
 // needs-unwind
 // aux-build:reachable-unnameable-items.rs
 

--- a/src/test/ui/proc-macro/expand-with-a-macro.rs
+++ b/src/test/ui/proc-macro/expand-with-a-macro.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // aux-build:expand-with-a-macro.rs
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![deny(warnings)]
 

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -33,7 +33,7 @@ LL |     async fn associated();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:15:5
@@ -46,7 +46,7 @@ LL |     async fn associated();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
@@ -2,7 +2,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(test)]
 

--- a/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
+++ b/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // revisions: default mir-opt
 //[mir-opt] compile-flags: -Zmir-opt-level=4
 

--- a/src/test/ui/rfcs/rfc1857-drop-order.rs
+++ b/src/test/ui/rfcs/rfc1857-drop-order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(dead_code, unreachable_code)]
 

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -2,9 +2,6 @@
 // needs-unwind
 // ignore-emscripten no processes
 // ignore-sgx no processes
-// ignore-wasm32-bare no unwinding panic
-// ignore-avr no unwinding panic
-// ignore-nvptx64 no unwinding panic
 
 use std::env;
 use std::process::Command;

--- a/src/test/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
+++ b/src/test/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
@@ -51,7 +51,7 @@ LL | trait C{async fn new(val: T) {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 warning: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:6:57

--- a/src/test/ui/test-attrs/test-panic-while-printing.rs
+++ b/src/test/ui/test-attrs/test-panic-while-printing.rs
@@ -1,7 +1,6 @@
 // compile-flags:--test
 // run-pass
 // needs-unwind
-// ignore-emscripten no subprocess support
 
 use std::fmt;
 use std::fmt::{Display, Formatter};

--- a/src/test/ui/test-attrs/test-should-fail-good-message.rs
+++ b/src/test/ui/test-attrs/test-should-fail-good-message.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: --test
 #[test]
 #[should_panic(expected = "foo")]

--- a/src/test/ui/type/type-mismatch-same-crate-name.stderr
+++ b/src/test/ui/type/type-mismatch-same-crate-name.stderr
@@ -6,6 +6,17 @@ LL |         a::try_foo(foo2);
    |         |
    |         arguments to this function are incorrect
    |
+   = note: struct `main::a::Foo` and struct `main::a::Foo` have similar names, but are actually distinct types
+note: struct `main::a::Foo` is defined in crate `crate_a2`.
+  --> $DIR/auxiliary/crate_a2.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
+note: struct `main::a::Foo` is defined in crate `crate_a1`.
+  --> $DIR/auxiliary/crate_a1.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `crate_a1` are being used?
 note: function defined here
   --> $DIR/auxiliary/crate_a1.rs:10:8

--- a/src/test/ui/type/type-mismatch-same-crate-name.stderr
+++ b/src/test/ui/type/type-mismatch-same-crate-name.stderr
@@ -7,12 +7,12 @@ LL |         a::try_foo(foo2);
    |         arguments to this function are incorrect
    |
    = note: struct `main::a::Foo` and struct `main::a::Foo` have similar names, but are actually distinct types
-note: struct `main::a::Foo` is defined in crate `crate_a2`.
+note: struct `main::a::Foo` is defined in crate `crate_a2`
   --> $DIR/auxiliary/crate_a2.rs:1:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
-note: struct `main::a::Foo` is defined in crate `crate_a1`.
+note: struct `main::a::Foo` is defined in crate `crate_a1`
   --> $DIR/auxiliary/crate_a1.rs:1:1
    |
 LL | pub struct Foo;

--- a/src/test/ui/unwind-abis/ffi-unwind-calls-lint.rs
+++ b/src/test/ui/unwind-abis/ffi-unwind-calls-lint.rs
@@ -1,6 +1,5 @@
 // build-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(c_unwind)]
 #![warn(ffi_unwind_calls)]

--- a/src/test/ui/unwind-abis/ffi-unwind-calls-lint.stderr
+++ b/src/test/ui/unwind-abis/ffi-unwind-calls-lint.stderr
@@ -1,17 +1,17 @@
 warning: call to foreign function with FFI-unwind ABI
-  --> $DIR/ffi-unwind-calls-lint.rs:21:14
+  --> $DIR/ffi-unwind-calls-lint.rs:20:14
    |
 LL |     unsafe { foo(); }
    |              ^^^^^ call to foreign function with FFI-unwind ABI
    |
 note: the lint level is defined here
-  --> $DIR/ffi-unwind-calls-lint.rs:6:9
+  --> $DIR/ffi-unwind-calls-lint.rs:5:9
    |
 LL | #![warn(ffi_unwind_calls)]
    |         ^^^^^^^^^^^^^^^^
 
 warning: call to function pointer with FFI-unwind ABI
-  --> $DIR/ffi-unwind-calls-lint.rs:25:5
+  --> $DIR/ffi-unwind-calls-lint.rs:24:5
    |
 LL |     ptr();
    |     ^^^^^ call to function pointer with FFI-unwind ABI

--- a/src/test/ui/unwind-no-uwtable.rs
+++ b/src/test/ui/unwind-no-uwtable.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 // ignore-windows target requires uwtable
-// ignore-wasm32-bare no proper panic=unwind support
 // compile-flags: -C panic=unwind -C force-unwind-tables=n
 
 use std::panic::{self, AssertUnwindSafe};

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -184,7 +184,7 @@ static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"
 
 static MINGW: &[&str] = &["i686-pc-windows-gnu", "x86_64-pc-windows-gnu"];
 
-static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview"];
+static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview", "rust-docs-json-preview"];
 
 macro_rules! t {
     ($e:expr) => {
@@ -318,6 +318,7 @@ impl Builder {
         package!("rust-mingw", MINGW);
         package!("rust-std", TARGETS);
         self.package("rust-docs", &mut manifest.pkg, HOSTS, DOCS_FALLBACK);
+        self.package("rust-docs-json-preview", &mut manifest.pkg, HOSTS, DOCS_FALLBACK);
         package!("rust-src", &["*"]);
         package!("rls-preview", HOSTS);
         package!("rust-analyzer-preview", HOSTS);
@@ -403,6 +404,7 @@ impl Builder {
         rename("rustfmt", "rustfmt-preview");
         rename("clippy", "clippy-preview");
         rename("miri", "miri-preview");
+        rename("rust-docs-json", "rust-docs-json-preview");
         rename("rust-analyzer", "rust-analyzer-preview");
     }
 
@@ -459,6 +461,7 @@ impl Builder {
             host_component("rustfmt-preview"),
             host_component("llvm-tools-preview"),
             host_component("rust-analysis"),
+            host_component("rust-docs-json"),
         ]);
 
         extensions.extend(

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -278,10 +278,6 @@ pub struct Config {
     /// override this setting.
     pub optimize_tests: bool,
 
-    /// What panic strategy the target is built with.  Unwind supports Abort, but
-    /// not vice versa.
-    pub target_panic: PanicStrategy,
-
     /// Target system to be tested
     pub target: String,
 
@@ -426,6 +422,10 @@ impl Config {
         *&self.target_cfg().pointer_width
     }
 
+    pub fn can_unwind(&self) -> bool {
+        self.target_cfg().panic == PanicStrategy::Unwind
+    }
+
     pub fn has_asm_support(&self) -> bool {
         static ASM_SUPPORTED_ARCHS: &[&str] = &[
             "x86", "x86_64", "arm", "aarch64", "riscv32",
@@ -446,6 +446,7 @@ pub struct TargetCfg {
     families: Vec<String>,
     pointer_width: u32,
     endian: Endian,
+    panic: PanicStrategy,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -481,6 +482,7 @@ impl TargetCfg {
         let mut families = Vec::new();
         let mut pointer_width = None;
         let mut endian = None;
+        let mut panic = None;
         for line in print_cfg.lines() {
             if let Some((name, value)) = line.split_once('=') {
                 let value = value.trim_matches('"');
@@ -498,6 +500,13 @@ impl TargetCfg {
                             s => panic!("unexpected {s}"),
                         })
                     }
+                    "panic" => {
+                        panic = match value {
+                            "abort" => Some(PanicStrategy::Abort),
+                            "unwind" => Some(PanicStrategy::Unwind),
+                            s => panic!("unexpected {s}"),
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -510,6 +519,7 @@ impl TargetCfg {
             families,
             pointer_width: pointer_width.unwrap(),
             endian: endian.unwrap(),
+            panic: panic.unwrap(),
         }
     }
 }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::*;
 
-use crate::common::{CompareMode, Config, Debugger, FailMode, Mode, PanicStrategy, PassMode};
+use crate::common::{CompareMode, Config, Debugger, FailMode, Mode, PassMode};
 use crate::util;
 use crate::{extract_cdb_version, extract_gdb_version};
 
@@ -949,8 +949,7 @@ pub fn make_test_description<R: Read>(
         ignore |= !has_memtag && config.parse_name_directive(ln, "needs-sanitizer-memtag");
         ignore |= !has_shadow_call_stack
             && config.parse_name_directive(ln, "needs-sanitizer-shadow-call-stack");
-        ignore |= config.target_panic == PanicStrategy::Abort
-            && config.parse_name_directive(ln, "needs-unwind");
+        ignore |= !config.can_unwind() && config.parse_name_directive(ln, "needs-unwind");
         ignore |= config.target == "wasm32-unknown-unknown"
             && config.parse_name_directive(ln, directives::CHECK_RUN_RESULTS);
         ignore |= config.debugger == Some(Debugger::Cdb) && ignore_cdb(config, ln);

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -5,9 +5,7 @@
 
 extern crate test;
 
-use crate::common::{
-    expected_output_path, output_base_dir, output_relative_path, PanicStrategy, UI_EXTENSIONS,
-};
+use crate::common::{expected_output_path, output_base_dir, output_relative_path, UI_EXTENSIONS};
 use crate::common::{CompareMode, Config, Debugger, Mode, PassMode, TestPaths};
 use crate::util::logv;
 use getopts::Options;
@@ -105,7 +103,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .optmulti("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
         .optmulti("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS")
         .optflag("", "optimize-tests", "run tests with optimizations enabled")
-        .optopt("", "target-panic", "what panic strategy the target supports", "unwind | abort")
         .optflag("", "verbose", "run tests verbosely, showing all output")
         .optflag(
             "",
@@ -258,11 +255,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
         host_rustcflags: Some(matches.opt_strs("host-rustcflags").join(" ")),
         target_rustcflags: Some(matches.opt_strs("target-rustcflags").join(" ")),
         optimize_tests: matches.opt_present("optimize-tests"),
-        target_panic: match matches.opt_str("target-panic").as_deref() {
-            Some("unwind") | None => PanicStrategy::Unwind,
-            Some("abort") => PanicStrategy::Abort,
-            _ => panic!("unknown `--target-panic` option `{}` given", mode),
-        },
         target,
         host: opt_str2(matches.opt_str("host")),
         cdb,


### PR DESCRIPTION
Successful merges:

 - #100734 (Split out async_fn_in_trait into a separate feature)
 - #101664 (Note if mismatched types have a similar name)
 - #101815 (Migrated the rustc_passes annotation without effect diagnostic infrastructure)
 - #102042 (Distribute rust-docs-json via rustup.)
 - #102066 (rustdoc: remove unnecessary `max-width` on headers)
 - #102095 (Deduplicate two functions that would soon have been three)
 - #102104 (Set 'exec-env:RUST_BACKTRACE=0' in const-eval-select tests)
 - #102112 (Allow full relro on powerpc64-unknown-linux-gnu)
 - #102134 (Detect panic strategy using `rustc --print cfg`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100734,101664,101815,102042,102066,102095,102104,102112,102134)
<!-- homu-ignore:end -->