### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1425,7 +1425,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let mut spans_and_needs_box = vec![];
 
         match liberated_sig.output().kind() {
-            ty::Dynamic(predicates, _, _) => {
+            ty::Dynamic(predicates, _, ty::Dyn) => {
                 let cause = ObligationCause::misc(ret_ty.span, fn_hir_id);
                 let param_env = ty::ParamEnv::empty();
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1247,13 +1247,11 @@ h3.variant {
 	font-weight: 600;
 	font-size: 1.125rem;
 	margin-bottom: 10px;
-	border-bottom: none;
 }
 
 .sub-variant h4 {
 	font-size: 1rem;
 	font-weight: 400;
-	border-bottom: none;
 	margin-top: 0;
 	margin-bottom: 0;
 }

--- a/src/test/ui/stats/hir-stats.rs
+++ b/src/test/ui/stats/hir-stats.rs
@@ -1,7 +1,6 @@
 // check-pass
 // compile-flags: -Zhir-stats
 // only-x86_64
-// ignore-stage1
 
 // The aim here is to include at least one of every different type of top-level
 // AST/HIR node reported by `-Zhir-stats`.

--- a/src/test/ui/type/issue-101866.rs
+++ b/src/test/ui/type/issue-101866.rs
@@ -1,0 +1,15 @@
+trait TraitA<T> {
+    fn func();
+}
+
+struct StructA {}
+
+impl TraitA<i32> for StructA {
+    fn func() {}
+}
+
+fn main() {
+    TraitA::<i32>::func();
+    //~^ ERROR: cannot call associated function on trait without specifying the corresponding `impl` type [E0790]
+    //~| help: use the fully-qualified path to the only available implementation
+}

--- a/src/test/ui/type/issue-101866.stderr
+++ b/src/test/ui/type/issue-101866.stderr
@@ -1,0 +1,18 @@
+error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
+  --> $DIR/issue-101866.rs:12:5
+   |
+LL |     fn func();
+   |     ---------- `TraitA::func` defined here
+...
+LL |     TraitA::<i32>::func();
+   |     ^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |
+help: use the fully-qualified path to the only available implementation
+   |
+LL -     TraitA::<i32>::func();
+LL +     <::StructA as TraitA<i32>>::func();
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0790`.


### PR DESCRIPTION
Successful merges:

 - #102421 (remove the unused :: between trait and type to give user correct diag…)
 - #102495 (Reinstate `hir-stats.rs` test for stage 1.)
 - #102505 (rustdoc: remove no-op CSS `h3.variant, .sub-variant h4 { border-bottom: none }`)
 - #102506 (Specify `DynKind::Dyn`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102421,102495,102505,102506)
<!-- homu-ignore:end -->