### PR TITLE
rustdoc: merge CSS `table` rules into `.docblock`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -299,11 +299,6 @@ summary {
 
 /* Fix some style changes due to normalize.css 8 */
 
-td,
-th {
-	padding: 0;
-}
-
 table {
 	border-collapse: collapse;
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -299,10 +299,6 @@ summary {
 
 /* Fix some style changes due to normalize.css 8 */
 
-table {
-	border-collapse: collapse;
-}
-
 button,
 input,
 optgroup,
@@ -690,6 +686,7 @@ pre, .rustdoc.source .example-wrap {
 	width: calc(100% - 2px);
 	overflow-x: auto;
 	display: block;
+	border-collapse: collapse;
 }
 
 .docblock table td {


### PR DESCRIPTION
This was added in 510107815fe888319028c5e96001cdee70e7a931, to fix the display of the module items and search results tables (see the discussion in https://github.com/rust-lang/rust/pull/86725).

Those aren't tables any more. The only remaining table is in docblock, which has its own padding declarations.