### PR TITLE
Add a tier 3 target for the Sony PlayStation 1

### DIFF
--- a/compiler/rustc_target/src/spec/mipsel_sony_psx.rs
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psx.rs
@@ -1,0 +1,37 @@
+use crate::spec::{cvs, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "mipsel-sony-psx".into(),
+        pointer_width: 32,
+        data_layout: "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".into(),
+        arch: "mips".into(),
+
+        options: TargetOptions {
+            os: "none".into(),
+            env: "psx".into(),
+            vendor: "sony".into(),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+            cpu: "mips1".into(),
+            executables: true,
+            linker: Some("rust-lld".into()),
+            relocation_model: RelocModel::Static,
+            exe_suffix: ".exe".into(),
+
+            // PSX doesn't natively support floats.
+            features: "+soft-float".into(),
+
+            // This should be 16 bits, but LLVM incorrectly tries emitting MIPS-II SYNC instructions
+            // for atomic loads and stores. This crashes rustc so we have to disable the Atomic* API
+            // until this is fixed upstream. See https://reviews.llvm.org/D122427#3420144 for more
+            // info.
+            max_atomic_width: Some(0),
+
+            // PSX does not support trap-on-condition instructions.
+            llvm_args: cvs!["-mno-check-zero-division"],
+            llvm_abiname: "o32".into(),
+            panic_strategy: PanicStrategy::Abort,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1222,6 +1222,7 @@ supported_targets! {
     ("armv7a-kmc-solid_asp3-eabihf", armv7a_kmc_solid_asp3_eabihf),
 
     ("mipsel-sony-psp", mipsel_sony_psp),
+    ("mipsel-sony-psx", mipsel_sony_psx),
     ("mipsel-unknown-none", mipsel_unknown_none),
     ("thumbv4t-none-eabi", thumbv4t_none_eabi),
     ("armv4t-none-eabi", armv4t_none_eabi),

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -29,6 +29,7 @@
     - [\*-kmc-solid_\*](platform-support/kmc-solid.md)
     - [m68k-unknown-linux-gnu](platform-support/m68k-unknown-linux-gnu.md)
     - [mips64-openwrt-linux-musl](platform-support/mips64-openwrt-linux-musl.md)
+    - [mipsel-sony-psx](platform-support/mipsel-sony-psx.md)
     - [nvptx64-nvidia-cuda](platform-support/nvptx64-nvidia-cuda.md)
     - [riscv32imac-unknown-xous-elf](platform-support/riscv32imac-unknown-xous-elf.md)
     - [*-pc-windows-gnullvm](platform-support/pc-windows-gnullvm.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -260,6 +260,7 @@ target | std | host | notes
 `mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
 [`mips64-openwrt-linux-musl`](platform-support/mips64-openwrt-linux-musl.md) | ? |  | MIPS64 for OpenWrt Linux MUSL
 `mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP)
+[`mipsel-sony-psx`](platform-support/mipsel-sony-psx.md) | * |  | MIPS (LE) Sony PlayStation 1 (PSX)
 `mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc
 `mipsel-unknown-none` | * |  | Bare MIPS (LE) softfloat
 `mipsisa32r6-unknown-linux-gnu` | ? |  |

--- a/src/doc/rustc/src/platform-support/mipsel-sony-psx.md
+++ b/src/doc/rustc/src/platform-support/mipsel-sony-psx.md
@@ -1,0 +1,49 @@
+# mipsel-sony-psx
+
+**Tier: 3**
+
+Sony PlayStation 1 (psx)
+
+## Designated Developer
+
+* [@ayrtonm](https://github.com/ayrtonm)
+
+## Requirements
+
+This target is cross-compiled.
+It has no special requirements for the host.
+
+## Building
+
+The target can be built by enabling it for a `rustc` build:
+
+```toml
+[build]
+build-stage = 1
+target = ["mipsel-sony-psx"]
+```
+
+## Cross-compilation
+
+This target can be cross-compiled from any host.
+
+## Testing
+
+Currently there is no support to run the rustc test suite for this target.
+
+## Building Rust programs
+
+Since it is Tier 3, rust doesn't ship pre-compiled artifacts for this target.
+
+Just use the `build-std` nightly cargo feature to build the `core` and `alloc` libraries:
+```shell
+cargo build -Zbuild-std=core,alloc --target mipsel-sony-psx
+```
+
+The command above generates an ELF. To generate binaries in the PSEXE format that emulators run, you can use [cargo-psx](https://github.com/ayrtonm/psx-sdk-rs#readme):
+
+```shell
+cargo psx build
+```
+
+or use `-Clink-arg=--oformat=binary` to produce a flat binary.


### PR DESCRIPTION
This adds a tier 3 target, `mipsel-sony-psx`, for the Sony PlayStation 1. I've tested it pretty thoroughly with [this SDK](https://github.com/ayrtonm/psx-sdk-rs) I wrote for it.

From the [tier 3 target policy](https://doc.rust-lang.org/rustc/target-tier-policy.html#tier-3-target-policy) (I've omitted the subpoints for brevity, but read over everything)
> A tier 3 target must have a designated developer or developers (the "target maintainers") on record to be CCed when issues arise regarding the target. (The mechanism to track and CC such developers may evolve over time.)

I'd be the designated developer

> Targets must use naming consistent with any existing targets; for instance, a target for the same CPU or OS as an existing Rust target should use the same name for that CPU or OS. Targets should normally use the same names and naming conventions as used elsewhere in the broader ecosystem beyond Rust (such as in other toolchains), unless they have a very good reason to diverge. Changing the name of a target can be highly disruptive, especially once the target reaches a higher tier, so getting the name right is important even for a tier 3 target. 

The target name follows the conventions of the existing PSP target (`mipsel-sony-psp`) and uses `psx` following the convention of the broader [PlayStation homebrew community](https://psx-spx.consoledev.net/).

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users.

No legal issues with this target.

> Neither this policy nor any decisions made regarding targets shall create any binding agreement or estoppel by any party. If any member of an approving Rust team serves as one of the maintainers of a target, or has any legal or employment requirement (explicit or implicit) that might affect their decisions regarding a target, they must recuse themselves from any approval decisions regarding the target's tier status, though they may otherwise participate in discussions.

:+1:

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate (core for most targets, alloc for targets that can support dynamic memory allocation, std for targets with an operating system or equivalent layer of system-provided functionality), but may leave some code unimplemented (either unavailable or stubbed out as appropriate), whether because the target makes it impossible to implement or challenging to implement. The authors of pull requests are not obligated to avoid calling any portions of the standard library on the basis of a tier 3 target not implementing those portions.

The psx supports `core` and `alloc`, but will likely not support `std` anytime soon.

> The target must provide documentation for the Rust community explaining how to build for the target, using cross-compilation if possible. If the target supports running binaries, or running tests (even if they do not pass), the documentation must explain how to run such binaries or tests for the target, using emulation if possible or dedicated hardware if necessary.

This target has an SDK and a `cargo-psx` tool for formatting binaries as psx executables. Documentation and examples are provided in the [psx-sdk-rs README](https://github.com/ayrtonm/psx-sdk-rs#psx-sdk-rs), the SDK and cargo tool are both available through crates.io and docs.rs has [SDK documentation](https://docs.rs/psx/latest/psx/).

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on a tier 3 target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding a tier 3 target, unless they have opted into such messages.

:+1:

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target. 

No problem