### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -351,25 +351,7 @@ impl<'cx, 'tcx> FallibleTypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
         &mut self,
         constant: mir::ConstantKind<'tcx>,
     ) -> Result<mir::ConstantKind<'tcx>, Self::Error> {
-        Ok(match constant {
-            mir::ConstantKind::Ty(c) => {
-                let const_folded = c.try_super_fold_with(self)?;
-                match const_folded.kind() {
-                    ty::ConstKind::Value(valtree) => {
-                        let tcx = self.infcx.tcx;
-                        let ty = const_folded.ty();
-                        let const_val = tcx.valtree_to_const_val((ty, valtree));
-                        debug!(?ty, ?valtree, ?const_val);
-
-                        mir::ConstantKind::Val(const_val, ty)
-                    }
-                    _ => mir::ConstantKind::Ty(const_folded),
-                }
-            }
-            mir::ConstantKind::Val(_, _) | mir::ConstantKind::Unevaluated(..) => {
-                constant.try_super_fold_with(self)?
-            }
-        })
+        constant.try_super_fold_with(self)
     }
 
     #[inline]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -58,6 +58,7 @@ impl bool {
     ///
     /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
+    /// assert_eq!(a, 1);
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,16 +18,16 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
     /// let mut function_with_side_effects = || { a += 1; };
-    /// 
+    ///
     /// true.then_some(function_with_side_effects());
     /// false.then_some(function_with_side_effects());
-    /// 
-    /// // `a` is incremented twice because the value passed to `then_some` is 
-    /// // evaluated eagerly. 
+    ///
+    /// // `a` is incremented twice because the value passed to `then_some` is
+    /// // evaluated eagerly.
     /// assert_eq!(a, 2);
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
@@ -49,14 +49,14 @@ impl bool {
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
-    /// 
+    ///
     /// true.then(|| { a += 1; });
     /// false.then(|| { a += 1; });
-    /// 
-    /// // `a` is incremented once because the closure is evaluated lazily by 
+    ///
+    /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,6 +18,18 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// let mut function_with_side_effects = || { a += 1; };
+    /// 
+    /// true.then_some(function_with_side_effects());
+    /// false.then_some(function_with_side_effects());
+    /// 
+    /// // `a` is incremented twice because the value passed to `then_some` is 
+    /// // evaluated eagerly. 
+    /// assert_eq!(a, 2);
+    /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]
     #[inline]
