### PR TITLE
rustdoc: remove unused CSS `.summary`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1130,10 +1130,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 1rem;
 }
 
-.summary {
-	padding-right: 0px;
-}
-
 pre.rust .question-mark {
 	font-weight: bold;
 }


### PR DESCRIPTION
It was added in 4d16de01d0beb84dc4a351022ea5cb587b4ab557 as part of a stability dashboard that was removed in 0a46933c4d81573e78ce16cd215ba155a3114fce.