### PR TITLE
bootstrap/miri: switch to non-deprecated env var for setting the sysroot folder

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -520,7 +520,7 @@ impl Step for Miri {
         cargo.arg("--").arg("miri").arg("setup");
 
         // Tell `cargo miri setup` where to find the sources.
-        cargo.env("XARGO_RUST_SRC", builder.src.join("library"));
+        cargo.env("MIRI_LIB_SRC", builder.src.join("library"));
         // Tell it where to find Miri.
         cargo.env("MIRI", &miri);
         // Debug things.


### PR DESCRIPTION
r? @oli-obk 