### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1415,7 +1415,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     if !self.is_tilde_const_allowed {
                         self.err_handler()
                             .struct_span_err(bound.span(), "`~const` is not allowed here")
-                            .note("only allowed on bounds on traits' associated types and functions, const fns, const impls and its associated functions")
+                            .note("only allowed on bounds on functions, traits' associated types and functions, const impls and its associated functions")
                             .emit();
                     }
                 }
@@ -1523,9 +1523,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             });
         }
 
-        let tilde_const_allowed =
-            matches!(fk.header(), Some(FnHeader { constness: Const::Yes(_), .. }))
-                || matches!(fk.ctxt(), Some(FnCtxt::Assoc(_)));
+        let tilde_const_allowed = matches!(fk.header(), Some(FnHeader { .. }))
+            || matches!(fk.ctxt(), Some(FnCtxt::Assoc(_)));
 
         self.with_tilde_const(tilde_const_allowed, |this| visit::walk_fn(this, fk));
     }

--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -158,3 +158,6 @@ parser_remove_let = expected pattern, found `let`
 
 parser_use_eq_instead = unexpected `==`
     .suggestion = try using `=` instead
+
+parser_use_empty_block_not_semi = expected { "`{}`" }, found `;`
+    .suggestion = try using { "`{}`" } instead

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -745,6 +745,14 @@ pub(crate) struct UseEqInstead {
     pub span: Span,
 }
 
+#[derive(Diagnostic)]
+#[diag(parser::use_empty_block_not_semi)]
+pub(crate) struct UseEmptyBlockNotSemi {
+    #[primary_span]
+    #[suggestion_hidden(applicability = "machine-applicable", code = "{{}}")]
+    pub span: Span,
+}
+
 // SnapshotParser is used to create a snapshot of the parser
 // without causing duplicate errors being emitted when the `Parser`
 // is dropped.

--- a/config.toml.example
+++ b/config.toml.example
@@ -291,6 +291,10 @@ changelog-seen = 2
 # on this runtime, such as `-C profile-generate` or `-C instrument-coverage`).
 #profiler = false
 
+# Use the optimized LLVM C intrinsics for `compiler_builtins`, rather than Rust intrinsics.
+# Requires the LLVM submodule to be managed by bootstrap (i.e. not external).
+#optimized-compiler-builtins = false
+
 # Indicates whether the native libraries linked into Cargo will be statically
 # linked or not.
 #cargo-native-static = false

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -73,6 +73,8 @@ pub struct Config {
     pub color: Color,
     pub patch_binaries_for_nix: bool,
     pub stage0_metadata: Stage0Metadata,
+    /// Whether to use the `c` feature of the `compiler_builtins` crate.
+    pub optimized_compiler_builtins: bool,
 
     pub on_fail: Option<String>,
     pub stage: u32,
@@ -597,6 +599,7 @@ define_config! {
         bench_stage: Option<u32> = "bench-stage",
         patch_binaries_for_nix: Option<bool> = "patch-binaries-for-nix",
         metrics: Option<bool> = "metrics",
+        optimized_compiler_builtins: Option<bool> = "optimized-compiler-builtins",
     }
 }
 
