### PR TITLE
Generate synthetic region from `impl` even in closure body within an associated fn

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -864,15 +864,13 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         };
 
         let tcx = self.infcx.tcx;
-        let body_parent_did = tcx.opt_parent(self.mir_def_id().to_def_id())?;
-        if tcx.parent(region.def_id) != body_parent_did
-            || tcx.def_kind(body_parent_did) != DefKind::Impl
-        {
+        let region_parent = tcx.parent(region.def_id);
+        if tcx.def_kind(region_parent) != DefKind::Impl {
             return None;
         }
 
         let mut found = false;
-        tcx.fold_regions(tcx.type_of(body_parent_did), |r: ty::Region<'tcx>, _| {
+        tcx.fold_regions(tcx.type_of(region_parent), |r: ty::Region<'tcx>, _| {
             if *r == ty::ReEarlyBound(region) {
                 found = true;
             }

--- a/src/test/ui/borrowck/issue-102209.rs
+++ b/src/test/ui/borrowck/issue-102209.rs
@@ -1,0 +1,28 @@
+use std::marker::PhantomData;
+
+pub struct NfaBuilder<'brand> {
+    brand: PhantomData<&'brand mut &'brand mut ()>,
+}
+
+impl NfaBuilder<'_> {
+    pub fn with<R, F: FnOnce(NfaBuilder<'_>) -> R>(f: F) -> R {
+        Brand::with(|brand| {
+            f(Self { brand: brand.lt })
+            //~^ ERROR lifetime may not live long enough
+            //~| ERROR lifetime may not live long enough
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Brand<'brand> {
+    lt: PhantomData<&'brand mut &'brand mut ()>,
+}
+
+impl Brand<'_> {
+    pub fn with<R, F: FnOnce(Brand<'_>) -> R>(f: F) -> R {
+        f(Self { lt: PhantomData })
+    }
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/issue-102209.stderr
+++ b/src/test/ui/borrowck/issue-102209.stderr
@@ -1,0 +1,22 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-102209.rs:10:29
+   |
+LL | impl NfaBuilder<'_> {
+   |                 -- lifetime `'2` appears in the `impl`'s self type
+LL |     pub fn with<R, F: FnOnce(NfaBuilder<'_>) -> R>(f: F) -> R {
+LL |         Brand::with(|brand| {
+   |                      ----- has type `Brand<'1>`
+LL |             f(Self { brand: brand.lt })
+   |                             ^^^^^^^^ this usage requires that `'1` must outlive `'2`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-102209.rs:10:29
+   |
+LL | impl NfaBuilder<'_> {
+   |                 -- lifetime `'1` appears in the `impl`'s self type
+...
+LL |             f(Self { brand: brand.lt })
+   |                             ^^^^^^^^ this usage requires that `'1` must outlive `'static`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #102209