### PR TITLE
The illumos linker does not support --strip-debug

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1034,13 +1034,33 @@ fn link_natively<'a>(
 
     if sess.target.is_like_osx {
         match (strip, crate_type) {
-            (Strip::Debuginfo, _) => strip_symbols_in_osx(sess, &out_filename, Some("-S")),
+            (Strip::Debuginfo, _) => {
+                strip_symbols_with_external_utility(sess, "strip", &out_filename, Some("-S"))
+            }
             // Per the manpage, `-x` is the maximum safe strip level for dynamic libraries. (#93988)
             (Strip::Symbols, CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro) => {
-                strip_symbols_in_osx(sess, &out_filename, Some("-x"))
+                strip_symbols_with_external_utility(sess, "strip", &out_filename, Some("-x"))
             }
-            (Strip::Symbols, _) => strip_symbols_in_osx(sess, &out_filename, None),
+            (Strip::Symbols, _) => {
+                strip_symbols_with_external_utility(sess, "strip", &out_filename, None)
+            }
             (Strip::None, _) => {}
+        }
+    }
+
+    if sess.target.os == "illumos" {
+        // Many illumos systems will have both the native 'strip' utility and
+        // the GNU one. Use the native version explicitly and do not rely on
+        // what's in the path.
+        let stripcmd = "/usr/bin/strip";
+        match strip {
+            // Always preserve the symbol table (-x).
+            Strip::Debuginfo => {
+                strip_symbols_with_external_utility(sess, stripcmd, &out_filename, Some("-x"))
+            }
+            // Strip::Symbols is handled via the --strip-all linker option.
+            Strip::Symbols => {}
+            Strip::None => {}
         }
     }
 
@@ -1055,8 +1075,13 @@ fn strip_value(sess: &Session) -> Strip {
     }
 }
 
-fn strip_symbols_in_osx<'a>(sess: &'a Session, out_filename: &Path, option: Option<&str>) {
-    let mut cmd = Command::new("strip");
+fn strip_symbols_with_external_utility<'a>(
+    sess: &'a Session,
+    util: &str,
+    out_filename: &Path,
+    option: Option<&str>,
+) {
+    let mut cmd = Command::new(util);
     if let Some(option) = option {
         cmd.arg(option);
     }
@@ -1067,14 +1092,14 @@ fn strip_symbols_in_osx<'a>(sess: &'a Session, out_filename: &Path, option: Opti
                 let mut output = prog.stderr.clone();
                 output.extend_from_slice(&prog.stdout);
                 sess.struct_warn(&format!(
-                    "stripping debug info with `strip` failed: {}",
-                    prog.status
+                    "stripping debug info with `{}` failed: {}",
+                    util, prog.status
                 ))
                 .note(&escape_string(&output))
                 .emit();
             }
         }
-        Err(e) => sess.fatal(&format!("unable to run `strip`: {}", e)),
+        Err(e) => sess.fatal(&format!("unable to run `{}`: {}", util, e)),
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -617,7 +617,13 @@ impl<'a> Linker for GccLinker<'a> {
         match strip {
             Strip::None => {}
             Strip::Debuginfo => {
-                self.linker_arg("--strip-debug");
+                // The illumos linker does not support --strip-debug although
+                // it does support --strip-all as a compatibility alias for -s.
+                // The --strip-debug case is handled by running an external
+                // `strip` utility as a separate step after linking.
+                if self.sess.target.os != "illumos" {
+                    self.linker_arg("--strip-debug");
+                }
             }
             Strip::Symbols => {
                 self.linker_arg("--strip-all");


### PR DESCRIPTION
When building and testing rust 1.64.0 on illumos, we saw a large number of failing tests associated with:

```
   = note: ld: fatal: unrecognized option '--strip-debug'
           ld: fatal: use the -z help option for usage information
           collect2: error: ld returned 1 exit status
```

The illumos linker does not support the `--strip-debug` option (although it does support `--strip-all`).