### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -215,8 +215,6 @@ impl<'a> iter::DoubleEndedIterator for EscapeAscii<'a> {
     }
 }
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
-impl<'a> iter::ExactSizeIterator for EscapeAscii<'a> {}
-#[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 impl<'a> iter::FusedIterator for EscapeAscii<'a> {}
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 impl<'a> fmt::Display for EscapeAscii<'a> {

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -172,9 +172,9 @@ build/
   # hand.
   x86_64-unknown-linux-gnu/
 
-    # The build artifacts for the `compiler-rt` library for the target that 
-    # this folder is under. The exact layout here will likely depend on the 
-    # platform, and this is also built with CMake, so the build system is 
+    # The build artifacts for the `compiler-rt` library for the target that
+    # this folder is under. The exact layout here will likely depend on the
+    # platform, and this is also built with CMake, so the build system is
     # also likely different.
     compiler-rt/
       build/

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -1,7 +1,7 @@
 # rustbuild - Bootstrapping Rust
 
 This is an in-progress README which is targeted at helping to explain how Rust
-is bootstrapped and in general some of the technical details of the build
+is bootstrapped and in general, some of the technical details of the build
 system.
 
 ## Using rustbuild
@@ -12,7 +12,7 @@ The rustbuild build system has a primary entry point, a top level `x.py` script:
 $ python ./x.py build
 ```
 
-Note that if you're on Unix you should be able to execute the script directly:
+Note that if you're on Unix, you should be able to execute the script directly:
 
 ```sh
 $ ./x.py build
@@ -20,8 +20,8 @@ $ ./x.py build
 
 The script accepts commands, flags, and arguments to determine what to do:
 
-* `build` - a general purpose command for compiling code. Alone `build` will
-  bootstrap the entire compiler, and otherwise arguments passed indicate what to
+* `build` - a general purpose command for compiling code. Alone, `build` will
+  bootstrap the entire compiler, and otherwise, arguments passed indicate what to
   build. For example:
 
   ```
@@ -38,7 +38,7 @@ The script accepts commands, flags, and arguments to determine what to do:
   ./x.py build --stage 0 library/test
   ```
 
-  If files are dirty that would normally be rebuilt from stage 0, that can be
+  If files that would normally be rebuilt from stage 0 are dirty, the rebuild can be
   overridden using `--keep-stage 0`. Using `--keep-stage n` will skip all steps
   that belong to stage n or earlier:
 
@@ -47,8 +47,8 @@ The script accepts commands, flags, and arguments to determine what to do:
   ./x.py build --keep-stage 0
   ```
 
-* `test` - a command for executing unit tests. Like the `build` command this
-  will execute the entire test suite by default, and otherwise it can be used to
+* `test` - a command for executing unit tests. Like the `build` command, this
+  will execute the entire test suite by default, and otherwise, it can be used to
   select which test suite is run:
 
   ```
@@ -75,7 +75,7 @@ The script accepts commands, flags, and arguments to determine what to do:
   ./x.py test src/doc
   ```
 
-* `doc` - a command for building documentation. Like above can take arguments
+* `doc` - a command for building documentation. Like above, can take arguments
   for what to document.
 
 ## Configuring rustbuild
@@ -110,12 +110,12 @@ compiler. What actually happens when you invoke rustbuild is:
    compiles the build system itself (this folder). Finally, it then invokes the
    actual `bootstrap` binary build system.
 2. In Rust, `bootstrap` will slurp up all configuration, perform a number of
-   sanity checks (compilers exist for example), and then start building the
+   sanity checks (whether compilers exist, for example), and then start building the
    stage0 artifacts.
-3. The stage0 `cargo` downloaded earlier is used to build the standard library
+3. The stage0 `cargo`, downloaded earlier, is used to build the standard library
    and the compiler, and then these binaries are then copied to the `stage1`
    directory. That compiler is then used to generate the stage1 artifacts which
-   are then copied to the stage2 directory, and then finally the stage2
+   are then copied to the stage2 directory, and then finally, the stage2
    artifacts are generated using that compiler.
 
 The goal of each stage is to (a) leverage Cargo as much as possible and failing
@@ -149,7 +149,7 @@ like this:
 build/
 
   # Location where the stage0 compiler downloads are all cached. This directory
-  # only contains the tarballs themselves as they're extracted elsewhere.
+  # only contains the tarballs themselves, as they're extracted elsewhere.
   cache/
     2015-12-19/
     2016-01-15/
@@ -172,10 +172,10 @@ build/
   # hand.
   x86_64-unknown-linux-gnu/
 
-    # The build artifacts for the `compiler-rt` library for the target this
-    # folder is under. The exact layout here will likely depend on the platform,
-    # and this is also built with CMake so the build system is also likely
-    # different.
+    # The build artifacts for the `compiler-rt` library for the target that 
+    # this folder is under. The exact layout here will likely depend on the 
+    # platform, and this is also built with CMake, so the build system is 
+    # also likely different.
     compiler-rt/
       build/
 
@@ -183,11 +183,11 @@ build/
     llvm/
 
       # build folder (e.g. the platform-specific build system). Like with
-      # compiler-rt this is compiled with CMake
+      # compiler-rt, this is compiled with CMake
       build/
 
       # Installation of LLVM. Note that we run the equivalent of 'make install'
-      # for LLVM to setup these folders.
+      # for LLVM, to setup these folders.
       bin/
       lib/
       include/
@@ -206,18 +206,18 @@ build/
 
     # Location where the stage0 Cargo and Rust compiler are unpacked. This
     # directory is purely an extracted and overlaid tarball of these two (done
-    # by the bootstrapy python script). In theory the build system does not
+    # by the bootstrap python script). In theory, the build system does not
     # modify anything under this directory afterwards.
     stage0/
 
-    # These to build directories are the cargo output directories for builds of
-    # the standard library and compiler, respectively. Internally these may also
+    # These to-build directories are the cargo output directories for builds of
+    # the standard library and compiler, respectively. Internally, these may also
     # have other target directories, which represent artifacts being compiled
     # from the host to the specified target.
     #
     # Essentially, each of these directories is filled in by one `cargo`
     # invocation. The build system instruments calling Cargo in the right order
-    # with the right variables to ensure these are filled in correctly.
+    # with the right variables to ensure that these are filled in correctly.
     stageN-std/
     stageN-test/
     stageN-rustc/
@@ -232,8 +232,8 @@ build/
     # being compiled (e.g. after libstd has been built), *this* is used as the
     # sysroot for the stage0 compiler being run.
     #
-    # Basically this directory is just a temporary artifact use to configure the
-    # stage0 compiler to ensure that the libstd we just built is used to
+    # Basically, this directory is just a temporary artifact used to configure the
+    # stage0 compiler to ensure that the libstd that we just built is used to
     # compile the stage1 compiler.
     stage0-sysroot/lib/
 
@@ -242,7 +242,7 @@ build/
     # system will link (using hard links) output from stageN-{std,rustc} into
     # each of these directories.
     #
-    # In theory there is no extra build output in these directories.
+    # In theory, there is no extra build output in these directories.
     stage1/
     stage2/
     stage3/
@@ -265,14 +265,14 @@ structure here serves two goals:
    depend on `std`, so libstd is a separate project compiled ahead of time
    before the actual compiler builds.
 2. Splitting "host artifacts" from "target artifacts". That is, when building
-   code for an arbitrary target you don't need the entire compiler, but you'll
+   code for an arbitrary target, you don't need the entire compiler, but you'll
    end up needing libraries like libtest that depend on std but also want to use
    crates.io dependencies. Hence, libtest is split out as its own project that
    is sequenced after `std` but before `rustc`. This project is built for all
    targets.
 
 There is some loss in build parallelism here because libtest can be compiled in
-parallel with a number of rustc artifacts, but in theory the loss isn't too bad!
+parallel with a number of rustc artifacts, but in theory, the loss isn't too bad!
 
 ## Build tools
 
@@ -285,13 +285,13 @@ appropriate libstd/libtest/librustc compile above.
 
 ## Extending rustbuild
 
-So you'd like to add a feature to the rustbuild build system or just fix a bug.
+So, you'd like to add a feature to the rustbuild build system or just fix a bug.
 Great! One of the major motivational factors for moving away from `make` is that
 Rust is in theory much easier to read, modify, and write. If you find anything
-excessively confusing, please open an issue on this and we'll try to get it
-documented or simplified pronto.
+excessively confusing, please open an issue on this, and we'll try to get it
+documented or simplified, pronto.
 
-First up, you'll probably want to read over the documentation above as that'll
+First up, you'll probably want to read over the documentation above, as that'll
 give you a high level overview of what rustbuild is doing. You also probably
 want to play around a bit yourself by just getting it up and running before you
 dive too much into the actual build system itself.
@@ -326,7 +326,7 @@ A 'major change' includes
 Changes that do not affect contributors to the compiler or users
 building rustc from source don't need an update to `VERSION`.
 
-If you have any questions feel free to reach out on the `#t-infra` channel in
+If you have any questions, feel free to reach out on the `#t-infra` channel in
 the [Rust Zulip server][rust-zulip] or ask on internals.rust-lang.org. When
 you encounter bugs, please file issues on the rust-lang/rust issue tracker.
 

--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -58,7 +58,6 @@ GDB_ARGS="--directory=\"$GDB_PYTHON_MODULE_DIRECTORY\" -iex \"add-auto-load-safe
 # Finally we execute gdbgui.
 PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" \
   exec ${RUST_GDBGUI} \
-  --gdb ${RUST_GDB} \
-  --gdb-args "${GDB_ARGS}" \
+  --gdb-cmd "${RUST_GDB} ${GDB_ARGS}" \
   "${@}"
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -400,7 +400,7 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                         if myitem.fn_header(cx.tcx()).unwrap().unsafety
                             == hir::Unsafety::Unsafe =>
                     {
-                        "<a title=\"unsafe function\" href=\"#\"><sup>⚠</sup></a>"
+                        "<sup title=\"unsafe function\">⚠</sup>"
                     }
                     _ => "",
                 };

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1807,10 +1807,6 @@ in storage.js plus the media query with (min-width: 701px)
 		top: 0;
 	}
 
