### PR TITLE
[WIP] Native library linking changes for crater testing

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -763,7 +763,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(no_profiler_runtime, true);
     tracked!(oom, OomStrategy::Panic);
     tracked!(osx_rpath_install_name, true);
-    tracked!(packed_bundled_libs, true);
+    tracked!(packed_bundled_libs, false);
     tracked!(panic_abort_tests, true);
     tracked!(panic_in_drop, PanicStrategy::Abort);
     tracked!(pick_stable_methods_before_any_unstable, false);

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -471,6 +471,14 @@ impl<'tcx> Collector<'tcx> {
                                 lib.name = Some(Symbol::intern(new_name));
                             }
                             lib.verbatim = passed_lib.verbatim;
+                            if lib.filename.is_none() {
+                                lib.filename = find_bundled_library(
+                                    lib.name,
+                                    lib.verbatim,
+                                    lib.kind,
+                                    self.tcx.sess,
+                                );
+                            }
                             return true;
                         }
                     }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1431,7 +1431,7 @@ options! {
         "pass `-install_name @rpath/...` to the macOS linker (default: no)"),
     diagnostic_width: Option<usize> = (None, parse_opt_number, [UNTRACKED],
         "set the current output width for diagnostic truncation"),
-    packed_bundled_libs: bool = (true, parse_bool, [TRACKED],
+    packed_bundled_libs: bool = (false, parse_bool, [TRACKED],
         "change rlib format to store native libraries as archives"),
     panic_abort_tests: bool = (false, parse_bool, [TRACKED],
         "support compiling tests with panic=abort (default: no)"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1431,7 +1431,7 @@ options! {
         "pass `-install_name @rpath/...` to the macOS linker (default: no)"),
     diagnostic_width: Option<usize> = (None, parse_opt_number, [UNTRACKED],
         "set the current output width for diagnostic truncation"),
-    packed_bundled_libs: bool = (false, parse_bool, [TRACKED],
+    packed_bundled_libs: bool = (true, parse_bool, [TRACKED],
         "change rlib format to store native libraries as archives"),
     panic_abort_tests: bool = (false, parse_bool, [TRACKED],
         "support compiling tests with panic=abort (default: no)"),

--- a/src/test/run-make-fulldeps/invalid-staticlib/Makefile
+++ b/src/test/run-make-fulldeps/invalid-staticlib/Makefile
@@ -1,5 +1,7 @@
+# Staticlib format is no longer checked during bundling
+
 include ../tools.mk
 
 all:
 	touch $(TMPDIR)/libfoo.a
-	echo | $(RUSTC) - --crate-type=rlib -lstatic=foo 2>&1 | $(CGREP) "failed to add native library"
+	$(RUSTC) lib.rs --crate-type=rlib -lstatic=foo

--- a/src/test/run-make-fulldeps/invalid-staticlib/lib.rs
+++ b/src/test/run-make-fulldeps/invalid-staticlib/lib.rs
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/src/test/run-make-fulldeps/link-dedup/Makefile
+++ b/src/test/run-make-fulldeps/link-dedup/Makefile
@@ -6,7 +6,7 @@ all:
 	$(RUSTC) depa.rs
 	$(RUSTC) depb.rs
 	$(RUSTC) depc.rs
-	$(RUSTC) empty.rs --cfg bar 2>&1 | $(CGREP) '"-ltesta" "-ltestb" "-ltesta"'
+	$(RUSTC) empty.rs --cfg bar 2>&1 | $(CGREP) -e '"-ltesta".*"-ltestb".*"-ltesta"'
 	$(RUSTC) empty.rs 2>&1 | $(CGREP) '"-ltesta"'
 	$(RUSTC) empty.rs 2>&1 | $(CGREP) -v '"-ltestb"'
 	$(RUSTC) empty.rs 2>&1 | $(CGREP) -v '"-ltesta" "-ltesta"'

--- a/src/test/run-make/native-link-modifier-bundle/Makefile
+++ b/src/test/run-make/native-link-modifier-bundle/Makefile
@@ -12,7 +12,7 @@ all: $(call NATIVE_STATICLIB,native-staticlib)
 	$(RUSTC) bundled.rs --crate-type=staticlib --crate-type=rlib
 	$(NM) $(TMPDIR)/libbundled.a | $(CGREP) -e "T _*native_func"
 	$(NM) $(TMPDIR)/libbundled.a | $(CGREP) -e "U _*native_func"
-	$(NM) $(TMPDIR)/libbundled.rlib | $(CGREP) -e "T _*native_func"
+	$(NM) $(TMPDIR)/libbundled.rlib | $(CGREP) -ve "T _*native_func"
 	$(NM) $(TMPDIR)/libbundled.rlib | $(CGREP) -e "U _*native_func"
 
 	# Build a staticlib and a rlib, the `native_func` symbol will not be bundled into it

--- a/src/test/ui/native-library-link-flags/auxiliary/mylib.rs
+++ b/src/test/ui/native-library-link-flags/auxiliary/mylib.rs
@@ -1,0 +1,3 @@
+// no-prefer-dynamic
+
+#![crate_type = "staticlib"]

--- a/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive-link-attr.rs
+++ b/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive-link-attr.rs
@@ -1,8 +1,10 @@
-// compile-flags: -Zunstable-options --crate-type rlib
-// build-fail
-// error-pattern: the linking modifiers `+bundle` and `+whole-archive` are not compatible with each other when generating rlibs
+// Mixing +bundle and +whole-archive is now allowed
+
+// build-pass
+// compile-flags: --crate-type rlib
+// aux-build:mylib.rs
 
 #[link(name = "mylib", kind = "static", modifiers = "+bundle,+whole-archive")]
-extern "C" { }
+extern "C" {}
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive-link-attr.stderr
+++ b/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive-link-attr.stderr
@@ -1,6 +1,0 @@
-error: the linking modifiers `+bundle` and `+whole-archive` are not compatible with each other when generating rlibs
-
-error: could not find native static library `mylib`, perhaps an -L flag is missing?
-
-error: aborting due to 2 previous errors
-

--- a/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive.rs
+++ b/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive.rs
@@ -1,7 +1,7 @@
-// Mixing +bundle and +whole-archive is not allowed
+// Mixing +bundle and +whole-archive is now allowed
 
-// compile-flags: -l static:+bundle,+whole-archive=mylib -Zunstable-options --crate-type rlib
-// build-fail
-// error-pattern: the linking modifiers `+bundle` and `+whole-archive` are not compatible with each other when generating rlibs
+// build-pass
+// compile-flags: --crate-type rlib -l static:+bundle,+whole-archive=mylib
+// aux-build:mylib.rs
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive.stderr
+++ b/src/test/ui/native-library-link-flags/mix-bundle-and-whole-archive.stderr
@@ -1,6 +1,0 @@
-error: the linking modifiers `+bundle` and `+whole-archive` are not compatible with each other when generating rlibs
-
-error: could not find native static library `mylib`, perhaps an -L flag is missing?
-
-error: aborting due to 2 previous errors
-


### PR DESCRIPTION
- Enable `-Zpacked-bundled-libs` by default
- Preserve order of `-l` options from upstream crates, including dynamic libraries