### PR TITLE
rustdoc: remove bad CSS font-weight on `.impl`, `.method`, etc

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -187,7 +187,6 @@ h4.code-header {
 .impl-items .associatedtype,
 .methods .associatedtype {
 	flex-basis: 100%;
-	font-weight: 600;
 	position: relative;
 }
 

--- a/src/test/rustdoc-gui/anchor-navigable.goml
+++ b/src/test/rustdoc-gui/anchor-navigable.goml
@@ -7,5 +7,5 @@
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 // We check that ".item-info" is bigger than its content.
 move-cursor-to: ".impl"
-assert-property: (".impl > a.anchor", {"offsetWidth": "9"})
+assert-property: (".impl > a.anchor", {"offsetWidth": "8"})
 assert-css: (".impl > a.anchor", {"left": "-8px"})

--- a/src/test/rustdoc-gui/font-weight.goml
+++ b/src/test/rustdoc-gui/font-weight.goml
@@ -13,7 +13,7 @@ goto: file://|DOC_PATH|/test_docs/type.SomeType.html
 assert-css: (".top-doc .docblock p", {"font-weight": "400"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
-assert-css: (".impl-items .method", {"font-weight": "600"}, ALL)
+assert-css: (".impl-items .method > .code-header", {"font-weight": "600"}, ALL)
 
 goto: file://|DOC_PATH|/lib2/trait.Trait.html
 
@@ -41,4 +41,4 @@ assert-count: (".methods .associatedtype", 1)
 assert-css: (".methods .associatedtype", {"font-weight": "600"})
 assert-count: (".methods .constant", 1)
 assert-css: (".methods .constant", {"font-weight": "600"})
-assert-css: (".methods .method", {"font-weight": "600"})
+assert-css: (".methods .method > .code-header", {"font-weight": "600"})

--- a/src/test/rustdoc-gui/src-font-size.goml
+++ b/src/test/rustdoc-gui/src-font-size.goml
@@ -4,8 +4,8 @@
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 show-text: true
 // Check the impl headers.
-assert-css: (".impl.has-srclink .srclink", {"font-size": "16px"}, ALL)
-assert-css: (".impl.has-srclink .code-header", {"font-size": "18px"}, ALL)
+assert-css: (".impl.has-srclink .srclink", {"font-size": "16px", "font-weight": 400}, ALL)
+assert-css: (".impl.has-srclink .code-header", {"font-size": "18px", "font-weight": 600}, ALL)
 // Check the impl items.
-assert-css: (".impl-items .has-srclink .srclink", {"font-size": "16px"}, ALL)
-assert-css: (".impl-items .has-srclink .code-header", {"font-size": "16px"}, ALL)
+assert-css: (".impl-items .has-srclink .srclink", {"font-size": "16px", "font-weight": 400}, ALL)
+assert-css: (".impl-items .has-srclink .code-header", {"font-size": "16px", "font-weight": 600}, ALL)


### PR DESCRIPTION
This line was added in c494a06064017f307a8d9dc4797e614d2ed99143, because at the time, the headers had these classes on them. Now, the headers are children of the `<section>` with the class on it.

This commit also adds a test case, to make sure the srclink font weight does not regress again.