### PR TITLE
Show let-else suggestion on stable.

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -491,7 +491,7 @@ impl<'p, 'tcx> MatchVisitor<'_, 'p, 'tcx> {
                     ],
                     Applicability::HasPlaceholders,
                 );
-                if !bindings.is_empty() && cx.tcx.sess.is_nightly_build() {
+                if !bindings.is_empty() {
                     err.span_suggestion_verbose(
                         semi_span.shrink_to_lo(),
                         &format!(


### PR DESCRIPTION
The E0005 error message has a suggestion to use let-else. Now that let-else is stabilized, I think this message should be included on non-nightly toolchains. I suspect this was just an oversight from #93628.  [`E0005.stderr`](https://github.com/ehuss/rust/blob/be1c7aad723126b2ea65543b4ceed54167b841a2/src/test/ui/error-codes/E0005.stderr#L22-L25) contains an example of what this suggestion looks like.

