### PR TITLE
Cleanup some error code explanations

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0045.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0045.md
@@ -3,9 +3,7 @@ Variadic parameters have been used on a non-C ABI function.
 Erroneous code example:
 
 ```compile_fail,E0045
-#![feature(unboxed_closures)]
-
-extern "rust-call" {
+extern "Rust" {
     fn foo(x: u8, ...); // error!
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0092.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0092.md
@@ -19,6 +19,6 @@ functions are defined in `compiler/rustc_codegen_llvm/src/intrinsic.rs` and in
 #![feature(intrinsics)]
 
 extern "rust-intrinsic" {
-    fn atomic_fence(); // ok!
+    fn atomic_fence_seqcst(); // ok!
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0161.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0161.md
@@ -3,7 +3,6 @@ A value was moved whose size was not known at compile time.
 Erroneous code example:
 
 ```compile_fail,E0161
-#![feature(box_syntax)]
 trait Bar {
     fn f(self);
 }
@@ -13,7 +12,7 @@ impl Bar for i32 {
 }
 
 fn main() {
-    let b: Box<dyn Bar> = box (0 as i32);
+    let b: Box<dyn Bar> = Box::new(0i32);
     b.f();
     // error: cannot move a value of type dyn Bar: the size of dyn Bar cannot
     //        be statically determined
@@ -27,8 +26,6 @@ either `&x` or `&mut x`. Since a reference has a fixed size, this lets you move
 it around as usual. Example:
 
 ```
-#![feature(box_syntax)]
-
 trait Bar {
     fn f(&self);
 }
@@ -38,7 +35,7 @@ impl Bar for i32 {
 }
 
 fn main() {
-    let b: Box<dyn Bar> = box (0 as i32);
+    let b: Box<dyn Bar> = Box::new(0i32);
     b.f();
     // ok!
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0579.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0579.md
@@ -8,9 +8,9 @@ Erroneous code example:
 fn main() {
     match 5u32 {
         // This range is ok, albeit pointless.
-        1 .. 2 => {}
+        1..2 => {}
         // This range is empty, and the compiler can tell.
-        5 .. 5 => {} // error!
+        5..5 => {} // error!
     }
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0622.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0622.md
@@ -5,7 +5,7 @@ Erroneous code example:
 ```compile_fail,E0622
 #![feature(intrinsics)]
 extern "rust-intrinsic" {
-    pub static breakpoint : fn(); // error: intrinsic must be a function
+    pub static breakpoint: fn(); // error: intrinsic must be a function
 }
 
 fn main() { unsafe { breakpoint(); } }

--- a/compiler/rustc_error_codes/src/error_codes/E0743.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0743.md
@@ -3,8 +3,6 @@ The C-variadic type `...` has been nested inside another type.
 Erroneous code example:
 
 ```compile_fail,E0743
-#![feature(c_variadic)]
-
 fn foo2(x: u8, y: &...) {} // error!
 ```
 


### PR DESCRIPTION
E0045: Use a stable non-C ABI instead
E0092: Use an atomic intrinsic that actually exists
E0161: Don't use box_syntax
E0579: Format ranges in the rustfmt style
E0622: Use the rustfmt style
E0743: Remove feature gate as it's not needed