### PR TITLE
Refactor build-manifest to minimize the number of changes needed to add a new component

### DIFF
--- a/src/tools/build-manifest/README.md
+++ b/src/tools/build-manifest/README.md
@@ -1,7 +1,16 @@
 # build-manifest
 
-This tool generates the manifests uploaded to static.rust-lang.org and used by
-rustup. The tool is invoked by the bootstrap tool.
+This tool generates the manifests uploaded to static.rust-lang.org and used by rustup.
+You can see a full list of all manifests at <https://static.rust-lang.org/manifests.txt>.
+
+This gets called by `promote-release` <https://github.com/rust-lang/promote-release> via `x.py dist hash-and-sign`.
+
+## Adding a new component
+
+There are several steps involved here.
+1. Add a new `Step` to `dist.rs`. This should usually be named after the filename of the uploaded tarball. See https://github.com/rust-lang/rust/pull/101799/files#diff-2c56335faa24486df09ba392d8900c57e2fac4633e1f7038469bcf9ed3feb871 for an example.
+    a. If appropriate, call `tarball.is_preview(true)` for the component.
+3. Add a new `PkgType` to build-manifest. Fix all the compile errors as appropriate.
 
 ## Testing changes locally
 
@@ -9,19 +18,16 @@ In order to test the changes locally you need to have a valid dist directory
 available locally. If you don't want to build all the compiler, you can easily
 create one from the nightly artifacts with:
 
-```
-#!/bin/bash
-for cmpn in rust rustc rust-std rust-docs cargo; do
-    wget https://static.rust-lang.org/dist/${cmpn}-nightly-x86_64-unknown-linux-gnu.tar.gz
+```sh
+for component in rust rustc rust-std rust-docs cargo; do
+    wget -P build/dist https://static.rust-lang.org/dist/${component}-nightly-x86_64-unknown-linux-gnu.tar.gz
 done
 ```
 
-Then, you can generate the manifest and all the packages from `path/to/dist` to
-`path/to/output` with:
+Then, you can generate the manifest and all the packages from `build/dist` to
+`build/manifest` with:
 
+```sh
+mkdir -p build/manifest
+cargo +nightly run -p build-manifest build/dist build/manifest 1970-01-01 http://example.com nightly
 ```
-$ cargo +nightly run path/to/dist path/to/output 1970-01-01 http://example.com CHANNEL
-```
-
-Remember to replace `CHANNEL` with the channel you produced dist artifacts of
-and `VERSION` with the current Rust version.

--- a/src/tools/build-manifest/README.md
+++ b/src/tools/build-manifest/README.md
@@ -8,10 +8,9 @@ This gets called by `promote-release` <https://github.com/rust-lang/promote-rele
 
 ## Adding a new component
 
-There are several steps involved here.
 1. Add a new `Step` to `dist.rs`. This should usually be named after the filename of the uploaded tarball. See https://github.com/rust-lang/rust/pull/101799/files#diff-2c56335faa24486df09ba392d8900c57e2fac4633e1f7038469bcf9ed3feb871 for an example.
     a. If appropriate, call `tarball.is_preview(true)` for the component.
-3. Add a new `PkgType` to build-manifest. Fix all the compile errors as appropriate.
+2. Add a new `PkgType` to build-manifest. Fix all the compile errors as appropriate.
 
 ## Testing changes locally
 
@@ -30,5 +29,5 @@ Then, you can generate the manifest and all the packages from `build/dist` to
 
 ```sh
 mkdir -p build/manifest
-cargo +nightly run -p build-manifest build/dist build/manifest 1970-01-01 http://example.com nightly
+cargo +nightly run --release -p build-manifest build/dist build/manifest 1970-01-01 http://example.com nightly
 ```

--- a/src/tools/build-manifest/README.md
+++ b/src/tools/build-manifest/README.md
@@ -2,6 +2,7 @@
 
 This tool generates the manifests uploaded to static.rust-lang.org and used by rustup.
 You can see a full list of all manifests at <https://static.rust-lang.org/manifests.txt>.
