### PR TITLE
Stabilize const `BTree{Map,Set}::new`

### DIFF
--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![feature(associated_type_defaults)]
 #![feature(closure_track_caller)]
-#![feature(const_btree_new)]
+#![feature(const_btree_len)]
 #![cfg_attr(bootstrap, feature(let_else))]
 #![feature(once_cell)]
 #![feature(min_specialization)]

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -580,7 +580,7 @@ impl<K, V> BTreeMap<K, V> {
     /// map.insert(1, "a");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_stable(feature = "const_btree_new", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     pub const fn new() -> BTreeMap<K, V> {
         BTreeMap { root: None, length: 0, alloc: ManuallyDrop::new(Global), _marker: PhantomData }
@@ -2392,7 +2392,7 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn len(&self) -> usize {
         self.length
     }
@@ -2413,7 +2413,7 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -343,7 +343,7 @@ impl<T> BTreeSet<T> {
     /// let mut set: BTreeSet<i32> = BTreeSet::new();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_stable(feature = "const_btree_new", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     pub const fn new() -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::new() }
@@ -1174,7 +1174,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn len(&self) -> usize {
         self.map.len()
     }
@@ -1193,7 +1193,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -99,7 +99,7 @@
 #![feature(coerce_unsized)]
 #![cfg_attr(not(no_global_oom_handling), feature(const_alloc_error))]
 #![feature(const_box)]
-#![cfg_attr(not(no_global_oom_handling), feature(const_btree_new))]
+#![cfg_attr(not(no_global_oom_handling), feature(const_btree_len))]
 #![feature(const_cow_is_borrowed)]
 #![feature(const_convert)]
 #![feature(const_size_of_val)]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -32,7 +32,7 @@
 #![feature(slice_group_by)]
 #![feature(slice_partition_dedup)]
 #![feature(string_remove_matches)]
-#![feature(const_btree_new)]
+#![feature(const_btree_len)]
 #![feature(const_default_impls)]
 #![feature(const_trait_impl)]
 #![feature(const_str_from_utf8)]

--- a/src/test/ui/consts/issue-88071.rs
+++ b/src/test/ui/consts/issue-88071.rs
@@ -2,8 +2,6 @@
 //
 // regression test for #88071
 
-#![feature(const_btree_new)]
-
 use std::collections::BTreeMap;
 
 pub struct CustomMap<K, V>(BTreeMap<K, V>);

--- a/src/tools/clippy/tests/ui/crashes/ice-7126.rs
+++ b/src/tools/clippy/tests/ui/crashes/ice-7126.rs
@@ -1,13 +1,13 @@
 // This test requires a feature gated const fn and will stop working in the future.
 
-#![feature(const_btree_new)]
+#![feature(const_btree_len)]
 
 use std::collections::BTreeMap;
 
-struct Foo(BTreeMap<i32, i32>);
+struct Foo(usize);
 impl Foo {
     fn new() -> Self {
-        Self(BTreeMap::new())
+        Self(BTreeMap::len(&BTreeMap::<u8, u8>::new()))
     }
 }
 


### PR DESCRIPTION
The FCP was completed in #71835.

Since `len` and `is_empty` are not const stable yet, this also creates a new feature for them since they previously used the same `const_btree_new` feature.