### PR TITLE
evaluation cache, freshen each predicate by itself

### DIFF
--- a/src/test/ui/coherence/issue-100191-2.rs
+++ b/src/test/ui/coherence/issue-100191-2.rs
@@ -1,5 +1,3 @@
-//~ ERROR overflow evaluating the requirement `T: Trait<_>`
-
 #![feature(specialization, with_negative_coherence)]
 #![allow(incomplete_features)]
 
@@ -8,5 +6,6 @@ pub trait Trait<T> {}
 default impl<T, U> Trait<T> for U {}
 
 impl<T> Trait<<T as Iterator>::Item> for T {}
+//~^ ERROR conflicting implementations of trait `Trait<_>`
 
 fn main() {}

--- a/src/test/ui/coherence/issue-100191-2.stderr
+++ b/src/test/ui/coherence/issue-100191-2.stderr
@@ -1,14 +1,12 @@
-error[E0275]: overflow evaluating the requirement `T: Trait<_>`
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_100191_2`)
-note: required for `T` to implement `Trait<_>`
-  --> $DIR/issue-100191-2.rs:8:20
+error[E0119]: conflicting implementations of trait `Trait<_>`
+  --> $DIR/issue-100191-2.rs:8:1
    |
 LL | default impl<T, U> Trait<T> for U {}
-   |                    ^^^^^^^^     ^
-   = note: 128 redundant requirements hidden
-   = note: required for `T` to implement `Trait<_>`
+   | --------------------------------- first implementation here
+LL |
+LL | impl<T> Trait<<T as Iterator>::Item> for T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0275`.
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/issues/issue-69683.rs
+++ b/src/test/ui/issues/issue-69683.rs
@@ -27,7 +27,6 @@ where
 fn main() {
     let b: [u8; 3] = [0u8; 3];
 
-    0u16.foo(b); //~ ERROR type annotations needed
-    //~^ ERROR type annotations needed
+    0u16.foo(b); //~ ERROR mismatched types
     //<u16 as Foo<[(); 3]>>::foo(0u16, b);
 }

--- a/src/test/ui/issues/issue-69683.stderr
+++ b/src/test/ui/issues/issue-69683.stderr
@@ -1,43 +1,17 @@
-error[E0284]: type annotations needed
-  --> $DIR/issue-69683.rs:30:10
+error[E0308]: mismatched types
+  --> $DIR/issue-69683.rs:30:14
    |
 LL |     0u16.foo(b);
-   |          ^^^
+   |          --- ^ expected `u8`, found array `[u8; 3]`
+   |          |
+   |          arguments to this function are incorrect
    |
-   = note: cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
-help: try using a fully qualified path to specify the expected types
+note: associated function defined here
+  --> $DIR/issue-69683.rs:17:8
    |
