### PR TITLE
Update Android target to use new build system integration

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -334,6 +334,18 @@ changelog-seen = 2
 # this is not intended to be used during local development.
 #metrics = false
 
+# When targeting Android, specify the location of the Android NDK. This variable
+# needs to be set to the location of the LLVM toolchain subdirectory within
+# the NDK, found under "toolchains/llvm/prebuilt/<host os>-<host arch>".
+#
+# This option is only compatible with Android NDK r19 or newer. If you are using
+# an older NDK, you will need to create a standalone toolchain and specify the
+# path via the target-specific android-ndk option.
+#android-ndk = <none> (path)
+
+# When targeting Android, specify the minimum API level to target.
+#android-api-level = 21
+
 # =============================================================================
 # General install configuration options
 # =============================================================================
@@ -700,6 +712,10 @@ changelog-seen = 2
 # the NDK for the target lives. This is used to find the C compiler to link and
 # build native code.
 # See `src/bootstrap/cc_detect.rs` for details.
+#
+# This option is deprecated as it requires building a standalone toolchain,
+# which is unnecessary with NDK r19 and newer. Instead, prefer to use the same
+# option under the [build] section.
 #android-ndk = <none> (path)
 
 # Build the sanitizer runtimes for this target.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -75,6 +75,8 @@ pub struct Config {
     pub stage0_metadata: Stage0Metadata,
     /// Whether to use the `c` feature of the `compiler_builtins` crate.
     pub optimized_compiler_builtins: bool,
+    pub android_ndk: Option<PathBuf>,
+    pub android_api_level: Option<u32>,
 
     pub on_fail: Option<String>,
     pub stage: u32,
@@ -600,6 +602,8 @@ define_config! {
         patch_binaries_for_nix: Option<bool> = "patch-binaries-for-nix",
         metrics: Option<bool> = "metrics",
         optimized_compiler_builtins: Option<bool> = "optimized-compiler-builtins",
+        android_ndk: Option<PathBuf> = "android-ndk",
+        android_api_level: Option<u32> = "android-api-level",
     }
 }
 
@@ -951,6 +955,8 @@ impl Config {
         config.gdb = build.gdb.map(PathBuf::from);
         config.python = build.python.map(PathBuf::from);
         config.submodules = build.submodules;
+        config.android_ndk = build.android_ndk;
+        config.android_api_level = build.android_api_level;
         set(&mut config.low_priority, build.low_priority);
         set(&mut config.compiler_docs, build.compiler_docs);
         set(&mut config.docs_minification, build.docs_minification);


### PR DESCRIPTION
Currently the Android build support relies on standalone toolchains which are obsolete as of NDK r19. This change adds support for the new build system integration described here:

https://developer.android.com/ndk/guides/other_build_systems

This avoids developers needing to create a standalone toolchain for each target as well as needing to specify the NDK path on each target, as the NDK path is now specified via [build]. The target-specific android-ndk option is still available for users of standalone toolchains.