### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -460,6 +460,7 @@ pub enum StashKey {
     ItemNoType,
     UnderscoreForArrayLengths,
     EarlySyntaxWarning,
+    CallIntoMethod,
 }
 
 fn default_track_diagnostic(_: &Diagnostic) {}

--- a/compiler/rustc_hir_analysis/src/check/callee.rs
+++ b/compiler/rustc_hir_analysis/src/check/callee.rs
@@ -473,7 +473,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         fn_sig.output()
     }
 
-    /// Attempts to reinterpret `method(rcvr, args...)` as `method.rcvr(args...)`
+    /// Attempts to reinterpret `method(rcvr, args...)` as `rcvr.method(args...)`
     /// and suggesting the fix if the method probe is successful.
     fn suggest_call_as_method(
         &self,

--- a/compiler/rustc_hir_analysis/src/check/callee.rs
+++ b/compiler/rustc_hir_analysis/src/check/callee.rs
@@ -1,7 +1,9 @@
+use super::method::probe::{IsSuggestion, Mode, ProbeScope};
 use super::method::MethodCallee;
 use super::{DefIdOrName, Expectation, FnCtxt, TupleArgumentsFlag};
 use crate::type_error_struct;
 
+use rustc_ast::util::parser::PREC_POSTFIX;
 use rustc_errors::{struct_span_err, Applicability, Diagnostic, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def::{self, Namespace, Res};
@@ -407,7 +409,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .diagnostic()
                         .steal_diagnostic(segment.ident.span, StashKey::CallIntoMethod)
                 {
-                    diag.emit();
+                    // Try suggesting `foo(a)` -> `a.foo()` if possible.
+                    if let Some(ty) =
+                        self.suggest_call_as_method(
+                            &mut diag,
+                            segment,
+                            arg_exprs,
+                            call_expr,
+                            expected
+                        )
+                    {
+                        diag.emit();
+                        return ty;
+                    } else {
+                        diag.emit();
+                    }
                 }
 
                 self.report_invalid_callee(call_expr, callee_expr, callee_ty, arg_exprs);
@@ -457,6 +473,105 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         fn_sig.output()
     }
 
+    /// Attempts to reinterpret `method(rcvr, args...)` as `method.rcvr(args...)`
+    /// and suggesting the fix if the method probe is successful.
+    fn suggest_call_as_method(
+        &self,
+        diag: &mut Diagnostic,
+        segment: &'tcx hir::PathSegment<'tcx>,
+        arg_exprs: &'tcx [hir::Expr<'tcx>],
+        call_expr: &'tcx hir::Expr<'tcx>,
+        expected: Expectation<'tcx>,
+    ) -> Option<Ty<'tcx>> {
+        if let [callee_expr, rest @ ..] = arg_exprs {
+            let callee_ty = self.check_expr(callee_expr);
+            // First, do a probe with `IsSuggestion(true)` to avoid emitting
+            // any strange errors. If it's successful, then we'll do a true
+            // method lookup.
+            let Ok(pick) = self
+            .probe_for_name(
+                call_expr.span,
+                Mode::MethodCall,
+                segment.ident,
+                IsSuggestion(true),
+                callee_ty,
+                call_expr.hir_id,
+                // We didn't record the in scope traits during late resolution
+                // so we need to probe AllTraits unfortunately
+                ProbeScope::AllTraits,
+            ) else {
+                return None;
+            };
+
+            let pick = self.confirm_method(
+                call_expr.span,
+                callee_expr,
+                call_expr,
+                callee_ty,
+                pick,
+                segment,
+            );
+            if pick.illegal_sized_bound.is_some() {
+                return None;
+            }
+
+            let up_to_rcvr_span = segment.ident.span.until(callee_expr.span);
+            let rest_span = callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
+            let rest_snippet = if let Some(first) = rest.first() {
+                self.tcx
+                    .sess
+                    .source_map()
+                    .span_to_snippet(first.span.to(call_expr.span.shrink_to_hi()))
+            } else {
+                Ok(")".to_string())
+            };
+
+            if let Ok(rest_snippet) = rest_snippet {
+                let sugg = if callee_expr.precedence().order() >= PREC_POSTFIX {
+                    vec![
+                        (up_to_rcvr_span, "".to_string()),
+                        (rest_span, format!(".{}({rest_snippet}", segment.ident)),
+                    ]
+                } else {
+                    vec![
+                        (up_to_rcvr_span, "(".to_string()),
+                        (rest_span, format!(").{}({rest_snippet}", segment.ident)),
+                    ]
+                };
+                let self_ty = self.resolve_vars_if_possible(pick.callee.sig.inputs()[0]);
+                diag.multipart_suggestion(
+                    format!(
+                        "use the `.` operator to call the method `{}{}` on `{self_ty}`",
+                        self.tcx
+                            .associated_item(pick.callee.def_id)
+                            .trait_container(self.tcx)
+                            .map_or_else(
+                                || String::new(),
+                                |trait_def_id| self.tcx.def_path_str(trait_def_id) + "::"
+                            ),
+                        segment.ident
+                    ),
+                    sugg,
+                    Applicability::MaybeIncorrect,
+                );
+
+                // Let's check the method fully now
+                let return_ty = self.check_method_argument_types(
+                    segment.ident.span,
+                    call_expr,
+                    Ok(pick.callee),
+                    rest,
+                    TupleArgumentsFlag::DontTupleArguments,
+                    expected,
+                );
+
+                return Some(return_ty);
+            }
+        }
+
+        None
+    }
+
     fn report_invalid_callee(
         &self,
         call_expr: &'tcx hir::Expr<'tcx>,
@@ -475,10 +590,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 def::CtorOf::Struct => "struct",
                 def::CtorOf::Variant => "enum variant",
             };
-            let removal_span =
-                callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
-            unit_variant =
-                Some((removal_span, descr, rustc_hir_pretty::qpath_to_string(qpath)));
+            let removal_span = callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
+            unit_variant = Some((removal_span, descr, rustc_hir_pretty::qpath_to_string(qpath)));
         }
 
         let callee_ty = self.resolve_vars_if_possible(callee_ty);
@@ -541,7 +654,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         if !self.maybe_suggest_bad_array_definition(&mut err, call_expr, callee_expr) {
-            if let Some((maybe_def, output_ty, _)) = self.extract_callable_info(callee_expr, callee_ty)
+            if let Some((maybe_def, output_ty, _)) =
+                self.extract_callable_info(callee_expr, callee_ty)
                 && !self.type_is_sized_modulo_regions(self.param_env, output_ty, callee_expr.span)
             {
                 let descr = match maybe_def {

--- a/compiler/rustc_hir_analysis/src/check/expr.rs
+++ b/compiler/rustc_hir_analysis/src/check/expr.rs
@@ -1044,6 +1044,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let rhs_ty = self.check_expr(&rhs);
             let (applicability, eq) = if self.can_coerce(rhs_ty, lhs_ty) {
                 (Applicability::MachineApplicable, true)
+            } else if let ExprKind::Binary(
+                Spanned { node: hir::BinOpKind::And | hir::BinOpKind::Or, .. },
+                _,
+                rhs_expr,
+            ) = lhs.kind
+            {
+                let actual_lhs_ty = self.check_expr(&rhs_expr);
+                (Applicability::MaybeIncorrect, self.can_coerce(rhs_ty, actual_lhs_ty))
             } else {
                 (Applicability::MaybeIncorrect, false)
             };

--- a/compiler/rustc_hir_analysis/src/check/expr.rs
+++ b/compiler/rustc_hir_analysis/src/check/expr.rs
@@ -1066,9 +1066,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             if eq {
                 err.span_suggestion_verbose(
-                    span,
+                    span.shrink_to_hi(),
                     "you might have meant to compare for equality",
-                    "==",
+                    '=',
                     applicability,
                 );
             }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3263,6 +3263,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                     instead,
                     suggestion,
                     path: path.into(),
+                    is_call: source.is_call(),
                 });
             }
 
@@ -3327,6 +3328,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                     instead: false,
                     suggestion: None,
                     path: path.into(),
