### PR TITLE
Migrate `codegen_ssa` to diagnostics structs - [Part 1]

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -362,10 +362,7 @@ fn link_rlib<'a>(
                 continue;
             }
             ab.add_archive(&location, Box::new(|_| false)).unwrap_or_else(|error| {
-                sess.emit_fatal(errors::AddNativeLibrary {
-                    library_path: &location.to_string_lossy(),
-                    error,
-                });
+                sess.emit_fatal(errors::AddNativeLibrary { library_path: location, error });
             });
         }
     }
@@ -381,10 +378,7 @@ fn link_rlib<'a>(
         );
 
         ab.add_archive(&output_path, Box::new(|_| false)).unwrap_or_else(|error| {
-            sess.emit_fatal(errors::AddNativeLibrary {
-                library_path: &output_path.display().to_string(),
-                error,
-            });
+            sess.emit_fatal(errors::AddNativeLibrary { library_path: output_path, error });
         });
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -31,7 +31,9 @@ use super::command::Command;
 use super::linker::{self, Linker};
 use super::metadata::{create_rmeta_file, MetadataPosition};
 use super::rpath::{self, RPathConfig};
-use crate::{looks_like_rust_object_file, CodegenResults, CompiledModule, CrateInfo, NativeLib};
+use crate::{
+    errors, looks_like_rust_object_file, CodegenResults, CompiledModule, CrateInfo, NativeLib,
+};
 
 use cc::windows_registry;
 use regex::Regex;
@@ -93,7 +95,7 @@ pub fn link_binary<'a>(
             let tmpdir = TempFileBuilder::new()
                 .prefix("rustc")
                 .tempdir()
-                .unwrap_or_else(|err| sess.fatal(&format!("couldn't create a temp dir: {}", err)));
+                .unwrap_or_else(|error| sess.emit_fatal(errors::CreateTempDir { error }));
             let path = MaybeTempDir::new(tmpdir, sess.opts.cg.save_temps);
             let out_filename = out_filename(
                 sess,
@@ -208,7 +210,7 @@ pub fn link_binary<'a>(
 pub fn each_linked_rlib(
     info: &CrateInfo,
     f: &mut dyn FnMut(CrateNum, &Path),
-) -> Result<(), String> {
+) -> Result<(), errors::LinkRlibError> {
     let crates = info.used_crates.iter();
     let mut fmts = None;
     for (ty, list) in info.dependency_formats.iter() {
@@ -224,26 +226,23 @@ pub fn each_linked_rlib(
         }
     }
     let Some(fmts) = fmts else {
-        return Err("could not find formats for rlibs".to_string());
+        return Err(errors::LinkRlibError::MissingFormat);
     };
     for &cnum in crates {
         match fmts.get(cnum.as_usize() - 1) {
             Some(&Linkage::NotLinked | &Linkage::IncludedFromDylib) => continue,
             Some(_) => {}
-            None => return Err("could not find formats for rlibs".to_string()),
+            None => return Err(errors::LinkRlibError::MissingFormat),
         }
-        let name = info.crate_name[&cnum];
+        let crate_name = info.crate_name[&cnum];
         let used_crate_source = &info.used_crate_source[&cnum];
         if let Some((path, _)) = &used_crate_source.rlib {
             f(cnum, &path);
         } else {
             if used_crate_source.rmeta.is_some() {
-                return Err(format!(
-                    "could not find rlib for: `{}`, found rmeta (metadata) file",
-                    name
-                ));
+                return Err(errors::LinkRlibError::OnlyRmetaFound { crate_name });
             } else {
-                return Err(format!("could not find rlib for: `{}`", name));
+                return Err(errors::LinkRlibError::NotFound { crate_name });
             }
         }
     }
@@ -340,10 +339,7 @@ fn link_rlib<'a>(
                 // -whole-archive and it isn't clear how we can currently handle such a
                 // situation correctly.
                 // See https://github.com/rust-lang/rust/issues/88085#issuecomment-901050897
-                sess.err(
-                    "the linking modifiers `+bundle` and `+whole-archive` are not compatible \
-                        with each other when generating rlibs",
-                );
+                sess.emit_err(errors::IncompatibleLinkingModifiers);
             }
             NativeLibKind::Static { bundle: None | Some(true), .. } => {}
             NativeLibKind::Static { bundle: Some(false), .. }
@@ -365,12 +361,11 @@ fn link_rlib<'a>(
                 ));
                 continue;
             }
-            ab.add_archive(&location, Box::new(|_| false)).unwrap_or_else(|e| {
-                sess.fatal(&format!(
-                    "failed to add native library {}: {}",
-                    location.to_string_lossy(),
-                    e
-                ));
+            ab.add_archive(&location, Box::new(|_| false)).unwrap_or_else(|error| {
+                sess.emit_fatal(errors::AddNativeLibrary {
+                    library_path: &location.to_string_lossy(),
+                    error,
+                });
             });
         }
     }
@@ -385,8 +380,11 @@ fn link_rlib<'a>(
             tmpdir.as_ref(),
         );
 
