### PR TITLE
Flush delayed bugs before codegen

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1133,6 +1133,12 @@ impl Handler {
         );
         std::mem::take(&mut self.inner.borrow_mut().fulfilled_expectations)
     }
+
+    pub fn flush_delayed(&self) {
+        let mut inner = self.inner.lock();
+        let bugs = std::mem::replace(&mut inner.delayed_span_bugs, Vec::new());
+        inner.flush_delayed(bugs, "no errors encountered even though `delay_span_bug` issued");
+    }
 }
 
 impl HandlerInner {

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -246,6 +246,8 @@ impl<'tcx> Queries<'tcx> {
                 // Don't do code generation if there were any errors
                 self.session().compile_status()?;
 
+                // If we have any delayed bugs, for example beacuse we created TyKind::Error earlier,
+                // it's likey that codegen will only cause more ICEs, obscuring the original problem
                 self.session().diagnostic().flush_delayed();
 
                 // Hook for UI tests.

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -246,6 +246,8 @@ impl<'tcx> Queries<'tcx> {
                 // Don't do code generation if there were any errors
                 self.session().compile_status()?;
 
+                self.session().diagnostic().flush_delayed();
+
                 // Hook for UI tests.
                 Self::check_for_rustc_errors_attr(tcx);
 

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -247,7 +247,7 @@ impl<'tcx> Queries<'tcx> {
                 self.session().compile_status()?;
 
                 // If we have any delayed bugs, for example because we created TyKind::Error earlier,
-                // it's likey that codegen will only cause more ICEs, obscuring the original problem
+                // it's likely that codegen will only cause more ICEs, obscuring the original problem
                 self.session().diagnostic().flush_delayed();
 
                 // Hook for UI tests.

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -246,7 +246,7 @@ impl<'tcx> Queries<'tcx> {
                 // Don't do code generation if there were any errors
                 self.session().compile_status()?;
 
-                // If we have any delayed bugs, for example beacuse we created TyKind::Error earlier,
+                // If we have any delayed bugs, for example because we created TyKind::Error earlier,
                 // it's likey that codegen will only cause more ICEs, obscuring the original problem
                 self.session().diagnostic().flush_delayed();
 


### PR DESCRIPTION
Sometimes it can happen that invalid code like a TyKind::Error makes its way through the compiler without triggering any errors (this is always a bug in rustc but bugs do happen sometimes :)). These ICEs will manifest in the backend like as cg_llvm not being able to get the layout of `[type error]`, which makes it hard to debug. By flushing before codegen, we display all the delayed bugs, making it easier to trace it to the root of the problem.

I tried this on #102366 and it showed tons of of delayed bugs and no error in cg_llvm, so it seems to be working.