### PR TITLE
suggestions: don't mention other impls of traits with type parameters

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -678,7 +678,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                                 None,
                                 obligation.cause.body_id,
                             );
-                        } else if !suggested  {
+                        } else if !suggested {
                             // Can't show anything else useful, try to find similar impls.
                             // This is skipped for traits with type parameters
                             // because those suggestions are  noisy and unhelpful

--- a/src/test/ui/binop/binop-mul-i32-f32.stderr
+++ b/src/test/ui/binop/binop-mul-i32-f32.stderr
@@ -5,16 +5,6 @@ LL |     x * y
    |       ^ no implementation for `i32 * f32`
    |
    = help: the trait `Mul<f32>` is not implemented for `i32`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
-           and 49 others
 
 error: aborting due to previous error
 

--- a/src/test/ui/binop/shift-various-bad-types.stderr
+++ b/src/test/ui/binop/shift-various-bad-types.stderr
@@ -5,16 +5,6 @@ LL |     22 >> p.char;
    |        ^^ no implementation for `{integer} >> char`
    |
    = help: the trait `Shr<char>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
-           and 568 others
 
 error[E0277]: no implementation for `{integer} >> &str`
   --> $DIR/shift-various-bad-types.rs:12:8
@@ -23,16 +13,6 @@ LL |     22 >> p.str;
    |        ^^ no implementation for `{integer} >> &str`
    |
    = help: the trait `Shr<&str>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
-           and 568 others
 
 error[E0277]: no implementation for `{integer} >> &Panolpy`
   --> $DIR/shift-various-bad-types.rs:15:8
@@ -41,16 +21,6 @@ LL |     22 >> p;
    |        ^^ no implementation for `{integer} >> &Panolpy`
    |
    = help: the trait `Shr<&Panolpy>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
-           and 568 others
 
 error[E0308]: mismatched types
   --> $DIR/shift-various-bad-types.rs:25:18

--- a/src/test/ui/const-generics/generic_const_exprs/issue-85848.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-85848.stderr
@@ -6,7 +6,6 @@ LL |     writes_to_specific_path(&cap);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Delegates<U>` is implemented for `T`
 note: required for `&C` to implement `Contains<(), true>`
   --> $DIR/issue-85848.rs:21:12
    |

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3b.stderr
@@ -11,16 +11,6 @@ LL |     = [0; (i8::MAX + 1u8) as usize];
    |                    ^ no implementation for `i8 + u8`
    |
    = help: the trait `~const Add<u8>` is not implemented for `i8`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -11,16 +11,6 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |                            ^ no implementation for `i8 + u8`
    |
    = help: the trait `~const Add<u8>` is not implemented for `i8`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error[E0604]: only `u8` can be cast as `char`, not `i8`
   --> $DIR/const-eval-overflow-4b.rs:22:13

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
@@ -10,16 +10,6 @@ note: the trait `PartialEq<_>` is implemented for `*const i32`, but that impleme
    |
 LL | const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 };
    |                                           ^^
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error[E0277]: can't compare `*const i32` with `_` in const contexts
   --> $DIR/const_raw_ptr_ops.rs:6:44
