### PR TITLE
rustdoc: add main-heading and example-wrap link CSS to big selector

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -163,9 +163,6 @@ h1.fqn {
 	padding-bottom: 6px;
 	margin-bottom: 15px;
 }
-.main-heading a:hover {
-	text-decoration: underline;
-}
 #toggle-all-docs {
 	text-decoration: none;
 }
@@ -584,10 +581,6 @@ pre.example-line-numbers {
 	border-bottom-left-radius: 5px;
 }
 
-.example-wrap > pre.rust a:hover {
-	text-decoration: underline;
-}
-
 .src-line-numbers {
 	text-align: right;
 }
@@ -767,6 +760,8 @@ h2.small-section-header > .anchor {
 	content: '§';
 }
 
+.main-heading a:hover,
+.example-wrap > pre.rust a:hover,
 .all-items a:hover,
 .docblock a:not(.test-arrow):not(.scrape-help):hover,
 .docblock-short a:not(.test-arrow):not(.scrape-help):hover,


### PR DESCRIPTION
This makes the stylesheet more consistent about how it handles link hover.