### PR TITLE
rustdoc: Update doc comment for splitn_mut to include mutable in the …

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2076,7 +2076,7 @@ impl<T> [T] {
         SplitN::new(self.split(pred), n)
     }
 
-    /// Returns an iterator over subslices separated by elements that match
+    /// Returns an iterator over mutable subslices separated by elements that match
     /// `pred`, limited to returning at most `n` items. The matched element is
     /// not contained in the subslices.
     ///


### PR DESCRIPTION
The doc comment for [splitn](https://github.com/rust-lang/rust/blob/master/library/core/src/slice/mod.rs#L2051:L2056) is the exact same as the comment for [splitn_mut](https://github.com/rust-lang/rust/blob/master/library/core/src/slice/mod.rs#L2079:L2084).  The doc comment for `splitn_mut` should instead say it's working on a mutable subslice.