-        ab.add_archive(&output_path, Box::new(|_| false)).unwrap_or_else(|e| {
-            sess.fatal(&format!("failed to add native library {}: {}", output_path.display(), e));
+        ab.add_archive(&output_path, Box::new(|_| false)).unwrap_or_else(|error| {
+            sess.emit_fatal(errors::AddNativeLibrary {
+                library_path: &output_path.display().to_string(),
+                error,
+            });
         });
     }
 
@@ -451,14 +449,11 @@ fn collate_raw_dylibs(
                     // FIXME: when we add support for ordinals, figure out if we need to do anything
                     // if we have two DllImport values with the same name but different ordinals.
                     if import.calling_convention != old_import.calling_convention {
-                        sess.span_err(
-                            import.span,
-                            &format!(
-                                "multiple declarations of external function `{}` from \
-                                 library `{}` have different calling conventions",
-                                import.name, name,
-                            ),
-                        );
+                        sess.emit_err(errors::MultipleExternalFuncDecl {
+                            span: import.span,
+                            function: import.name,
+                            library_name: &name,
+                        });
                     }
                 }
             }
@@ -560,7 +555,7 @@ fn link_staticlib<'a>(
         all_native_libs.extend(codegen_results.crate_info.native_libraries[&cnum].iter().cloned());
     });
     if let Err(e) = res {
-        sess.fatal(&e);
+        sess.emit_fatal(e);
     }
 
     ab.build(out_filename);
@@ -673,9 +668,8 @@ fn link_dwarf_object<'a>(
     }) {
         Ok(()) => {}
         Err(e) => {
-            sess.struct_err("linking dwarf objects with thorin failed")
-                .note(&format!("{:?}", e))
-                .emit();
+            let thorin_error = errors::ThorinErrorWrapper(e);
+            sess.emit_err(errors::ThorinDwarfLinking { thorin_error });
             sess.abort_if_errors();
         }
     }
@@ -879,23 +873,14 @@ fn link_natively<'a>(
                 let mut output = prog.stderr.clone();
                 output.extend_from_slice(&prog.stdout);
                 let escaped_output = escape_string(&output);
-                let mut err = sess.struct_err(&format!(
-                    "linking with `{}` failed: {}",
-                    linker_path.display(),
-                    prog.status
-                ));
-                err.note(&format!("{:?}", &cmd)).note(&escaped_output);
-                if escaped_output.contains("undefined reference to") {
-                    err.help(
-                        "some `extern` functions couldn't be found; some native libraries may \
-                         need to be installed or have their path specified",
-                    );
-                    err.note("use the `-l` flag to specify native libraries to link");
-                    err.note("use the `cargo:rustc-link-lib` directive to specify the native \
-                              libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)");
-                }
-                err.emit();
-
+                // FIXME: Add UI tests for this error.
+                let err = errors::LinkingFailed {
+                    linker_path: &linker_path,
+                    exit_status: prog.status,
+                    command: &cmd,
+                    escaped_output: &escaped_output,
+                };
+                sess.diagnostic().emit_err(err);
                 // If MSVC's `link.exe` was expected but the return code
                 // is not a Microsoft LNK error then suggest a way to fix or
                 // install the Visual Studio build tools.

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -662,8 +662,7 @@ fn link_dwarf_object<'a>(
     }) {
         Ok(()) => {}
         Err(e) => {
-            let thorin_error = errors::ThorinErrorWrapper(e);
-            sess.emit_err(errors::ThorinDwarfLinking { thorin_error });
+            sess.emit_err(errors::ThorinErrorWrapper(e));
             sess.abort_if_errors();
         }
     }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -666,8 +666,8 @@ impl<'a> Linker for GccLinker<'a> {
                     writeln!(f, "_{}", sym)?;
                 }
             };
-            if let Err(e) = res {
-                self.sess.emit_fatal(LibDefWriteFailure { error_description: format!("{e}") });
+            if let Err(error) = res {
+                self.sess.emit_fatal(LibDefWriteFailure { error });
             }
         } else if is_windows {
             let res: io::Result<()> = try {
@@ -681,8 +681,8 @@ impl<'a> Linker for GccLinker<'a> {
                     writeln!(f, "  {}", symbol)?;
                 }
             };
-            if let Err(e) = res {
-                self.sess.emit_fatal(LibDefWriteFailure { error_description: format!("{e}") });
+            if let Err(error) = res {
+                self.sess.emit_fatal(LibDefWriteFailure { error });
             }
         } else {
             // Write an LD version script
@@ -972,8 +972,8 @@ impl<'a> Linker for MsvcLinker<'a> {
                 writeln!(f, "  {}", symbol)?;
             }
         };
-        if let Err(e) = res {
-            self.sess.emit_fatal(LibDefWriteFailure { error_description: format!("{e}") });
+        if let Err(error) = res {
+            self.sess.emit_fatal(LibDefWriteFailure { error });
         }
         let mut arg = OsString::from("/DEF:");
         arg.push(path);

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1,6 +1,6 @@
 use super::command::Command;
 use super::symbol_export;
-use crate::errors::LibDefWriteFailure;
+use crate::errors;
 use rustc_span::symbol::sym;
 
 use std::ffi::{OsStr, OsString};
@@ -91,13 +91,13 @@ pub fn get_linker<'a>(
                     arg.push(format!("{}\\lib\\{}\\store", root_lib_path.display(), a));
                     cmd.arg(&arg);
                 } else {
-                    warn!("arch is not supported");
+                    sess.emit_warning(errors::UnsupportedArch);
                 }
             } else {
-                warn!("MSVC root path lib location not found");
+                sess.emit_warning(errors::MsvcPathNotFound);
             }
         } else {
-            warn!("link.exe not found");
+            sess.emit_warning(errors::LinkExeNotFound);
         }
     }
 
