### PR TITLE
Elaborate supertrait bounds when triggering `unused_must_use` on `impl Trait`

### DIFF
--- a/src/test/ui/lint/unused/unused-supertrait.rs
+++ b/src/test/ui/lint/unused/unused-supertrait.rs
@@ -1,0 +1,11 @@
+#![deny(unused_must_use)]
+
+fn it() -> impl ExactSizeIterator<Item = ()> {
+    let x: Box<dyn ExactSizeIterator<Item = ()>> = todo!();
+    x
+}
+
+fn main() {
+    it();
+    //~^ ERROR unused implementer of `Iterator` that must be used
+}

--- a/src/test/ui/lint/unused/unused-supertrait.stderr
+++ b/src/test/ui/lint/unused/unused-supertrait.stderr
@@ -1,0 +1,15 @@
+error: unused implementer of `Iterator` that must be used
+  --> $DIR/unused-supertrait.rs:9:5
+   |
+LL |     it();
+   |     ^^^^^
+   |
+   = note: iterators are lazy and do nothing unless consumed
+note: the lint level is defined here
+  --> $DIR/unused-supertrait.rs:1:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Given `impl Trait`, if one of its supertraits has a `#[must_use]`, then trigger the lint. This means that, for example, `-> impl ExactSizeIterator` also triggers the `must_use` on `trait Iterator`, which fixes #102183.

This might need @rust-lang/lang sign-off, since it changes the behavior of the lint, so cc'ing them.