### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -351,25 +351,7 @@ impl<'cx, 'tcx> FallibleTypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
         &mut self,
         constant: mir::ConstantKind<'tcx>,
     ) -> Result<mir::ConstantKind<'tcx>, Self::Error> {
-        Ok(match constant {
-            mir::ConstantKind::Ty(c) => {
-                let const_folded = c.try_super_fold_with(self)?;
-                match const_folded.kind() {
-                    ty::ConstKind::Value(valtree) => {
-                        let tcx = self.infcx.tcx;
-                        let ty = const_folded.ty();
-                        let const_val = tcx.valtree_to_const_val((ty, valtree));
-                        debug!(?ty, ?valtree, ?const_val);
-
-                        mir::ConstantKind::Val(const_val, ty)
-                    }
-                    _ => mir::ConstantKind::Ty(const_folded),
-                }
-            }
-            mir::ConstantKind::Val(_, _) | mir::ConstantKind::Unevaluated(..) => {
-                constant.try_super_fold_with(self)?
-            }
-        })
+        constant.try_super_fold_with(self)
     }
 
     #[inline]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -58,6 +58,7 @@ impl bool {
     ///
     /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
+    /// assert_eq!(a, 1);
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,16 +18,16 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
     /// let mut function_with_side_effects = || { a += 1; };
-    /// 
+    ///
     /// true.then_some(function_with_side_effects());
     /// false.then_some(function_with_side_effects());
-    /// 
-    /// // `a` is incremented twice because the value passed to `then_some` is 
-    /// // evaluated eagerly. 
+    ///
+    /// // `a` is incremented twice because the value passed to `then_some` is
+    /// // evaluated eagerly.
     /// assert_eq!(a, 2);
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
@@ -49,14 +49,14 @@ impl bool {
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
     /// ```
-    /// 
+    ///
     /// ```
     /// let mut a = 0;
-    /// 
+    ///
     /// true.then(|| { a += 1; });
     /// false.then(|| { a += 1; });
-    /// 
-    /// // `a` is incremented once because the closure is evaluated lazily by 
+    ///
+    /// // `a` is incremented once because the closure is evaluated lazily by
     /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -18,6 +18,18 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// let mut function_with_side_effects = || { a += 1; };
+    /// 
+    /// true.then_some(function_with_side_effects());
+    /// false.then_some(function_with_side_effects());
+    /// 
+    /// // `a` is incremented twice because the value passed to `then_some` is 
+    /// // evaluated eagerly. 
+    /// assert_eq!(a, 2);
+    /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]
     #[inline]
