### PR TITLE
Add `#[inline]` to trivial functions on `core::sync::Exclusive`

### DIFF
--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -100,6 +100,7 @@ impl<T: Sized> Exclusive<T> {
     /// Wrap a value in an `Exclusive`
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
+    #[inline]
     pub const fn new(t: T) -> Self {
         Self { inner: t }
     }
@@ -107,6 +108,7 @@ impl<T: Sized> Exclusive<T> {
     /// Unwrap the value contained in the `Exclusive`
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
+    #[inline]
     pub const fn into_inner(self) -> T {
         self.inner
     }
@@ -116,6 +118,7 @@ impl<T: ?Sized> Exclusive<T> {
     /// Get exclusive access to the underlying value.
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
+    #[inline]
     pub const fn get_mut(&mut self) -> &mut T {
         &mut self.inner
     }
@@ -128,6 +131,7 @@ impl<T: ?Sized> Exclusive<T> {
     /// produce _pinned_ access to the underlying value.
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
+    #[inline]
     pub const fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
         // SAFETY: `Exclusive` can only produce `&mut T` if itself is unpinned
         // `Pin::map_unchecked_mut` is not const, so we do this conversion manually
@@ -139,6 +143,7 @@ impl<T: ?Sized> Exclusive<T> {
     /// building an `Exclusive` with [`Exclusive::new`].
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
+    #[inline]
     pub const fn from_mut(r: &'_ mut T) -> &'_ mut Exclusive<T> {
         // SAFETY: repr is ≥ C, so refs have the same layout; and `Exclusive` properties are `&mut`-agnostic
         unsafe { &mut *(r as *mut T as *mut Exclusive<T>) }
@@ -149,6 +154,7 @@ impl<T: ?Sized> Exclusive<T> {
     /// building an `Exclusive` with [`Exclusive::new`].
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
+    #[inline]
     pub const fn from_pin_mut(r: Pin<&'_ mut T>) -> Pin<&'_ mut Exclusive<T>> {
         // SAFETY: `Exclusive` can only produce `&mut T` if itself is unpinned
         // `Pin::map_unchecked_mut` is not const, so we do this conversion manually
@@ -158,6 +164,7 @@ impl<T: ?Sized> Exclusive<T> {
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T> From<T> for Exclusive<T> {
+    #[inline]
     fn from(t: T) -> Self {
         Self::new(t)
     }
@@ -166,7 +173,7 @@ impl<T> From<T> for Exclusive<T> {
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T: Future + ?Sized> Future for Exclusive<T> {
     type Output = T::Output;
-
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.get_pin_mut().poll(cx)
     }


### PR DESCRIPTION
When optimizing for size things like these sometimes don't inlined even though they're generic. This is bad because they're no-ops.

Only dodgy one is poll I guess since it forwards to the inner poll, but it's not like we're doing `#[inline(always)]` here.