### PR TITLE
Mark Vec::drop() as #[inline]

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2913,6 +2913,7 @@ impl<T: Ord, A: Allocator> Ord for Vec<T, A> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {
+    #[inline]
     fn drop(&mut self) {
         unsafe {
             // use drop for [T]


### PR DESCRIPTION
As seen in https://github.com/rust-lang/rust/issues/102539#issuecomment-1264398807, `Vec::drop()` is commonly a no-op, if the underlying type does not need drop. Checking to see what the impact of this would be, I'm not sure the change can be done in this form (an alternative would be to do a needs_drop check and only instantiate that part in each CGU).

r? @ghost