@@ -36,6 +48,16 @@ impl bool {
     /// ```
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
+    /// ```
+    /// 
+    /// ```
+    /// let mut a = 0;
+    /// 
+    /// true.then(|| { a += 1; });
+    /// false.then(|| { a += 1; });
+    /// 
+    /// // `a` is incremented once because the closure is evaluated lazily by 
+    /// // `then`.
     /// ```
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -573,8 +573,8 @@ impl FromStr for bool {
 
     /// Parse a `bool` from a string.
     ///
-    /// Yields a `Result<bool, ParseBoolError>`, because `s` may or may not
-    /// actually be parseable.
+    /// The only accepted values are `"true"` and `"false"`. Any other input
+    /// will return an error.
     ///
     /// # Examples
     ///

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -145,8 +145,8 @@
 //! abstracting over differences in common platforms, most notably Windows and
 //! Unix derivatives.
 //!
-//! Common types of I/O, including [files], [TCP], [UDP], are defined in the
-//! [`io`], [`fs`], and [`net`] modules.
+//! Common types of I/O, including [files], [TCP], and [UDP], are defined in
+//! the [`io`], [`fs`], and [`net`] modules.
 //!
 //! The [`thread`] module contains Rust's threading abstractions. [`sync`]
 //! contains further primitive shared memory types, including [`atomic`] and

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -1,5 +1,5 @@
 use super::{find_testable_code, plain_text_summary, short_markdown_summary};
-use super::{ErrorCodes, HeadingOffset, IdMap, Ignore, LangString, Markdown, MarkdownHtml};
+use super::{ErrorCodes, HeadingOffset, IdMap, Ignore, LangString, Markdown, MarkdownItemInfo};
 use rustc_span::edition::{Edition, DEFAULT_EDITION};
 
 #[test]
@@ -279,14 +279,13 @@ fn test_plain_text_summary() {
 fn test_markdown_html_escape() {
     fn t(input: &str, expect: &str) {
         let mut idmap = IdMap::new();
-        let output =
-            MarkdownHtml(input, &mut idmap, ErrorCodes::Yes, DEFAULT_EDITION, &None).into_string();
+        let output = MarkdownItemInfo(input, &mut idmap).into_string();
         assert_eq!(output, expect, "original: {}", input);
     }
 
-    t("`Struct<'a, T>`", "<p><code>Struct&lt;'a, T&gt;</code></p>\n");
-    t("Struct<'a, T>", "<p>Struct&lt;’a, T&gt;</p>\n");
-    t("Struct<br>", "<p>Struct&lt;br&gt;</p>\n");
+    t("`Struct<'a, T>`", "<code>Struct&lt;'a, T&gt;</code>");
+    t("Struct<'a, T>", "Struct&lt;’a, T&gt;");
+    t("Struct<br>", "Struct&lt;br&gt;");
 }
 
 #[test]

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -74,7 +74,9 @@ use crate::html::format::{
     PrintWithSpace,
 };
 use crate::html::highlight;
-use crate::html::markdown::{HeadingOffset, IdMap, Markdown, MarkdownHtml, MarkdownSummaryLine};
+use crate::html::markdown::{
+    HeadingOffset, IdMap, Markdown, MarkdownItemInfo, MarkdownSummaryLine,
+};
 use crate::html::sources;
 use crate::html::static_files::SCRAPE_EXAMPLES_HELP_MD;
 use crate::scrape_examples::{CallData, CallLocation};
@@ -582,7 +584,6 @@ fn short_item_info(
     parent: Option<&clean::Item>,
 ) -> Vec<String> {
     let mut extra_info = vec![];
-    let error_codes = cx.shared.codes;
 
     if let Some(depr @ Deprecation { note, since, is_since_rustc_version: _, suggestion: _ }) =
         item.deprecation(cx.tcx())
@@ -606,13 +607,7 @@ fn short_item_info(
 
         if let Some(note) = note {
             let note = note.as_str();
-            let html = MarkdownHtml(
-                note,
-                &mut cx.id_map,
-                error_codes,
-                cx.shared.edition(),
-                &cx.shared.playground,
-            );
+            let html = MarkdownItemInfo(note, &mut cx.id_map);
             message.push_str(&format!(": {}", html.into_string()));
         }
         extra_info.push(format!(

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1078,10 +1078,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 0.875rem;
 	font-weight: normal;
 }
-.stab p {
-	display: inline;
-	margin: 0;
-}
 
 .stab .emoji {
 	font-size: 1.25rem;

--- a/src/test/ui/async-await/async-fn-size-moved-locals.rs
+++ b/src/test/ui/async-await/async-fn-size-moved-locals.rs
@@ -7,7 +7,6 @@
 //
 // See issue #59123 for a full explanation.
 
-// ignore-emscripten (sizes don't match)
 // needs-unwind Size of Futures change on panic=abort
 // run-pass
 

--- a/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
+++ b/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
@@ -6,7 +6,6 @@
 // error-pattern: thread 'main' panicked at '`async fn` resumed after panicking'
 // edition:2018
 // ignore-wasm no panic or subprocess support
-// ignore-emscripten no panic or subprocess support
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
+++ b/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
@@ -3,7 +3,6 @@
 // Check that partially moved from function parameters are dropped after the
 // named bindings that move from them.
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::{panic, cell::RefCell};
 

--- a/src/test/ui/builtin-clone-unwind.rs
+++ b/src/test/ui/builtin-clone-unwind.rs
@@ -3,7 +3,6 @@
 
 #![allow(unused_variables)]
 #![allow(unused_imports)]
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // Test that builtin implementations of `Clone` cleanup everything
 // in case of unwinding.

--- a/src/test/ui/catch-unwind-bang.rs
+++ b/src/test/ui/catch-unwind-bang.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 fn worker() -> ! {
     panic!()

--- a/src/test/ui/cfg/cfg-panic.rs
+++ b/src/test/ui/cfg/cfg-panic.rs
@@ -1,9 +1,6 @@
 // build-pass
 // compile-flags: -C panic=unwind
 // needs-unwind
-// ignore-emscripten no panic_unwind implementation
-// ignore-wasm32     no panic_unwind implementation
-// ignore-wasm64     no panic_unwind implementation
 
 
 #[cfg(panic = "abort")]

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -3,7 +3,6 @@
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-// ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -3,7 +3,6 @@
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-// ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,5 +1,5 @@
 error: changes to closure capture in Rust 2021 will affect which traits the closure implements
-  --> $DIR/mir_calls_to_shims.rs:21:38
+  --> $DIR/mir_calls_to_shims.rs:20:38
    |
 LL |     let result = panic::catch_unwind(move || {
    |                                      ^^^^^^^

--- a/src/test/ui/drop/dynamic-drop-async.rs
+++ b/src/test/ui/drop/dynamic-drop-async.rs
@@ -6,7 +6,6 @@
 // run-pass
 // needs-unwind
 // edition:2018
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(unused)]
 

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/drop/repeat-drop.rs
+++ b/src/test/ui/drop/repeat-drop.rs
@@ -1,8 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare no unwinding panic
-// ignore-avr no unwinding panic
-// ignore-nvptx64 no unwinding panic
 
 static mut CHECK: usize = 0;
 

--- a/src/test/ui/extern-flag/empty-extern-arg.rs
+++ b/src/test/ui/extern-flag/empty-extern-arg.rs
@@ -1,6 +1,5 @@
 // compile-flags: --extern std=
 // error-pattern: extern location for std does not exist
 // needs-unwind since it affects the error output
-// ignore-emscripten compiled with panic=abort, personality not required
 
 fn main() {}

--- a/src/test/ui/extern-flag/empty-extern-arg.rs
+++ b/src/test/ui/extern-flag/empty-extern-arg.rs
@@ -1,5 +1,6 @@
 // compile-flags: --extern std=
 // error-pattern: extern location for std does not exist
 // needs-unwind since it affects the error output
+// ignore-emscripten missing eh_catch_typeinfo lang item
 
 fn main() {}

--- a/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
+++ b/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 
 // rust-lang/rust#64655: with panic=unwind, a panic from a subroutine

--- a/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
+++ b/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 
 // rust-lang/rust#64655: with panic=unwind, a panic from a subroutine

--- a/src/test/ui/generator/panic-drops-resume.rs
+++ b/src/test/ui/generator/panic-drops-resume.rs
@@ -2,8 +2,6 @@
 
 // run-pass
 // needs-unwind
-// ignore-wasm       no unwind support
-// ignore-emscripten no unwind support
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/panic-drops.rs
+++ b/src/test/ui/generator/panic-drops.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/panic-safe.rs
+++ b/src/test/ui/generator/panic-safe.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/generator/resume-after-return.rs
+++ b/src/test/ui/generator/resume-after-return.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // revisions: mir thir strict
 // [thir]compile-flags: -Zthir-unsafeck
 // [strict]compile-flags: -Zstrict-init-checks

--- a/src/test/ui/issues/issue-14875.rs
+++ b/src/test/ui/issues/issue-14875.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // Check that values are not leaked when a dtor panics (#14875)
 

--- a/src/test/ui/issues/issue-29948.rs
+++ b/src/test/ui/issues/issue-29948.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;
 

--- a/src/test/ui/issues/issue-43853.rs
+++ b/src/test/ui/issues/issue-43853.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;
 

--- a/src/test/ui/issues/issue-46519.rs
+++ b/src/test/ui/issues/issue-46519.rs
@@ -2,7 +2,6 @@
 // compile-flags:--test -O
 
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #[test]
 #[should_panic(expected = "creating inhabited type")]

--- a/src/test/ui/iterators/iter-count-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;

--- a/src/test/ui/iterators/iter-position-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;

--- a/src/test/ui/iterators/iter-step-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-step-overflow-debug.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 
 use std::panic;

--- a/src/test/ui/iterators/iter-sum-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-debug.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 
 use std::panic;

--- a/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C overflow-checks
 
 use std::panic;

--- a/src/test/ui/macros/macro-comma-behavior-rpass.rs
+++ b/src/test/ui/macros/macro-comma-behavior-rpass.rs
@@ -14,7 +14,6 @@
 // compile-flags: --test -C debug_assertions=yes
 // revisions: std core
 
-// ignore-wasm32-bare compiled with panic=abort by default
 #![cfg_attr(core, no_std)]
 
 #[cfg(core)]

--- a/src/test/ui/mir/mir_calls_to_shims.rs
+++ b/src/test/ui/mir/mir_calls_to_shims.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(fn_traits)]
 #![feature(never_type)]

--- a/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
+++ b/src/test/ui/mir/mir_codegen_calls_diverging_drops.rs
@@ -1,7 +1,6 @@
 // run-fail
 // error-pattern:diverging_fn called
 // error-pattern:0 dropped
-// ignore-emscripten no processes
 // needs-unwind this test checks that a destructor is called after panicking
 
 struct Droppable(u8);

--- a/src/test/ui/mir/mir_drop_order.rs
+++ b/src/test/ui/mir/mir_drop_order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 use std::cell::RefCell;
 use std::panic;

--- a/src/test/ui/mir/mir_drop_panics.rs
+++ b/src/test/ui/mir/mir_drop_panics.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // error-pattern:panic 1
 // error-pattern:drop 2
-// ignore-emscripten no processes
 
 struct Droppable(u32);
 impl Drop for Droppable {

--- a/src/test/ui/mir/mir_let_chains_drop_order.rs
+++ b/src/test/ui/mir/mir_let_chains_drop_order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 // See `mir_drop_order.rs` for more information
 

--- a/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
+++ b/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
@@ -1,7 +1,6 @@
 // run-pass
 // compile-flags: -C debug_assertions=yes
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten dies with an LLVM error
 
 use std::panic;

--- a/src/test/ui/panic-handler/weak-lang-item.rs
+++ b/src/test/ui/panic-handler/weak-lang-item.rs
@@ -2,7 +2,6 @@
 // error-pattern: `#[panic_handler]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // needs-unwind since it affects the error output
-// ignore-emscripten compiled with panic=abort, personality not required
 
 #![no_std]
 

--- a/src/test/ui/panic-handler/weak-lang-item.rs
+++ b/src/test/ui/panic-handler/weak-lang-item.rs
@@ -2,6 +2,7 @@
 // error-pattern: `#[panic_handler]` function required, but not found
 // error-pattern: language item required, but not found: `eh_personality`
 // needs-unwind since it affects the error output
+// ignore-emscripten missing eh_catch_typeinfo lang item
 
 #![no_std]
 

--- a/src/test/ui/panic-handler/weak-lang-item.stderr
+++ b/src/test/ui/panic-handler/weak-lang-item.stderr
@@ -1,5 +1,5 @@
 error[E0259]: the name `core` is defined multiple times
-  --> $DIR/weak-lang-item.rs:8:1
+  --> $DIR/weak-lang-item.rs:9:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ `core` reimported here

--- a/src/test/ui/panic-handler/weak-lang-item.stderr
+++ b/src/test/ui/panic-handler/weak-lang-item.stderr
@@ -1,5 +1,5 @@
 error[E0259]: the name `core` is defined multiple times
-  --> $DIR/weak-lang-item.rs:9:1
+  --> $DIR/weak-lang-item.rs:8:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ `core` reimported here

--- a/src/test/ui/panic-runtime/need-abort-got-unwind.rs
+++ b/src/test/ui/panic-runtime/need-abort-got-unwind.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // error-pattern:is incompatible with this crate's strategy of `unwind`
 // aux-build:needs-abort.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 extern crate needs_abort;
 

--- a/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
+++ b/src/test/ui/panic-runtime/transitive-link-a-bunch.rs
@@ -6,7 +6,6 @@
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
 // error-pattern: is not compiled with this crate's panic strategy `unwind`
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-runtime/want-unwind-got-abort.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort.rs
@@ -3,7 +3,6 @@
 // error-pattern:is not compiled with this crate's panic strategy `unwind`
 // aux-build:panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
+++ b/src/test/ui/panic-runtime/want-unwind-got-abort2.rs
@@ -4,7 +4,6 @@
 // aux-build:panic-runtime-abort.rs
 // aux-build:wants-panic-runtime-abort.rs
 // aux-build:panic-runtime-lang-items.rs
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![no_std]
 #![no_main]

--- a/src/test/ui/panic-while-printing.rs
+++ b/src/test/ui/panic-while-printing.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-emscripten no subprocess support
 
 #![feature(internal_output_capture)]
 

--- a/src/test/ui/privacy/reachable-unnameable-items.rs
+++ b/src/test/ui/privacy/reachable-unnameable-items.rs
@@ -1,5 +1,4 @@
 // run-pass
-// ignore-wasm32-bare compiled with panic=abort by default
 // needs-unwind
 // aux-build:reachable-unnameable-items.rs
 

--- a/src/test/ui/proc-macro/expand-with-a-macro.rs
+++ b/src/test/ui/proc-macro/expand-with-a-macro.rs
@@ -2,7 +2,6 @@
 // needs-unwind
 // aux-build:expand-with-a-macro.rs
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![deny(warnings)]
 

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
@@ -2,7 +2,6 @@
 // run-pass
 // needs-unwind
 
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(test)]
 

--- a/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
+++ b/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // revisions: default mir-opt
 //[mir-opt] compile-flags: -Zmir-opt-level=4
 

--- a/src/test/ui/rfcs/rfc1857-drop-order.rs
+++ b/src/test/ui/rfcs/rfc1857-drop-order.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(dead_code, unreachable_code)]
 

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -2,9 +2,6 @@
 // needs-unwind
 // ignore-emscripten no processes
 // ignore-sgx no processes
-// ignore-wasm32-bare no unwinding panic
-// ignore-avr no unwinding panic
-// ignore-nvptx64 no unwinding panic
 
 use std::env;
 use std::process::Command;

--- a/src/test/ui/test-attrs/test-panic-while-printing.rs
+++ b/src/test/ui/test-attrs/test-panic-while-printing.rs
@@ -1,7 +1,6 @@
 // compile-flags:--test
 // run-pass
 // needs-unwind
-// ignore-emscripten no subprocess support
 
 use std::fmt;
 use std::fmt::{Display, Formatter};

--- a/src/test/ui/test-attrs/test-should-fail-good-message.rs
+++ b/src/test/ui/test-attrs/test-should-fail-good-message.rs
@@ -1,6 +1,5 @@
 // run-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: --test
 #[test]
 #[should_panic(expected = "foo")]

--- a/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.rs
+++ b/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.rs
@@ -24,10 +24,6 @@ mod assert {
             Src,
             Context,
             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-            //~^ ERROR E0080
-            //~| ERROR E0080
-            //~| ERROR E0080
-            //~| ERROR E0080
         >,
     {}
 

--- a/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.stderr
+++ b/src/test/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.stderr
@@ -1,52 +1,27 @@
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:53:51
+  --> $DIR/wrong-type-assume.rs:49:51
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, {0u8}, false, false, false>();
    |                                                   ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, {0u8}, false, false, false>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:54:58
+  --> $DIR/wrong-type-assume.rs:50:58
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, false, {0u8}, false, false>();
    |                                                          ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, false, {0u8}, false, false>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:55:65
+  --> $DIR/wrong-type-assume.rs:51:65
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, false, false, {0u8}, false>();
    |                                                                 ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, false, false, {0u8}, false>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
 error[E0308]: mismatched types
-  --> $DIR/wrong-type-assume.rs:56:72
+  --> $DIR/wrong-type-assume.rs:52:72
    |
 LL |     assert::is_transmutable::<Src, Dst, Context, false, false, false, {0u8}>();
    |                                                                        ^^^ expected `bool`, found `u8`
 
-error[E0080]: evaluation of `assert::is_transmutable::<test::Src, test::Dst, test::Context, false, false, false, {0u8}>::{constant#0}` failed
-  --> $DIR/wrong-type-assume.rs:26:15
-   |
-LL |             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+error: aborting due to 4 previous errors
 
-error: aborting due to 8 previous errors
-
-Some errors have detailed explanations: E0080, E0308.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/unwind-abis/ffi-unwind-calls-lint.rs
+++ b/src/test/ui/unwind-abis/ffi-unwind-calls-lint.rs
@@ -1,6 +1,5 @@
 // build-pass
 // needs-unwind
-// ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(c_unwind)]
 #![warn(ffi_unwind_calls)]

--- a/src/test/ui/unwind-abis/ffi-unwind-calls-lint.stderr
+++ b/src/test/ui/unwind-abis/ffi-unwind-calls-lint.stderr
@@ -1,17 +1,17 @@
 warning: call to foreign function with FFI-unwind ABI
-  --> $DIR/ffi-unwind-calls-lint.rs:21:14
+  --> $DIR/ffi-unwind-calls-lint.rs:20:14
    |
 LL |     unsafe { foo(); }
    |              ^^^^^ call to foreign function with FFI-unwind ABI
    |
 note: the lint level is defined here
-  --> $DIR/ffi-unwind-calls-lint.rs:6:9
+  --> $DIR/ffi-unwind-calls-lint.rs:5:9
    |
 LL | #![warn(ffi_unwind_calls)]
    |         ^^^^^^^^^^^^^^^^
 
 warning: call to function pointer with FFI-unwind ABI
-  --> $DIR/ffi-unwind-calls-lint.rs:25:5
+  --> $DIR/ffi-unwind-calls-lint.rs:24:5
    |
 LL |     ptr();
    |     ^^^^^ call to function pointer with FFI-unwind ABI

--- a/src/test/ui/unwind-no-uwtable.rs
+++ b/src/test/ui/unwind-no-uwtable.rs
@@ -1,7 +1,6 @@
 // run-pass
 // needs-unwind
 // ignore-windows target requires uwtable
-// ignore-wasm32-bare no proper panic=unwind support
 // compile-flags: -C panic=unwind -C force-unwind-tables=n
 
 use std::panic::{self, AssertUnwindSafe};

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -278,10 +278,6 @@ pub struct Config {
     /// override this setting.
     pub optimize_tests: bool,
 
-    /// What panic strategy the target is built with.  Unwind supports Abort, but
-    /// not vice versa.
-    pub target_panic: PanicStrategy,
-
     /// Target system to be tested
     pub target: String,
 
@@ -426,6 +422,10 @@ impl Config {
         *&self.target_cfg().pointer_width
     }
 
+    pub fn can_unwind(&self) -> bool {
+        self.target_cfg().panic == PanicStrategy::Unwind
+    }
+
     pub fn has_asm_support(&self) -> bool {
         static ASM_SUPPORTED_ARCHS: &[&str] = &[
             "x86", "x86_64", "arm", "aarch64", "riscv32",
@@ -446,6 +446,7 @@ pub struct TargetCfg {
     families: Vec<String>,
     pointer_width: u32,
     endian: Endian,
+    panic: PanicStrategy,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -481,6 +482,7 @@ impl TargetCfg {
         let mut families = Vec::new();
         let mut pointer_width = None;
         let mut endian = None;
+        let mut panic = None;
         for line in print_cfg.lines() {
             if let Some((name, value)) = line.split_once('=') {
                 let value = value.trim_matches('"');
@@ -498,6 +500,13 @@ impl TargetCfg {
                             s => panic!("unexpected {s}"),
                         })
                     }
+                    "panic" => {
+                        panic = match value {
+                            "abort" => Some(PanicStrategy::Abort),
+                            "unwind" => Some(PanicStrategy::Unwind),
+                            s => panic!("unexpected {s}"),
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -510,6 +519,7 @@ impl TargetCfg {
             families,
             pointer_width: pointer_width.unwrap(),
             endian: endian.unwrap(),
+            panic: panic.unwrap(),
         }
     }
 }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::*;
 
-use crate::common::{CompareMode, Config, Debugger, FailMode, Mode, PanicStrategy, PassMode};
+use crate::common::{CompareMode, Config, Debugger, FailMode, Mode, PassMode};
 use crate::util;
 use crate::{extract_cdb_version, extract_gdb_version};
 
@@ -949,8 +949,7 @@ pub fn make_test_description<R: Read>(
         ignore |= !has_memtag && config.parse_name_directive(ln, "needs-sanitizer-memtag");
         ignore |= !has_shadow_call_stack
             && config.parse_name_directive(ln, "needs-sanitizer-shadow-call-stack");
-        ignore |= config.target_panic == PanicStrategy::Abort
-            && config.parse_name_directive(ln, "needs-unwind");
+        ignore |= !config.can_unwind() && config.parse_name_directive(ln, "needs-unwind");
         ignore |= config.target == "wasm32-unknown-unknown"
             && config.parse_name_directive(ln, directives::CHECK_RUN_RESULTS);
         ignore |= config.debugger == Some(Debugger::Cdb) && ignore_cdb(config, ln);

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -5,9 +5,7 @@
 
 extern crate test;
 
-use crate::common::{
-    expected_output_path, output_base_dir, output_relative_path, PanicStrategy, UI_EXTENSIONS,
-};
+use crate::common::{expected_output_path, output_base_dir, output_relative_path, UI_EXTENSIONS};
 use crate::common::{CompareMode, Config, Debugger, Mode, PassMode, TestPaths};
 use crate::util::logv;
 use getopts::Options;
@@ -105,7 +103,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .optmulti("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
         .optmulti("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS")
         .optflag("", "optimize-tests", "run tests with optimizations enabled")
-        .optopt("", "target-panic", "what panic strategy the target supports", "unwind | abort")
         .optflag("", "verbose", "run tests verbosely, showing all output")
         .optflag(
             "",
@@ -258,11 +255,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
         host_rustcflags: Some(matches.opt_strs("host-rustcflags").join(" ")),
         target_rustcflags: Some(matches.opt_strs("target-rustcflags").join(" ")),
         optimize_tests: matches.opt_present("optimize-tests"),
-        target_panic: match matches.opt_str("target-panic").as_deref() {
-            Some("unwind") | None => PanicStrategy::Unwind,
-            Some("abort") => PanicStrategy::Abort,
-            _ => panic!("unknown `--target-panic` option `{}` given", mode),
-        },
         target,
         host: opt_str2(matches.opt_str("host")),
         cdb,

--- a/src/tools/miri/cargo-miri/src/main.rs
+++ b/src/tools/miri/cargo-miri/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(bootstrap, feature(let_else))]
 #![allow(clippy::useless_format, clippy::derive_partial_eq_without_eq, rustc::internal)]
 
 #[macro_use]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(is_some_with)]
 #![feature(nonzero_ops)]
 #![feature(local_key_cell_methods)]
+#![cfg_attr(bootstrap, feature(let_else))]
 // Configure clippy and other lints
 #![allow(
     clippy::collapsible_else_if,

--- a/src/tools/miri/tests/pass/issues/issue-miri-2433.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-2433.rs
@@ -1,0 +1,22 @@
+#![feature(type_alias_impl_trait)]
+
+trait T { type Item; }
+
+type Alias<'a> = impl T<Item = &'a ()>;
+
+struct S;
+impl<'a> T for &'a S {
+    type Item = &'a ();
+}
+
+fn filter_positive<'a>() -> Alias<'a> {
+    &S
+}
+
+fn with_positive(fun: impl Fn(Alias<'_>)) {
+    fun(filter_positive());
+}
+
+fn main() {
+    with_positive(|_| ());
+}


### PR DESCRIPTION
Successful merges:

 - #102094 (Add missing documentation for `bool::from_str`)
 - #102115 (Add examples to `bool::then` and `bool::then_some`)
 - #102134 (Detect panic strategy using `rustc --print cfg`)
 - #102137 (Don't convert valtree to constvalue during normalization)
 - #102148 (add regression test for miri issue 2433)
 - #102158 (rustdoc: clean up CSS/DOM for deprecation warnings)
 - #102177 (Fix a typo in `std`'s root docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102094,102115,102134,102137,102148,102158,102177)
<!-- homu-ignore:end -->