### PR TITLE
Fix search result colors

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -257,7 +257,9 @@ pre.rust a,
 }
 
 .content span.fn, .content a.fn,
-.content .fnname {
+.content .fnname,
+.content span.method, .content a.method,
+.content span.tymethod, .content a.tymethod {
 	color: var(--function-link-color);
 }
 

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -7,7 +7,6 @@ show-text: true
 // Ayu theme
 local-storage: {
     "rustdoc-theme": "ayu",
-    "rustdoc-preferred-dark-theme": "ayu",
     "rustdoc-use-system-theme": "false",
 }
 reload:
@@ -23,16 +22,66 @@ assert-css: (
     {"color": "rgb(0, 150, 207)"},
 )
 
-// Checking the color for "keyword".
+// Checking the color of "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
     {"color": "rgb(120, 135, 151)"},
+)
+
+// Checking the color of "keyword".
+assert-css: (
+    ".result-name .keyword",
+    {"color": "rgb(57, 175, 215)"},
+    ALL,
+)
+// Check the color of "struct".
+assert-css: (
+    ".result-name .struct",
+    {"color": "rgb(255, 160, 165)"},
+    ALL,
+)
+// Check the color of "associated type".
+assert-css: (
+    ".result-name .associatedtype",
+    {"color": "rgb(57, 175, 215)"},
+    ALL,
+)
+// Check the color of "type method".
+assert-css: (
+    ".result-name .tymethod",
+    {"color": "rgb(253, 214, 135)"},
+    ALL,
+)
+// Check the color of "method".
+assert-css: (
+    ".result-name .method",
+    {"color": "rgb(253, 214, 135)"},
+    ALL,
+)
+// Check the color of "struct field".
+assert-css: (
+    ".result-name .structfield",
+    {"color": "rgb(0, 150, 207)"},
+    ALL,
+)
+// Check the color of "macro".
+assert-css: (
+    ".result-name .macro",
+    {"color": "rgb(163, 122, 204)"},
+    ALL,
+)
+// Check the color of "fn".
+assert-css: (
+    ".result-name .fn",
+    {"color": "rgb(253, 214, 135)"},
+    ALL,
 )
 
 // Checking the `<a>` container.
 assert-css: (
     "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
     {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+    ALL,
 )
 
 // Checking color and background on hover.
@@ -49,7 +98,6 @@ assert-css: (
 // Dark theme
 local-storage: {
     "rustdoc-theme": "dark",
-    "rustdoc-preferred-dark-theme": "dark",
     "rustdoc-use-system-theme": "false",
 }
 reload:
@@ -69,6 +117,55 @@ assert-css: (
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
     {"color": "rgb(221, 221, 221)"},
+)
+
+// Checking the color of "keyword".
+assert-css: (
+    ".result-name .keyword",
+    {"color": "rgb(210, 153, 29)"},
+    ALL,
+)
+// Check the color of "struct".
+assert-css: (
+    ".result-name .struct",
+    {"color": "rgb(45, 191, 184)"},
+    ALL,
+)
+// Check the color of "associated type".
+assert-css: (
+    ".result-name .associatedtype",
+    {"color": "rgb(210, 153, 29)"},
+    ALL,
+)
+// Check the color of "type method".
+assert-css: (
+    ".result-name .tymethod",
+    {"color": "rgb(43, 171, 99)"},
+    ALL,
+)
+// Check the color of "method".
+assert-css: (
+    ".result-name .method",
+    {"color": "rgb(43, 171, 99)"},
+    ALL,
+)
+// Check the color of "struct field".
+assert-css: (
+    ".result-name .structfield",
+    {"color": "rgb(221, 221, 221)"},
+    ALL,
+)
+// Check the color of "macro".
+assert-css: (
+    ".result-name .macro",
+    {"color": "rgb(9, 189, 0)"},
+    ALL,
+)
+// Check the color of "fn".
+assert-css: (
+    ".result-name .fn",
+    {"color": "rgb(43, 171, 99)"},
+    ALL,
 )
 
 // Checking the `<a>` container.
@@ -109,6 +206,55 @@ assert-css: (
     {"color": "rgb(0, 0, 0)"},
 )
 
+// Checking the color of "keyword".
+assert-css: (
+    ".result-name .keyword",
+    {"color": "rgb(56, 115, 173)"},
+    ALL,
+)
+// Check the color of "struct".
+assert-css: (
+    ".result-name .struct",
+    {"color": "rgb(173, 55, 138)"},
+    ALL,
+)
+// Check the color of "associated type".
+assert-css: (
+    ".result-name .associatedtype",
+    {"color": "rgb(56, 115, 173)"},
+    ALL,
+)
+// Check the color of "type method".
+assert-css: (
+    ".result-name .tymethod",
+    {"color": "rgb(173, 124, 55)"},
+    ALL,
+)
+// Check the color of "method".
+assert-css: (
+    ".result-name .method",
+    {"color": "rgb(173, 124, 55)"},
+    ALL,
+)
+// Check the color of "struct field".
+assert-css: (
+    ".result-name .structfield",
+    {"color": "rgb(0, 0, 0)"},
+    ALL,
+)
+// Check the color of "macro".
+assert-css: (
+    ".result-name .macro",
+    {"color": "rgb(6, 128, 0)"},
+    ALL,
+)
+// Check the color of "fn".
+assert-css: (
+    ".result-name .fn",
+    {"color": "rgb(173, 124, 55)"},
+    ALL,
+)
+
 // Checking the `<a>` container.
 assert-css: (
     "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
@@ -132,7 +278,6 @@ goto: file://|DOC_PATH|/test_docs/index.html
 // this test is running on.
 local-storage: {
     "rustdoc-theme": "dark",
-    "rustdoc-preferred-dark-theme": "dark",
     "rustdoc-use-system-theme": "false",
 }
 // If the text isn't displayed, the browser doesn't compute color style correctly...

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -38,11 +38,14 @@ pub trait Trait {
 
     #[deprecated = "Whatever [`Foo`](#tadam)"]
     fn foo() {}
+    fn fooo();
 }
 
 impl Trait for Foo {
     type X = u32;
     const Y: u32 = 0;
+
+    fn fooo() {}
 }
 
 impl implementors::Whatever for Foo {


### PR DESCRIPTION
Fixes regression introduced in https://github.com/rust-lang/rust/commit/99c00714cff0d13b6c5092c9949cb4e93a121346.

As you can see, ayu lost some colors for its search results:

beta/nightly:
![Screenshot from 2022-09-27 19-46-49](https://user-images.githubusercontent.com/3050060/192606456-e7bb58dd-cf76-49a0-b1ae-28565adb1dc6.png)

stable:
![Screenshot from 2022-09-27 19-46-36](https://user-images.githubusercontent.com/3050060/192606453-e720e219-a336-4ff1-989b-2fdb76e789eb.png)

We'll need to backport it to beta too to prevent it reaching stable.

r? @notriddle 