### PR TITLE
Deny associated type bindings within associated type bindings

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -595,7 +595,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             "create_substs_for_associated_item(span: {:?}, item_def_id: {:?}, item_segment: {:?}",
             span, item_def_id, item_segment
         );
-        self.create_substs_for_ast_path(
+        let (args, _) = self.create_substs_for_ast_path(
             span,
             item_def_id,
             parent_substs,
@@ -603,8 +603,14 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             item_segment.args(),
             item_segment.infer_args,
             None,
-        )
-        .0
+        );
+
+        let assoc_bindings = self.create_assoc_bindings_for_generic_args(item_segment.args());
+        if let Some(b) = assoc_bindings.first() {
+            Self::prohibit_assoc_ty_binding(self.tcx(), b.span);
+        }
+
+        args
     }
 
     /// Instantiates the path for the given trait reference, assuming that it's

--- a/src/test/ui/associated-consts/issue-102335-const.rs
+++ b/src/test/ui/associated-consts/issue-102335-const.rs
@@ -1,0 +1,12 @@
+#![feature(associated_const_equality)]
+
+trait T {
+    type A: S<C<X = 0i32> = 34>;
+    //~^ ERROR associated type bindings are not allowed here
+}
+
+trait S {
+    const C: i32;
+}
+
+fn main() {}

--- a/src/test/ui/associated-consts/issue-102335-const.stderr
+++ b/src/test/ui/associated-consts/issue-102335-const.stderr
@@ -1,0 +1,9 @@
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-102335-const.rs:4:17
+   |
+LL |     type A: S<C<X = 0i32> = 34>;
+   |                 ^^^^^^^^ associated type not allowed here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0229`.

--- a/src/test/ui/associated-type-bounds/issue-102335-ty.rs
+++ b/src/test/ui/associated-type-bounds/issue-102335-ty.rs
@@ -1,0 +1,12 @@
+trait T {
+    type A: S<C<i32 = u32> = ()>;
+    //~^ ERROR associated type bindings are not allowed here
+}
+
+trait Q {}
+
+trait S {
+    type C: Q;
+}
+
+fn main() {}

--- a/src/test/ui/associated-type-bounds/issue-102335-ty.stderr
+++ b/src/test/ui/associated-type-bounds/issue-102335-ty.stderr
@@ -1,0 +1,9 @@
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-102335-ty.rs:2:17
+   |
+LL |     type A: S<C<i32 = u32> = ()>;
+   |                 ^^^^^^^^^ associated type not allowed here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0229`.

--- a/src/test/ui/generic-associated-types/issue-102335-gat.rs
+++ b/src/test/ui/generic-associated-types/issue-102335-gat.rs
@@ -1,0 +1,12 @@
+trait T {
+    type A: S<C<(), i32 = ()> = ()>;
+    //~^ ERROR associated type bindings are not allowed here
+}
+
+trait Q {}
+
+trait S {
+    type C<T>: Q;
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-102335-gat.stderr
+++ b/src/test/ui/generic-associated-types/issue-102335-gat.stderr
@@ -1,0 +1,9 @@
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-102335-gat.rs:2:21
+   |
+LL |     type A: S<C<(), i32 = ()> = ()>;
+   |                     ^^^^^^^^ associated type not allowed here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0229`.

--- a/src/test/ui/suggestions/issue-85347.rs
+++ b/src/test/ui/suggestions/issue-85347.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 trait Foo {
     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
     //~^ ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+    //~| ERROR associated type bindings are not allowed here
     //~| HELP add missing
 }
 

--- a/src/test/ui/suggestions/issue-85347.stderr
+++ b/src/test/ui/suggestions/issue-85347.stderr
@@ -14,6 +14,13 @@ help: add missing lifetime argument
 LL |     type Bar<'a>: Deref<Target = <Self>::Bar<'a, Target = Self>>;
    |                                              +++
 
-error: aborting due to previous error
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-85347.rs:3:46
+   |
+LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
+   |                                              ^^^^^^^^^^^^^ associated type not allowed here
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0229.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes #102335

This was made worse by #100865, which unified the way we generate substs for GATs and non-generic associated types. However, the issue was not _caused_ by #100865, evidenced by the test I added for GATs:

```rust
trait T {
    type A: S<C<(), i32 = ()> = ()>;
    //~^ ERROR associated type bindings are not allowed here
}

trait Q {}

trait S {
    type C<T>: Q;
}

fn main() {}
```

^ which passes on beta (where GATs are stable) and presumably ever since GATs support was added to `create_substs_for_associated_item` in astconv.