### PR TITLE
Fix span of byte-escaped left format args brace

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -224,7 +224,7 @@ impl<'a> Iterator for Parser<'a> {
                 '{' => {
                     let curr_last_brace = self.last_opening_brace;
                     let byte_pos = self.to_span_index(pos);
-                    let lbrace_end = InnerOffset(byte_pos.0 + 1);
+                    let lbrace_end = self.to_span_index(pos + 1);
                     self.last_opening_brace = Some(byte_pos.to(lbrace_end));
                     self.cur.next();
                     if self.consume('{') {

--- a/src/test/ui/fmt/format-args-capture-issue-102057.rs
+++ b/src/test/ui/fmt/format-args-capture-issue-102057.rs
@@ -1,0 +1,19 @@
+fn main() {
+    format!("\x7Ba}");
+    //~^ ERROR cannot find value `a` in this scope
+    format!("\x7Ba\x7D");
+    //~^ ERROR cannot find value `a` in this scope
+
+    let a = 0;
+
+    format!("\x7Ba} {b}");
+    //~^ ERROR cannot find value `b` in this scope
+    format!("\x7Ba\x7D {b}");
+    //~^ ERROR cannot find value `b` in this scope
+    format!("\x7Ba} \x7Bb}");
+    //~^ ERROR cannot find value `b` in this scope
+    format!("\x7Ba\x7D \x7Bb}");
+    //~^ ERROR cannot find value `b` in this scope
+    format!("\x7Ba\x7D \x7Bb\x7D");
+    //~^ ERROR cannot find value `b` in this scope
+}

--- a/src/test/ui/fmt/format-args-capture-issue-102057.stderr
+++ b/src/test/ui/fmt/format-args-capture-issue-102057.stderr
@@ -1,0 +1,45 @@
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/format-args-capture-issue-102057.rs:2:18
+   |
+LL |     format!("\x7Ba}");
+   |                  ^ not found in this scope
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/format-args-capture-issue-102057.rs:4:18
+   |
+LL |     format!("\x7Ba\x7D");
+   |                  ^ not found in this scope
+
+error[E0425]: cannot find value `b` in this scope
+  --> $DIR/format-args-capture-issue-102057.rs:9:22
+   |
+LL |     format!("\x7Ba} {b}");
+   |                      ^ help: a local variable with a similar name exists: `a`
+
+error[E0425]: cannot find value `b` in this scope
+  --> $DIR/format-args-capture-issue-102057.rs:11:25
+   |
+LL |     format!("\x7Ba\x7D {b}");
+   |                         ^ help: a local variable with a similar name exists: `a`
+
+error[E0425]: cannot find value `b` in this scope
+  --> $DIR/format-args-capture-issue-102057.rs:13:25
+   |
+LL |     format!("\x7Ba} \x7Bb}");
+   |                         ^ help: a local variable with a similar name exists: `a`
+
+error[E0425]: cannot find value `b` in this scope
+  --> $DIR/format-args-capture-issue-102057.rs:15:28
+   |
+LL |     format!("\x7Ba\x7D \x7Bb}");
+   |                            ^ help: a local variable with a similar name exists: `a`
+
+error[E0425]: cannot find value `b` in this scope
+  --> $DIR/format-args-capture-issue-102057.rs:17:28
+   |
+LL |     format!("\x7Ba\x7D \x7Bb\x7D");
+   |                            ^ help: a local variable with a similar name exists: `a`
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fix #102057 (see issue for example).

Previously, the use of escaped left braces (`\x7B`) in format args resulted in an incorrectly offset span. This patch fixes that by considering any escaped characters within the string instead of using a constant offset.