### PR TITLE
Reinstate `hir-stats.rs` test for stage 1.

### DIFF
--- a/src/test/ui/stats/hir-stats.rs
+++ b/src/test/ui/stats/hir-stats.rs
@@ -1,7 +1,6 @@
 // check-pass
 // compile-flags: -Zhir-stats
 // only-x86_64
-// ignore-stage1
 
 // The aim here is to include at least one of every different type of top-level
 // AST/HIR node reported by `-Zhir-stats`.


### PR DESCRIPTION
It was disabled in #94075 for stage 1 because that PR changed type layouts such that the results for this test were different for stage 1 and stage 2. But now that #94075 is in beta, the results for this test are now the same for stage 1 and stage 2.

r? @lqd