### PR TITLE
add a few more assert_unsafe_precondition

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -100,7 +100,10 @@ use crate::intrinsics;
 pub const unsafe fn unreachable_unchecked() -> ! {
     // SAFETY: the safety contract for `intrinsics::unreachable` must
     // be upheld by the caller.
-    unsafe { intrinsics::unreachable() }
+    unsafe {
+        intrinsics::assert_unsafe_precondition!(() => false);
+        intrinsics::unreachable()
+    }
 }
 
 /// Emits a machine instruction to signal the processor that it is running in

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1114,6 +1114,7 @@ pub const unsafe fn read<T>(src: *const T) -> T {
     // Also, since we just wrote a valid value into `tmp`, it is guaranteed
     // to be properly initialized.
     unsafe {
+        assert_unsafe_precondition!([T](src: *const T) => is_aligned_and_not_null(src));
         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
         tmp.assume_init()
     }
@@ -1307,6 +1308,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
     // `dst` cannot overlap `src` because the caller has mutable access
     // to `dst` while `src` is owned by this function.
     unsafe {
+        assert_unsafe_precondition!([T](dst: *mut T) => is_aligned_and_not_null(dst));
         copy_nonoverlapping(&src as *const T, dst, 1);
         intrinsics::forget(src);
     }

--- a/src/test/codegen/mem-replace-direct-memcpy.rs
+++ b/src/test/codegen/mem-replace-direct-memcpy.rs
@@ -4,6 +4,7 @@
 // known to be `1` after inlining).
 
 // compile-flags: -C no-prepopulate-passes -Zinline-mir=no
+// ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/hint.rs:LL:COL
    |
-LL |     unsafe { intrinsics::unreachable() }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |              |
-   |              entering unreachable code
-   |              inside `unreachable_unchecked` at $SRC_DIR/core/src/hint.rs:LL:COL
+LL |         intrinsics::unreachable()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         entering unreachable code
+   |         inside `unreachable_unchecked` at $SRC_DIR/core/src/hint.rs:LL:COL
    |
   ::: $DIR/const_unsafe_unreachable_ub.rs:6:18
    |

--- a/src/tools/miri/tests/fail/unaligned_pointers/unaligned_ptr1.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/unaligned_ptr1.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     // Try many times as this might work by chance.
-    for _ in 0..10 {
+    for _ in 0..20 {
         let x = [2u16, 3, 4]; // Make it big enough so we don't get an out-of-bounds error.
         let x = &x[0] as *const _ as *const u32;
         // This must fail because alignment is violated: the allocation's base is not sufficiently aligned.

--- a/src/tools/miri/tests/fail/unaligned_pointers/unaligned_ptr_addr_of.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/unaligned_ptr_addr_of.rs
@@ -4,7 +4,7 @@ use std::ptr;
 
 fn main() {
     // Try many times as this might work by chance.
-    for _ in 0..10 {
+    for _ in 0..20 {
         let x = [2u16, 3, 4]; // Make it big enough so we don't get an out-of-bounds error.
         let x = &x[0] as *const _ as *const u32;
         // This must fail because alignment is violated: the allocation's base is not sufficiently aligned.


### PR DESCRIPTION
Add debug-assertion checking for `ptr.read()`, `ptr.write(_)`, and `unreachable_unchecked.`

This is quite useful for [cargo-careful](https://github.com/RalfJung/cargo-careful).