### PR TITLE
let-else: test else block with non-never uninhabited type

### DIFF
--- a/src/test/ui/let-else/let-else-non-diverging.rs
+++ b/src/test/ui/let-else/let-else-non-diverging.rs
@@ -8,4 +8,15 @@ fn main() {
         }
     };
     let Some(x) = Some(1) else { Some(2) }; //~ ERROR does not diverge
+
+    // Ensure that uninhabited types do not "diverge".
+    // This might be relaxed in the future, but when it is,
+    // it should be an explicitly wanted descision.
+    let Some(x) = Some(1) else { foo::<Uninhabited>() }; //~ ERROR does not diverge
+}
+
+enum Uninhabited {}
+
+fn foo<T>() -> T {
+    panic!()
 }

--- a/src/test/ui/let-else/let-else-non-diverging.stderr
+++ b/src/test/ui/let-else/let-else-non-diverging.stderr
@@ -39,6 +39,17 @@ LL |     let Some(x) = Some(1) else { Some(2) };
    = help: try adding a diverging expression, such as `return` or `panic!(..)`
    = help: ...or use `match` instead of `let...else`
 
-error: aborting due to 3 previous errors
+error[E0308]: `else` clause of `let...else` does not diverge
+  --> $DIR/let-else-non-diverging.rs:15:32
+   |
+LL |     let Some(x) = Some(1) else { foo::<Uninhabited>() };
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^ expected `!`, found enum `Uninhabited`
+   |
+   = note: expected type `!`
+              found enum `Uninhabited`
+   = help: try adding a diverging expression, such as `return` or `panic!(..)`
+   = help: ...or use `match` instead of `let...else`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
let else currently does not allow uninhabited types for the `else` block that aren't `!`. One can maybe think about relaxing this in the future, but if it is done, it should be an explicit choice and not an unexpected side effect of e.g. a refactor. Thus, I'm extending a test that will fail if the behaviour changes.