### PR TITLE
Replace `AsRef<Path>` with the `PathLike` trait

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -17,7 +17,9 @@ use crate::error::Error;
 use crate::ffi::{OsStr, OsString};
 use crate::fmt;
 use crate::io;
-use crate::path::{Path, PathBuf};
+#[cfg(doc)]
+use crate::path::Path;
+use crate::path::{PathBuf, PathLike};
 use crate::sys;
 use crate::sys::os as os_imp;
 
@@ -80,8 +82,8 @@ pub fn current_dir() -> io::Result<PathBuf> {
 /// ```
 #[doc(alias = "chdir")]
 #[stable(feature = "env", since = "1.0.0")]
-pub fn set_current_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    os_imp::chdir(path.as_ref())
+pub fn set_current_dir<P: PathLike>(path: P) -> io::Result<()> {
+    path.with_path(os_imp::chdir)
 }
 
 /// An iterator over a snapshot of the environment variables of this process.

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1126,14 +1126,20 @@ pub trait PathLike {
     /// Convert to a `Path` reference.
     fn with_path<T, F: FnOnce(&Path) -> T>(&self, f: F) -> T;
     /// Convert to the native platform representation of a path.
-    fn with_native_path<T, F: FnOnce(&crate::sys::path::NativePath) -> io::Result<T>>(&self, f: F) -> io::Result<T>;
+    fn with_native_path<T, F: FnOnce(&crate::sys::path::NativePath) -> io::Result<T>>(
+        &self,
+        f: F,
+    ) -> io::Result<T>;
 }
 #[unstable(feature = "path_like", issue = "none")]
 impl<P: AsRef<Path>> PathLike for P {
     fn with_path<T, F: FnOnce(&Path) -> T>(&self, f: F) -> T {
         f(self.as_ref())
     }
-    fn with_native_path<T, F: FnOnce(&crate::sys::path::NativePath) -> io::Result<T>>(&self, f: F) -> io::Result<T> {
+    fn with_native_path<T, F: FnOnce(&crate::sys::path::NativePath) -> io::Result<T>>(
+        &self,
+        f: F,
+    ) -> io::Result<T> {
         crate::sys::path::with_native_path(self.as_ref(), f)
     }
 }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1109,6 +1109,30 @@ impl FusedIterator for Ancestors<'_> {}
 // Basic types and traits
 ////////////////////////////////////////////////////////////////////////////////
 
+/// # Stable use
+///
+/// Any function that requires a path may take a `PathLike` type.
+///
+/// These types include [`OsStr`], [`Path`] and [`str`] as well as their owned
+/// counterparts [`OsString`], [`PathBuf`] and [`String`].
+///
+/// # Unstable use
+///
+/// The `PathLike` trait can be implemented for custom path types. This requires
+/// a nightly compiler with the `path_like` feature enabled. Note that this
+/// trait is unstable and highly likely to change between nightly versions.
+#[unstable(feature = "path_like", issue = "none")]
+pub trait PathLike {
+    /// Convert to a `Path` reference.
+    fn with_path<T, F: FnOnce(&Path) -> T>(&self, f: F) -> T;
+}
+#[unstable(feature = "path_like", issue = "none")]
+impl<P: AsRef<Path>> PathLike for P {
+    fn with_path<T, F: FnOnce(&Path) -> T>(&self, f: F) -> T {
+        f(self.as_ref())
+    }
+}
+
 /// An owned, mutable path (akin to [`String`]).
 ///
 /// This type provides methods like [`push`] and [`set_extension`] that mutate

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1125,11 +1125,16 @@ impl FusedIterator for Ancestors<'_> {}
 pub trait PathLike {
     /// Convert to a `Path` reference.
     fn with_path<T, F: FnOnce(&Path) -> T>(&self, f: F) -> T;
+    /// Convert to the native platform representation of a path.
+    fn with_native_path<T, F: FnOnce(&crate::sys::path::NativePath) -> io::Result<T>>(&self, f: F) -> io::Result<T>;
 }
 #[unstable(feature = "path_like", issue = "none")]
 impl<P: AsRef<Path>> PathLike for P {
     fn with_path<T, F: FnOnce(&Path) -> T>(&self, f: F) -> T {
         f(self.as_ref())
+    }
+    fn with_native_path<T, F: FnOnce(&crate::sys::path::NativePath) -> io::Result<T>>(&self, f: F) -> io::Result<T> {
+        crate::sys::path::with_native_path(self.as_ref(), f)
     }
 }
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -112,7 +112,7 @@ use crate::fmt;
 use crate::fs;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::num::NonZeroI32;
-use crate::path::Path;
+use crate::path::{Path, PathLike};
 use crate::str;
 use crate::sys::pipe::{read2, AnonPipe};
 use crate::sys::process as imp;
@@ -769,8 +769,8 @@ impl Command {
     ///
     /// [`canonicalize`]: crate::fs::canonicalize
     #[stable(feature = "process", since = "1.0.0")]
-    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Command {
-        self.inner.cwd(dir.as_ref().as_ref());
+    pub fn current_dir<P: PathLike>(&mut self, dir: P) -> &mut Command {
+        dir.with_path(|dir| self.inner.cwd(dir.as_ref()));
         self
     }
 

--- a/library/std/src/sys/unix/path.rs
+++ b/library/std/src/sys/unix/path.rs
@@ -5,7 +5,10 @@ use crate::path::{Path, PathBuf, Prefix};
 use crate::sys::common::small_c_string::run_path_with_cstr;
 
 pub type NativePath = CStr;
-pub fn with_native_path<T, F: FnOnce(&NativePath) -> io::Result<T>>(path: &Path, f: F) -> io::Result<T> {
+pub fn with_native_path<T, F: FnOnce(&NativePath) -> io::Result<T>>(
+    path: &Path,
+    f: F,
+) -> io::Result<T> {
     run_path_with_cstr(path, f)
 }
 

--- a/library/std/src/sys/unix/path.rs
+++ b/library/std/src/sys/unix/path.rs
@@ -1,7 +1,13 @@
 use crate::env;
-use crate::ffi::OsStr;
+use crate::ffi::{CStr, OsStr};
 use crate::io;
 use crate::path::{Path, PathBuf, Prefix};
+use crate::sys::common::small_c_string::run_path_with_cstr;
+
+pub type NativePath = CStr;
+pub fn with_native_path<T, F: FnOnce(&NativePath) -> io::Result<T>>(path: &Path, f: F) -> io::Result<T> {
+    run_path_with_cstr(path, f)
+}
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/library/std/src/sys/windows/path.rs
+++ b/library/std/src/sys/windows/path.rs
@@ -11,6 +11,12 @@ mod tests;
 pub const MAIN_SEP_STR: &str = "\\";
 pub const MAIN_SEP: char = '\\';
 
+// Currently a no-op. Should convert to a wide string.
+pub type NativePath = Path;
+pub fn with_native_path<T, F: FnOnce(&NativePath) -> T>(path: &Path, f: F) -> T {
+    f(path)
+}
+
 /// # Safety
 ///
 /// `bytes` must be a valid wtf8 encoded slice

--- a/src/test/ui/async-await/issue-72442.stderr
+++ b/src/test/ui/async-await/issue-72442.stderr
@@ -6,11 +6,12 @@ LL |             let mut f = File::open(path.to_str())?;
    |                         |
    |                         required by a bound introduced by this call
    |
+   = note: required for `Option<&str>` to implement `PathLike`
 note: required by a bound in `File::open`
   --> $SRC_DIR/std/src/fs.rs:LL:COL
    |
-LL |     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<File> {
-   |                    ^^^^^^^^^^^ required by this bound in `File::open`
+LL |     pub fn open<P: PathLike>(path: P) -> io::Result<File> {
+   |                    ^^^^^^^^ required by this bound in `File::open`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is to test the feasibility of using a trait instead of `AsRef<Path>`. The ultimate goal is to allow other path types (e,g, UTF-16 path on Windows) without having to go through `std::path::Path`.

r? @ghost