### PR TITLE
Fix unwind drop glue for if-then scopes

### DIFF
--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -245,11 +245,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                                 OutsideGuard,
                                                 true,
                                             );
-                                            this.schedule_drop_for_binding(
-                                                node,
-                                                span,
-                                                OutsideGuard,
-                                            );
                                         },
                                     );
                                     this.ast_let_else(

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 this.source_info(then_expr.span)
                             };
                             let (then_block, else_block) =
-                                this.in_if_then_scope(condition_scope, |this| {
+                                this.in_if_then_scope(condition_scope, then_expr.span, |this| {
                                     let then_blk = unpack!(this.then_else_break(
                                         block,
                                         &this.thir[cond],
@@ -107,7 +107,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             ExprKind::Let { expr, ref pat } => {
                 let scope = this.local_scope();
-                let (true_block, false_block) = this.in_if_then_scope(scope, |this| {
+                let (true_block, false_block) = this.in_if_then_scope(scope, expr_span, |this| {
                     this.lower_let_expr(block, &this.thir[expr], pat, scope, None, expr_span)
                 });
 

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1986,7 +1986,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let mut guard_span = rustc_span::DUMMY_SP;
 
             let (post_guard_block, otherwise_post_guard_block) =
-                self.in_if_then_scope(match_scope, |this| match *guard {
+                self.in_if_then_scope(match_scope, guard_span, |this| match *guard {
                     Guard::If(e) => {
                         let e = &this.thir[e];
                         guard_span = e.span;
@@ -2301,7 +2301,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         pattern: &Pat<'tcx>,
     ) -> BlockAnd<BasicBlock> {
         let else_block_span = self.thir[else_block].span;
-        let (matching, failure) = self.in_if_then_scope(*let_else_scope, |this| {
+        let (matching, failure) = self.in_if_then_scope(*let_else_scope, else_block_span, |this| {
             let scrutinee = unpack!(block = this.lower_scrutinee(block, init, initializer_span));
             let pat = Pat { ty: init.ty, span: else_block_span, kind: PatKind::Wild };
             let mut wildcard = Candidate::new(scrutinee.clone(), &pat, false, this);

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -1023,7 +1023,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         cached_drop
     }
 
-    /// This is similar to [diverge_cleanup_target] except its target is set to
+    /// This is similar to [diverge_cleanup] except its target is set to
     /// some ancestor scope instead of the current scope.
     /// It is possible to unwind to some ancestor scope if some drop panics as
     /// the program breaks out of a if-then scope.

--- a/src/test/ui/let-else/issue-102317.rs
+++ b/src/test/ui/let-else/issue-102317.rs
@@ -1,5 +1,5 @@
 // issue #102317
-// run-pass
+// build-pass
 // compile-flags: --edition 2021 -C opt-level=3 -Zvalidate-mir
 
 struct SegmentJob;

--- a/src/test/ui/let-else/issue-102317.rs
+++ b/src/test/ui/let-else/issue-102317.rs
@@ -1,0 +1,20 @@
+// issue #102317
+// run-pass
+// compile-flags: --edition 2021 -C opt-level=3 -Zvalidate-mir
+
+struct SegmentJob;
+
+impl Drop for SegmentJob {
+    fn drop(&mut self) {}
+}
+
+pub async fn run() -> Result<(), ()> {
+    let jobs = Vec::<SegmentJob>::new();
+    let Some(_job) = jobs.into_iter().next() else {
+        return Ok(())
+    };
+
+    Ok(())
+}
+
+fn main() {}

--- a/src/test/ui/mir/issue-99852.rs
+++ b/src/test/ui/mir/issue-99852.rs
@@ -1,0 +1,24 @@
+// check-pass
+// compile-flags: -Z validate-mir
+#![feature(let_chains)]
+
+fn lambda<T, U>() -> U
+where
+    T: Default,
+    U: Default,
+{
+    let foo: Result<T, ()> = Ok(T::default());
+    let baz: U = U::default();
+
+    if let Ok(foo) = foo && let Ok(bar) = transform(foo) {
+        bar
+    } else {
+        baz
+    }
+}
+
+fn transform<T, U>(input: T) -> Result<U, ()> {
+    todo!()
+}
+
+fn main() {}


### PR DESCRIPTION
cc @est31

Fix #102317
Fix #99852

This PR fixes the drop glue for unwinding from a panic originated in a drop while breaking out for the else block in an `if-then` scope.
MIR validation does not fail for the synchronous versions of the test program, because `StorageDead` statements are skipped over in the unwinding process. It is only becoming a problem when it is inside a generator where `StorageDead` must be kept around.