### PR TITLE
Fix MIR inlining of asm_unwind

### DIFF
--- a/src/test/mir-opt/inline/asm-unwind.rs
+++ b/src/test/mir-opt/inline/asm-unwind.rs
@@ -1,0 +1,21 @@
+// Tests inlining of `may_unwind` inline assembly.
+//
+// ignore-wasm32-bare compiled with panic=abort by default
+#![feature(asm_unwind)]
+
+struct D;
+
+impl Drop for D {
+    fn drop(&mut self) {}
+}
+
+#[inline(always)]
+fn foo() {
+    let _d = D;
+    unsafe { std::arch::asm!("", options(may_unwind)) };
+}
+
+// EMIT_MIR asm_unwind.main.Inline.diff
+pub fn main() {
+    foo();
+}

--- a/src/test/mir-opt/inline/asm-unwind.rs
+++ b/src/test/mir-opt/inline/asm-unwind.rs
@@ -1,6 +1,7 @@
 // Tests inlining of `may_unwind` inline assembly.
 //
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-asm-support
 #![feature(asm_unwind)]
 
 struct D;

--- a/src/test/mir-opt/inline/asm_unwind.main.Inline.diff
+++ b/src/test/mir-opt/inline/asm_unwind.main.Inline.diff
@@ -1,0 +1,45 @@
+- // MIR for `main` before Inline
++ // MIR for `main` after Inline
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/asm-unwind.rs:+0:15: +0:15
+      let _1: ();                          // in scope 0 at $DIR/asm-unwind.rs:+1:5: +1:10
++     scope 1 (inlined foo) {              // at $DIR/asm-unwind.rs:20:5: 20:10
++         let _2: D;                       // in scope 1 at $DIR/asm-unwind.rs:14:9: 14:11
++         scope 2 {
++             debug _d => _2;              // in scope 2 at $DIR/asm-unwind.rs:14:9: 14:11
++             scope 3 {
++             }
++         }
++     }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/asm-unwind.rs:+1:5: +1:10
+-         _1 = foo() -> bb1;               // scope 0 at $DIR/asm-unwind.rs:+1:5: +1:10
+-                                          // mir::Constant
+-                                          // + span: $DIR/asm-unwind.rs:20:5: 20:8
+-                                          // + literal: Const { ty: fn() {foo}, val: Value(<ZST>) }
++         StorageLive(_2);                 // scope 1 at $DIR/asm-unwind.rs:14:9: 14:11
++         asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind: bb3]; // scope 3 at $DIR/asm-unwind.rs:15:14: 15:54
+      }
+  
+      bb1: {
++         drop(_2) -> bb2;                 // scope 1 at $DIR/asm-unwind.rs:16:1: 16:2
++     }
++ 
++     bb2: {
++         StorageDead(_2);                 // scope 1 at $DIR/asm-unwind.rs:16:1: 16:2
+          StorageDead(_1);                 // scope 0 at $DIR/asm-unwind.rs:+1:10: +1:11
+          _0 = const ();                   // scope 0 at $DIR/asm-unwind.rs:+0:15: +2:2
+          return;                          // scope 0 at $DIR/asm-unwind.rs:+2:2: +2:2
++     }
++ 
++     bb3 (cleanup): {
++         drop(_2) -> bb4;                 // scope 1 at $DIR/asm-unwind.rs:16:1: 16:2
++     }
++ 
++     bb4 (cleanup): {
++         resume;                          // scope 1 at $DIR/asm-unwind.rs:13:1: 16:2
+      }
+  }
+  

--- a/src/test/mir-opt/inline/asm_unwind.main.Inline.diff
+++ b/src/test/mir-opt/inline/asm_unwind.main.Inline.diff
@@ -4,10 +4,10 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/asm-unwind.rs:+0:15: +0:15
       let _1: ();                          // in scope 0 at $DIR/asm-unwind.rs:+1:5: +1:10
-+     scope 1 (inlined foo) {              // at $DIR/asm-unwind.rs:20:5: 20:10
-+         let _2: D;                       // in scope 1 at $DIR/asm-unwind.rs:14:9: 14:11
++     scope 1 (inlined foo) {              // at $DIR/asm-unwind.rs:21:5: 21:10
++         let _2: D;                       // in scope 1 at $DIR/asm-unwind.rs:15:9: 15:11
 +         scope 2 {
-+             debug _d => _2;              // in scope 2 at $DIR/asm-unwind.rs:14:9: 14:11
++             debug _d => _2;              // in scope 2 at $DIR/asm-unwind.rs:15:9: 15:11
 +             scope 3 {
 +             }
 +         }
@@ -17,29 +17,29 @@
           StorageLive(_1);                 // scope 0 at $DIR/asm-unwind.rs:+1:5: +1:10
 -         _1 = foo() -> bb1;               // scope 0 at $DIR/asm-unwind.rs:+1:5: +1:10
 -                                          // mir::Constant
--                                          // + span: $DIR/asm-unwind.rs:20:5: 20:8
+-                                          // + span: $DIR/asm-unwind.rs:21:5: 21:8
 -                                          // + literal: Const { ty: fn() {foo}, val: Value(<ZST>) }
-+         StorageLive(_2);                 // scope 1 at $DIR/asm-unwind.rs:14:9: 14:11
-+         asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind: bb3]; // scope 3 at $DIR/asm-unwind.rs:15:14: 15:54
++         StorageLive(_2);                 // scope 1 at $DIR/asm-unwind.rs:15:9: 15:11
++         asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind: bb3]; // scope 3 at $DIR/asm-unwind.rs:16:14: 16:54
       }
   
       bb1: {
-+         drop(_2) -> bb2;                 // scope 1 at $DIR/asm-unwind.rs:16:1: 16:2
++         drop(_2) -> bb2;                 // scope 1 at $DIR/asm-unwind.rs:17:1: 17:2
 +     }
 + 
 +     bb2: {
-+         StorageDead(_2);                 // scope 1 at $DIR/asm-unwind.rs:16:1: 16:2
++         StorageDead(_2);                 // scope 1 at $DIR/asm-unwind.rs:17:1: 17:2
           StorageDead(_1);                 // scope 0 at $DIR/asm-unwind.rs:+1:10: +1:11
           _0 = const ();                   // scope 0 at $DIR/asm-unwind.rs:+0:15: +2:2
           return;                          // scope 0 at $DIR/asm-unwind.rs:+2:2: +2:2
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_2) -> bb4;                 // scope 1 at $DIR/asm-unwind.rs:16:1: 16:2
++         drop(_2) -> bb4;                 // scope 1 at $DIR/asm-unwind.rs:17:1: 17:2
 +     }
 + 
 +     bb4 (cleanup): {
-+         resume;                          // scope 1 at $DIR/asm-unwind.rs:13:1: 16:2
++         resume;                          // scope 1 at $DIR/asm-unwind.rs:14:1: 17:2
       }
   }
   


### PR DESCRIPTION
The MIR inlining currently doesn't handle inline asm's unwind edge correctly.

This code will cause ICE:
```rust
struct D;

impl Drop for D {
    fn drop(&mut self) {}
}

#[inline(always)]
fn foo() {
    let _d = D;
    unsafe { std::arch::asm!("", options(may_unwind)) };
}

pub fn main() {
    foo();
}
```

This PR fixes this issue. I also take the opportunity to extract common code into a method.