### PR TITLE
Migrate CSS theme for search results

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -970,6 +970,11 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	padding-right: 1em;
 }
 
+.search-results a:hover,
+.search-results a:focus {
+	background-color: var(--search-result-link-focus-background-color);
+}
+
 .popover {
 	font-size: 1rem;
 	position: absolute;

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -37,6 +37,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--link-color: #39afd7;
 	--sidebar-link-color: #53b1db;
 	--sidebar-current-link-background-color: transparent;
+	--search-result-link-focus-background-color: #3c3c3c;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 }
@@ -249,30 +250,6 @@ pre.rust .kw {}
 #titles > button:hover, #titles > button.selected {}
 pre.rust .self, pre.rust .bool-val, pre.rust .prelude-val, pre.rust .attribute {}
 pre.rust .kw-2, pre.rust .prelude-ty {}
-
-.search-results a:focus span {}
-a.result-trait:focus {}
-a.result-traitalias:focus {}
-a.result-mod:focus,
-a.result-externcrate:focus {}
-a.result-mod:focus {}
-a.result-externcrate:focus {}
-a.result-enum:focus {}
-a.result-struct:focus {}
-a.result-union:focus {}
-a.result-fn:focus,
-a.result-method:focus,
-a.result-tymethod:focus {}
-a.result-type:focus {}
-a.result-associatedtype:focus {}
-a.result-foreigntype:focus {}
-a.result-attr:focus,
-a.result-derive:focus,
-a.result-macro:focus {}
-a.result-constant:focus,
-a.result-static:focus {}
-a.result-primitive:focus {}
-a.result-keyword:focus {}
 
 kbd {
 	color: #c5c5c5;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -32,6 +32,7 @@
 	--link-color: #d2991d;
 	--sidebar-link-color: #fdbf35;
 	--sidebar-current-link-background-color: #444;
+	--search-result-link-focus-background-color: #616161;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 }
@@ -57,36 +58,6 @@ input:focus + .slider {
 .src-line-numbers .line-highlighted {
 	background-color: #0a042f !important;
 }
-
-.search-results a:hover {
-	background-color: #777;
-}
-
-.search-results a:focus {
-	color: #eee !important;
-	background-color: #616161;
-}
-.search-results a:focus span { color: #eee !important; }
-a.result-trait:focus { background-color: #013191; }
-a.result-traitalias:focus { background-color: #013191; }
-a.result-mod:focus,
-a.result-externcrate:focus { background-color: #884719; }
-a.result-enum:focus { background-color: #194e9f; }
-a.result-struct:focus { background-color: #194e9f; }
-a.result-union:focus { background-color: #194e9f; }
-a.result-fn:focus,
-a.result-method:focus,
-a.result-tymethod:focus { background-color: #4950ed; }
-a.result-type:focus { background-color: #194e9f; }
-a.result-associatedtype:focus { background-color: #884719; }
-a.result-foreigntype:focus { background-color: #194e9f; }
-a.result-attr:focus,
-a.result-derive:focus,
-a.result-macro:focus { background-color: #217d1c; }
-a.result-constant:focus,
-a.result-static:focus { background-color: #884719; }
-a.result-primitive:focus { background-color: #194e9f; }
-a.result-keyword:focus { background-color: #884719; }
 
 .content .item-info::before { color: #ccc; }
 

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -32,6 +32,7 @@
 	--link-color: #3873ad;
 	--sidebar-link-color: #356da4;
 	--sidebar-current-link-background-color: #fff;
+	--search-result-link-focus-background-color: #ccc;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 }
@@ -56,36 +57,6 @@ input:focus + .slider {
 .src-line-numbers .line-highlighted {
 	background-color: #FDFFD3 !important;
 }
-
-.search-results a:hover {
-	background-color: #ddd;
-}
-
-.search-results a:focus {
-	color: #000 !important;
-	background-color: #ccc;
-}
-.search-results a:focus span { color: #000 !important; }
-a.result-trait:focus { background-color: #c7b6ff; }
-a.result-traitalias:focus { background-color: #c7b6ff; }
-a.result-mod:focus,
-a.result-externcrate:focus { background-color: #afc6e4; }
-a.result-enum:focus { background-color: #e7b1a0; }
-a.result-struct:focus { background-color: #e7b1a0; }
-a.result-union:focus { background-color: #e7b1a0; }
-a.result-fn:focus,
-a.result-method:focus,
-a.result-tymethod:focus { background-color: #c6afb3; }
-a.result-type:focus { background-color: #e7b1a0; }
-a.result-associatedtype:focus { background-color: #afc6e4; }
-a.result-foreigntype:focus { background-color: #e7b1a0; }
-a.result-attr:focus,
-a.result-derive:focus,
-a.result-macro:focus { background-color: #8ce488; }
-a.result-constant:focus,
-a.result-static:focus { background-color: #afc6e4; }
-a.result-primitive:focus { background-color: #e7b1a0; }
-a.result-keyword:focus { background-color: #afc6e4; }
 
 .content .item-info::before { color: #ccc; }
 

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -30,54 +30,243 @@ assert-css: (
 
 // Checking the color of "keyword".
 assert-css: (
-    ".result-name .keyword",
+    ".result-keyword .keyword",
     {"color": "rgb(57, 175, 215)"},
     ALL,
 )
+assert-css: (
+    ".result-keyword",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-keyword"
+assert-css: (
+    ".result-keyword:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-keyword:hover .keyword",
+    {"color": "rgb(57, 175, 215)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-keyword"
+assert-css: (
+    ".result-keyword:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-keyword:focus .keyword",
+    {"color": "rgb(57, 175, 215)"},
+)
+
 // Check the color of "struct".
 assert-css: (
-    ".result-name .struct",
+    ".result-struct .struct",
     {"color": "rgb(255, 160, 165)"},
     ALL,
 )
+assert-css: (
+    ".result-struct",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-struct"
+assert-css: (
+    ".result-struct:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-struct:hover .struct",
+    {"color": "rgb(255, 160, 165)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-struct"
+assert-css: (
+    ".result-struct:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-struct:focus .struct",
+    {"color": "rgb(255, 160, 165)"},
+)
+
 // Check the color of "associated type".
 assert-css: (
-    ".result-name .associatedtype",
+    ".result-associatedtype .associatedtype",
     {"color": "rgb(57, 175, 215)"},
     ALL,
 )
+assert-css: (
+    ".result-associatedtype",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-associatedtype"
+assert-css: (
+    ".result-associatedtype:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-associatedtype:hover .associatedtype",
+    {"color": "rgb(57, 175, 215)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-associatedtype"
+assert-css: (
+    ".result-associatedtype:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-associatedtype:focus .associatedtype",
+    {"color": "rgb(57, 175, 215)"},
+)
+
 // Check the color of "type method".
 assert-css: (
-    ".result-name .tymethod",
+    ".result-tymethod .tymethod",
     {"color": "rgb(253, 214, 135)"},
     ALL,
 )
+assert-css: (
+    ".result-tymethod",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+assert-css: (
+    ".result-tymethod .tymethod",
+    {"color": "rgb(253, 214, 135)"},
+)
+move-cursor-to: ".result-tymethod"
+assert-css: (
+    ".result-tymethod:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-tymethod"
+assert-css: (
+    ".result-tymethod:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+
 // Check the color of "method".
 assert-css: (
-    ".result-name .method",
+    ".result-method .method",
     {"color": "rgb(253, 214, 135)"},
     ALL,
 )
+assert-css: (
+    ".result-method",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-method"
+assert-css: (
+    ".result-method:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-method:hover .method",
+    {"color": "rgb(253, 214, 135)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-method"
+assert-css: (
+    ".result-method:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-method:focus .method",
+    {"color": "rgb(253, 214, 135)"},
+)
+
 // Check the color of "struct field".
 assert-css: (
-    ".result-name .structfield",
+    ".result-structfield .structfield",
     {"color": "rgb(0, 150, 207)"},
     ALL,
 )
+assert-css: (
+    ".result-structfield",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-structfield"
+assert-css: (
+    ".result-structfield:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-structfield:hover .structfield",
+    {"color": "rgb(255, 255, 255)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-structfield"
+assert-css: (
+    ".result-structfield:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-structfield:focus .structfield",
+    {"color": "rgb(255, 255, 255)"},
+)
+
 // Check the color of "macro".
 assert-css: (
-    ".result-name .macro",
+    ".result-macro .macro",
     {"color": "rgb(163, 122, 204)"},
     ALL,
 )
+assert-css: (
+    ".result-macro",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-macro"
+assert-css: (
+    ".result-macro:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-macro:hover .macro",
+    {"color": "rgb(163, 122, 204)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-macro"
+assert-css: (
+    ".result-macro:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-macro:focus .macro",
+    {"color": "rgb(163, 122, 204)"},
+)
+
 // Check the color of "fn".
 assert-css: (
-    ".result-name .fn",
+    ".result-fn .fn",
     {"color": "rgb(253, 214, 135)"},
     ALL,
 )
+assert-css: (
+    ".result-fn",
+    {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-fn"
+assert-css: (
+    ".result-fn:hover",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-fn:hover .fn",
+    {"color": "rgb(253, 214, 135)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-fn"
+assert-css: (
+    ".result-fn:focus",
+    {"color": "rgb(255, 255, 255)", "background-color": "rgb(60, 60, 60)"},
+)
+assert-css: (
+    ".result-fn:focus .fn",
+    {"color": "rgb(253, 214, 135)"},
+)
 
 // Checking the `<a>` container.
+move-cursor-to: ".search-input"
+focus: ".search-input" // To ensure the `<a>` container isnt focus or hover.
 assert-css: (
     "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
     {"color": "rgb(0, 150, 207)", "background-color": "rgba(0, 0, 0, 0)"},
@@ -113,7 +302,7 @@ assert-css: (
     {"color": "rgb(221, 221, 221)"},
 )
 
-// Checking the color for "keyword".
+// Checking the color for "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
     {"color": "rgb(221, 221, 221)"},
@@ -121,68 +310,250 @@ assert-css: (
 
 // Checking the color of "keyword".
 assert-css: (
-    ".result-name .keyword",
+    ".result-keyword .keyword",
     {"color": "rgb(210, 153, 29)"},
     ALL,
 )
+assert-css: (
+    ".result-keyword",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-keyword"
+assert-css: (
+    ".result-keyword:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-keyword:hover .keyword",
+    {"color": "rgb(210, 153, 29)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-keyword"
+assert-css: (
+    ".result-keyword:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-keyword:focus .keyword",
+    {"color": "rgb(210, 153, 29)"},
+)
+
 // Check the color of "struct".
 assert-css: (
-    ".result-name .struct",
+    ".result-struct .struct",
     {"color": "rgb(45, 191, 184)"},
     ALL,
 )
+assert-css: (
+    ".result-struct",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-struct"
+assert-css: (
+    ".result-struct:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-struct:hover .struct",
+    {"color": "rgb(45, 191, 184)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-struct"
+assert-css: (
+    ".result-struct:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-struct:focus .struct",
+    {"color": "rgb(45, 191, 184)"},
+)
+
 // Check the color of "associated type".
 assert-css: (
-    ".result-name .associatedtype",
+    ".result-associatedtype .associatedtype",
     {"color": "rgb(210, 153, 29)"},
     ALL,
 )
+assert-css: (
+    ".result-associatedtype",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-associatedtype"
+assert-css: (
+    ".result-associatedtype:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-associatedtype:hover .associatedtype",
+    {"color": "rgb(210, 153, 29)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-associatedtype"
+assert-css: (
+    ".result-associatedtype:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-associatedtype:focus .associatedtype",
+    {"color": "rgb(210, 153, 29)"},
+)
+
 // Check the color of "type method".
 assert-css: (
-    ".result-name .tymethod",
+    ".result-tymethod .tymethod",
     {"color": "rgb(43, 171, 99)"},
     ALL,
 )
+assert-css: (
+    ".result-tymethod",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-tymethod"
+assert-css: (
+    ".result-tymethod:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-tymethod:hover .tymethod",
+    {"color": "rgb(43, 171, 99)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-tymethod"
+assert-css: (
+    ".result-tymethod:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-tymethod:focus .tymethod",
+    {"color": "rgb(43, 171, 99)"},
+)
+
 // Check the color of "method".
 assert-css: (
-    ".result-name .method",
+    ".result-method .method",
     {"color": "rgb(43, 171, 99)"},
     ALL,
 )
+assert-css: (
+    ".result-method",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-method"
+assert-css: (
+    ".result-method:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-method:hover .method",
+    {"color": "rgb(43, 171, 99)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-method"
+assert-css: (
+    ".result-method:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-method:focus .method",
+    {"color": "rgb(43, 171, 99)"},
+)
+
 // Check the color of "struct field".
 assert-css: (
-    ".result-name .structfield",
+    ".result-structfield .structfield",
     {"color": "rgb(221, 221, 221)"},
     ALL,
 )
+assert-css: (
+    ".result-structfield",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-structfield"
+assert-css: (
+    ".result-structfield:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-structfield:hover .structfield",
+    {"color": "rgb(221, 221, 221)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-structfield"
+assert-css: (
+    ".result-structfield:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-structfield:focus .structfield",
+    {"color": "rgb(221, 221, 221)"},
+)
+
 // Check the color of "macro".
 assert-css: (
-    ".result-name .macro",
+    ".result-macro .macro",
     {"color": "rgb(9, 189, 0)"},
     ALL,
 )
+assert-css: (
+    ".result-macro",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-macro"
+assert-css: (
+    ".result-macro:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-macro:hover .macro",
+    {"color": "rgb(9, 189, 0)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-macro"
+assert-css: (
+    ".result-macro:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-macro:focus .macro",
+    {"color": "rgb(9, 189, 0)"},
+)
+
 // Check the color of "fn".
 assert-css: (
-    ".result-name .fn",
+    ".result-fn .fn",
     {"color": "rgb(43, 171, 99)"},
     ALL,
 )
+assert-css: (
+    ".result-fn",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-fn"
+assert-css: (
+    ".result-fn:hover",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-fn:hover .fn",
+    {"color": "rgb(43, 171, 99)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-fn"
+assert-css: (
+    ".result-fn:focus",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(97, 97, 97)"},
+)
+assert-css: (
+    ".result-fn:focus .fn",
+    {"color": "rgb(43, 171, 99)"},
+)
 
 // Checking the `<a>` container.
+move-cursor-to: ".search-input"
+focus: ".search-input" // To ensure the `<a>` container isnt focus or hover.
 assert-css: (
     "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
     {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
-)
-
-// Checking color and background on hover.
-move-cursor-to: "//*[@class='desc']//*[text()='Just a normal struct.']"
-assert-css: (
-    "//*[@class='result-name']/*[text()='test_docs::']",
-    {"color": "rgb(221, 221, 221)"},
-)
-assert-css: (
-    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
-    {"color": "rgb(221, 221, 221)", "background-color": "rgb(119, 119, 119)"},
 )
 
 // Light theme
@@ -200,7 +571,7 @@ assert-css: (
     {"color": "rgb(0, 0, 0)"},
 )
 
-// Checking the color for "keyword".
+// Checking the color for "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
     {"color": "rgb(0, 0, 0)"},
@@ -208,68 +579,250 @@ assert-css: (
 
 // Checking the color of "keyword".
 assert-css: (
-    ".result-name .keyword",
+    ".result-keyword .keyword",
     {"color": "rgb(56, 115, 173)"},
     ALL,
 )
+assert-css: (
+    ".result-keyword",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-keyword"
+assert-css: (
+    ".result-keyword:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-keyword:hover .keyword",
+    {"color": "rgb(56, 115, 173)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-keyword"
+assert-css: (
+    ".result-keyword:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-keyword:focus .keyword",
+    {"color": "rgb(56, 115, 173)"},
+)
+
 // Check the color of "struct".
 assert-css: (
-    ".result-name .struct",
+    ".result-struct .struct",
     {"color": "rgb(173, 55, 138)"},
     ALL,
 )
+assert-css: (
+    ".result-struct",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-struct"
+assert-css: (
+    ".result-struct:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-struct:hover .struct",
+    {"color": "rgb(173, 55, 138)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-struct"
+assert-css: (
+    ".result-struct:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-struct:focus .struct",
+    {"color": "rgb(173, 55, 138)"},
+)
+
 // Check the color of "associated type".
 assert-css: (
-    ".result-name .associatedtype",
+    ".result-associatedtype .associatedtype",
     {"color": "rgb(56, 115, 173)"},
     ALL,
 )
+assert-css: (
+    ".result-associatedtype",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-associatedtype"
+assert-css: (
+    ".result-associatedtype:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-associatedtype:hover .associatedtype",
+    {"color": "rgb(56, 115, 173)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-associatedtype"
+assert-css: (
+    ".result-associatedtype:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-associatedtype:focus .associatedtype",
+    {"color": "rgb(56, 115, 173)"},
+)
+
 // Check the color of "type method".
 assert-css: (
-    ".result-name .tymethod",
+    ".result-tymethod .tymethod",
     {"color": "rgb(173, 124, 55)"},
     ALL,
 )
+assert-css: (
+    ".result-tymethod",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-tymethod"
+assert-css: (
+    ".result-tymethod:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-tymethod:hover .tymethod",
+    {"color": "rgb(173, 124, 55)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-tymethod"
+assert-css: (
+    ".result-tymethod:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-tymethod:focus .tymethod",
+    {"color": "rgb(173, 124, 55)"},
+)
+
 // Check the color of "method".
 assert-css: (
-    ".result-name .method",
+    ".result-method .method",
     {"color": "rgb(173, 124, 55)"},
     ALL,
 )
+assert-css: (
+    ".result-method",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-method"
+assert-css: (
+    ".result-method:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-method:hover .method",
+    {"color": "rgb(173, 124, 55)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-method"
+assert-css: (
+    ".result-method:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-method:focus .method",
+    {"color": "rgb(173, 124, 55)"},
+)
+
 // Check the color of "struct field".
 assert-css: (
-    ".result-name .structfield",
+    ".result-structfield .structfield",
     {"color": "rgb(0, 0, 0)"},
     ALL,
 )
+assert-css: (
+    ".result-structfield",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-structfield"
+assert-css: (
+    ".result-structfield:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-structfield:hover .structfield",
+    {"color": "rgb(0, 0, 0)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-structfield"
+assert-css: (
+    ".result-structfield:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-structfield:focus .structfield",
+    {"color": "rgb(0, 0, 0)"},
+)
+
 // Check the color of "macro".
 assert-css: (
-    ".result-name .macro",
+    ".result-macro .macro",
     {"color": "rgb(6, 128, 0)"},
     ALL,
 )
+assert-css: (
+    ".result-macro",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-macro"
+assert-css: (
+    ".result-macro:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-macro:hover .macro",
+    {"color": "rgb(6, 128, 0)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-macro"
+assert-css: (
+    ".result-macro:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-macro:focus .macro",
+    {"color": "rgb(6, 128, 0)"},
+)
+
 // Check the color of "fn".
 assert-css: (
-    ".result-name .fn",
+    ".result-fn .fn",
     {"color": "rgb(173, 124, 55)"},
     ALL,
 )
+assert-css: (
+    ".result-fn",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+)
+move-cursor-to: ".result-fn"
+assert-css: (
+    ".result-fn:hover",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-fn:hover .fn",
+    {"color": "rgb(173, 124, 55)"},
+)
+move-cursor-to: ".search-input"
+focus: ".result-fn"
+assert-css: (
+    ".result-fn:focus",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(204, 204, 204)"},
+)
+assert-css: (
+    ".result-fn:focus .fn",
+    {"color": "rgb(173, 124, 55)"},
+)
 
 // Checking the `<a>` container.
+move-cursor-to: ".search-input"
+focus: ".search-input" // To ensure the `<a>` container isnt focus or hover.
 assert-css: (
     "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
     {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
-)
-
-// Checking color and background on hover.
-move-cursor-to: "//*[@class='desc']//*[text()='Just a normal struct.']"
-assert-css: (
-    "//*[@class='result-name']/*[text()='test_docs::']",
-    {"color": "rgb(0, 0, 0)"},
-)
-assert-css: (
-    "//*[@class='result-name']/*[text()='test_docs::']/ancestor::a",
-    {"color": "rgb(0, 0, 0)", "background-color": "rgb(221, 221, 221)"},
 )
 
 // Check the alias more specifically in the dark theme.


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/pull/98460.

Just like https://github.com/rust-lang/rust/pull/102237, I unified theme to how the `ayu` handles this one: only one color for the background when search results are focused or hovered.

You can test it [here](https://rustdoc.crud.net/imperio/migrate-css-theme-search-result/lib2/index.html?search=coo).

cc @jsha 
r? @notriddle 

PS: The repetition in GUI tests is getting out of hand so I opened https://github.com/GuillaumeGomez/browser-UI-test/issues/363 to think about adding possibility to declare functions so we can greatly improve this.