### PR TITLE
Don't export `__wasm_init_memory` on WebAssembly.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1180,18 +1180,12 @@ impl<'a> WasmLd<'a> {
         //   sharing memory and instantiating the module multiple times. As a
         //   result if it were exported then we'd just have no sharing.
         //
-        // * `--export=__wasm_init_memory` - when using `--passive-segments` the
-        //   linker will synthesize this function, and so we need to make sure
-        //   that our usage of `--export` below won't accidentally cause this
-        //   function to get deleted.
-        //
         // * `--export=*tls*` - when `#[thread_local]` symbols are used these
         //   symbols are how the TLS segments are initialized and configured.
         if sess.target_features.contains(&sym::atomics) {
             cmd.arg("--shared-memory");
             cmd.arg("--max-memory=1073741824");
             cmd.arg("--import-memory");
-            cmd.arg("--export=__wasm_init_memory");
             cmd.arg("--export=__wasm_init_tls");
             cmd.arg("--export=__tls_size");
             cmd.arg("--export=__tls_align");


### PR DESCRIPTION
Since #72889, the Rust wasm target doesn't use --passive-segments, so remove the `--export=__wasm_init_memory`.

As documented in the [tool-conventions Linking convention], `__wasm_init_memory` is not intended to be exported.

[tool-conventions Linking convention]: https://github.com/WebAssembly/tool-conventions/blob/7c064f304858f67ebf22964a84b7e9658e29557a/Linking.md#shared-memory-and-passive-segments