### PR TITLE
Remove empty core::lazy and std::lazy

### DIFF
--- a/library/core/src/lazy.rs
+++ b/library/core/src/lazy.rs
@@ -1,1 +1,0 @@
-//! Lazy values and one-time initialization of static data.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -326,8 +326,6 @@ pub mod cell;
 pub mod char;
 pub mod ffi;
 pub mod iter;
-#[unstable(feature = "once_cell", issue = "74465")]
-pub mod lazy;
 pub mod option;
 pub mod panic;
 pub mod panicking;

--- a/library/std/src/lazy.rs
+++ b/library/std/src/lazy.rs
@@ -1,1 +1,0 @@
-//! Lazy values and one-time initialization of static data.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -529,9 +529,6 @@ pub mod process;
 pub mod sync;
 pub mod time;
 
-#[unstable(feature = "once_cell", issue = "74465")]
-pub mod lazy;
-
 // Pull in `std_float` crate  into libstd. The contents of
 // `std_float` are in a different repository: rust-lang/portable-simd.
 #[path = "../../portable-simd/crates/std_float/src/lib.rs"]


### PR DESCRIPTION
PR #98165 with commits 7c360dc117d554a11f7193505da0835c4b890c6f and c1a2db3372a4d6896744919284f3287650a38ab7 has moved all of the components of these modules into different places, namely {std,core}::sync and {std,core}::cell. The empty modules remained. As they are unstable, we can simply remove them.