### PR TITLE
Package `rust-docs-json` into nightly components (take 3)

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1365,6 +1365,7 @@ impl Step for Extended {
         }
 
         add_component!("rust-docs" => Docs { host: target });
+        add_component!("rust-json-docs" => JsonDocs { host: target });
         add_component!("rust-demangler"=> RustDemangler { compiler, target });
         add_component!("cargo" => Cargo { compiler, target });
         add_component!("rustfmt" => Rustfmt { compiler, target });

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -437,7 +437,7 @@ impl Builder {
             host_component("rustfmt-preview"),
             host_component("llvm-tools-preview"),
             host_component("rust-analysis"),
-            host_component("rust-docs-json"),
+            host_component("rust-docs-json-preview"),
         ]);
 
         extensions.extend(

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -193,6 +193,12 @@ macro_rules! t {
             Err(e) => panic!("{} failed with {}", stringify!($e), e),
         }
     };
+    ($e:expr, $extra:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {}: {}", stringify!($e), e, $extra),
+        }
+    };
 }
 
 struct Builder {
@@ -584,7 +590,7 @@ impl Builder {
         self.shipped_files.insert(name.clone());
 
         let dst = self.output.join(name);
-        t!(fs::write(&dst, contents));
+        t!(fs::write(&dst, contents), format!("failed to create manifest {}", dst.display()));
     }
 
     fn write_shipped_files(&self, path: &Path) {

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -117,6 +117,9 @@ impl Versions {
             Some(version) => Ok(version.clone()),
             None => {
                 let version_info = self.load_version_from_tarball(package)?;
+                if *package == PkgType::Rust && version_info.version.is_none() {
+                    panic!("missing version info for toolchain");
+                }
                 self.versions.insert(package.clone(), version_info.clone());
                 Ok(version_info)
             }
@@ -131,6 +134,7 @@ impl Versions {
             Ok(file) => file,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 // Missing tarballs do not return an error, but return empty data.
+                println!("warning: missing tarball {}", tarball.display());
                 return Ok(VersionInfo::default());
             }
             Err(err) => return Err(err.into()),

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -20,6 +20,7 @@ pub(crate) enum PkgType {
     Rustfmt,
     LlvmTools,
     Miri,
+    JsonDocs,
     Other(String),
 }
 
@@ -36,6 +37,7 @@ impl PkgType {
             "rustfmt" | "rustfmt-preview" => PkgType::Rustfmt,
             "llvm-tools" | "llvm-tools-preview" => PkgType::LlvmTools,
             "miri" | "miri-preview" => PkgType::Miri,
+            "rust-docs-json" | "rust-docs-json-preview" => PkgType::JsonDocs,
             other => PkgType::Other(other.into()),
         }
     }
@@ -53,6 +55,7 @@ impl PkgType {
             PkgType::Rustfmt => "rustfmt",
             PkgType::LlvmTools => "llvm-tools",
             PkgType::Miri => "miri",
+            PkgType::JsonDocs => "rust-docs-json",
             PkgType::Other(component) => component,
         }
     }
@@ -72,6 +75,7 @@ impl PkgType {
             PkgType::Rust => true,
             PkgType::RustSrc => true,
             PkgType::Rustc => true,
+            PkgType::JsonDocs => true,
             PkgType::Other(_) => true,
         }
     }


### PR DESCRIPTION
`dist` creates a `rust-docs-json.tar.xz` tarfile. But build-manifest expected it to be named `rust-docs-json-preview.tar.xz`. Change build-manifest to allow the name without the `-preview` suffix.

I haven't actually tested this :( build-manifest is a pain to run locally.