### PR TITLE
Ignore `file://` links from linkchecker

### DIFF
--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -216,6 +216,7 @@ impl Checker {
                 || url.starts_with("irc:")
                 || url.starts_with("data:")
                 || url.starts_with("mailto:")
+                || url.starts_with("file:")
             {
                 report.links_ignored_external += 1;
                 return;


### PR DESCRIPTION
In Ferrocene some of the documentation can contain `file://` links when built locally, which trips linkchecker. This PR changes linkchecker to treat `file://` links as external URLs when performing the checks.