### PR TITLE
rustdoc: remove unused CSS class `in-band`

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -634,9 +634,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 write!(
                     buf,
                     "<div class=\"main-heading\">\
-                     <h1 class=\"fqn\">\
-                         <span class=\"in-band\">Rustdoc settings</span>\
-                     </h1>\
+                     <h1 class=\"fqn\">Rustdoc settings</h1>\
                      <span class=\"out-of-band\">\
                          <a id=\"back\" href=\"javascript:void(0)\" onclick=\"history.back();\">\
                             Back\

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -364,11 +364,7 @@ impl AllTypes {
             }
         }
 
-        f.write_str(
-            "<h1 class=\"fqn\">\
-                 <span class=\"in-band\">List of all items</span>\
-             </h1>",
-        );
+        f.write_str("<h1 class=\"fqn\">List of all items</h1>");
         // Note: print_entries does not escape the title, because we know the current set of titles
         // doesn't require escaping.
         print_entries(f, &self.structs, ItemSection::Structs);
@@ -398,9 +394,7 @@ fn scrape_examples_help(shared: &SharedContext<'_>) -> String {
     let mut ids = IdMap::default();
     format!(
         "<div class=\"main-heading\">\
-            <h1 class=\"fqn\">\
-                <span class=\"in-band\">About scraped examples</span>\
-            </h1>\
+            <h1 class=\"fqn\">About scraped examples</h1>\
         </div>\
         <div>{}</div>",
         Markdown {

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -517,9 +517,7 @@ if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
             };
 
             let content = format!(
-                "<h1 class=\"fqn\">\
-                     <span class=\"in-band\">List of all crates</span>\
-                </h1><ul class=\"all-items\">{}</ul>",
+                "<h1 class=\"fqn\">List of all crates</h1><ul class=\"all-items\">{}</ul>",
                 krates
                     .iter()
                     .map(|s| {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -148,6 +148,13 @@ h1, h2, h3, h4 {
 h1.fqn {
 	margin: 0;
 	padding: 0;
+	flex-grow: 1;
+	/* We use overflow-wrap: break-word for Safari, which doesn't recognize
+	   `anywhere`: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap */
+	overflow-wrap: break-word;
+	/* Then override it with `anywhere`, which is required to make non-Safari browsers break
+	   more aggressively when we want them to. */
+	overflow-wrap: anywhere;
 }
 .main-heading {
 	display: flex;
@@ -214,7 +221,7 @@ pre.rust a,
 .sidebar h2 a,
 .sidebar h3 a,
 .mobile-topbar h2 a,
-.in-band a,
+h1.fqn a,
 .search-results a,
 .module-item .stab,
 .import-item .stab,
@@ -654,19 +661,6 @@ pre.example-line-numbers {
 	font-weight: normal;
 }
 
-.in-band {
-	flex-grow: 1;
-	margin: 0px;
-	padding: 0px;
-	/* We use overflow-wrap: break-word for Safari, which doesn't recognize
-	   `anywhere`: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap */
-	overflow-wrap: break-word;
-	/* Then override it with `anywhere`, which is required to make non-Safari browsers break
-	   more aggressively when we want them to. */
-	overflow-wrap: anywhere;
-	background-color: var(--main-background-color);
-}
-
 .docblock code, .docblock-short code,
 pre, .rustdoc.source .example-wrap {
 	background-color: var(--code-block-background-color);
@@ -752,7 +746,7 @@ a {
 	display: initial;
 }
 
-.in-band:hover > .anchor, .impl:hover > .anchor, .method.trait-impl:hover > .anchor,
+.impl:hover > .anchor, .method.trait-impl:hover > .anchor,
 .type.trait-impl:hover > .anchor, .associatedconstant.trait-impl:hover > .anchor,
 .associatedtype.trait-impl:hover > .anchor {
 	display: inline-block;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -522,7 +522,7 @@ function loadCss(cssFileName) {
         }
 
         let currentNbImpls = implementors.getElementsByClassName("impl").length;
-        const traitName = document.querySelector("h1.fqn > .in-band > .trait").textContent;
+        const traitName = document.querySelector("h1.fqn > .trait").textContent;
         const baseIdName = "impl-" + traitName + "-";
         const libs = Object.getOwnPropertyNames(imp);
         // We don't want to include impls from this JS file, when the HTML already has them.

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -1,18 +1,16 @@
 <div class="main-heading"> {#- -#}
     <h1 class="fqn"> {#- -#}
-        <span class="in-band"> {#- -#}
-            {{-typ-}}
-            {#- The breadcrumbs of the item path, like std::string -#}
-            {%- for component in path_components -%}
-            <a href="{{component.path|safe}}index.html">{{component.name}}</a>::<wbr>
-            {%- endfor -%}
-            <a class="{{item_type}}" href="#">{{name}}</a> {#- -#}
-            <button id="copy-path" onclick="copy_path(this)" title="Copy item path to clipboard"> {#- -#}
-                <img src="{{static_root_path|safe}}clipboard{{page.resource_suffix}}.svg" {# -#}
-                    width="19" height="18" {# -#}
-                    alt="Copy item path"> {#- -#}
-            </button> {#- -#}
-        </span> {#- -#}
+        {{-typ-}}
+        {#- The breadcrumbs of the item path, like std::string -#}
+        {%- for component in path_components -%}
+        <a href="{{component.path|safe}}index.html">{{component.name}}</a>::<wbr>
+        {%- endfor -%}
+        <a class="{{item_type}}" href="#">{{name}}</a> {#- -#}
+        <button id="copy-path" onclick="copy_path(this)" title="Copy item path to clipboard"> {#- -#}
+            <img src="{{static_root_path|safe}}clipboard{{page.resource_suffix}}.svg" {# -#}
+                width="19" height="18" {# -#}
+                alt="Copy item path"> {#- -#}
+        </button> {#- -#}
     </h1> {#- -#}
     <span class="out-of-band"> {#- -#}
         {% if !stability_since_raw.is_empty() %}

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -10,8 +10,8 @@ local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 reload:
 
 assert-css: ("#toggle-all-docs", {"color": "rgb(0, 0, 0)"})
-assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgb(0, 0, 0)"})
-assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(173, 55, 138)"})
+assert-css: (".fqn a:nth-of-type(1)", {"color": "rgb(0, 0, 0)"})
+assert-css: (".fqn a:nth-of-type(2)", {"color": "rgb(173, 55, 138)"})
 assert-css: (
     ".rightside .srclink",
     {"color": "rgb(56, 115, 173)", "text-decoration": "none solid rgb(56, 115, 173)"},
@@ -41,7 +41,7 @@ goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 assert-css: ("#top-doc-prose-title", {"color": "rgb(0, 0, 0)"})
 
 assert-css: (".sidebar a", {"color": "rgb(53, 109, 164)"})
-assert-css: (".in-band a", {"color": "rgb(0, 0, 0)"})
+assert-css: ("h1.fqn a", {"color": "rgb(0, 0, 0)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.
 move-cursor-to: "h2#implementations"
@@ -60,8 +60,8 @@ local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"}
 goto: file://|DOC_PATH|/staged_api/struct.Foo.html
 
 assert-css: ("#toggle-all-docs", {"color": "rgb(221, 221, 221)"})
-assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgb(221, 221, 221)"})
-assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(45, 191, 184)"})
+assert-css: (".fqn a:nth-of-type(1)", {"color": "rgb(221, 221, 221)"})
+assert-css: (".fqn a:nth-of-type(2)", {"color": "rgb(45, 191, 184)"})
 assert-css: (
     ".rightside .srclink",
     {"color": "rgb(210, 153, 29)", "text-decoration": "none solid rgb(210, 153, 29)"},
@@ -91,7 +91,7 @@ goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 assert-css: ("#top-doc-prose-title", {"color": "rgb(221, 221, 221)"})
 
 assert-css: (".sidebar a", {"color": "rgb(253, 191, 53)"})
-assert-css: (".in-band a", {"color": "rgb(221, 221, 221)"})
+assert-css: ("h1.fqn a", {"color": "rgb(221, 221, 221)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.
 move-cursor-to: "h2#implementations"
@@ -110,8 +110,8 @@ local-storage: {"rustdoc-theme": "ayu", "rustdoc-use-system-theme": "false"}
 goto: file://|DOC_PATH|/staged_api/struct.Foo.html
 
 assert-css: ("#toggle-all-docs", {"color": "rgb(197, 197, 197)"})
-assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgb(255, 255, 255)"})
-assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(255, 160, 165)"})
+assert-css: (".fqn a:nth-of-type(1)", {"color": "rgb(255, 255, 255)"})
+assert-css: (".fqn a:nth-of-type(2)", {"color": "rgb(255, 160, 165)"})
 assert-css: (
     ".rightside .srclink",
     {"color": "rgb(57, 175, 215)", "text-decoration": "none solid rgb(57, 175, 215)"},
@@ -141,7 +141,7 @@ goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 assert-css: ("#top-doc-prose-title", {"color": "rgb(255, 255, 255)"})
 
 assert-css: (".sidebar a", {"color": "rgb(83, 177, 219)"})
-assert-css: (".in-band a", {"color": "rgb(255, 255, 255)"})
+assert-css: ("h1.fqn a", {"color": "rgb(255, 255, 255)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.
 move-cursor-to: "h2#implementations"

--- a/src/test/rustdoc-gui/search-result-go-to-first.goml
+++ b/src/test/rustdoc-gui/search-result-go-to-first.goml
@@ -3,17 +3,17 @@
 // First, we check that the first page doesn't have the string we're looking for to ensure
 // that the feature is changing page as expected.
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-text-false: (".fqn .in-band", "Struct test_docs::Foo")
+assert-text-false: (".fqn", "Struct test_docs::Foo")
 
 // We now check that we land on the search result page if "go_to_first" isn't set.
 goto: file://|DOC_PATH|/test_docs/index.html?search=struct%3AFoo
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-text-false: (".fqn .in-band", "Struct test_docs::Foo")
+assert-text-false: (".fqn", "Struct test_docs::Foo")
 // Ensure that the search results are displayed, not the "normal" content.
 assert-css: ("#main-content", {"display": "none"})
 
 // Now we can check that the feature is working as expected!
 goto: file://|DOC_PATH|/test_docs/index.html?search=struct%3AFoo&go_to_first=true
 // Waiting for the page to load...
-wait-for-text: (".fqn .in-band", "Struct test_docs::Foo")
+wait-for-text: (".fqn", "Struct test_docs::Foo")

--- a/src/test/rustdoc-gui/toggle-click-deadspace.goml
+++ b/src/test/rustdoc-gui/toggle-click-deadspace.goml
@@ -12,4 +12,4 @@ assert-attribute-false: (".impl-items .rustdoc-toggle", {"open": ""})
 
 // Click the "Trait" part of "impl Trait" and verify it navigates.
 click: "#impl-Trait-for-Foo h3 a:first-of-type"
-assert-text: (".fqn .in-band", "Trait lib2::Trait")
+assert-text: (".fqn", "Trait lib2::Trait")

--- a/src/test/rustdoc/index-page.rs
+++ b/src/test/rustdoc/index-page.rs
@@ -5,7 +5,7 @@
 #![crate_name = "foo"]
 
 // @has foo/../index.html
-// @has - '//span[@class="in-band"]' 'List of all crates'
+// @has - '//h1[@class="fqn"]' 'List of all crates'
 // @has - '//ul[@class="all-items"]//a[@href="foo/index.html"]' 'foo'
 // @has - '//ul[@class="all-items"]//a[@href="all_item_types/index.html"]' 'all_item_types'
 pub struct Foo;

--- a/src/test/rustdoc/keyword.rs
+++ b/src/test/rustdoc/keyword.rs
@@ -7,7 +7,7 @@
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a' 'Keywords'
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a/@href' '#keywords'
 // @has foo/keyword.match.html '//a[@class="keyword"]' 'match'
-// @has foo/keyword.match.html '//span[@class="in-band"]' 'Keyword match'
+// @has foo/keyword.match.html '//h1[@class="fqn"]' 'Keyword match'
 // @has foo/keyword.match.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has foo/index.html '//a/@href' '../foo/index.html'
 // @!has foo/foo/index.html

--- a/src/test/rustdoc/primitive-reference.rs
+++ b/src/test/rustdoc/primitive-reference.rs
@@ -9,7 +9,7 @@
 // @has - '//div[@class="sidebar-elems"]//li/a/@href' '#primitives'
 // @has foo/primitive.reference.html
 // @has - '//a[@class="primitive"]' 'reference'
-// @has - '//span[@class="in-band"]' 'Primitive Type reference'
+// @has - '//h1[@class="fqn"]' 'Primitive Type reference'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 
 // There should be only one implementation listed.

--- a/src/test/rustdoc/primitive-slice-auto-trait.rs
+++ b/src/test/rustdoc/primitive-slice-auto-trait.rs
@@ -4,7 +4,7 @@
 #![feature(rustdoc_internals)]
 
 // @has foo/primitive.slice.html '//a[@class="primitive"]' 'slice'
-// @has - '//span[@class="in-band"]' 'Primitive Type slice'
+// @has - '//h1[@class="fqn"]' 'Primitive Type slice'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has - '//h2[@id="synthetic-implementations"]' 'Auto Trait Implementations'
 // @has - '//div[@id="synthetic-implementations-list"]//h3' 'impl<T> Send for [T]where T: Send'

--- a/src/test/rustdoc/primitive-tuple-auto-trait.rs
+++ b/src/test/rustdoc/primitive-tuple-auto-trait.rs
@@ -4,7 +4,7 @@
 #![feature(rustdoc_internals)]
 
 // @has foo/primitive.tuple.html '//a[@class="primitive"]' 'tuple'
-// @has - '//span[@class="in-band"]' 'Primitive Type tuple'
+// @has - '//h1[@class="fqn"]' 'Primitive Type tuple'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has - '//h2[@id="synthetic-implementations"]' 'Auto Trait Implementations'
 // @has - '//div[@id="synthetic-implementations-list"]//h3' 'Send'

--- a/src/test/rustdoc/primitive-unit-auto-trait.rs
+++ b/src/test/rustdoc/primitive-unit-auto-trait.rs
@@ -4,7 +4,7 @@
 #![feature(rustdoc_internals)]
 
 // @has foo/primitive.unit.html '//a[@class="primitive"]' 'unit'
-// @has - '//span[@class="in-band"]' 'Primitive Type unit'
+// @has - '//h1[@class="fqn"]' 'Primitive Type unit'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has - '//h2[@id="synthetic-implementations"]' 'Auto Trait Implementations'
 // @has - '//div[@id="synthetic-implementations-list"]//h3' 'impl Send for ()'

--- a/src/test/rustdoc/primitive.rs
+++ b/src/test/rustdoc/primitive.rs
@@ -7,7 +7,7 @@
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a' 'Primitive Types'
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a/@href' '#primitives'
 // @has foo/primitive.i32.html '//a[@class="primitive"]' 'i32'
-// @has foo/primitive.i32.html '//span[@class="in-band"]' 'Primitive Type i32'
+// @has foo/primitive.i32.html '//h1[@class="fqn"]' 'Primitive Type i32'
 // @has foo/primitive.i32.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has foo/index.html '//a/@href' '../foo/index.html'
 // @!has foo/index.html '//span' '🔒'


### PR DESCRIPTION
Since a7c25b29575c17434406b69773f8c2961af343b3 removed `in-band` from code headers, the only remaining uses of the `in-band` class are:

https://github.com/rust-lang/rust/blob/02cd79afb8080fce8c8ce35533c54d8ecf8f390e/src/librustdoc/html/render/write_shared.rs#L520-L521

https://github.com/rust-lang/rust/blob/02cd79afb8080fce8c8ce35533c54d8ecf8f390e/src/librustdoc/html/templates/print_item.html#L2-L3

https://github.com/rust-lang/rust/blob/02cd79afb8080fce8c8ce35533c54d8ecf8f390e/src/librustdoc/html/render/context.rs#L637-L638

https://github.com/rust-lang/rust/blob/02cd79afb8080fce8c8ce35533c54d8ecf8f390e/src/librustdoc/html/render/mod.rs#L368-L369

https://github.com/rust-lang/rust/blob/02cd79afb8080fce8c8ce35533c54d8ecf8f390e/src/librustdoc/html/render/mod.rs#L401-L402

https://github.com/rust-lang/rust/blob/02cd79afb8080fce8c8ce35533c54d8ecf8f390e/src/librustdoc/html/static/js/main.js#L525

Since all of these uses are nested below `h1.fqn`, we can get rid of it, and the support code that was used for when `in-band` was part of item rendering.