### PR TITLE
Tentatively #[inline] Option::from

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1973,6 +1973,7 @@ impl<T> const From<T> for Option<T> {
     ///
     /// assert_eq!(Some(67), o);
     /// ```
+    #[inline]
     fn from(val: T) -> Option<T> {
         Some(val)
     }


### PR DESCRIPTION
Probably not gonna have much of an impact because into can't be inlined. But let's try it?

(please perf run this whenever)