### PR TITLE
Slightly improve no return for returning function error

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_analysis/src/check/fn_ctxt/suggestions.rs
@@ -1122,7 +1122,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             } else {
                 err.span_suggestion_short(
                     span_semi,
-                    "remove this semicolon",
+                    "remove this semicolon to return this value",
                     "",
                     Applicability::MachineApplicable,
                 );

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -7,7 +7,7 @@ LL | pub fn f() -> String {
    |        implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
-   |                      - help: remove this semicolon
+   |                      - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
   --> $DIR/consider-removing-last-semi.rs:8:15
@@ -18,7 +18,7 @@ LL | pub fn g() -> String {
    |        implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
-   |                           - help: remove this semicolon
+   |                           - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
   --> $DIR/consider-removing-last-semi.rs:13:25
@@ -29,7 +29,7 @@ LL | pub fn macro_tests() -> u32 {
    |        implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     mac!();
-   |           - help: remove this semicolon
+   |           - help: remove this semicolon to return this value
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -7,7 +7,7 @@ LL | fn blah() -> i32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
-   |     - help: remove this semicolon
+   |     - help: remove this semicolon to return this value
 
 error: aborting due to previous error
 

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -15,7 +15,7 @@ LL | fn bar() -> String {
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
-   |     - help: remove this semicolon
+   |     - help: remove this semicolon to return this value
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/old-closure-expression-remove-semicolon.fixed
+++ b/src/test/ui/closures/old-closure-expression-remove-semicolon.fixed
@@ -7,6 +7,6 @@ fn foo() -> i32 {
 fn main() {
     let _x: i32 = {
         //~^ ERROR mismatched types
-        foo() //~ HELP remove this semicolon
+        foo() //~ HELP remove this semicolon to return this value
     };
 }

--- a/src/test/ui/closures/old-closure-expression-remove-semicolon.rs
+++ b/src/test/ui/closures/old-closure-expression-remove-semicolon.rs
@@ -7,6 +7,6 @@ fn foo() -> i32 {
 fn main() {
     let _x: i32 = {
         //~^ ERROR mismatched types
-        foo(); //~ HELP remove this semicolon
+        foo(); //~ HELP remove this semicolon to return this value
     };
 }

--- a/src/test/ui/closures/old-closure-expression-remove-semicolon.stderr
+++ b/src/test/ui/closures/old-closure-expression-remove-semicolon.stderr
@@ -5,7 +5,7 @@ LL |       let _x: i32 = {
    |  ___________________^
 LL | |
 LL | |         foo();
-   | |              - help: remove this semicolon
+   | |              - help: remove this semicolon to return this value
 LL | |     };
    | |_____^ expected `i32`, found `()`
 

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -6,7 +6,7 @@ LL | fn plus_one(x: i32) -> i32 {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
-   |          - help: remove this semicolon
+   |          - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
   --> $DIR/coercion-missing-tail-expected-type.rs:8:13
@@ -16,7 +16,7 @@ LL | fn foo() -> Result<u8, u64> {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
-   |          - help: remove this semicolon
+   |          - help: remove this semicolon to return this value
    |
    = note:   expected enum `Result<u8, u64>`
            found unit type `()`

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -6,7 +6,7 @@ LL | fn foo(b: bool) -> Result<bool,String> {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
-   |                           - help: remove this semicolon
+   |                           - help: remove this semicolon to return this value
    |
    = note:   expected enum `Result<bool, String>`
            found unit type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.rs
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.rs
@@ -1,4 +1,3 @@
-//
 // regression test for #8005
 
 macro_rules! test { () => { fn foo() -> i32 { 1; } } }

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:7:19
+  --> $DIR/liveness-return-last-stmt-semi.rs:6:19
    |
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected `i32`, found `()`
@@ -7,17 +7,17 @@ LL | fn no_return() -> i32 {}
    |    implicitly returns `()` as its body has no tail or `return` expression
 
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:9:19
+  --> $DIR/liveness-return-last-stmt-semi.rs:8:19
    |
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected `u32`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
-   |          - help: remove this semicolon
+   |          - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:13:19
+  --> $DIR/liveness-return-last-stmt-semi.rs:12:19
    |
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected `u32`, found `()`
@@ -25,7 +25,7 @@ LL | fn baz(x: u64) -> u32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
 
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:4:41
+  --> $DIR/liveness-return-last-stmt-semi.rs:3:41
    |
 LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^ expected `i32`, found `()`

--- a/src/test/ui/suggestions/match-with-different-arm-types-as-stmt-instead-of-expr.stderr
+++ b/src/test/ui/suggestions/match-with-different-arm-types-as-stmt-instead-of-expr.stderr
@@ -7,7 +7,7 @@ LL | fn not_all_paths(a: &str) -> u32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     };
-   |      - help: remove this semicolon
+   |      - help: remove this semicolon to return this value
 
 error[E0308]: `match` arms have incompatible types
   --> $DIR/match-with-different-arm-types-as-stmt-instead-of-expr.rs:26:14


### PR DESCRIPTION
Fixes #100607

The rationale is that absolute beginners will be slightly confused as to why certain lines of code in a function does not require a semicolon. (I have actually witness a beginner having this confusion). Hence, a slight rationale is added "to return this value", which signals to the user that after removing said semicolon the value is returned resolving that error.

However, if this is not desirable, I welcome any other suggestions. Thanks.