### PR TITLE
Suggest `.into()` when all other coercion suggestions fail

### DIFF
--- a/src/test/ui/parser/expr-as-stmt-2.stderr
+++ b/src/test/ui/parser/expr-as-stmt-2.stderr
@@ -36,11 +36,6 @@ LL | /     &&
 LL | |     if let Some(y) = a { true } else { false }
    | |______________________________________________^ expected `bool`, found `&&bool`
    |
-help: consider removing the `&&`
-   |
-LL -     &&
-LL +     if let Some(y) = a { true } else { false }
-   |
 help: parentheses are required to parse this as an expression
    |
 LL |     (if let Some(x) = a { true } else { false })

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -170,11 +170,6 @@ LL | fn revenge_from_mars() -> bool {
 LL |     { true } && { true }
    |              ^^^^^^^^^^^ expected `bool`, found `&&bool`
    |
-help: consider removing the `&&`
-   |
-LL -     { true } && { true }
-LL +     { true } { true }
-   |
 help: parentheses are required to parse this as an expression
    |
 LL |     ({ true }) && { true }
@@ -201,10 +196,6 @@ LL |     { true } || { true }
    |
    = note: expected type `bool`
            found closure `[closure@$DIR/expr-as-stmt.rs:51:14: 51:16]`
-help: use parentheses to call this closure
-   |
-LL |     { true } (|| { true })()
-   |              +           +++
 help: parentheses are required to parse this as an expression
    |
 LL |     ({ true }) || { true }

--- a/src/test/ui/suggestions/boxed-variant-field.rs
+++ b/src/test/ui/suggestions/boxed-variant-field.rs
@@ -9,7 +9,6 @@ fn foo(x: Ty) -> Ty {
         Ty::List(elem) => foo(elem),
         //~^ ERROR mismatched types
         //~| HELP consider unboxing the value
-        //~| HELP try wrapping
     }
 }
 

--- a/src/test/ui/suggestions/boxed-variant-field.stderr
+++ b/src/test/ui/suggestions/boxed-variant-field.stderr
@@ -17,10 +17,6 @@ help: consider unboxing the value
    |
 LL |         Ty::List(elem) => foo(*elem),
    |                               +
-help: try wrapping the expression in `Ty::List`
-   |
-LL |         Ty::List(elem) => foo(Ty::List(elem)),
-   |                               +++++++++    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/into-convert.rs
+++ b/src/test/ui/suggestions/into-convert.rs
@@ -1,0 +1,26 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+
+fn main() {
+    let x: A = B;
+    //~^ ERROR mismatched types
+    //~| HELP call `Into::into` on this expression to convert `B` into `A`
+
+    let y: Arc<Path> = PathBuf::new();
+    //~^ ERROR mismatched types
+    //~| HELP call `Into::into` on this expression to convert `PathBuf` into `Arc<Path>`
+
+    let z: AtomicU32 = 1;
+    //~^ ERROR mismatched types
+    //~| HELP call `Into::into` on this expression to convert `{integer}` into `AtomicU32`
+}
+
+struct A;
+struct B;
+
+impl From<B> for A {
+    fn from(_: B) -> Self {
+        A
+    }
+}

--- a/src/test/ui/suggestions/into-convert.stderr
+++ b/src/test/ui/suggestions/into-convert.stderr
@@ -1,0 +1,44 @@
+error[E0308]: mismatched types
+  --> $DIR/into-convert.rs:6:16
+   |
+LL |     let x: A = B;
+   |            -   ^ expected struct `A`, found struct `B`
+   |            |
+   |            expected due to this
+   |
+help: call `Into::into` on this expression to convert `B` into `A`
+   |
+LL |     let x: A = B.into();
+   |                 +++++++
+
+error[E0308]: mismatched types
+  --> $DIR/into-convert.rs:10:24
+   |
+LL |     let y: Arc<Path> = PathBuf::new();
+   |            ---------   ^^^^^^^^^^^^^^ expected struct `Arc`, found struct `PathBuf`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Arc<Path>`
+              found struct `PathBuf`
+help: call `Into::into` on this expression to convert `PathBuf` into `Arc<Path>`
+   |
+LL |     let y: Arc<Path> = PathBuf::new().into();
+   |                                      +++++++
+
+error[E0308]: mismatched types
+  --> $DIR/into-convert.rs:14:24
+   |
+LL |     let z: AtomicU32 = 1;
+   |            ---------   ^ expected struct `AtomicU32`, found integer
+   |            |
+   |            expected due to this
+   |
+help: call `Into::into` on this expression to convert `{integer}` into `AtomicU32`
+   |
+LL |     let z: AtomicU32 = 1.into();
+   |                         +++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Also removes some bogus suggestions because we now short-circuit when offering coercion suggestions(instead of, for example, suggesting every one that could possibly apply)

Fixes #102415