### PR TITLE
Support casting boxes to dyn*

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -14,6 +14,7 @@ use rustc_middle::ty::cast::{CastTy, IntTy};
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf};
 use rustc_middle::ty::{self, adjustment::PointerCast, Instance, Ty, TyCtxt};
 use rustc_span::source_map::{Span, DUMMY_SP};
+use rustc_target::abi::Size;
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     #[instrument(level = "trace", skip(self, bx))]
@@ -285,6 +286,10 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 bug!("Only valid to do a DynStar cast into a DynStar type")
                             };
                         let vtable = get_vtable(bx.cx(), source.ty(self.mir, bx.tcx()), trait_ref);
+                        let data = match operand.layout.pointee_info_at(bx.cx(), Size::ZERO) {
+                            Some(_) => bx.ptrtoint(data, bx.cx().type_isize()),
+                            None => data,
+                        };
                         OperandValue::Pair(data, vtable)
                     }
                     mir::CastKind::Pointer(

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -286,6 +286,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 bug!("Only valid to do a DynStar cast into a DynStar type")
                             };
                         let vtable = get_vtable(bx.cx(), source.ty(self.mir, bx.tcx()), trait_ref);
+                        let vtable = bx.pointercast(vtable, bx.cx().type_ptr_to(bx.cx().type_isize()));
                         let data = match operand.layout.pointee_info_at(bx.cx(), Size::ZERO) {
                             Some(_) => bx.ptrtoint(data, bx.cx().type_isize()),
                             None => data,

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -287,6 +287,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             };
                         let vtable = get_vtable(bx.cx(), source.ty(self.mir, bx.tcx()), trait_ref);
                         let vtable = bx.pointercast(vtable, bx.cx().type_ptr_to(bx.cx().type_isize()));
+                        // FIXME(dyn-star): this is probably not the best way to check if this is
+                        // a pointer, and really we should ensure that the value is a suitable
+                        // pointer earlier in the compilation process.
                         let data = match operand.layout.pointee_info_at(bx.cx(), Size::ZERO) {
                             Some(_) => bx.ptrtoint(data, bx.cx().type_isize()),
                             None => data,

--- a/src/test/ui/dyn-star/box.rs
+++ b/src/test/ui/dyn-star/box.rs
@@ -1,0 +1,17 @@
+// run-pass
+// compile-flags: -C opt-level=0
+
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+use std::fmt::Display;
+
+fn make_dyn_star() -> dyn* Display {
+    Box::new(42) as dyn* Display
+}
+
+fn main() {
+    let x = make_dyn_star();
+
+    println!("{x}");
+}


### PR DESCRIPTION
Boxes have a pointer type at codegen time which LLVM does not allow to be transparently converted to an integer. Work around this by inserting a `ptrtoint` instruction if the argument is a pointer.

r? @compiler-errors 

Fixes #102427