@@ -33,16 +23,6 @@ note: the trait `PartialEq<_>` is implemented for `*const i32`, but that impleme
    |
 LL | const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
    |                                            ^^
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/too_generic_eval_ice.stderr
+++ b/src/test/ui/consts/too_generic_eval_ice.stderr
@@ -21,16 +21,6 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |                              ^^ no implementation for `[{integer}; _] == [{integer}; 0]`
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; _]`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&[B] as PartialEq<[A; N]>>
-             <&[T] as PartialEq<Vec<U, A>>>
-             <&mut [B] as PartialEq<[A; N]>>
-             <&mut [T] as PartialEq<Vec<U, A>>>
-             <[A; N] as PartialEq<&[B]>>
-             <[A; N] as PartialEq<&mut [B]>>
-             <[A; N] as PartialEq<[B; N]>>
-             <[A; N] as PartialEq<[B]>>
-           and 3 others
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
+++ b/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
@@ -5,10 +5,6 @@ LL |     f1.foo(1usize);
    |        --- ^^^^^^ the trait `Foo<usize>` is not implemented for `Bar`
    |        |
    |        required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `Foo<A>`:
-             <Bar as Foo<i32>>
-             <Bar as Foo<u8>>
 
 error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
+++ b/src/test/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
@@ -5,14 +5,6 @@ LL |     f1.foo(1usize);
    |        --- ^^^^^^ the trait `Foo<usize>` is not implemented for `Bar`
    |        |
    |        required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `Foo<A>`:
-             <Bar as Foo<i16>>
-             <Bar as Foo<i32>>
-             <Bar as Foo<i8>>
-             <Bar as Foo<u16>>
-             <Bar as Foo<u32>>
-             <Bar as Foo<u8>>
 
 error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -5,17 +5,6 @@ LL |     Foo::<i32>::bar(&1i8);
    |     --------------- ^^^^ the trait `Foo<i32>` is not implemented for `i8`
    |     |
    |     required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `Foo<B>`:
-             <i8 as Foo<bool>>
-             <i8 as Foo<u16>>
-             <i8 as Foo<u32>>
-             <i8 as Foo<u64>>
-             <i8 as Foo<u8>>
-             <u8 as Foo<bool>>
-             <u8 as Foo<u16>>
-             <u8 as Foo<u32>>
-             <u8 as Foo<u64>>
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
@@ -24,17 +13,6 @@ LL |     Foo::<i32>::bar(&1u8);
    |     --------------- ^^^^ the trait `Foo<i32>` is not implemented for `u8`
    |     |
    |     required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `Foo<B>`:
-             <i8 as Foo<bool>>
-             <i8 as Foo<u16>>
-             <i8 as Foo<u32>>
-             <i8 as Foo<u64>>
-             <i8 as Foo<u8>>
-             <u8 as Foo<bool>>
-             <u8 as Foo<u16>>
-             <u8 as Foo<u32>>
-             <u8 as Foo<u64>>
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:21
@@ -43,14 +21,6 @@ LL |     Foo::<i32>::bar(&true);
    |     --------------- ^^^^^ the trait `Foo<i32>` is not implemented for `bool`
    |     |
    |     required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `Foo<B>`:
-             <bool as Foo<bool>>
-             <bool as Foo<i8>>
-             <bool as Foo<u16>>
-             <bool as Foo<u32>>
-             <bool as Foo<u64>>
-             <bool as Foo<u8>>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
+++ b/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
@@ -22,16 +22,6 @@ LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹
    |                                                     ^ no implementation for `{float} - {integer}`
    |
    = help: the trait `~const Sub<{integer}>` is not implemented for `{float}`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/impl-trait/equality.stderr
+++ b/src/test/ui/impl-trait/equality.stderr
@@ -29,16 +29,6 @@ LL |         n + sum_to(n - 1)
    |           ^ no implementation for `u32 + impl Foo`
    |
    = help: the trait `Add<impl Foo>` is not implemented for `u32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/impl-trait/issues/issue-62742.stderr
+++ b/src/test/ui/impl-trait/issues/issue-62742.stderr
@@ -4,7 +4,6 @@ error[E0277]: the trait bound `RawImpl<_>: Raw<_>` is not satisfied
 LL |     WrongImpl::foo(0i32);
    |     ^^^^^^^^^ the trait `Raw<_>` is not implemented for `RawImpl<_>`
    |
-   = help: the trait `Raw<[T]>` is implemented for `RawImpl<T>`
 note: required by a bound in `SafeImpl`
   --> $DIR/issue-62742.rs:26:35
    |
@@ -37,7 +36,6 @@ error[E0277]: the trait bound `RawImpl<()>: Raw<()>` is not satisfied
 LL |     WrongImpl::<()>::foo(0i32);
    |     ^^^^^^^^^^^^^^^ the trait `Raw<()>` is not implemented for `RawImpl<()>`
    |
-   = help: the trait `Raw<[T]>` is implemented for `RawImpl<T>`
 note: required by a bound in `SafeImpl`
   --> $DIR/issue-62742.rs:26:35
    |

--- a/src/test/ui/impl-trait/nested_impl_trait.stderr
+++ b/src/test/ui/impl-trait/nested_impl_trait.stderr
@@ -52,7 +52,6 @@ error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfie
 LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                              ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
-   = help: the trait `Into<U>` is implemented for `T`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
 error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfied
@@ -61,7 +60,6 @@ error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfie
 LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
-   = help: the trait `Into<U>` is implemented for `T`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
 error: aborting due to 8 previous errors

