### PR TITLE
re-add git-commit-hash file to tarballs

### DIFF
--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -150,3 +150,8 @@ pub fn write_commit_info_file(root: &Path, info: &Info) {
     let commit_info = format!("{}\n{}\n{}\n", info.sha, info.short_sha, info.commit_date);
     t!(fs::write(root.join("git-commit-info"), &commit_info));
 }
+
+/// Write the commit hash to the `git-commit-hash` file given the project root.
+pub fn write_commit_hash_file(root: &Path, sha: &str) {
+    t!(fs::write(root.join("git-commit-hash"), sha));
+}

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -920,6 +920,7 @@ impl Step for PlainSourceTarball {
         // Create the version file
         builder.create(&plain_dst_src.join("version"), &builder.rust_version());
         if let Some(info) = builder.rust_info.info() {
+            channel::write_commit_hash_file(&plain_dst_src, &info.sha);
             channel::write_commit_info_file(&plain_dst_src, info);
         }
 

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -299,6 +299,7 @@ impl<'a> Tarball<'a> {
         t!(std::fs::create_dir_all(&self.overlay_dir));
         self.builder.create(&self.overlay_dir.join("version"), &self.overlay.version(self.builder));
         if let Some(info) = self.builder.rust_info.info() {
+            channel::write_commit_hash_file(&self.overlay_dir, &info.sha);
             channel::write_commit_info_file(&self.overlay_dir, info);
         }
         for file in self.overlay.legal_and_readme() {


### PR DESCRIPTION
rust-lang/rust#100557 removed the `git-commit-hash` file and replaced it with `git-commit-info`. However, build-manifest relies on the `git-commit-hash` file being present, so this adds it back.

r? @Mark-Simulacrum