### PR TITLE
Fix hamburger button color

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1830,6 +1830,7 @@ in storage.js plus the media query with (min-width: 701px)
 		   as an icon, it's okay to specify its sizes in pixels. */
 		font-size: 32px;
 		border: none;
+		color: var(--main-color);
 	}
 
 	.sidebar-elems {

--- a/src/test/rustdoc-gui/sidebar-mobile.goml
+++ b/src/test/rustdoc-gui/sidebar-mobile.goml
@@ -42,23 +42,24 @@ scroll-to: ".block.keyword li:nth-child(1)"
 compare-elements-position-near: (".block.keyword li:nth-child(1)", ".mobile-topbar", {"y": 543})
 
 // Now checking the background color of the sidebar.
+show-text: true
 local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": "dark"}
 reload:
 
 // Open the sidebar menu.
 click: ".sidebar-menu-toggle"
-assert-css: (".sidebar", {"background-color": "rgb(80, 80, 80)"})
+assert-css: (".sidebar", {"background-color": "rgb(80, 80, 80)", "color": "rgb(221, 221, 221)"})
 
 local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": "ayu"}
 reload:
 
 // Open the sidebar menu.
 click: ".sidebar-menu-toggle"
-assert-css: (".sidebar", {"background-color": "rgb(20, 25, 31)"})
+assert-css: (".sidebar", {"background-color": "rgb(20, 25, 31)", "color": "rgb(197, 197, 197)"})
 
 local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": "light"}
 reload:
 
 // Open the sidebar menu.
 click: ".sidebar-menu-toggle"
-assert-css: (".sidebar", {"background-color": "rgb(245, 245, 245)"})
+assert-css: (".sidebar", {"background-color": "rgb(245, 245, 245)", "color": "rgb(0, 0, 0)"})


### PR DESCRIPTION
Before:

![Screenshot from 2022-10-05 11-14-20](https://user-images.githubusercontent.com/3050060/194026621-e4df5750-92df-4194-a163-9787b45ace26.png)

After:

![Screenshot from 2022-10-05 11-14-15](https://user-images.githubusercontent.com/3050060/194026618-6a365623-5181-4174-b6af-66962e5ba6a5.png)

No need to backport it, beta doesn't seem affected.

r? @notriddle 