### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![feature(associated_type_defaults)]
 #![feature(closure_track_caller)]
-#![feature(const_btree_new)]
+#![feature(const_btree_len)]
 #![cfg_attr(bootstrap, feature(let_else))]
 #![feature(once_cell)]
 #![feature(min_specialization)]

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -580,7 +580,7 @@ impl<K, V> BTreeMap<K, V> {
     /// map.insert(1, "a");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_stable(feature = "const_btree_new", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     pub const fn new() -> BTreeMap<K, V> {
         BTreeMap { root: None, length: 0, alloc: ManuallyDrop::new(Global), _marker: PhantomData }
@@ -2392,7 +2392,7 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn len(&self) -> usize {
         self.length
     }
@@ -2413,7 +2413,7 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -343,7 +343,7 @@ impl<T> BTreeSet<T> {
     /// let mut set: BTreeSet<i32> = BTreeSet::new();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_stable(feature = "const_btree_new", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     pub const fn new() -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::new() }
@@ -1174,7 +1174,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn len(&self) -> usize {
         self.map.len()
     }
@@ -1193,7 +1193,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    #[rustc_const_unstable(feature = "const_btree_len", issue = "71835")]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -99,7 +99,7 @@
 #![feature(coerce_unsized)]
 #![cfg_attr(not(no_global_oom_handling), feature(const_alloc_error))]
 #![feature(const_box)]
-#![cfg_attr(not(no_global_oom_handling), feature(const_btree_new))]
+#![cfg_attr(not(no_global_oom_handling), feature(const_btree_len))]
 #![feature(const_cow_is_borrowed)]
 #![feature(const_convert)]
 #![feature(const_size_of_val)]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -32,7 +32,7 @@
 #![feature(slice_group_by)]
 #![feature(slice_partition_dedup)]
 #![feature(string_remove_matches)]
-#![feature(const_btree_new)]
+#![feature(const_btree_len)]
 #![feature(const_default_impls)]
 #![feature(const_trait_impl)]
 #![feature(const_str_from_utf8)]

--- a/src/bootstrap/build.rs
+++ b/src/bootstrap/build.rs
@@ -1,43 +1,7 @@
-use env::consts::{EXE_EXTENSION, EXE_SUFFIX};
 use std::env;
-use std::ffi::OsString;
-use std::path::PathBuf;
-
-/// Given an executable called `name`, return the filename for the
-/// executable for a particular target.
-pub fn exe(name: &PathBuf) -> PathBuf {
-    if EXE_EXTENSION != "" && name.extension() != Some(EXE_EXTENSION.as_ref()) {
-        let mut name: OsString = name.clone().into();
-        name.push(EXE_SUFFIX);
-        name.into()
-    } else {
-        name.clone()
-    }
-}
 
 fn main() {
     let host = env::var("HOST").unwrap();
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-env-changed=RUSTC");
     println!("cargo:rustc-env=BUILD_TRIPLE={}", host);
-
-    // This may not be a canonicalized path.
-    let mut rustc = PathBuf::from(env::var_os("RUSTC").unwrap());
-
-    if rustc.is_relative() {
-        println!("cargo:rerun-if-env-changed=PATH");
-        for dir in env::split_paths(&env::var_os("PATH").unwrap_or_default()) {
-            let absolute = dir.join(&exe(&rustc));
-            if absolute.exists() {
-                rustc = absolute;
-                break;
-            }
-        }
-    }
-    assert!(rustc.is_absolute());
-
-    // FIXME: if the path is not utf-8, this is going to break. Unfortunately
-    // Cargo doesn't have a way for us to specify non-utf-8 paths easily, so
-    // we'll need to invent some encoding scheme if this becomes a problem.
-    println!("cargo:rustc-env=RUSTC={}", rustc.to_str().unwrap());
 }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1556,13 +1556,12 @@ impl<'a> Builder<'a> {
         match mode {
             Mode::ToolBootstrap => {
                 // Restrict the allowed features to those passed by rustbuild, so we don't depend on nightly accidentally.
-                // HACK: because anyhow does feature detection in build.rs, we need to allow the backtrace feature too.
-                rustflags.arg("-Zallow-features=binary-dep-depinfo,backtrace");
+                rustflags.arg("-Zallow-features=binary-dep-depinfo");
             }
             Mode::ToolStd => {
                 // Right now this is just compiletest and a few other tools that build on stable.
                 // Allow them to use `feature(test)`, but nothing else.
-                rustflags.arg("-Zallow-features=binary-dep-depinfo,test,backtrace,proc_macro_internals,proc_macro_diagnostic,proc_macro_span");
+                rustflags.arg("-Zallow-features=binary-dep-depinfo,test,proc_macro_internals,proc_macro_diagnostic,proc_macro_span");
             }
             Mode::Std | Mode::Rustc | Mode::Codegen | Mode::ToolRustc => {}
         }

--- a/src/test/ui/consts/issue-88071.rs
+++ b/src/test/ui/consts/issue-88071.rs
@@ -2,8 +2,6 @@
 //
 // regression test for #88071
 
-#![feature(const_btree_new)]
-
 use std::collections::BTreeMap;
 
 pub struct CustomMap<K, V>(BTreeMap<K, V>);

--- a/src/tools/clippy/tests/ui/crashes/ice-7126.rs
+++ b/src/tools/clippy/tests/ui/crashes/ice-7126.rs
@@ -1,13 +1,13 @@
 // This test requires a feature gated const fn and will stop working in the future.
 
-#![feature(const_btree_new)]
+#![feature(const_btree_len)]
 
 use std::collections::BTreeMap;
 
-struct Foo(BTreeMap<i32, i32>);
+struct Foo(usize);
 impl Foo {
     fn new() -> Self {
-        Self(BTreeMap::new())
+        Self(BTreeMap::len(&BTreeMap::<u8, u8>::new()))
     }
 }
 


### PR DESCRIPTION
Successful merges:

 - #102178 (bootstrap: the backtrace feature is stable, no need to allow it any more)
 - #102197 (Stabilize const `BTree{Map,Set}::new`)
 - #102267 (Don't set RUSTC in the bootstrap build script)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102178,102197,102267)
<!-- homu-ignore:end -->