### PR TITLE
rustdoc: remove weird `<a href="#">` wrapper around unsafe triangle

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -400,7 +400,7 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                         if myitem.fn_header(cx.tcx()).unwrap().unsafety
                             == hir::Unsafety::Unsafe =>
                     {
-                        "<a title=\"unsafe function\" href=\"#\"><sup>⚠</sup></a>"
+                        "<sup title=\"unsafe function\">⚠</sup>"
                     }
                     _ => "",
                 };

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -367,3 +367,7 @@ impl TypeWithNoDocblocks {
     pub fn first_fn(&self) {}
     pub fn second_fn(&self) {}
 }
+
+pub unsafe fn unsafe_fn() {}
+
+pub fn safe_fn() {}

--- a/src/test/rustdoc-gui/unsafe-fn.goml
+++ b/src/test/rustdoc-gui/unsafe-fn.goml
@@ -1,0 +1,37 @@
+goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
+
+compare-elements-property: (
+	"//a[@title='test_docs::safe_fn fn']/..",
+	"//a[@title='test_docs::unsafe_fn fn']/..",
+	["clientHeight"]
+)
+
+// If the text isn't displayed, the browser doesn't compute color style correctly...
+show-text: true
+
+// Set the theme to dark.
+local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+// We reload the page so the local storage settings are being used.
+reload:
+
+assert-css: (".item-left sup", {
+	"color": "rgb(221, 221, 221)"
+})
+
+// Set the theme to ayu.
+local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+// We reload the page so the local storage settings are being used.
+reload:
+
+assert-css: (".item-left sup", {
+	"color": "rgb(197, 197, 197)"
+})
+
+// Set the theme to light.
+local-storage: {"rustdoc-theme": "light", "rustdoc-preferred-dark-theme": "light", "rustdoc-use-system-theme": "false"}
+// We reload the page so the local storage settings are being used.
+reload:
+
+assert-css: (".item-left sup", {
+	"color": "rgb(0, 0, 0)"
+})


### PR DESCRIPTION
This DOM cleanup changes the color of the triangle, from blue to black, but since it's still a different color from the link it's next to, it should still be noticeable.

# Before

![image](https://user-images.githubusercontent.com/1593513/193352428-929b3026-acc3-448e-9bac-44dddf206b1d.png)

# After

![image](https://user-images.githubusercontent.com/1593513/193352500-2f7a0112-b478-4cc4-9ddb-32ba11575530.png)
