### PR TITLE
correct spans in parem_env to deduplicate errors

### DIFF
--- a/src/test/ui/associated-types/issue-102185.rs
+++ b/src/test/ui/associated-types/issue-102185.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
+fn f<T>(_: impl A<X = T>) {}
+                //~^ ERROR the trait bound `T: B` is not satisfied [E0277]
+trait A: C<Z = <<Self as A>::X as B>::Y> {
+    type X: B;
+}
+
+trait B {
+    type Y;
+}
+
+trait C {
+    type Z;
+}
+
+fn main() {}

--- a/src/test/ui/associated-types/issue-102185.stderr
+++ b/src/test/ui/associated-types/issue-102185.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `T: B` is not satisfied
+  --> $DIR/issue-102185.rs:3:17
+   |
+LL | fn f<T>(_: impl A<X = T>) {}
+   |                 ^^^^^^^^ the trait `B` is not implemented for `T`
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn f<T: B>(_: impl A<X = T>) {}
+   |       +++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This is part of the workaround for #102185.
`param_env` will set all spans to same when normalizing predictions, which is inconsistent with the behavior in typeck, causing the same error to appear twice, and cannot be deduplicated because the spans are different.
This PR has two commits. The first one is to optimize the calculation process of `param_env` to reduce the number of times to collect `Vec`s. The second is to use correct spans when normalize predictions of `Fn` items, so that errors generated is consistent with ones from typeck, so that they can be deduplicated.