### PR TITLE
Adjust the s390x data layout for LLVM 16

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -154,6 +154,11 @@ pub unsafe fn create_module<'ll>(
             target_data_layout = target_data_layout.replace("-p10:8:8-p20:8:8", "");
         }
     }
+    if llvm_version < (16, 0, 0) {
+        if sess.target.arch == "s390x" {
+            target_data_layout = target_data_layout.replace("-v128:64", "");
+        }
+    }
 
     // Ensure the data-layout values hardcoded remain the defaults.
     if sess.target.is_builtin {

--- a/compiler/rustc_target/src/spec/s390x_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/s390x_unknown_linux_gnu.rs
@@ -6,9 +6,9 @@ pub fn target() -> Target {
     base.endian = Endian::Big;
     // z10 is the oldest CPU supported by LLVM
     base.cpu = "z10".into();
-    // FIXME: The data_layout string below and the ABI implementation in
-    // cabi_s390x.rs are for now hard-coded to assume the no-vector ABI.
-    // Pass the -vector feature string to LLVM to respect this assumption.
+    // FIXME: The ABI implementation in cabi_s390x.rs is for now hard-coded to assume the no-vector
+    // ABI. Pass the -vector feature string to LLVM to respect this assumption. On LLVM < 16, we
+    // also strip v128 from the data_layout below to match the older LLVM's expectation.
     base.features = "-vector".into();
     base.max_atomic_width = Some(64);
     base.min_global_align = Some(16);
@@ -17,7 +17,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "s390x-unknown-linux-gnu".into(),
         pointer_width: 64,
-        data_layout: "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-a:8:16-n32:64".into(),
+        data_layout: "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64".into(),
         arch: "s390x".into(),
         options: base,
     }

--- a/compiler/rustc_target/src/spec/s390x_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/s390x_unknown_linux_musl.rs
@@ -6,9 +6,9 @@ pub fn target() -> Target {
     base.endian = Endian::Big;
     // z10 is the oldest CPU supported by LLVM
     base.cpu = "z10".into();
-    // FIXME: The data_layout string below and the ABI implementation in
-    // cabi_s390x.rs are for now hard-coded to assume the no-vector ABI.
-    // Pass the -vector feature string to LLVM to respect this assumption.
+    // FIXME: The ABI implementation in cabi_s390x.rs is for now hard-coded to assume the no-vector
+    // ABI. Pass the -vector feature string to LLVM to respect this assumption. On LLVM < 16, we
+    // also strip v128 from the data_layout below to match the older LLVM's expectation.
     base.features = "-vector".into();
     base.max_atomic_width = Some(64);
     base.min_global_align = Some(16);
@@ -18,7 +18,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "s390x-unknown-linux-musl".into(),
         pointer_width: 64,
-        data_layout: "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-a:8:16-n32:64".into(),
+        data_layout: "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64".into(),
         arch: "s390x".into(),
         options: base,
     }


### PR DESCRIPTION
LLVM [D131158] changed the SystemZ data layout to always set 64-bit
vector alignment, which used to be conditional on the "vector" feature.

[D131158]: https://reviews.llvm.org/D131158

r? @nikic 
