### PR TITLE
rustc: Use `unix_sigpipe` instead of `rustc_driver::set_sigpipe_handler`

### DIFF
--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(unix_sigpipe)]
+
 // A note about jemalloc: rustc uses jemalloc when built for CI and
 // distribution. The obvious way to do this is with the `#[global_allocator]`
 // mechanism. However, for complicated reasons (see
@@ -23,6 +25,7 @@
 // libraries. So we must reference jemalloc symbols one way or another, because
 // this file is the only object code in the rustc executable.
 
+#[unix_sigpipe = "sig_dfl"]
 fn main() {
     // See the comment at the top of this file for an explanation of this.
     #[cfg(feature = "jemalloc-sys")]
@@ -58,6 +61,5 @@ fn main() {
         }
     }
 
-    rustc_driver::set_sigpipe_handler();
     rustc_driver::main()
 }


### PR DESCRIPTION
This is the first (known) step towards starting to use `unix_sigpipe` in the wild. Eventually, `rustc_driver::set_sigpipe_handler` can be removed and all clients can use `unix_sigpipe` instead.

For now we just start using `unix_sigpipe` in one place: `rustc` itself.

It is easy to manually verify this change. If you remove `#[unix_sigpipe = "sig_dfl"]` and run `./x.py build` you will get an ICE when you do `./build/x86_64-unknown-linux-gnu/stage1/bin/rustc --help | false`. Add back `#[unix_sigpipe = "sig_dfl"]` and the ICE disappears again.

PR that added `set_sigpipe_handler`: https://github.com/rust-lang/rust/pull/49606


Tracking issue for `unix_sigpipe`: #97889

Not sure exactly how to label this PR. Going with T-libs for now since this is a T-libs feature.

@rustdoc labels +T-libs