-	.source .mobile-topbar {
-		display: none;
-	}
-
 	.sidebar-menu-toggle {
 		width: 45px;
 		/* Rare exception to specifying font sizes in rem. Since this is acting

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -735,14 +735,15 @@ function loadCss(cssFileName) {
     let oldSidebarScrollPosition = null;
 
     function showSidebar() {
-        if (window.innerWidth < window.RUSTDOC_MOBILE_BREAKPOINT) {
+        const mobile_topbar = document.querySelector(".mobile-topbar");
+        if (window.innerWidth < window.RUSTDOC_MOBILE_BREAKPOINT && mobile_topbar) {
             // This is to keep the scroll position on mobile.
             oldSidebarScrollPosition = window.scrollY;
             document.body.style.width = `${document.body.offsetWidth}px`;
             document.body.style.position = "fixed";
             document.body.style.top = `-${oldSidebarScrollPosition}px`;
-            document.querySelector(".mobile-topbar").style.top = `${oldSidebarScrollPosition}px`;
-            document.querySelector(".mobile-topbar").style.position = "relative";
+            mobile_topbar.style.top = `${oldSidebarScrollPosition}px`;
+            mobile_topbar.style.position = "relative";
         } else {
             oldSidebarScrollPosition = null;
         }
@@ -751,13 +752,14 @@ function loadCss(cssFileName) {
     }
 
     function hideSidebar() {
-        if (oldSidebarScrollPosition !== null) {
+        const mobile_topbar = document.querySelector(".mobile-topbar");
+        if (oldSidebarScrollPosition !== null && mobile_topbar) {
             // This is to keep the scroll position on mobile.
             document.body.style.width = "";
             document.body.style.position = "";
             document.body.style.top = "";
-            document.querySelector(".mobile-topbar").style.top = "";
-            document.querySelector(".mobile-topbar").style.position = "";
+            mobile_topbar.style.top = "";
+            mobile_topbar.style.position = "";
             // The scroll position is lost when resetting the style, hence why we store it in
             // `oldSidebarScrollPosition`.
             window.scrollTo(0, oldSidebarScrollPosition);

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -73,6 +73,7 @@
     </div> {#- -#}
     <![endif]--> {#- -#}
     {{- layout.external_html.before_content|safe -}}
+    {%- if page.css_class != "source" -%}
     <nav class="mobile-topbar"> {#- -#}
         <button class="sidebar-menu-toggle">&#9776;</button> {#- -#}
         <a class="sidebar-logo" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {#- -#}
@@ -86,6 +87,7 @@
         </a> {#- -#}
         <h2 class="location"></h2> {#- -#}
     </nav> {#- -#}
+    {%- endif -%}
     <nav class="sidebar"> {#- -#}
         <a class="sidebar-logo" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {#- -#}
             <div class="logo-container"> {#- -#}

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,10 +1,6 @@
-# ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
+# ignore-cross-compile $(call RUN,foo) expects to run the target executable natively
 #                              so it won't work with remote-test-server
-# ignore-arm Another build using remote-test-server
 # ignore-none no-std is not supported
-# ignore-wasm32 FIXME: don't attempt to compile C++ to WASM
-# ignore-wasm64 FIXME: don't attempt to compile C++ to WASM
-# ignore-nvptx64-nvidia-cuda FIXME: can't find crate for `std`
 # ignore-musl FIXME: this makefile needs teaching how to use a musl toolchain
 #                    (see dist-i586-gnu-i586-i686-musl Dockerfile)
 

--- a/src/test/rustdoc-gui/sidebar-source-code.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code.goml
@@ -42,4 +42,4 @@ assert-false: ".source-sidebar-expanded"
 assert: "nav.sidebar"
 
 // Check that the topbar is not visible
-assert-property: (".mobile-topbar", {"offsetParent": "null"})
+assert-false: ".mobile-topbar"

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -367,3 +367,7 @@ impl TypeWithNoDocblocks {
     pub fn first_fn(&self) {}
     pub fn second_fn(&self) {}
 }
+
+pub unsafe fn unsafe_fn() {}
+
+pub fn safe_fn() {}

--- a/src/test/rustdoc-gui/unsafe-fn.goml
+++ b/src/test/rustdoc-gui/unsafe-fn.goml
@@ -1,0 +1,37 @@
+goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
+
+compare-elements-property: (
+	"//a[@title='test_docs::safe_fn fn']/..",
+	"//a[@title='test_docs::unsafe_fn fn']/..",
+	["clientHeight"]
+)
+
+// If the text isn't displayed, the browser doesn't compute color style correctly...
+show-text: true
+
+// Set the theme to dark.
+local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+// We reload the page so the local storage settings are being used.
+reload:
+
+assert-css: (".item-left sup", {
+	"color": "rgb(221, 221, 221)"
+})
+
+// Set the theme to ayu.
+local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+// We reload the page so the local storage settings are being used.
+reload:
+
+assert-css: (".item-left sup", {
+	"color": "rgb(197, 197, 197)"
+})
+
+// Set the theme to light.
+local-storage: {"rustdoc-theme": "light", "rustdoc-preferred-dark-theme": "light", "rustdoc-use-system-theme": "false"}
+// We reload the page so the local storage settings are being used.
+reload:
+
+assert-css: (".item-left sup", {
+	"color": "rgb(0, 0, 0)"
+})


### PR DESCRIPTION
Successful merges:

 - #99194 (Fix gdb-cmd for rust-gdbgui)
 - #99880 (`EscapeAscii` is not an `ExactSizeIterator`)
 - #102524 (rustdoc: remove weird `<a href="#">` wrapper around unsafe triangle)
 - #102581 (Make the `config.src` handling for downloadable bootstrap more conservative)
 - #102604 (Improve readability of bootstrap's README)
 - #102723 (test: run-make: skip when cross-compiling)
 - #102815 (rustdoc: remove mobile topbar from source pages instead of hiding it)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99194,99880,102524,102581,102604,102723,102815)
<!-- homu-ignore:end -->