@@ -36,6 +48,16 @@ impl bool {
     /// ```
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
+    /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// 
+    /// true.then(|| { a += 1; });
+    /// false.then(|| { a += 1; });
+    /// 
+    /// // `a` is incremented once because the closure is evaluated lazily by 
+    /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -573,8 +573,8 @@ impl FromStr for bool {
 
     /// Parse a `bool` from a string.
     ///
-    /// Yields a `Result<bool, ParseBoolError>`, because `s` may or may not
-    /// actually be parseable.
+    /// The only accepted values are `"true"` and `"false"`. Any other input
+    /// will return an error.
     ///
     /// # Examples
     ///

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -145,8 +145,8 @@
 //! abstracting over differences in common platforms, most notably Windows and
 //! Unix derivatives.
 //!
-//! Common types of I/O, including [files], [TCP], [UDP], are defined in the
-//! [`io`], [`fs`], and [`net`] modules.
+//! Common types of I/O, including [files], [TCP], and [UDP], are defined in
+//! the [`io`], [`fs`], and [`net`] modules.
 //!
 //! The [`thread`] module contains Rust's threading abstractions. [`sync`]
 //! contains further primitive shared memory types, including [`atomic`] and

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -1,5 +1,5 @@
 use super::{find_testable_code, plain_text_summary, short_markdown_summary};
-use super::{ErrorCodes, HeadingOffset, IdMap, Ignore, LangString, Markdown, MarkdownHtml};
+use super::{ErrorCodes, HeadingOffset, IdMap, Ignore, LangString, Markdown, MarkdownItemInfo};
 use rustc_span::edition::{Edition, DEFAULT_EDITION};
 
 #[test]
@@ -279,14 +279,13 @@ fn test_plain_text_summary() {
 fn test_markdown_html_escape() {
     fn t(input: &str, expect: &str) {
         let mut idmap = IdMap::new();
-        let output =
-            MarkdownHtml(input, &mut idmap, ErrorCodes::Yes, DEFAULT_EDITION, &None).into_string();
+        let output = MarkdownItemInfo(input, &mut idmap).into_string();
         assert_eq!(output, expect, "original: {}", input);
     }
 
-    t("`Struct<'a, T>`", "<p><code>Struct&lt;'a, T&gt;</code></p>\n");
-    t("Struct<'a, T>", "<p>Struct&lt;’a, T&gt;</p>\n");
-    t("Struct<br>", "<p>Struct&lt;br&gt;</p>\n");
+    t("`Struct<'a, T>`", "<code>Struct&lt;'a, T&gt;</code>");
+    t("Struct<'a, T>", "Struct&lt;’a, T&gt;");
+    t("Struct<br>", "Struct&lt;br&gt;");
 }
 
 #[test]

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -74,7 +74,9 @@ use crate::html::format::{
     PrintWithSpace,
 };
 use crate::html::highlight;
-use crate::html::markdown::{HeadingOffset, IdMap, Markdown, MarkdownHtml, MarkdownSummaryLine};
+use crate::html::markdown::{
+    HeadingOffset, IdMap, Markdown, MarkdownItemInfo, MarkdownSummaryLine,
+};
 use crate::html::sources;
 use crate::html::static_files::SCRAPE_EXAMPLES_HELP_MD;
 use crate::scrape_examples::{CallData, CallLocation};
@@ -582,7 +584,6 @@ fn short_item_info(
     parent: Option<&clean::Item>,
 ) -> Vec<String> {
     let mut extra_info = vec![];
-    let error_codes = cx.shared.codes;
 
     if let Some(depr @ Deprecation { note, since, is_since_rustc_version: _, suggestion: _ }) =
         item.deprecation(cx.tcx())
@@ -606,13 +607,7 @@ fn short_item_info(
 
         if let Some(note) = note {
             let note = note.as_str();
-            let html = MarkdownHtml(
-                note,
-                &mut cx.id_map,
-                error_codes,
-                cx.shared.edition(),
-                &cx.shared.playground,
-            );
+            let html = MarkdownItemInfo(note, &mut cx.id_map);
             message.push_str(&format!(": {}", html.into_string()));
         }
         extra_info.push(format!(

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1078,10 +1078,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 0.875rem;
 	font-weight: normal;
 }
-.stab p {
-	display: inline;
-	margin: 0;
-}
 
 .stab .emoji {
 	font-size: 1.25rem;

--- a/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.rs
+++ b/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.rs
@@ -24,10 +24,6 @@ mod assert {
             Src,
             Context,
             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-            //~^ ERROR E0080
-            //~| ERROR E0080
-            //~| ERROR E0080
-            //~| ERROR E0080
         >,
     {}
 

--- a/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.stderr
+++ b/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.stderr
@@ -1,52 +1,27 @@
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:53:51
+  --> $DIR/wrong-type-assume.rs:49:51
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, {0u8}, false, false, false>();
    |                                                   ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, {0u8}, false, false, false>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:54:58
+  --> $DIR/wrong-type-assume.rs:50:58
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, false, {0u8}, false, false>();
    |                                                          ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, false, {0u8}, false, false>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:55:65
+  --> $DIR/wrong-type-assume.rs:51:65
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, false, false, {0u8}, false>();
    |                                                                 ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, false, false, {0u8}, false>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:56:72
+  --> $DIR/wrong-type-assume.rs:52:72
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, false, false, false, {0u8}>();
    |                                                                        ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, false, false, false, {0u8}>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+error: aborting due to 4 previous errors
 
-error: aborting due to 8 previous errors
-
-Some errors have detailed explanations: E0080, E0308.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/tools/miri/cargo-miri/src/main.rs
+++ b/src/tools/miri/cargo-miri/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(bootstrap, feature(let_else))]
 #![allow(clippy::useless_format, clippy::derive_partial_eq_without_eq, rustc::internal)]
 
 #[macro_use]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(is_some_with)]
 #![feature(nonzero_ops)]
 #![feature(local_key_cell_methods)]
+#![cfg_attr(bootstrap, feature(let_else))]
 // Configure clippy and other lints
 #![allow(
     clippy::collapsible_else_if,

--- a/src/tools/miri/tests/pass/issues/issue-miri-2433.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-2433.rs
@@ -1,0 +1,22 @@
+#![feature(type_alias_impl_trait)]
+
+trait T { type Item; }
+
+type Alias<'a> = impl T<Item = &'a ()>;
+
+struct S;
+impl<'a> T for &'a S {
+    type Item = &'a ();
+}
+
+fn filter_positive<'a>() -> Alias<'a> {
+    &S
+}
+
+fn with_positive(fun: impl Fn(Alias<'_>)) {
+    fun(filter_positive());
+}
+
+fn main() {
+    with_positive(|_| ());
+}


### PR DESCRIPTION
Successful merges:

 - #100734 (Split out async_fn_in_trait into a separate feature)
 - #101815 (Migrated the rustc_passes annotation without effect diagnostic infrastructure)
 - #102042 (Distribute rust-docs-json via rustup.)
 - #102066 (rustdoc: remove unnecessary `max-width` on headers)
 - #102094 (Add missing documentation for `bool::from_str`)
 - #102115 (Add examples to `bool::then` and `bool::then_some`)
 - #102137 (Don't convert valtree to constvalue during normalization)
 - #102148 (add regression test for miri issue 2433)
 - #102158 (rustdoc: clean up CSS/DOM for deprecation warnings)
 - #102177 (Fix a typo in `std`'s root docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=100734,101815,102042,102066,102094,102115,102137,102148,102158,102177)
<!-- homu-ignore:end -->