### PR TITLE
Simpler diagnostic when passing arg to closure and missing borrow

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1234,6 +1234,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     _ => None,
                 };
 
+                let found_node = found_did.and_then(|did| self.tcx.hir().get_if_local(did));
                 let found_span = found_did.and_then(|did| self.tcx.hir().span_if_local(did));
 
                 if self.reported_closure_mismatch.borrow().contains(&(span, found_span)) {
@@ -1287,6 +1288,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         found_trait_ref,
                         expected_trait_ref,
                         obligation.cause.code(),
+                        found_node,
                     )
                 } else {
                     let (closure_span, closure_arg_span, found) = found_did

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3449,11 +3449,11 @@ fn hint_missing_borrow<'tcx>(
 
         if found_ty == expected_ty {
             let hint = if found_refs < expected_refs {
-                "consider borrowing here:"
+                "consider borrowing the argument"
             } else if found_refs == expected_refs {
                 continue;
             } else {
-                "consider removing the borrow:"
+                "do not borrow the argument"
             };
             err.span_suggestion_verbose(
                 arg_span,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-filelength
+
 use super::{DefIdOrName, Obligation, ObligationCause, ObligationCauseCode, PredicateObligation};
 
 use crate::autoderef::Autoderef;

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1758,73 +1758,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
         self.note_conflicting_closure_bounds(cause, &mut err);
 
-        let found_args = match found.kind() {
-            ty::FnPtr(f) => f.inputs().skip_binder().iter(),
-            kind => {
-                span_bug!(span, "found was converted to a FnPtr above but is now {:?}", kind)
-            }
-        };
-        let expected_args = match expected.kind() {
-            ty::FnPtr(f) => f.inputs().skip_binder().iter(),
-            kind => {
-                span_bug!(span, "expected was converted to a FnPtr above but is now {:?}", kind)
-            }
-        };
-
         if let Some(found_node) = found_node {
-            let fn_decl = match found_node {
-                Node::Expr(expr) => match &expr.kind {
-                    hir::ExprKind::Closure(hir::Closure { fn_decl, .. }) => fn_decl,
-                    kind => {
-                        span_bug!(found_span, "expression must be a closure but is {:?}", kind)
-                    }
-                },
-                Node::Item(item) => match &item.kind {
-                    hir::ItemKind::Fn(signature, _generics, _body) => signature.decl,
-                    kind => {
-                        span_bug!(found_span, "item must be a function but is {:?}", kind)
-                    }
-                },
-                node => {
-                    span_bug!(found_span, "node must be a expr or item but is {:?}", node)
-                }
-            };
-
-            let arg_spans = fn_decl.inputs.iter().map(|ty| ty.span);
-
-            fn get_deref_type_and_refs(mut ty: Ty<'_>) -> (Ty<'_>, usize) {
-                let mut refs = 0;
-
-                while let ty::Ref(_, new_ty, _) = ty.kind() {
-                    ty = *new_ty;
-                    refs += 1;
-                }
-
-                (ty, refs)
-            }
-
-            for ((found_arg, expected_arg), arg_span) in
-                found_args.zip(expected_args).zip(arg_spans)
-            {
-                let (found_ty, found_refs) = get_deref_type_and_refs(*found_arg);
-                let (expected_ty, expected_refs) = get_deref_type_and_refs(*expected_arg);
-
-                if found_ty == expected_ty {
-                    let hint = if found_refs < expected_refs {
-                        "consider borrowing here:"
-                    } else if found_refs == expected_refs {
-                        continue;
-                    } else {
-                        "consider removing the borrow:"
-                    };
-                    err.span_suggestion_verbose(
-                        arg_span,
-                        hint,
-                        expected_arg.to_string(),
-                        Applicability::MaybeIncorrect,
-                    );
-                }
-            }
+            hint_missing_borrow(span, found_span, found, expected, found_node, &mut err);
         }
 
         err
@@ -3450,6 +3385,81 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     "the method call chain might not have had the expected \
                                      associated types",
                 ),
+            );
+        }
+    }
+}
+
+/// Add a hint to add a missing borrow or remove an unnecessary one.
+fn hint_missing_borrow<'tcx>(
+    span: Span,
+    found_span: Span,
+    found: Ty<'tcx>,
+    expected: Ty<'tcx>,
+    found_node: Node<'_>,
+    err: &mut Diagnostic,
+) {
+    let found_args = match found.kind() {
+        ty::FnPtr(f) => f.inputs().skip_binder().iter(),
+        kind => {
+            span_bug!(span, "found was converted to a FnPtr above but is now {:?}", kind)
+        }
+    };
+    let expected_args = match expected.kind() {
+        ty::FnPtr(f) => f.inputs().skip_binder().iter(),
+        kind => {
+            span_bug!(span, "expected was converted to a FnPtr above but is now {:?}", kind)
+        }
+    };
+
+    let fn_decl = match found_node {
+        Node::Expr(expr) => match &expr.kind {
+            hir::ExprKind::Closure(hir::Closure { fn_decl, .. }) => fn_decl,
+            kind => {
+                span_bug!(found_span, "expression must be a closure but is {:?}", kind)
+            }
+        },
+        Node::Item(item) => match &item.kind {
+            hir::ItemKind::Fn(signature, _generics, _body) => signature.decl,
+            kind => {
+                span_bug!(found_span, "item must be a function but is {:?}", kind)
+            }
+        },
+        node => {
+            span_bug!(found_span, "node must be a expr or item but is {:?}", node)
+        }
+    };
+
+    let arg_spans = fn_decl.inputs.iter().map(|ty| ty.span);
+
+    fn get_deref_type_and_refs<'tcx>(mut ty: Ty<'tcx>) -> (Ty<'tcx>, usize) {
+        let mut refs = 0;
+
+        while let ty::Ref(_, new_ty, _) = ty.kind() {
+            ty = *new_ty;
+            refs += 1;
+        }
+
+        (ty, refs)
+    }
+
+    for ((found_arg, expected_arg), arg_span) in found_args.zip(expected_args).zip(arg_spans) {
+        let (found_ty, found_refs) = get_deref_type_and_refs(*found_arg);
+        let (expected_ty, expected_refs) = get_deref_type_and_refs(*expected_arg);
+
+        if found_ty == expected_ty {
+            let hint = if found_refs < expected_refs {
+                "consider borrowing here:"
+            } else if found_refs == expected_refs {
+                continue;
+            } else {
+                "consider removing the borrow:"
+            };
+            err.span_suggestion_verbose(
+                arg_span,
+                hint,
+                expected_arg.to_string(),
+                Applicability::MaybeIncorrect,
             );
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1811,11 +1811,11 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
                 if found_ty == expected_ty {
                     let hint = if found_refs < expected_refs {
-                        "hint: consider borrowing here:"
+                        "consider borrowing here:"
                     } else if found_refs == expected_refs {
                         continue;
                     } else {
-                        "hint: consider removing the borrow:"
+                        "consider removing the borrow:"
                     };
                     err.span_suggestion_verbose(
                         arg_span,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3412,23 +3412,9 @@ fn hint_missing_borrow<'tcx>(
         }
     };
 
-    let fn_decl = match found_node {
-        Node::Expr(expr) => match &expr.kind {
-            hir::ExprKind::Closure(hir::Closure { fn_decl, .. }) => fn_decl,
-            kind => {
-                span_bug!(found_span, "expression must be a closure but is {:?}", kind)
-            }
-        },
-        Node::Item(item) => match &item.kind {
-            hir::ItemKind::Fn(signature, _generics, _body) => signature.decl,
-            kind => {
-                span_bug!(found_span, "item must be a function but is {:?}", kind)
-            }
-        },
-        node => {
-            span_bug!(found_span, "node must be a expr or item but is {:?}", node)
-        }
-    };
+    let fn_decl = found_node
+        .fn_decl()
+        .unwrap_or_else(|| span_bug!(found_span, "found node must be a function"));
 
     let arg_spans = fn_decl.inputs.iter().map(|ty| ty.span);
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -258,6 +258,7 @@ pub trait TypeErrCtxtExt<'tcx> {
         found: ty::PolyTraitRef<'tcx>,
         expected: ty::PolyTraitRef<'tcx>,
         cause: &ObligationCauseCode<'tcx>,
+        found_node: Option<Node<'_>>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed>;
 
     fn note_conflicting_closure_bounds(
@@ -1695,6 +1696,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         found: ty::PolyTraitRef<'tcx>,
         expected: ty::PolyTraitRef<'tcx>,
         cause: &ObligationCauseCode<'tcx>,
+        found_node: Option<Node<'_>>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
         pub(crate) fn build_fn_sig_ty<'tcx>(
             infcx: &InferCtxt<'tcx>,
@@ -1755,6 +1757,75 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         err.note_expected_found(&signature_kind, expected_str, &signature_kind, found_str);
 
         self.note_conflicting_closure_bounds(cause, &mut err);
+
+        let found_args = match found.kind() {
+            ty::FnPtr(f) => f.inputs().skip_binder().iter(),
+            kind => {
+                span_bug!(span, "found was converted to a FnPtr above but is now {:?}", kind)
+            }
+        };
+        let expected_args = match expected.kind() {
+            ty::FnPtr(f) => f.inputs().skip_binder().iter(),
+            kind => {
+                span_bug!(span, "expected was converted to a FnPtr above but is now {:?}", kind)
+            }
+        };
+
+        if let Some(found_node) = found_node {
+            let fn_decl = match found_node {
+                Node::Expr(expr) => match &expr.kind {
+                    hir::ExprKind::Closure(hir::Closure { fn_decl, .. }) => fn_decl,
+                    kind => {
+                        span_bug!(found_span, "expression must be a closure but is {:?}", kind)
+                    }
+                },
+                Node::Item(item) => match &item.kind {
+                    hir::ItemKind::Fn(signature, _generics, _body) => signature.decl,
+                    kind => {
+                        span_bug!(found_span, "item must be a function but is {:?}", kind)
+                    }
+                },
+                node => {
+                    span_bug!(found_span, "node must be a expr or item but is {:?}", node)
+                }
+            };
+
+            let arg_spans = fn_decl.inputs.iter().map(|ty| ty.span);
+
+            fn get_deref_type_and_refs(mut ty: Ty<'_>) -> (Ty<'_>, usize) {
+                let mut refs = 0;
+
+                while let ty::Ref(_, new_ty, _) = ty.kind() {
+                    ty = *new_ty;
+                    refs += 1;
+                }
+
+                (ty, refs)
+            }
+
+            for ((found_arg, expected_arg), arg_span) in
+                found_args.zip(expected_args).zip(arg_spans)
+            {
+                let (found_ty, found_refs) = get_deref_type_and_refs(*found_arg);
+                let (expected_ty, expected_refs) = get_deref_type_and_refs(*expected_arg);
+
+                if found_ty == expected_ty {
+                    let hint = if found_refs < expected_refs {
+                        "hint: consider borrowing here:"
+                    } else if found_refs == expected_refs {
+                        continue;
+                    } else {
+                        "hint: consider removing the borrow:"
+                    };
+                    err.span_suggestion_verbose(
+                        arg_span,
+                        hint,
+                        expected_arg.to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+            }
+        }
 
         err
     }

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -13,11 +13,11 @@ note: required by a bound in `f1`
    |
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
    |                         ^^^^^^^^^^^^ required by this bound in `f1`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f1(|_: &(), _: ()| {});
    |            ~~~
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f1(|_: (), _: &()| {});
    |                   ~~~
@@ -37,11 +37,11 @@ note: required by a bound in `f2`
    |
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f2`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f2(|_: &'a (), _: ()| {});
    |            ~~~~~~
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f2(|_: (), _: &()| {});
    |                   ~~~
@@ -61,11 +61,11 @@ note: required by a bound in `f3`
    |
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
    |                             ^^^^^^^^^^^^^^^ required by this bound in `f3`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f3(|_: &(), _: ()| {});
    |            ~~~
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f3(|_: (), _: &()| {});
    |                   ~~~
@@ -85,11 +85,11 @@ note: required by a bound in `f4`
    |
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f4`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f4(|_: &(), _: ()| {});
    |            ~~~
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f4(|_: (), _: &'r ()| {});
    |                   ~~~~~~
@@ -109,11 +109,11 @@ note: required by a bound in `f5`
    |
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f5`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f5(|_: &'r (), _: ()| {});
    |            ~~~~~~
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     f5(|_: (), _: &'r ()| {});
    |                   ~~~~~~
@@ -133,7 +133,7 @@ note: required by a bound in `g1`
    |
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g1`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     g1(|_: &(), _: ()| {});
    |            ~~~
@@ -153,7 +153,7 @@ note: required by a bound in `g2`
    |
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
    |                         ^^^^^^^^^^^^^^^^ required by this bound in `g2`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     g2(|_: &(), _: ()| {});
    |            ~~~
@@ -173,7 +173,7 @@ note: required by a bound in `g3`
    |
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g3`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     g3(|_: &'s (), _: ()| {});
    |            ~~~~~~
@@ -193,7 +193,7 @@ note: required by a bound in `g4`
    |
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g4`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     g4(|_: &(), _: ()| {});
    |            ~~~
@@ -213,11 +213,11 @@ note: required by a bound in `h1`
    |
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h1`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     h1(|_: &(), _: (), _: (), _: ()| {});
    |            ~~~
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     h1(|_: (), _: (), _: &(), _: ()| {});
    |                          ~~~
@@ -237,11 +237,11 @@ note: required by a bound in `h2`
    |
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     h2(|_: &(), _: (), _: (), _: ()| {});
    |            ~~~
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     h2(|_: (), _: (), _: &'t0 (), _: ()| {});
    |                          ~~~~~~~

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -13,11 +13,11 @@ note: required by a bound in `f1`
    |
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
    |                         ^^^^^^^^^^^^ required by this bound in `f1`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f1(|_: &(), _: ()| {});
    |            ~~~
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f1(|_: (), _: &()| {});
    |                   ~~~
@@ -37,11 +37,11 @@ note: required by a bound in `f2`
    |
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f2`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f2(|_: &'a (), _: ()| {});
    |            ~~~~~~
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f2(|_: (), _: &()| {});
    |                   ~~~
@@ -61,11 +61,11 @@ note: required by a bound in `f3`
    |
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
    |                             ^^^^^^^^^^^^^^^ required by this bound in `f3`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f3(|_: &(), _: ()| {});
    |            ~~~
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f3(|_: (), _: &()| {});
    |                   ~~~
@@ -85,11 +85,11 @@ note: required by a bound in `f4`
    |
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f4`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f4(|_: &(), _: ()| {});
    |            ~~~
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f4(|_: (), _: &'r ()| {});
    |                   ~~~~~~
@@ -109,11 +109,11 @@ note: required by a bound in `f5`
    |
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f5`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f5(|_: &'r (), _: ()| {});
    |            ~~~~~~
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     f5(|_: (), _: &'r ()| {});
    |                   ~~~~~~
@@ -133,7 +133,7 @@ note: required by a bound in `g1`
    |
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g1`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     g1(|_: &(), _: ()| {});
    |            ~~~
@@ -153,7 +153,7 @@ note: required by a bound in `g2`
    |
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
    |                         ^^^^^^^^^^^^^^^^ required by this bound in `g2`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     g2(|_: &(), _: ()| {});
    |            ~~~
@@ -173,7 +173,7 @@ note: required by a bound in `g3`
    |
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g3`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     g3(|_: &'s (), _: ()| {});
    |            ~~~~~~
@@ -193,7 +193,7 @@ note: required by a bound in `g4`
    |
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g4`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     g4(|_: &(), _: ()| {});
    |            ~~~
@@ -213,11 +213,11 @@ note: required by a bound in `h1`
    |
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h1`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     h1(|_: &(), _: (), _: (), _: ()| {});
    |            ~~~
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     h1(|_: (), _: (), _: &(), _: ()| {});
    |                          ~~~
@@ -237,11 +237,11 @@ note: required by a bound in `h2`
    |
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     h2(|_: &(), _: (), _: (), _: ()| {});
    |            ~~~
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     h2(|_: (), _: (), _: &'t0 (), _: ()| {});
    |                          ~~~~~~~

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -15,12 +15,8 @@ LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
    |                         ^^^^^^^^^^^^ required by this bound in `f1`
 help: consider borrowing the argument
    |
-LL |     f1(|_: &(), _: ()| {});
-   |            ~~~
-help: consider borrowing the argument
-   |
-LL |     f1(|_: (), _: &()| {});
-   |                   ~~~
+LL |     f1(|_: &(), _: &()| {});
+   |            ~~~     ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:3:5
@@ -39,12 +35,8 @@ LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f2`
 help: consider borrowing the argument
    |
-LL |     f2(|_: &'a (), _: ()| {});
-   |            ~~~~~~
-help: consider borrowing the argument
-   |
-LL |     f2(|_: (), _: &()| {});
-   |                   ~~~
+LL |     f2(|_: &'a (), _: &()| {});
+   |            ~~~~~~     ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -63,12 +55,8 @@ LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
    |                             ^^^^^^^^^^^^^^^ required by this bound in `f3`
 help: consider borrowing the argument
    |
-LL |     f3(|_: &(), _: ()| {});
-   |            ~~~
-help: consider borrowing the argument
-   |
-LL |     f3(|_: (), _: &()| {});
-   |                   ~~~
+LL |     f3(|_: &(), _: &()| {});
+   |            ~~~     ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:5:5
@@ -87,12 +75,8 @@ LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f4`
 help: consider borrowing the argument
    |
-LL |     f4(|_: &(), _: ()| {});
-   |            ~~~
-help: consider borrowing the argument
-   |
-LL |     f4(|_: (), _: &'r ()| {});
-   |                   ~~~~~~
+LL |     f4(|_: &(), _: &'r ()| {});
+   |            ~~~     ~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -111,19 +95,17 @@ LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f5`
 help: consider borrowing the argument
    |
-LL |     f5(|_: &'r (), _: ()| {});
-   |            ~~~~~~
-help: consider borrowing the argument
-   |
-LL |     f5(|_: (), _: &'r ()| {});
-   |                   ~~~~~~
+LL |     f5(|_: &'r (), _: &'r ()| {});
+   |            ~~~~~~     ~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:7:5
    |
 LL |     g1(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^ --------------
+   |     |  |   |
+   |     |  |   help: consider borrowing the argument: `&()`
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>) -> _`
@@ -133,17 +115,15 @@ note: required by a bound in `g1`
    |
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g1`
-help: consider borrowing the argument
-   |
-LL |     g1(|_: &(), _: ()| {});
-   |            ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
    |
 LL |     g2(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^ --------------
+   |     |  |   |
+   |     |  |   help: consider borrowing the argument: `&()`
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a> fn(&'a (), for<'a> fn(&'a ())) -> _`
@@ -153,17 +133,15 @@ note: required by a bound in `g2`
    |
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
    |                         ^^^^^^^^^^^^^^^^ required by this bound in `g2`
-help: consider borrowing the argument
-   |
-LL |     g2(|_: &(), _: ()| {});
-   |            ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:9:5
    |
 LL |     g3(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^ --------------
+   |     |  |   |
+   |     |  |   help: consider borrowing the argument: `&'s ()`
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'s> fn(&'s (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>) -> _`
@@ -173,17 +151,15 @@ note: required by a bound in `g3`
    |
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g3`
-help: consider borrowing the argument
-   |
-LL |     g3(|_: &'s (), _: ()| {});
-   |            ~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
    |
 LL |     g4(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^ --------------
+   |     |  |   |
+   |     |  |   help: consider borrowing the argument: `&()`
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a> fn(&'a (), for<'r> fn(&'r ())) -> _`
@@ -193,10 +169,6 @@ note: required by a bound in `g4`
    |
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g4`
-help: consider borrowing the argument
-   |
-LL |     g4(|_: &(), _: ()| {});
-   |            ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:11:5
@@ -215,12 +187,8 @@ LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h1`
 help: consider borrowing the argument
    |
-LL |     h1(|_: &(), _: (), _: (), _: ()| {});
-   |            ~~~
-help: consider borrowing the argument
-   |
-LL |     h1(|_: (), _: (), _: &(), _: ()| {});
-   |                          ~~~
+LL |     h1(|_: &(), _: (), _: &(), _: ()| {});
+   |            ~~~            ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -239,12 +207,8 @@ LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(),
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
 help: consider borrowing the argument
    |
-LL |     h2(|_: &(), _: (), _: (), _: ()| {});
-   |            ~~~
-help: consider borrowing the argument
-   |
-LL |     h2(|_: (), _: (), _: &'t0 (), _: ()| {});
-   |                          ~~~~~~~
+LL |     h2(|_: &(), _: (), _: &'t0 (), _: ()| {});
+   |            ~~~            ~~~~~~~
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -13,6 +13,14 @@ note: required by a bound in `f1`
    |
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
    |                         ^^^^^^^^^^^^ required by this bound in `f1`
+help: hint: consider borrowing here:
+   |
+LL |     f1(|_: &(), _: ()| {});
+   |            ~~~
+help: hint: consider borrowing here:
+   |
+LL |     f1(|_: (), _: &()| {});
+   |                   ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:3:5
@@ -29,6 +37,14 @@ note: required by a bound in `f2`
    |
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f2`
+help: hint: consider borrowing here:
+   |
+LL |     f2(|_: &'a (), _: ()| {});
+   |            ~~~~~~
+help: hint: consider borrowing here:
+   |
+LL |     f2(|_: (), _: &()| {});
+   |                   ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -45,6 +61,14 @@ note: required by a bound in `f3`
    |
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
    |                             ^^^^^^^^^^^^^^^ required by this bound in `f3`
+help: hint: consider borrowing here:
+   |
+LL |     f3(|_: &(), _: ()| {});
+   |            ~~~
+help: hint: consider borrowing here:
+   |
+LL |     f3(|_: (), _: &()| {});
+   |                   ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:5:5
@@ -61,6 +85,14 @@ note: required by a bound in `f4`
    |
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f4`
+help: hint: consider borrowing here:
+   |
+LL |     f4(|_: &(), _: ()| {});
+   |            ~~~
+help: hint: consider borrowing here:
+   |
+LL |     f4(|_: (), _: &'r ()| {});
+   |                   ~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -77,6 +109,14 @@ note: required by a bound in `f5`
    |
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f5`
+help: hint: consider borrowing here:
+   |
+LL |     f5(|_: &'r (), _: ()| {});
+   |            ~~~~~~
+help: hint: consider borrowing here:
+   |
+LL |     f5(|_: (), _: &'r ()| {});
+   |                   ~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:7:5
@@ -93,6 +133,10 @@ note: required by a bound in `g1`
    |
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g1`
+help: hint: consider borrowing here:
+   |
+LL |     g1(|_: &(), _: ()| {});
+   |            ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -109,6 +153,10 @@ note: required by a bound in `g2`
    |
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
    |                         ^^^^^^^^^^^^^^^^ required by this bound in `g2`
+help: hint: consider borrowing here:
+   |
+LL |     g2(|_: &(), _: ()| {});
+   |            ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:9:5
@@ -125,6 +173,10 @@ note: required by a bound in `g3`
    |
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g3`
+help: hint: consider borrowing here:
+   |
+LL |     g3(|_: &'s (), _: ()| {});
+   |            ~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -141,6 +193,10 @@ note: required by a bound in `g4`
    |
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g4`
+help: hint: consider borrowing here:
+   |
+LL |     g4(|_: &(), _: ()| {});
+   |            ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:11:5
@@ -157,6 +213,14 @@ note: required by a bound in `h1`
    |
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h1`
+help: hint: consider borrowing here:
+   |
+LL |     h1(|_: &(), _: (), _: (), _: ()| {});
+   |            ~~~
+help: hint: consider borrowing here:
+   |
+LL |     h1(|_: (), _: (), _: &(), _: ()| {});
+   |                          ~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -173,6 +237,14 @@ note: required by a bound in `h2`
    |
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
+help: hint: consider borrowing here:
+   |
+LL |     h2(|_: &(), _: (), _: (), _: ()| {});
+   |            ~~~
+help: hint: consider borrowing here:
+   |
+LL |     h2(|_: (), _: (), _: &'t0 (), _: ()| {});
+   |                          ~~~~~~~
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/closures/multiple-fn-bounds.stderr
+++ b/src/test/ui/closures/multiple-fn-bounds.stderr
@@ -18,6 +18,10 @@ note: required by a bound in `foo`
    |
 LL | fn foo<F: Fn(&char) -> bool + Fn(char) -> bool>(f: F) {
    |                               ^^^^^^^^^^^^^^^^ required by this bound in `foo`
+help: do not borrow the argument
+   |
+LL |     foo(move |char| v);
+   |               ~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/multiple-fn-bounds.stderr
+++ b/src/test/ui/closures/multiple-fn-bounds.stderr
@@ -2,8 +2,10 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/multiple-fn-bounds.rs:10:5
    |
 LL |     foo(move |x| v);
-   |     ^^^ -------- found signature defined here
-   |     |
+   |     ^^^ --------
+   |     |   |     |
+   |     |   |     help: do not borrow the argument: `char`
+   |     |   found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `fn(char) -> _`
@@ -18,10 +20,6 @@ note: required by a bound in `foo`
    |
 LL | fn foo<F: Fn(&char) -> bool + Fn(char) -> bool>(f: F) {
    |                               ^^^^^^^^^^^^^^^^ required by this bound in `foo`
-help: do not borrow the argument
-   |
-LL |     foo(move |char| v);
-   |               ~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `map`
    |
 LL |         F: FnMut(Self::Item) -> B,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::map`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     a.iter().map(|_: &(u32, u32)| 45);
    |                      ~~~~~~~~~~~

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `map`
    |
 LL |         F: FnMut(Self::Item) -> B,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::map`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     a.iter().map(|_: &(u32, u32)| 45);
    |                      ~~~~~~~~~~~

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `map`
    |
 LL |         F: FnMut(Self::Item) -> B,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::map`
+help: hint: consider borrowing here:
+   |
+LL |     a.iter().map(|_: &(u32, u32)| 45);
+   |                      ~~~~~~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:4:14

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -15,10 +15,6 @@ note: required by a bound in `map`
    |
 LL |         F: FnMut(Self::Item) -> B,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::map`
-help: consider borrowing the argument
-   |
-LL |     a.iter().map(|_: &(u32, u32)| 45);
-   |                      ~~~~~~~~~~~
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:4:14

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -2,8 +2,10 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-arg-type-mismatch.rs:3:14
    |
 LL |     a.iter().map(|_: (u32, u32)| 45);
-   |              ^^^ --------------- found signature defined here
-   |              |
+   |              ^^^ ---------------
+   |              |   |   |
+   |              |   |   help: consider borrowing the argument: `&(u32, u32)`
+   |              |   found signature defined here
    |              expected due to this
    |
    = note: expected closure signature `fn(&(u32, u32)) -> _`

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `filter`
    |
 LL |         P: FnMut(&Self::Item) -> bool,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::filter`
-help: hint: consider borrowing here:
+help: consider borrowing here:
    |
 LL |     once::<&str>("str").fuse().filter(|a: &&str| true).count();
    |                                           ~~~~~

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -2,8 +2,10 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/issue-36053-2.rs:7:32
    |
 LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
-   |                                ^^^^^^ --------- found signature defined here
-   |                                |
+   |                                ^^^^^^ ---------
+   |                                |      |   |
+   |                                |      |   help: consider borrowing the argument: `&&str`
+   |                                |      found signature defined here
    |                                expected due to this
    |
    = note: expected closure signature `for<'a> fn(&'a &str) -> _`

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `filter`
    |
 LL |         P: FnMut(&Self::Item) -> bool,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::filter`
-help: consider borrowing here:
+help: consider borrowing the argument
    |
 LL |     once::<&str>("str").fuse().filter(|a: &&str| true).count();
    |                                           ~~~~~

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -15,10 +15,6 @@ note: required by a bound in `filter`
    |
 LL |         P: FnMut(&Self::Item) -> bool,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::filter`
-help: consider borrowing the argument
-   |
-LL |     once::<&str>("str").fuse().filter(|a: &&str| true).count();
-   |                                           ~~~~~
 
 error[E0599]: the method `count` exists for struct `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:48]>`, but its trait bounds were not satisfied
   --> $DIR/issue-36053-2.rs:7:55

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `filter`
    |
 LL |         P: FnMut(&Self::Item) -> bool,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::filter`
+help: hint: consider borrowing here:
+   |
+LL |     once::<&str>("str").fuse().filter(|a: &&str| true).count();
+   |                                           ~~~~~
 
 error[E0599]: the method `count` exists for struct `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:48]>`, but its trait bounds were not satisfied
   --> $DIR/issue-36053-2.rs:7:55


### PR DESCRIPTION
fixes #64915

I followed roughly the instructions and the older PR #76362.
The number of references for the expected and the found types will be compared and depending on which has more the diagnostic will be emitted.

I'm not quite sure if my approach with the many `span_bug!`s is good, it could lead to some ICEs. Would it be better if  those errors are ignored?

As far as I know the following code works similarly but in a different context. Is this probably reusable since it looks like it would emit better diagnostics? 
https://github.com/rust-lang/rust/blob/a688a0305fad9219505a8f2576446510601bafe8/compiler/rustc_hir_analysis/src/check/demand.rs#L713-L1061

When running the tests locally, a codegen test failed. Is there something I can/ should do about that?

If you have some improvements/ corrections please say so and I will happily include them.

r? @estebank (as you added the mentoring instructions to the issue)