### PR TITLE
rustdoc: remove unused CSS `.content .item-list`

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -890,7 +890,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
             w,
             "implementors",
             "Implementors",
-            "<div class=\"item-list\" id=\"implementors-list\">",
+            "<div id=\"implementors-list\">",
         );
         for implementor in concrete {
             render_implementor(cx, implementor, it, w, &implementor_dups, &[]);
@@ -902,7 +902,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
                 w,
                 "synthetic-implementors",
                 "Auto implementors",
-                "<div class=\"item-list\" id=\"synthetic-implementors-list\">",
+                "<div id=\"synthetic-implementors-list\">",
             );
             for implementor in synthetic {
                 render_implementor(
@@ -923,7 +923,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
             w,
             "implementors",
             "Implementors",
-            "<div class=\"item-list\" id=\"implementors-list\"></div>",
+            "<div id=\"implementors-list\"></div>",
         );
 
         if t.is_auto(cx.tcx()) {
@@ -931,7 +931,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
                 w,
                 "synthetic-implementors",
                 "Auto implementors",
-                "<div class=\"item-list\" id=\"synthetic-implementors-list\"></div>",
+                "<div id=\"synthetic-implementors-list\"></div>",
             );
         }
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -690,11 +690,6 @@ pre, .rustdoc.source .example-wrap {
 	border: 1px solid var(--border-color);
 }
 
-.content .item-list {
-	list-style-type: none;
-	padding: 0;
-}
-
 /* Shift "where ..." part of method or fn definition down a line */
 .content .method .where,
 .content .fn .where,

--- a/src/test/rustdoc/impl-disambiguation.rs
+++ b/src/test/rustdoc/impl-disambiguation.rs
@@ -4,13 +4,13 @@ pub trait Foo {}
 
 pub struct Bar<T> { field: T }
 
-// @has foo/trait.Foo.html '//*[@class="item-list"]//h3[@class="code-header"]' \
+// @has foo/trait.Foo.html '//*[@id="implementors-list"]//h3[@class="code-header"]' \
 //     "impl Foo for Bar<u8>"
 impl Foo for Bar<u8> {}
-// @has foo/trait.Foo.html '//*[@class="item-list"]//h3[@class="code-header"]' \
+// @has foo/trait.Foo.html '//*[@id="implementors-list"]//h3[@class="code-header"]' \
 //     "impl Foo for Bar<u16>"
 impl Foo for Bar<u16> {}
-// @has foo/trait.Foo.html '//*[@class="item-list"]//h3[@class="code-header"]' \
+// @has foo/trait.Foo.html '//*[@id="implementors-list"]//h3[@class="code-header"]' \
 //     "impl<'a> Foo for &'a Bar<u8>"
 impl<'a> Foo for &'a Bar<u8> {}
 
@@ -22,9 +22,9 @@ pub mod mod2 {
     pub enum Baz {}
 }
 
-// @has foo/trait.Foo.html '//*[@class="item-list"]//h3[@class="code-header"]' \
+// @has foo/trait.Foo.html '//*[@id="implementors-list"]//h3[@class="code-header"]' \
 //     "impl Foo for foo::mod1::Baz"
 impl Foo for mod1::Baz {}
-// @has foo/trait.Foo.html '//*[@class="item-list"]//h3[@class="code-header"]' \
+// @has foo/trait.Foo.html '//*[@id="implementors-list"]//h3[@class="code-header"]' \
 //     "impl<'a> Foo for &'a foo::mod2::Baz"
 impl<'a> Foo for &'a mod2::Baz {}

--- a/src/test/rustdoc/impl-parts.rs
+++ b/src/test/rustdoc/impl-parts.rs
@@ -7,6 +7,6 @@ pub struct Foo<T> { field: T }
 
 // @has impl_parts/struct.Foo.html '//*[@class="impl has-srclink"]//h3[@class="code-header"]' \
 //     "impl<T: Clone> !AnAutoTrait for Foo<T>where T: Sync,"
-// @has impl_parts/trait.AnAutoTrait.html '//*[@class="item-list"]//h3[@class="code-header"]' \
+// @has impl_parts/trait.AnAutoTrait.html '//*[@id="implementors-list"]//h3[@class="code-header"]' \
 //     "impl<T: Clone> !AnAutoTrait for Foo<T>where T: Sync,"
 impl<T: Clone> !AnAutoTrait for Foo<T> where T: Sync {}


### PR DESCRIPTION
When these rules were added in 4fd061c426902b0904c65e64a3780b21f9ab3afb (yeah, that's the very first commit of rustdoc_ng), `.item-list` was a `<ul>`, and this would override the default style for that tag.

In c1b1d6804bfce1aee3a95b3cbff3eaeb15bad9a4, it was changed to use a `<div>` tag, so these rules are both no-ops.