### PR TITLE
rustdoc: remove no-op CSS on `.impl, .method` etc

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -184,17 +184,6 @@ h4.code-header {
 	margin: 0;
 	padding: 0;
 }
-.impl,
-.impl-items .method,
-.methods .method,
-.impl-items .type,
-.methods .type,
-.impl-items .associatedconstant,
-.methods .associatedconstant,
-.impl-items .associatedtype,
-.methods .associatedtype {
-	position: relative;
-}
 
 #crate-search,
 h1, h2, h3, h4, h5, h6,

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -193,7 +193,6 @@ h4.code-header {
 .methods .associatedconstant,
 .impl-items .associatedtype,
 .methods .associatedtype {
-	flex-basis: 100%;
 	position: relative;
 }
 


### PR DESCRIPTION
Preview: http://notriddle.com/notriddle-rustdoc-demos/impl/index.html

# `flex-basis: 100%`

When `.impl-items { flex-basis: 100% }` and `h3.impl, h3.method, h4.method, h3.type, h4.type, h4.associatedconstant` were added in https://github.com/rust-lang/rust/commit/34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9, it seems like it was a mistake even then. According to MDN, [flex-basis] does nothing unless the box it's applied to is a flex *item*, a child of a flex container. However, when this was added, these elements were flex containers themselves.

[flex-basis]: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis

# `position: relative`

This property was added to help with positioning the `[+]/[-]` toggle. It is no longer necessary, because `details.rustdoc-toggle` already has `position:relative` set on it.