### PR TITLE
Fix the sanitizer_scs_attr_check.rs test

### DIFF
--- a/src/test/codegen/sanitizer_scs_attr_check.rs
+++ b/src/test/codegen/sanitizer_scs_attr_check.rs
@@ -7,11 +7,11 @@
 #![crate_type = "lib"]
 #![feature(no_sanitize)]
 
-// CHECK: ; Function Attrs:{{.*}}shadowcallstack
-// CHECK-NEXT: scs
+// CHECK: ; sanitizer_scs_attr_check::scs
+// CHECK-NEXT: ; Function Attrs:{{.*}}shadowcallstack
 pub fn scs() {}
 
+// CHECK: ; sanitizer_scs_attr_check::no_scs
 // CHECK-NOT: ; Function Attrs:{{.*}}shadowcallstack
-// CHECK-NEXT: no_scs
 #[no_sanitize(shadow_call_stack)]
 pub fn no_scs() {}


### PR DESCRIPTION
The test is failing when targeting aarch64 Android. The intent appears to have been to look for a function attributes comment (or the absence of one) on the line preceding the function declaration. But this isn't quite possible with FileCheck and the test as written was looking for a line with `no_scs` after a line with `scs`, which doesn't appear in the output. Instead, match on the function attributes comment on the line following the demangled function name comment.