### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_analysis/src/check/fn_ctxt/suggestions.rs
@@ -1122,7 +1122,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             } else {
                 err.span_suggestion_short(
                     span_semi,
-                    "remove this semicolon",
+                    "remove this semicolon to return this value",
                     "",
                     Applicability::MachineApplicable,
                 );

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2265,7 +2265,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                             };
                             let mut suggestions = vec![(
                                 trait_path_segment.ident.span.shrink_to_lo(),
-                                format!("<{} as ", self.tcx.def_path(impl_def_id).to_string_no_crate_verbose())
+                                format!("<{} as ", self.tcx.type_of(impl_def_id))
                             )];
                             if let Some(generic_arg) = trait_path_segment.args {
                                 let between_span = trait_path_segment.ident.span.between(generic_arg.span_ext);

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -280,7 +280,8 @@ impl<K, V, S> HashMap<K, V, S> {
     /// ```
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
-    pub fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
+    #[rustc_const_unstable(feature = "const_collections_with_hasher", issue = "102575")]
+    pub const fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
         HashMap { base: base::HashMap::with_hasher(hash_builder) }
     }
 

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -1115,3 +1115,9 @@ fn from_array() {
     // that's a problem!
     let _must_not_require_type_annotation = HashMap::from([(1, 2)]);
 }
+
+#[test]
+fn const_with_hasher() {
+    const X: HashMap<(), (), ()> = HashMap::with_hasher(());
+    assert_eq!(X.len(), 0);
+}

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -376,7 +376,8 @@ impl<T, S> HashSet<T, S> {
     /// ```
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
-    pub fn with_hasher(hasher: S) -> HashSet<T, S> {
+    #[rustc_const_unstable(feature = "const_collections_with_hasher", issue = "102575")]
+    pub const fn with_hasher(hasher: S) -> HashSet<T, S> {
         HashSet { base: base::HashSet::with_hasher(hasher) }
     }
 

--- a/library/std/src/collections/hash/set/tests.rs
+++ b/library/std/src/collections/hash/set/tests.rs
@@ -496,3 +496,9 @@ fn from_array() {
     // that's a problem!
     let _must_not_require_type_annotation = HashSet::from([1, 2]);
 }
+
+#[test]
+fn const_with_hasher() {
+    const X: HashSet<(), ()> = HashSet::with_hasher(());
+    assert_eq!(X.len(), 0);
+}

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -351,6 +351,7 @@
 // Only used in tests/benchmarks:
 //
 // Only for const-ness:
+#![feature(const_collections_with_hasher)]
 #![feature(const_io_structs)]
 #![feature(const_ip)]
 #![feature(const_ipv4)]

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -870,10 +870,10 @@ tool_extended!((self, builder),
     Clippy, "src/tools/clippy", "clippy-driver", stable=true, in_tree=true, {};
     Miri, "src/tools/miri", "miri", stable=false, in_tree=true, {};
     CargoMiri, "src/tools/miri/cargo-miri", "cargo-miri", stable=false, in_tree=true, {};
-    Rls, "src/tools/rls", "rls", stable=true, {};
     // FIXME: tool_std is not quite right, we shouldn't allow nightly features.
     // But `builder.cargo` doesn't know how to handle ToolBootstrap in stages other than 0,
     // and this is close enough for now.
+    Rls, "src/tools/rls", "rls", stable=true, in_tree=true, tool_std=true, {};
     RustDemangler, "src/tools/rust-demangler", "rust-demangler", stable=false, in_tree=true, tool_std=true, {};
     Rustfmt, "src/tools/rustfmt", "rustfmt", stable=true, in_tree=true, {};
 );

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -654,10 +654,6 @@ pre.example-line-numbers {
 	font-weight: normal;
 }
 
-.method > .code-header, .trait-impl > .code-header {
-	display: block;
-}
-
 .in-band {
 	flex-grow: 1;
 	margin: 0px;

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -7,7 +7,7 @@ LL | pub fn f() -> String {
    |        implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
-   |                      - help: remove this semicolon
+   |                      - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
   --> $DIR/consider-removing-last-semi.rs:8:15
@@ -18,7 +18,7 @@ LL | pub fn g() -> String {
    |        implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
-   |                           - help: remove this semicolon
+   |                           - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
   --> $DIR/consider-removing-last-semi.rs:13:25
@@ -29,7 +29,7 @@ LL | pub fn macro_tests() -> u32 {
    |        implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     mac!();
-   |           - help: remove this semicolon
+   |           - help: remove this semicolon to return this value
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -7,7 +7,7 @@ LL | fn blah() -> i32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
-   |     - help: remove this semicolon
+   |     - help: remove this semicolon to return this value
 
 error: aborting due to previous error
 

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -15,7 +15,7 @@ LL | fn bar() -> String {
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
-   |     - help: remove this semicolon
+   |     - help: remove this semicolon to return this value
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/old-closure-expression-remove-semicolon.fixed
+++ b/src/test/ui/closures/old-closure-expression-remove-semicolon.fixed
@@ -7,6 +7,6 @@ fn foo() -> i32 {
 fn main() {
     let _x: i32 = {
         //~^ ERROR mismatched types
-        foo() //~ HELP remove this semicolon
+        foo() //~ HELP remove this semicolon to return this value
     };
 }

--- a/src/test/ui/closures/old-closure-expression-remove-semicolon.rs
+++ b/src/test/ui/closures/old-closure-expression-remove-semicolon.rs
@@ -7,6 +7,6 @@ fn foo() -> i32 {
 fn main() {
     let _x: i32 = {
         //~^ ERROR mismatched types
-        foo(); //~ HELP remove this semicolon
+        foo(); //~ HELP remove this semicolon to return this value
     };
 }

--- a/src/test/ui/closures/old-closure-expression-remove-semicolon.stderr
+++ b/src/test/ui/closures/old-closure-expression-remove-semicolon.stderr
@@ -5,7 +5,7 @@ LL |       let _x: i32 = {
    |  ___________________^
 LL | |
 LL | |         foo();
-   | |              - help: remove this semicolon
+   | |              - help: remove this semicolon to return this value
 LL | |     };
    | |_____^ expected `i32`, found `()`
 

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -6,7 +6,7 @@ LL | fn plus_one(x: i32) -> i32 {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
-   |          - help: remove this semicolon
+   |          - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
   --> $DIR/coercion-missing-tail-expected-type.rs:8:13
@@ -16,7 +16,7 @@ LL | fn foo() -> Result<u8, u64> {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
-   |          - help: remove this semicolon
+   |          - help: remove this semicolon to return this value
    |
    = note:   expected enum `Result<u8, u64>`
            found unit type `()`

--- a/src/test/ui/error-codes/E0283.stderr
+++ b/src/test/ui/error-codes/E0283.stderr
@@ -9,8 +9,8 @@ LL |     let cont: u32 = Generator::create();
    |
 help: use a fully-qualified path to a specific available implementation (2 found)
    |
-LL |     let cont: u32 = <::Impl as Generator>::create();
-   |                     ++++++++++          +
+LL |     let cont: u32 = <Impl as Generator>::create();
+   |                     ++++++++          +
 
 error[E0283]: type annotations needed
   --> $DIR/E0283.rs:35:24

--- a/src/test/ui/error-codes/E0790.stderr
+++ b/src/test/ui/error-codes/E0790.stderr
@@ -9,8 +9,8 @@ LL |         MyTrait::my_fn();
    |
 help: use the fully-qualified path to the only available implementation
    |
-LL |         <::inner::MyStruct as MyTrait>::my_fn();
-   |         +++++++++++++++++++++        +
+LL |         <MyStruct as MyTrait>::my_fn();
+   |         ++++++++++++        +
 
 error[E0790]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
   --> $DIR/E0790.rs:21:17
@@ -23,8 +23,8 @@ LL |         let _ = MyTrait::MY_ASSOC_CONST;
    |
 help: use the fully-qualified path to the only available implementation
    |
-LL |         let _ = <::inner::MyStruct as MyTrait>::MY_ASSOC_CONST;
-   |                 +++++++++++++++++++++        +
+LL |         let _ = <MyStruct as MyTrait>::MY_ASSOC_CONST;
+   |                 ++++++++++++        +
 
 error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/E0790.rs:26:5
@@ -37,8 +37,8 @@ LL |     inner::MyTrait::my_fn();
    |
 help: use the fully-qualified path to the only available implementation
    |
-LL |     inner::<::inner::MyStruct as MyTrait>::my_fn();
-   |            +++++++++++++++++++++        +
+LL |     inner::<MyStruct as MyTrait>::my_fn();
+   |            ++++++++++++        +
 
 error[E0790]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
   --> $DIR/E0790.rs:30:13
@@ -51,8 +51,8 @@ LL |     let _ = inner::MyTrait::MY_ASSOC_CONST;
    |
 help: use the fully-qualified path to the only available implementation
    |
-LL |     let _ = inner::<::inner::MyStruct as MyTrait>::MY_ASSOC_CONST;
-   |                    +++++++++++++++++++++        +
+LL |     let _ = inner::<MyStruct as MyTrait>::MY_ASSOC_CONST;
+   |                    ++++++++++++        +
 
 error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/E0790.rs:50:5
@@ -65,8 +65,8 @@ LL |     MyTrait2::my_fn();
    |
 help: use a fully-qualified path to a specific available implementation (2 found)
    |
-LL |     <::Impl1 as MyTrait2>::my_fn();
-   |     +++++++++++         +
+LL |     <Impl1 as MyTrait2>::my_fn();
+   |     +++++++++         +
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -6,7 +6,7 @@ LL | fn foo(b: bool) -> Result<bool,String> {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
-   |                           - help: remove this semicolon
+   |                           - help: remove this semicolon to return this value
    |
    = note:   expected enum `Result<bool, String>`
            found unit type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.rs
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.rs
@@ -1,4 +1,3 @@
-//
 // regression test for #8005
 
 macro_rules! test { () => { fn foo() -> i32 { 1; } } }

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:7:19
+  --> $DIR/liveness-return-last-stmt-semi.rs:6:19
    |
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected `i32`, found `()`
@@ -7,17 +7,17 @@ LL | fn no_return() -> i32 {}
    |    implicitly returns `()` as its body has no tail or `return` expression
 
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:9:19
+  --> $DIR/liveness-return-last-stmt-semi.rs:8:19
    |
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected `u32`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
-   |          - help: remove this semicolon
+   |          - help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:13:19
+  --> $DIR/liveness-return-last-stmt-semi.rs:12:19
    |
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected `u32`, found `()`
@@ -25,7 +25,7 @@ LL | fn baz(x: u64) -> u32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
 
 error[E0308]: mismatched types
-  --> $DIR/liveness-return-last-stmt-semi.rs:4:41
+  --> $DIR/liveness-return-last-stmt-semi.rs:3:41
    |
 LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^ expected `i32`, found `()`

--- a/src/test/ui/suggestions/match-with-different-arm-types-as-stmt-instead-of-expr.stderr
+++ b/src/test/ui/suggestions/match-with-different-arm-types-as-stmt-instead-of-expr.stderr
@@ -7,7 +7,7 @@ LL | fn not_all_paths(a: &str) -> u32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     };
-   |      - help: remove this semicolon
+   |      - help: remove this semicolon to return this value
 
 error[E0308]: `match` arms have incompatible types
   --> $DIR/match-with-different-arm-types-as-stmt-instead-of-expr.rs:26:14

--- a/src/test/ui/traits/static-method-generic-inference.stderr
+++ b/src/test/ui/traits/static-method-generic-inference.stderr
@@ -9,8 +9,8 @@ LL |     let _f: base::Foo = base::HasNew::new();
    |
 help: use the fully-qualified path to the only available implementation
    |
-LL |     let _f: base::Foo = base::<::base::Foo as HasNew>::new();
-   |                               +++++++++++++++       +
+LL |     let _f: base::Foo = base::<Foo as HasNew>::new();
+   |                               +++++++       +
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/issue-101866.stderr
+++ b/src/test/ui/type/issue-101866.stderr
@@ -10,7 +10,7 @@ LL |     TraitA::<i32>::func();
 help: use the fully-qualified path to the only available implementation
    |
 LL -     TraitA::<i32>::func();
-LL +     <::StructA as TraitA<i32>>::func();
+LL +     <StructA as TraitA<i32>>::func();
    |
 
 error: aborting due to previous error


### PR DESCRIPTION
Successful merges:

 - #102574 (Make Hash{Set,Map}::with_hasher unstably const)
 - #102650 (Slightly improve no return for returning function error)
 - #102662 (rustdoc: remove no-op CSS `.code-header { display: block }`)
 - #102670 (follow-up fix about 101866 to print the self type.)
 - #102686 (Don't build the compiler before building rls)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102574,102650,102662,102670,102686)
<!-- homu-ignore:end -->