### PR TITLE
rustdoc: remove orphaned link on array bracket

### DIFF
--- a/src/test/rustdoc/array-links.link_box_generic.html
+++ b/src/test/rustdoc/array-links.link_box_generic.html
@@ -1,0 +1,1 @@
+<code>pub fn delta&lt;T&gt;() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;<a class="primitive" href="{{channel}}/core/primitive.array.html">[T; 1]</a>&gt;</code>

--- a/src/test/rustdoc/array-links.link_box_u32.html
+++ b/src/test/rustdoc/array-links.link_box_u32.html
@@ -1,0 +1,1 @@
+<code>pub fn gamma() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;[<a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a>; <a class="primitive" href="{{channel}}/core/primitive.array.html">1</a>]&gt;</code>

--- a/src/test/rustdoc/array-links.link_slice_generic.html
+++ b/src/test/rustdoc/array-links.link_slice_generic.html
@@ -1,0 +1,1 @@
+<code>pub fn beta&lt;T&gt;() -&gt; &amp;'static <a class="primitive" href="{{channel}}/core/primitive.array.html">[T; 1]</a></code>

--- a/src/test/rustdoc/array-links.link_slice_u32.html
+++ b/src/test/rustdoc/array-links.link_slice_u32.html
@@ -1,0 +1,1 @@
+<code>pub fn alpha() -&gt; &amp;'static [<a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a>; <a class="primitive" href="{{channel}}/core/primitive.array.html">1</a>]</code>

--- a/src/test/rustdoc/array-links.rs
+++ b/src/test/rustdoc/array-links.rs
@@ -1,0 +1,28 @@
+#![crate_name = "foo"]
+#![no_std]
+
+pub struct MyBox<T: ?Sized>(*const T);
+
+// @has 'foo/fn.alpha.html'
+// @snapshot link_slice_u32 - '//pre[@class="rust fn"]/code'
+pub fn alpha() -> &'static [u32; 1] {
+    loop {}
+}
+
+// @has 'foo/fn.beta.html'
+// @snapshot link_slice_generic - '//pre[@class="rust fn"]/code'
+pub fn beta<T>() -> &'static [T; 1] {
+    loop {}
+}
+
+// @has 'foo/fn.gamma.html'
+// @snapshot link_box_u32 - '//pre[@class="rust fn"]/code'
+pub fn gamma() -> MyBox<[u32; 1]> {
+    loop {}
+}
+
+// @has 'foo/fn.delta.html'
+// @snapshot link_box_generic - '//pre[@class="rust fn"]/code'
+pub fn delta<T>() -> MyBox<[T; 1]> {
+    loop {}
+}


### PR DESCRIPTION
This is #98069, but for arrays instead.

For non-generics, this retains links to the array page, but instead of trying to link it all, it only links the length part, which distinguishes arrays from slices.

For generics, the entire thing becomes a link, just like slices.

| Type | Before | After |
|--|--|--|
| u32 | <code>pub fn alpha() -&gt; &amp;'static <a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.array.html">[</a><a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.u32.html">u32</a><a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.array.html">; 1]</a></code> | <code>pub fn alpha() -&gt; &amp;'static [<a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.u32.html">u32</a>; <a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.array.html">1</a>]</code>
| generic | <code>pub fn beta&lt;T&gt;() -&gt; &amp;'static <a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.array.html">[</a>T<a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.array.html">; 1]</a></code> | <code>pub fn beta&lt;T&gt;() -&gt; &amp;'static <a class="primitive" href="http://doc.rust-lang.org/nightly/core/primitive.array.html">[T; 1]</a></code>