### PR TITLE
rustdoc: remove no-op CSS `.code-header { display: block }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -654,10 +654,6 @@ pre.example-line-numbers {
 	font-weight: normal;
 }
 
-.method > .code-header, .trait-impl > .code-header {
-	display: block;
-}
-
 .in-band {
 	flex-grow: 1;
 	margin: 0px;


### PR DESCRIPTION
Since 76a3b609d0b93c5d8da5e4e3db37bd03e5cb1c30 converted code headers to real headers, `display: block` is now the default.