### PR TITLE
rustdoc: remove no-op CSS `.srclink { font-weight; font-size }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1118,13 +1118,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	color: var(--right-side-color);
 }
 
-
-.impl-items .srclink, .impl .srclink, .methods .srclink {
-	/* Override header settings otherwise it's too bold */
-	font-weight: normal;
-	font-size: 1rem;
-}
-
 pre.rust .question-mark {
 	font-weight: bold;
 }


### PR DESCRIPTION
When this CSS was added in 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9, source links were nested below headers.

https://github.com/rust-lang/rust/blob/34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9/src/librustdoc/html/render.rs#L4015-L4019

Now, thanks to 458e7219bc2a62f72368279945cfda632a016da1, they are now siblings of headers, and thanks to 270d09dca9aae263671c4d32bbc7cb60dc378af8, they have the same font size that they would've had anyway.