### PR TITLE
rustdoc: add method spacing to trait methods

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -716,7 +716,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
         document(&mut content, cx, m, Some(t), HeadingOffset::H5);
         let toggled = !content.is_empty();
         if toggled {
-            write!(w, "<details class=\"rustdoc-toggle\" open><summary>");
+            write!(w, "<details class=\"rustdoc-toggle method-toggle\" open><summary>");
         }
         write!(w, "<div id=\"{}\" class=\"method has-srclink\">", id);
         render_rightside(w, cx, m, t, RenderMode::Normal);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2011,7 +2011,8 @@ in storage.js plus the media query with (min-width: 701px)
 
 .method-toggle summary,
 .implementors-toggle summary,
-.impl {
+.impl,
+#implementors-list > .docblock {
 	margin-bottom: 0.75em;
 }
 

--- a/src/test/rustdoc/toggle-trait-fn.rs
+++ b/src/test/rustdoc/toggle-trait-fn.rs
@@ -4,12 +4,12 @@
 // summary. Trait methods with no documentation should not be wrapped.
 //
 // @has foo/trait.Foo.html
-// @has -  '//details[@class="rustdoc-toggle"]//summary//h4[@class="code-header"]' 'is_documented()'
-// @!has - '//details[@class="rustdoc-toggle"]//summary//h4[@class="code-header"]' 'not_documented()'
-// @has -  '//details[@class="rustdoc-toggle"]//*[@class="docblock"]' 'is_documented is documented'
-// @has -  '//details[@class="rustdoc-toggle"]//summary//h4[@class="code-header"]' 'is_documented_optional()'
-// @!has - '//details[@class="rustdoc-toggle"]//summary//h4[@class="code-header"]' 'not_documented_optional()'
-// @has -  '//details[@class="rustdoc-toggle"]//*[@class="docblock"]' 'is_documented_optional is documented'
+// @has -  '//details[@class="rustdoc-toggle method-toggle"]//summary//h4[@class="code-header"]' 'is_documented()'
+// @!has - '//details[@class="rustdoc-toggle method-toggle"]//summary//h4[@class="code-header"]' 'not_documented()'
+// @has -  '//details[@class="rustdoc-toggle method-toggle"]//*[@class="docblock"]' 'is_documented is documented'
+// @has -  '//details[@class="rustdoc-toggle method-toggle"]//summary//h4[@class="code-header"]' 'is_documented_optional()'
+// @!has - '//details[@class="rustdoc-toggle method-toggle"]//summary//h4[@class="code-header"]' 'not_documented_optional()'
+// @has -  '//details[@class="rustdoc-toggle method-toggle"]//*[@class="docblock"]' 'is_documented_optional is documented'
 pub trait Foo {
     fn not_documented();
 


### PR DESCRIPTION
More cleanup for 8846c0853d8687fda0e5f23f6687b03b243980ee, this time in trait layouts when things are collapsed.

This PR makes two changes to the appearance of trait pages:

* It adds the `method-toggle` class to method toggles on traits, making the DOM more consistent with type pages (which already have this class).

  ## Before

  ![image](https://user-images.githubusercontent.com/1593513/192914353-ed17e1eb-df1d-480b-9998-3b5e8283b0ee.png)

  ## After

  ![image](https://user-images.githubusercontent.com/1593513/192914570-bdd0f2e1-5254-4e2e-9576-a797b82b3b3b.png)
  
* It adds a bottom margin to docblocks nested directly in the implementors list, giving it a similar appearance to if it was nested within a toggle.

  ## Before

  ![image](https://user-images.githubusercontent.com/1593513/192914503-1c3f39d5-690f-44ec-8f11-385302477d04.png)

  ## After

  ![image](https://user-images.githubusercontent.com/1593513/192914702-cbce4b3b-5cc6-49dc-b7f8-73be9e76791c.png)
