### PR TITLE
Remove dbg!'s print for release builds

### DIFF
--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -342,15 +342,19 @@ macro_rules! dbg {
     // `$val` expression could be a block (`{ .. }`), in which case the `eprintln!`
     // will be malformed.
     () => {
-        $crate::eprintln!("[{}:{}]", $crate::file!(), $crate::line!())
+        if cfg!(debug_assertions) {
+            $crate::eprintln!("[{}:{}]", $crate::file!(), $crate::line!())
+        }
     };
     ($val:expr $(,)?) => {
         // Use of `match` here is intentional because it affects the lifetimes
         // of temporaries - https://stackoverflow.com/a/48732525/1063961
         match $val {
             tmp => {
-                $crate::eprintln!("[{}:{}] {} = {:#?}",
-                    $crate::file!(), $crate::line!(), $crate::stringify!($val), &tmp);
+                if cfg!(debug_assertions) {
+                    $crate::eprintln!("[{}:{}] {} = {:#?}",
+                        $crate::file!(), $crate::line!(), $crate::stringify!($val), &tmp);
+                }
                 tmp
             }
         }

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -342,7 +342,7 @@ macro_rules! dbg {
     // `$val` expression could be a block (`{ .. }`), in which case the `eprintln!`
     // will be malformed.
     () => {
-        if cfg!(debug_assertions) {
+        if $crate::cfg!(debug_assertions) || $crate::cfg!(test) {
             $crate::eprintln!("[{}:{}]", $crate::file!(), $crate::line!())
         }
     };
@@ -351,7 +351,7 @@ macro_rules! dbg {
         // of temporaries - https://stackoverflow.com/a/48732525/1063961
         match $val {
             tmp => {
-                if cfg!(debug_assertions) {
+                if $crate::cfg!(debug_assertions) || $crate::cfg!(test) {
                     $crate::eprintln!("[{}:{}] {} = {:#?}",
                         $crate::file!(), $crate::line!(), $crate::stringify!($val), &tmp);
                 }


### PR DESCRIPTION
Program:
```rs
fn main() {
    dbg!("test");
}
```
If you build it for release and debug, you will get dbg's output in both cases. I think that dbg shouldn't print in release build.