### PR TITLE
Cleanup TLS implementation

### DIFF
--- a/library/std/src/sys/unix/thread_local_key.rs
+++ b/library/std/src/sys/unix/thread_local_key.rs
@@ -6,8 +6,23 @@ pub type Key = libc::pthread_key_t;
 
 #[inline]
 pub unsafe fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
+    let dtor = mem::transmute(dtor);
     let mut key = 0;
-    assert_eq!(libc::pthread_key_create(&mut key, mem::transmute(dtor)), 0);
+    assert_eq!(libc::pthread_key_create(&mut key, dtor), 0);
+    // POSIX allows the key created here to be 0, but `StaticKey` needs to
+    // use 0 as a sentinel value to check who won the race to set the shared
+    // TLS key. Therefore, we employ this small trick to avoid having to waste
+    // the key value.
+    if key == 0 {
+        let mut new = 0;
+        // Only check the results after the old key has been destroyed to avoid
+        // leaking it.
+        let r_c = libc::pthread_key_create(&mut new, dtor);
+        let r_d = libc::pthread_key_delete(key);
+        assert_eq!(r_c, 0);
+        debug_assert_eq!(r_d, 0);
+        key = new;
+    }
     key
 }
 


### PR DESCRIPTION
The previous implementation checked for keys with value zero on every platform except Windows, even though it is only necessary on UNIX (SGX does not hand out 0-keys and all other platforms panic anyway).