@@ -435,11 +435,11 @@ impl<'a> Linker for GccLinker<'a> {
                 // FIXME(81490): ld64 doesn't support these flags but macOS 11
                 // has -needed-l{} / -needed_library {}
                 // but we have no way to detect that here.
-                self.sess.warn("`as-needed` modifier not implemented yet for ld64");
+                self.sess.emit_warning(errors::Ld64UnimplementedModifier);
             } else if self.is_gnu && !self.sess.target.is_like_windows {
                 self.linker_arg("--no-as-needed");
             } else {
-                self.sess.warn("`as-needed` modifier not supported for current linker");
+                self.sess.emit_warning(errors::LinkerUnsupportedModifier);
             }
         }
         self.hint_dynamic();
@@ -493,7 +493,7 @@ impl<'a> Linker for GccLinker<'a> {
             // FIXME(81490): ld64 as of macOS 11 supports the -needed_framework
             // flag but we have no way to detect that here.
             // self.cmd.arg("-needed_framework").arg(framework);
-            self.sess.warn("`as-needed` modifier not implemented yet for ld64");
+            self.sess.emit_warning(errors::Ld64UnimplementedModifier);
         }
         self.cmd.arg("-framework").arg(framework);
     }
@@ -667,7 +667,7 @@ impl<'a> Linker for GccLinker<'a> {
                 }
             };
             if let Err(error) = res {
-                self.sess.emit_fatal(LibDefWriteFailure { error });
+                self.sess.emit_fatal(errors::LibDefWriteFailure { error });
             }
         } else if is_windows {
             let res: io::Result<()> = try {
@@ -682,7 +682,7 @@ impl<'a> Linker for GccLinker<'a> {
                 }
             };
             if let Err(error) = res {
-                self.sess.emit_fatal(LibDefWriteFailure { error });
+                self.sess.emit_fatal(errors::LibDefWriteFailure { error });
             }
         } else {
             // Write an LD version script
@@ -698,8 +698,8 @@ impl<'a> Linker for GccLinker<'a> {
                 }
                 writeln!(f, "\n  local:\n    *;\n}};")?;
             };
-            if let Err(e) = res {
-                self.sess.fatal(&format!("failed to write version script: {}", e));
+            if let Err(error) = res {
+                self.sess.emit_fatal(errors::VersionScriptWriteFailure { error });
             }
         }
 
@@ -916,9 +916,8 @@ impl<'a> Linker for MsvcLinker<'a> {
                                     self.cmd.arg(arg);
                                 }
                             }
-                            Err(err) => {
-                                self.sess
-                                    .warn(&format!("error enumerating natvis directory: {}", err));
+                            Err(error) => {
+                                self.sess.emit_warning(errors::NoNatvisDirectory { error });
                             }
                         }
                     }
@@ -973,7 +972,7 @@ impl<'a> Linker for MsvcLinker<'a> {
             }
         };
         if let Err(error) = res {
-            self.sess.emit_fatal(LibDefWriteFailure { error });
+            self.sess.emit_fatal(errors::LibDefWriteFailure { error });
         }
         let mut arg = OsString::from("/DEF:");
         arg.push(path);
@@ -1436,7 +1435,7 @@ impl<'a> Linker for L4Bender<'a> {
 
     fn export_symbols(&mut self, _: &Path, _: CrateType, _: &[String]) {
         // ToDo, not implemented, copy from GCC
-        self.sess.warn("exporting symbols not implemented yet for L4Bender");
+        self.sess.emit_warning(errors::L4BenderExportingSymbolsUnimplemented);
         return;
     }
 
@@ -1728,8 +1727,8 @@ impl<'a> Linker for BpfLinker<'a> {
                 writeln!(f, "{}", sym)?;
             }
         };
-        if let Err(e) = res {
-            self.sess.fatal(&format!("failed to write symbols file: {}", e));
+        if let Err(error) = res {
+            self.sess.emit_fatal(errors::SymbolFileWriteFailure { error });
         } else {
             self.cmd.arg("--export-symbols").arg(&path);
         }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -91,13 +91,13 @@ pub fn get_linker<'a>(
                     arg.push(format!("{}\\lib\\{}\\store", root_lib_path.display(), a));
                     cmd.arg(&arg);
                 } else {
-                    sess.emit_warning(errors::UnsupportedArch);
+                    warn!("arch is not supported");
                 }
             } else {
-                sess.emit_warning(errors::MsvcPathNotFound);
+                warn!("MSVC root path lib location not found");
             }
         } else {
-            sess.emit_warning(errors::LinkExeNotFound);
+            warn!("link.exe not found");
         }
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1,5 +1,6 @@
 use super::command::Command;
 use super::symbol_export;
+use crate::errors::LibDefWriteFailure;
 use rustc_span::symbol::sym;
 
 use std::ffi::{OsStr, OsString};
