### PR TITLE
Warn about Visual Studio Code branding confusion

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -979,9 +979,10 @@ fn link_natively<'a>(
                      but `link.exe` was not found",
                 );
                 sess.note_without_error(
-                    "please ensure that VS 2013, VS 2015, VS 2017, VS 2019 or VS 2022 \
-                     was installed with the Visual C++ option",
+                    "please ensure that Visual Studio 2017 or later, or Build Tools \
+                     for Visual Studio were installed with the Visual C++ option.",
                 );
+                sess.note_without_error("VS Code is a different product, and is not sufficient.");
             }
             sess.abort_if_errors();
         }


### PR DESCRIPTION
VS Code is a popular companion for Rust, but Microsoft's branding is confusing, and users [may not understand](https://users.rust-lang.org/t/complie-error-when-i-run-rustc/82127) they also need the *other* VS.
