### PR TITLE
Fix rustdoc ICE in invalid_rust_codeblocks lint

### DIFF
--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -192,8 +192,11 @@ impl Translate for BufferEmitter {
 impl Emitter for BufferEmitter {
     fn emit_diagnostic(&mut self, diag: &Diagnostic) {
         let mut buffer = self.buffer.borrow_mut();
-        // FIXME(davidtwco): need to support translation here eventually
-        buffer.messages.push(format!("error from rustc: {}", diag.message[0].0.expect_str()));
+
+        let fluent_args = self.to_fluent_args(diag.args());
+        let translated_main_message = self.translate_message(&diag.message[0].0, &fluent_args);
+
+        buffer.messages.push(format!("error from rustc: {}", translated_main_message));
         if diag.is_error() {
             buffer.has_errors = true;
         }

--- a/src/test/rustdoc-ui/invalid-syntax.rs
+++ b/src/test/rustdoc-ui/invalid-syntax.rs
@@ -99,3 +99,9 @@ pub fn indent_after_fenced() {}
 /// ```
 pub fn invalid() {}
 //~^^^^ WARNING could not parse code block as Rust code
+
+/// ```
+/// fn wook_at_my_beautifuw_bwaces_plz() {);
+/// ```
+pub fn uwu() {}
+//~^^^^ WARNING could not parse code block as Rust code

--- a/src/test/rustdoc-ui/invalid-syntax.stderr
+++ b/src/test/rustdoc-ui/invalid-syntax.stderr
@@ -150,5 +150,20 @@ help: mark blocks that do not contain Rust code as text
 LL | /// ```text
    |        ++++
 
-warning: 12 warnings emitted
+warning: could not parse code block as Rust code
+  --> $DIR/invalid-syntax.rs:103:5
+   |
+LL |   /// ```
+   |  _____^
+LL | | /// fn wook_at_my_beautifuw_bwaces_plz() {);
+LL | | /// ```
+   | |_______^
+   |
+   = note: error from rustc: mismatched closing delimiter: `)`
+help: mark blocks that do not contain Rust code as text
+   |
+LL | /// ```text
+   |        ++++
+
+warning: 13 warnings emitted
 


### PR DESCRIPTION
The diagnostic message extraction code didn't handle translations yet.
Fixes #102603
Fixes #102631

r? @davidtwco