+This listing is updated by <https://github.com/rust-lang/generate-manifest-list> every 7 days.
 
 This gets called by `promote-release` <https://github.com/rust-lang/promote-release> via `x.py dist hash-and-sign`.
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -365,12 +365,11 @@ impl Builder {
         let mut rename = |from: &str, to: &str| {
             manifest.renames.insert(from.to_owned(), Rename { to: to.to_owned() })
         };
-        rename("rls", "rls-preview");
-        rename("rustfmt", "rustfmt-preview");
-        rename("clippy", "clippy-preview");
-        rename("miri", "miri-preview");
-        rename("rust-docs-json", "rust-docs-json-preview");
-        rename("rust-analyzer", "rust-analyzer-preview");
+        for pkg in PkgType::all() {
+            if pkg.is_preview() {
+                rename(pkg.tarball_component_name(), &pkg.manifest_component_name());
+            }
+        }
     }
 
     fn rust_package(&mut self, manifest: &Manifest) -> Package {

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -284,8 +284,7 @@ impl Builder {
 
     fn add_packages_to(&mut self, manifest: &mut Manifest) {
         for pkg in PkgType::all() {
-            let fallback = if pkg.use_docs_fallback() { DOCS_FALLBACK } else { &[] };
-            self.package(pkg, &mut manifest.pkg, fallback);
+            self.package(pkg, &mut manifest.pkg);
         }
     }
 
@@ -471,18 +470,14 @@ impl Builder {
             .extend(pkgs.iter().map(|s| s.manifest_component_name()));
     }
 
-    fn package(
-        &mut self,
-        pkg: &PkgType,
-        dst: &mut BTreeMap<String, Package>,
-        fallback: &[(&str, &str)],
-    ) {
+    fn package(&mut self, pkg: &PkgType, dst: &mut BTreeMap<String, Package>) {
         if *pkg == PkgType::Rust {
             // This is handled specially by `rust_package` later.
             // Order is important, so don't call `rust_package` here.
             return;
         }
 
+        let fallback = if pkg.use_docs_fallback() { DOCS_FALLBACK } else { &[] };
         let version_info = self.versions.version(&pkg).expect("failed to load package version");
         let mut is_present = version_info.present;
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -1,8 +1,4 @@
-//! Build a dist manifest, hash and sign everything.
-//! This gets called by `promote-release`
-//! (https://github.com/rust-lang/rust-central-station/tree/master/promote-release)
-//! via `x.py dist hash-and-sign`; the cmdline arguments are set up
-//! by rustbuild (in `src/bootstrap/dist.rs`).
+#![doc = include_str!("../README.md")]
 
 mod checksum;
 mod manifest;

--- a/src/tools/build-manifest/src/manifest.rs
+++ b/src/tools/build-manifest/src/manifest.rs
@@ -1,3 +1,4 @@
+use crate::versions::PkgType;
 use crate::Builder;
 use serde::{Serialize, Serializer};
 use std::collections::BTreeMap;
@@ -116,8 +117,8 @@ pub(crate) struct Component {
 }
 
 impl Component {
-    pub(crate) fn from_str(pkg: &str, target: &str) -> Self {
-        Self { pkg: pkg.to_string(), target: target.to_string() }
+    pub(crate) fn from_pkg(pkg: &PkgType, target: &str) -> Self {
+        Self { pkg: pkg.manifest_component_name(), target: target.to_string() }
     }
 }
 

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -39,7 +39,6 @@ macro_rules! pkg_type {
                 }
             }
 
-            /// Component name in the manifest. In particular, this includes the `-preview` suffix where appropriate.
             pub(crate) fn all() -> &'static [PkgType] {
                 &[ $(PkgType::$variant),+ ]
             }
@@ -69,7 +68,7 @@ pkg_type! {
 }
 
 impl PkgType {
-    // / Component name in the manifest. In particular, this includes the `-preview` suffix where appropriate.
+    /// Component name in the manifest. In particular, this includes the `-preview` suffix where appropriate.
     pub(crate) fn manifest_component_name(&self) -> String {
         if self.is_preview() {
             format!("{}-preview", self.tarball_component_name())

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -13,7 +13,6 @@ macro_rules! pkg_type {
         #[derive(Debug, Hash, Eq, PartialEq, Clone)]
         pub(crate) enum PkgType {
             $($variant,)+
-            Other(String),
         }
 
         impl PkgType {
@@ -24,18 +23,10 @@ macro_rules! pkg_type {
                 }
             }
 
-            pub(crate) fn from_component(component: &str) -> Self {
-                match component {
-                    $( $component  $( | concat!($($is_preview)? $component, "-preview") )? => PkgType::$variant,)+
-                    _ => PkgType::Other(component.into()),
-                }
-            }
-
             /// First part of the tarball name.
             pub(crate) fn tarball_component_name(&self) -> &str {
                 match self {
                     $( PkgType::$variant => $component,)+
-                    PkgType::Other(component) => component,
                 }
             }
 
@@ -100,7 +91,6 @@ impl PkgType {
             PkgType::ReproducibleArtifacts => true,
             PkgType::RustMingw => true,
             PkgType::RustAnalysis => true,
-            PkgType::Other(_) => true,
         }
     }
 
@@ -127,7 +117,6 @@ impl PkgType {
             Rustfmt => HOSTS,
             RustAnalysis => TARGETS,
             LlvmTools => TARGETS,
-            Other(pkg) => panic!("add {pkg} to the list of known `PkgType`s"),
         }
     }
 

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -17,7 +17,7 @@ macro_rules! pkg_type {
         }
 
         impl PkgType {
-            fn is_preview(&self) -> bool {
+            pub(crate) fn is_preview(&self) -> bool {
                 match self {
                     $( $( $($is_preview)? PkgType::$variant => true, )? )+
                     _ => false,
@@ -32,7 +32,7 @@ macro_rules! pkg_type {
             }
 
             /// First part of the tarball name.
-            fn tarball_component_name(&self) -> &str {
+            pub(crate) fn tarball_component_name(&self) -> &str {
                 match self {
                     $( PkgType::$variant => $component,)+
                     PkgType::Other(component) => component,


### PR DESCRIPTION
- Add all components to `PkgType`
- Automate functionality wherever possible, so functions often don't have to be manually edited
- Where that's not possible, use exhaustive matches on `PkgType` instead of adding individual strings.
- Add documentation for how to add a component. Improve the existing documentation for how to test changes.

I tested locally that this generates an identical manifest before and after my change, as follows:
```sh
git checkout d44e14225ab00e164aa9ea9e8d9e1bee40f96b3e
cargo +nightly run --manifest-path src/tools/build-manifest/Cargo.toml build/dist build/manifest-before 1970-01-01 http://example.com nightly
git checkout refactor-build-manifest
cargo +nightly run --manifest-path src/tools/build-manifest/Cargo.toml build/dist build/manifest-before 1970-01-01 http://example.com nightly
sort -u build/manifest-before/channel-rust-nightly.toml | diff - <(sort -u build/manifest-after/channel-rust-nightly.toml)
```
I then verified by hand that the differences before sorting are inconsequential (mostly targets being slightly reordered).

The only change in behavior is that `llvm-tools` is now properly renamed to `llvm-tools-preview`:
```
; sort -u build/manifest-before/channel-rust-nightly.toml | diff - <(sort -u build/manifest-after/channel-rust-nightly.toml)
784a785
> [renames.llvm-tools]
894a896
> to = "llvm-tools-preview"
```

This is based on https://github.com/rust-lang/rust/pull/102241 and should not be merged before.