### PR TITLE
rustdoc: remove unused CSS selector `a.source`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -201,7 +201,6 @@ h4.code-header {
 h1, h2, h3, h4, h5, h6,
 .sidebar,
 .mobile-topbar,
-a.source,
 .search-input,
 .search-results .result-name,
 .item-left > a,


### PR DESCRIPTION
The link with this class attribute was removed in https://github.com/rust-lang/rust/commit/4d16de01d0beb84dc4a351022ea5cb587b4ab557#diff-3fe025bd3bd6b48044d0bd8d8c3122de5ecdb1dcd72a9dbe3c24430883595012L1281-R1324