### PR TITLE
remove the unused :: between trait and type to give user correct diag…

### DIFF
--- a/src/test/ui/type/issue-101866.rs
+++ b/src/test/ui/type/issue-101866.rs
@@ -1,0 +1,15 @@
+trait TraitA<T> {
+    fn func();
+}
+
+struct StructA {}
+
+impl TraitA<i32> for StructA {
+    fn func() {}
+}
+
+fn main() {
+    TraitA::<i32>::func();
+    //~^ ERROR: cannot call associated function on trait without specifying the corresponding `impl` type [E0790]
+    //~| help: use the fully-qualified path to the only available implementation
+}

--- a/src/test/ui/type/issue-101866.stderr
+++ b/src/test/ui/type/issue-101866.stderr
@@ -1,0 +1,18 @@
+error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
+  --> $DIR/issue-101866.rs:12:5
+   |
+LL |     fn func();
+   |     ---------- `TraitA::func` defined here
+...
+LL |     TraitA::<i32>::func();
+   |     ^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |
+help: use the fully-qualified path to the only available implementation
+   |
+LL -     TraitA::<i32>::func();
+LL +     <::StructA as TraitA<i32>>::func();
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0790`.


### PR DESCRIPTION
…nostic information

	modified:   compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
	new file:   src/test/ui/type/issue-101866.rs
	new file:   src/test/ui/type/issue-101866.stderr