### PR TITLE
rustdoc: render more cross-crate HRTBs properly

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1350,7 +1350,7 @@ impl Lifetime {
 pub(crate) enum WherePredicate {
     BoundPredicate { ty: Type, bounds: Vec<GenericBound>, bound_params: Vec<Lifetime> },
     RegionPredicate { lifetime: Lifetime, bounds: Vec<GenericBound> },
-    EqPredicate { lhs: Type, rhs: Term },
+    EqPredicate { lhs: Box<Type>, rhs: Box<Term>, bound_params: Vec<Lifetime> },
 }
 
 impl WherePredicate {
@@ -1358,6 +1358,15 @@ impl WherePredicate {
         match *self {
             WherePredicate::BoundPredicate { ref bounds, .. } => Some(bounds),
             WherePredicate::RegionPredicate { ref bounds, .. } => Some(bounds),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn get_bound_params(&self) -> Option<&[Lifetime]> {
+        match self {
+            Self::BoundPredicate { bound_params, .. } | Self::EqPredicate { bound_params, .. } => {
+                Some(bound_params)
+            }
             _ => None,
         }
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -331,7 +331,8 @@ pub(crate) fn print_where_clause<'a, 'tcx: 'a>(
                         bounds_display.truncate(bounds_display.len() - " + ".len());
                         write!(f, "{}: {bounds_display}", lifetime.print())
                     }
-                    clean::WherePredicate::EqPredicate { lhs, rhs } => {
+                    // FIXME(fmease): Render bound params.
+                    clean::WherePredicate::EqPredicate { lhs, rhs, bound_params: _ } => {
                         if f.alternate() {
                             write!(f, "{:#} == {:#}", lhs.print(cx), rhs.print(cx))
                         } else {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -432,8 +432,9 @@ impl FromWithTcx<clean::WherePredicate> for WherePredicate {
                 lifetime: convert_lifetime(lifetime),
                 bounds: bounds.into_tcx(tcx),
             },
-            EqPredicate { lhs, rhs } => {
-                WherePredicate::EqPredicate { lhs: lhs.into_tcx(tcx), rhs: rhs.into_tcx(tcx) }
+            // FIXME(fmease): Convert bound parameters as well.
+            EqPredicate { lhs, rhs, bound_params: _ } => {
+                WherePredicate::EqPredicate { lhs: (*lhs).into_tcx(tcx), rhs: (*rhs).into_tcx(tcx) }
             }
         }
     }

--- a/src/test/rustdoc/inline_cross/assoc_item_trait_bounds_with_bindings.rs
+++ b/src/test/rustdoc/inline_cross/assoc_item_trait_bounds_with_bindings.rs
@@ -8,8 +8,6 @@ extern crate assoc_item_trait_bounds_with_bindings as aux;
 
 // FIXME(fmease): Don't render an incorrect `T: ?Sized` where-clause for parameters
 //                of GATs like `Main::Out{2,4}`. Add a snapshot test once it's fixed.
-// FIXME(fmease): Print the `for<>` parameter list in the bounds of
-//                `Main::Out{6,11,12}`.
 
 // @has main/trait.Main.html
 // @has - '//*[@id="associatedtype.Out0"]' 'type Out0: Support<Item = ()>'
@@ -18,13 +16,14 @@ extern crate assoc_item_trait_bounds_with_bindings as aux;
 // @has - '//*[@id="associatedtype.Out3"]' 'type Out3: Support<Produce<()> = bool>'
 // @has - '//*[@id="associatedtype.Out4"]' 'type Out4<T>: Support<Produce<T> = T>'
 // @has - '//*[@id="associatedtype.Out5"]' "type Out5: Support<Output<'static> = &'static ()>"
-// @has - '//*[@id="associatedtype.Out6"]' "type Out6: Support<Output<'a> = &'a ()>"
+// @has - '//*[@id="associatedtype.Out6"]' "type Out6: for<'a> Support<Output<'a> = &'a ()>"
 // @has - '//*[@id="associatedtype.Out7"]' "type Out7: Support<Item = String, Produce<i32> = u32> + Unrelated"
 // @has - '//*[@id="associatedtype.Out8"]' "type Out8: Unrelated + Protocol<i16, Q1 = u128, Q0 = ()>"
 // @has - '//*[@id="associatedtype.Out9"]' "type Out9: FnMut(i32) -> bool + Clone"
 // @has - '//*[@id="associatedtype.Out10"]' "type Out10<'q>: Support<Output<'q> = ()>"
-// @has - '//*[@id="associatedtype.Out11"]' "type Out11: Helper<A<'s> = &'s (), B<'r> = ()>"
-// @has - '//*[@id="associatedtype.Out12"]' "type Out12: Helper<B<'w> = Cow<'w, str>, A<'w> = bool>"
+// @has - '//*[@id="associatedtype.Out11"]' "type Out11: for<'r, 's> Helper<A<'s> = &'s (), B<'r> = ()>"
+// @has - '//*[@id="associatedtype.Out12"]' "type Out12: for<'w> Helper<B<'w> = Cow<'w, str>, A<'w> = bool>"
+// @has - '//*[@id="associatedtype.Out13"]' "type Out13: for<'fst, 'snd> Aid<'snd, Result<'fst> = &'fst mut str>"
 //
 // Snapshots: Check that we do not render any where-clauses for those associated types since all of
 // the trait bounds contained within were moved to the bounds of the respective item.

--- a/src/test/rustdoc/inline_cross/auxiliary/assoc_item_trait_bounds_with_bindings.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/assoc_item_trait_bounds_with_bindings.rs
@@ -14,6 +14,7 @@ pub trait Main {
     type Out10<'q>: Support<Output<'q> = ()>;
     type Out11: for<'r, 's> Helper<A<'s> = &'s (), B<'r> = ()>;
     type Out12: for<'w> Helper<B<'w> = std::borrow::Cow<'w, str>, A<'w> = bool>;
+    type Out13: for<'fst, 'snd> Aid<'snd, Result<'fst> = &'fst mut str>;
 
     fn make<F>(_: F, _: impl FnMut(&str) -> bool)
     where
@@ -37,4 +38,8 @@ pub trait Unrelated {}
 pub trait Helper {
     type A<'q>;
     type B<'q>;
+}
+
+pub trait Aid<'src> {
+    type Result<'inter>;
 }

--- a/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
@@ -13,6 +13,19 @@ pub fn func3(_x: impl Iterator<Item = impl Iterator<Item = u8>> + Clone) {}
 
 pub fn func4<T: Iterator<Item = impl Clone>>(_x: T) {}
 
+pub fn func5(
+    _f: impl for<'any> Fn(&'any str, &'any str) -> bool + for<'r> Other<T<'r> = ()>,
+    _a: impl for<'alpha, 'beta> Auxiliary<'alpha, Item<'beta> = fn(&'beta ())>,
+) {}
+
+pub trait Other {
+    type T<'dependency>;
+}
+
+pub trait Auxiliary<'arena> {
+    type Item<'input>;
+}
+
 pub async fn async_fn() {}
 
 pub struct Foo;

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -26,6 +26,13 @@ pub use impl_trait_aux::func3;
 // @has - '//pre[@class="rust fn"]' "T: Iterator<Item = impl Clone>,"
 pub use impl_trait_aux::func4;
 
+// @has impl_trait/fn.func5.html
+// @has - '//pre[@class="rust fn"]' "func5("
+// @has - '//pre[@class="rust fn"]' "_f: impl for<'any> Fn(&'any str, &'any str) -> bool + for<'r> Other<T<'r> = ()>,"
+// @has - '//pre[@class="rust fn"]' "_a: impl for<'alpha, 'beta> Auxiliary<'alpha, Item<'beta> = fn(&'beta ())>"
+// @!has - '//pre[@class="rust fn"]' 'where'
+pub use impl_trait_aux::func5;
+
 // @has impl_trait/fn.async_fn.html
 // @has - '//pre[@class="rust fn"]' "pub async fn async_fn()"
 pub use impl_trait_aux::async_fn;


### PR DESCRIPTION
Follow-up to #102439.
Render the `for<>` parameter lists of cross-crate higher-rank trait bounds (in where-clauses and in `impl Trait`).

I've added a new field `bound_params` to `clean::WherePredicate::EqPredicate` (mirroring its sibling variant `BoundPredicate`). However, I had to box the existing fields since `EqPredicate` used to be the largest variant (128 bytes on 64-bit systems) and it would only have gotten bigger).
Not sure if you like that approach. As an alternative, I could pass the uncleaned `ty::Predicate` alongside the cleaned `WherePredicate` to the various re-sugaring methods (similar to what `clean::AutoTraitFinder::param_env_to_generics` does).

I haven't yet added the HTML & JSON rendering code for the newly added `bound_params` field since I am waiting for your opinion. Those two rendering code paths should actually be unreachable in practice given the fact(?) that we re-sugar all equality predicates to associated type bindings (and arbitrary equality predicates are not part of the Rust surface language at the time of this writing).

If you agree with storing `bound_params` in `EqPredicate`, I think I can use it to greatly simplify the `clean::auto_trait` module (by also using `simplify::merge_bounds`). Maybe I can do that in any case though.

@rustbot label T-rustdoc A-cross-crate-reexports
r? @GuillaumeGomez