### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -268,3 +268,6 @@ passes_link_ordinal = attribute should be applied to a foreign function or stati
 
 passes_collapse_debuginfo = `collapse_debuginfo` attribute should be applied to macro definitions
     .label = not a macro definition
+
+passes_deprecated_annotation_has_no_effect = this `#[deprecated]` annotation has no effect
+    .suggestion = remove the unnecessary deprecation attribute

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -312,6 +312,8 @@ declare_features! (
     (active, associated_type_defaults, "1.2.0", Some(29661), None),
     /// Allows `async || body` closures.
     (active, async_closure, "1.37.0", Some(62290), None),
+    /// Alows async functions to be declared, implemented, and used in traits.
+    (incomplete, async_fn_in_trait, "CURRENT_RUSTC_VERSION", Some(91611), None),
     /// Allows `extern "C-unwind" fn` to enable unwinding across ABI boundaries.
     (active, c_unwind, "1.52.0", Some(74990), None),
     /// Allows using C-variadics.

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1779,11 +1779,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                         .tcx
                                         .parent_module_from_def_id(defid.expect_local())
                                         .to_def_id();
-                                    let module_name =
-                                        self.tcx.def_path(module).to_string_no_crate_verbose();
-                                    format!(
-                                        "{name} is defined in module {module_name} of the current crate"
-                                    )
+                                    let module_name = self.tcx.def_path(module).to_string_no_crate_verbose();
+                                    format!("{name} is defined in module `crate{module_name}` of the current crate")
                                 } else if defid.is_local() {
                                     format!("{name} is defined in the current crate")
                                 } else {

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,6 +20,8 @@
 #![cfg_attr(bootstrap, feature(label_break_value))]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(let_else))]
+#![feature(let_else)]
+#![feature(if_let_guard)]
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(try_blocks)]

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,7 +20,6 @@
 #![cfg_attr(bootstrap, feature(label_break_value))]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(let_else))]
-#![feature(let_else)]
 #![feature(if_let_guard)]
 #![feature(min_specialization)]
 #![feature(never_type)]

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -19,7 +19,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_index::vec::Idx;
 use rustc_macros::HashStable;
-use rustc_span::symbol::{kw, Symbol};
+use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_target::abi::VariantIdx;
 use rustc_target::spec::abi;
 use std::borrow::Cow;
@@ -2272,6 +2272,35 @@ impl<'tcx> Ty<'tcx> {
             ty::Bound(..) | ty::Placeholder(..) => {
                 bug!("`is_trivially_pure_clone_copy` applied to unexpected type: {:?}", self);
             }
+        }
+    }
+
+    // If `self` is a primitive, return its [`Symbol`].
+    pub fn primitive_symbol(self) -> Option<Symbol> {
+        match self.kind() {
+            ty::Bool => Some(sym::bool),
+            ty::Char => Some(sym::char),
+            ty::Float(f) => match f {
+                ty::FloatTy::F32 => Some(sym::f32),
+                ty::FloatTy::F64 => Some(sym::f64),
+            },
+            ty::Int(f) => match f {
+                ty::IntTy::Isize => Some(sym::isize),
+                ty::IntTy::I8 => Some(sym::i8),
+                ty::IntTy::I16 => Some(sym::i16),
+                ty::IntTy::I32 => Some(sym::i32),
+                ty::IntTy::I64 => Some(sym::i64),
+                ty::IntTy::I128 => Some(sym::i128),
+            },
+            ty::Uint(f) => match f {
+                ty::UintTy::Usize => Some(sym::usize),
+                ty::UintTy::U8 => Some(sym::u8),
+                ty::UintTy::U16 => Some(sym::u16),
+                ty::UintTy::U32 => Some(sym::u32),
+                ty::UintTy::U64 => Some(sym::u64),
+                ty::UintTy::U128 => Some(sym::u128),
+            },
+            _ => None,
         }
     }
 }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -658,3 +658,10 @@ pub struct CollapseDebuginfo {
     #[label]
     pub defn_span: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(passes::deprecated_annotation_has_no_effect)]
