### PR TITLE
rustdoc: Stabilize --diagnostic-width

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -461,7 +461,7 @@ fn opts() -> Vec<RustcOptGroup> {
                 "human|json|short",
             )
         }),
-        unstable("diagnostic-width", |o| {
+        stable("diagnostic-width", |o| {
             o.optopt(
                 "",
                 "diagnostic-width",

--- a/src/test/rustdoc-ui/diagnostic-width.rs
+++ b/src/test/rustdoc-ui/diagnostic-width.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunstable-options --diagnostic-width=10
+// compile-flags: --diagnostic-width=10
 #![deny(rustdoc::bare_urls)]
 
 /// This is a long line that contains a http://link.com


### PR DESCRIPTION
This stabilizes the `--diagnostic-width` flag for rustdoc. This flag was stabilized in rustc in #95635, but it isn't clear from the discussion there why it wasn't stabilized in rustdoc. I believe this flag works as expected, following the same behavior as rustc.

I'd like to stabilize this so that the same support can be stabilized in cargo, and it would help simplify things if both rustc and rustdoc supported it.
