### PR TITLE
Don't ICE when trying to copy unsized value in const prop

### DIFF
--- a/src/test/ui/const_prop/issue-102553.rs
+++ b/src/test/ui/const_prop/issue-102553.rs
@@ -1,0 +1,24 @@
+// compile-flags: --crate-type=lib
+// check-pass
+
+pub trait Widget<E> {
+    fn boxed<'w>(self) -> Box<dyn WidgetDyn<E> + 'w>
+    where
+        Self: Sized + 'w;
+}
+
+pub trait WidgetDyn<E> {}
+
+impl<T, E> WidgetDyn<E> for T where T: Widget<E> {}
+
+impl<E> Widget<E> for dyn WidgetDyn<E> + '_ {
+    fn boxed<'w>(self) -> Box<dyn WidgetDyn<E> + 'w>
+    where
+        Self: Sized + 'w,
+    {
+        // Even though this is illegal to const evaluate, this should never
+        // trigger an ICE because it can never be called from actual code
+        // (due to the trivially false where-clause predicate).
+        Box::new(self)
+    }
+}


### PR DESCRIPTION
When we have a trivially false where-clause predicate like `Self: Sized` where `Self = dyn Trait`, we sometimes don't throw an error during typeck for an illegal operation such as copying an unsized type. 

This, unfortunately, cannot be made into an error (at least not without some migration -- see #95611 for example), but we should at least not ICE, since this function will never actually be reachable from main, for example.

r? @RalfJung since I think you added these assertions? but feel free to reassign.

Fixes #102553