### PR TITLE
Improve errors for incomplete functions in struct definitions

### DIFF
--- a/src/test/ui/parser/fn-field-parse-error-ice.rs
+++ b/src/test/ui/parser/fn-field-parse-error-ice.rs
@@ -3,7 +3,7 @@
 struct Baz {
     inner : dyn fn ()
     //~^ ERROR expected `,`, or `}`, found keyword `fn`
-    //~| ERROR functions are not allowed in struct definitions
+    //~| ERROR expected identifier, found keyword `fn`
     //~| ERROR cannot find type `dyn` in this scope
 }
 

--- a/src/test/ui/parser/fn-field-parse-error-ice.stderr
+++ b/src/test/ui/parser/fn-field-parse-error-ice.stderr
@@ -4,16 +4,18 @@ error: expected `,`, or `}`, found keyword `fn`
 LL |     inner : dyn fn ()
    |                ^ help: try adding a comma: `,`
 
-error: functions are not allowed in struct definitions
+error: expected identifier, found keyword `fn`
   --> $DIR/fn-field-parse-error-ice.rs:4:17
    |
 LL | struct Baz {
    |        --- while parsing this struct
 LL |     inner : dyn fn ()
-   |                 ^^
+   |                 ^^ expected identifier, found keyword
    |
-   = help: unlike in C++, Java, and C#, functions are declared in `impl` blocks
-   = help: see https://doc.rust-lang.org/book/ch05-03-method-syntax.html for more information
+help: escape `fn` to use it as an identifier
+   |
+LL |     inner : dyn r#fn ()
+   |                 ++
 
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/fn-field-parse-error-ice.rs:4:13

--- a/src/test/ui/structs/incomplete-fn-in-struct-definition.rs
+++ b/src/test/ui/structs/incomplete-fn-in-struct-definition.rs
@@ -1,5 +1,5 @@
 fn main() {}
 
 struct S {
-    fn //~ ERROR expected identifier, found keyword `fn`
+    fn: u8 //~ ERROR expected identifier, found keyword `fn`
 }

--- a/src/test/ui/structs/incomplete-fn-in-struct-definition.rs
+++ b/src/test/ui/structs/incomplete-fn-in-struct-definition.rs
@@ -1,0 +1,5 @@
+fn main() {}
+
+struct S {
+    fn //~ ERROR expected identifier, found keyword `fn`
+}

--- a/src/test/ui/structs/incomplete-fn-in-struct-definition.stderr
+++ b/src/test/ui/structs/incomplete-fn-in-struct-definition.stderr
@@ -1,0 +1,13 @@
+error: expected identifier, found keyword `fn`
+  --> $DIR/incomplete-fn-in-struct-definition.rs:4:5
+   |
+LL |     fn
+   |     ^^ expected identifier, found keyword
+   |
+help: escape `fn` to use it as an identifier
+   |
+LL |     r#fn
+   |     ++
+
+error: aborting due to previous error
+

--- a/src/test/ui/structs/incomplete-fn-in-struct-definition.stderr
+++ b/src/test/ui/structs/incomplete-fn-in-struct-definition.stderr
@@ -1,12 +1,14 @@
 error: expected identifier, found keyword `fn`
   --> $DIR/incomplete-fn-in-struct-definition.rs:4:5
    |
-LL |     fn
+LL | struct S {
+   |        - while parsing this struct
+LL |     fn: u8
    |     ^^ expected identifier, found keyword
    |
 help: escape `fn` to use it as an identifier
    |
-LL |     r#fn
+LL |     r#fn: u8
    |     ++
 
 error: aborting due to previous error


### PR DESCRIPTION
Given the following code:

```rust
fn main() {}

struct Foo {
    fn
}
```

[playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=29139f870511f6918324be5ddc26c345)

The current output is:

```
   Compiling playground v0.0.1 (/playground)
error: functions are not allowed in struct definitions
 --> src/main.rs:4:5
  |
4 |     fn
  |     ^^
  |
  = help: unlike in C++, Java, and C#, functions are declared in `impl` blocks
  = help: see https://doc.rust-lang.org/book/ch05-03-method-syntax.html for more information

error: could not compile `playground` due to previous error
```

In this case, rustc should suggest escaping `fn` to use it as an identifier.