### PR TITLE
fix issue with x.py setup running into explicit panic

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -654,8 +654,6 @@ impl Build {
             job::setup(self);
         }
 
-        // Download rustfmt early so that it can be used in rust-analyzer configs.
-        let _ = &builder::Builder::new(&self).initial_rustfmt();
         self.maybe_update_submodules();
 
         if let Subcommand::Format { check, paths } = &self.config.cmd {
@@ -669,6 +667,9 @@ impl Build {
         if let Subcommand::Setup { profile } = &self.config.cmd {
             return setup::setup(&self.config, *profile);
         }
+
+        // Download rustfmt early so that it can be used in rust-analyzer configs.
+        let _ = &builder::Builder::new(&self).initial_rustfmt();
 
         {
             let builder = builder::Builder::new(&self);


### PR DESCRIPTION
Fixes problem with [Issue #102555](https://github.com/rust-lang/rust/issues/102555) causing `x.py` setup to fail. Simply requires `rustfmt` be downloaded a little later.