+                    is_call: source.is_call(),
                 });
             } else {
                 err.cancel();

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -674,6 +674,8 @@ struct UseError<'a> {
     /// Path `Segment`s at the place of use that failed. Used for accurate suggestion after telling
     /// the user to import the item directly.
     path: Vec<Segment>,
+    /// Whether the expected source is a call
+    is_call: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/library/std/src/sys/unix/rand.rs
+++ b/library/std/src/sys/unix/rand.rs
@@ -137,9 +137,11 @@ mod imp {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
+#[cfg(target_os = "macos")]
 mod imp {
-    use crate::io;
+    use crate::fs::File;
+    use crate::io::Read;
+    use crate::sys::os::errno;
     use crate::sys::weak::weak;
     use libc::{c_int, c_void, size_t};
 
@@ -153,7 +155,7 @@ mod imp {
                 for s in v.chunks_mut(256) {
                     let ret = unsafe { f(s.as_mut_ptr() as *mut c_void, s.len()) };
                     if ret == -1 {
-                        panic!("unexpected getentropy error: {}", io::Error::last_os_error());
+                        panic!("unexpected getentropy error: {}", errno());
                     }
                 }
                 true
@@ -161,64 +163,14 @@ mod imp {
             .unwrap_or(false)
     }
 
-    #[cfg(target_os = "macos")]
-    fn fallback_fill_bytes(v: &mut [u8]) {
-        use crate::fs::File;
-        use crate::io::Read;
-
-        let mut file = File::open("/dev/urandom").expect("failed to open /dev/urandom");
-        file.read_exact(v).expect("failed to read /dev/urandom")
-    }
-
-    // On iOS and MacOS `SecRandomCopyBytes` calls `CCRandomCopyBytes` with
-    // `kCCRandomDefault`. `CCRandomCopyBytes` manages a CSPRNG which is seeded
-    // from `/dev/random` and which runs on its own thread accessed via GCD.
-    //
-    // This is very heavyweight compared to the alternatives, but they may not be usable:
-    // - `getentropy` was added in iOS 10, but we support a minimum of iOS 7
-    // - `/dev/urandom` is not accessible inside the iOS app sandbox.
-    //
-    // Therefore `SecRandomCopyBytes` is only used on older iOS versions where no
-    // better options are present.
-    #[cfg(target_os = "ios")]
-    fn fallback_fill_bytes(v: &mut [u8]) {
-        use crate::ptr;
-
-        enum SecRandom {}
-
-        #[allow(non_upper_case_globals)]
-        const kSecRandomDefault: *const SecRandom = ptr::null();
-
-        extern "C" {
-            fn SecRandomCopyBytes(rnd: *const SecRandom, count: size_t, bytes: *mut u8) -> c_int;
-        }
-
-        let ret = unsafe { SecRandomCopyBytes(kSecRandomDefault, v.len(), v.as_mut_ptr()) };
-        if ret == -1 {
-            panic!("couldn't generate random bytes: {}", io::Error::last_os_error());
-        }
-    }
-
-    // All supported versions of watchOS (>= 5) have support for `getentropy`.
-    #[cfg(target_os = "watchos")]
-    #[cold]
-    fn fallback_fill_bytes(_: &mut [u8]) {
-        unreachable!()
-    }
-
     pub fn fill_bytes(v: &mut [u8]) {
         if getentropy_fill_bytes(v) {
             return;
         }
 
-        // Older macOS versions (< 10.12) don't support `getentropy`. Fallback to
-        // reading from `/dev/urandom` on these systems.
-        //
-        // Older iOS versions (< 10) don't support it either. Fallback to
-        // `SecRandomCopyBytes` on these systems. On watchOS, this is unreachable
-        // because the minimum supported version is 5 while `getentropy` became accessible
-        // in 3.
-        fallback_fill_bytes(v)
+        // for older macos which doesn't support getentropy
+        let mut file = File::open("/dev/urandom").expect("failed to open /dev/urandom");
+        file.read_exact(v).expect("failed to read /dev/urandom")
     }
 }
 
@@ -233,6 +185,36 @@ mod imp {
             if ret == -1 {
                 panic!("unexpected getentropy error: {}", errno());
             }
+        }
+    }
+}
+
+// On iOS and MacOS `SecRandomCopyBytes` calls `CCRandomCopyBytes` with
+// `kCCRandomDefault`. `CCRandomCopyBytes` manages a CSPRNG which is seeded
+// from `/dev/random` and which runs on its own thread accessed via GCD.
+// This seems needlessly heavyweight for the purposes of generating two u64s
+// once per thread in `hashmap_random_keys`. Therefore `SecRandomCopyBytes` is
+// only used on iOS where direct access to `/dev/urandom` is blocked by the
+// sandbox.
+#[cfg(any(target_os = "ios", target_os = "watchos"))]
+mod imp {
+    use crate::io;
+    use crate::ptr;
+    use libc::{c_int, size_t};
+
+    enum SecRandom {}
+
+    #[allow(non_upper_case_globals)]
+    const kSecRandomDefault: *const SecRandom = ptr::null();
+
+    extern "C" {
+        fn SecRandomCopyBytes(rnd: *const SecRandom, count: size_t, bytes: *mut u8) -> c_int;
+    }
+
+    pub fn fill_bytes(v: &mut [u8]) {
+        let ret = unsafe { SecRandomCopyBytes(kSecRandomDefault, v.len(), v.as_mut_ptr()) };
+        if ret == -1 {
+            panic!("couldn't generate random bytes: {}", io::Error::last_os_error());
         }
     }
 }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -634,9 +634,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 write!(
                     buf,
                     "<div class=\"main-heading\">\
-                     <h1 class=\"fqn\">\
-                         <span class=\"in-band\">Rustdoc settings</span>\
-                     </h1>\
+                     <h1 class=\"fqn\">Rustdoc settings</h1>\
                      <span class=\"out-of-band\">\
                          <a id=\"back\" href=\"javascript:void(0)\" onclick=\"history.back();\">\
                             Back\

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -364,11 +364,7 @@ impl AllTypes {
             }
         }
 
-        f.write_str(
-            "<h1 class=\"fqn\">\
-                 <span class=\"in-band\">List of all items</span>\
-             </h1>",
-        );
+        f.write_str("<h1 class=\"fqn\">List of all items</h1>");
         // Note: print_entries does not escape the title, because we know the current set of titles
         // doesn't require escaping.
         print_entries(f, &self.structs, ItemSection::Structs);
@@ -398,9 +394,7 @@ fn scrape_examples_help(shared: &SharedContext<'_>) -> String {
     let mut ids = IdMap::default();
     format!(
         "<div class=\"main-heading\">\
-            <h1 class=\"fqn\">\
-                <span class=\"in-band\">About scraped examples</span>\
-            </h1>\
+            <h1 class=\"fqn\">About scraped examples</h1>\
         </div>\
         <div>{}</div>",
         Markdown {

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -517,9 +517,7 @@ if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
             };
 
             let content = format!(
-                "<h1 class=\"fqn\">\
-                     <span class=\"in-band\">List of all crates</span>\
-                </h1><ul class=\"all-items\">{}</ul>",
+                "<h1 class=\"fqn\">List of all crates</h1><ul class=\"all-items\">{}</ul>",
                 krates
                     .iter()
                     .map(|s| {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -148,6 +148,13 @@ h1, h2, h3, h4 {
 h1.fqn {
 	margin: 0;
 	padding: 0;
+	flex-grow: 1;
+	/* We use overflow-wrap: break-word for Safari, which doesn't recognize
+	   `anywhere`: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap */
+	overflow-wrap: break-word;
+	/* Then override it with `anywhere`, which is required to make non-Safari browsers break
+	   more aggressively when we want them to. */
+	overflow-wrap: anywhere;
 }
 .main-heading {
 	display: flex;
@@ -214,7 +221,7 @@ pre.rust a,
 .sidebar h2 a,
 .sidebar h3 a,
 .mobile-topbar h2 a,
-.in-band a,
+h1.fqn a,
 .search-results a,
 .module-item .stab,
 .import-item .stab,
@@ -654,19 +661,6 @@ pre.example-line-numbers {
 	font-weight: normal;
 }
 
-.in-band {
-	flex-grow: 1;
-	margin: 0px;
-	padding: 0px;
-	/* We use overflow-wrap: break-word for Safari, which doesn't recognize
-	   `anywhere`: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap */
-	overflow-wrap: break-word;
-	/* Then override it with `anywhere`, which is required to make non-Safari browsers break
-	   more aggressively when we want them to. */
-	overflow-wrap: anywhere;
-	background-color: var(--main-background-color);
-}
-
 .docblock code, .docblock-short code,
 pre, .rustdoc.source .example-wrap {
 	background-color: var(--code-block-background-color);
@@ -752,7 +746,7 @@ a {
 	display: initial;
 }
 
-.in-band:hover > .anchor, .impl:hover > .anchor, .method.trait-impl:hover > .anchor,
+.impl:hover > .anchor, .method.trait-impl:hover > .anchor,
 .type.trait-impl:hover > .anchor, .associatedconstant.trait-impl:hover > .anchor,
 .associatedtype.trait-impl:hover > .anchor {
 	display: inline-block;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -522,7 +522,7 @@ function loadCss(cssFileName) {
         }
 
         let currentNbImpls = implementors.getElementsByClassName("impl").length;
-        const traitName = document.querySelector("h1.fqn > .in-band > .trait").textContent;
+        const traitName = document.querySelector("h1.fqn > .trait").textContent;
         const baseIdName = "impl-" + traitName + "-";
         const libs = Object.getOwnPropertyNames(imp);
         // We don't want to include impls from this JS file, when the HTML already has them.

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -1,18 +1,16 @@
 <div class="main-heading"> {#- -#}
     <h1 class="fqn"> {#- -#}
-        <span class="in-band"> {#- -#}
-            {{-typ-}}
-            {#- The breadcrumbs of the item path, like std::string -#}
-            {%- for component in path_components -%}
-            <a href="{{component.path|safe}}index.html">{{component.name}}</a>::<wbr>
-            {%- endfor -%}
-            <a class="{{item_type}}" href="#">{{name}}</a> {#- -#}
-            <button id="copy-path" onclick="copy_path(this)" title="Copy item path to clipboard"> {#- -#}
-                <img src="{{static_root_path|safe}}clipboard{{page.resource_suffix}}.svg" {# -#}
-                    width="19" height="18" {# -#}
-                    alt="Copy item path"> {#- -#}
-            </button> {#- -#}
-        </span> {#- -#}
+        {{-typ-}}
+        {#- The breadcrumbs of the item path, like std::string -#}
+        {%- for component in path_components -%}
+        <a href="{{component.path|safe}}index.html">{{component.name}}</a>::<wbr>
+        {%- endfor -%}
+        <a class="{{item_type}}" href="#">{{name}}</a> {#- -#}
+        <button id="copy-path" onclick="copy_path(this)" title="Copy item path to clipboard"> {#- -#}
+            <img src="{{static_root_path|safe}}clipboard{{page.resource_suffix}}.svg" {# -#}
+                width="19" height="18" {# -#}
+                alt="Copy item path"> {#- -#}
+        </button> {#- -#}
     </h1> {#- -#}
     <span class="out-of-band"> {#- -#}
         {% if !stability_since_raw.is_empty() %}

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -10,8 +10,8 @@ local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 reload:
 
 assert-css: ("#toggle-all-docs", {"color": "rgb(0, 0, 0)"})
-assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgb(0, 0, 0)"})
-assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(173, 55, 138)"})
+assert-css: (".fqn a:nth-of-type(1)", {"color": "rgb(0, 0, 0)"})
+assert-css: (".fqn a:nth-of-type(2)", {"color": "rgb(173, 55, 138)"})
 assert-css: (
     ".rightside .srclink",
     {"color": "rgb(56, 115, 173)", "text-decoration": "none solid rgb(56, 115, 173)"},
@@ -41,7 +41,7 @@ goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 assert-css: ("#top-doc-prose-title", {"color": "rgb(0, 0, 0)"})
 
 assert-css: (".sidebar a", {"color": "rgb(53, 109, 164)"})
-assert-css: (".in-band a", {"color": "rgb(0, 0, 0)"})
+assert-css: ("h1.fqn a", {"color": "rgb(0, 0, 0)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.
 move-cursor-to: "h2#implementations"
@@ -60,8 +60,8 @@ local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"}
 goto: file://|DOC_PATH|/staged_api/struct.Foo.html
 
 assert-css: ("#toggle-all-docs", {"color": "rgb(221, 221, 221)"})
-assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgb(221, 221, 221)"})
-assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(45, 191, 184)"})
+assert-css: (".fqn a:nth-of-type(1)", {"color": "rgb(221, 221, 221)"})
+assert-css: (".fqn a:nth-of-type(2)", {"color": "rgb(45, 191, 184)"})
 assert-css: (
     ".rightside .srclink",
     {"color": "rgb(210, 153, 29)", "text-decoration": "none solid rgb(210, 153, 29)"},
@@ -91,7 +91,7 @@ goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 assert-css: ("#top-doc-prose-title", {"color": "rgb(221, 221, 221)"})
 
 assert-css: (".sidebar a", {"color": "rgb(253, 191, 53)"})
-assert-css: (".in-band a", {"color": "rgb(221, 221, 221)"})
+assert-css: ("h1.fqn a", {"color": "rgb(221, 221, 221)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.
 move-cursor-to: "h2#implementations"
@@ -110,8 +110,8 @@ local-storage: {"rustdoc-theme": "ayu", "rustdoc-use-system-theme": "false"}
 goto: file://|DOC_PATH|/staged_api/struct.Foo.html
 
 assert-css: ("#toggle-all-docs", {"color": "rgb(197, 197, 197)"})
-assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgb(255, 255, 255)"})
-assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(255, 160, 165)"})
+assert-css: (".fqn a:nth-of-type(1)", {"color": "rgb(255, 255, 255)"})
+assert-css: (".fqn a:nth-of-type(2)", {"color": "rgb(255, 160, 165)"})
 assert-css: (
     ".rightside .srclink",
     {"color": "rgb(57, 175, 215)", "text-decoration": "none solid rgb(57, 175, 215)"},
@@ -141,7 +141,7 @@ goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 assert-css: ("#top-doc-prose-title", {"color": "rgb(255, 255, 255)"})
 
 assert-css: (".sidebar a", {"color": "rgb(83, 177, 219)"})
-assert-css: (".in-band a", {"color": "rgb(255, 255, 255)"})
+assert-css: ("h1.fqn a", {"color": "rgb(255, 255, 255)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.
 move-cursor-to: "h2#implementations"

--- a/src/test/rustdoc-gui/search-result-go-to-first.goml
+++ b/src/test/rustdoc-gui/search-result-go-to-first.goml
@@ -3,17 +3,17 @@
 // First, we check that the first page doesn't have the string we're looking for to ensure
 // that the feature is changing page as expected.
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-text-false: (".fqn .in-band", "Struct test_docs::Foo")
+assert-text-false: (".fqn", "Struct test_docs::Foo")
 
 // We now check that we land on the search result page if "go_to_first" isn't set.
 goto: file://|DOC_PATH|/test_docs/index.html?search=struct%3AFoo
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-text-false: (".fqn .in-band", "Struct test_docs::Foo")
+assert-text-false: (".fqn", "Struct test_docs::Foo")
 // Ensure that the search results are displayed, not the "normal" content.
 assert-css: ("#main-content", {"display": "none"})
 
 // Now we can check that the feature is working as expected!
 goto: file://|DOC_PATH|/test_docs/index.html?search=struct%3AFoo&go_to_first=true
 // Waiting for the page to load...
-wait-for-text: (".fqn .in-band", "Struct test_docs::Foo")
+wait-for-text: (".fqn", "Struct test_docs::Foo")

--- a/src/test/rustdoc-gui/toggle-click-deadspace.goml
+++ b/src/test/rustdoc-gui/toggle-click-deadspace.goml
@@ -12,4 +12,4 @@ assert-attribute-false: (".impl-items .rustdoc-toggle", {"open": ""})
 
 // Click the "Trait" part of "impl Trait" and verify it navigates.
 click: "#impl-Trait-for-Foo h3 a:first-of-type"
-assert-text: (".fqn .in-band", "Trait lib2::Trait")
+assert-text: (".fqn", "Trait lib2::Trait")

--- a/src/test/rustdoc/index-page.rs
+++ b/src/test/rustdoc/index-page.rs
@@ -5,7 +5,7 @@
 #![crate_name = "foo"]
 
 // @has foo/../index.html
-// @has - '//span[@class="in-band"]' 'List of all crates'
+// @has - '//h1[@class="fqn"]' 'List of all crates'
 // @has - '//ul[@class="all-items"]//a[@href="foo/index.html"]' 'foo'
 // @has - '//ul[@class="all-items"]//a[@href="all_item_types/index.html"]' 'all_item_types'
 pub struct Foo;

--- a/src/test/rustdoc/keyword.rs
+++ b/src/test/rustdoc/keyword.rs
@@ -7,7 +7,7 @@
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a' 'Keywords'
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a/@href' '#keywords'
 // @has foo/keyword.match.html '//a[@class="keyword"]' 'match'
-// @has foo/keyword.match.html '//span[@class="in-band"]' 'Keyword match'
+// @has foo/keyword.match.html '//h1[@class="fqn"]' 'Keyword match'
 // @has foo/keyword.match.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has foo/index.html '//a/@href' '../foo/index.html'
 // @!has foo/foo/index.html

--- a/src/test/rustdoc/primitive-reference.rs
+++ b/src/test/rustdoc/primitive-reference.rs
@@ -9,7 +9,7 @@
 // @has - '//div[@class="sidebar-elems"]//li/a/@href' '#primitives'
 // @has foo/primitive.reference.html
 // @has - '//a[@class="primitive"]' 'reference'
-// @has - '//span[@class="in-band"]' 'Primitive Type reference'
+// @has - '//h1[@class="fqn"]' 'Primitive Type reference'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 
 // There should be only one implementation listed.

--- a/src/test/rustdoc/primitive-slice-auto-trait.rs
+++ b/src/test/rustdoc/primitive-slice-auto-trait.rs
@@ -4,7 +4,7 @@
 #![feature(rustdoc_internals)]
 
 // @has foo/primitive.slice.html '//a[@class="primitive"]' 'slice'
-// @has - '//span[@class="in-band"]' 'Primitive Type slice'
+// @has - '//h1[@class="fqn"]' 'Primitive Type slice'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has - '//h2[@id="synthetic-implementations"]' 'Auto Trait Implementations'
 // @has - '//div[@id="synthetic-implementations-list"]//h3' 'impl<T> Send for [T]where T: Send'

--- a/src/test/rustdoc/primitive-tuple-auto-trait.rs
+++ b/src/test/rustdoc/primitive-tuple-auto-trait.rs
@@ -4,7 +4,7 @@
 #![feature(rustdoc_internals)]
 
 // @has foo/primitive.tuple.html '//a[@class="primitive"]' 'tuple'
-// @has - '//span[@class="in-band"]' 'Primitive Type tuple'
+// @has - '//h1[@class="fqn"]' 'Primitive Type tuple'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has - '//h2[@id="synthetic-implementations"]' 'Auto Trait Implementations'
 // @has - '//div[@id="synthetic-implementations-list"]//h3' 'Send'

--- a/src/test/rustdoc/primitive-unit-auto-trait.rs
+++ b/src/test/rustdoc/primitive-unit-auto-trait.rs
@@ -4,7 +4,7 @@
 #![feature(rustdoc_internals)]
 
 // @has foo/primitive.unit.html '//a[@class="primitive"]' 'unit'
-// @has - '//span[@class="in-band"]' 'Primitive Type unit'
+// @has - '//h1[@class="fqn"]' 'Primitive Type unit'
 // @has - '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has - '//h2[@id="synthetic-implementations"]' 'Auto Trait Implementations'
 // @has - '//div[@id="synthetic-implementations-list"]//h3' 'impl Send for ()'

--- a/src/test/rustdoc/primitive.rs
+++ b/src/test/rustdoc/primitive.rs
@@ -7,7 +7,7 @@
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a' 'Primitive Types'
 // @has foo/index.html '//div[@class="sidebar-elems"]//li/a/@href' '#primitives'
 // @has foo/primitive.i32.html '//a[@class="primitive"]' 'i32'
-// @has foo/primitive.i32.html '//span[@class="in-band"]' 'Primitive Type i32'
+// @has foo/primitive.i32.html '//h1[@class="fqn"]' 'Primitive Type i32'
 // @has foo/primitive.i32.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 // @has foo/index.html '//a/@href' '../foo/index.html'
 // @!has foo/index.html '//span' '🔒'

--- a/src/test/ui/closures/closure-return-type-must-be-sized.rs
+++ b/src/test/ui/closures/closure-return-type-must-be-sized.rs
@@ -1,0 +1,74 @@
+#![feature(unboxed_closures)]
+
+trait A {
+    fn a() where Self: Sized;
+}
+
+mod a {
+    use crate::A;
+
+    pub fn foo<F: FnOnce<()>>() where F::Output: A {
+        F::Output::a()
+    }
+
+    pub fn bar<F: FnOnce() -> R, R: ?Sized>() {}
+
+    pub fn baz<F: FnOnce<()>>() where F::Output: A, F::Output: Sized {
+        F::Output::a()
+    }
+}
+
+mod b {
+    use crate::A;
+
+    pub fn foo<F: Fn<()>>() where F::Output: A {
+        F::Output::a()
+    }
+
+    pub fn bar<F: Fn() -> R, R: ?Sized>() {}
+
+    pub fn baz<F: Fn<()>>() where F::Output: A, F::Output: Sized {
+        F::Output::a()
+    }
+}
+
+mod c {
+    use crate::A;
+
+    pub fn foo<F: FnMut<()>>() where F::Output: A {
+        F::Output::a()
+    }
+
+    pub fn bar<F: FnMut() -> R, R: ?Sized>() {}
+
+    pub fn baz<F: FnMut<()>>() where F::Output: A, F::Output: Sized {
+        F::Output::a()
+    }
+}
+
+impl A for Box<dyn A> {
+    fn a() {}
+}
+
+fn main() {
+    a::foo::<fn() -> dyn A>();         //~ ERROR E0277
+    a::bar::<fn() -> dyn A, _>();      //~ ERROR E0277
+    a::baz::<fn() -> dyn A>();         //~ ERROR E0277
+    a::foo::<fn() -> Box<dyn A>>();    //  ok
+    a::bar::<fn() -> Box<dyn A>, _>(); //  ok
+    a::baz::<fn() -> Box<dyn A>>();    //  ok
+
+    b::foo::<fn() -> dyn A>();         //~ ERROR E0277
+    b::bar::<fn() -> dyn A, _>();      //~ ERROR E0277
+    b::baz::<fn() -> dyn A>();         //~ ERROR E0277
+    b::foo::<fn() -> Box<dyn A>>();    //  ok
+    b::bar::<fn() -> Box<dyn A>, _>(); //  ok
+    b::baz::<fn() -> Box<dyn A>>();    //  ok
+
+    c::foo::<fn() -> dyn A>();         //~ ERROR E0277
+    c::bar::<fn() -> dyn A, _>();      //~ ERROR E0277
+    c::baz::<fn() -> dyn A>();         //~ ERROR E0277
+    c::foo::<fn() -> Box<dyn A>>();    //  ok
+    c::bar::<fn() -> Box<dyn A>, _>(); //  ok
+    c::baz::<fn() -> Box<dyn A>>();    //  ok
+}

--- a/src/test/ui/closures/closure-return-type-must-be-sized.stderr
+++ b/src/test/ui/closures/closure-return-type-must-be-sized.stderr
@@ -1,0 +1,99 @@
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:54:5
+   |
+LL |     a::foo::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:55:14
+   |
+LL |     a::bar::<fn() -> dyn A, _>();
+   |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+note: required by a bound in `a::bar`
+  --> $DIR/closure-return-type-must-be-sized.rs:14:19
+   |
+LL |     pub fn bar<F: FnOnce() -> R, R: ?Sized>() {}
+   |                   ^^^^^^^^^^^^^ required by this bound in `a::bar`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:56:5
+   |
+LL |     a::baz::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:61:5
+   |
+LL |     b::foo::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:62:14
+   |
+LL |     b::bar::<fn() -> dyn A, _>();
+   |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+note: required by a bound in `b::bar`
+  --> $DIR/closure-return-type-must-be-sized.rs:28:19
+   |
+LL |     pub fn bar<F: Fn() -> R, R: ?Sized>() {}
+   |                   ^^^^^^^^^ required by this bound in `b::bar`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:63:5
+   |
+LL |     b::baz::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:68:5
+   |
+LL |     c::foo::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:69:14
+   |
+LL |     c::bar::<fn() -> dyn A, _>();
+   |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+note: required by a bound in `c::bar`
+  --> $DIR/closure-return-type-must-be-sized.rs:42:19
+   |
+LL |     pub fn bar<F: FnMut() -> R, R: ?Sized>() {}
+   |                   ^^^^^^^^^^^^ required by this bound in `c::bar`
+
+error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:70:5
+   |
+LL |     c::baz::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = note: required because it appears within the type `fn() -> dyn A`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
+++ b/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
@@ -1,11 +1,3 @@
-error[E0423]: expected function, tuple struct or tuple variant, found enum `Option`
-  --> $DIR/issue-43871-enum-instead-of-variant.rs:19:13
-   |
-LL |     let x = Option(1);
-   |             ^^^^^^ help: try to construct one of the enum's variants: `std::option::Option::Some`
-   |
-   = help: you might have meant to construct the enum's non-tuple variant
-
 error[E0532]: expected tuple struct or tuple variant, found enum `Option`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:21:12
    |
@@ -26,6 +18,14 @@ note: the enum is defined here
    |
 LL | enum Example { Ex(String), NotEx }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0423]: expected function, tuple struct or tuple variant, found enum `Option`
+  --> $DIR/issue-43871-enum-instead-of-variant.rs:19:13
+   |
+LL |     let x = Option(1);
+   |             ^^^^^^ help: try to construct one of the enum's variants: `std::option::Option::Some`
+   |
+   = help: you might have meant to construct the enum's non-tuple variant
 
 error[E0423]: expected function, tuple struct or tuple variant, found enum `Void`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:31:13

--- a/src/test/ui/empty/empty-struct-braces-expr.stderr
+++ b/src/test/ui/empty/empty-struct-braces-expr.stderr
@@ -21,29 +21,6 @@ help: a unit struct with a similar name exists
 LL |     let e1 = XEmpty2;
    |              ~~~~~~~
 
-error[E0423]: expected function, tuple struct or tuple variant, found struct `Empty1`
-  --> $DIR/empty-struct-braces-expr.rs:16:14
-   |
-LL | struct Empty1 {}
-   | ---------------- `Empty1` defined here
-...
-LL |     let e1 = Empty1();
-   |              ^^^^^^^^
-   |
-  ::: $DIR/auxiliary/empty-struct.rs:2:1
-   |
-LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
-   |
-help: use struct literal syntax instead
-   |
-LL |     let e1 = Empty1 {};
-   |              ~~~~~~~~~
-help: a unit struct with a similar name exists
-   |
-LL |     let e1 = XEmpty2();
-   |              ~~~~~~~
-
 error[E0423]: expected value, found struct variant `E::Empty3`
   --> $DIR/empty-struct-braces-expr.rs:18:14
    |
@@ -83,6 +60,29 @@ help: a unit struct with a similar name exists
    |
 LL |     let xe1 = XEmpty2;
    |               ~~~~~~~
+
+error[E0423]: expected function, tuple struct or tuple variant, found struct `Empty1`
+  --> $DIR/empty-struct-braces-expr.rs:16:14
+   |
+LL | struct Empty1 {}
+   | ---------------- `Empty1` defined here
+...
+LL |     let e1 = Empty1();
+   |              ^^^^^^^^
+   |
+  ::: $DIR/auxiliary/empty-struct.rs:2:1
+   |
+LL | pub struct XEmpty2;
+   | ------------------ similarly named unit struct `XEmpty2` defined here
+   |
+help: use struct literal syntax instead
+   |
+LL |     let e1 = Empty1 {};
+   |              ~~~~~~~~~
+help: a unit struct with a similar name exists
+   |
+LL |     let e1 = XEmpty2();
+   |              ~~~~~~~
 
 error[E0423]: expected function, tuple struct or tuple variant, found struct `XEmpty1`
   --> $DIR/empty-struct-braces-expr.rs:23:15

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -26,6 +26,17 @@ help: surround the struct literal with parentheses
 LL |     for _ in (std::ops::Range { start: 0, end: 10 }) {}
    |              +                                     +
 
+error[E0423]: expected value, found struct `T`
+  --> $DIR/E0423.rs:14:8
+   |
+LL |     if T {} == T {} { println!("Ok"); }
+   |        ^ not a value
+   |
+help: surround the struct literal with parentheses
+   |
+LL |     if (T {}) == T {} { println!("Ok"); }
+   |        +    +
+
 error[E0423]: expected function, tuple struct or tuple variant, found struct `Foo`
   --> $DIR/E0423.rs:4:13
    |
@@ -46,17 +57,6 @@ help: a function with a similar name exists
    |
 LL |     let f = foo();
    |             ~~~
-
-error[E0423]: expected value, found struct `T`
-  --> $DIR/E0423.rs:14:8
-   |
-LL |     if T {} == T {} { println!("Ok"); }
-   |        ^ not a value
-   |
-help: surround the struct literal with parentheses
-   |
-LL |     if (T {}) == T {} { println!("Ok"); }
-   |        +    +
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/src/test/ui/expr/if/bad-if-let-suggestion.stderr
@@ -62,6 +62,11 @@ error[E0308]: mismatched types
    |
 LL |     if let x = 1 && i = 2 {}
    |        ^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if let x = 1 && i == 2 {}
+   |                        +
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/issues/issue-58022.stderr
+++ b/src/test/ui/issues/issue-58022.stderr
@@ -1,9 +1,3 @@
-error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo`
-  --> $DIR/issue-58022.rs:14:9
-   |
-LL |         Foo(Box::new(*slice))
-   |         ^^^ not a function, tuple struct or tuple variant
-
 error[E0790]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
   --> $DIR/issue-58022.rs:4:25
    |
@@ -12,6 +6,12 @@ LL |     const SIZE: usize;
 LL |
 LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
    |                         ^^^^^^^^^ cannot refer to the associated constant of trait
+
+error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo`
+  --> $DIR/issue-58022.rs:14:9
+   |
+LL |         Foo(Box::new(*slice))
+   |         ^^^ not a function, tuple struct or tuple variant
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lang-items/issue-83471.stderr
+++ b/src/test/ui/lang-items/issue-83471.stderr
@@ -4,12 +4,6 @@ error[E0573]: expected type, found built-in attribute `export_name`
 LL |     fn call(export_name);
    |             ^^^^^^^^^^^ not a type
 
-error[E0425]: cannot find function `a` in this scope
-  --> $DIR/issue-83471.rs:21:5
-   |
-LL |     a()
-   |     ^ not found in this scope
-
 error[E0658]: language items are subject to change
   --> $DIR/issue-83471.rs:7:1
    |
@@ -44,6 +38,12 @@ LL | #[lang = "fn"]
 ...
 LL | trait Fn {
    |         - this trait has 0 generic arguments
+
+error[E0425]: cannot find function `a` in this scope
+  --> $DIR/issue-83471.rs:21:5
+   |
+LL |     a()
+   |     ^ not found in this scope
 
 error: aborting due to 5 previous errors; 1 warning emitted
 

--- a/src/test/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -319,11 +319,11 @@ LL |     unknown_metavar!(a);
    |
    = note: this error originates in the macro `unknown_metavar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0425]: cannot find function `count` in this scope
-  --> $DIR/syntax-errors.rs:29:30
+error[E0425]: cannot find value `i` in this scope
+  --> $DIR/syntax-errors.rs:29:36
    |
 LL |     ( $( $i:ident ),* ) => { count(i) };
-   |                              ^^^^^ not found in this scope
+   |                                    ^ not found in this scope
 ...
 LL |     no_curly__no_rhs_dollar__round!(a, b, c);
    |     ---------------------------------------- in this macro invocation
@@ -331,10 +331,27 @@ LL |     no_curly__no_rhs_dollar__round!(a, b, c);
    = note: this error originates in the macro `no_curly__no_rhs_dollar__round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/syntax-errors.rs:29:36
+  --> $DIR/syntax-errors.rs:35:29
+   |
+LL |     ( $i:ident ) => { count(i) };
+   |                             ^ not found in this scope
+...
+LL |     no_curly__no_rhs_dollar__no_round!(a);
+   |     ------------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `no_curly__no_rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/syntax-errors.rs:153:37
+   |
+LL |     no_curly__rhs_dollar__no_round!(a);
+   |                                     ^ not found in this scope
+
+error[E0425]: cannot find function `count` in this scope
+  --> $DIR/syntax-errors.rs:29:30
    |
 LL |     ( $( $i:ident ),* ) => { count(i) };
-   |                                    ^ not found in this scope
+   |                              ^^^^^ not found in this scope
 ...
 LL |     no_curly__no_rhs_dollar__round!(a, b, c);
    |     ---------------------------------------- in this macro invocation
@@ -352,17 +369,6 @@ LL |     no_curly__no_rhs_dollar__no_round!(a);
    |
    = note: this error originates in the macro `no_curly__no_rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0425]: cannot find value `i` in this scope
-  --> $DIR/syntax-errors.rs:35:29
-   |
-LL |     ( $i:ident ) => { count(i) };
-   |                             ^ not found in this scope
-...
-LL |     no_curly__no_rhs_dollar__no_round!(a);
-   |     ------------------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `no_curly__no_rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0425]: cannot find function `count` in this scope
   --> $DIR/syntax-errors.rs:46:23
    |
@@ -373,12 +379,6 @@ LL |     no_curly__rhs_dollar__no_round!(a);
    |     ---------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `no_curly__rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0425]: cannot find value `a` in this scope
-  --> $DIR/syntax-errors.rs:153:37
-   |
-LL |     no_curly__rhs_dollar__no_round!(a);
-   |                                     ^ not found in this scope
 
 error: aborting due to 40 previous errors
 

--- a/src/test/ui/namespace/namespaced-enum-glob-import-no-impls-xcrate.stderr
+++ b/src/test/ui/namespace/namespaced-enum-glob-import-no-impls-xcrate.stderr
@@ -1,26 +1,26 @@
-error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/namespaced-enum-glob-import-no-impls-xcrate.rs:11:5
-   |
-LL |     foo();
-   |     ^^^ not found in this scope
-
 error[E0425]: cannot find function `foo` in module `m`
   --> $DIR/namespaced-enum-glob-import-no-impls-xcrate.rs:12:8
    |
 LL |     m::foo();
    |        ^^^ not found in `m`
 
-error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/namespaced-enum-glob-import-no-impls-xcrate.rs:13:5
-   |
-LL |     bar();
-   |     ^^^ not found in this scope
-
 error[E0425]: cannot find function `bar` in module `m`
   --> $DIR/namespaced-enum-glob-import-no-impls-xcrate.rs:14:8
    |
 LL |     m::bar();
    |        ^^^ not found in `m`
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/namespaced-enum-glob-import-no-impls-xcrate.rs:11:5
+   |
+LL |     foo();
+   |     ^^^ not found in this scope
+
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/namespaced-enum-glob-import-no-impls-xcrate.rs:13:5
+   |
+LL |     bar();
+   |     ^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/namespace/namespaced-enum-glob-import-no-impls.stderr
+++ b/src/test/ui/namespace/namespaced-enum-glob-import-no-impls.stderr
@@ -1,26 +1,26 @@
-error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/namespaced-enum-glob-import-no-impls.rs:21:5
-   |
-LL |     foo();
-   |     ^^^ not found in this scope
-
 error[E0425]: cannot find function `foo` in module `m`
   --> $DIR/namespaced-enum-glob-import-no-impls.rs:22:8
    |
 LL |     m::foo();
    |        ^^^ not found in `m`
 
-error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/namespaced-enum-glob-import-no-impls.rs:23:5
-   |
-LL |     bar();
-   |     ^^^ not found in this scope
-
 error[E0425]: cannot find function `bar` in module `m`
   --> $DIR/namespaced-enum-glob-import-no-impls.rs:24:8
    |
 LL |     m::bar();
    |        ^^^ not found in `m`
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/namespaced-enum-glob-import-no-impls.rs:21:5
+   |
+LL |     foo();
+   |     ^^^ not found in this scope
+
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/namespaced-enum-glob-import-no-impls.rs:23:5
+   |
+LL |     bar();
+   |     ^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/emoji-identifiers.stderr
+++ b/src/test/ui/parser/emoji-identifiers.stderr
@@ -9,15 +9,6 @@ help: Unicode character '➖' (Heavy Minus Sign) looks like '-' (Minus/Hyphen), 
 LL |     let _ = i_like_to_😄_a_lot() - 4;
    |                                  ~
 
-error[E0425]: cannot find function `i_like_to_😄_a_lot` in this scope
-  --> $DIR/emoji-identifiers.rs:13:13
-   |
-LL | fn i_like_to_😅_a_lot() -> 👀 {
-   | ----------------------------- similarly named function `i_like_to_😅_a_lot` defined here
-...
-LL |     let _ = i_like_to_😄_a_lot() ➖ 4;
-   |             ^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `i_like_to_😅_a_lot`
-
 error: Ferris cannot be used as an identifier
   --> $DIR/emoji-identifiers.rs:17:9
    |
@@ -84,6 +75,15 @@ LL |     👀::full_of✨()
    |         |
    |         function or associated item not found in `👀`
    |         help: there is an associated function with a similar name: `full_of_✨`
+
+error[E0425]: cannot find function `i_like_to_😄_a_lot` in this scope
+  --> $DIR/emoji-identifiers.rs:13:13
+   |
+LL | fn i_like_to_😅_a_lot() -> 👀 {
+   | ----------------------------- similarly named function `i_like_to_😅_a_lot` defined here
+...
+LL |     let _ = i_like_to_😄_a_lot() ➖ 4;
+   |             ^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `i_like_to_😅_a_lot`
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/parser/parser-recovery-1.stderr
+++ b/src/test/ui/parser/parser-recovery-1.stderr
@@ -18,17 +18,17 @@ error: unexpected token: `;`
 LL |     let x = y.;
    |               ^
 
-error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/parser-recovery-1.rs:5:17
-   |
-LL |         let x = foo();
-   |                 ^^^ not found in this scope
-
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/parser-recovery-1.rs:10:13
    |
 LL |     let x = y.;
    |             ^ not found in this scope
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/parser-recovery-1.rs:5:17
+   |
+LL |         let x = foo();
+   |                 ^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/parser-recovery-2.stderr
+++ b/src/test/ui/parser/parser-recovery-2.stderr
@@ -13,17 +13,17 @@ LL |         let x = foo();
 LL |     )
    |     ^ mismatched closing delimiter
 
-error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/parser-recovery-2.rs:5:17
-   |
-LL |         let x = foo();
-   |                 ^^^ not found in this scope
-
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/parser-recovery-2.rs:10:13
    |
 LL |     let x = y.;
    |             ^ not found in this scope
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/parser-recovery-2.rs:5:17
+   |
+LL |         let x = foo();
+   |                 ^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/unmatched-langle-1.stderr
+++ b/src/test/ui/parser/unmatched-langle-1.stderr
@@ -4,17 +4,17 @@ error: unmatched angle brackets
 LL |     foo::<<<<Ty<i32>>();
    |          ^^^ help: remove extra angle brackets
 
-error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/unmatched-langle-1.rs:5:5
-   |
-LL |     foo::<<<<Ty<i32>>();
-   |     ^^^ not found in this scope
-
 error[E0412]: cannot find type `Ty` in this scope
   --> $DIR/unmatched-langle-1.rs:5:14
    |
 LL |     foo::<<<<Ty<i32>>();
    |              ^^ not found in this scope
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/unmatched-langle-1.rs:5:5
+   |
+LL |     foo::<<<<Ty<i32>>();
+   |     ^^^ not found in this scope
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/proc-macro/keep-expr-tokens.stderr
+++ b/src/test/ui/proc-macro/keep-expr-tokens.stderr
@@ -1,14 +1,14 @@
-error[E0425]: cannot find function `missing_fn` in this scope
-  --> $DIR/keep-expr-tokens.rs:17:17
-   |
-LL |     for item in missing_fn() {}
-   |                 ^^^^^^^^^^ not found in this scope
-
 error[E0425]: cannot find value `bad` in this scope
   --> $DIR/keep-expr-tokens.rs:19:62
    |
 LL |     (#[recollect_attr] #[recollect_attr] ((#[recollect_attr] bad)));
    |                                                              ^^^ not found in this scope
+
+error[E0425]: cannot find function `missing_fn` in this scope
+  --> $DIR/keep-expr-tokens.rs:17:17
+   |
+LL |     for item in missing_fn() {}
+   |                 ^^^^^^^^^^ not found in this scope
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/bad-env-capture.stderr
+++ b/src/test/ui/resolve/bad-env-capture.stderr
@@ -6,17 +6,17 @@ LL |     fn bar() { log(debug, x); }
    |
    = help: use the `|| { ... }` closure form instead
 
-error[E0425]: cannot find function `log` in this scope
-  --> $DIR/bad-env-capture.rs:4:16
-   |
-LL |     fn bar() { log(debug, x); }
-   |                ^^^ not found in this scope
-
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-env-capture.rs:4:20
    |
 LL |     fn bar() { log(debug, x); }
    |                    ^^^^^ not found in this scope
+
+error[E0425]: cannot find function `log` in this scope
+  --> $DIR/bad-env-capture.rs:4:16
+   |
+LL |     fn bar() { log(debug, x); }
+   |                ^^^ not found in this scope
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/bad-env-capture2.stderr
+++ b/src/test/ui/resolve/bad-env-capture2.stderr
@@ -6,17 +6,17 @@ LL |     fn bar() { log(debug, x); }
    |
    = help: use the `|| { ... }` closure form instead
 
-error[E0425]: cannot find function `log` in this scope
-  --> $DIR/bad-env-capture2.rs:3:16
-   |
-LL |     fn bar() { log(debug, x); }
-   |                ^^^ not found in this scope
-
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-env-capture2.rs:3:20
    |
 LL |     fn bar() { log(debug, x); }
    |                    ^^^^^ not found in this scope
+
+error[E0425]: cannot find function `log` in this scope
+  --> $DIR/bad-env-capture2.rs:3:16
+   |
+LL |     fn bar() { log(debug, x); }
+   |                ^^^ not found in this scope
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/bad-env-capture3.stderr
+++ b/src/test/ui/resolve/bad-env-capture3.stderr
@@ -6,17 +6,17 @@ LL |         fn bar() { log(debug, x); }
    |
    = help: use the `|| { ... }` closure form instead
 
-error[E0425]: cannot find function `log` in this scope
-  --> $DIR/bad-env-capture3.rs:4:20
-   |
-LL |         fn bar() { log(debug, x); }
-   |                    ^^^ not found in this scope
-
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-env-capture3.rs:4:24
    |
 LL |         fn bar() { log(debug, x); }
    |                        ^^^^^ not found in this scope
+
+error[E0425]: cannot find function `log` in this scope
+  --> $DIR/bad-env-capture3.rs:4:20
+   |
+LL |         fn bar() { log(debug, x); }
+   |                    ^^^ not found in this scope
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/bad-expr-path.stderr
+++ b/src/test/ui/resolve/bad-expr-path.stderr
@@ -1,9 +1,3 @@
-error[E0425]: cannot find function `log` in this scope
-  --> $DIR/bad-expr-path.rs:4:5
-   |
-LL |     log(debug, m1::arguments);
-   |     ^^^ not found in this scope
-
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-expr-path.rs:4:9
    |
@@ -15,6 +9,12 @@ error[E0425]: cannot find value `arguments` in module `m1`
    |
 LL |     log(debug, m1::arguments);
    |                    ^^^^^^^^^ not found in `m1`
+
+error[E0425]: cannot find function `log` in this scope
+  --> $DIR/bad-expr-path.rs:4:5
+   |
+LL |     log(debug, m1::arguments);
+   |     ^^^ not found in this scope
 
 error[E0580]: `main` function has wrong type
   --> $DIR/bad-expr-path.rs:3:1

--- a/src/test/ui/resolve/bad-expr-path2.stderr
+++ b/src/test/ui/resolve/bad-expr-path2.stderr
@@ -1,9 +1,3 @@
-error[E0425]: cannot find function `log` in this scope
-  --> $DIR/bad-expr-path2.rs:6:5
-   |
-LL |     log(debug, m1::arguments);
-   |     ^^^ not found in this scope
-
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-expr-path2.rs:6:9
    |
@@ -15,6 +9,12 @@ error[E0423]: expected value, found module `m1::arguments`
    |
 LL |     log(debug, m1::arguments);
    |                ^^^^^^^^^^^^^ not a value
+
+error[E0425]: cannot find function `log` in this scope
+  --> $DIR/bad-expr-path2.rs:6:5
+   |
+LL |     log(debug, m1::arguments);
+   |     ^^^ not found in this scope
 
 error[E0580]: `main` function has wrong type
   --> $DIR/bad-expr-path2.rs:5:1

--- a/src/test/ui/resolve/issue-14254.stderr
+++ b/src/test/ui/resolve/issue-14254.stderr
@@ -1,20 +1,8 @@
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:19:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
-
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:21:9
    |
 LL |         a;
    |         ^ not found in this scope
-
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:28:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
 
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:30:9
@@ -46,12 +34,6 @@ error[E0425]: cannot find value `b` in this scope
 LL |         b;
    |         ^ not found in this scope
 
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:45:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
-
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:47:9
    |
@@ -82,23 +64,11 @@ error[E0425]: cannot find value `b` in this scope
 LL |         b;
    |         ^ not found in this scope
 
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:62:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
-
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:64:9
    |
 LL |         bah;
    |         ^^^ help: you might have meant to call the associated function: `Self::bah`
-
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:71:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:73:9
@@ -106,23 +76,11 @@ error[E0425]: cannot find value `bah` in this scope
 LL |         bah;
    |         ^^^ help: you might have meant to call the associated function: `Self::bah`
 
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:80:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
-
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:82:9
    |
 LL |         bah;
    |         ^^^ help: you might have meant to call the associated function: `Self::bah`
-
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:89:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:91:9
@@ -130,17 +88,59 @@ error[E0425]: cannot find value `bah` in this scope
 LL |         bah;
    |         ^^^ help: you might have meant to call the associated function: `Self::bah`
 
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/issue-14254.rs:98:9
-   |
-LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
-
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:100:9
    |
 LL |         bah;
    |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:19:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:28:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:45:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:62:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:71:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:80:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:89:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/issue-14254.rs:98:9
+   |
+LL |         baz();
+   |         ^^^ help: you might have meant to call the method: `self.baz`
 
 error: aborting due to 24 previous errors
 

--- a/src/test/ui/resolve/issue-2356.stderr
+++ b/src/test/ui/resolve/issue-2356.stderr
@@ -1,15 +1,3 @@
-error[E0425]: cannot find function `shave` in this scope
-  --> $DIR/issue-2356.rs:17:5
-   |
-LL |     shave();
-   |     ^^^^^ not found in this scope
-
-error[E0425]: cannot find function `clone` in this scope
-  --> $DIR/issue-2356.rs:24:5
-   |
-LL |     clone();
-   |     ^^^^^ help: you might have meant to call the method: `self.clone`
-
 error[E0425]: cannot find function `default` in this scope
   --> $DIR/issue-2356.rs:31:5
    |
@@ -30,6 +18,51 @@ error[E0425]: cannot find value `whiskers` in this scope
    |
 LL |     whiskers -= other;
    |     ^^^^^^^^ a field by this name exists in `Self`
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/issue-2356.rs:65:8
+   |
+LL |   fn meow() {
+   |      ---- this function doesn't have a `self` parameter
+LL |     if self.whiskers > 3 {
+   |        ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |   fn meow(&self) {
+   |           +++++
+
+error[E0425]: cannot find value `whiskers` in this scope
+  --> $DIR/issue-2356.rs:79:5
+   |
+LL |     whiskers = 0;
+   |     ^^^^^^^^ help: you might have meant to use the available field: `self.whiskers`
+
+error[E0425]: cannot find value `whiskers` in this scope
+  --> $DIR/issue-2356.rs:84:5
+   |
+LL |     whiskers = 4;
+   |     ^^^^^^^^ a field by this name exists in `Self`
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/issue-2356.rs:92:5
+   |
+LL | fn main() {
+   |    ---- this function can't have a `self` parameter
+LL |     self += 1;
+   |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+
+error[E0425]: cannot find function `shave` in this scope
+  --> $DIR/issue-2356.rs:17:5
+   |
+LL |     shave();
+   |     ^^^^^ not found in this scope
+
+error[E0425]: cannot find function `clone` in this scope
+  --> $DIR/issue-2356.rs:24:5
+   |
+LL |     clone();
+   |     ^^^^^ help: you might have meant to call the method: `self.clone`
 
 error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:41:5
@@ -72,19 +105,6 @@ error[E0425]: cannot find function `purr` in this scope
 LL |         purr();
    |         ^^^^ not found in this scope
 
-error[E0424]: expected value, found module `self`
-  --> $DIR/issue-2356.rs:65:8
-   |
-LL |   fn meow() {
-   |      ---- this function doesn't have a `self` parameter
-LL |     if self.whiskers > 3 {
-   |        ^^^^ `self` value is a keyword only available in methods with a `self` parameter
-   |
-help: add a `self` receiver parameter to make the associated `fn` a method
-   |
-LL |   fn meow(&self) {
-   |           +++++
-
 error[E0425]: cannot find function `grow_older` in this scope
   --> $DIR/issue-2356.rs:72:5
    |
@@ -102,31 +122,11 @@ error[E0425]: cannot find function `shave` in this scope
 LL |     shave();
    |     ^^^^^ not found in this scope
 
-error[E0425]: cannot find value `whiskers` in this scope
-  --> $DIR/issue-2356.rs:79:5
-   |
-LL |     whiskers = 0;
-   |     ^^^^^^^^ help: you might have meant to use the available field: `self.whiskers`
-
-error[E0425]: cannot find value `whiskers` in this scope
-  --> $DIR/issue-2356.rs:84:5
-   |
-LL |     whiskers = 4;
-   |     ^^^^^^^^ a field by this name exists in `Self`
-
 error[E0425]: cannot find function `purr_louder` in this scope
   --> $DIR/issue-2356.rs:86:5
    |
 LL |     purr_louder();
    |     ^^^^^^^^^^^ not found in this scope
-
-error[E0424]: expected value, found module `self`
-  --> $DIR/issue-2356.rs:92:5
-   |
-LL | fn main() {
-   |    ---- this function can't have a `self` parameter
-LL |     self += 1;
-   |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/resolve/issue-42944.stderr
+++ b/src/test/ui/resolve/issue-42944.stderr
@@ -1,15 +1,3 @@
-error[E0423]: cannot initialize a tuple struct which contains private fields
-  --> $DIR/issue-42944.rs:9:9
-   |
-LL |         Bx(());
-   |         ^^
-   |
-note: constructor is not visible here due to private fields
-  --> $DIR/issue-42944.rs:2:19
-   |
-LL |     pub struct Bx(());
-   |                   ^^ private field
-
 error[E0425]: cannot find function, tuple struct or tuple variant `Bx` in this scope
   --> $DIR/issue-42944.rs:16:9
    |
@@ -21,6 +9,18 @@ note: tuple struct `foo::Bx` exists but is inaccessible
    |
 LL |     pub struct Bx(());
    |     ^^^^^^^^^^^^^^^^^^ not accessible
+
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> $DIR/issue-42944.rs:9:9
+   |
+LL |         Bx(());
+   |         ^^
+   |
+note: constructor is not visible here due to private fields
+  --> $DIR/issue-42944.rs:2:19
+   |
+LL |     pub struct Bx(());
+   |                   ^^ private field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-73427.stderr
+++ b/src/test/ui/resolve/issue-73427.stderr
@@ -124,31 +124,6 @@ LL | use std::f32::consts::E;
 LL | use std::f64::consts::E;
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found enum `A`
-  --> $DIR/issue-73427.rs:46:13
-   |
-LL |     let x = A(3);
-   |             ^
-   |
-   = help: you might have meant to construct one of the enum's non-tuple variants
-note: the enum is defined here
-  --> $DIR/issue-73427.rs:1:1
-   |
-LL | / enum A {
-LL | |     StructWithFields { x: () },
-LL | |     TupleWithFields(()),
-LL | |     Struct {},
-LL | |     Tuple(),
-LL | |     Unit,
-LL | | }
-   | |_^
-help: try to construct one of the enum's variants
-   |
-LL |     let x = A::Tuple(3);
-   |             ~~~~~~~~
-LL |     let x = A::TupleWithFields(3);
-   |             ~~~~~~~~~~~~~~~~~~
-
 error[E0532]: expected tuple struct or tuple variant, found enum `A`
   --> $DIR/issue-73427.rs:48:12
    |
@@ -173,6 +148,31 @@ LL |     if let A::Tuple(3) = x { }
    |            ~~~~~~~~
 LL |     if let A::TupleWithFields(3) = x { }
    |            ~~~~~~~~~~~~~~~~~~
+
+error[E0423]: expected function, tuple struct or tuple variant, found enum `A`
+  --> $DIR/issue-73427.rs:46:13
+   |
+LL |     let x = A(3);
+   |             ^
+   |
+   = help: you might have meant to construct one of the enum's non-tuple variants
+note: the enum is defined here
+  --> $DIR/issue-73427.rs:1:1
+   |
+LL | / enum A {
+LL | |     StructWithFields { x: () },
+LL | |     TupleWithFields(()),
+LL | |     Struct {},
+LL | |     Tuple(),
+LL | |     Unit,
+LL | | }
+   | |_^
+help: try to construct one of the enum's variants
+   |
+LL |     let x = A::Tuple(3);
+   |             ~~~~~~~~
+LL |     let x = A::TupleWithFields(3);
+   |             ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -39,15 +39,6 @@ LL | const MAX_ITEM: usize = 10;
 LL |     let v = [0u32; MAXITEM]; // Misspelled constant name.
    |                    ^^^^^^^ help: a constant with a similar name exists: `MAX_ITEM`
 
-error[E0425]: cannot find function `foobar` in this scope
-  --> $DIR/levenshtein.rs:26:5
-   |
-LL | fn foo_bar() {}
-   | ------------ similarly named function `foo_bar` defined here
-...
-LL |     foobar(); // Misspelled function name.
-   |     ^^^^^^ help: a function with a similar name exists: `foo_bar`
-
 error[E0412]: cannot find type `first` in module `m`
   --> $DIR/levenshtein.rs:28:15
    |
@@ -65,6 +56,15 @@ LL |     pub struct Second;
 ...
 LL |     let b: m::first = m::second; // Misspelled item in module.
    |                          ^^^^^^ help: a unit struct with a similar name exists (notice the capitalization): `Second`
+
+error[E0425]: cannot find function `foobar` in this scope
+  --> $DIR/levenshtein.rs:26:5
+   |
+LL | fn foo_bar() {}
+   | ------------ similarly named function `foo_bar` defined here
+...
+LL |     foobar(); // Misspelled function name.
+   |     ^^^^^^ help: a function with a similar name exists: `foo_bar`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/resolve/resolve-hint-macro.stderr
+++ b/src/test/ui/resolve/resolve-hint-macro.stderr
@@ -14,17 +14,6 @@ LL |     assert_eq { 1, 1 };
    |     |
    |     while parsing this struct
 
-error[E0423]: expected function, found macro `assert_eq`
-  --> $DIR/resolve-hint-macro.rs:3:5
-   |
-LL |     assert_eq(1, 1);
-   |     ^^^^^^^^^ not a function
-   |
-help: use `!` to invoke the macro
-   |
-LL |     assert_eq!(1, 1);
-   |              +
-
 error[E0574]: expected struct, variant or union type, found macro `assert_eq`
   --> $DIR/resolve-hint-macro.rs:5:5
    |
@@ -46,6 +35,17 @@ help: use `!` to invoke the macro
    |
 LL |     assert![true];
    |           +
+
+error[E0423]: expected function, found macro `assert_eq`
+  --> $DIR/resolve-hint-macro.rs:3:5
+   |
+LL |     assert_eq(1, 1);
+   |     ^^^^^^^^^ not a function
+   |
+help: use `!` to invoke the macro
+   |
+LL |     assert_eq!(1, 1);
+   |              +
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/resolve/resolve-speculative-adjustment.stderr
+++ b/src/test/ui/resolve/resolve-speculative-adjustment.stderr
@@ -4,12 +4,6 @@ error[E0425]: cannot find value `field` in this scope
 LL |             field;
    |             ^^^^^ not found in this scope
 
-error[E0425]: cannot find function `method` in this scope
-  --> $DIR/resolve-speculative-adjustment.rs:19:13
-   |
-LL |             method();
-   |             ^^^^^^ not found in this scope
-
 error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:23:9
    |
@@ -21,6 +15,12 @@ error[E0425]: cannot find function `method` in this scope
    |
 LL |         method();
    |         ^^^^^^ help: you might have meant to call the method: `self.method`
+
+error[E0425]: cannot find function `method` in this scope
+  --> $DIR/resolve-speculative-adjustment.rs:19:13
+   |
+LL |             method();
+   |             ^^^^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/resolve/tuple-struct-alias.stderr
+++ b/src/test/ui/resolve/tuple-struct-alias.stderr
@@ -1,14 +1,3 @@
-error[E0423]: expected function, tuple struct or tuple variant, found type alias `A`
-  --> $DIR/tuple-struct-alias.rs:5:13
-   |
-LL | struct S(u8, u16);
-   | ------------------ similarly named tuple struct `S` defined here
-...
-LL |     let s = A(0, 1);
-   |             ^ help: a tuple struct with a similar name exists: `S`
-   |
-   = note: can't use a type alias as a constructor
-
 error[E0532]: expected tuple struct or tuple variant, found type alias `A`
   --> $DIR/tuple-struct-alias.rs:7:9
    |
@@ -17,6 +6,17 @@ LL | struct S(u8, u16);
 ...
 LL |         A(..) => {}
    |         ^ help: a tuple struct with a similar name exists: `S`
+   |
+   = note: can't use a type alias as a constructor
+
+error[E0423]: expected function, tuple struct or tuple variant, found type alias `A`
+  --> $DIR/tuple-struct-alias.rs:5:13
+   |
+LL | struct S(u8, u16);
+   | ------------------ similarly named tuple struct `S` defined here
+...
+LL |     let s = A(0, 1);
+   |             ^ help: a tuple struct with a similar name exists: `S`
    |
    = note: can't use a type alias as a constructor
 

--- a/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -31,24 +31,6 @@ help: a local variable with a similar name exists
 LL |         println!("{cofig}");
    |                    ~~~~~
 
-error[E0425]: cannot find function `baz` in this scope
-  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:31:9
-   |
-LL |         baz();
-   |         ^^^
-...
-LL | fn ba() {}
-   | ------- similarly named function `ba` defined here
-   |
-help: you might have meant to call the method
-   |
-LL |         self.baz();
-   |         ~~~~~~~~
-help: a function with a similar name exists
-   |
-LL |         ba();
-   |         ~~
-
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:33:9
    |
@@ -102,6 +84,24 @@ help: a type alias with a similar name exists
    |
 LL |         let foo: Bar = "".to_string();
    |                  ~~~
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:31:9
+   |
+LL |         baz();
+   |         ^^^
+...
+LL | fn ba() {}
+   | ------- similarly named function `ba` defined here
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         ~~~~~~~~
+help: a function with a similar name exists
+   |
+LL |         ba();
+   |         ~~
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -1,9 +1,3 @@
-error[E0423]: cannot initialize a tuple struct which contains private fields
-  --> $DIR/struct.rs:20:14
-   |
-LL |     let ts = TupleStruct(640, 480);
-   |              ^^^^^^^^^^^
-
 error[E0423]: expected value, found struct `UnitStruct`
   --> $DIR/struct.rs:29:14
    |
@@ -67,6 +61,12 @@ help: add `..` at the end of the field list to ignore all other fields
    |
 LL |     let NormalStruct { first_field, second_field , .. } = ns;
    |                                                  ~~~~~~
+
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> $DIR/struct.rs:20:14
+   |
+LL |     let ts = TupleStruct(640, 480);
+   |              ^^^^^^^^^^^
 
 error[E0638]: `..` required with struct marked as non-exhaustive
   --> $DIR/struct.rs:26:9

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1510,7 +1510,7 @@ LL |     if x = let 0 = 0 {}
 help: you might have meant to compare for equality
    |
 LL |     if x == let 0 = 0 {}
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:157:8
@@ -1704,7 +1704,7 @@ LL |     while x = let 0 = 0 {}
 help: you might have meant to compare for equality
    |
 LL |     while x == let 0 = 0 {}
-   |             ~~
+   |              +
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:249:11

--- a/src/test/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
+++ b/src/test/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.stderr
@@ -25,12 +25,6 @@ LL | trait C{async fn new(val: T) {}
    = help: pass `--edition 2021` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
-error[E0423]: expected function, found module `crate`
-  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:9:5
-   |
-LL |     crate(move || {} ).await
-   |     ^^^^^ not a function
-
 error[E0412]: cannot find type `T` in this scope
   --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:13:27
    |
@@ -52,6 +46,12 @@ LL | trait C{async fn new(val: T) {}
    = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
    = help: add `#![feature(async_fn_in_trait)]` to the crate attributes to enable
+
+error[E0423]: expected function, found module `crate`
+  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:9:5
+   |
+LL |     crate(move || {} ).await
+   |     ^^^^^ not a function
 
 warning: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-93117.rs:6:57

--- a/src/test/ui/suggestions/assoc_fn_without_self.stderr
+++ b/src/test/ui/suggestions/assoc_fn_without_self.stderr
@@ -1,10 +1,4 @@
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/assoc_fn_without_self.rs:14:13
-   |
-LL |             foo();
-   |             ^^^ not found in this scope
-
-error[E0425]: cannot find function `foo` in this scope
   --> $DIR/assoc_fn_without_self.rs:16:9
    |
 LL |         foo();
@@ -31,6 +25,12 @@ help: consider using the associated function
    |
 LL |         Self::baz(2, 3);
    |         ~~~~~~~~~
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/assoc_fn_without_self.rs:14:13
+   |
+LL |             foo();
+   |             ^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/fn-to-method.rs
+++ b/src/test/ui/suggestions/fn-to-method.rs
@@ -1,0 +1,19 @@
+struct Foo;
+
+impl Foo {
+    fn bar(self) {}
+}
+
+fn main() {
+    let x = cmp(&1, &2);
+    //~^ ERROR cannot find function `cmp` in this scope
+    //~| HELP use the `.` operator to call the method `Ord::cmp` on `&{integer}`
+
+    let y = len([1, 2, 3]);
+    //~^ ERROR cannot find function `len` in this scope
+    //~| HELP use the `.` operator to call the method `len` on `&[{integer}]`
+
+    let z = bar(Foo);
+    //~^ ERROR cannot find function `bar` in this scope
+    //~| HELP use the `.` operator to call the method `bar` on `Foo`
+}

--- a/src/test/ui/suggestions/fn-to-method.stderr
+++ b/src/test/ui/suggestions/fn-to-method.stderr
@@ -1,0 +1,38 @@
+error[E0425]: cannot find function `cmp` in this scope
+  --> $DIR/fn-to-method.rs:8:13
+   |
+LL |     let x = cmp(&1, &2);
+   |             ^^^ not found in this scope
+   |
+help: use the `.` operator to call the method `Ord::cmp` on `&{integer}`
+   |
+LL |     let x = (&1).cmp(&2);
+   |             ~  ~~~~~~~~~
+
+error[E0425]: cannot find function `len` in this scope
+  --> $DIR/fn-to-method.rs:12:13
+   |
+LL |     let y = len([1, 2, 3]);
+   |             ^^^ not found in this scope
+   |
+help: use the `.` operator to call the method `len` on `&[{integer}]`
+   |
+LL -     let y = len([1, 2, 3]);
+LL +     let y = [1, 2, 3].len();
+   |
+
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/fn-to-method.rs:16:13
+   |
+LL |     let z = bar(Foo);
+   |             ^^^ not found in this scope
+   |
+help: use the `.` operator to call the method `bar` on `Foo`
+   |
+LL -     let z = bar(Foo);
+LL +     let z = Foo.bar();
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/type/type-check/assignment-expected-bool.stderr
+++ b/src/test/ui/type/type-check/assignment-expected-bool.stderr
@@ -7,7 +7,7 @@ LL |     let _: bool = 0 = 0;
 help: you might have meant to compare for equality
    |
 LL |     let _: bool = 0 == 0;
-   |                     ~~
+   |                      +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:9:14
@@ -18,7 +18,7 @@ LL |         0 => 0 = 0,
 help: you might have meant to compare for equality
    |
 LL |         0 => 0 == 0,
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:10:14
@@ -29,7 +29,7 @@ LL |         _ => 0 = 0,
 help: you might have meant to compare for equality
    |
 LL |         _ => 0 == 0,
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:14:17
@@ -40,7 +40,7 @@ LL |         true => 0 = 0,
 help: you might have meant to compare for equality
    |
 LL |         true => 0 == 0,
-   |                   ~~
+   |                    +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:18:8
@@ -51,7 +51,7 @@ LL |     if 0 = 0 {}
 help: you might have meant to compare for equality
    |
 LL |     if 0 == 0 {}
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:20:24
@@ -62,7 +62,7 @@ LL |     let _: bool = if { 0 = 0 } {
 help: you might have meant to compare for equality
    |
 LL |     let _: bool = if { 0 == 0 } {
-   |                          ~~
+   |                           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:21:9
@@ -73,7 +73,7 @@ LL |         0 = 0
 help: you might have meant to compare for equality
    |
 LL |         0 == 0
-   |           ~~
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:23:9
@@ -84,7 +84,7 @@ LL |         0 = 0
 help: you might have meant to compare for equality
    |
 LL |         0 == 0
-   |           ~~
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:26:13
@@ -95,7 +95,7 @@ LL |     let _ = (0 = 0)
 help: you might have meant to compare for equality
    |
 LL |     let _ = (0 == 0)
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:27:14
@@ -106,7 +106,7 @@ LL |         && { 0 = 0 }
 help: you might have meant to compare for equality
    |
 LL |         && { 0 == 0 }
-   |                ~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:28:12
@@ -117,7 +117,7 @@ LL |         || (0 = 0);
 help: you might have meant to compare for equality
    |
 LL |         || (0 == 0);
-   |               ~~
+   |                +
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/assignment-expected-bool.rs:31:22

--- a/src/test/ui/type/type-check/assignment-in-if.rs
+++ b/src/test/ui/type/type-check/assignment-in-if.rs
@@ -40,4 +40,17 @@ fn main() {
     ) {
         println!("{}", x);
     }
+
+    if x == x && x = x && x == x {
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        //~| ERROR mismatched types
+        println!("{}", x);
+    }
+
+    if x == x && x == x && x = x {
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        println!("{}", x);
+    }
 }

--- a/src/test/ui/type/type-check/assignment-in-if.stderr
+++ b/src/test/ui/type/type-check/assignment-in-if.stderr
@@ -7,7 +7,7 @@ LL |     if x = x {
 help: you might have meant to compare for equality
    |
 LL |     if x == x {
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:20:8
@@ -18,7 +18,7 @@ LL |     if (x = x) {
 help: you might have meant to compare for equality
    |
 LL |     if (x == x) {
-   |           ~~
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:25:8
@@ -29,7 +29,7 @@ LL |     if y = (Foo { foo: x }) {
 help: you might have meant to compare for equality
    |
 LL |     if y == (Foo { foo: x }) {
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:30:8
@@ -40,7 +40,7 @@ LL |     if 3 = x {
 help: you might have meant to compare for equality
    |
 LL |     if 3 == x {
-   |          ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:36:13
@@ -51,7 +51,7 @@ LL |             x = 4
 help: you might have meant to compare for equality
    |
 LL |             x == 4
-   |               ~~
+   |                +
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:38:13
@@ -62,8 +62,48 @@ LL |             x = 5
 help: you might have meant to compare for equality
    |
 LL |             x == 5
-   |               ~~
+   |                +
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:44:18
+   |
+LL |     if x == x && x = x && x == x {
+   |                  ^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:44:22
+   |
+LL |     if x == x && x = x && x == x {
+   |                      ^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:44:8
+   |
+LL |     if x == x && x = x && x == x {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == x && x == x && x == x {
+   |                     +
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:51:28
+   |
+LL |     if x == x && x == x && x = x {
+   |                            ^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:51:8
+   |
+LL |     if x == x && x == x && x = x {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == x && x == x && x == x {
+   |                               +
+
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #102672 (rustdoc: remove unused CSS class `in-band`)
 - #102693 (Revert "Use getentropy when possible on all Apple platforms")
 - #102694 (Suggest calling method if fn does not exist)
 - #102708 (Suggest `==` to wrong assign expr)
 - #102710 (Add test for issue 82633)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102672,102693,102694,102708,102710)
<!-- homu-ignore:end -->