### PR TITLE
rustdoc: remove font family CSS on `.rustdoc-toggle summary::before`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -207,13 +207,10 @@ a.source,
 .item-left > a,
 .out-of-band,
 span.since,
-details.rustdoc-toggle > summary::before,
 a.srclink,
 #help-button > button,
 details.rustdoc-toggle.top-doc > summary,
-details.rustdoc-toggle.top-doc > summary::before,
 details.rustdoc-toggle.non-exhaustive > summary,
-details.rustdoc-toggle.non-exhaustive > summary::before,
 .scraped-example-title,
 .more-examples-toggle summary, .more-examples-toggle .hide-more,
 .example-links a,
@@ -1573,7 +1570,6 @@ details.rustdoc-toggle > summary::before {
 }
 
 details.rustdoc-toggle > summary.hideme > span,
-details.rustdoc-toggle > summary::before,
 .more-examples-toggle summary, .more-examples-toggle .hide-more {
 	color: var(--toggles-color);
 }


### PR DESCRIPTION
This rule became irrelevant since c58246efe47bea09d4f3e70f536e4c9bb7770749 made it so that the `summary::before` pseudo-element contains an SVG instead of text.