--- a/src/test/ui/index-help.stderr
+++ b/src/test/ui/index-help.stderr
@@ -5,7 +5,6 @@ LL |     x[0i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`
 
 error: aborting due to previous error

--- a/src/test/ui/indexing-requires-a-uint.stderr
+++ b/src/test/ui/indexing-requires-a-uint.stderr
@@ -5,7 +5,6 @@ LL |     [0][0u8];
    |         ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `[{integer}]` to implement `Index<u8>`
 
 error[E0308]: mismatched types

--- a/src/test/ui/integral-indexing.stderr
+++ b/src/test/ui/integral-indexing.stderr
@@ -5,7 +5,6 @@ LL |     v[3u8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `Vec<isize>` to implement `Index<u8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i8`
@@ -15,7 +14,6 @@ LL |     v[3i8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `Vec<isize>` to implement `Index<i8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `u32`
@@ -25,7 +23,6 @@ LL |     v[3u32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `Vec<isize>` to implement `Index<u32>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i32`
@@ -35,7 +32,6 @@ LL |     v[3i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `Vec<isize>` to implement `Index<i32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u8`
@@ -45,7 +41,6 @@ LL |     s.as_bytes()[3u8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `[u8]` to implement `Index<u8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i8`
@@ -55,7 +50,6 @@ LL |     s.as_bytes()[3i8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `[u8]` to implement `Index<i8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u32`
@@ -65,7 +59,6 @@ LL |     s.as_bytes()[3u32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `[u8]` to implement `Index<u32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i32`
@@ -75,7 +68,6 @@ LL |     s.as_bytes()[3i32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `[u8]` to implement `Index<i32>`
 
 error: aborting due to 8 previous errors

--- a/src/test/ui/issues/issue-11771.stderr
+++ b/src/test/ui/issues/issue-11771.stderr
@@ -5,16 +5,6 @@ LL |     1 +
    |       ^ no implementation for `{integer} + ()`
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error[E0277]: cannot add `()` to `{integer}`
   --> $DIR/issue-11771.rs:8:7
@@ -23,16 +13,6 @@ LL |     1 +
    |       ^ no implementation for `{integer} + ()`
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-24352.stderr
+++ b/src/test/ui/issues/issue-24352.stderr
@@ -5,16 +5,6 @@ LL |     1.0f64 - 1
    |            ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     1.0f64 - 1.0

--- a/src/test/ui/issues/issue-32709.stderr
+++ b/src/test/ui/issues/issue-32709.stderr
@@ -7,9 +7,6 @@ LL |     Err(5)?;
    |           ^ the trait `From<{integer}>` is not implemented for `()`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
    = note: required for `Result<i32, ()>` to implement `FromResidual<Result<Infallible, {integer}>>`
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-34334.stderr
+++ b/src/test/ui/issues/issue-34334.stderr
@@ -21,7 +21,6 @@ LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_rece
    |                                 value of type `Vec<(u32, _, _)>` cannot be built from `std::iter::Iterator<Item=()>`
    |
    = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
-   = help: the trait `FromIterator<T>` is implemented for `Vec<T>`
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |

--- a/src/test/ui/issues/issue-45801.stderr
+++ b/src/test/ui/issues/issue-45801.stderr
@@ -3,8 +3,6 @@ error[E0277]: the trait bound `Params: Plugin<i32>` is not satisfied
    |
 LL |     req.get_ref::<Params>();
    |         ^^^^^^^ the trait `Plugin<i32>` is not implemented for `Params`
-   |
-   = help: the trait `Plugin<Foo>` is implemented for `Params`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50582.stderr
+++ b/src/test/ui/issues/issue-50582.stderr
@@ -14,16 +14,6 @@ LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
    |                  ^ no implementation for `{integer} + ()`
    |
    = help: the trait `~const Add<()>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-66923-show-error-for-correct-call.stderr
+++ b/src/test/ui/issues/issue-66923-show-error-for-correct-call.stderr
@@ -7,7 +7,6 @@ LL |     let x2: Vec<f64> = x1.into_iter().collect();
    |                        value of type `Vec<f64>` cannot be built from `std::iter::Iterator<Item=&f64>`
    |
    = help: the trait `FromIterator<&f64>` is not implemented for `Vec<f64>`
-   = help: the trait `FromIterator<T>` is implemented for `Vec<T>`
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
@@ -23,7 +22,6 @@ LL |     let x3 = x1.into_iter().collect::<Vec<f64>>();
    |              value of type `Vec<f64>` cannot be built from `std::iter::Iterator<Item=&f64>`
    |
    = help: the trait `FromIterator<&f64>` is not implemented for `Vec<f64>`
-   = help: the trait `FromIterator<T>` is implemented for `Vec<T>`
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |

--- a/src/test/ui/kindck/kindck-impl-type-params.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.stderr
@@ -72,7 +72,6 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
 LL |     let a = t as Box<dyn Gettable<String>>;
    |             ^ the trait `Copy` is not implemented for `String`
    |
-   = help: the trait `Gettable<T>` is implemented for `S<T>`
 note: required for `S<String>` to implement `Gettable<String>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |
@@ -86,7 +85,6 @@ error[E0277]: the trait bound `Foo: Copy` is not satisfied
 LL |     let a: Box<dyn Gettable<Foo>> = t;
    |                                     ^ the trait `Copy` is not implemented for `Foo`
    |
-   = help: the trait `Gettable<T>` is implemented for `S<T>`
 note: required for `S<Foo>` to implement `Gettable<Foo>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |

--- a/src/test/ui/lexer/lex-bad-char-literals-6.stderr
+++ b/src/test/ui/lexer/lex-bad-char-literals-6.stderr
@@ -38,16 +38,6 @@ LL |     if x == y {}
    |          ^^ no implementation for `&str == char`
    |
    = help: the trait `PartialEq<char>` is not implemented for `&str`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&'a str as PartialEq<OsString>>
-             <&'a str as PartialEq<String>>
-             <&'b str as PartialEq<Cow<'a, str>>>
-             <String as PartialEq<&'a str>>
-             <String as PartialEq<Cow<'a, str>>>
-             <String as PartialEq<str>>
-             <String as PartialEq>
-             <str as PartialEq<Cow<'a, str>>>
-           and 4 others
 
 error[E0308]: mismatched types
   --> $DIR/lex-bad-char-literals-6.rs:15:20
@@ -64,16 +54,6 @@ LL |     if x == z {}
    |          ^^ no implementation for `&str == char`
    |
    = help: the trait `PartialEq<char>` is not implemented for `&str`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&'a str as PartialEq<OsString>>
-             <&'a str as PartialEq<String>>
-             <&'b str as PartialEq<Cow<'a, str>>>
-             <String as PartialEq<&'a str>>
-             <String as PartialEq<Cow<'a, str>>>
-             <String as PartialEq<str>>
-             <String as PartialEq>
-             <str as PartialEq<Cow<'a, str>>>
-           and 4 others
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/mismatched_types/binops.stderr
+++ b/src/test/ui/mismatched_types/binops.stderr
@@ -5,16 +5,6 @@ LL |     1 + Some(1);
    |       ^ no implementation for `{integer} + Option<{integer}>`
    |
    = help: the trait `Add<Option<{integer}>>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error[E0277]: cannot subtract `Option<{integer}>` from `usize`
   --> $DIR/binops.rs:3:16
@@ -23,16 +13,6 @@ LL |     2 as usize - Some(1);
    |                ^ no implementation for `usize - Option<{integer}>`
    |
    = help: the trait `Sub<Option<{integer}>>` is not implemented for `usize`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 
 error[E0277]: cannot multiply `{integer}` by `()`
   --> $DIR/binops.rs:4:7
@@ -41,16 +21,6 @@ LL |     3 * ();
    |       ^ no implementation for `{integer} * ()`
    |
    = help: the trait `Mul<()>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
-           and 49 others
 
 error[E0277]: cannot divide `{integer}` by `&str`
   --> $DIR/binops.rs:5:7
@@ -59,16 +29,6 @@ LL |     4 / "";
    |       ^ no implementation for `{integer} / &str`
    |
    = help: the trait `Div<&str>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
-             <&'a i8 as Div<i8>>
-             <&'a isize as Div<isize>>
-           and 54 others
 
 error[E0277]: can't compare `{integer}` with `String`
   --> $DIR/binops.rs:6:7
@@ -77,16 +37,6 @@ LL |     5 < String::new();
    |       ^ no implementation for `{integer} < String` and `{integer} > String`
    |
    = help: the trait `PartialOrd<String>` is not implemented for `{integer}`
-   = help: the following other types implement trait `PartialOrd<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error[E0277]: can't compare `{integer}` with `Result<{integer}, _>`
   --> $DIR/binops.rs:7:7
@@ -95,16 +45,6 @@ LL |     6 == Ok(1);
    |       ^^ no implementation for `{integer} == Result<{integer}, _>`
    |
    = help: the trait `PartialEq<Result<{integer}, _>>` is not implemented for `{integer}`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/never_type/issue-13352.stderr
+++ b/src/test/ui/never_type/issue-13352.stderr
@@ -5,16 +5,6 @@ LL |     2_usize + (loop {});
    |             ^ no implementation for `usize + ()`
    |
    = help: the trait `Add<()>` is not implemented for `usize`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to previous error
 

--- a/src/test/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
+++ b/src/test/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
@@ -5,8 +5,6 @@ LL |     <E as From<_>>::from(never);
    |     -------------------- ^^^^^ the trait `From<()>` is not implemented for `E`
    |     |
    |     required by a bound introduced by this call
-   |
-   = help: the trait `From<!>` is implemented for `E`
 
 error: aborting due to previous error
 

--- a/src/test/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/src/test/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -5,16 +5,6 @@ LL |     x + 100.0
    |       ^ no implementation for `u8 + {float}`
    |
    = help: the trait `Add<{float}>` is not implemented for `u8`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error[E0277]: cannot add `&str` to `f64`
   --> $DIR/not-suggest-float-literal.rs:6:7
@@ -23,16 +13,6 @@ LL |     x + "foo"
    |       ^ no implementation for `f64 + &str`
    |
    = help: the trait `Add<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error[E0277]: cannot add `{integer}` to `f64`
   --> $DIR/not-suggest-float-literal.rs:11:7
@@ -41,16 +21,6 @@ LL |     x + y
    |       ^ no implementation for `f64 + {integer}`
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error[E0277]: cannot subtract `{float}` from `u8`
   --> $DIR/not-suggest-float-literal.rs:15:7
@@ -59,16 +29,6 @@ LL |     x - 100.0
    |       ^ no implementation for `u8 - {float}`
    |
    = help: the trait `Sub<{float}>` is not implemented for `u8`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 
 error[E0277]: cannot subtract `&str` from `f64`
   --> $DIR/not-suggest-float-literal.rs:19:7
@@ -77,16 +37,6 @@ LL |     x - "foo"
    |       ^ no implementation for `f64 - &str`
    |
    = help: the trait `Sub<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 
 error[E0277]: cannot subtract `{integer}` from `f64`
   --> $DIR/not-suggest-float-literal.rs:24:7
@@ -95,16 +45,6 @@ LL |     x - y
    |       ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 
 error[E0277]: cannot multiply `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:28:7
@@ -113,16 +53,6 @@ LL |     x * 100.0
    |       ^ no implementation for `u8 * {float}`
    |
    = help: the trait `Mul<{float}>` is not implemented for `u8`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
-           and 49 others
 
 error[E0277]: cannot multiply `f64` by `&str`
   --> $DIR/not-suggest-float-literal.rs:32:7
@@ -131,16 +61,6 @@ LL |     x * "foo"
    |       ^ no implementation for `f64 * &str`
    |
    = help: the trait `Mul<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
-           and 49 others
 
 error[E0277]: cannot multiply `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:37:7
@@ -149,16 +69,6 @@ LL |     x * y
    |       ^ no implementation for `f64 * {integer}`
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
-           and 49 others
 
 error[E0277]: cannot divide `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:41:7
@@ -167,16 +77,6 @@ LL |     x / 100.0
    |       ^ no implementation for `u8 / {float}`
    |
    = help: the trait `Div<{float}>` is not implemented for `u8`
-   = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
-             <&'a i8 as Div<i8>>
-             <&'a isize as Div<isize>>
-           and 54 others
 
 error[E0277]: cannot divide `f64` by `&str`
   --> $DIR/not-suggest-float-literal.rs:45:7
@@ -185,16 +85,6 @@ LL |     x / "foo"
    |       ^ no implementation for `f64 / &str`
    |
    = help: the trait `Div<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
-             <&'a i8 as Div<i8>>
-             <&'a isize as Div<isize>>
-           and 54 others
 
 error[E0277]: cannot divide `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:50:7
@@ -203,16 +93,6 @@ LL |     x / y
    |       ^ no implementation for `f64 / {integer}`
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
-             <&'a i8 as Div<i8>>
-             <&'a isize as Div<isize>>
-           and 54 others
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/src/test/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -5,16 +5,6 @@ LL |     x + 100
    |       ^ no implementation for `f32 + {integer}`
    |
    = help: the trait `Add<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -27,16 +17,6 @@ LL |     x + 100
    |       ^ no implementation for `f64 + {integer}`
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -49,16 +29,6 @@ LL |     x - 100
    |       ^ no implementation for `f32 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -71,16 +41,6 @@ LL |     x - 100
    |       ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
-           and 48 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -93,16 +53,6 @@ LL |     x * 100
    |       ^ no implementation for `f32 * {integer}`
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
-           and 49 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -115,16 +65,6 @@ LL |     x * 100
    |       ^ no implementation for `f64 * {integer}`
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
-           and 49 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -137,16 +77,6 @@ LL |     x / 100
    |       ^ no implementation for `f32 / {integer}`
    |
    = help: the trait `Div<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
-             <&'a i8 as Div<i8>>
-             <&'a isize as Div<isize>>
-           and 54 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0
@@ -159,16 +89,6 @@ LL |     x / 100
    |       ^ no implementation for `f64 / {integer}`
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
-             <&'a i8 as Div<i8>>
-             <&'a isize as Div<isize>>
-           and 54 others
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0

--- a/src/test/ui/on-unimplemented/impl-substs.stderr
+++ b/src/test/ui/on-unimplemented/impl-substs.stderr
@@ -7,7 +7,6 @@ LL |     Foo::<usize>::foo((1i32, 1i32, 1i32));
    |     required by a bound introduced by this call
    |
    = help: the trait `Foo<usize>` is not implemented for `(i32, i32, i32)`
-   = help: the trait `Foo<A>` is implemented for `(A, B, C)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/multiple-impls.stderr
+++ b/src/test/ui/on-unimplemented/multiple-impls.stderr
@@ -7,9 +7,6 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |     required by a bound introduced by this call
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
@@ -18,9 +15,6 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait message
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:37:33
@@ -31,9 +25,6 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     required by a bound introduced by this call
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:37:5
@@ -42,9 +33,6 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Foo
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:41:33
@@ -55,9 +43,6 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     required by a bound introduced by this call
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:41:5
@@ -66,9 +51,6 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Bar
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
@@ -77,9 +59,6 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |     ^^^^^^^^^^^^ trait message
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:37:5
@@ -88,9 +67,6 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     ^^^^^^^^^^^^ on impl for Foo
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:41:5
@@ -99,9 +75,6 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     ^^^^^^^^^^^^ on impl for Bar
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/on-unimplemented/on-impl.stderr
+++ b/src/test/ui/on-unimplemented/on-impl.stderr
@@ -7,7 +7,6 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     required by a bound introduced by this call
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<usize>` is implemented for `[i32]`
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:5
@@ -16,7 +15,6 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<usize>` is implemented for `[i32]`
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:5
@@ -25,7 +23,6 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     ^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<usize>` is implemented for `[i32]`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/on-unimplemented/slice-index.stderr
+++ b/src/test/ui/on-unimplemented/slice-index.stderr
@@ -5,7 +5,6 @@ LL |     x[1i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `[i32]` to implement `Index<i32>`
 
 error[E0277]: the type `[i32]` cannot be indexed by `RangeTo<i32>`
@@ -15,9 +14,6 @@ LL |     x[..1i32];
    |       ^^^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             <RangeTo<usize> as SliceIndex<[T]>>
-             <RangeTo<usize> as SliceIndex<str>>
    = note: required for `[i32]` to implement `Index<RangeTo<i32>>`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
@@ -9,7 +9,6 @@ note: the trait `PartialEq<_>` is implemented for `T`, but that implementation i
    |
 LL |     *t == *t
    |        ^^
-   = help: the trait `PartialEq<&B>` is implemented for `&A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/multiline-span-simple.stderr
+++ b/src/test/ui/span/multiline-span-simple.stderr
@@ -5,16 +5,6 @@ LL |     foo(1 as u32 +
    |                  ^ no implementation for `u32 + ()`
    |
    = help: the trait `Add<()>` is not implemented for `u32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-idx.stderr
+++ b/src/test/ui/str/str-idx.stderr
@@ -7,7 +7,6 @@ LL |     let _: u8 = s[4];
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `str` to implement `Index<{integer}>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -21,7 +20,6 @@ LL |     let _ = s.get(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
 note: required by a bound in `core::str::<impl str>::get`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
    |
@@ -39,7 +37,6 @@ LL |     let _ = s.get_unchecked(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
 note: required by a bound in `core::str::<impl str>::get_unchecked`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
    |

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -31,7 +31,6 @@ LL |     s[1usize] = bot();
    |       ^^^^^^ string indices are ranges of `usize`
    |
    = help: the trait `SliceIndex<str>` is not implemented for `usize`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `str` to implement `Index<usize>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -45,7 +44,6 @@ LL |     s.get_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
 note: required by a bound in `core::str::<impl str>::get_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
    |
@@ -63,7 +61,6 @@ LL |     s.get_unchecked_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
 note: required by a bound in `core::str::<impl str>::get_unchecked_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
    |

--- a/src/test/ui/suggestions/into-str.stderr
+++ b/src/test/ui/suggestions/into-str.stderr
@@ -7,13 +7,6 @@ LL |     foo(String::new());
    |     required by a bound introduced by this call
    |
    = note: to coerce a `String` into a `&str`, use `&*` as a prefix
-   = help: the following other types implement trait `From<T>`:
-             <String as From<&String>>
-             <String as From<&mut str>>
-             <String as From<&str>>
-             <String as From<Box<str>>>
-             <String as From<Cow<'a, str>>>
-             <String as From<char>>
    = note: required for `String` to implement `Into<&str>`
 note: required by a bound in `foo`
   --> $DIR/into-str.rs:1:31

--- a/src/test/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/src/test/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -6,9 +6,6 @@ LL |     let _: &[i8] = data.into();
    |                    |
    |                    the trait `From<&[u8]>` is not implemented for `&[i8]`
    |
-   = help: the following other types implement trait `From<T>`:
-             <[T; LANES] as From<Simd<T, LANES>>>
-             <[bool; LANES] as From<Mask<T, LANES>>>
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/src/test/ui/suggestions/suggest-dereferencing-index.stderr
@@ -5,7 +5,6 @@ LL |     let one_item_please: i32 = [1, 2, 3][i];
    |                                          ^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`
-   = help: the trait `SliceIndex<[T]>` is implemented for `usize`
    = note: required for `[{integer}]` to implement `Index<&usize>`
 help: dereference this index
    |

--- a/src/test/ui/traits/coercion-generic-bad.stderr
+++ b/src/test/ui/traits/coercion-generic-bad.stderr
@@ -4,7 +4,6 @@ error[E0277]: the trait bound `Struct: Trait<isize>` is not satisfied
 LL |     let s: Box<dyn Trait<isize>> = Box::new(Struct { person: "Fred" });
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<isize>` is not implemented for `Struct`
    |
-   = help: the trait `Trait<&'static str>` is implemented for `Struct`
    = note: required for the cast from `Struct` to the object type `dyn Trait<isize>`
 
 error: aborting due to previous error

--- a/src/test/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/src/test/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -5,10 +5,6 @@ LL |     c.same_as(22)
    |       ------- ^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
    |       |
    |       required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `CompareTo<T>`:
-             <i64 as CompareTo<i64>>
-             <i64 as CompareTo<u64>>
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:30:15
@@ -30,10 +26,6 @@ LL |     <dyn CompareToInts>::same_as(c, 22)
    |     ----------------------------    ^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
    |     |
    |     required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `CompareTo<T>`:
-             <i64 as CompareTo<i64>>
-             <i64 as CompareTo<u64>>
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:38:27
@@ -55,10 +47,6 @@ LL |     assert_eq!(22_i64.same_as(22), true);
    |                       ------- ^^ the trait `CompareTo<i32>` is not implemented for `i64`
    |                       |
    |                       required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `CompareTo<T>`:
-             <i64 as CompareTo<i64>>
-             <i64 as CompareTo<u64>>
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/traits/issue-91594.stderr
+++ b/src/test/ui/traits/issue-91594.stderr
@@ -4,7 +4,6 @@ error[E0277]: the trait bound `Foo: HasComponent<()>` is not satisfied
 LL | impl HasComponent<<Foo as Component<Foo>>::Interface> for Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HasComponent<()>` is not implemented for `Foo`
    |
-   = help: the trait `HasComponent<<Foo as Component<Foo>>::Interface>` is implemented for `Foo`
 note: required for `Foo` to implement `Component<Foo>`
   --> $DIR/issue-91594.rs:13:27
    |

--- a/src/test/ui/traits/map-types.stderr
+++ b/src/test/ui/traits/map-types.stderr
@@ -4,7 +4,6 @@ error[E0277]: the trait bound `Box<dyn Map<isize, isize>>: Map<usize, isize>` is
 LL |     let y: Box<dyn Map<usize, isize>> = Box::new(x);
    |                                         ^^^^^^^^^^^ the trait `Map<usize, isize>` is not implemented for `Box<dyn Map<isize, isize>>`
    |
-   = help: the trait `Map<K, V>` is implemented for `HashMap<K, V>`
    = note: required for the cast from `Box<dyn Map<isize, isize>>` to the object type `dyn Map<usize, isize>`
 
 error: aborting due to previous error

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -5,7 +5,6 @@ LL |         Err("")?;
    |                ^ the trait `From<&str>` is not implemented for `TryFromSliceError`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the trait `From<Infallible>` is implemented for `TryFromSliceError`
    = note: required for `Result<u32, TryFromSliceError>` to implement `FromResidual<Result<Infallible, &str>>`
 
 error[E0271]: type mismatch resolving `<Result<i32, i32> as Try>::Output == &str`

--- a/src/test/ui/try-trait/bad-interconversion.stderr
+++ b/src/test/ui/try-trait/bad-interconversion.stderr
@@ -7,16 +7,6 @@ LL |     Ok(Err(123_i32)?)
    |                    ^ the trait `From<i32>` is not implemented for `u8`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             <f32 as From<i16>>
-             <f32 as From<i8>>
-             <f32 as From<u16>>
-             <f32 as From<u8>>
-             <f64 as From<f32>>
-             <f64 as From<i16>>
-             <f64 as From<i32>>
-             <f64 as From<i8>>
-           and 67 others
    = note: required for `Result<u64, u8>` to implement `FromResidual<Result<Infallible, i32>>`
 
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`
@@ -28,9 +18,6 @@ LL |     Some(3)?;
    |            ^ use `.ok_or(...)?` to provide an error compatible with `Result<u64, String>`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u64, String>`
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
 
 error[E0277]: the `?` operator can only be used on `Result`s in a function that returns `Result`
   --> $DIR/bad-interconversion.rs:17:31
@@ -41,9 +28,6 @@ LL |     Ok(ControlFlow::Break(123)?)
    |                               ^ this `?` produces `ControlFlow<{integer}, Infallible>`, which is incompatible with `Result<u64, String>`
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Result<u64, String>`
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/bad-interconversion.rs:22:22
@@ -54,9 +38,6 @@ LL |     Some(Err("hello")?)
    |                      ^ use `.ok()?` if you want to discard the `Result<Infallible, &str>` error information
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `Option<u16>`
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Option<T> as FromResidual<Yeet<()>>>
-             <Option<T> as FromResidual>
 
 error[E0277]: the `?` operator can only be used on `Option`s in a function that returns `Option`
   --> $DIR/bad-interconversion.rs:27:33
@@ -67,9 +48,6 @@ LL |     Some(ControlFlow::Break(123)?)
    |                                 ^ this `?` produces `ControlFlow<{integer}, Infallible>`, which is incompatible with `Option<u64>`
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Option<u64>`
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Option<T> as FromResidual<Yeet<()>>>
-             <Option<T> as FromResidual>
 
 error[E0277]: the `?` operator can only be used on `ControlFlow`s in a function that returns `ControlFlow`
   --> $DIR/bad-interconversion.rs:32:39
@@ -80,7 +58,6 @@ LL |     ControlFlow::Continue(Err("hello")?)
    |                                       ^ this `?` produces `Result<Infallible, &str>`, which is incompatible with `ControlFlow<String>`
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
-   = help: the trait `FromResidual` is implemented for `ControlFlow<B, C>`
 
 error[E0277]: the `?` operator can only be used on `ControlFlow`s in a function that returns `ControlFlow`
   --> $DIR/bad-interconversion.rs:37:12
@@ -91,7 +68,6 @@ LL |     Some(3)?;
    |            ^ this `?` produces `Option<Infallible>`, which is incompatible with `ControlFlow<u64>`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
-   = help: the trait `FromResidual` is implemented for `ControlFlow<B, C>`
 
 error[E0277]: the `?` operator in a function that returns `ControlFlow<B, _>` can only be used on other `ControlFlow<B, _>`s (with the same Break type)
   --> $DIR/bad-interconversion.rs:43:29
@@ -103,7 +79,6 @@ LL |     ControlFlow::Break(4_u8)?;
    |
    = help: the trait `FromResidual<ControlFlow<u8, Infallible>>` is not implemented for `ControlFlow<i64>`
    = note: unlike `Result`, there's no `From`-conversion performed for `ControlFlow`
-   = help: the trait `FromResidual` is implemented for `ControlFlow<B, C>`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/try-trait/option-to-result.stderr
+++ b/src/test/ui/try-trait/option-to-result.stderr
@@ -8,9 +8,6 @@ LL |     a?;
    |      ^ use `.ok_or(...)?` to provide an error compatible with `Result<(), ()>`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<(), ()>`
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/option-to-result.rs:11:6
@@ -22,9 +19,6 @@ LL |     a?;
    |      ^ use `.ok()?` if you want to discard the `Result<Infallible, i32>` error information
    |
    = help: the trait `FromResidual<Result<Infallible, i32>>` is not implemented for `Option<i32>`
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Option<T> as FromResidual<Yeet<()>>>
-             <Option<T> as FromResidual>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/try-trait/try-on-option.stderr
+++ b/src/test/ui/try-trait/try-on-option.stderr
@@ -8,9 +8,6 @@ LL |     x?;
    |      ^ use `.ok_or(...)?` to provide an error compatible with `Result<u32, ()>`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u32, ()>`
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option.rs:11:6

--- a/src/test/ui/type-alias-impl-trait/nested-tait-inference.stderr
+++ b/src/test/ui/type-alias-impl-trait/nested-tait-inference.stderr
@@ -6,8 +6,6 @@ LL | fn foo() -> impl Foo<FooX> {
 ...
 LL |     ()
    |     -- return type was inferred to be `()` here
-   |
-   = help: the trait `Foo<()>` is implemented for `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/nested-tait-inference2.stderr
+++ b/src/test/ui/type-alias-impl-trait/nested-tait-inference2.stderr
@@ -6,10 +6,6 @@ LL | fn foo() -> impl Foo<FooX> {
 LL |
 LL |     ()
    |     -- return type was inferred to be `()` here
-   |
-   = help: the following other types implement trait `Foo<A>`:
-             <() as Foo<()>>
-             <() as Foo<u32>>
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/self-referential-2.stderr
+++ b/src/test/ui/type-alias-impl-trait/self-referential-2.stderr
@@ -7,16 +7,6 @@ LL |     42_i32
    |     ------ return type was inferred to be `i32` here
    |
    = help: the trait `PartialEq<Foo>` is not implemented for `i32`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/self-referential-4.stderr
+++ b/src/test/ui/type-alias-impl-trait/self-referential-4.stderr
@@ -7,16 +7,6 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Bar<'b, 'static>>` is not implemented for `&i32`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error[E0277]: can't compare `&i32` with `Foo<'static, 'b>`
   --> $DIR/self-referential-4.rs:11:31
@@ -27,16 +17,6 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Foo<'static, 'b>>` is not implemented for `&i32`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error[E0277]: can't compare `&i32` with `Moo<'static, 'a>`
   --> $DIR/self-referential-4.rs:17:31
@@ -47,16 +27,6 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Moo<'static, 'a>>` is not implemented for `&i32`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/self-referential.stderr
+++ b/src/test/ui/type-alias-impl-trait/self-referential.stderr
@@ -8,16 +8,6 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Bar<'b, 'a>>` is not implemented for `&i32`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error[E0277]: can't compare `&i32` with `(i32, &i32)`
   --> $DIR/self-referential.rs:12:31
@@ -29,16 +19,6 @@ LL |     (42, i)
    |     ------- return type was inferred to be `(i32, &i32)` here
    |
    = help: the trait `PartialEq<(i32, &i32)>` is not implemented for `&i32`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error[E0277]: can't compare `&i32` with `(i32, Moo<'b, 'a>::{opaque#0})`
   --> $DIR/self-referential.rs:19:31
@@ -50,16 +30,6 @@ LL |     (42, i)
    |     ------- return type was inferred to be `(i32, &i32)` here
    |
    = help: the trait `PartialEq<(i32, Moo<'b, 'a>::{opaque#0})>` is not implemented for `&i32`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and 6 others
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -65,16 +65,6 @@ LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    |                                                                  ^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `Add<u8>` is not implemented for `i32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/typeck/issue-81293.stderr
+++ b/src/test/ui/typeck/issue-81293.stderr
@@ -20,16 +20,6 @@ LL |     a = c + b * 5;
    |           ^ no implementation for `usize + u16`
    |
    = help: the trait `Add<u16>` is not implemented for `usize`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/typeck/issue-90101.stderr
+++ b/src/test/ui/typeck/issue-90101.stderr
@@ -6,12 +6,6 @@ LL |     func(Path::new("hello").to_path_buf().to_string_lossy(), "world")
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `From<T>`:
-             <PathBuf as From<&T>>
-             <PathBuf as From<Box<Path>>>
-             <PathBuf as From<Cow<'a, Path>>>
-             <PathBuf as From<OsString>>
-             <PathBuf as From<String>>
    = note: required for `Cow<'_, str>` to implement `Into<PathBuf>`
 note: required by a bound in `func`
   --> $DIR/issue-90101.rs:3:20

--- a/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -7,16 +7,6 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |     required by a bound introduced by this call
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error[E0308]: mismatched types
   --> $DIR/ufcs-qpath-self-mismatch.rs:7:28
@@ -61,16 +51,6 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u32`
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
-           and 48 others
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
These are almost always useless and they can take up a *lot* of space in error messages.