### PR TITLE
Ignore fuchsia on two compiler tests

### DIFF
--- a/src/test/ui/process/process-panic-after-fork.rs
+++ b/src/test/ui/process/process-panic-after-fork.rs
@@ -6,6 +6,7 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-android: FIXME(#85261)
+// ignore-fuchsia no fork
 
 #![feature(rustc_private)]
 #![feature(never_type)]

--- a/src/test/ui/simd/target-feature-mixup.rs
+++ b/src/test/ui/simd/target-feature-mixup.rs
@@ -5,6 +5,7 @@
 
 // ignore-emscripten
 // ignore-sgx no processes
+// ignore-fuchsia must translate zircon signal to SIGILL, FIXME (#58590)
 
 #![feature(repr_simd, target_feature, cfg_target_feature)]
 #![feature(avx512_target_feature)]


### PR DESCRIPTION
Adding `ignore-fuchsia` to two irrelevant compiler tests

cc. @djkoloski  

r? @tmandry  