@@ -916,6 +919,7 @@ impl Config {
         set(&mut config.print_step_timings, build.print_step_timings);
         set(&mut config.print_step_rusage, build.print_step_rusage);
         set(&mut config.patch_binaries_for_nix, build.patch_binaries_for_nix);
+        set(&mut config.optimized_compiler_builtins, build.optimized_compiler_builtins);
 
         config.verbose = cmp::max(config.verbose, flags.verbose);
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1838,23 +1838,21 @@ fn add_env(builder: &Builder<'_>, cmd: &mut Command, target: TargetSelection) {
 ///
 /// Returns whether the files were actually copied.
 fn maybe_install_llvm(builder: &Builder<'_>, target: TargetSelection, dst_libdir: &Path) -> bool {
-    if let Some(config) = builder.config.target_config.get(&target) {
-        if config.llvm_config.is_some() && !builder.config.llvm_from_ci {
-            // If the LLVM was externally provided, then we don't currently copy
-            // artifacts into the sysroot. This is not necessarily the right
-            // choice (in particular, it will require the LLVM dylib to be in
-            // the linker's load path at runtime), but the common use case for
-            // external LLVMs is distribution provided LLVMs, and in that case
-            // they're usually in the standard search path (e.g., /usr/lib) and
-            // copying them here is going to cause problems as we may end up
-            // with the wrong files and isn't what distributions want.
-            //
-            // This behavior may be revisited in the future though.
-            //
-            // If the LLVM is coming from ourselves (just from CI) though, we
-            // still want to install it, as it otherwise won't be available.
-            return false;
-        }
+    if builder.is_rust_llvm(target) {
+        // If the LLVM was externally provided, then we don't currently copy
+        // artifacts into the sysroot. This is not necessarily the right
+        // choice (in particular, it will require the LLVM dylib to be in
+        // the linker's load path at runtime), but the common use case for
+        // external LLVMs is distribution provided LLVMs, and in that case
+        // they're usually in the standard search path (e.g., /usr/lib) and
+        // copying them here is going to cause problems as we may end up
+        // with the wrong files and isn't what distributions want.
+        //
+        // This behavior may be revisited in the future though.
+        //
+        // If the LLVM is coming from ourselves (just from CI) though, we
+        // still want to install it, as it otherwise won't be available.
+        return false;
     }
 
     // On macOS, rustc (and LLVM tools) link to an unversioned libLLVM.dylib

--- a/src/ci/docker/host-x86_64/disabled/dist-x86_64-haiku/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-x86_64-haiku/Dockerfile
@@ -47,4 +47,6 @@ ENV RUST_CONFIGURE_ARGS --disable-jemalloc \
   --set=$TARGET.cc=x86_64-unknown-haiku-gcc \
   --set=$TARGET.cxx=x86_64-unknown-haiku-g++ \
   --set=$TARGET.llvm-config=/bin/llvm-config-haiku
+ENV EXTERNAL_LLVM 1
+
 ENV SCRIPT python3 ../x.py dist --host=$HOST --target=$HOST

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -129,4 +129,6 @@ ENV RUST_CONFIGURE_ARGS --enable-extended --enable-lld --disable-docs \
   --set target.wasm32-wasi.wasi-root=/wasm32-wasi \
   --musl-root-armv7=/musl-armv7
 
+ENV EXTERNAL_LLVM 1
+
 ENV SCRIPT python3 ../x.py dist --host='' --target $TARGETS

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-13-stage1/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-13-stage1/Dockerfile
@@ -29,6 +29,7 @@ RUN sh /scripts/sccache.sh
 # We are disabling CI LLVM since this builder is intentionally using a host
 # LLVM, rather than the typical src/llvm-project LLVM.
 ENV NO_DOWNLOAD_CI_LLVM 1
+ENV EXTERNAL_LLVM 1
 
 # Using llvm-link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-13/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-13/Dockerfile
@@ -40,6 +40,7 @@ RUN sh /scripts/sccache.sh
 # We are disabling CI LLVM since this builder is intentionally using a host
 # LLVM, rather than the typical src/llvm-project LLVM.
 ENV NO_DOWNLOAD_CI_LLVM 1
+ENV EXTERNAL_LLVM 1
 
 # Using llvm-link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -69,6 +69,11 @@ RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.codegen-units-std=1"
 # space required for CI artifacts.
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --dist-compression-formats=xz"
 
+# Enable the `c` feature for compiler_builtins, but only when the `compiler-rt` source is available.
+if [ "$EXTERNAL_LLVM" = "" ]; then
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.optimized-compiler-builtins"
+fi
+
 if [ "$DIST_SRC" = "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-dist-src"
 fi

--- a/src/test/ui/coherence/coherence-negative-impls-copy-bad.rs
+++ b/src/test/ui/coherence/coherence-negative-impls-copy-bad.rs
@@ -1,0 +1,11 @@
+#![feature(negative_impls)]
+#![crate_type = "lib"]
+
+impl !Copy for str {}
+//~^ ERROR only traits defined in the current crate can be implemented
+
+impl !Copy for fn() {}
+//~^ ERROR only traits defined in the current crate can be implemented
+
+impl !Copy for () {}
+//~^ ERROR only traits defined in the current crate can be implemented

--- a/src/test/ui/coherence/coherence-negative-impls-copy-bad.stderr
+++ b/src/test/ui/coherence/coherence-negative-impls-copy-bad.stderr
@@ -1,0 +1,36 @@
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-negative-impls-copy-bad.rs:4:1
+   |
+LL | impl !Copy for str {}
+   | ^^^^^^^^^^^^^^^---
+   | |              |
+   | |              `str` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-negative-impls-copy-bad.rs:7:1
+   |
+LL | impl !Copy for fn() {}
+   | ^^^^^^^^^^^^^^^----
+   | |              |
+   | |              `fn()` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-negative-impls-copy-bad.rs:10:1
+   |
+LL | impl !Copy for () {}
+   | ^^^^^^^^^^^^^^^--
+   | |              |
+   | |              this is not defined in the current crate because tuples are always foreign
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0117`.

--- a/src/test/ui/coherence/coherence-negative-impls-copy.rs
+++ b/src/test/ui/coherence/coherence-negative-impls-copy.rs
@@ -1,0 +1,29 @@
+// check-pass
+// regression test for issue #101836
+
+#![feature(negative_impls, extern_types)]
+#![crate_type = "lib"]
+
+struct NonCopy;
+struct NeverCopy(NonCopy);
+
+impl !Copy for NeverCopy {}
+
+
+struct WithDrop;
+impl Drop for WithDrop { fn drop(&mut self) {} }
+
+impl !Copy for WithDrop {}
+
+
+struct Type;
+trait Trait {}
+extern {
+    type ExternType;
+}
+
+impl !Copy for &mut Type {}
+
+impl !Copy for dyn Trait {}
+
+impl !Copy for ExternType {}

--- a/src/test/ui/coherence/deep-bad-copy-reason.stderr
+++ b/src/test/ui/coherence/deep-bad-copy-reason.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/deep-bad-copy-reason.rs:33:15
+  --> $DIR/deep-bad-copy-reason.rs:33:24
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
    |                          ------------------------ this field does not implement `Copy`
 ...
 LL | impl<'tcx, T> Copy for List<'tcx, T> {}
-   |               ^^^^
+   |                        ^^^^^^^^^^^^^
    |
 note: the `Copy` impl for `Interned<'tcx, ListS<T>>` requires that `OpaqueListContents: Sized`
   --> $DIR/deep-bad-copy-reason.rs:23:26

--- a/src/test/ui/consts/const-eval/issue-100878.rs
+++ b/src/test/ui/consts/const-eval/issue-100878.rs
@@ -1,0 +1,8 @@
+// This checks that the const-eval ICE in issue #100878 does not recur.
+//
+// build-pass
+pub fn bitshift_data(data: [u8; 1]) -> u8 {
+    data[0] << 8
+}
+
+fn main() {}

--- a/src/test/ui/opt-in-copy.stderr
+++ b/src/test/ui/opt-in-copy.stderr
@@ -1,20 +1,20 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/opt-in-copy.rs:7:6
+  --> $DIR/opt-in-copy.rs:7:15
    |
 LL |     but_i_cant: CantCopyThis,
    |     ------------------------ this field does not implement `Copy`
 ...
 LL | impl Copy for IWantToCopyThis {}
-   |      ^^^^
+   |               ^^^^^^^^^^^^^^^
 
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/opt-in-copy.rs:19:6
+  --> $DIR/opt-in-copy.rs:19:15
    |
 LL |     ButICant(CantCopyThisEither),
    |              ------------------ this field does not implement `Copy`
 ...
 LL | impl Copy for IWantToCopyThisToo {}
-   |      ^^^^
+   |               ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/empty-impl-semicolon.rs
+++ b/src/test/ui/parser/empty-impl-semicolon.rs
@@ -1,1 +1,4 @@
-impl Foo; //~ ERROR expected one of `!`, `(`, `+`, `::`, `<`, `for`, `where`, or `{`, found `;`
+struct Foo;
+impl Foo; //~ ERROR expected `{}`, found `;`
+
+fn main() {}

--- a/src/test/ui/parser/empty-impl-semicolon.stderr
+++ b/src/test/ui/parser/empty-impl-semicolon.stderr
@@ -1,8 +1,10 @@
-error: expected one of `!`, `(`, `+`, `::`, `<`, `for`, `where`, or `{`, found `;`
-  --> $DIR/empty-impl-semicolon.rs:1:9
+error: expected `{}`, found `;`
+  --> $DIR/empty-impl-semicolon.rs:2:9
    |
 LL | impl Foo;
-   |         ^ expected one of 8 possible tokens
+   |         ^
+   |
+   = help: try using `{}` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/item-needs-block.rs
+++ b/src/test/ui/parser/item-needs-block.rs
@@ -1,0 +1,10 @@
+trait Trait;
+//~^ ERROR expected `{}`, found `;`
+
+impl Trait for ();
+//~^ ERROR expected `{}`, found `;`
+
+enum Enum;
+//~^ ERROR expected `{}`, found `;`
+
+fn main() {}

--- a/src/test/ui/parser/item-needs-block.stderr
+++ b/src/test/ui/parser/item-needs-block.stderr
@@ -1,0 +1,26 @@
+error: expected `{}`, found `;`
+  --> $DIR/item-needs-block.rs:1:12
+   |
+LL | trait Trait;
+   |            ^
+   |
+   = help: try using `{}` instead
+
+error: expected `{}`, found `;`
+  --> $DIR/item-needs-block.rs:4:18
+   |
+LL | impl Trait for ();
+   |                  ^
+   |
+   = help: try using `{}` instead
+
+error: expected `{}`, found `;`
+  --> $DIR/item-needs-block.rs:7:10
+   |
+LL | enum Enum;
+   |          ^
+   |
+   = help: try using `{}` instead
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-const-and-const-params.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-const-and-const-params.rs
@@ -1,0 +1,34 @@
+// check-pass
+#![feature(const_trait_impl)]
+#![feature(generic_arg_infer)]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+struct Foo<const N: usize>;
+
+impl<const N: usize> Foo<N> {
+   fn add<A: ~const Add42>(self) -> Foo<{ A::add(N) }> {
+      Foo
+   }
+}
+
+#[const_trait]
+trait Add42 {
+    fn add(a: usize) -> usize;
+}
+
+impl const Add42 for () {
+    fn add(a: usize) -> usize {
+        a + 42
+    }
+}
+
+fn bar<A: ~const Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
+    Foo
+}
+
+fn main() {
+   let foo = Foo::<0>;
+   let foo = bar::<(), _>(foo);
+   let _foo = bar::<(), _>(foo);
+}

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
@@ -17,12 +17,6 @@ fn rpit_assoc_bound() -> impl IntoIterator<Item: ~const T> { Some(S) }
 fn apit_assoc_bound(_: impl IntoIterator<Item: ~const T>) {}
 //~^ ERROR `~const` is not allowed
 
-fn generic<P: ~const T>() {}
-//~^ ERROR `~const` is not allowed
-
-fn where_clause<P>() where P: ~const T {}
-//~^ ERROR `~const` is not allowed
-
 struct TildeQuestion<T: ~const ?Sized>(std::marker::PhantomData<T>);
 //~^ ERROR `~const` and `?` are mutually exclusive
 

--- a/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -4,7 +4,7 @@ error: `~const` is not allowed here
 LL | fn rpit() -> impl ~const T { S }
    |                   ^^^^^^^^
    |
-   = note: only allowed on bounds on traits' associated types and functions, const fns, const impls and its associated functions
+   = note: only allowed on bounds on functions, traits' associated types and functions, const impls and its associated functions
 
 error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:11:17
@@ -12,7 +12,7 @@ error: `~const` is not allowed here
 LL | fn apit(_: impl ~const T) {}
    |                 ^^^^^^^^
    |
-   = note: only allowed on bounds on traits' associated types and functions, const fns, const impls and its associated functions
+   = note: only allowed on bounds on functions, traits' associated types and functions, const impls and its associated functions
 
 error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:14:50
@@ -20,7 +20,7 @@ error: `~const` is not allowed here
 LL | fn rpit_assoc_bound() -> impl IntoIterator<Item: ~const T> { Some(S) }
    |                                                  ^^^^^^^^
    |
-   = note: only allowed on bounds on traits' associated types and functions, const fns, const impls and its associated functions
+   = note: only allowed on bounds on functions, traits' associated types and functions, const impls and its associated functions
 
 error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:17:48
@@ -28,29 +28,13 @@ error: `~const` is not allowed here
 LL | fn apit_assoc_bound(_: impl IntoIterator<Item: ~const T>) {}
    |                                                ^^^^^^^^
    |
-   = note: only allowed on bounds on traits' associated types and functions, const fns, const impls and its associated functions
-
-error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:20:15
-   |
-LL | fn generic<P: ~const T>() {}
-   |               ^^^^^^^^
-   |
-   = note: only allowed on bounds on traits' associated types and functions, const fns, const impls and its associated functions
-
-error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:23:31
-   |
-LL | fn where_clause<P>() where P: ~const T {}
-   |                               ^^^^^^^^
-   |
-   = note: only allowed on bounds on traits' associated types and functions, const fns, const impls and its associated functions
+   = note: only allowed on bounds on functions, traits' associated types and functions, const impls and its associated functions
 
 error: `~const` and `?` are mutually exclusive
-  --> $DIR/tilde-const-invalid-places.rs:26:25
+  --> $DIR/tilde-const-invalid-places.rs:20:25
    |
 LL | struct TildeQuestion<T: ~const ?Sized>(std::marker::PhantomData<T>);
    |                         ^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/E0204.stderr
+++ b/src/test/ui/span/E0204.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/E0204.rs:5:6
+  --> $DIR/E0204.rs:5:15
    |
 LL |     foo: Vec<u32>,
    |     ------------- this field does not implement `Copy`
 ...
 LL | impl Copy for Foo { }
-   |      ^^^^
+   |               ^^^
 
 error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/E0204.rs:7:10
@@ -19,13 +19,13 @@ LL |     ty: &'a mut bool,
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/E0204.rs:17:6
+  --> $DIR/E0204.rs:17:15
    |
 LL |     Bar { x: Vec<u32> },
    |           ----------- this field does not implement `Copy`
 ...
 LL | impl Copy for EFoo { }
-   |      ^^^^
+   |               ^^^^
 
 error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/E0204.rs:19:10

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:16:9
+  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:16:18
    |
 LL | struct Wrapper<T>(T);
    |                   - this field does not implement `Copy`
 ...
 LL | impl<S> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
-   |         ^^^^
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the `Copy` impl for `OnlyCopyIfDisplay<S>` requires that `S: std::fmt::Display`
   --> $DIR/missing-bound-in-manual-copy-impl-2.rs:4:19

--- a/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/missing-bound-in-manual-copy-impl.rs:6:9
+  --> $DIR/missing-bound-in-manual-copy-impl.rs:6:18
    |
 LL | struct Wrapper<T>(T);
    |                   - this field does not implement `Copy`
 LL |
 LL | impl<S> Copy for Wrapper<S> {}
-   |         ^^^^
+   |                  ^^^^^^^^^^
    |
 help: consider restricting type parameter `S`
    |

--- a/src/test/ui/traits/copy-impl-cannot-normalize.stderr
+++ b/src/test/ui/traits/copy-impl-cannot-normalize.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: TraitFoo` is not satisfied
-  --> $DIR/copy-impl-cannot-normalize.rs:22:1
+  --> $DIR/copy-impl-cannot-normalize.rs:22:18
    |
 LL | impl<T> Copy for Foo<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `TraitFoo` is not implemented for `T`
+   |                  ^^^^^^ the trait `TraitFoo` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/union/union-copy.stderr
+++ b/src/test/ui/union/union-copy.stderr
@@ -1,11 +1,11 @@
 error[E0204]: the trait `Copy` may not be implemented for this type
-  --> $DIR/union-copy.rs:12:6
+  --> $DIR/union-copy.rs:12:15
    |
 LL |     a: std::mem::ManuallyDrop<String>
    |     --------------------------------- this field does not implement `Copy`
 ...
 LL | impl Copy for W {}
-   |      ^^^^
+   |               ^
    |
 note: the `Copy` impl for `ManuallyDrop<String>` requires that `String: Copy`
   --> $DIR/union-copy.rs:8:8


### PR DESCRIPTION
Successful merges:

 - #101833 (Make the `c` feature for `compiler-builtins` an explicit opt-in)
 - #101875 (Allow more `!Copy` impls)
 - #102181 (Add regression test)
 - #102257 (Fix lint scoping for let-else.)
 - #102273 (Allow `~const` bounds on non-const functions)
 - #102286 (Recover some items that expect braces and don't take semicolons)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=101833,101875,102181,102257,102273,102286)
<!-- homu-ignore:end -->