### PR TITLE
Reuse `NeverShortCircuit` in various iterators

### DIFF
--- a/library/core/src/iter/adapters/map_while.rs
+++ b/library/core/src/iter/adapters/map_while.rs
@@ -1,6 +1,6 @@
 use crate::fmt;
 use crate::iter::{adapters::SourceIter, InPlaceIterable};
-use crate::ops::{ControlFlow, Try};
+use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 
 /// An iterator that only accepts elements while `predicate` returns `Some(_)`.
 ///
@@ -70,12 +70,7 @@ where
         Self: Sized,
         Fold: FnMut(Acc, Self::Item) -> Acc,
     {
-        #[inline]
-        fn ok<B, T>(mut f: impl FnMut(B, T) -> B) -> impl FnMut(B, T) -> Result<B, !> {
-            move |acc, x| Ok(f(acc, x))
-        }
-
-        self.try_fold(init, ok(fold)).unwrap()
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2_imp(fold)).0
     }
 }
 

--- a/library/core/src/iter/adapters/scan.rs
+++ b/library/core/src/iter/adapters/scan.rs
@@ -1,6 +1,6 @@
 use crate::fmt;
 use crate::iter::{adapters::SourceIter, InPlaceIterable};
-use crate::ops::{ControlFlow, Try};
+use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 
 /// An iterator to maintain state while iterating another iterator.
 ///
@@ -80,12 +80,7 @@ where
         Self: Sized,
         Fold: FnMut(Acc, Self::Item) -> Acc,
     {
-        #[inline]
-        fn ok<B, T>(mut f: impl FnMut(B, T) -> B) -> impl FnMut(B, T) -> Result<B, !> {
-            move |acc, x| Ok(f(acc, x))
-        }
-
-        self.try_fold(init, ok(fold)).unwrap()
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2_imp(fold)).0
     }
 }
 

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -1,6 +1,6 @@
 use crate::intrinsics::unlikely;
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
-use crate::ops::{ControlFlow, Try};
+use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 
 /// An iterator that skips over `n` elements of `iter`.
 ///
@@ -210,12 +210,7 @@ where
     where
         Fold: FnMut(Acc, Self::Item) -> Acc,
     {
-        #[inline]
-        fn ok<Acc, T>(mut f: impl FnMut(Acc, T) -> Acc) -> impl FnMut(Acc, T) -> Result<Acc, !> {
-            move |acc, x| Ok(f(acc, x))
-        }
-
-        self.try_rfold(init, ok(fold)).unwrap()
+        self.try_rfold(init, NeverShortCircuit::wrap_mut_2_imp(fold)).0
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -1,6 +1,6 @@
 use crate::cmp;
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable, TrustedLen};
-use crate::ops::{ControlFlow, Try};
+use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
 ///
@@ -104,12 +104,7 @@ where
         Self: Sized,
         Fold: FnMut(Acc, Self::Item) -> Acc,
     {
-        #[inline]
-        fn ok<B, T>(mut f: impl FnMut(B, T) -> B) -> impl FnMut(B, T) -> Result<B, !> {
-            move |acc, x| Ok(f(acc, x))
-        }
-
-        self.try_fold(init, ok(fold)).unwrap()
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2_imp(fold)).0
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/take_while.rs
+++ b/library/core/src/iter/adapters/take_while.rs
@@ -1,6 +1,6 @@
 use crate::fmt;
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
-use crate::ops::{ControlFlow, Try};
+use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 
 /// An iterator that only accepts elements while `predicate` returns `true`.
 ///
@@ -100,12 +100,7 @@ where
         Self: Sized,
         Fold: FnMut(Acc, Self::Item) -> Acc,
     {
-        #[inline]
-        fn ok<B, T>(mut f: impl FnMut(B, T) -> B) -> impl FnMut(B, T) -> Result<B, !> {
-            move |acc, x| Ok(f(acc, x))
-        }
-
-        self.try_fold(init, ok(fold)).unwrap()
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2_imp(fold)).0
     }
 }
 

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -1,7 +1,7 @@
 use crate::char;
 use crate::convert::TryFrom;
 use crate::mem;
-use crate::ops::{self, Try};
+use crate::ops::{self, NeverShortCircuit, Try};
 
 use super::{
     FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce, TrustedStep,
@@ -1156,12 +1156,7 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        #[inline]
-        fn ok<B, T>(mut f: impl FnMut(B, T) -> B) -> impl FnMut(B, T) -> Result<B, !> {
-            move |acc, x| Ok(f(acc, x))
-        }
-
-        self.try_fold(init, ok(f)).unwrap()
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2_imp(f)).0
     }
 
     #[inline]
@@ -1236,12 +1231,7 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        #[inline]
-        fn ok<B, T>(mut f: impl FnMut(B, T) -> B) -> impl FnMut(B, T) -> Result<B, !> {
-            move |acc, x| Ok(f(acc, x))
-        }
-
-        self.try_rfold(init, ok(f)).unwrap()
+        self.try_rfold(init, NeverShortCircuit::wrap_mut_2_imp(f)).0
     }
 }
 


### PR DESCRIPTION
Since it exists for this, avoiding copy-pasting the same closure wrappers and (easily optimized-out) `unwrap` calls.

EDIT: Oh, there's a whole bunch more of these, so I added more instances of the same to the PR.

