### PR TITLE
Suggest `==` to the first expr which has `ExprKind::Assign` kind

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/expr.rs
+++ b/compiler/rustc_hir_analysis/src/check/expr.rs
@@ -1051,8 +1051,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 rhs_expr,
             ) = lhs.kind
             {
+                // if x == 1 && y == 2 { .. }
+                //                 +
                 let actual_lhs_ty = self.check_expr(&rhs_expr);
                 (Applicability::MaybeIncorrect, self.can_coerce(rhs_ty, actual_lhs_ty))
+            } else if let ExprKind::Binary(
+                Spanned { node: hir::BinOpKind::And | hir::BinOpKind::Or, .. },
+                lhs_expr,
+                _,
+            ) = rhs.kind
+            {
+                // if x == 1 && y == 2 { .. }
+                //       +
+                let actual_rhs_ty = self.check_expr(&lhs_expr);
+                (Applicability::MaybeIncorrect, self.can_coerce(actual_rhs_ty, lhs_ty))
             } else {
                 (Applicability::MaybeIncorrect, false)
             };

--- a/src/test/ui/type/type-check/assignment-in-if.rs
+++ b/src/test/ui/type/type-check/assignment-in-if.rs
@@ -53,4 +53,10 @@ fn main() {
         //~| ERROR mismatched types
         println!("{}", x);
     }
+
+    if x = 1 && x == 1 {
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        println!("{}", x);
+    }
 }

--- a/src/test/ui/type/type-check/assignment-in-if.stderr
+++ b/src/test/ui/type/type-check/assignment-in-if.stderr
@@ -104,6 +104,23 @@ help: you might have meant to compare for equality
 LL |     if x == x && x == x && x == x {
    |                               +
 
-error: aborting due to 11 previous errors
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:57:12
+   |
+LL |     if x = 1 && x == 1 {
+   |            ^ expected `bool`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:57:8
+   |
+LL |     if x = 1 && x == 1 {
+   |        ^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == 1 && x == 1 {
+   |           +
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
follow-up to #102708

[playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=4241dc33ed8af02e1ef530d6b14903fd)