### PR TITLE
test: run-make: skip when cross-compiling

### DIFF
--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,10 +1,6 @@
-# ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
+# ignore-cross-compile $(call RUN,foo) expects to run the target executable natively
 #                              so it won't work with remote-test-server
-# ignore-arm Another build using remote-test-server
 # ignore-none no-std is not supported
-# ignore-wasm32 FIXME: don't attempt to compile C++ to WASM
-# ignore-wasm64 FIXME: don't attempt to compile C++ to WASM
-# ignore-nvptx64-nvidia-cuda FIXME: can't find crate for `std`
 # ignore-musl FIXME: this makefile needs teaching how to use a musl toolchain
 #                    (see dist-i586-gnu-i586-i686-musl Dockerfile)
 


### PR DESCRIPTION
This test fails when targeting aarch64 Android. Instead of adding yet another architecture here (and one that's increasingly more common as the host), let's replace the growing list of architectures with ignore-cross-compile.