### PR TITLE
rustdoc: remove no-op CSS `h3.variant, .sub-variant h4 { border-bottom: none }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1247,13 +1247,11 @@ h3.variant {
 	font-weight: 600;
 	font-size: 1.125rem;
 	margin-bottom: 10px;
-	border-bottom: none;
 }
 
 .sub-variant h4 {
 	font-size: 1rem;
 	font-weight: 400;
-	border-bottom: none;
 	margin-top: 0;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
This rule, added in 69df43b041f76251391f11264c1ff763ca2a64a0 to override the default `h4` style, has been obsoleted when a65c98fefb78cddee955b87214732b0de30a769f changed it so that only the top docblock put `border-bottom` on `h4.`