### PR TITLE
Improve error output for const delayed bug in rustdoc

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -555,6 +555,9 @@ impl Session {
     pub fn abort_if_errors(&self) {
         self.diagnostic().abort_if_errors();
     }
+    pub fn abort_if_errors_or_delayed_span_bugs(&self) {
+        self.diagnostic().abort_if_errors_or_delayed_span_bugs();
+    }
     pub fn compile_status(&self) -> Result<(), ErrorGuaranteed> {
         if let Some(reported) = self.diagnostic().has_errors_or_lint_errors() {
             let _ = self.diagnostic().emit_stashed_diagnostics();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -381,7 +381,9 @@ fn clean_hir_term<'tcx>(term: &hir::Term<'tcx>, cx: &mut DocContext<'tcx>) -> Te
         hir::Term::Ty(ty) => Term::Type(clean_ty(ty, cx)),
         hir::Term::Const(c) => {
             let def_id = cx.tcx.hir().local_def_id(c.hir_id);
-            Term::Constant(clean_middle_const(ty::Const::from_anon_const(cx.tcx, def_id), cx))
+            let ty = ty::Const::from_anon_const(cx.tcx, def_id);
+            cx.tcx.sess.abort_if_errors_or_delayed_span_bugs();
+            Term::Constant(clean_middle_const(ty, cx))
         }
     }
 }

--- a/src/test/rustdoc-ui/issue-102467.rs
+++ b/src/test/rustdoc-ui/issue-102467.rs
@@ -1,0 +1,17 @@
+// failure-status: 101
+//~^ ERROR
+
+#![feature(associated_const_equality)]
+#![feature(no_core)]
+
+#![no_core]
+#![crate_type = "lib"]
+
+trait T {
+    type A: S<C<X = 0i32> = 34>;
+    //~^ ERROR
+}
+
+trait S {
+    const C: i32;
+}

--- a/src/test/rustdoc-ui/issue-102467.stderr
+++ b/src/test/rustdoc-ui/issue-102467.stderr
@@ -1,0 +1,72 @@
+error: internal compiler error: no errors encountered even though `delay_span_bug` issued
+
+error: internal compiler error: unexpected const parent in type_of(): TypeBinding(TypeBinding { hir_id: HirId { owner: OwnerId { def_id: DefId(0:2 ~ issue_102467[9541]::T::A) }, local_id: 3 }, ident: X#0, gen_args: GenericArgs { args: [], bindings: [], parenthesized: false, span_ext: no-location (#0) }, kind: Equality { term: Const(AnonConst { hir_id: HirId { owner: OwnerId { def_id: DefId(0:2 ~ issue_102467[9541]::T::A) }, local_id: 1 }, body: BodyId { hir_id: HirId { owner: OwnerId { def_id: DefId(0:2 ~ issue_102467[9541]::T::A) }, local_id: 2 } } }) }, span: $DIR/issue-102467.rs:11:17: 11:25 (#0) })
+   |
+   = note: delayed at compiler/rustc_hir_analysis/src/collect/type_of.rs:456:23
+
+error: internal compiler error: Const::from_anon_const: couldn't lit_to_const TypeError
+  --> $DIR/issue-102467.rs:11:21
+   |
+LL |     type A: S<C<X = 0i32> = 34>;
+   |                     ^^^^
+   |
+   = note: delayed at compiler/rustc_middle/src/ty/consts.rs:122:30
+
+thread 'rustc' panicked at 'Box<dyn Any>', compiler/rustc_errors/src/lib.rs:1542:13
+stack backtrace:
+   0:     0x7fe93eb4f090 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h69c219382a706de4
+   1:     0x7fe93ebbc84e - core::fmt::write::hfaba6c7f5d324983
+   2:     0x7fe93eb1e6d5 - std::io::Write::write_fmt::he0f5763098f70719
+   3:     0x7fe93eb31e04 - std::panicking::default_hook::{{closure}}::hadd9f7be4096b7a1
+   4:     0x7fe93eb31a58 - std::panicking::default_hook::h7c40de63bd1ac842
+   5:     0x7fe93f2b8826 - rustc_driver[bf5b15a4efa2da32]::DEFAULT_HOOK::{closure#0}::{closure#0}
+   6:     0x7fe93eb325bd - std::panicking::rust_panic_with_hook::hd33806f1a523247b
+   7:     0x7fe941c437a3 - std[77418543e64ae431]::panicking::begin_panic::<rustc_errors[e621a6510cc517c5]::ExplicitBug>::{closure#0}
+   8:     0x7fe941c42cd6 - std[77418543e64ae431]::sys_common::backtrace::__rust_end_short_backtrace::<std[77418543e64ae431]::panicking::begin_panic<rustc_errors[e621a6510cc517c5]::ExplicitBug>::{closure#0}, !>
+   9:     0x7fe93f292496 - std[77418543e64ae431]::panicking::begin_panic::<rustc_errors[e621a6510cc517c5]::ExplicitBug>
+  10:     0x7fe941c38096 - std[77418543e64ae431]::panic::panic_any::<rustc_errors[e621a6510cc517c5]::ExplicitBug>
+  11:     0x7fe941c40579 - <rustc_errors[e621a6510cc517c5]::HandlerInner>::flush_delayed::<alloc[344271dbb998174e]::vec::Vec<rustc_errors[e621a6510cc517c5]::diagnostic::Diagnostic>, &str>
+  12:     0x7fe941c3eb6a - <rustc_errors[e621a6510cc517c5]::Handler>::abort_if_errors_or_delayed_span_bugs
+  13:     0x558045f8bf5e - rustdoc[3755b0600f342e0c]::clean::clean_generic_args
+  14:     0x558045f8be38 - rustdoc[3755b0600f342e0c]::clean::clean_generic_args
+  15:     0x55804608981d - <alloc[344271dbb998174e]::vec::Vec<rustdoc[3755b0600f342e0c]::clean::types::PathSegment> as alloc[344271dbb998174e]::vec::spec_from_iter::SpecFromIter<rustdoc[3755b0600f342e0c]::clean::types::PathSegment, core[d55ced6309a25c5f]::iter::adapters::map::Map<core[d55ced6309a25c5f]::slice::iter::Iter<rustc_hir[854dfe8484ba389]::hir::PathSegment>, rustdoc[3755b0600f342e0c]::clean::clean_path::{closure#0}>>>::from_iter
+  16:     0x558045f8583e - rustdoc[3755b0600f342e0c]::clean::clean_poly_trait_ref
+  17:     0x558045f80a0b - rustdoc[3755b0600f342e0c]::clean::clean_generic_bound
+  18:     0x55804608a6ae - <alloc[344271dbb998174e]::vec::Vec<rustdoc[3755b0600f342e0c]::clean::types::GenericBound> as alloc[344271dbb998174e]::vec::spec_from_iter::SpecFromIter<rustdoc[3755b0600f342e0c]::clean::types::GenericBound, core[d55ced6309a25c5f]::iter::adapters::filter_map::FilterMap<core[d55ced6309a25c5f]::slice::iter::Iter<rustc_hir[854dfe8484ba389]::hir::GenericBound>, rustdoc[3755b0600f342e0c]::clean::clean_maybe_renamed_item::{closure#1}::{closure#0}>>>::from_iter
+  19:     0x558045e8c364 - <rustdoc[3755b0600f342e0c]::core::DocContext>::with_param_env::<rustdoc[3755b0600f342e0c]::clean::types::Item, rustdoc[3755b0600f342e0c]::clean::clean_trait_item::{closure#0}>
+  20:     0x55804608f811 - <alloc[344271dbb998174e]::vec::Vec<rustdoc[3755b0600f342e0c]::clean::types::Item> as alloc[344271dbb998174e]::vec::spec_from_iter::SpecFromIter<rustdoc[3755b0600f342e0c]::clean::types::Item, core[d55ced6309a25c5f]::iter::adapters::map::Map<core[d55ced6309a25c5f]::slice::iter::Iter<rustc_hir[854dfe8484ba389]::hir::TraitItemRef>, rustdoc[3755b0600f342e0c]::clean::clean_maybe_renamed_item::{closure#1}::{closure#5}>>>::from_iter
+  21:     0x558045e8a197 - <rustdoc[3755b0600f342e0c]::core::DocContext>::with_param_env::<alloc[344271dbb998174e]::vec::Vec<rustdoc[3755b0600f342e0c]::clean::types::Item>, rustdoc[3755b0600f342e0c]::clean::clean_maybe_renamed_item::{closure#1}>
+  22:     0x558045f7effb - <&mut rustdoc[3755b0600f342e0c]::clean::clean_doc_module::{closure#2} as core[d55ced6309a25c5f]::ops::function::FnOnce<(&(&rustc_hir[854dfe8484ba389]::hir::Item, core[d55ced6309a25c5f]::option::Option<rustc_span[a05d955188b2abc7]::symbol::Symbol>),)>>::call_once
+  23:     0x55804608013a - <alloc[344271dbb998174e]::vec::Vec<rustdoc[3755b0600f342e0c]::clean::types::Item> as alloc[344271dbb998174e]::vec::spec_extend::SpecExtend<rustdoc[3755b0600f342e0c]::clean::types::Item, core[d55ced6309a25c5f]::iter::adapters::flatten::FlatMap<core[d55ced6309a25c5f]::slice::iter::Iter<(&rustc_hir[854dfe8484ba389]::hir::Item, core[d55ced6309a25c5f]::option::Option<rustc_span[a05d955188b2abc7]::symbol::Symbol>)>, alloc[344271dbb998174e]::vec::Vec<rustdoc[3755b0600f342e0c]::clean::types::Item>, rustdoc[3755b0600f342e0c]::clean::clean_doc_module::{closure#2}>>>::spec_extend
+  24:     0x558045f80640 - rustdoc[3755b0600f342e0c]::clean::clean_doc_module
+  25:     0x55804610f374 - rustdoc[3755b0600f342e0c]::clean::utils::krate
+  26:     0x558045fa2e44 - <rustc_session[605dacab06639d89]::session::Session>::time::<rustdoc[3755b0600f342e0c]::clean::types::Crate, rustdoc[3755b0600f342e0c]::core::run_global_ctxt::{closure#4}>
+  27:     0x558045e919c1 - rustdoc[3755b0600f342e0c]::core::run_global_ctxt
+  28:     0x558045fa326f - <rustc_session[605dacab06639d89]::session::Session>::time::<(rustdoc[3755b0600f342e0c]::clean::types::Crate, rustdoc[3755b0600f342e0c]::config::RenderOptions, rustdoc[3755b0600f342e0c]::formats::cache::Cache), rustdoc[3755b0600f342e0c]::main_options::{closure#0}::{closure#0}::{closure#1}::{closure#0}>
+  29:     0x558045ef9261 - <rustc_interface[158590035fe8886d]::passes::QueryContext>::enter::<rustdoc[3755b0600f342e0c]::main_options::{closure#0}::{closure#0}::{closure#1}, core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>>
+  30:     0x558045e4b36b - <rustc_interface[158590035fe8886d]::interface::Compiler>::enter::<rustdoc[3755b0600f342e0c]::main_options::{closure#0}::{closure#0}, core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>>
+  31:     0x5580460194b0 - rustc_span[a05d955188b2abc7]::with_source_map::<core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>, rustc_interface[158590035fe8886d]::interface::create_compiler_and_run<core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>, rustdoc[3755b0600f342e0c]::main_options::{closure#0}>::{closure#1}>
+  32:     0x558045e4f49e - rustc_interface[158590035fe8886d]::interface::create_compiler_and_run::<core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>, rustdoc[3755b0600f342e0c]::main_options::{closure#0}>
+  33:     0x558045e496e0 - rustdoc[3755b0600f342e0c]::main_options
+  34:     0x558045e4c93b - <scoped_tls[10d8a9c768e14d1c]::ScopedKey<rustc_span[a05d955188b2abc7]::SessionGlobals>>::set::<rustdoc[3755b0600f342e0c]::main_args::{closure#0}, core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>>
+  35:     0x558045fb8de0 - std[77418543e64ae431]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[158590035fe8886d]::util::run_in_thread_pool_with_globals<rustdoc[3755b0600f342e0c]::main_args::{closure#0}, core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>>::{closure#0}, core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>>
+  36:     0x558045e7e0ac - <<std[77418543e64ae431]::thread::Builder>::spawn_unchecked_<rustc_interface[158590035fe8886d]::util::run_in_thread_pool_with_globals<rustdoc[3755b0600f342e0c]::main_args::{closure#0}, core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>>::{closure#0}, core[d55ced6309a25c5f]::result::Result<(), rustc_errors[e621a6510cc517c5]::ErrorGuaranteed>>::{closure#1} as core[d55ced6309a25c5f]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  37:     0x7fe93eb0baf3 - std::sys::unix::thread::Thread::new::thread_start::heafa918dcc1208d8
+  38:     0x7fe93e7d1b43 - start_thread
+                               at ./nptl/./nptl/pthread_create.c:442:8
+  39:     0x7fe93e863a00 - clone3
+                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
+  40:                0x0 - <unknown>
+
+note: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md
+
+note: rustc 1.66.0-dev running on x86_64-unknown-linux-gnu
+
+note: compiler flags: -Z threads=1 -C codegen-units=1 -Z ui-testing -Z deduplicate-diagnostics=no -C strip=debuginfo -C debuginfo=0
+
+query stack during panic:
+end of query stack
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Part of #102467.

I'm not convinced it's an improvement but I'll let @matthiaskrgr decide if it's better for them or not.

cc @rust-lang/rustdoc 
r? @matthiaskrgr 