### PR TITLE
Adding target_rustcflags to `compiletest` TargetCfg creation

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -385,7 +385,8 @@ impl Config {
     }
 
     fn target_cfg(&self) -> &TargetCfg {
-        self.target_cfg.borrow_with(|| TargetCfg::new(&self.rustc_path, &self.target))
+        self.target_cfg
+            .borrow_with(|| TargetCfg::new(&self.rustc_path, &self.target, &self.target_rustcflags))
     }
 
     pub fn matches_arch(&self, arch: &str) -> bool {
@@ -456,11 +457,12 @@ pub enum Endian {
 }
 
 impl TargetCfg {
-    fn new(rustc_path: &Path, target: &str) -> TargetCfg {
+    fn new(rustc_path: &Path, target: &str, target_rustcflags: &Option<String>) -> TargetCfg {
         let output = match Command::new(rustc_path)
             .arg("--print=cfg")
             .arg("--target")
             .arg(target)
+            .args(target_rustcflags.into_iter().map(|s| s.split_whitespace()).flatten())
             .output()
         {
             Ok(output) => output,


### PR DESCRIPTION
Adjustment to https://github.com/rust-lang/rust/pull/102134, ensures config returned by `rustc --target foo --print cfg` accurately reflects rustflags passed via `target_rustcflags`.

Fixes breaking change of not correctly handling `x.py test ... --test-args "--target-rustcflags -Cpanic=abort --target-rustcflags -Zpanic_abort_tests"`

cc @djkoloski 