### PR TITLE
Update doc for `PhantomData` to match code example

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -695,7 +695,7 @@ impl<T: ?Sized> !Sync for *mut T {}
 /// }
 /// ```
 ///
-/// This also in turn requires the annotation `T: 'a`, indicating
+/// This also in turn infers the lifetime bound `T: 'a`, indicating
 /// that any references in `T` are valid over the lifetime `'a`.
 ///
 /// When initializing a `Slice` you simply provide the value


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/106621, there is no longer a `T: 'a` annotation in the doc example, so update the text to match the code.