### PR TITLE
Add rust-lang CI environment check

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1294,7 +1294,7 @@ impl Config {
 
         // CI should always run stage 2 builds, unless it specifically states otherwise
         #[cfg(not(test))]
-        if flags.stage.is_none() && crate::CiEnv::current() != crate::CiEnv::None {
+        if flags.stage.is_none() && crate::CiEnv::is_rust_lang_ci() {
             match config.cmd {
                 Subcommand::Test { .. }
                 | Subcommand::Doc { .. }

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -264,6 +264,21 @@ impl CiEnv {
         Self::current() != CiEnv::None
     }
 
+    pub fn is_rust_lang_ci() -> bool {
+        if let Ok(rust_lang_ci) = env::var("RUST_LANG_CI") {
+            match rust_lang_ci.as_str() {
+                "1" | "true" | "yes" | "on" => true,
+                "0" | "false" | "no" | "off" => false,
+                other => {
+                    // Let's make sure typos don't go unnoticed
+                    panic!("Unrecognized option '{}' set in RUST_LANG_CI", other)
+                }
+            }
+        } else {
+            Self::is_ci()
+        }
+    }
+
     /// If in a CI environment, forces the command to run with colors.
     pub fn force_coloring_in_ci(self, cmd: &mut Command) {
         if self != CiEnv::None {


### PR DESCRIPTION
The current Rust bootstrap build scripts detect CI environments to enforce specific build options in the official rust-lang CI environment. The only problem is that it doesn't really distinguish between the official rust-lang CI environment, and just running in any CI environment. For my own Rust distribution built in GitHub Actions, I had to manually unset the GITHUB_ACTIONS environment variable as a temporary workaround. This pull request adds a new CiEnv::is_rust_lang_ci() check meant to detect when the scripts are executed from the official rust-lang CI environment.

To avoid undefining the GITHUB_ACTIONS environment variable, I added a check for the RUST_LANG_CI environment: if it is defined, it will override the result from CiEnv::is_rust_lang_ci(), if it is not defined, CiEnv::is_rust_lang_ci() will return true if it detects a CI environment. This should be sufficient to force-disable rust-lang CI specific checks in third-party CI environments, without affecting the current default behavior.