@@ -666,7 +667,7 @@ impl<'a> Linker for GccLinker<'a> {
                 }
             };
             if let Err(e) = res {
-                self.sess.fatal(&format!("failed to write lib.def file: {}", e));
+                self.sess.emit_fatal(LibDefWriteFailure { error_description: format!("{e}") });
             }
         } else if is_windows {
             let res: io::Result<()> = try {
@@ -681,7 +682,7 @@ impl<'a> Linker for GccLinker<'a> {
                 }
             };
             if let Err(e) = res {
-                self.sess.fatal(&format!("failed to write list.def file: {}", e));
+                self.sess.emit_fatal(LibDefWriteFailure { error_description: format!("{e}") });
             }
         } else {
             // Write an LD version script
@@ -972,7 +973,7 @@ impl<'a> Linker for MsvcLinker<'a> {
             }
         };
         if let Err(e) = res {
-            self.sess.fatal(&format!("failed to write lib.def file: {}", e));
+            self.sess.emit_fatal(LibDefWriteFailure { error_description: format!("{e}") });
         }
         let mut arg = OsString::from("/DEF:");
         arg.push(path);

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -872,19 +872,12 @@ fn execute_copy_from_cache_work_item<B: ExtraBackendMethods>(
         );
         match link_or_copy(&source_file, &output_path) {
             Ok(_) => Some(output_path),
-            Err(_) => {
-                // FIXME:
-                // Should we add Translations support in Handler, or should we pass a session here ?
-                //
-                // As Luis Cardoso mentioned here https://github.com/rust-lang/rust/pull/100753#discussion_r952975345,
-                // Translations support in Handler is tricky because SessionDiagnostic is not a trait,
-                // and we can't implement it in Handler because rustc_errors cannot depend on rustc_session.
-                //
-                // As for passing a session here, my understanding is that all these errors should be reported via
-                // the Shared Handler, which leads us to probably having to support Translations in another way.
-
-                // let diag_handler = cgcx.create_diag_handler();
-                // diag_handler.emit_err(errors::CopyPathBuf { source_file, output_path, error });
+            Err(error) => {
+                cgcx.create_diag_handler().emit_err(errors::CopyPathBuf {
+                    source_file,
+                    output_path,
+                    error,
+                });
                 None
             }
         }

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -7,12 +7,6 @@ use std::io::Error;
 use std::path::{Path, PathBuf};
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::missing_native_static_library)]
-pub struct MissingNativeStaticLibrary<'a> {
-    pub library_name: &'a str,
-}
-
-#[derive(Diagnostic)]
 #[diag(codegen_ssa::lib_def_write_failure)]
 pub struct LibDefWriteFailure {
     pub error: Error,

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -14,3 +14,45 @@ pub struct MissingNativeStaticLibrary<'a> {
 pub struct LibDefWriteFailure {
     pub error: Error,
 }
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::version_script_write_failure)]
+pub struct VersionScriptWriteFailure {
+    pub error: Error,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::symbol_file_write_failure)]
+pub struct SymbolFileWriteFailure {
+    pub error: Error,
+}
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::unsupported_arch)]
+pub struct UnsupportedArch;
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::msvc_path_not_found)]
+pub struct MsvcPathNotFound;
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::link_exe_not_found)]
+pub struct LinkExeNotFound;
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::ld64_unimplemented_modifier)]
+pub struct Ld64UnimplementedModifier;
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::linker_unsupported_modifier)]
+pub struct LinkerUnsupportedModifier;
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::L4Bender_exporting_symbols_unimplemented)]
+pub struct L4BenderExportingSymbolsUnimplemented;
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::no_natvis_directory)]
+pub struct NoNatvisDirectory {
+    pub error: Error,
+}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -7,3 +7,9 @@ use rustc_macros::SessionDiagnostic;
 pub struct MissingNativeStaticLibrary<'a> {
     pub library_name: &'a str,
 }
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::lib_def_write_failure)]
+pub struct LibDefWriteFailure {
+    pub error_description: String,
+}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -31,18 +31,6 @@ pub struct SymbolFileWriteFailure {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::unsupported_arch)]
-pub struct UnsupportedArch;
-
-#[derive(Diagnostic)]
-#[diag(codegen_ssa::msvc_path_not_found)]
-pub struct MsvcPathNotFound;
-
-#[derive(Diagnostic)]
-#[diag(codegen_ssa::link_exe_not_found)]
-pub struct LinkExeNotFound;
-
-#[derive(Diagnostic)]
 #[diag(codegen_ssa::ld64_unimplemented_modifier)]
 pub struct Ld64UnimplementedModifier;
 
@@ -115,8 +103,8 @@ pub struct IncompatibleLinkingModifiers;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa::add_native_library)]
-pub struct AddNativeLibrary<'a> {
-    pub library_path: &'a str,
+pub struct AddNativeLibrary {
+    pub library_path: PathBuf,
     pub error: Error,
 }
 
@@ -129,30 +117,16 @@ pub struct MultipleExternalFuncDecl<'a> {
     pub library_name: &'a str,
 }
 
+#[derive(Diagnostic)]
 pub enum LinkRlibError {
+    #[diag(codegen_ssa::rlib_missing_format)]
     MissingFormat,
-    OnlyRmetaFound { crate_name: Symbol },
-    NotFound { crate_name: Symbol },
-}
 
