### PR TITLE
rustdoc: remove redundant `#help-button` CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1019,8 +1019,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	font-size: 1.125rem;
 }
 #help-button span.top {
-	text-align: center;
-	display: block;
 	margin: 10px 0;
 	border-bottom: 1px solid var(--border-color);
 	padding-bottom: 4px;
@@ -1029,9 +1027,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 #help-button span.bottom {
 	clear: both;
 	border-top: 1px solid var(--border-color);
-}
-.side-by-side {
-	text-align: initial;
 }
 .side-by-side > div {
 	width: 50%;


### PR DESCRIPTION
When the separate top and bottom styles were added in cd3f4da244578a2ab4d17d10016c61b9191b21e4, some of the CSS rules were needlessly duplicated.

The `text-align: initial` rule on `.side-by-side` was always redundant, since the rules that centered the text were set on children, not parents.