### PR TITLE
Get rid of exclude-list for Windows-only tests

### DIFF
--- a/src/test/ui/abi/x86stdcall.rs
+++ b/src/test/ui/abi/x86stdcall.rs
@@ -1,16 +1,14 @@
 // run-pass
-// ignore-wasm32-bare no libc to test ffi with
-// ignore-sgx no libc
+// only-windows
 // GetLastError doesn't seem to work with stack switching
 
 #[cfg(windows)]
 mod kernel32 {
-  extern "system" {
-    pub fn SetLastError(err: usize);
-    pub fn GetLastError() -> usize;
-  }
+    extern "system" {
+        pub fn SetLastError(err: usize);
+        pub fn GetLastError() -> usize;
+    }
 }
-
 
 #[cfg(windows)]
 pub fn main() {
@@ -22,17 +20,3 @@ pub fn main() {
         assert_eq!(expected, actual);
     }
 }
-
-#[cfg(any(target_os = "android",
-          target_os = "dragonfly",
-          target_os = "emscripten",
-          target_os = "freebsd",
-          target_os = "fuchsia",
-          target_os = "illumos",
-          target_os = "linux",
-          target_os = "macos",
-          target_os = "netbsd",
-          target_os = "openbsd",
-          target_os = "solaris",
-          target_os = "vxworks"))]
-pub fn main() { }

--- a/src/test/ui/abi/x86stdcall2.rs
+++ b/src/test/ui/abi/x86stdcall2.rs
@@ -1,4 +1,5 @@
 // run-pass
+// only-windows
 
 #![allow(non_camel_case_types)]
 pub type HANDLE = usize;
@@ -7,20 +8,16 @@ pub type SIZE_T = u32;
 pub type LPVOID = usize;
 pub type BOOL = u8;
 
-#[cfg(windows)]
 mod kernel32 {
-    use super::{HANDLE, DWORD, SIZE_T, LPVOID, BOOL};
+    use super::{BOOL, DWORD, HANDLE, LPVOID, SIZE_T};
 
     extern "system" {
         pub fn GetProcessHeap() -> HANDLE;
-        pub fn HeapAlloc(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T)
-                      -> LPVOID;
+        pub fn HeapAlloc(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T) -> LPVOID;
         pub fn HeapFree(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID) -> BOOL;
     }
 }
 
-
-#[cfg(windows)]
 pub fn main() {
     let heap = unsafe { kernel32::GetProcessHeap() };
     let mem = unsafe { kernel32::HeapAlloc(heap, 0, 100) };
@@ -28,6 +25,3 @@ pub fn main() {
     let res = unsafe { kernel32::HeapFree(heap, 0, mem) };
     assert!(res != 0);
 }
-
-#[cfg(not(windows))]
-pub fn main() { }


### PR DESCRIPTION
Main purpose of this change is to get rid of a quite long (and growing) list of excluded targets, while this test should only be useful on Windows (as far as I understand it). The `// only-windows` header seams to implement exactly what we need here.

I don't know why there are some whitespace changes, but `x.py fmt` and `.git/hooks/pre-push` are happy.