### PR TITLE
rustdoc: remove unused CSS `.docblock a:not(.srclink)`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -773,8 +773,9 @@ h2.small-section-header > .anchor {
 }
 
 .all-items a:hover,
-.docblock a:not(.srclink):not(.test-arrow):not(.scrape-help):hover,
-.docblock-short a:not(.srclink):not(.test-arrow):not(.scrape-help):hover, .item-info a {
+.docblock a:not(.test-arrow):not(.scrape-help):hover,
+.docblock-short a:not(.test-arrow):not(.scrape-help):hover,
+.item-info a {
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
This selector was added in c7312fbae4979c6d4fdfbd1f55a71cd47d82a480, because the list of impl items could be nested below `docblock`.

https://github.com/rust-lang/rust/blob/c7312fbae4979c6d4fdfbd1f55a71cd47d82a480/src/librustdoc/html/render.rs#L3841-L3845

Now that rustdoc toggles have been switched to `<details>`, there shouldn't be any need to put things inside docblock containers just to give them disclosure toggles.