### PR TITLE
rustdoc: remove no-op CSS `#source-sidebar { z-index }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1416,7 +1416,6 @@ pre.rust {
 }
 #source-sidebar {
 	width: 100%;
-	z-index: 1;
 	overflow: auto;
 }
 #source-sidebar > .title {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1922,10 +1922,6 @@ in storage.js plus the media query with (min-width: 701px)
 		border-bottom: 1px solid;
 	}
 
-	#source-sidebar {
-		z-index: 11;
-	}
-
 	#main-content > .line-numbers {
 		margin-top: 0;
 	}


### PR DESCRIPTION
This rule became redundant in 07e3f998b1ceb4b8d2a7992782e60f5e776aa114. When `#source-sidebar` became nested below `.sidebar`, it went from being `position: fixed` to `position: static`, and according to MDN's [z-index] documentation, this means it has no effect.

[z-index]: https://developer.mozilla.org/en-US/docs/Web/CSS/z-index