-impl IntoDiagnostic<'_, !> for LinkRlibError {
-    fn into_diagnostic(self, handler: &Handler) -> DiagnosticBuilder<'_, !> {
-        match self {
-            LinkRlibError::MissingFormat => {
-                handler.struct_fatal(fluent::codegen_ssa::rlib_missing_format)
-            }
-            LinkRlibError::OnlyRmetaFound { crate_name } => {
-                let mut diag = handler.struct_fatal(fluent::codegen_ssa::rlib_only_rmeta_found);
-                diag.set_arg("crate_name", crate_name);
-                diag
-            }
-            LinkRlibError::NotFound { crate_name } => {
-                let mut diag = handler.struct_fatal(fluent::codegen_ssa::rlib_not_found);
-                diag.set_arg("crate_name", crate_name);
-                diag
-            }
-        }
-    }
+    #[diag(codegen_ssa::rlib_only_rmeta_found)]
+    OnlyRmetaFound { crate_name: Symbol },
+
+    #[diag(codegen_ssa::rlib_not_found)]
+    NotFound { crate_name: Symbol },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1,0 +1,9 @@
+//! Errors emitted by codegen_ssa
+
+use rustc_macros::SessionDiagnostic;
+
+#[derive(SessionDiagnostic)]
+#[diag(codegen_ssa::missing_native_static_library)]
+pub struct MissingNativeStaticLibrary<'a> {
+    pub library_name: &'a str,
+}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1,10 +1,16 @@
 //! Errors emitted by codegen_ssa
 
-use rustc_errors::{DiagnosticArgValue, IntoDiagnosticArg};
+use crate::back::command::Command;
+use rustc_errors::{
+    fluent, DiagnosticArgValue, DiagnosticBuilder, ErrorGuaranteed, Handler, IntoDiagnostic,
+    IntoDiagnosticArg,
+};
 use rustc_macros::Diagnostic;
+use rustc_span::{Span, Symbol};
 use std::borrow::Cow;
 use std::io::Error;
 use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa::lib_def_write_failure)]
@@ -73,17 +79,15 @@ pub struct CopyPath<'a> {
 
 impl<'a> CopyPath<'a> {
     pub fn new(from: &'a Path, to: &'a Path, error: Error) -> CopyPath<'a> {
-        CopyPath { from: DebugArgPath { path: from }, to: DebugArgPath { path: to }, error }
+        CopyPath { from: DebugArgPath(from), to: DebugArgPath(to), error }
     }
 }
 
-struct DebugArgPath<'a> {
-    pub path: &'a Path,
-}
+struct DebugArgPath<'a>(pub &'a Path);
 
 impl IntoDiagnosticArg for DebugArgPath<'_> {
     fn into_diagnostic_arg(self) -> rustc_errors::DiagnosticArgValue<'static> {
-        DiagnosticArgValue::Str(Cow::Owned(format!("{:?}", self.path)))
+        DiagnosticArgValue::Str(Cow::Owned(format!("{:?}", self.0)))
     }
 }
 
@@ -97,4 +101,97 @@ pub struct IgnoringEmitPath {
 #[diag(codegen_ssa::ignoring_output)]
 pub struct IgnoringOutput {
     pub extension: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa::create_temp_dir)]
+pub struct CreateTempDir {
+    pub error: Error,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa::incompatible_linking_modifiers)]
+pub struct IncompatibleLinkingModifiers;
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa::add_native_library)]
+pub struct AddNativeLibrary<'a> {
+    pub library_path: &'a str,
+    pub error: Error,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa::multiple_external_func_decl)]
+pub struct MultipleExternalFuncDecl<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub function: Symbol,
+    pub library_name: &'a str,
+}
+
+pub enum LinkRlibError {
+    MissingFormat,
+    OnlyRmetaFound { crate_name: Symbol },
+    NotFound { crate_name: Symbol },
+}
+
+impl IntoDiagnostic<'_, !> for LinkRlibError {
+    fn into_diagnostic(self, handler: &Handler) -> DiagnosticBuilder<'_, !> {
+        match self {
+            LinkRlibError::MissingFormat => {
+                handler.struct_fatal(fluent::codegen_ssa::rlib_missing_format)
+            }
+            LinkRlibError::OnlyRmetaFound { crate_name } => {
+                let mut diag = handler.struct_fatal(fluent::codegen_ssa::rlib_only_rmeta_found);
+                diag.set_arg("crate_name", crate_name);
+                diag
+            }
+            LinkRlibError::NotFound { crate_name } => {
+                let mut diag = handler.struct_fatal(fluent::codegen_ssa::rlib_not_found);
+                diag.set_arg("crate_name", crate_name);
+                diag
+            }
+        }
+    }
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa::thorin_dwarf_linking)]
+#[note]
+pub struct ThorinDwarfLinking {
+    pub thorin_error: ThorinErrorWrapper,
+}
+pub struct ThorinErrorWrapper(pub thorin::Error);
+
+// FIXME: How should we support translations for external crate errors?
+impl IntoDiagnosticArg for ThorinErrorWrapper {
+    fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
+        DiagnosticArgValue::Str(Cow::Owned(format!("{:?}", self.0)))
+    }
+}
+
+pub struct LinkingFailed<'a> {
+    pub linker_path: &'a PathBuf,
+    pub exit_status: ExitStatus,
+    pub command: &'a Command,
+    pub escaped_output: &'a str,
+}
+
+impl IntoDiagnostic<'_> for LinkingFailed<'_> {
+    fn into_diagnostic(self, handler: &Handler) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
+        let mut diag = handler.struct_err(fluent::codegen_ssa::linking_failed);
+        diag.set_arg("linker_path", format!("{}", self.linker_path.display()));
+        diag.set_arg("exit_status", format!("{}", self.exit_status));
+
+        diag.note(format!("{:?}", self.command)).note(self.escaped_output);
+
+        // Trying to match an error from OS linkers
+        // which by now we have no way to translate.
+        if self.escaped_output.contains("undefined reference to") {
+            diag.note(fluent::codegen_ssa::extern_funcs_not_found)
+                .note(fluent::codegen_ssa::specify_libraries_to_link)
+                .note(fluent::codegen_ssa::use_cargo_directive);
+        }
+        diag
+    }
 }

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1,66 +1,66 @@
 //! Errors emitted by codegen_ssa
 
 use rustc_errors::{DiagnosticArgValue, IntoDiagnosticArg};
