### PR TITLE
Fix llvm-tblgen for cross compiling

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2028,6 +2028,7 @@ impl Step for RustDev {
             "llvm-nm",
             "llvm-dwarfdump",
             "llvm-dis",
+            "llvm-tblgen",
         ] {
             tarball.add_file(src_bindir.join(exe(bin, target)), "bin", 0o755);
         }

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/97550
+Last change is for: https://github.com/rust-lang/rust/pull/102790

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -498,11 +498,16 @@ impl Step for Llvm {
         // https://llvm.org/docs/HowToCrossCompileLLVM.html
         if target != builder.config.build {
             let llvm_config = builder.ensure(Llvm { target: builder.config.build });
-            let llvm_bindir = output(Command::new(&llvm_config).arg("--bindir"));
-            let host_bin = Path::new(llvm_bindir.trim());
-            cfg.define("LLVM_TABLEGEN", host_bin.join("llvm-tblgen").with_extension(EXE_EXTENSION));
-            // LLVM_NM is required for cross compiling using MSVC
-            cfg.define("LLVM_NM", host_bin.join("llvm-nm").with_extension(EXE_EXTENSION));
+            if !builder.config.dry_run {
+                let llvm_bindir = output(Command::new(&llvm_config).arg("--bindir"));
+                let host_bin = Path::new(llvm_bindir.trim());
+                cfg.define(
+                    "LLVM_TABLEGEN",
+                    host_bin.join("llvm-tblgen").with_extension(EXE_EXTENSION),
+                );
+                // LLVM_NM is required for cross compiling using MSVC
+                cfg.define("LLVM_NM", host_bin.join("llvm-nm").with_extension(EXE_EXTENSION));
+            }
             cfg.define("LLVM_CONFIG_PATH", llvm_config);
             if builder.config.llvm_clang {
                 let build_bin = builder.llvm_out(builder.config.build).join("build").join("bin");

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -497,18 +497,13 @@ impl Step for Llvm {
 
         // https://llvm.org/docs/HowToCrossCompileLLVM.html
         if target != builder.config.build {
-            builder.ensure(Llvm { target: builder.config.build });
-            // FIXME: if the llvm root for the build triple is overridden then we
-            //        should use llvm-tblgen from there, also should verify that it
-            //        actually exists most of the time in normal installs of LLVM.
-            let host_bin = builder.llvm_out(builder.config.build).join("bin");
+            let llvm_config = builder.ensure(Llvm { target: builder.config.build });
+            let llvm_bindir = output(Command::new(&llvm_config).arg("--bindir"));
+            let host_bin = Path::new(llvm_bindir.trim());
             cfg.define("LLVM_TABLEGEN", host_bin.join("llvm-tblgen").with_extension(EXE_EXTENSION));
             // LLVM_NM is required for cross compiling using MSVC
             cfg.define("LLVM_NM", host_bin.join("llvm-nm").with_extension(EXE_EXTENSION));
-            cfg.define(
-                "LLVM_CONFIG_PATH",
-                host_bin.join("llvm-config").with_extension(EXE_EXTENSION),
-            );
+            cfg.define("LLVM_CONFIG_PATH", llvm_config);
             if builder.config.llvm_clang {
                 let build_bin = builder.llvm_out(builder.config.build).join("build").join("bin");
                 let clang_tblgen = build_bin.join("clang-tblgen").with_extension(EXE_EXTENSION);


### PR DESCRIPTION
- Let llvm-config tell us where to find its tools
- Add llvm-tblgen to rust-dev for cross-compiling

Fixes #86890.
r? @jyn514 
