### PR TITLE
rustdoc: remove unused CSS `#main-content > .line-numbers`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1917,10 +1917,6 @@ in storage.js plus the media query with (min-width: 701px)
 		border-bottom: 1px solid;
 	}
 
-	#main-content > .line-numbers {
-		margin-top: 0;
-	}
-
 	.notable-traits .notable-traits-tooltiptext {
 		left: 0;
 		top: 100%;


### PR DESCRIPTION
This selector was added in 10b937028660e079cf15735cfb5c4d58892fb10e. It became unreachable when 09150f81930e035254e58ee56f5905c2eb421617 made it so that `.line-numbers` are always nested below `.example-wrap`, even on source pages.