### PR TITLE
rustdoc: remove no-op CSS `.rightside { position: initial }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1093,7 +1093,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 .rightside {
 	padding-left: 12px;
 	padding-right: 2px;
-	position: initial;
 	float: right;
 }
 


### PR DESCRIPTION
This CSS, added in 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9, overrode CSS that was applied to the `.since` class:

https://github.com/rust-lang/rust/blob/34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9/src/librustdoc/html/static/rustdoc.css#L782-L795

The absolute positioning for `.since` was abandoned in favor of always floating it, so this is no longer needed:

https://github.com/rust-lang/rust/commit/5de1391b88007a1d4f7b1517657a86aae352af1e#diff-7dc22a0530802d77c2f2ec9e834024a5657b6eab4055520fca46edc99a544413L902-L904