-use rustc_macros::SessionDiagnostic;
+use rustc_macros::Diagnostic;
 use std::borrow::Cow;
 use std::io::Error;
 use std::path::{Path, PathBuf};
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::missing_native_static_library)]
 pub struct MissingNativeStaticLibrary<'a> {
     pub library_name: &'a str,
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::lib_def_write_failure)]
 pub struct LibDefWriteFailure {
     pub error: Error,
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::version_script_write_failure)]
 pub struct VersionScriptWriteFailure {
     pub error: Error,
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::symbol_file_write_failure)]
 pub struct SymbolFileWriteFailure {
     pub error: Error,
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::unsupported_arch)]
 pub struct UnsupportedArch;
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::msvc_path_not_found)]
 pub struct MsvcPathNotFound;
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::link_exe_not_found)]
 pub struct LinkExeNotFound;
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::ld64_unimplemented_modifier)]
 pub struct Ld64UnimplementedModifier;
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::linker_unsupported_modifier)]
 pub struct LinkerUnsupportedModifier;
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::L4Bender_exporting_symbols_unimplemented)]
 pub struct L4BenderExportingSymbolsUnimplemented;
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::no_natvis_directory)]
 pub struct NoNatvisDirectory {
     pub error: Error,
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::copy_path_buf)]
 pub struct CopyPathBuf {
     pub source_file: PathBuf,
@@ -69,7 +69,7 @@ pub struct CopyPathBuf {
 }
 
 // Reports Paths using `Debug` implementation rather than Path's `Display` implementation.
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::copy_path)]
 pub struct CopyPath<'a> {
     from: DebugArgPath<'a>,
@@ -93,13 +93,13 @@ impl IntoDiagnosticArg for DebugArgPath<'_> {
     }
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::ignoring_emit_path)]
 pub struct IgnoringEmitPath {
     pub extension: String,
 }
 
-#[derive(SessionDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(codegen_ssa::ignoring_output)]
 pub struct IgnoringOutput {
     pub extension: String,

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1,6 +1,7 @@
 //! Errors emitted by codegen_ssa
 
 use rustc_macros::SessionDiagnostic;
+use std::io::Error;
 
 #[derive(SessionDiagnostic)]
 #[diag(codegen_ssa::missing_native_static_library)]
@@ -11,5 +12,5 @@ pub struct MissingNativeStaticLibrary<'a> {
 #[derive(SessionDiagnostic)]
 #[diag(codegen_ssa::lib_def_write_failure)]
 pub struct LibDefWriteFailure {
-    pub error_description: String,
+    pub error: Error,
 }

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(strict_provenance)]
 #![feature(int_roundings)]
 #![feature(if_let_guard)]
+#![feature(never_type)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
 

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -43,6 +43,7 @@ pub mod base;
 pub mod common;
 pub mod coverageinfo;
 pub mod debuginfo;
+pub mod errors;
 pub mod glue;
 pub mod meth;
 pub mod mir;

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -19,3 +19,11 @@ codegen_ssa_linker_unsupported_modifier = `as-needed` modifier not supported for
 codegen_ssa_L4Bender_exporting_symbols_unimplemented = exporting symbols not implemented yet for L4Bender
 
 codegen_ssa_no_natvis_directory = error enumerating natvis directory: {$error}
