### PR TITLE
Don't require `feature(restricted_std)` for tvOS targets

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -15,6 +15,7 @@ fn main() {
         || target.contains("illumos")
         || target.contains("apple-darwin")
         || target.contains("apple-ios")
+        || target.contains("apple-tvos")
         || target.contains("apple-watchos")
         || target.contains("uwp")
         || target.contains("windows")
@@ -41,7 +42,6 @@ fn main() {
         // - mipsel-sony-psp
         // - nvptx64-nvidia-cuda
         // - arch=avr
-        // - tvos (aarch64-apple-tvos, x86_64-apple-tvos)
         // - uefi (x86_64-unknown-uefi, i686-unknown-uefi)
         // - JSON targets
         // - Any new targets that have not been explicitly added above.


### PR DESCRIPTION
This is kind of goofy, since tvOS is basically iOS with with a funny hat on (to the point that tvOS and iOS basically use the same version numbers). For the most part there's no reason people should be expected to use `no_std` for tvOS, when we don't expect it for even watchOS. We already even have `target_os = "tvos"` inside `cfg`s all over libstd (usually inside an `any` that also has `target_os = "ios"`), so there's not really any reason for this.

I don't expect issues from this, but I'm happy to help out if any come up (like if we're using an API thats stable on iOS and not tvOS, if any exist).

Note that this still requires -Zbuild-std.