### PR TITLE
rustdoc: cut margin-top from first header in docblock

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -138,6 +138,13 @@ h1, h2, h3, h4 {
 .docblock h3, .docblock h4, h5, h6 {
 	margin: 15px 0 5px 0;
 }
+.docblock > h2:first-child,
+.docblock > h3:first-child,
+.docblock > h4:first-child,
+.docblock > h5:first-child,
+.docblock > h6:first-child {
+	margin-top: 0;
+}
 h1.fqn {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
Fixes a regression caused by 8846c0853d8687fda0e5f23f6687b03b243980ee, where a header's top margin used to be collapsed, but isn't any more.

## Before

![image](https://user-images.githubusercontent.com/1593513/192893092-8e158bf7-ae18-41ef-8f11-6f34c724d345.png)

## After

![image](https://user-images.githubusercontent.com/1593513/192893139-d6ee06bf-9c0b-4194-bd5d-636312c89367.png)
