### PR TITLE
Check `WhereClauseReferencesSelf` after all other object safety checks

### DIFF
--- a/src/test/ui/object-safety/issue-102762.rs
+++ b/src/test/ui/object-safety/issue-102762.rs
@@ -1,0 +1,26 @@
+// compile-flags: --crate-type=lib
+// This test checks that the `where_clauses_object_safety` lint does not cause
+// other object safety *hard errors* to be suppressed, because we currently
+// only emit one object safety error per trait...
+
+use std::future::Future;
+use std::pin::Pin;
+
+pub trait Fetcher: Send + Sync {
+    fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
+    where
+        Self: Sync,
+    {
+        todo!()
+    }
+}
+
+fn fetcher() -> Box<dyn Fetcher> {
+    //~^ ERROR the trait `Fetcher` cannot be made into an object
+    todo!()
+}
+
+pub fn foo() {
+    let fetcher = fetcher();
+    let _ = fetcher.get();
+}

--- a/src/test/ui/object-safety/issue-102762.stderr
+++ b/src/test/ui/object-safety/issue-102762.stderr
@@ -1,0 +1,20 @@
+error[E0038]: the trait `Fetcher` cannot be made into an object
+  --> $DIR/issue-102762.rs:18:21
+   |
+LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
+   |                      ------------- help: consider changing method `get`'s `self` parameter to be `&self`: `&Self`
+...
+LL | fn fetcher() -> Box<dyn Fetcher> {
+   |                     ^^^^^^^^^^^ `Fetcher` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-102762.rs:10:22
+   |
+LL | pub trait Fetcher: Send + Sync {
+   |           ------- this trait cannot be made into an object...
+LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
+   |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0038`.


### PR DESCRIPTION
This fixes the ICE because it causes us to detect another *non-lint* `MethodViolationCode` first, instead of breaking on `WhereClauseReferencesSelf`. 

We could also approach this issue by instead returning a vector of *all* of the `MethodViolationCode`s, and just reporting the first one we see, but treating it as a hard error if we return both `WhereClauseReferencesSelf` and some other violation code -- let me know if this is desired.

Fixes #102762