### PR TITLE
Suggest `==` to wrong assign expr

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/expr.rs
+++ b/compiler/rustc_hir_analysis/src/check/expr.rs
@@ -1044,6 +1044,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let rhs_ty = self.check_expr(&rhs);
             let (applicability, eq) = if self.can_coerce(rhs_ty, lhs_ty) {
                 (Applicability::MachineApplicable, true)
+            } else if let ExprKind::Binary(
+                Spanned { node: hir::BinOpKind::And | hir::BinOpKind::Or, .. },
+                _,
+                rhs_expr,
+            ) = lhs.kind
+            {
+                let actual_lhs_ty = self.check_expr(&rhs_expr);
+                (Applicability::MaybeIncorrect, self.can_coerce(rhs_ty, actual_lhs_ty))
             } else {
                 (Applicability::MaybeIncorrect, false)
             };

--- a/compiler/rustc_hir_analysis/src/check/expr.rs
+++ b/compiler/rustc_hir_analysis/src/check/expr.rs
@@ -1066,9 +1066,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             if eq {
                 err.span_suggestion_verbose(
-                    span,
+                    span.shrink_to_hi(),
                     "you might have meant to compare for equality",
-                    "==",
+                    '=',
                     applicability,
                 );
             }

--- a/src/test/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/src/test/ui/expr/if/bad-if-let-suggestion.stderr
@@ -62,6 +62,11 @@ error[E0308]: mismatched types
    |
 LL |     if let x = 1 && i = 2 {}
    |        ^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if let x = 1 && i == 2 {}
+   |                        +
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1510,7 +1510,7 @@ LL |     if x = let 0 = 0 {}
 help: you might have meant to compare for equality
    |
 LL |     if x == let 0 = 0 {}
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:157:8
@@ -1704,7 +1704,7 @@ LL |     while x = let 0 = 0 {}
 help: you might have meant to compare for equality
    |
 LL |     while x == let 0 = 0 {}
-   |             ~~
+   |              +
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:249:11

--- a/src/test/ui/type/type-check/assignment-expected-bool.stderr
+++ b/src/test/ui/type/type-check/assignment-expected-bool.stderr
@@ -7,7 +7,7 @@ LL |     let _: bool = 0 = 0;
 help: you might have meant to compare for equality
    |
 LL |     let _: bool = 0 == 0;
-   |                     ~~
+   |                      +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:9:14
@@ -18,7 +18,7 @@ LL |         0 => 0 = 0,
 help: you might have meant to compare for equality
    |
 LL |         0 => 0 == 0,
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:10:14
@@ -29,7 +29,7 @@ LL |         _ => 0 = 0,
 help: you might have meant to compare for equality
    |
 LL |         _ => 0 == 0,
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:14:17
@@ -40,7 +40,7 @@ LL |         true => 0 = 0,
 help: you might have meant to compare for equality
    |
 LL |         true => 0 == 0,
-   |                   ~~
+   |                    +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:18:8
@@ -51,7 +51,7 @@ LL |     if 0 = 0 {}
 help: you might have meant to compare for equality
    |
 LL |     if 0 == 0 {}
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:20:24
@@ -62,7 +62,7 @@ LL |     let _: bool = if { 0 = 0 } {
 help: you might have meant to compare for equality
    |
 LL |     let _: bool = if { 0 == 0 } {
-   |                          ~~
+   |                           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:21:9
@@ -73,7 +73,7 @@ LL |         0 = 0
 help: you might have meant to compare for equality
    |
 LL |         0 == 0
-   |           ~~
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:23:9
@@ -84,7 +84,7 @@ LL |         0 = 0
 help: you might have meant to compare for equality
    |
 LL |         0 == 0
-   |           ~~
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:26:13
@@ -95,7 +95,7 @@ LL |     let _ = (0 = 0)
 help: you might have meant to compare for equality
    |
 LL |     let _ = (0 == 0)
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:27:14
@@ -106,7 +106,7 @@ LL |         && { 0 = 0 }
 help: you might have meant to compare for equality
    |
 LL |         && { 0 == 0 }
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:28:12
@@ -117,7 +117,7 @@ LL |         || (0 = 0);
 help: you might have meant to compare for equality
    |
 LL |         || (0 == 0);
-   |               ~~
+   |                +
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/assignment-expected-bool.rs:31:22

--- a/src/test/ui/type/type-check/assignment-in-if.rs
+++ b/src/test/ui/type/type-check/assignment-in-if.rs
@@ -40,4 +40,17 @@ fn main() {
     ) {
         println!("{}", x);
     }
+
+    if x == x && x = x && x == x {
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        //~| ERROR mismatched types
+        println!("{}", x);
+    }
+
+    if x == x && x == x && x = x {
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        println!("{}", x);
+    }
 }

--- a/src/test/ui/type/type-check/assignment-in-if.stderr
+++ b/src/test/ui/type/type-check/assignment-in-if.stderr
@@ -7,7 +7,7 @@ LL |     if x = x {
 help: you might have meant to compare for equality
    |
 LL |     if x == x {
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:20:8
@@ -18,7 +18,7 @@ LL |     if (x = x) {
 help: you might have meant to compare for equality
    |
 LL |     if (x == x) {
-   |           ~~
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:25:8
@@ -29,7 +29,7 @@ LL |     if y = (Foo { foo: x }) {
 help: you might have meant to compare for equality
    |
 LL |     if y == (Foo { foo: x }) {
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:30:8
@@ -40,7 +40,7 @@ LL |     if 3 = x {
 help: you might have meant to compare for equality
    |
 LL |     if 3 == x {
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:36:13
@@ -51,7 +51,7 @@ LL |             x = 4
 help: you might have meant to compare for equality
    |
 LL |             x == 4
-   |               ~~
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:38:13
@@ -62,8 +62,48 @@ LL |             x = 5
 help: you might have meant to compare for equality
    |
 LL |             x == 5
-   |               ~~
+   |                +
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:44:18
+   |
+LL |     if x == x && x = x && x == x {
+   |                  ^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:44:22
+   |
+LL |     if x == x && x = x && x == x {
+   |                      ^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:44:8
+   |
+LL |     if x == x && x = x && x == x {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == x && x == x && x == x {
+   |                     +
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:51:28
+   |
+LL |     if x == x && x == x && x = x {
+   |                            ^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:51:8
+   |
+LL |     if x == x && x == x && x = x {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == x && x == x && x == x {
+   |                               +
+
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Given the following code:

```rust
fn main() {
    let x = 3;
    let y = 3;
    if x == x && y = y {
        println!("{}", x);
    }
}
```

Current output is:

```
error[E0308]: mismatched types
 --> src/main.rs:4:18
  |
4 |     if x == x && y = y {
  |                  ^ expected `bool`, found integer

error[E0308]: mismatched types
 --> src/main.rs:4:8
  |
4 |     if x == x && y = y {
  |        ^^^^^^^^^^^^^^^ expected `bool`, found `()`
```

This adds a suggestion:

```diff
error[E0308]: mismatched types
 --> src/main.rs:6:18
  |
6 |     if x == x && y = y {
  |                  ^ expected `bool`, found integer

error[E0308]: mismatched types
 --> src/main.rs:6:8
  |
6 |     if x == x && y = y {
  |        ^^^^^^^^^^^^^^^ expected `bool`, found `()`
  |
+ help: you might have meant to compare for equality
+   |
+ 6 |     if x == x && y == y {
+   |                     +
```

And this fixes a part of #97469