### PR TITLE
Use correct location for type tests in promoted constants

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -587,6 +587,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
         // modify their locations.
         let all_facts = &mut None;
         let mut constraints = Default::default();
+        let mut type_tests = Default::default();
         let mut closure_bounds = Default::default();
         let mut liveness_constraints =
             LivenessValues::new(Rc::new(RegionValueElements::new(&promoted_body)));
@@ -598,6 +599,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                 &mut this.cx.borrowck_context.constraints.outlives_constraints,
                 &mut constraints,
             );
+            mem::swap(&mut this.cx.borrowck_context.constraints.type_tests, &mut type_tests);
             mem::swap(
                 &mut this.cx.borrowck_context.constraints.closure_bounds_mapping,
                 &mut closure_bounds,
@@ -622,6 +624,13 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
         swap_constraints(self);
 
         let locations = location.to_locations();
+
+        // Use location of promoted const in collected constraints
+        for type_test in type_tests.iter() {
+            let mut type_test = type_test.clone();
+            type_test.locations = locations;
+            self.cx.borrowck_context.constraints.type_tests.push(type_test)
+        }
         for constraint in constraints.outlives().iter() {
             let mut constraint = constraint.clone();
             constraint.locations = locations;

--- a/src/test/ui/consts/issue-102117.rs
+++ b/src/test/ui/consts/issue-102117.rs
@@ -1,0 +1,30 @@
+#![feature(inline_const, const_type_id)]
+
+use std::alloc::Layout;
+use std::any::TypeId;
+use std::mem::transmute;
+use std::ptr::drop_in_place;
+
+pub struct VTable {
+    layout: Layout,
+    type_id: TypeId,
+    drop_in_place: unsafe fn(*mut ()),
+}
+
+impl VTable {
+    pub fn new<T>() -> &'static Self {
+        const {
+          //~^ ERROR the parameter type `T` may not live long enough
+          //~| ERROR the parameter type `T` may not live long enough
+            &VTable {
+                layout: Layout::new::<T>(),
+                type_id: TypeId::of::<T>(),
+                drop_in_place: unsafe {
+                    transmute::<unsafe fn(*mut T), unsafe fn(*mut ())>(drop_in_place::<T>)
+                },
+            }
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-102117.stderr
+++ b/src/test/ui/consts/issue-102117.stderr
@@ -1,0 +1,37 @@
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue-102117.rs:16:9
+   |
+LL | /         const {
+LL | |
+LL | |
+LL | |             &VTable {
+...  |
+LL | |             }
+LL | |         }
+   | |_________^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL |     pub fn new<T: 'static>() -> &'static Self {
+   |                 +++++++++
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue-102117.rs:16:9
+   |
+LL | /         const {
+LL | |
+LL | |
+LL | |             &VTable {
+...  |
+LL | |             }
+LL | |         }
+   | |_________^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL |     pub fn new<T: 'static>() -> &'static Self {
+   |                 +++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
Previously we forgot to remap the location in a type test collected when visiting the body of a promoted constant back to the usage location, causing an ICE when trying to get span information for that type test.

Fixes https://github.com/rust-lang/rust/issues/102117