### PR TITLE
Constify remaining `Layout` methods

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -157,9 +157,10 @@ impl Layout {
     /// allocate backing structure for `T` (which could be a trait
     /// or other unsized type like a slice).
     #[stable(feature = "alloc_layout", since = "1.28.0")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[must_use]
     #[inline]
-    pub fn for_value<T: ?Sized>(t: &T) -> Self {
+    pub const fn for_value<T: ?Sized>(t: &T) -> Self {
         let (size, align) = (mem::size_of_val(t), mem::align_of_val(t));
         // SAFETY: see rationale in `new` for why this is using the unsafe variant
         unsafe { Layout::from_size_align_unchecked(size, align) }
@@ -191,8 +192,9 @@ impl Layout {
     /// [trait object]: ../../book/ch17-02-trait-objects.html
     /// [extern type]: ../../unstable-book/language-features/extern-types.html
     #[unstable(feature = "layout_for_ptr", issue = "69835")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[must_use]
-    pub unsafe fn for_value_raw<T: ?Sized>(t: *const T) -> Self {
+    pub const unsafe fn for_value_raw<T: ?Sized>(t: *const T) -> Self {
         // SAFETY: we pass along the prerequisites of these functions to the caller
         let (size, align) = unsafe { (mem::size_of_val_raw(t), mem::align_of_val_raw(t)) };
         // SAFETY: see rationale in `new` for why this is using the unsafe variant
@@ -229,8 +231,9 @@ impl Layout {
     /// Returns an error if the combination of `self.size()` and the given
     /// `align` violates the conditions listed in [`Layout::from_size_align`].
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub fn align_to(&self, align: usize) -> Result<Self, LayoutError> {
+    pub const fn align_to(&self, align: usize) -> Result<Self, LayoutError> {
         Layout::from_size_align(self.size(), cmp::max(self.align(), align))
     }
 
@@ -287,10 +290,11 @@ impl Layout {
     /// This is equivalent to adding the result of `padding_needed_for`
     /// to the layout's current size.
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[must_use = "this returns a new `Layout`, \
                   without modifying the original"]
     #[inline]
-    pub fn pad_to_align(&self) -> Layout {
+    pub const fn pad_to_align(&self) -> Layout {
         let pad = self.padding_needed_for(self.align());
         // This cannot overflow. Quoting from the invariant of Layout:
         // > `size`, when rounded up to the nearest multiple of `align`,
@@ -311,8 +315,9 @@ impl Layout {
     ///
     /// On arithmetic overflow, returns `LayoutError`.
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub fn repeat(&self, n: usize) -> Result<(Self, usize), LayoutError> {
+    pub const fn repeat(&self, n: usize) -> Result<(Self, usize), LayoutError> {
         // This cannot overflow. Quoting from the invariant of Layout:
         // > `size`, when rounded up to the nearest multiple of `align`,
         // > must not overflow isize (i.e., the rounded value must be
@@ -370,8 +375,9 @@ impl Layout {
     /// # assert_eq!(repr_c(&[u64, u32, u16, u32]), Ok((s, vec![0, 8, 12, 16])));
     /// ```
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub fn extend(&self, next: Self) -> Result<(Self, usize), LayoutError> {
+    pub const fn extend(&self, next: Self) -> Result<(Self, usize), LayoutError> {
         let new_align = cmp::max(self.align, next.align);
         let pad = self.padding_needed_for(next.align());
 
@@ -396,8 +402,9 @@ impl Layout {
     ///
     /// On arithmetic overflow, returns `LayoutError`.
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub fn repeat_packed(&self, n: usize) -> Result<Self, LayoutError> {
+    pub const fn repeat_packed(&self, n: usize) -> Result<Self, LayoutError> {
         let size = self.size().checked_mul(n).ok_or(LayoutError)?;
         // The safe constructor is called here to enforce the isize size limit.
         Layout::from_size_alignment(size, self.align)
@@ -410,8 +417,9 @@ impl Layout {
     ///
     /// On arithmetic overflow, returns `LayoutError`.
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub fn extend_packed(&self, next: Self) -> Result<Self, LayoutError> {
+    pub const fn extend_packed(&self, next: Self) -> Result<Self, LayoutError> {
         let new_size = self.size().checked_add(next.size()).ok_or(LayoutError)?;
         // The safe constructor is called here to enforce the isize size limit.
         Layout::from_size_alignment(new_size, self.align)
@@ -422,13 +430,18 @@ impl Layout {
     /// On arithmetic overflow or when the total size would exceed
     /// `isize::MAX`, returns `LayoutError`.
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
+    #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub fn array<T>(n: usize) -> Result<Self, LayoutError> {
+    pub const fn array<T>(n: usize) -> Result<Self, LayoutError> {
         // Reduce the amount of code we need to monomorphize per `T`.
         return inner(mem::size_of::<T>(), Alignment::of::<T>(), n);
 
         #[inline]
-        fn inner(element_size: usize, align: Alignment, n: usize) -> Result<Layout, LayoutError> {
+        const fn inner(
+            element_size: usize,
+            align: Alignment,
+            n: usize,
+        ) -> Result<Layout, LayoutError> {
             // We need to check two things about the size:
             //  - That the total size won't overflow a `usize`, and
             //  - That the total size still fits in an `isize`.

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -326,10 +326,8 @@ impl Layout {
         let alloc_size = padded_size.checked_mul(n).ok_or(LayoutError)?;
 
         // The safe constructor is called here to enforce the isize size limit.
-        match Layout::from_size_alignment(alloc_size, self.align) {
-            Ok(layout) => Ok((layout, padded_size)),
-            Err(e) => Err(e),
-        }
+        let layout = Layout::from_size_alignment(alloc_size, self.align)?;
+        Ok((layout, padded_size))
     }
 
     /// Creates a layout describing the record for `self` followed by

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -326,7 +326,10 @@ impl Layout {
         let alloc_size = padded_size.checked_mul(n).ok_or(LayoutError)?;
 
         // The safe constructor is called here to enforce the isize size limit.
-        Layout::from_size_alignment(alloc_size, self.align).map(|layout| (layout, padded_size))
+        match Layout::from_size_alignment(alloc_size, self.align) {
+            Ok(layout) => Ok((layout, padded_size)),
+            Err(e) => Err(e),
+        }
     }
 
     /// Creates a layout describing the record for `self` followed by

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -157,6 +157,7 @@
 #![feature(const_unsafecell_get_mut)]
 #![feature(const_waker)]
 #![feature(core_panic)]
+#![cfg_attr(not(bootstrap), feature(derive_const))]
 #![feature(duration_consts_float)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(ptr_alignment_type)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -98,6 +98,8 @@
 // Library features:
 #![feature(const_align_offset)]
 #![feature(const_align_of_val)]
+#![feature(const_align_of_val_raw)]
+#![feature(const_alloc_layout)]
 #![feature(const_arguments_as_str)]
 #![feature(const_array_into_iter_constructors)]
 #![feature(const_bigint_helper_methods)]
@@ -140,6 +142,7 @@
 #![feature(const_ptr_write)]
 #![feature(const_raw_ptr_comparison)]
 #![feature(const_size_of_val)]
+#![feature(const_size_of_val_raw)]
 #![feature(const_slice_from_raw_parts_mut)]
 #![feature(const_slice_ptr_len)]
 #![feature(const_slice_split_at_mut)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -157,7 +157,6 @@
 #![feature(const_unsafecell_get_mut)]
 #![feature(const_waker)]
 #![feature(core_panic)]
-#![cfg_attr(not(bootstrap), feature(derive_const))]
 #![feature(duration_consts_float)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(ptr_alignment_type)]

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -10,6 +10,8 @@ use crate::{cmp, fmt, hash, mem, num};
 /// are likely not to be supported by actual allocators and linkers.
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
 #[derive(Copy, Clone, Eq)]
+#[cfg_attr(bootstrap, derive(PartialEq))]
+#[cfg_attr(not(bootstrap), derive_const(PartialEq))]
 #[repr(transparent)]
 pub struct Alignment(AlignmentEnum);
 
@@ -169,15 +171,6 @@ impl From<Alignment> for usize {
 
 #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-impl const cmp::PartialEq for Alignment {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.as_nonzero().get() == other.as_nonzero().get()
-    }
-}
-
-#[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
-#[unstable(feature = "ptr_alignment_type", issue = "102070")]
 impl const cmp::Ord for Alignment {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
@@ -209,7 +202,9 @@ type AlignmentEnum = AlignmentEnum32;
 #[cfg(target_pointer_width = "64")]
 type AlignmentEnum = AlignmentEnum64;
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq)]
+#[cfg_attr(bootstrap, derive(PartialEq))]
+#[cfg_attr(not(bootstrap), derive_const(PartialEq))]
 #[repr(u16)]
 enum AlignmentEnum16 {
     _Align1Shl0 = 1 << 0,
@@ -230,7 +225,9 @@ enum AlignmentEnum16 {
     _Align1Shl15 = 1 << 15,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq)]
+#[cfg_attr(bootstrap, derive(PartialEq))]
+#[cfg_attr(not(bootstrap), derive_const(PartialEq))]
 #[repr(u32)]
 enum AlignmentEnum32 {
     _Align1Shl0 = 1 << 0,
@@ -267,7 +264,9 @@ enum AlignmentEnum32 {
     _Align1Shl31 = 1 << 31,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq)]
+#[cfg_attr(bootstrap, derive(PartialEq))]
+#[cfg_attr(not(bootstrap), derive_const(PartialEq))]
 #[repr(u64)]
 enum AlignmentEnum64 {
     _Align1Shl0 = 1 << 0,

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -168,6 +168,7 @@ impl From<Alignment> for usize {
 }
 
 #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
+#[unstable(feature = "ptr_alignment_type", issue = "102070")]
 impl const cmp::PartialEq for Alignment {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -176,6 +177,7 @@ impl const cmp::PartialEq for Alignment {
 }
 
 #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
+#[unstable(feature = "ptr_alignment_type", issue = "102070")]
 impl const cmp::Ord for Alignment {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -178,7 +178,7 @@ impl const cmp::Ord for Alignment {
     }
 }
 
-#[rustc_const_unstable(feature = "const_alloc_layout", issue = "87864")]
+#[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
 impl const cmp::PartialOrd for Alignment {
     #[inline]

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -9,7 +9,7 @@ use crate::{cmp, fmt, hash, mem, num};
 /// Note that particularly large alignments, while representable in this type,
 /// are likely not to be supported by actual allocators and linkers.
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq)]
 #[repr(transparent)]
 pub struct Alignment(AlignmentEnum);
 
@@ -167,16 +167,25 @@ impl From<Alignment> for usize {
     }
 }
 
-#[unstable(feature = "ptr_alignment_type", issue = "102070")]
-impl cmp::Ord for Alignment {
+#[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
+impl const cmp::PartialEq for Alignment {
     #[inline]
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.as_nonzero().cmp(&other.as_nonzero())
+    fn eq(&self, other: &Self) -> bool {
+        self.as_nonzero().get() == other.as_nonzero().get()
     }
 }
 
+#[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
+impl const cmp::Ord for Alignment {
+    #[inline]
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.as_nonzero().get().cmp(&other.as_nonzero().get())
+    }
+}
+
+#[rustc_const_unstable(feature = "const_alloc_layout", issue = "87864")]
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-impl cmp::PartialOrd for Alignment {
+impl const cmp::PartialOrd for Alignment {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))


### PR DESCRIPTION
Makes the methods on `Layout` that aren't yet unstably const, under the same feature and issue, #67521. Most of them required no changes, only non-trivial change is probably constifying `ValidAlignment` which may affect #102072