### PR TITLE
Delay evaluating lint primary message until after it would be suppressed

### DIFF
--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -354,7 +354,6 @@ pub fn struct_lint_level<'s, 'd>(
             (Level::Deny | Level::Forbid, None) => sess.diagnostic().struct_err_lint(""),
         };
 
-        err.set_primary_message(msg);
         err.set_is_lint();
 
         // If this code originates in a foreign macro, aka something that this crate
@@ -378,6 +377,10 @@ pub fn struct_lint_level<'s, 'd>(
                 return;
             }
         }
+
+        // Delay evaluating and setting the primary message until after we've
+        // suppressed the lint due to macros.
+        err.set_primary_message(msg);
 
         // Lint diagnostics that are covered by the expect level will not be emitted outside
         // the compiler. It is therefore not necessary to add any information for the user.

--- a/src/test/ui/lint/auxiliary/trivial-cast-ice.rs
+++ b/src/test/ui/lint/auxiliary/trivial-cast-ice.rs
@@ -1,0 +1,7 @@
+#[macro_export]
+macro_rules! foo {
+    () => {
+        let x: &Option<i32> = &Some(1);
+        let _y = x as *const Option<i32>;
+    }
+}

--- a/src/test/ui/lint/trivial-cast-ice.rs
+++ b/src/test/ui/lint/trivial-cast-ice.rs
@@ -1,0 +1,12 @@
+// aux-build:trivial-cast-ice.rs
+// check-pass
+
+// Demonstrates the ICE in #102561
+
+#![deny(trivial_casts)]
+
+extern crate trivial_cast_ice;
+
+fn main() {
+    trivial_cast_ice::foo!();
+}


### PR DESCRIPTION
Fixes #102561
Fixes #102572