### PR TITLE
rustdoc: remove redundant mobile `.source > .sidebar` CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1770,9 +1770,6 @@ in storage.js plus the media query with (min-width: 701px)
 	}
 
 	.rustdoc.source > .sidebar {
-		position: fixed;
-		margin: 0;
-		z-index: 11;
 		width: 0;
 	}
 


### PR DESCRIPTION
When the source sidebar and standard sidebar had most of their code merged in 07e3f998b1ceb4b8d2a7992782e60f5e776aa114, the properties `z-index: 11`, `margin: 0`, and `position: fixed` were already being set on the `.sidebar` class, so no need to repeat them.

https://github.com/rust-lang/rust/blob/57ee5cf5a93923dae9c98bffb11545fc3a31368d/src/librustdoc/html/static/css/rustdoc.css#L1742-L1754