### PR TITLE
Remove an unnecessary normalization

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -305,7 +305,6 @@ impl<'tcx> Inliner<'tcx> {
             let func_ty = func.ty(caller_body, self.tcx);
             if let ty::FnDef(def_id, substs) = *func_ty.kind() {
                 // To resolve an instance its substs have to be fully normalized.
-                let substs = self.tcx.try_normalize_erasing_regions(self.param_env, substs).ok()?;
                 let callee =
                     Instance::resolve(self.tcx, self.param_env, def_id, substs).ok().flatten()?;
 


### PR DESCRIPTION
All types have already been normalized in `RevealAllVisitor::visit_ty`.

https://github.com/rust-lang/rust/blob/cd4d9d934fd3bc1b6a0b0fcb3548a1b26fc53c9d/compiler/rustc_mir_transform/src/reveal_all.rs#L38-L43