### PR TITLE
sync thread_local key conditions exactly with what the macro uses

### DIFF
--- a/library/std/src/sys/unix/thread_local_dtor.rs
+++ b/library/std/src/sys/unix/thread_local_dtor.rs
@@ -17,6 +17,7 @@
     target_os = "redox",
     target_os = "emscripten"
 ))]
+#[cfg_attr(target_family = "wasm", allow(unused))] // might remain unused depending on target details (e.g. wasm32-unknown-emscripten)
 pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     use crate::mem;
     use crate::sys_common::thread_local_dtor::register_dtor_fallback;

--- a/library/std/src/sys/unsupported/thread_local_dtor.rs
+++ b/library/std/src/sys/unsupported/thread_local_dtor.rs
@@ -1,5 +1,6 @@
 #![unstable(feature = "thread_local_internals", issue = "none")]
 
+#[cfg_attr(target_family = "wasm", allow(unused))] // unused on wasm32-unknown-unknown
 pub unsafe fn register_dtor(_t: *mut u8, _dtor: unsafe extern "C" fn(*mut u8)) {
     // FIXME: right now there is no concept of "thread exit", but this is likely
     // going to show up at some point in the form of an exported symbol that the

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -901,7 +901,7 @@ pub mod statik {
 }
 
 #[doc(hidden)]
-#[cfg(target_thread_local)]
+#[cfg(all(target_thread_local, not(all(target_family = "wasm", not(target_feature = "atomics"))),))]
 pub mod fast {
     use super::lazy::LazyKeyInner;
     use crate::cell::Cell;
@@ -1037,7 +1037,10 @@ pub mod fast {
 }
 
 #[doc(hidden)]
-#[cfg(not(target_thread_local))]
+#[cfg(all(
+    not(target_thread_local),
+    not(all(target_family = "wasm", not(target_feature = "atomics"))),
+))]
 pub mod os {
     use super::lazy::LazyKeyInner;
     use crate::cell::Cell;

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -150,6 +150,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deny(unsafe_op_in_unsafe_fn)]
+// Under `test`, `__FastLocalKeyInner` seems unused.
+#![cfg_attr(test, allow(dead_code))]
 
 #[cfg(all(test, not(target_os = "emscripten")))]
 mod tests;
@@ -217,15 +219,6 @@ pub use self::local::fast::Key as __FastLocalKeyInner;
     not(all(target_family = "wasm", not(target_feature = "atomics"))),
 ))]
 pub use realstd::thread::__FastLocalKeyInner;
-
-// but import the local one anyway to silence 'unused' warnings
-#[unstable(feature = "libstd_thread_internals", issue = "none")]
-#[cfg(test)]
-#[cfg(all(
-    target_thread_local,
-    not(all(target_family = "wasm", not(target_feature = "atomics"))),
-))]
-pub use self::local::fast::Key as __FastLocalKeyInnerUnused;
 
 #[unstable(feature = "libstd_thread_internals", issue = "none")]
 #[cfg(all(

--- a/src/test/ui/threads-sendsync/issue-43733-2.rs
+++ b/src/test/ui/threads-sendsync/issue-43733-2.rs
@@ -1,5 +1,5 @@
+// ignore-wasm32
 // dont-check-compiler-stderr
-
 #![feature(cfg_target_thread_local, thread_local_internals)]
 
 // On platforms *without* `#[thread_local]`, use

--- a/src/test/ui/threads-sendsync/issue-43733.rs
+++ b/src/test/ui/threads-sendsync/issue-43733.rs
@@ -1,8 +1,8 @@
+// ignore-wasm32
 // revisions: mir thir
 // [thir]compile-flags: -Z thir-unsafeck
 // normalize-stderr-test: "__FastLocalKeyInner::<T>::get" -> "$$LOCALKEYINNER::<T>::get"
 // normalize-stderr-test: "__OsLocalKeyInner::<T>::get" -> "$$LOCALKEYINNER::<T>::get"
-
 #![feature(thread_local)]
 #![feature(cfg_target_thread_local, thread_local_internals)]
 


### PR DESCRIPTION
This makes the `cfg` in `mod.rs` syntactically the same as those in `local.rs`.

I don't think this should actually change anything, but seems better to be consistent?
I looked into this due to https://github.com/rust-lang/rust/issues/102549, but this PR would make it *less* likely that `__OsLocalKeyInner` is going to get provided, so this cannot help with that issue.

r? @thomcc