### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1088,17 +1088,9 @@ pub trait PrettyPrinter<'tcx>:
                         .generics_of(principal.def_id)
                         .own_substs_no_defaults(cx.tcx(), principal.substs);
 
-                    // Don't print `'_` if there's no unerased regions.
-                    let print_regions = args.iter().any(|arg| match arg.unpack() {
-                        GenericArgKind::Lifetime(r) => !r.is_erased(),
-                        _ => false,
-                    });
-                    let mut args = args.iter().cloned().filter(|arg| match arg.unpack() {
-                        GenericArgKind::Lifetime(_) => print_regions,
-                        _ => true,
-                    });
                     let mut projections = predicates.projection_bounds();
 
+                    let mut args = args.iter().cloned();
                     let arg0 = args.next();
                     let projection0 = projections.next();
                     if arg0.is_some() || projection0.is_some() {
@@ -1847,22 +1839,11 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
     ) -> Result<Self::Path, Self::Error> {
         self = print_prefix(self)?;
 
-        // Don't print `'_` if there's no unerased regions.
-        let print_regions = self.tcx.sess.verbose()
-            || args.iter().any(|arg| match arg.unpack() {
-                GenericArgKind::Lifetime(r) => !r.is_erased(),
-                _ => false,
-            });
-        let args = args.iter().cloned().filter(|arg| match arg.unpack() {
-            GenericArgKind::Lifetime(_) => print_regions,
-            _ => true,
-        });
-
-        if args.clone().next().is_some() {
+        if args.first().is_some() {
             if self.in_value {
                 write!(self, "::")?;
             }
-            self.generic_delimiters(|cx| cx.comma_sep(args))
+            self.generic_delimiters(|cx| cx.comma_sep(args.iter().cloned()))
         } else {
             Ok(self)
         }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -272,7 +272,10 @@ impl<'tcx, A: Lift<'tcx>, B: Lift<'tcx>, C: Lift<'tcx>> Lift<'tcx> for (A, B, C)
 impl<'tcx, T: Lift<'tcx>> Lift<'tcx> for Option<T> {
     type Lifted = Option<T::Lifted>;
     fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
-        tcx.lift(self?).map(Some)
+        Some(match self {
+            Some(x) => Some(tcx.lift(x)?),
+            None => None,
+        })
     }
 }
 

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -58,6 +58,7 @@ impl bool {
     ///
     /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
+    /// assert_eq!(a, 1);
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,16 +18,16 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
     /// let mut function_with_side_effects = || { a += 1; };
-    /// 
+    ///
     /// true.then_some(function_with_side_effects());
     /// false.then_some(function_with_side_effects());
-    /// 
-    /// // `a` is incremented twice because the value passed to `then_some` is 
-    /// // evaluated eagerly. 
+    ///
+    /// // `a` is incremented twice because the value passed to `then_some` is
+    /// // evaluated eagerly.
     /// assert_eq!(a, 2);
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
@@ -49,14 +49,14 @@ impl bool {
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
-    /// 
+    ///
     /// true.then(|| { a += 1; });
     /// false.then(|| { a += 1; });
-    /// 
-    /// // `a` is incremented once because the closure is evaluated lazily by 
+    ///
+    /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,6 +18,18 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// let mut function_with_side_effects = || { a += 1; };
+    /// 
+    /// true.then_some(function_with_side_effects());
+    /// false.then_some(function_with_side_effects());
+    /// 
+    /// // `a` is incremented twice because the value passed to `then_some` is 
+    /// // evaluated eagerly. 
+    /// assert_eq!(a, 2);
+    /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]
     #[inline]
@@ -36,6 +48,16 @@ impl bool {
     /// ```
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
+    /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// 
+    /// true.then(|| { a += 1; });
+    /// false.then(|| { a += 1; });
+    /// 
+    /// // `a` is incremented once because the closure is evaluated lazily by 
+    /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -573,8 +573,8 @@ impl FromStr for bool {
 
     /// Parse a `bool` from a string.
     ///
-    /// Yields a `Result<bool, ParseBoolError>`, because `s` may or may not
-    /// actually be parseable.
+    /// The only accepted values are `"true"` and `"false"`. Any other input
+    /// will return an error.
     ///
     /// # Examples
     ///

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -1,5 +1,5 @@
 use super::{find_testable_code, plain_text_summary, short_markdown_summary};
-use super::{ErrorCodes, HeadingOffset, IdMap, Ignore, LangString, Markdown, MarkdownHtml};
+use super::{ErrorCodes, HeadingOffset, IdMap, Ignore, LangString, Markdown, MarkdownItemInfo};
 use rustc_span::edition::{Edition, DEFAULT_EDITION};
 
 #[test]
@@ -279,14 +279,13 @@ fn test_plain_text_summary() {
 fn test_markdown_html_escape() {
     fn t(input: &str, expect: &str) {
         let mut idmap = IdMap::new();
-        let output =
-            MarkdownHtml(input, &mut idmap, ErrorCodes::Yes, DEFAULT_EDITION, &None).into_string();
+        let output = MarkdownItemInfo(input, &mut idmap).into_string();
         assert_eq!(output, expect, "original: {}", input);
     }
 
-    t("`Struct<'a, T>`", "<p><code>Struct&lt;'a, T&gt;</code></p>\n");
-    t("Struct<'a, T>", "<p>Struct&lt;’a, T&gt;</p>\n");
-    t("Struct<br>", "<p>Struct&lt;br&gt;</p>\n");
+    t("`Struct<'a, T>`", "<code>Struct&lt;'a, T&gt;</code>");
+    t("Struct<'a, T>", "Struct&lt;’a, T&gt;");
+    t("Struct<br>", "Struct&lt;br&gt;");
 }
 
 #[test]

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -74,7 +74,9 @@ use crate::html::format::{
     PrintWithSpace,
 };
 use crate::html::highlight;
-use crate::html::markdown::{HeadingOffset, IdMap, Markdown, MarkdownHtml, MarkdownSummaryLine};
+use crate::html::markdown::{
+    HeadingOffset, IdMap, Markdown, MarkdownItemInfo, MarkdownSummaryLine,
+};
 use crate::html::sources;
 use crate::html::static_files::SCRAPE_EXAMPLES_HELP_MD;
 use crate::scrape_examples::{CallData, CallLocation};
@@ -582,7 +584,6 @@ fn short_item_info(
     parent: Option<&clean::Item>,
 ) -> Vec<String> {
     let mut extra_info = vec![];
-    let error_codes = cx.shared.codes;
 
     if let Some(depr @ Deprecation { note, since, is_since_rustc_version: _, suggestion: _ }) =
         item.deprecation(cx.tcx())
@@ -606,13 +607,7 @@ fn short_item_info(
 
         if let Some(note) = note {
             let note = note.as_str();
-            let html = MarkdownHtml(
-                note,
-                &mut cx.id_map,
-                error_codes,
-                cx.shared.edition(),
-                &cx.shared.playground,
-            );
+            let html = MarkdownItemInfo(note, &mut cx.id_map);
             message.push_str(&format!(": {}", html.into_string()));
         }
         extra_info.push(format!(

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1078,10 +1078,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 0.875rem;
 	font-weight: normal;
 }
-.stab p {
-	display: inline;
-	margin: 0;
-}
 
 .stab .emoji {
 	font-size: 1.25rem;

--- a/src/test/codegen-units/item-collection/generic-impl.rs
+++ b/src/test/codegen-units/item-collection/generic-impl.rs
@@ -30,11 +30,11 @@ pub struct LifeTimeOnly<'a> {
 
 impl<'a> LifeTimeOnly<'a> {
 
-    //~ MONO_ITEM fn LifeTimeOnly::foo
+    //~ MONO_ITEM fn LifeTimeOnly::<'_>::foo
     pub fn foo(&self) {}
-    //~ MONO_ITEM fn LifeTimeOnly::bar
+    //~ MONO_ITEM fn LifeTimeOnly::<'_>::bar
     pub fn bar(&'a self) {}
-    //~ MONO_ITEM fn LifeTimeOnly::baz
+    //~ MONO_ITEM fn LifeTimeOnly::<'_>::baz
     pub fn baz<'b>(&'b self) {}
 
     pub fn non_instantiated<T>(&self) {}

--- a/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_complex_case.main.Derefer.diff
@@ -3,15 +3,15 @@
   
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/derefer_complex_case.rs:+0:11: +0:11
-      let mut _1: std::slice::Iter<i32>;   // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _1: std::slice::Iter<'_, i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       let mut _2: &[i32; 2];               // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       let _3: [i32; 2];                    // in scope 0 at $DIR/derefer_complex_case.rs:+1:18: +1:26
-      let mut _4: std::slice::Iter<i32>;   // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _4: std::slice::Iter<'_, i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       let mut _5: ();                      // in scope 0 at $DIR/derefer_complex_case.rs:+0:1: +2:2
       let _6: ();                          // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       let mut _7: std::option::Option<&i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
-      let mut _8: &mut std::slice::Iter<i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
-      let mut _9: &mut std::slice::Iter<i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _8: &mut std::slice::Iter<'_, i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+      let mut _9: &mut std::slice::Iter<'_, i32>; // in scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
       let mut _10: isize;                  // in scope 0 at $DIR/derefer_complex_case.rs:+1:5: +1:40
       let mut _11: !;                      // in scope 0 at $DIR/derefer_complex_case.rs:+1:5: +1:40
       let mut _13: i32;                    // in scope 0 at $DIR/derefer_complex_case.rs:+1:34: +1:37
@@ -53,10 +53,10 @@
           StorageLive(_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
           _9 = &mut _4;                    // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
           _8 = &mut (*_9);                 // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
-          _7 = <std::slice::Iter<i32> as Iterator>::next(move _8) -> bb3; // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
+          _7 = <std::slice::Iter<'_, i32> as Iterator>::next(move _8) -> bb3; // scope 1 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:6:17: 6:26
-                                           // + literal: Const { ty: for<'r> fn(&'r mut std::slice::Iter<i32>) -> Option<<std::slice::Iter<i32> as Iterator>::Item> {<std::slice::Iter<i32> as Iterator>::next}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: for<'r> fn(&'r mut std::slice::Iter<'_, i32>) -> Option<<std::slice::Iter<'_, i32> as Iterator>::Item> {<std::slice::Iter<'_, i32> as Iterator>::next}, val: Value(<ZST>) }
       }
   
       bb3: {

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
@@ -1,12 +1,12 @@
 - // MIR for `no_downcast` before EarlyOtherwiseBranch
 + // MIR for `no_downcast` after EarlyOtherwiseBranch
   
-  fn no_downcast(_1: &E) -> u32 {
+  fn no_downcast(_1: &E<'_>) -> u32 {
       debug e => _1;                       // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:16: +0:17
       let mut _0: u32;                     // return place in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:26: +0:29
       let mut _2: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:20: +1:30
       let mut _3: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
-      let mut _4: &E;                      // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:16: +0:17
+      let mut _4: &E<'_>;                  // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:+0:16: +0:17
       scope 1 {
       }
   
@@ -16,7 +16,7 @@
       }
   
       bb1: {
-          _4 = deref_copy (((*_1) as Some).0: &E); // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
+          _4 = deref_copy (((*_1) as Some).0: &E<'_>); // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
           _2 = discriminant((*_4));        // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
           switchInt(move _2) -> [1_isize: bb2, otherwise: bb3]; // scope 1 at $DIR/early_otherwise_branch_soundness.rs:+1:12: +1:31
       }

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -1,24 +1,24 @@
 - // MIR for `float_to_exponential_common` before ConstProp
 + // MIR for `float_to_exponential_common` after ConstProp
   
-  fn float_to_exponential_common(_1: &mut Formatter, _2: &T, _3: bool) -> Result<(), std::fmt::Error> {
+  fn float_to_exponential_common(_1: &mut Formatter<'_>, _2: &T, _3: bool) -> Result<(), std::fmt::Error> {
       debug fmt => _1;                     // in scope 0 at $DIR/funky_arms.rs:+0:35: +0:38
       debug num => _2;                     // in scope 0 at $DIR/funky_arms.rs:+0:60: +0:63
       debug upper => _3;                   // in scope 0 at $DIR/funky_arms.rs:+0:69: +0:74
       let mut _0: std::result::Result<(), std::fmt::Error>; // return place in scope 0 at $DIR/funky_arms.rs:+0:85: +0:91
       let _4: bool;                        // in scope 0 at $DIR/funky_arms.rs:+4:9: +4:19
-      let mut _5: &std::fmt::Formatter;    // in scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
+      let mut _5: &std::fmt::Formatter<'_>; // in scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
       let mut _7: std::option::Option<usize>; // in scope 0 at $DIR/funky_arms.rs:+13:30: +13:45
-      let mut _8: &std::fmt::Formatter;    // in scope 0 at $DIR/funky_arms.rs:+13:30: +13:45
+      let mut _8: &std::fmt::Formatter<'_>; // in scope 0 at $DIR/funky_arms.rs:+13:30: +13:45
       let mut _9: isize;                   // in scope 0 at $DIR/funky_arms.rs:+13:12: +13:27
-      let mut _11: &mut std::fmt::Formatter; // in scope 0 at $DIR/funky_arms.rs:+15:43: +15:46
+      let mut _11: &mut std::fmt::Formatter<'_>; // in scope 0 at $DIR/funky_arms.rs:+15:43: +15:46
       let mut _12: &T;                     // in scope 0 at $DIR/funky_arms.rs:+15:48: +15:51
       let mut _13: core::num::flt2dec::Sign; // in scope 0 at $DIR/funky_arms.rs:+15:53: +15:57
       let mut _14: u32;                    // in scope 0 at $DIR/funky_arms.rs:+15:59: +15:79
       let mut _15: u32;                    // in scope 0 at $DIR/funky_arms.rs:+15:59: +15:75
       let mut _16: usize;                  // in scope 0 at $DIR/funky_arms.rs:+15:59: +15:68
       let mut _17: bool;                   // in scope 0 at $DIR/funky_arms.rs:+15:81: +15:86
-      let mut _18: &mut std::fmt::Formatter; // in scope 0 at $DIR/funky_arms.rs:+17:46: +17:49
+      let mut _18: &mut std::fmt::Formatter<'_>; // in scope 0 at $DIR/funky_arms.rs:+17:46: +17:49
       let mut _19: &T;                     // in scope 0 at $DIR/funky_arms.rs:+17:51: +17:54
       let mut _20: core::num::flt2dec::Sign; // in scope 0 at $DIR/funky_arms.rs:+17:56: +17:60
       let mut _21: bool;                   // in scope 0 at $DIR/funky_arms.rs:+17:62: +17:67
@@ -38,10 +38,10 @@
           StorageLive(_4);                 // scope 0 at $DIR/funky_arms.rs:+4:9: +4:19
           StorageLive(_5);                 // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
           _5 = &(*_1);                     // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
-          _4 = Formatter::sign_plus(move _5) -> bb1; // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
+          _4 = Formatter::<'_>::sign_plus(move _5) -> bb1; // scope 0 at $DIR/funky_arms.rs:+4:22: +4:37
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:15:26: 15:35
-                                           // + literal: Const { ty: for<'r> fn(&'r Formatter) -> bool {Formatter::sign_plus}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: for<'r> fn(&'r Formatter<'_>) -> bool {Formatter::<'_>::sign_plus}, val: Value(<ZST>) }
       }
   
       bb1: {
@@ -66,10 +66,10 @@
           StorageLive(_7);                 // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
           StorageLive(_8);                 // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
           _8 = &(*_1);                     // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
-          _7 = Formatter::precision(move _8) -> bb5; // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
+          _7 = Formatter::<'_>::precision(move _8) -> bb5; // scope 3 at $DIR/funky_arms.rs:+13:30: +13:45
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:24:34: 24:43
-                                           // + literal: Const { ty: for<'r> fn(&'r Formatter) -> Option<usize> {Formatter::precision}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: for<'r> fn(&'r Formatter<'_>) -> Option<usize> {Formatter::<'_>::precision}, val: Value(<ZST>) }
       }
   
       bb5: {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff
@@ -25,7 +25,7 @@
       let _24: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _25: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _27: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _27: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:+1:9: +1:14
           let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:+6:9: +6:14

--- a/src/test/mir-opt/issue_99325.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_99325.main.mir_map.0.mir
@@ -26,7 +26,7 @@ fn main() -> () {
     let _19: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _20: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _21: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _22: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _22: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _23: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _24: (&&[u8], &&[u8; 4]);    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _25: &&[u8];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -46,7 +46,7 @@ fn main() -> () {
     let _40: &&[u8];                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _41: &&[u8; 4];              // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _42: &&[u8; 4];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _43: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _43: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug left_val => _8;            // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         debug right_val => _9;           // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -128,7 +128,7 @@ fn main() -> () {
         _21 = &(*_9);                    // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _20 = &(*_21);                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_22);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _22 = Option::<Arguments>::None; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _22 = Option::<Arguments<'_>>::None; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _16 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _17, move _18, move _20, move _22) -> bb19; // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -237,7 +237,7 @@ fn main() -> () {
         _42 = &(*_30);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _41 = &(*_42);                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_43);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _43 = Option::<Arguments>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _43 = Option::<Arguments<'_>>::None; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _37 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _38, move _39, move _41, move _43) -> bb19; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -29,7 +29,7 @@ fn array_casts() -> () {
     let _31: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _32: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _33: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _34: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _34: std::option::Option<std::fmt::Arguments<'_>>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug x => _1;                   // in scope 1 at $DIR/retag.rs:+1:9: +1:14
         let _2: *mut usize;              // in scope 1 at $DIR/retag.rs:+2:9: +2:10

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -34,10 +34,10 @@ fn bar() ({
                     ((::alloc::fmt::format as
                             for<'r> fn(Arguments<'r>) -> String {format})(((::core::fmt::Arguments::new_v1
                                 as
-                                fn(&[&'static str], &[ArgumentV1]) -> Arguments {Arguments::new_v1})((&([("test"
+                                fn(&[&'static str], &[ArgumentV1<'_>]) -> Arguments<'_> {Arguments::<'_>::new_v1})((&([("test"
                                             as &str)] as [&str; 1]) as &[&str; 1]),
-                            (&([] as [ArgumentV1; 0]) as &[ArgumentV1; 0])) as
-                            Arguments)) as String);
+                            (&([] as [ArgumentV1<'_>; 0]) as &[ArgumentV1<'_>; 0])) as
+                            Arguments<'_>)) as String);
                 (res as String)
             } as String);
     } as ())

--- a/src/test/ui/async-await/async-fn-size-moved-locals.rs
+++ b/src/test/ui/async-await/async-fn-size-moved-locals.rs
@@ -7,7 +7,6 @@
 //
 // See issue #59123 for a full explanation.
 
-// ignore-emscripten (sizes don't match)
 // needs-unwind Size of Futures change on panic=abort
 // run-pass
 

--- a/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
+++ b/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
@@ -6,7 +6,6 @@
 // error-pattern: thread 'main' panicked at '`async fn` resumed after panicking'
 // edition:2018
 // ignore-wasm no panic or subprocess support
-// ignore-emscripten no panic or subprocess support
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
+++ b/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
@@ -3,7 +3,6 @@
 // Check that partially moved from function parameters are dropped after the
 // named bindings that move from them.
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::{panic, cell::RefCell};
 

--- a/src/test/ui/builtin-clone-unwind.rs
+++ b/src/test/ui/builtin-clone-unwind.rs
@@ -3,7 +3,6 @@
 
 #![allow(unused_variables)]
 #![allow(unused_imports)]
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // Test that builtin implementations of `Clone` cleanup everything
 // in case of unwinding.

--- a/src/test/ui/catch-unwind-bang.rs
+++ b/src/test/ui/catch-unwind-bang.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 fn worker() -> ! {
     panic!()

--- a/src/test/ui/cfg/cfg-panic.rs
+++ b/src/test/ui/cfg/cfg-panic.rs
@@ -1,9 +1,6 @@
 // build-pass
 // compile-flags: -C panic=unwind
 // needs-unwind
-// ignore-emscripten no panic_unwind implementation
-// ignore-wasm32     no panic_unwind implementation
-// ignore-wasm64     no panic_unwind implementation
 
 
 #[cfg(panic = "abort")]

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -3,7 +3,6 @@
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-// ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -3,7 +3,6 @@
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-// ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,5 +1,5 @@
 error: changes to closure capture in Rust 2021 will affect which traits the closure implements
-  --> $DIR/mir_calls_to_shims.rs:21:38
+  --> $DIR/mir_calls_to_shims.rs:20:38
    |
 LL |     let result = panic::catch_unwind(move || {
    |                                      ^^^^^^^

--- a/src/test/ui/const-generics/issues/issue-83765.stderr
+++ b/src/test/ui/const-generics/issues/issue-83765.stderr
@@ -1,16 +1,16 @@
-error[E0391]: cycle detected when resolving instance `<LazyUpdim<T, { T::DIM }, DIM> as TensorDimension>::DIM`
+error[E0391]: cycle detected when resolving instance `<LazyUpdim<'_, T, { T::DIM }, DIM> as TensorDimension>::DIM`
   --> $DIR/issue-83765.rs:5:5
    |
 LL |     const DIM: usize;
    |     ^^^^^^^^^^^^^^^^
    |
-note: ...which requires computing candidate for `<LazyUpdim<T, { T::DIM }, DIM> as TensorDimension>`...
+note: ...which requires computing candidate for `<LazyUpdim<'_, T, { T::DIM }, DIM> as TensorDimension>`...
   --> $DIR/issue-83765.rs:4:1
    |
 LL | trait TensorDimension {
    | ^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires resolving instance `<LazyUpdim<T, { T::DIM }, DIM> as TensorDimension>::DIM`, completing the cycle
-note: cycle used when computing candidate for `<LazyUpdim<T, { T::DIM }, DIM> as TensorDimension>`
+   = note: ...which again requires resolving instance `<LazyUpdim<'_, T, { T::DIM }, DIM> as TensorDimension>::DIM`, completing the cycle
+note: cycle used when computing candidate for `<LazyUpdim<'_, T, { T::DIM }, DIM> as TensorDimension>`
   --> $DIR/issue-83765.rs:4:1
    |
 LL | trait TensorDimension {

--- a/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
@@ -5,7 +5,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: null pointer is a dangling pointer (it has no provenance)
-   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:18:34
    |
@@ -19,7 +19,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: null pointer is a dangling pointer (it has no provenance)
-   |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, ()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:19:33
    |
@@ -33,7 +33,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
-   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:22:34
    |
@@ -92,7 +92,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
-   |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:43:5
    |
@@ -111,7 +111,7 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:46:34
    |
@@ -130,7 +130,7 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, ()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:47:33
    |
@@ -230,7 +230,7 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:79:34
    |
@@ -249,7 +249,7 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:80:35
    |

--- a/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
@@ -5,7 +5,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: null pointer is a dangling pointer (it has no provenance)
-   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:18:34
    |
@@ -19,7 +19,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: null pointer is a dangling pointer (it has no provenance)
-   |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, ()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:19:33
    |
@@ -33,7 +33,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
-   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:22:34
    |
@@ -92,7 +92,7 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         dereferencing pointer failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
-   |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |         inside `std::slice::from_raw_parts::<'_, u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:43:5
    |
@@ -111,7 +111,7 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:46:34
    |
@@ -130,7 +130,7 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, ()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:47:33
    |
@@ -230,7 +230,7 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:79:34
    |
@@ -249,7 +249,7 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
   ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
-   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |                                          ------------------------------ inside `from_ptr_range::<'_, u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
   ::: $DIR/forbidden_slices.rs:80:35
    |

--- a/src/test/ui/drop/dynamic-drop-async.rs
+++ b/src/test/ui/drop/dynamic-drop-async.rs
@@ -6,7 +6,6 @@
 // run-pass
 // needs-unwind
 // edition:2018
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(unused)]
 

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/drop/repeat-drop.rs
+++ b/src/test/ui/drop/repeat-drop.rs
@@ -1,8 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare no unwinding panic
-// ignore-avr no unwinding panic
-// ignore-nvptx64 no unwinding panic
 
 static mut CHECK: usize = 0;
 

--- a/src/test/ui/extern-flag/empty-extern-arg.rs
+++ b/src/test/ui/extern-flag/empty-extern-arg.rs
@@ -1,6 +1,5 @@
 // compile-flags: --extern std=
 // error-pattern: extern location for std does not exist
 // needs-unwind since it affects the error output
-// ignore-emscripten compiled with panic=abort, personality not required
 
 fn main() {}

--- a/src/test/ui/extern-flag/empty-extern-arg.rs
+++ b/src/test/ui/extern-flag/empty-extern-arg.rs
@@ -1,5 +1,6 @@
 // compile-flags: --extern std=
 // error-pattern: extern location for std does not exist
 // needs-unwind since it affects the error output
+// ignore-emscripten missing eh_catch_typeinfo lang item
 
 fn main() {}

--- a/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
+++ b/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 
 // rust-lang/rust#64655: with panic=unwind, a panic from a subroutine

--- a/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
+++ b/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 
 // rust-lang/rust#64655: with panic=unwind, a panic from a subroutine

--- a/src/test/ui/generator/panic-drops-resume.rs
+++ b/src/test/ui/generator/panic-drops-resume.rs
@@ -2,8 +2,6 @@
 
 // run-pass
 // needs-unwind
-// ignore-wasm       no unwind support
-// ignore-emscripten no unwind support
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/panic-drops.rs
+++ b/src/test/ui/generator/panic-drops.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/panic-safe.rs
+++ b/src/test/ui/generator/panic-safe.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/resume-after-return.rs
+++ b/src/test/ui/generator/resume-after-return.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // revisions: mir thir strict
 // [thir]compile-flags: -Zthir-unsafeck
 // [strict]compile-flags: -Zstrict-init-checks

--- a/src/test/ui/issues/issue-14875.rs
+++ b/src/test/ui/issues/issue-14875.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // Check that values are not leaked when a dtor panics (#14875)
 

--- a/src/test/ui/issues/issue-21174.stderr
+++ b/src/test/ui/issues/issue-21174.stderr
@@ -4,8 +4,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     let new: T::B = unsafe { std::mem::transmute(value) };
    |                              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `<T as Trait>::A` (this type does not have a fixed size)
-   = note: target type: `<T as Trait>::B` (this type does not have a fixed size)
+   = note: source type: `<T as Trait<'_>>::A` (this type does not have a fixed size)
+   = note: target type: `<T as Trait<'_>>::B` (this type does not have a fixed size)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-29948.rs
+++ b/src/test/ui/issues/issue-29948.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;
 

--- a/src/test/ui/issues/issue-43853.rs
+++ b/src/test/ui/issues/issue-43853.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;
 

--- a/src/test/ui/issues/issue-46519.rs
+++ b/src/test/ui/issues/issue-46519.rs
@@ -2,7 +2,6 @@
 // compile-flags:--test -O
 
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #[test]
 #[should_panic(expected = "creating inhabited type")]

--- a/src/test/ui/iterators/iter-count-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;

--- a/src/test/ui/iterators/iter-position-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;

--- a/src/test/ui/iterators/iter-step-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-step-overflow-debug.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 
 use std::panic;

--- a/src/test/ui/iterators/iter-sum-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-debug.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 
 use std::panic;

--- a/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C overflow-checks
 
 use std::panic;

--- a/src/test/ui/macros/macro-comma-behavior-rpass.rs
+++ b/src/test/ui/macros/macro-comma-behavior-rpass.rs
@@ -14,7 +14,6 @@
 // compile-flags: --test -C debug_assertions=yes
 // revisions: std core
 
-// ignore-wasm32-bare compiled with panic=abort by default
 #![cfg_attr(core, no_std)]
 
 #[cfg(core)]

--- a/src/test/ui/mir/mir_calls_to_shims.rs
+++ b/src/test/ui/mir/mir_calls_to_shims.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(fn_traits)]
 #![feature(never_type)]

--- a/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
+++ b/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
@@ -1,7 +1,6 @@
 // run-fail
 // error-pattern:diverging_fn called
 // error-pattern:0 dropped
-// ignore-emscripten no processes
 // needs-unwind this test checks that a destructor is called after panicking
 
 struct Droppable(u8);

--- a/src/test/ui/mir/mir_drop_order.rs
+++ b/src/test/ui/mir/mir_drop_order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::cell::RefCell;
 use std::panic;

--- a/src/test/ui/mir/mir_drop_panics.rs
+++ b/src/test/ui/mir/mir_drop_panics.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // error-pattern:panic 1
 // error-pattern:drop 2
-// ignore-emscripten no processes
 
 struct Droppable(u32);
 impl Drop for Droppable {

--- a/src/test/ui/mir/mir_let_chains_drop_order.rs
+++ b/src/test/ui/mir/mir_let_chains_drop_order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // See `mir_drop_order.rs` for more information
 

--- a/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
+++ b/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // compile-flags: -C debug_assertions=yes
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten dies with an LLVM error
 
 use std::panic;

--- a/src/test/ui/panic-handler/weak-lang-item.rs
+++ b/src/test/ui/panic-handler/weak-lang-item.rs
@@ -2,7 +2,6 @@
 // error-pattern: `#[panic_handler]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // needs-unwind since it affects the error output
-// ignore-emscripten compiled with panic=abort, personality not required
 
 #![no_std]
 

--- a/src/test/ui/panic-handler/weak-lang-item.rs
+++ b/src/test/ui/panic-handler/weak-lang-item.rs
@@ -2,6 +2,7 @@
 // error-pattern: `#[panic_handler]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // needs-unwind since it affects the error output
+// ignore-emscripten missing eh_catch_typeinfo lang item
 
 #![no_std]
 

--- a/src/test/ui/panic-handler/weak-lang-item.stderr
+++ b/src/test/ui/panic-handler/weak-lang-item.stderr
@@ -1,5 +1,5 @@
 error[E0259]: the name `core` is defined multiple times
-  --> $DIR/weak-lang-item.rs:8:1
+  --> $DIR/weak-lang-item.rs:9:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ `core` reimported here

--- a/src/test/ui/panic-handler/weak-lang-item.stderr
+++ b/src/test/ui/panic-handler/weak-lang-item.stderr
@@ -1,5 +1,5 @@
 error[E0259]: the name `core` is defined multiple times
-  --> $DIR/weak-lang-item.rs:9:1
+  --> $DIR/weak-lang-item.rs:8:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ `core` reimported here

--- a/src/test/ui/panic-runtime/need-abort-got-unwind.rs
+++ b/src/test/ui/panic-runtime/need-abort-got-unwind.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // error-pattern:is incompatible with this crate's strategy of `unwind`
 // aux-build:needs-abort.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 extern crate needs_abort;
 

--- a/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
+++ b/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
@@ -6,7 +6,6 @@
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
 // error-pattern: is not compiled with this crate's panic strategy `unwind`
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-runtime/want-unwind-got-abort.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort.rs
@@ -3,7 +3,6 @@
 // error-pattern:is not compiled with this crate's panic strategy `unwind`
 // aux-build:panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
@@ -4,7 +4,6 @@
 // aux-build:panic-runtime-abort.rs
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-while-printing.rs
+++ b/src/test/ui/panic-while-printing.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-emscripten no subprocess support
 
 #![feature(internal_output_capture)]
 

--- a/src/test/ui/polymorphization/predicates.stderr
+++ b/src/test/ui/polymorphization/predicates.stderr
@@ -41,7 +41,7 @@ error: item has unused generic parameters
 LL | fn bar<I>() {
    |    ^^^ - generic parameter `I` is unused
 
-note: the above error was encountered while instantiating `fn foo::<std::slice::Iter<u32>, T>`
+note: the above error was encountered while instantiating `fn foo::<std::slice::Iter<'_, u32>, T>`
   --> $DIR/predicates.rs:86:5
    |
 LL |     foo(x.iter());

--- a/src/test/ui/privacy/reachable-unnameable-items.rs
+++ b/src/test/ui/privacy/reachable-unnameable-items.rs
@@ -1,5 +1,4 @@
 // run-pass
-// ignore-wasm32-bare compiled with panic=abort by default
 // needs-unwind
 // aux-build:reachable-unnameable-items.rs
 

--- a/src/test/ui/proc-macro/expand-with-a-macro.rs
+++ b/src/test/ui/proc-macro/expand-with-a-macro.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // aux-build:expand-with-a-macro.rs
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![deny(warnings)]
 

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
@@ -6,7 +6,7 @@ LL |     let Ok(x) = res;
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
-note: `Result<u32, &R>` defined here
+note: `Result<u32, &R<'_>>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL | pub enum Result<T, E> {
@@ -14,7 +14,7 @@ LL | pub enum Result<T, E> {
 ...
 LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
    |     ^^^ not covered
-   = note: the matched value is of type `Result<u32, &R>`
+   = note: the matched value is of type `Result<u32, &R<'_>>`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     let x = if let Ok(x) = res { x } else { todo!() };

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
@@ -2,7 +2,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(test)]
 

--- a/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
+++ b/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // revisions: default mir-opt
 //[mir-opt] compile-flags: -Zmir-opt-level=4
 

--- a/src/test/ui/rfcs/rfc1857-drop-order.rs
+++ b/src/test/ui/rfcs/rfc1857-drop-order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(dead_code, unreachable_code)]
 

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -2,9 +2,6 @@
 // needs-unwind
 // ignore-emscripten no processes
 // ignore-sgx no processes
-// ignore-wasm32-bare no unwinding panic
-// ignore-avr no unwinding panic
-// ignore-nvptx64 no unwinding panic
 
 use std::env;
 use std::process::Command;

--- a/src/test/ui/specialization/issue-38091-2.stderr
+++ b/src/test/ui/specialization/issue-38091-2.stderr
@@ -10,7 +10,7 @@ LL | #![feature(specialization)]
 
 error[E0275]: overflow evaluating the requirement `i32: Check`
    |
-note: required for `i32` to implement `Iterate`
+note: required for `i32` to implement `Iterate<'_>`
   --> $DIR/issue-38091-2.rs:11:13
    |
 LL | impl<'a, T> Iterate<'a> for T

--- a/src/test/ui/test-attrs/test-panic-while-printing.rs
+++ b/src/test/ui/test-attrs/test-panic-while-printing.rs
@@ -1,7 +1,6 @@
 // compile-flags:--test
 // run-pass
 // needs-unwind
-// ignore-emscripten no subprocess support
 
 use std::fmt;
 use std::fmt::{Display, Formatter};

--- a/src/test/ui/test-attrs/test-should-fail-good-message.rs
+++ b/src/test/ui/test-attrs/test-should-fail-good-message.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: --test
 #[test]
 #[should_panic(expected = "foo")]

--- a/src/test/ui/transmute/main.stderr
+++ b/src/test/ui/transmute/main.stderr
@@ -4,7 +4,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     transmute(x)
    |     ^^^^^^^^^
    |
-   = note: `<C as TypeConstructor>::T` does not have a fixed size
+   = note: `<C as TypeConstructor<'_>>::T` does not have a fixed size
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/main.rs:17:17

--- a/src/test/ui/unwind-abis/ffi-unwind-calls-lint.rs
+++ b/src/test/ui/unwind-abis/ffi-unwind-calls-lint.rs
@@ -1,6 +1,5 @@
 // build-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(c_unwind)]
 #![warn(ffi_unwind_calls)]

--- a/src/test/ui/unwind-abis/ffi-unwind-calls-lint.stderr
+++ b/src/test/ui/unwind-abis/ffi-unwind-calls-lint.stderr
@@ -1,17 +1,17 @@
 warning: call to foreign function with FFI-unwind ABI
-  --> $DIR/ffi-unwind-calls-lint.rs:21:14
+  --> $DIR/ffi-unwind-calls-lint.rs:20:14
    |
 LL |     unsafe { foo(); }
    |              ^^^^^ call to foreign function with FFI-unwind ABI
    |
 note: the lint level is defined here
-  --> $DIR/ffi-unwind-calls-lint.rs:6:9
+  --> $DIR/ffi-unwind-calls-lint.rs:5:9
    |
 LL | #![warn(ffi_unwind_calls)]
    |         ^^^^^^^^^^^^^^^^
 
 warning: call to function pointer with FFI-unwind ABI
-  --> $DIR/ffi-unwind-calls-lint.rs:25:5
+  --> $DIR/ffi-unwind-calls-lint.rs:24:5
    |
 LL |     ptr();
    |     ^^^^^ call to function pointer with FFI-unwind ABI

--- a/src/test/ui/unwind-no-uwtable.rs
+++ b/src/test/ui/unwind-no-uwtable.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 // ignore-windows target requires uwtable
-// ignore-wasm32-bare no proper panic=unwind support
 // compile-flags: -C panic=unwind -C force-unwind-tables=n
 
 use std::panic::{self, AssertUnwindSafe};

--- a/src/tools/clippy/tests/ui/inefficient_to_string.stderr
+++ b/src/tools/clippy/tests/ui/inefficient_to_string.stderr
@@ -35,21 +35,21 @@ LL |     let _: String = rrrstring.to_string();
    |
    = help: `&&std::string::String` implements `ToString` through a slower blanket impl, but `std::string::String` has a fast specialization of `ToString`
 
-error: calling `to_string` on `&&std::borrow::Cow<str>`
+error: calling `to_string` on `&&std::borrow::Cow<'_, str>`
   --> $DIR/inefficient_to_string.rs:29:21
    |
 LL |     let _: String = rrcow.to_string();
    |                     ^^^^^^^^^^^^^^^^^ help: try dereferencing the receiver: `(*rrcow).to_string()`
    |
-   = help: `&std::borrow::Cow<str>` implements `ToString` through a slower blanket impl, but `std::borrow::Cow<str>` has a fast specialization of `ToString`
+   = help: `&std::borrow::Cow<'_, str>` implements `ToString` through a slower blanket impl, but `std::borrow::Cow<'_, str>` has a fast specialization of `ToString`
 
-error: calling `to_string` on `&&&std::borrow::Cow<str>`
+error: calling `to_string` on `&&&std::borrow::Cow<'_, str>`
   --> $DIR/inefficient_to_string.rs:30:21
    |
 LL |     let _: String = rrrcow.to_string();
    |                     ^^^^^^^^^^^^^^^^^^ help: try dereferencing the receiver: `(**rrrcow).to_string()`
    |
-   = help: `&&std::borrow::Cow<str>` implements `ToString` through a slower blanket impl, but `std::borrow::Cow<str>` has a fast specialization of `ToString`
+   = help: `&&std::borrow::Cow<'_, str>` implements `ToString` through a slower blanket impl, but `std::borrow::Cow<'_, str>` has a fast specialization of `ToString`
 
 error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui/suspicious_to_owned.stderr
+++ b/src/tools/clippy/tests/ui/suspicious_to_owned.stderr
@@ -1,4 +1,4 @@
-error: this `to_owned` call clones the std::borrow::Cow<str> itself and does not cause the std::borrow::Cow<str> contents to become owned
+error: this `to_owned` call clones the std::borrow::Cow<'_, str> itself and does not cause the std::borrow::Cow<'_, str> contents to become owned
   --> $DIR/suspicious_to_owned.rs:16:13
    |
 LL |     let _ = cow.to_owned();
@@ -6,19 +6,19 @@ LL |     let _ = cow.to_owned();
    |
    = note: `-D clippy::suspicious-to-owned` implied by `-D warnings`
 
-error: this `to_owned` call clones the std::borrow::Cow<[char; 3]> itself and does not cause the std::borrow::Cow<[char; 3]> contents to become owned
+error: this `to_owned` call clones the std::borrow::Cow<'_, [char; 3]> itself and does not cause the std::borrow::Cow<'_, [char; 3]> contents to become owned
   --> $DIR/suspicious_to_owned.rs:26:13
    |
 LL |     let _ = cow.to_owned();
    |             ^^^^^^^^^^^^^^ help: consider using, depending on intent: `cow.clone()` or `cow.into_owned()`
 
-error: this `to_owned` call clones the std::borrow::Cow<std::vec::Vec<char>> itself and does not cause the std::borrow::Cow<std::vec::Vec<char>> contents to become owned
+error: this `to_owned` call clones the std::borrow::Cow<'_, std::vec::Vec<char>> itself and does not cause the std::borrow::Cow<'_, std::vec::Vec<char>> contents to become owned
   --> $DIR/suspicious_to_owned.rs:36:13
    |
 LL |     let _ = cow.to_owned();
    |             ^^^^^^^^^^^^^^ help: consider using, depending on intent: `cow.clone()` or `cow.into_owned()`
 
-error: this `to_owned` call clones the std::borrow::Cow<str> itself and does not cause the std::borrow::Cow<str> contents to become owned
+error: this `to_owned` call clones the std::borrow::Cow<'_, str> itself and does not cause the std::borrow::Cow<'_, str> contents to become owned
   --> $DIR/suspicious_to_owned.rs:46:13
    |
 LL |     let _ = cow.to_owned();

--- a/src/tools/clippy/tests/ui/transmute_ptr_to_ref.stderr
+++ b/src/tools/clippy/tests/ui/transmute_ptr_to_ref.stderr
@@ -42,13 +42,13 @@ error: transmute from a pointer type (`*mut U`) to a reference type (`&T`)
 LL |     let _: &T = std::mem::transmute(om);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(om as *const T)`
 
-error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<u8>`)
+error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, u8>`)
   --> $DIR/transmute_ptr_to_ref.rs:36:32
    |
 LL |     let _: &Foo<u8> = unsafe { std::mem::transmute::<_, &Foo<_>>(raw) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*raw.cast::<Foo<_>>()`
 
-error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<&u8>`)
+error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, &u8>`)
   --> $DIR/transmute_ptr_to_ref.rs:38:33
    |
 LL |     let _: &Foo<&u8> = unsafe { std::mem::transmute::<_, &Foo<&_>>(raw) };

--- a/src/tools/clippy/tests/ui/useless_conversion.stderr
+++ b/src/tools/clippy/tests/ui/useless_conversion.stderr
@@ -46,7 +46,7 @@ error: useless conversion to the same type: `std::string::String`
 LL |     let _ = String::from(format!("A: {:04}", 123));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `format!("A: {:04}", 123)`
 
-error: useless conversion to the same type: `std::str::Lines`
+error: useless conversion to the same type: `std::str::Lines<'_>`
   --> $DIR/useless_conversion.rs:65:13
    |
 LL |     let _ = "".lines().into_iter();

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -278,10 +278,6 @@ pub struct Config {
     /// override this setting.
     pub optimize_tests: bool,
 
-    /// What panic strategy the target is built with.  Unwind supports Abort, but
-    /// not vice versa.
-    pub target_panic: PanicStrategy,
-
     /// Target system to be tested
     pub target: String,
 
@@ -426,6 +422,10 @@ impl Config {
         *&self.target_cfg().pointer_width
     }
 
+    pub fn can_unwind(&self) -> bool {
+        self.target_cfg().panic == PanicStrategy::Unwind
+    }
+
     pub fn has_asm_support(&self) -> bool {
         static ASM_SUPPORTED_ARCHS: &[&str] = &[
             "x86", "x86_64", "arm", "aarch64", "riscv32",
@@ -446,6 +446,7 @@ pub struct TargetCfg {
     families: Vec<String>,
     pointer_width: u32,
     endian: Endian,
+    panic: PanicStrategy,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -481,6 +482,7 @@ impl TargetCfg {
         let mut families = Vec::new();
         let mut pointer_width = None;
         let mut endian = None;
+        let mut panic = None;
         for line in print_cfg.lines() {
             if let Some((name, value)) = line.split_once('=') {
                 let value = value.trim_matches('"');
@@ -498,6 +500,13 @@ impl TargetCfg {
                             s => panic!("unexpected {s}"),
                         })
                     }
+                    "panic" => {
+                        panic = match value {
+                            "abort" => Some(PanicStrategy::Abort),
+                            "unwind" => Some(PanicStrategy::Unwind),
+                            s => panic!("unexpected {s}"),
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -510,6 +519,7 @@ impl TargetCfg {
             families,
             pointer_width: pointer_width.unwrap(),
             endian: endian.unwrap(),
+            panic: panic.unwrap(),
         }
     }
 }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::*;
 
-use crate::common::{CompareMode, Config, Debugger, FailMode, Mode, PanicStrategy, PassMode};
+use crate::common::{CompareMode, Config, Debugger, FailMode, Mode, PassMode};
 use crate::util;
 use crate::{extract_cdb_version, extract_gdb_version};
 
@@ -949,8 +949,7 @@ pub fn make_test_description<R: Read>(
         ignore |= !has_memtag && config.parse_name_directive(ln, "needs-sanitizer-memtag");
         ignore |= !has_shadow_call_stack
             && config.parse_name_directive(ln, "needs-sanitizer-shadow-call-stack");
-        ignore |= config.target_panic == PanicStrategy::Abort
-            && config.parse_name_directive(ln, "needs-unwind");
+        ignore |= !config.can_unwind() && config.parse_name_directive(ln, "needs-unwind");
         ignore |= config.target == "wasm32-unknown-unknown"
             && config.parse_name_directive(ln, directives::CHECK_RUN_RESULTS);
         ignore |= config.debugger == Some(Debugger::Cdb) && ignore_cdb(config, ln);

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -5,9 +5,7 @@
 
 extern crate test;
 
-use crate::common::{
-    expected_output_path, output_base_dir, output_relative_path, PanicStrategy, UI_EXTENSIONS,
-};
+use crate::common::{expected_output_path, output_base_dir, output_relative_path, UI_EXTENSIONS};
 use crate::common::{CompareMode, Config, Debugger, Mode, PassMode, TestPaths};
 use crate::util::logv;
 use getopts::Options;
@@ -105,7 +103,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .optmulti("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
         .optmulti("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS")
         .optflag("", "optimize-tests", "run tests with optimizations enabled")
-        .optopt("", "target-panic", "what panic strategy the target supports", "unwind | abort")
         .optflag("", "verbose", "run tests verbosely, showing all output")
         .optflag(
             "",
@@ -258,11 +255,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
         host_rustcflags: Some(matches.opt_strs("host-rustcflags").join(" ")),
         target_rustcflags: Some(matches.opt_strs("target-rustcflags").join(" ")),
         optimize_tests: matches.opt_present("optimize-tests"),
-        target_panic: match matches.opt_str("target-panic").as_deref() {
-            Some("unwind") | None => PanicStrategy::Unwind,
-            Some("abort") => PanicStrategy::Abort,
-            _ => panic!("unknown `--target-panic` option `{}` given", mode),
-        },
         target,
         host: opt_str2(matches.opt_str("host")),
         cdb,

--- a/src/tools/miri/cargo-miri/src/main.rs
+++ b/src/tools/miri/cargo-miri/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(bootstrap, feature(let_else))]
 #![allow(clippy::useless_format, clippy::derive_partial_eq_without_eq, rustc::internal)]
 
 #[macro_use]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(is_some_with)]
 #![feature(nonzero_ops)]
 #![feature(local_key_cell_methods)]
+#![cfg_attr(bootstrap, feature(let_else))]
 // Configure clippy and other lints
 #![allow(
     clippy::collapsible_else_if,

--- a/src/tools/miri/tests/pass/issues/issue-miri-2433.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-2433.rs
@@ -1,0 +1,22 @@
+#![feature(type_alias_impl_trait)]
+
+trait T { type Item; }
+
+type Alias<'a> = impl T<Item = &'a ()>;
+
+struct S;
+impl<'a> T for &'a S {
+    type Item = &'a ();
+}
+
+fn filter_positive<'a>() -> Alias<'a> {
+    &S
+}
+
+fn with_positive(fun: impl Fn(Alias<'_>)) {
+    fun(filter_positive());
+}
+
+fn main() {
+    with_positive(|_| ());
+}


### PR DESCRIPTION
Successful merges:

 - #102068 (Always print '_, even for erased lifetimes.)
 - #102088 (Fix wrongly refactored Lift impl)
 - #102094 (Add missing documentation for `bool::from_str`)
 - #102115 (Add examples to `bool::then` and `bool::then_some`)
 - #102134 (Detect panic strategy using `rustc --print cfg`)
 - #102148 (add regression test for miri issue 2433)
 - #102158 (rustdoc: clean up CSS/DOM for deprecation warnings)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102068,102088,102094,102115,102134,102148,102158)
<!-- homu-ignore:end -->