### PR TITLE
[perf test] Turn the `UnusedBrokenConst` lint into a no-op.

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1551,7 +1551,7 @@ declare_lint_pass!(
 );
 
 impl<'tcx> LateLintPass<'tcx> for UnusedBrokenConst {
-    fn check_item(&mut self, cx: &LateContext<'_>, it: &hir::Item<'_>) {
+    /*fn check_item(&mut self, cx: &LateContext<'_>, it: &hir::Item<'_>) {
         match it.kind {
             hir::ItemKind::Const(_, body_id) => {
                 let def_id = cx.tcx.hir().body_owner_def_id(body_id).to_def_id();
@@ -1564,7 +1564,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedBrokenConst {
             }
             _ => {}
         }
-    }
+    }*/
 }
 
 declare_lint! {


### PR DESCRIPTION
It's still traversing the HIR, just not doing anything.

This is a performance test to see the cost of doing these const evaluations. See also #102420 which does likewise for all lints.

r? @DutchGhost 