+pub struct DeprecatedAnnotationHasNoEffect {
+    #[suggestion(applicability = "machine-applicable", code = "")]
+    pub span: Span,
+}

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -396,6 +396,7 @@ symbols! {
         assume_init,
         async_await,
         async_closure,
+        async_fn_in_trait,
         atomic,
         atomic_mod,
         atomics,

--- a/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
@@ -1,15 +1,11 @@
 use crate::abi::Endian;
-use crate::spec::{LinkerFlavor, RelroLevel, Target, TargetOptions};
+use crate::spec::{LinkerFlavor, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
     base.cpu = "ppc64".into();
     base.add_pre_link_args(LinkerFlavor::Gcc, &["-m64"]);
     base.max_atomic_width = Some(64);
-
-    // ld.so in at least RHEL6 on ppc64 has a bug related to BIND_NOW, so only enable partial RELRO
-    // for now. https://github.com/rust-lang/rust/pull/43170#issuecomment-315411474
-    base.relro_level = RelroLevel::Partial;
 
     Target {
         llvm_target: "powerpc64-unknown-linux-gnu".into(),

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -98,29 +98,23 @@ impl Step for JsonDocs {
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let default = run.builder.config.docs;
-        run.alias("rust-json-docs").default_condition(default)
+        run.alias("rust-docs-json").default_condition(default)
     }
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(JsonDocs { host: run.target });
     }
 
-    /// Builds the `rust-json-docs` installer component.
+    /// Builds the `rust-docs-json` installer component.
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
-        // This prevents JSON docs from being built for "dist" or "install"
-        // on the stable/beta channels. The JSON format is not stable yet and
-        // should not be included in stable/beta toolchains.
-        if !builder.build.unstable_features() {
-            return None;
-        }
-
         let host = self.host;
         builder.ensure(crate::doc::JsonStd { stage: builder.top_stage, target: host });
 
         let dest = "share/doc/rust/json";
 
-        let mut tarball = Tarball::new(builder, "rust-json-docs", &host.triple);
+        let mut tarball = Tarball::new(builder, "rust-docs-json", &host.triple);
         tarball.set_product_name("Rust Documentation In JSON Format");
+        tarball.is_preview(true);
         tarball.add_bulk_dir(&builder.json_doc_out(host), dest);
         Some(tarball.generate())
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -674,7 +674,6 @@ h2.location a {
 }
 
 .method > .code-header, .trait-impl > .code-header {
-	max-width: calc(100% - 41px);
 	display: block;
 }
 

--- a/src/test/rustdoc-gui/notable-trait.goml
+++ b/src/test/rustdoc-gui/notable-trait.goml
@@ -83,7 +83,7 @@ assert-position: (
 )
 
 // Checking on very small mobile. The `i` should be on its own line.
-size: (410, 600)
+size: (365, 600)
 compare-elements-position-false: (
     "//*[@id='method.create_an_iterator_from_read']//a[text()='NotableStructWithLongName']",
     "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",

--- a/src/test/ui/async-await/async-trait-fn.stderr
+++ b/src/test/ui/async-await/async-trait-fn.stderr
@@ -9,7 +9,7 @@ LL |     async fn foo() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/async-trait-fn.rs:5:5
@@ -22,7 +22,7 @@ LL |     async fn bar(&self) {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/async-trait-fn.rs:7:5
@@ -35,7 +35,7 @@ LL |     async fn baz() {
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
   --> $DIR/async-trait-fn.rs:3:20

--- a/src/test/ui/async-await/edition-deny-async-fns-2015.stderr
+++ b/src/test/ui/async-await/edition-deny-async-fns-2015.stderr
@@ -90,7 +90,7 @@ LL |     async fn foo() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
   --> $DIR/edition-deny-async-fns-2015.rs:18:20

--- a/src/test/ui/async-await/feature-gate-async_fn_in_trait.rs
+++ b/src/test/ui/async-await/feature-gate-async_fn_in_trait.rs
@@ -1,0 +1,25 @@
+// edition:2021
+
+// RPITIT is not enough to allow use of async functions
+#![allow(incomplete_features)]
+#![feature(return_position_impl_trait_in_trait)]
+
+trait T {
+    async fn foo(); //~ ERROR functions in traits cannot be declared `async`
+}
+
+// Both return_position_impl_trait_in_trait and async_fn_in_trait are required for this (see also
+// feature-gate-return_position_impl_trait_in_trait.rs)
+trait T2 {
+    async fn foo() -> impl Sized; //~ ERROR functions in traits cannot be declared `async`
+}
+
+trait T3 {
+    fn foo() -> impl std::future::Future<Output = ()>;
+}
+
+impl T3 for () {
+    async fn foo() {} //~ ERROR functions in traits cannot be declared `async`
+}
+
+fn main() {}

--- a/src/test/ui/async-await/feature-gate-async_fn_in_trait.stderr
+++ b/src/test/ui/async-await/feature-gate-async_fn_in_trait.stderr
@@ -1,0 +1,42 @@
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/feature-gate-async_fn_in_trait.rs:8:5
+   |
+LL |     async fn foo();
+   |     -----^^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/feature-gate-async_fn_in_trait.rs:14:5
+   |
+LL |     async fn foo() -> impl Sized;
+   |     -----^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/feature-gate-async_fn_in_trait.rs:22:5
+   |
+LL |     async fn foo() {}
+   |     -----^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0706`.

--- a/src/test/ui/async-await/issues/issue-95307.stderr
+++ b/src/test/ui/async-await/issues/issue-95307.stderr
@@ -9,7 +9,7 @@ LL |     async fn new() -> [u8; _];
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error: in expressions, `_` can only be used on the left-hand side of an assignment
   --> $DIR/issue-95307.rs:7:28

--- a/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.rs
+++ b/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.rs
@@ -1,5 +1,18 @@
+// edition:2021
+
+// async_fn_in_trait is not enough to allow use of RPITIT
+#![allow(incomplete_features)]
+#![feature(async_fn_in_trait)]
+
 trait Foo {
     fn bar() -> impl Sized; //~ ERROR `impl Trait` only allowed in function and inherent method return types, not in trait method return
+    fn baz() -> Box<impl std::fmt::Display>; //~ ERROR `impl Trait` only allowed in function and inherent method return types, not in trait method return
+}
+
+// Both return_position_impl_trait_in_trait and async_fn_in_trait are required for this (see also
+// feature-gate-async_fn_in_trait.rs)
+trait AsyncFoo {
+    async fn bar() -> impl Sized; //~ ERROR `impl Trait` only allowed in function and inherent method return types, not in trait method return
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
+++ b/src/test/ui/feature-gates/feature-gate-return_position_impl_trait_in_trait.stderr
@@ -1,5 +1,5 @@
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
-  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:2:17
+  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:8:17
    |
 LL |     fn bar() -> impl Sized;
    |                 ^^^^^^^^^^
@@ -7,6 +7,24 @@ LL |     fn bar() -> impl Sized;
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:9:21
+   |
+LL |     fn baz() -> Box<impl std::fmt::Display>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
+  --> $DIR/feature-gate-return_position_impl_trait_in_trait.rs:15:23
+   |
+LL |     async fn bar() -> impl Sized;
+   |                       ^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -7,12 +7,12 @@ LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
    |
    = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
-note: enum `x::Foo` is defined in module ::x of the current crate
+note: enum `x::Foo` is defined in module `crate::x` of the current crate
   --> $DIR/fully-qualified-type-name2.rs:4:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^
-note: enum `y::Foo` is defined in module ::y of the current crate
+note: enum `y::Foo` is defined in module `crate::y` of the current crate
   --> $DIR/fully-qualified-type-name2.rs:8:5
    |
 LL |     pub enum Foo { }

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -7,12 +7,12 @@ LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
    |
    = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
-note: enum `x::Foo` is defined in the current crate.
+note: enum `x::Foo` is defined in module ::x of the current crate
   --> $DIR/fully-qualified-type-name2.rs:4:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^
-note: enum `y::Foo` is defined in the current crate.
+note: enum `y::Foo` is defined in module ::y of the current crate
   --> $DIR/fully-qualified-type-name2.rs:8:5
    |
 LL |     pub enum Foo { }

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -5,6 +5,18 @@ LL | fn bar(x: x::Foo) -> y::Foo {
    |                      ------ expected `y::Foo` because of return type
 LL |     return x;
    |            ^ expected enum `y::Foo`, found enum `x::Foo`
+   |
+   = note: enum `x::Foo` and enum `y::Foo` have similar names, but are actually distinct types
+note: enum `x::Foo` is defined in the current crate.
+  --> $DIR/fully-qualified-type-name2.rs:4:5
+   |
+LL |     pub enum Foo { }
+   |     ^^^^^^^^^^^^
+note: enum `y::Foo` is defined in the current crate.
+  --> $DIR/fully-qualified-type-name2.rs:8:5
+   |
+LL |     pub enum Foo { }
+   |     ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/intrinsics/const-eval-select-backtrace-std.rs
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace-std.rs
@@ -1,6 +1,7 @@
 // See issue #100696.
 // run-fail
 // check-run-results
+// exec-env:RUST_BACKTRACE=0
 fn main() {
     &""[1..];
 }

--- a/src/test/ui/intrinsics/const-eval-select-backtrace-std.run.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace-std.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'byte index 1 is out of bounds of ``', $DIR/const-eval-select-backtrace-std.rs:5:6
+thread 'main' panicked at 'byte index 1 is out of bounds of ``', $DIR/const-eval-select-backtrace-std.rs:6:6
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/intrinsics/const-eval-select-backtrace.rs
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace.rs
@@ -2,6 +2,7 @@
 // See issue #100696.
 // run-fail
 // check-run-results
+// exec-env:RUST_BACKTRACE=0
 
 #[track_caller]
 fn uhoh() {

--- a/src/test/ui/intrinsics/const-eval-select-backtrace.run.stderr
+++ b/src/test/ui/intrinsics/const-eval-select-backtrace.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'Aaah!', $DIR/const-eval-select-backtrace.rs:16:9
+thread 'main' panicked at 'Aaah!', $DIR/const-eval-select-backtrace.rs:17:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/issues/issue-56943.stderr
+++ b/src/test/ui/issues/issue-56943.stderr
@@ -5,6 +5,18 @@ LL |     let _: issue_56943::S = issue_56943::S2;
    |            --------------   ^^^^^^^^^^^^^^^ expected struct `S`, found struct `S2`
    |            |
    |            expected due to this
+   |
+   = note: struct `S2` and struct `S` have similar names, but are actually distinct types
+note: struct `S2` is defined in crate `issue_56943`.
+  --> $DIR/auxiliary/issue-56943.rs:2:9
+   |
+LL | mod m { pub struct S; }
+   |         ^^^^^^^^^^^^
+note: struct `S` is defined in crate `issue_56943`.
+  --> $DIR/auxiliary/issue-56943.rs:1:1
+   |
+LL | pub struct S;
+   | ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-56943.stderr
+++ b/src/test/ui/issues/issue-56943.stderr
@@ -5,18 +5,6 @@ LL |     let _: issue_56943::S = issue_56943::S2;
    |            --------------   ^^^^^^^^^^^^^^^ expected struct `S`, found struct `S2`
    |            |
    |            expected due to this
-   |
-   = note: struct `S2` and struct `S` have similar names, but are actually distinct types
-note: struct `S2` is defined in crate `issue_56943`.
-  --> $DIR/auxiliary/issue-56943.rs:2:9
-   |
-LL | mod m { pub struct S; }
-   |         ^^^^^^^^^^^^
-note: struct `S` is defined in crate `issue_56943`.
-  --> $DIR/auxiliary/issue-56943.rs:1:1
-   |
-LL | pub struct S;
-   | ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/show_module.rs
+++ b/src/test/ui/mismatched_types/show_module.rs
@@ -1,0 +1,18 @@
+pub mod blah{
+    pub mod baz{
+        pub struct Foo;
+    }
+}
+
+pub mod meh{
+    pub struct Foo;
+}
+
+pub type Foo = blah::baz::Foo;
+
+fn foo() -> Foo {
+    meh::Foo
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn main(){}

--- a/src/test/ui/mismatched_types/show_module.rs
+++ b/src/test/ui/mismatched_types/show_module.rs
@@ -1,10 +1,10 @@
-pub mod blah{
-    pub mod baz{
+pub mod blah {
+    pub mod baz {
         pub struct Foo;
     }
 }
 
-pub mod meh{
+pub mod meh {
     pub struct Foo;
 }
 
@@ -15,4 +15,4 @@ fn foo() -> Foo {
     //~^ ERROR mismatched types [E0308]
 }
 
-fn main(){}
+fn main() {}

--- a/src/test/ui/mismatched_types/show_module.stderr
+++ b/src/test/ui/mismatched_types/show_module.stderr
@@ -7,12 +7,12 @@ LL |     meh::Foo
    |     ^^^^^^^^ expected struct `baz::Foo`, found struct `meh::Foo`
    |
    = note: struct `meh::Foo` and struct `baz::Foo` have similar names, but are actually distinct types
-note: struct `meh::Foo` is defined in module ::meh of the current crate
+note: struct `meh::Foo` is defined in module `crate::meh` of the current crate
   --> $DIR/show_module.rs:8:5
    |
 LL |     pub struct Foo;
    |     ^^^^^^^^^^^^^^
-note: struct `baz::Foo` is defined in module ::blah::baz of the current crate
+note: struct `baz::Foo` is defined in module `crate::blah::baz` of the current crate
   --> $DIR/show_module.rs:3:9
    |
 LL |         pub struct Foo;

--- a/src/test/ui/mismatched_types/show_module.stderr
+++ b/src/test/ui/mismatched_types/show_module.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/show_module.rs:14:5
+   |
+LL | fn foo() -> Foo {
+   |             --- expected `baz::Foo` because of return type
+LL |     meh::Foo
+   |     ^^^^^^^^ expected struct `baz::Foo`, found struct `meh::Foo`
+   |
+   = note: struct `meh::Foo` and struct `baz::Foo` have similar names, but are actually distinct types
+note: struct `meh::Foo` is defined in module ::meh of the current crate
+  --> $DIR/show_module.rs:8:5
+   |
+LL |     pub struct Foo;
+   |     ^^^^^^^^^^^^^^
+note: struct `baz::Foo` is defined in module ::blah::baz of the current crate
+  --> $DIR/show_module.rs:3:9
+   |
+LL |         pub struct Foo;
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/similar_paths.rs
+++ b/src/test/ui/mismatched_types/similar_paths.rs
@@ -1,11 +1,11 @@
-enum Option<T>{
+enum Option<T> {
     Some(T),
     None,
 }
 
-pub fn foo() -> Option<u8>{
+pub fn foo() -> Option<u8> {
     Some(42_u8)
     //~^ ERROR mismatched types [E0308]
 }
 
-fn main(){}
+fn main() {}

--- a/src/test/ui/mismatched_types/similar_paths.rs
+++ b/src/test/ui/mismatched_types/similar_paths.rs
@@ -1,0 +1,11 @@
+enum Option<T>{
+    Some(T),
+    None,
+}
+
+pub fn foo() -> Option<u8>{
+    Some(42_u8)
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn main(){}

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/similar_paths.rs:7:5
+   |
+LL | pub fn foo() -> Option<u8>{
+   |                 ---------- expected `Option<u8>` because of return type
+LL |     Some(42_u8)
+   |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
+   |
+   = note: enum `std::option::Option` and enum `Option` have similar names, but are actually distinct types
+note: enum `std::option::Option` is defined in the standard library.
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL | pub enum Option<T> {
+   | ^^^^^^^^^^^^^^^^^^
+note: enum `Option` is defined in the current crate.
+  --> $DIR/similar_paths.rs:1:1
+   |
+LL | enum Option<T>{
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -7,12 +7,12 @@ LL |     Some(42_u8)
    |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
    |
    = note: enum `std::option::Option` and enum `Option` have similar names, but are actually distinct types
-note: enum `std::option::Option` is defined in the standard library.
+note: enum `std::option::Option` is defined in crate `core`
   --> $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {
    | ^^^^^^^^^^^^^^^^^^
-note: enum `Option` is defined in the current crate.
+note: enum `Option` is defined in the current crate
   --> $DIR/similar_paths.rs:1:1
    |
 LL | enum Option<T>{

--- a/src/test/ui/mismatched_types/similar_paths.stderr
+++ b/src/test/ui/mismatched_types/similar_paths.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
   --> $DIR/similar_paths.rs:7:5
    |
-LL | pub fn foo() -> Option<u8>{
+LL | pub fn foo() -> Option<u8> {
    |                 ---------- expected `Option<u8>` because of return type
 LL |     Some(42_u8)
    |     ^^^^^^^^^^^ expected enum `Option`, found enum `std::option::Option`
@@ -15,7 +15,7 @@ LL | pub enum Option<T> {
 note: enum `Option` is defined in the current crate
   --> $DIR/similar_paths.rs:1:1
    |
-LL | enum Option<T>{
+LL | enum Option<T> {
    | ^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/mismatched_types/similar_paths_primitive.rs
+++ b/src/test/ui/mismatched_types/similar_paths_primitive.rs
@@ -1,0 +1,10 @@
+#![allow(non_camel_case_types)]
+
+struct bool;
+
+fn foo(_: bool) {}
+
+fn main() {
+    foo(true);
+    //~^ ERROR mismatched types [E0308]
+}

--- a/src/test/ui/mismatched_types/similar_paths_primitive.stderr
+++ b/src/test/ui/mismatched_types/similar_paths_primitive.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/similar_paths_primitive.rs:8:9
+   |
+LL |     foo(true);
+   |     --- ^^^^ expected struct `bool`, found `bool`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: bool and struct `bool` have similar names, but are actually distinct types
+   = note: bool is a primitive defined by the language
+note: struct `bool` is defined in the current crate
+  --> $DIR/similar_paths_primitive.rs:3:1
+   |
+LL | struct bool;
+   | ^^^^^^^^^^^
+note: function defined here
+  --> $DIR/similar_paths_primitive.rs:5:4
+   |
+LL | fn foo(_: bool) {}
+   |    ^^^ -------
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -147,7 +147,7 @@ LL |         async fn ft1();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/fn-header-semantic-fail.rs:21:9
@@ -160,7 +160,7 @@ LL |         const async unsafe extern "C" fn ft5();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/fn-header-semantic-fail.rs:29:9
@@ -173,7 +173,7 @@ LL |         async fn ft1() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/fn-header-semantic-fail.rs:33:9
@@ -186,7 +186,7 @@ LL |         const async unsafe extern "C" fn ft5() {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0391]: cycle detected when computing type of `main::ff5::{opaque#0}`
   --> $DIR/fn-header-semantic-fail.rs:12:44

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -33,7 +33,7 @@ LL |     async fn associated();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error[E0706]: functions in traits cannot be declared `async`
   --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:15:5
@@ -46,7 +46,7 @@ LL |     async fn associated();
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
+++ b/src/test/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
@@ -51,7 +51,7 @@ LL | trait C{async fn new(val: T) {}
    = note: `async` trait functions are not currently supported
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
-   = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
+   = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
 
 warning: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:6:57

--- a/src/test/ui/type/type-mismatch-same-crate-name.stderr
+++ b/src/test/ui/type/type-mismatch-same-crate-name.stderr
@@ -6,6 +6,17 @@ LL |         a::try_foo(foo2);
    |         |
    |         arguments to this function are incorrect
    |
+   = note: struct `main::a::Foo` and struct `main::a::Foo` have similar names, but are actually distinct types
+note: struct `main::a::Foo` is defined in crate `crate_a2`.
+  --> $DIR/auxiliary/crate_a2.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
+note: struct `main::a::Foo` is defined in crate `crate_a1`.
+  --> $DIR/auxiliary/crate_a1.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `crate_a1` are being used?
 note: function defined here
   --> $DIR/auxiliary/crate_a1.rs:10:8

--- a/src/test/ui/type/type-mismatch-same-crate-name.stderr
+++ b/src/test/ui/type/type-mismatch-same-crate-name.stderr
@@ -7,12 +7,12 @@ LL |         a::try_foo(foo2);
    |         arguments to this function are incorrect
    |
    = note: struct `main::a::Foo` and struct `main::a::Foo` have similar names, but are actually distinct types
-note: struct `main::a::Foo` is defined in crate `crate_a2`.
+note: struct `main::a::Foo` is defined in crate `crate_a2`
   --> $DIR/auxiliary/crate_a2.rs:1:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
-note: struct `main::a::Foo` is defined in crate `crate_a1`.
+note: struct `main::a::Foo` is defined in crate `crate_a1`
   --> $DIR/auxiliary/crate_a1.rs:1:1
    |
 LL | pub struct Foo;

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -184,7 +184,7 @@ static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"
 
 static MINGW: &[&str] = &["i686-pc-windows-gnu", "x86_64-pc-windows-gnu"];
 
-static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview"];
+static NIGHTLY_ONLY_COMPONENTS: &[&str] = &["miri-preview", "rust-docs-json-preview"];
 
 macro_rules! t {
     ($e:expr) => {
@@ -318,6 +318,7 @@ impl Builder {
         package!("rust-mingw", MINGW);
         package!("rust-std", TARGETS);
         self.package("rust-docs", &mut manifest.pkg, HOSTS, DOCS_FALLBACK);
+        self.package("rust-docs-json-preview", &mut manifest.pkg, HOSTS, DOCS_FALLBACK);
         package!("rust-src", &["*"]);
         package!("rls-preview", HOSTS);
         package!("rust-analyzer-preview", HOSTS);
@@ -403,6 +404,7 @@ impl Builder {
         rename("rustfmt", "rustfmt-preview");
         rename("clippy", "clippy-preview");
         rename("miri", "miri-preview");
+        rename("rust-docs-json", "rust-docs-json-preview");
         rename("rust-analyzer", "rust-analyzer-preview");
     }
 
@@ -459,6 +461,7 @@ impl Builder {
             host_component("rustfmt-preview"),
             host_component("llvm-tools-preview"),
             host_component("rust-analysis"),
+            host_component("rust-docs-json"),
         ]);
 
         extensions.extend(


### PR DESCRIPTION
Successful merges:

 - #100734 (Split out async_fn_in_trait into a separate feature)
 - #101664 (Note if mismatched types have a similar name)
 - #101815 (Migrated the rustc_passes annotation without effect diagnostic infrastructure)
 - #102042 (Distribute rust-docs-json via rustup.)
 - #102066 (rustdoc: remove unnecessary `max-width` on headers)
 - #102095 (Deduplicate two functions that would soon have been three)
 - #102104 (Set 'exec-env:RUST_BACKTRACE=0' in const-eval-select tests)
 - #102112 (Allow full relro on powerpc64-unknown-linux-gnu)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100734,101664,101815,102042,102066,102095,102104,102112)
<!-- homu-ignore:end -->