### PR TITLE
Remove `mir::CastKind::Misc`

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2209,25 +2209,104 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                             }
                         }
                     }
-
-                    CastKind::Misc => {
+                    CastKind::IntToInt => {
                         let ty_from = op.ty(body, tcx);
                         let cast_ty_from = CastTy::from_ty(ty_from);
                         let cast_ty_to = CastTy::from_ty(*ty);
-                        // Misc casts are either between floats and ints, or one ptr type to another.
                         match (cast_ty_from, cast_ty_to) {
-                            (
-                                Some(CastTy::Int(_) | CastTy::Float),
-                                Some(CastTy::Int(_) | CastTy::Float),
-                            )
-                            | (Some(CastTy::Ptr(_) | CastTy::FnPtr), Some(CastTy::Ptr(_))) => (),
+                            (Some(CastTy::Int(_)), Some(CastTy::Int(_))) => (),
                             _ => {
                                 span_mirbug!(
                                     self,
                                     rvalue,
-                                    "Invalid Misc cast {:?} -> {:?}",
+                                    "Invalid IntToInt cast {:?} -> {:?}",
                                     ty_from,
-                                    ty,
+                                    ty
+                                )
+                            }
+                        }
+                    }
+                    CastKind::IntToFloat => {
+                        let ty_from = op.ty(body, tcx);
+                        let cast_ty_from = CastTy::from_ty(ty_from);
+                        let cast_ty_to = CastTy::from_ty(*ty);
+                        match (cast_ty_from, cast_ty_to) {
+                            (Some(CastTy::Int(_)), Some(CastTy::Float)) => (),
+                            _ => {
+                                span_mirbug!(
+                                    self,
+                                    rvalue,
+                                    "Invalid IntToFloat cast {:?} -> {:?}",
+                                    ty_from,
+                                    ty
+                                )
+                            }
+                        }
+                    }
+                    CastKind::FloatToInt => {
+                        let ty_from = op.ty(body, tcx);
+                        let cast_ty_from = CastTy::from_ty(ty_from);
+                        let cast_ty_to = CastTy::from_ty(*ty);
+                        match (cast_ty_from, cast_ty_to) {
+                            (Some(CastTy::Float), Some(CastTy::Int(_))) => (),
+                            _ => {
+                                span_mirbug!(
+                                    self,
+                                    rvalue,
+                                    "Invalid FloatToInt cast {:?} -> {:?}",
+                                    ty_from,
+                                    ty
+                                )
+                            }
+                        }
+                    }
+                    CastKind::FloatToFloat => {
+                        let ty_from = op.ty(body, tcx);
+                        let cast_ty_from = CastTy::from_ty(ty_from);
+                        let cast_ty_to = CastTy::from_ty(*ty);
+                        match (cast_ty_from, cast_ty_to) {
+                            (Some(CastTy::Float), Some(CastTy::Float)) => (),
+                            _ => {
+                                span_mirbug!(
+                                    self,
+                                    rvalue,
+                                    "Invalid FloatToFloat cast {:?} -> {:?}",
+                                    ty_from,
+                                    ty
+                                )
+                            }
+                        }
+                    }
+                    CastKind::FnPtrToPtr => {
+                        let ty_from = op.ty(body, tcx);
+                        let cast_ty_from = CastTy::from_ty(ty_from);
+                        let cast_ty_to = CastTy::from_ty(*ty);
+                        match (cast_ty_from, cast_ty_to) {
+                            (Some(CastTy::FnPtr), Some(CastTy::Ptr(_))) => (),
+                            _ => {
+                                span_mirbug!(
+                                    self,
+                                    rvalue,
+                                    "Invalid FnPtrToPtr cast {:?} -> {:?}",
+                                    ty_from,
+                                    ty
+                                )
+                            }
+                        }
+                    }
+                    CastKind::PtrToPtr => {
+                        let ty_from = op.ty(body, tcx);
+                        let cast_ty_from = CastTy::from_ty(ty_from);
+                        let cast_ty_to = CastTy::from_ty(*ty);
+                        match (cast_ty_from, cast_ty_to) {
+                            (Some(CastTy::Ptr(_)), Some(CastTy::Ptr(_))) => (),
+                            _ => {
+                                span_mirbug!(
+                                    self,
+                                    rvalue,
+                                    "Invalid PtrToPtr cast {:?} -> {:?}",
+                                    ty_from,
+                                    ty
                                 )
                             }
                         }

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -633,7 +633,12 @@ fn codegen_stmt<'tcx>(
                     lval.write_cvalue(fx, operand.cast_pointer_to(to_layout));
                 }
                 Rvalue::Cast(
-                    CastKind::Misc
+                    CastKind::IntToInt
+                    | CastKind::FloatToFloat
+                    | CastKind::FloatToInt
+                    | CastKind::IntToFloat
+                    | CastKind::FnPtrToPtr
+                    | CastKind::PtrToPtr
                     | CastKind::PointerExposeAddress
                     | CastKind::PointerFromExposedAddress,
                     ref operand,

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -490,7 +490,16 @@ pub(crate) fn mir_operand_get_const_val<'tcx>(
                     match &stmt.kind {
                         StatementKind::Assign(local_and_rvalue) if &local_and_rvalue.0 == place => {
                             match &local_and_rvalue.1 {
-                                Rvalue::Cast(CastKind::Misc, operand, ty) => {
+                                Rvalue::Cast(
+                                    CastKind::IntToInt
+                                    | CastKind::FloatToFloat
+                                    | CastKind::FloatToInt
+                                    | CastKind::IntToFloat
+                                    | CastKind::FnPtrToPtr
+                                    | CastKind::PtrToPtr,
+                                    operand,
+                                    ty,
+                                ) => {
                                     if computed_const_val.is_some() {
                                         return None; // local assigned twice
                                     }

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -250,7 +250,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         OperandValue::Pair(lldata, llextra)
                     }
                     mir::CastKind::Pointer(PointerCast::MutToConstPointer)
-                    | mir::CastKind::Misc
+                    | mir::CastKind::PtrToPtr
                         if bx.cx().is_backend_scalar_pair(operand.layout) =>
                     {
                         if let OperandValue::Pair(data_ptr, meta) = operand.val {
@@ -290,7 +290,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     mir::CastKind::Pointer(
                         PointerCast::MutToConstPointer | PointerCast::ArrayToPointer,
                     )
-                    | mir::CastKind::Misc
+                    | mir::CastKind::IntToInt
+                    | mir::CastKind::FloatToInt
+                    | mir::CastKind::FloatToFloat
+                    | mir::CastKind::IntToFloat
+                    | mir::CastKind::PtrToPtr
+                    | mir::CastKind::FnPtrToPtr
+
                     // Since int2ptr can have arbitrary integer types as input (so we have to do
                     // sign extension and all that), it is currently best handled in the same code
                     // path as the other integer-to-X casts.

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -42,8 +42,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let res = self.pointer_from_exposed_address_cast(&src, cast_ty)?;
                 self.write_immediate(res, dest)?;
             }
-
-            Misc => {
+            // FIXME: We shouldn't use `misc_cast` for these but handle them separately.
+            IntToInt | FloatToInt | FloatToFloat | IntToFloat | FnPtrToPtr | PtrToPtr => {
                 let src = self.read_immediate(src)?;
                 let res = self.misc_cast(&src, cast_ty)?;
                 self.write_immediate(res, dest)?;

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -553,7 +553,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 unimplemented!()
             }
 
-            Rvalue::Cast(CastKind::Misc, _, _) => {}
+            Rvalue::Cast(_, _, _) => {}
 
             Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => {}
             Rvalue::ShallowInitBox(_, _) => {}

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -557,7 +557,14 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             }
             Rvalue::Cast(kind, operand, target_type) => {
                 match kind {
-                    CastKind::Misc => {
+                    CastKind::DynStar => {
+                        // FIXME(dyn-star): make sure nothing needs to be done here.
+                    }
+                    // Nothing to check here
+                    CastKind::PointerFromExposedAddress
+                    | CastKind::PointerExposeAddress
+                    | CastKind::Pointer(_) => {}
+                    _ => {
                         let op_ty = operand.ty(self.body, self.tcx);
                         if op_ty.is_enum() {
                             self.fail(
@@ -568,13 +575,6 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             );
                         }
                     }
-                    CastKind::DynStar => {
-                        // FIXME(dyn-star): make sure nothing needs to be done here.
-                    }
-                    // Nothing to check here
-                    CastKind::PointerFromExposedAddress
-                    | CastKind::PointerExposeAddress
-                    | CastKind::Pointer(_) => {}
                 }
             }
             Rvalue::Repeat(_, _)

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1834,7 +1834,14 @@ impl<'tcx> Rvalue<'tcx> {
             | Rvalue::AddressOf(_, _)
             | Rvalue::Len(_)
             | Rvalue::Cast(
-                CastKind::Misc | CastKind::Pointer(_) | CastKind::PointerFromExposedAddress,
+                CastKind::IntToInt
+                | CastKind::FloatToInt
+                | CastKind::FloatToFloat
+                | CastKind::IntToFloat
+                | CastKind::FnPtrToPtr
+                | CastKind::PtrToPtr
+                | CastKind::Pointer(_)
+                | CastKind::PointerFromExposedAddress,
                 _,
                 _,
             )

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1149,8 +1149,12 @@ pub enum CastKind {
     Pointer(PointerCast),
     /// Cast into a dyn* object.
     DynStar,
-    /// Remaining unclassified casts.
-    Misc,
+    IntToInt,
+    FloatToInt,
+    FloatToFloat,
+    IntToFloat,
+    PtrToPtr,
+    FnPtrToPtr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -823,9 +823,10 @@ where
             // tmp = &raw mut P;
             // cur = tmp as *mut T;
             // end = Offset(cur, len);
+            let mir_cast_kind = ty::cast::mir_cast_kind(iter_ty, tmp_ty);
             vec![
                 self.assign(tmp, Rvalue::AddressOf(Mutability::Mut, self.place)),
-                self.assign(cur, Rvalue::Cast(CastKind::Misc, Operand::Move(tmp), iter_ty)),
+                self.assign(cur, Rvalue::Cast(mir_cast_kind, Operand::Move(tmp), iter_ty)),
                 self.assign(
                     length_or_end,
                     Rvalue::BinaryOp(

--- a/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
@@ -14,10 +14,10 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/cast.rs:+1:9: +1:10
--         _1 = const 42_u8 as u32 (Misc);  // scope 0 at $DIR/cast.rs:+1:13: +1:24
+-         _1 = const 42_u8 as u32 (IntToInt); // scope 0 at $DIR/cast.rs:+1:13: +1:24
 +         _1 = const 42_u32;               // scope 0 at $DIR/cast.rs:+1:13: +1:24
           StorageLive(_2);                 // scope 1 at $DIR/cast.rs:+3:9: +3:10
--         _2 = const 42_u32 as u8 (Misc);  // scope 1 at $DIR/cast.rs:+3:13: +3:24
+-         _2 = const 42_u32 as u8 (IntToInt); // scope 1 at $DIR/cast.rs:+3:13: +3:24
 +         _2 = const 42_u8;                // scope 1 at $DIR/cast.rs:+3:13: +3:24
           _0 = const ();                   // scope 0 at $DIR/cast.rs:+0:11: +4:2
           StorageDead(_2);                 // scope 1 at $DIR/cast.rs:+4:1: +4:2

--- a/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
@@ -13,7 +13,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/indirect.rs:+1:9: +1:10
           StorageLive(_2);                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25
--         _2 = const 2_u32 as u8 (Misc);   // scope 0 at $DIR/indirect.rs:+1:13: +1:25
+-         _2 = const 2_u32 as u8 (IntToInt); // scope 0 at $DIR/indirect.rs:+1:13: +1:25
 -         _3 = CheckedAdd(_2, const 1_u8); // scope 0 at $DIR/indirect.rs:+1:13: +1:29
 -         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:+1:13: +1:29
 +         _2 = const 2_u8;                 // scope 0 at $DIR/indirect.rs:+1:13: +1:25

--- a/src/test/mir-opt/enum_cast.bar.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.bar.mir_map.0.mir
@@ -7,7 +7,7 @@ fn bar(_1: Bar) -> usize {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
-        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _0 = move _2 as usize (IntToInt); // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
         return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/enum_cast.boo.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.boo.mir_map.0.mir
@@ -7,7 +7,7 @@ fn boo(_1: Boo) -> usize {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
-        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _0 = move _2 as usize (IntToInt); // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
         return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/enum_cast.droppy.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.droppy.mir_map.0.mir
@@ -26,7 +26,7 @@ fn droppy() -> () {
         FakeRead(ForLet(None), _2);      // scope 0 at $DIR/enum_cast.rs:+2:13: +2:14
         StorageLive(_3);                 // scope 3 at $DIR/enum_cast.rs:+5:13: +5:14
         _4 = discriminant(_2);           // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
-        _3 = move _4 as usize (Misc);    // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
+        _3 = move _4 as usize (IntToInt); // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
         FakeRead(ForLet(None), _3);      // scope 3 at $DIR/enum_cast.rs:+5:13: +5:14
         _1 = const ();                   // scope 0 at $DIR/enum_cast.rs:+1:5: +6:6
         StorageDead(_3);                 // scope 1 at $DIR/enum_cast.rs:+6:5: +6:6

--- a/src/test/mir-opt/enum_cast.foo.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.foo.mir_map.0.mir
@@ -7,7 +7,7 @@ fn foo(_1: Foo) -> usize {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
-        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _0 = move _2 as usize (IntToInt); // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
         return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2
     }
 }

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -91,7 +91,7 @@
           StorageLive(_15);                // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
           StorageLive(_16);                // scope 3 at $DIR/funky_arms.rs:+15:59: +15:68
           _16 = _10;                       // scope 3 at $DIR/funky_arms.rs:+15:59: +15:68
-          _15 = move _16 as u32 (Misc);    // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
+          _15 = move _16 as u32 (IntToInt); // scope 3 at $DIR/funky_arms.rs:+15:59: +15:75
           StorageDead(_16);                // scope 3 at $DIR/funky_arms.rs:+15:74: +15:75
           _14 = Add(move _15, const 1_u32); // scope 3 at $DIR/funky_arms.rs:+15:59: +15:79
           StorageDead(_15);                // scope 3 at $DIR/funky_arms.rs:+15:78: +15:79

--- a/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
@@ -31,7 +31,7 @@
           StorageLive(_6);                 // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:31
           StorageLive(_7);                 // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:24
           _7 = _2;                         // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:24
-          _6 = move _7 as i32 (Misc);      // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:31
+          _6 = move _7 as i32 (IntToInt);  // scope 1 at $DIR/if-condition-int.rs:+4:23: +4:31
           StorageDead(_7);                 // scope 1 at $DIR/if-condition-int.rs:+4:30: +4:31
           _0 = Add(const 100_i32, move _6); // scope 1 at $DIR/if-condition-int.rs:+4:17: +4:31
           StorageDead(_6);                 // scope 1 at $DIR/if-condition-int.rs:+4:30: +4:31
@@ -43,7 +43,7 @@
           StorageLive(_4);                 // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:31
           StorageLive(_5);                 // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:24
           _5 = _2;                         // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:24
-          _4 = move _5 as i32 (Misc);      // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:31
+          _4 = move _5 as i32 (IntToInt);  // scope 1 at $DIR/if-condition-int.rs:+3:23: +3:31
           StorageDead(_5);                 // scope 1 at $DIR/if-condition-int.rs:+3:30: +3:31
           _0 = Add(const 10_i32, move _4); // scope 1 at $DIR/if-condition-int.rs:+3:18: +3:31
           StorageDead(_4);                 // scope 1 at $DIR/if-condition-int.rs:+3:30: +3:31

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -25,7 +25,7 @@
       bb1: {
           StorageLive(_4);                 // scope 0 at $DIR/inline-diverging.rs:+2:9: +2:10
           _4 = _1;                         // scope 0 at $DIR/inline-diverging.rs:+2:9: +2:10
-          _0 = move _4 as u32 (Misc);      // scope 0 at $DIR/inline-diverging.rs:+2:9: +2:17
+          _0 = move _4 as u32 (IntToInt);  // scope 0 at $DIR/inline-diverging.rs:+2:9: +2:17
           StorageDead(_4);                 // scope 0 at $DIR/inline-diverging.rs:+2:16: +2:17
           StorageDead(_2);                 // scope 0 at $DIR/inline-diverging.rs:+5:5: +5:6
           return;                          // scope 0 at $DIR/inline-diverging.rs:+6:2: +6:2

--- a/src/test/mir-opt/issue_101973.inner.ConstProp.diff
+++ b/src/test/mir-opt/issue_101973.inner.ConstProp.diff
@@ -90,9 +90,9 @@
           StorageDead(_16);                // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
           StorageDead(_6);                 // scope 0 at $DIR/issue-101973.rs:+1:57: +1:58
           StorageDead(_4);                 // scope 0 at $DIR/issue-101973.rs:+1:57: +1:58
-          _2 = move _3 as i32 (Misc);      // scope 0 at $DIR/issue-101973.rs:+1:5: +1:65
+          _2 = move _3 as i32 (IntToInt);  // scope 0 at $DIR/issue-101973.rs:+1:5: +1:65
           StorageDead(_3);                 // scope 0 at $DIR/issue-101973.rs:+1:64: +1:65
-          _0 = move _2 as i64 (Misc);      // scope 0 at $DIR/issue-101973.rs:+1:5: +1:72
+          _0 = move _2 as i64 (IntToInt);  // scope 0 at $DIR/issue-101973.rs:+1:5: +1:72
           StorageDead(_2);                 // scope 0 at $DIR/issue-101973.rs:+1:71: +1:72
           return;                          // scope 0 at $DIR/issue-101973.rs:+2:2: +2:2
       }

--- a/src/test/mir-opt/lower_intrinsics.f_copy_nonoverlapping.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.f_copy_nonoverlapping.LowerIntrinsics.diff
@@ -36,7 +36,7 @@
           _7 = &_1;                        // scope 3 at $DIR/lower_intrinsics.rs:+4:29: +4:33
           _6 = &raw const (*_7);           // scope 3 at $DIR/lower_intrinsics.rs:+4:29: +4:33
           _5 = _6;                         // scope 3 at $DIR/lower_intrinsics.rs:+4:29: +4:45
-          _4 = move _5 as *const i32 (Misc); // scope 3 at $DIR/lower_intrinsics.rs:+4:29: +4:59
+          _4 = move _5 as *const i32 (PtrToPtr); // scope 3 at $DIR/lower_intrinsics.rs:+4:29: +4:59
           StorageDead(_5);                 // scope 3 at $DIR/lower_intrinsics.rs:+4:58: +4:59
           StorageLive(_8);                 // scope 3 at $DIR/lower_intrinsics.rs:+4:61: +4:91
           StorageLive(_9);                 // scope 3 at $DIR/lower_intrinsics.rs:+4:61: +4:79
@@ -45,7 +45,7 @@
           _11 = &mut _2;                   // scope 3 at $DIR/lower_intrinsics.rs:+4:61: +4:69
           _10 = &raw mut (*_11);           // scope 3 at $DIR/lower_intrinsics.rs:+4:61: +4:69
           _9 = _10;                        // scope 3 at $DIR/lower_intrinsics.rs:+4:61: +4:79
-          _8 = move _9 as *mut i32 (Misc); // scope 3 at $DIR/lower_intrinsics.rs:+4:61: +4:91
+          _8 = move _9 as *mut i32 (PtrToPtr); // scope 3 at $DIR/lower_intrinsics.rs:+4:61: +4:91
           StorageDead(_9);                 // scope 3 at $DIR/lower_intrinsics.rs:+4:90: +4:91
 -         _3 = copy_nonoverlapping::<i32>(move _4, move _8, const 0_usize) -> bb1; // scope 3 at $DIR/lower_intrinsics.rs:+4:9: +4:95
 -                                          // mir::Constant

--- a/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
@@ -84,7 +84,7 @@ fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
 
     bb13: {
         _15 = &raw mut (*_1);            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
-        _9 = move _15 as *mut std::string::String (Misc); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
+        _9 = move _15 as *mut std::string::String (PtrToPtr); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
         _10 = Offset(_9, move _3);       // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
         goto -> bb12;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:+0:1: +0:56
     }

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -129,7 +129,12 @@ fn check_rvalue<'tcx>(
         | Rvalue::Use(operand)
         | Rvalue::Cast(
             CastKind::PointerFromExposedAddress
-            | CastKind::Misc
+            | CastKind::IntToInt
+            | CastKind::FloatToInt
+            | CastKind::IntToFloat
+            | CastKind::FloatToFloat
+            | CastKind::FnPtrToPtr
+            | CastKind::PtrToPtr
             | CastKind::Pointer(PointerCast::MutToConstPointer | PointerCast::ArrayToPointer),
             operand,
             _,


### PR DESCRIPTION
As discussed in #97649 `mir::CastKind::Misc` is not clear, this PR addresses that by creating a new enum variant for every valid cast.

r? @oli-obk 