### PR TITLE
rustdoc: remove unneeded CSS `.rust-example-rendered { position }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1316,11 +1316,6 @@ h3.variant {
 	font-size: 1.25rem;
 }
 
-/* Example code has the "Run" button that needs to be positioned relative to the pre */
-pre.rust.rust-example-rendered {
-	position: relative;
-}
-
 pre.rust {
 	tab-size: 4;
 	-moz-tab-size: 4;


### PR DESCRIPTION
The Run button isn't inside the `<pre>` any more. It's instead nested below the example wrapper.

The class name can't be removed from the DOM, because `main.js` uses it.