-LL |     <u16 as Foo<I>>::foo(0u16, b);
-   |     +++++++++++++++++++++    ~
-
-error[E0283]: type annotations needed
-  --> $DIR/issue-69683.rs:30:10
-   |
-LL |     0u16.foo(b);
-   |          ^^^
-   |
-note: multiple `impl`s satisfying `u8: Element<_>` found
-  --> $DIR/issue-69683.rs:5:1
-   |
-LL | impl<T> Element<()> for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | impl<T: Element<S>, S> Element<[S; 3]> for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: required by a bound in `Foo::foo`
-  --> $DIR/issue-69683.rs:15:9
-   |
-LL |     u8: Element<I>,
-   |         ^^^^^^^^^^ required by this bound in `Foo::foo`
-LL | {
 LL |     fn foo(self, x: <u8 as Element<I>>::Array);
-   |        --- required by a bound in this
-help: try using a fully qualified path to specify the expected types
-   |
-LL |     <u16 as Foo<I>>::foo(0u16, b);
-   |     +++++++++++++++++++++    ~
+   |        ^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0283, E0284.
-For more information about an error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/partialeq_help.stderr
+++ b/src/test/ui/partialeq_help.stderr
@@ -5,10 +5,13 @@ LL |     a == b;
    |       ^^ no implementation for `&T == T`
    |
    = help: the trait `PartialEq<T>` is not implemented for `&T`
-help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
-   |
-LL | fn foo<T: PartialEq>(a: &T, b: T) where &T: PartialEq<T> {
-   |                                   ++++++++++++++++++++++
+   = help: the following other types implement trait `PartialEq<Rhs>`:
+             <&A as PartialEq<&B>>
+             <&A as PartialEq<&mut B>>
+             <&mut A as PartialEq<&B>>
+             <&mut A as PartialEq<&mut B>>
+             <*const T as PartialEq>
+             <*mut T as PartialEq>
 
 error[E0277]: can't compare `&T` with `T`
   --> $DIR/partialeq_help.rs:6:7
@@ -17,10 +20,13 @@ LL |     a == b;
    |       ^^ no implementation for `&T == T`
    |
    = help: the trait `PartialEq<T>` is not implemented for `&T`
-help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
-   |
-LL | fn foo2<T: PartialEq>(a: &T, b: T) where &T: PartialEq<T> {
-   |                                          ++++++++++++++++
+   = help: the following other types implement trait `PartialEq<Rhs>`:
+             <&A as PartialEq<&B>>
+             <&A as PartialEq<&mut B>>
+             <&mut A as PartialEq<&B>>
+             <&mut A as PartialEq<&mut B>>
+             <*const T as PartialEq>
+             <*mut T as PartialEq>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/specialization/issue-45814.rs
+++ b/src/test/ui/specialization/issue-45814.rs
@@ -1,5 +1,3 @@
-//~ ERROR overflow evaluating the requirement `T: Trait<_>`
-
 #![feature(specialization)]
 #![allow(incomplete_features)]
 
@@ -8,5 +6,6 @@ pub trait Trait<T> {}
 default impl<T, U> Trait<T> for U {}
 
 impl<T> Trait<<T as Iterator>::Item> for T {}
+//~^ ERROR conflicting implementations of trait `Trait<_>`
 
 fn main() {}

--- a/src/test/ui/specialization/issue-45814.stderr
+++ b/src/test/ui/specialization/issue-45814.stderr
@@ -1,14 +1,12 @@
-error[E0275]: overflow evaluating the requirement `T: Trait<_>`
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_45814`)
-note: required for `T` to implement `Trait<_>`
-  --> $DIR/issue-45814.rs:8:20
+error[E0119]: conflicting implementations of trait `Trait<_>`
+  --> $DIR/issue-45814.rs:8:1
    |
 LL | default impl<T, U> Trait<T> for U {}
-   |                    ^^^^^^^^     ^
-   = note: 128 redundant requirements hidden
-   = note: required for `T` to implement `Trait<_>`
+   | --------------------------------- first implementation here
+LL |
+LL | impl<T> Trait<<T as Iterator>::Item> for T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0275`.
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/traits/issue-18400.rs
+++ b/src/test/ui/traits/issue-18400.rs
@@ -22,5 +22,5 @@ fn main() {
     let bits: &[_] = &[0, 1];
 
     0.contains(bits);
-    //~^ ERROR overflow
+    //~^ ERROR can't call method `contains` on ambiguous numeric type `{integer}
 }

--- a/src/test/ui/traits/issue-18400.stderr
+++ b/src/test/ui/traits/issue-18400.stderr
@@ -1,18 +1,14 @@
-error[E0275]: overflow evaluating the requirement `_: Sized`
+error[E0689]: can't call method `contains` on ambiguous numeric type `{integer}`
   --> $DIR/issue-18400.rs:24:7
    |
 LL |     0.contains(bits);
    |       ^^^^^^^^
    |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_18400`)
-note: required for `{integer}` to implement `Set<&[_]>`
-  --> $DIR/issue-18400.rs:6:16
+help: you must specify a concrete type for this numeric value, like `i32`
    |
-LL | impl<'a, T, S> Set<&'a [T]> for S where
-   |                ^^^^^^^^^^^^     ^
-   = note: 128 redundant requirements hidden
-   = note: required for `{integer}` to implement `Set<&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[&[_]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]>`
+LL |     0_i32.contains(bits);
+   |     ~~~~~
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0275`.
+For more information about this error, try `rustc --explain E0689`.


### PR DESCRIPTION
I think this change is correct. Here's my understanding of this:

This previously wasn't done was so that we don't consider `Foo<?0>: Trait` requiring `Foo<?0>: Trait` (which is trivially a cycle), the same as `Foo<?0>: Trait` requiring `Foo<?1>: Trait`, which is an infinite chain instead.

For inductive obligations, cycles and infinite chains should both result in ambiguity, so for these this doesn't matter.

For coinductive obligations, cycles result in success and I believe that infinitely diverging chains should also be a success. That's my understanding given my limited experience with coq and the general intuition of "coinduction means stuff is true unless proven otherwise, induction means stuff is wrong unless proven otherwise".

r? @nikomatsakis cc @rust-lang/types 