+
+codegen_ssa_copy_path = could not copy {$from} to {$to}: {$error}
+
+codegen_ssa_copy_path_buf = unable to copy {$source_file} to {$output_path}: {$error}
+
+codegen_ssa_ignoring_emit_path = ignoring emit path because multiple .{$extension} files were produced
+
+codegen_ssa_ignoring_output = ignoring -o because multiple .{$extension} files were produced

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -1,0 +1,1 @@
+codegen_ssa_missing_native_static_library = could not find native static library `{$library_name}`, perhaps an -L flag is missing?

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -4,12 +4,6 @@ codegen_ssa_version_script_write_failure = failed to write version script: {$err
 
 codegen_ssa_symbol_file_write_failure = failed to write symbols file: {$error}
 
-codegen_ssa_unsupported_arch = arch is not supported
-
-codegen_ssa_msvc_path_not_found = MSVC root path lib location not found
-
-codegen_ssa_link_exe_not_found = link.exe not found
-
 codegen_ssa_ld64_unimplemented_modifier = `as-needed` modifier not implemented yet for ld64
 
 codegen_ssa_linker_unsupported_modifier = `as-needed` modifier not supported for current linker

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -34,9 +34,6 @@ codegen_ssa_rlib_only_rmeta_found = could not find rlib for: `{$crate_name}`, fo
 
 codegen_ssa_rlib_not_found = could not find rlib for: `{$crate_name}`
 
-codegen_ssa_thorin_dwarf_linking = linking dwarf objects with thorin failed
-    .note = {$thorin_error}
-
 codegen_ssa_linking_failed = linking with `{$linker_path}` failed: {$exit_status}
 
 codegen_ssa_extern_funcs_not_found = some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
@@ -44,3 +41,79 @@ codegen_ssa_extern_funcs_not_found = some `extern` functions couldn't be found; 
 codegen_ssa_specify_libraries_to_link = use the `-l` flag to specify native libraries to link
 
 codegen_ssa_use_cargo_directive = use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
+
+codegen_ssa_thorin_read_input_failure = failed to read input file
+
+codegen_ssa_thorin_parse_input_file_kind = failed to parse input file kind
+
+codegen_ssa_thorin_parse_input_object_file = failed to parse input object file
+
+codegen_ssa_thorin_parse_input_archive_file = failed to parse input archive file
+
+codegen_ssa_thorin_parse_archive_member = failed to parse archive member
+
+codegen_ssa_thorin_invalid_input_kind = input is not an archive or elf object
+
+codegen_ssa_thorin_decompress_data = failed to decompress compressed section
+
+codegen_ssa_thorin_section_without_name = section without name at offset {$offset}
+
+codegen_ssa_thorin_relocation_with_invalid_symbol = relocation with invalid symbol for section `{$section}` at offset {$offset}
+
+codegen_ssa_thorin_multiple_relocations = multiple relocations for section `{$section}` at offset {$offset}
+
+codegen_ssa_thorin_unsupported_relocation = unsupported relocation for section {$section} at offset {$offset}
+
+codegen_ssa_thorin_missing_dwo_name = missing path attribute to DWARF object ({$id})
+
+codegen_ssa_thorin_no_compilation_units = input object has no compilation units
+
+codegen_ssa_thorin_no_die = no top-level debugging information entry in compilation/type unit
+
+codegen_ssa_thorin_top_level_die_not_unit = top-level debugging information entry is not a compilation/type unit
+
+codegen_ssa_thorin_missing_required_section = input object missing required section `{$section}`
+
+codegen_ssa_thorin_parse_unit_abbreviations = failed to parse unit abbreviations
+
+codegen_ssa_thorin_parse_unit_attribute = failed to parse unit attribute
+
+codegen_ssa_thorin_parse_unit_header = failed to parse unit header
+
+codegen_ssa_thorin_parse_unit = failed to parse unit
+
+codegen_ssa_thorin_incompatible_index_version = incompatible `{$section}` index version: found version {$actual}, expected version {$format}
+
+codegen_ssa_thorin_offset_at_index = read offset at index {$index} of `.debug_str_offsets.dwo` section
+
+codegen_ssa_thorin_str_at_offset = read string at offset {$offset} of `.debug_str.dwo` section
+
+codegen_ssa_thorin_parse_index = failed to parse `{$section}` index section
+
+codegen_ssa_thorin_unit_not_in_index = unit {$unit} from input package is not in its index
+
+codegen_ssa_thorin_row_not_in_index = row {$row} found in index's hash table not present in index
+
+codegen_ssa_thorin_section_not_in_row = section not found in unit's row in index
+
+codegen_ssa_thorin_empty_unit = unit {$unit} in input DWARF object with no data
+
+codegen_ssa_thorin_multiple_debug_info_section = multiple `.debug_info.dwo` sections
+
+codegen_ssa_thorin_multiple_debug_types_section = multiple `.debug_types.dwo` sections in a package
+
+codegen_ssa_thorin_not_split_unit = regular compilation unit in object (missing dwo identifier)
+
+codegen_ssa_thorin_duplicate_unit = duplicate split compilation unit ({$unit})
+
+codegen_ssa_thorin_missing_referenced_unit = unit {$unit} referenced by executable was not found
+
+codegen_ssa_thorin_not_output_object_created = no output object was created from inputs
+
+codegen_ssa_thorin_mixed_input_encodings = input objects haved mixed encodings
+
+codegen_ssa_thorin_io = {$error}
+codegen_ssa_thorin_object_read = {$error}
+codegen_ssa_thorin_object_write = {$error}
+codegen_ssa_thorin_gimli_read = {$error}
+codegen_ssa_thorin_gimli_write = {$error}

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -1,3 +1,21 @@
 codegen_ssa_missing_native_static_library = could not find native static library `{$library_name}`, perhaps an -L flag is missing?
 
 codegen_ssa_lib_def_write_failure = failed to write lib.def file: {$error}
+
+codegen_ssa_version_script_write_failure = failed to write version script: {$error}
+
+codegen_ssa_symbol_file_write_failure = failed to write symbols file: {$error}
+
+codegen_ssa_unsupported_arch = arch is not supported
+
+codegen_ssa_msvc_path_not_found = MSVC root path lib location not found
+
+codegen_ssa_link_exe_not_found = link.exe not found
+
+codegen_ssa_ld64_unimplemented_modifier = `as-needed` modifier not implemented yet for ld64
+
+codegen_ssa_linker_unsupported_modifier = `as-needed` modifier not supported for current linker
+
+codegen_ssa_L4Bender_exporting_symbols_unimplemented = exporting symbols not implemented yet for L4Bender
+
+codegen_ssa_no_natvis_directory = error enumerating natvis directory: {$error}

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -1,1 +1,3 @@
 codegen_ssa_missing_native_static_library = could not find native static library `{$library_name}`, perhaps an -L flag is missing?
+
+codegen_ssa_lib_def_write_failure = failed to write lib.def file: {$error_description}

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -1,3 +1,3 @@
 codegen_ssa_missing_native_static_library = could not find native static library `{$library_name}`, perhaps an -L flag is missing?
 
-codegen_ssa_lib_def_write_failure = failed to write lib.def file: {$error_description}
+codegen_ssa_lib_def_write_failure = failed to write lib.def file: {$error}

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -1,5 +1,3 @@
-codegen_ssa_missing_native_static_library = could not find native static library `{$library_name}`, perhaps an -L flag is missing?
-
 codegen_ssa_lib_def_write_failure = failed to write lib.def file: {$error}
 
 codegen_ssa_version_script_write_failure = failed to write version script: {$error}

--- a/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/codegen_ssa.ftl
@@ -25,3 +25,28 @@ codegen_ssa_copy_path_buf = unable to copy {$source_file} to {$output_path}: {$e
 codegen_ssa_ignoring_emit_path = ignoring emit path because multiple .{$extension} files were produced
 
 codegen_ssa_ignoring_output = ignoring -o because multiple .{$extension} files were produced
+
+codegen_ssa_create_temp_dir = couldn't create a temp dir: {$error}
+
+codegen_ssa_incompatible_linking_modifiers = the linking modifiers `+bundle` and `+whole-archive` are not compatible with each other when generating rlibs
+
+codegen_ssa_add_native_library = failed to add native library {$library_path}: {$error}
+
+codegen_ssa_multiple_external_func_decl = multiple declarations of external function `{$function}` from library `{$library_name}` have different calling conventions
+
+codegen_ssa_rlib_missing_format = could not find formats for rlibs
+
+codegen_ssa_rlib_only_rmeta_found = could not find rlib for: `{$crate_name}`, found rmeta (metadata) file
+
+codegen_ssa_rlib_not_found = could not find rlib for: `{$crate_name}`
+
+codegen_ssa_thorin_dwarf_linking = linking dwarf objects with thorin failed
+    .note = {$thorin_error}
+
+codegen_ssa_linking_failed = linking with `{$linker_path}` failed: {$exit_status}
+
+codegen_ssa_extern_funcs_not_found = some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
+
+codegen_ssa_specify_libraries_to_link = use the `-l` flag to specify native libraries to link
+
+codegen_ssa_use_cargo_directive = use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -63,6 +63,7 @@ fluent_messages! {
     symbol_mangling => "../locales/en-US/symbol_mangling.ftl",
     trait_selection => "../locales/en-US/trait_selection.ftl",
     ty_utils => "../locales/en-US/ty_utils.ftl",
+    codegen_ssa => "../locales/en-US/codegen_ssa.ftl",
 }
 
 pub use fluent_generated::{self as fluent, DEFAULT_LOCALE_RESOURCES};

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -40,9 +40,10 @@ fluent_messages! {
     attr => "../locales/en-US/attr.ftl",
     borrowck => "../locales/en-US/borrowck.ftl",
     builtin_macros => "../locales/en-US/builtin_macros.ftl",
+    codegen_gcc => "../locales/en-US/codegen_gcc.ftl",
+    codegen_ssa => "../locales/en-US/codegen_ssa.ftl",
     compiletest => "../locales/en-US/compiletest.ftl",
     const_eval => "../locales/en-US/const_eval.ftl",
-    codegen_gcc => "../locales/en-US/codegen_gcc.ftl",
     driver => "../locales/en-US/driver.ftl",
     expand => "../locales/en-US/expand.ftl",
     hir_analysis => "../locales/en-US/hir_analysis.ftl",
@@ -63,7 +64,6 @@ fluent_messages! {
     symbol_mangling => "../locales/en-US/symbol_mangling.ftl",
     trait_selection => "../locales/en-US/trait_selection.ftl",
     ty_utils => "../locales/en-US/ty_utils.ftl",
-    codegen_ssa => "../locales/en-US/codegen_ssa.ftl",
 }
 
 pub use fluent_generated::{self as fluent, DEFAULT_LOCALE_RESOURCES};


### PR DESCRIPTION
Initial migration of `codegen_ssa`. Going to split this crate migration in at least two PRs in order to avoid a huge PR and to quick off some questions around:

1. Translating messages from "external" crates.
2. Interfacing with OS messages.
3. Adding UI tests while migrating diagnostics.

_See comments below._
