### PR TITLE
Stabilize `ControlFlow::{BREAK, CONTINUE}`

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -265,7 +265,6 @@ impl<B> ControlFlow<B, ()> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(control_flow_enum)]
     /// use std::ops::ControlFlow;
     ///
     /// let mut partial_sum = 0;
@@ -274,9 +273,9 @@ impl<B> ControlFlow<B, ()> {
     ///     if partial_sum > 100 { ControlFlow::Break(x) }
     ///     else { ControlFlow::CONTINUE }
     /// });
-    /// assert_eq!(last_used.break_value(), Some(22));
+    /// assert_eq!(last_used, ControlFlow::Break(22));
     /// ```
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
+    #[stable(feature = "control_flow_unit_consts", since = "CURRENT_RUSTC_VERSION")]
     pub const CONTINUE: Self = ControlFlow::Continue(());
 }
 
@@ -287,7 +286,6 @@ impl<C> ControlFlow<(), C> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(control_flow_enum)]
     /// use std::ops::ControlFlow;
     ///
     /// let mut partial_sum = 0;
@@ -297,6 +295,6 @@ impl<C> ControlFlow<(), C> {
     /// });
     /// assert_eq!(partial_sum, 108);
     /// ```
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
+    #[stable(feature = "control_flow_unit_consts", since = "CURRENT_RUSTC_VERSION")]
     pub const BREAK: Self = ControlFlow::Break(());
 }


### PR DESCRIPTION
I don't think these ever had any libs-api oversight, but they're super-simple so I figured I'd just send this PR to prompt discussion.

I wasn't confident in them when I first added them (https://github.com/rust-lang/rust/pull/76318#discussion_r483467298), but they've been extensively used in the compiler, and https://github.com/rust-lang/rust/issues/75744#issuecomment-869513873 got posted in their favour.  So that makes me think they're worth having.  Here's a few examples:

https://github.com/rust-lang/rust/blob/d8613f792c11d6d348b15eee79da561323fa0199/compiler/rustc_middle/src/ty/visit.rs#L645-L649

https://github.com/rust-lang/rust/blob/d8613f792c11d6d348b15eee79da561323fa0199/compiler/rustc_middle/src/ty/sty.rs#L1897-L1899

https://github.com/rust-lang/rust/blob/d8613f792c11d6d348b15eee79da561323fa0199/compiler/rustc_data_structures/src/graph/iterate/mod.rs#L347-L352

I think that `ControlFlow::CONTINUE` is particularly justified because the `C`ontinue generic parameter is defaulted to `()`.  And if that constant exists, I think there might as well be `BREAK` to go with it.  It's useful too, for any situation in which you're replacing `bool` with `ControlFlow<()>` in chain-of-responsibility style code, or similar.

@rustbot label +needs-fcp +T-libs-api -T-libs

cc the tracking issue #75744, though this is only a partial stabilization so this does **not** close that.