### PR TITLE
Don't use `QueryNormalizer` to normalize in rustdoc

### DIFF
--- a/src/test/rustdoc/issue-102835.rs
+++ b/src/test/rustdoc/issue-102835.rs
@@ -1,0 +1,21 @@
+// compile-flags: -Znormalize-docs
+
+#![feature(type_alias_impl_trait)]
+
+trait Allocator {
+    type Buffer;
+}
+
+struct DefaultAllocator;
+
+impl<T> Allocator for DefaultAllocator {
+    type Buffer = ();
+}
+
+type A = impl Fn(<DefaultAllocator as Allocator>::Buffer);
+
+fn foo() -> A {
+    |_| ()
+}
+
+fn main() {}


### PR DESCRIPTION
The `QueryNormalizer`, which is what rustdoc was using to normalize its types, has a note:
```
/// N.B., this will *eventually* be the main means of
/// normalizing, but for now should be used only when we actually
/// know that normalization will succeed, since error reporting
/// and other details are still "under development".
```

In Rustdoc, this is currently not true -- it will gladly accept programs that aren't completely correct (see issue that this PR fixes #102827). This causes an ICE currently, because the normalizer doesn't currently handle normalization ambiguity correctly.

So let's use another normalization scheme, namely `fully_normalize`, to normalize types in rustdoc. It's slightly different in semantics, like how it doesn't allow escaping bound vars, so I added an extra normalization call in one place where we're pretty blatantly skipping binders. More normalize calls may need to be added in other places before we call `skip_binder`.

---

Alternatively, I could just revert 7808f69ad7a31e54719bf71017b745ee3ceac167, which caused this ICE. It's not clear that that's a better solution than this, since @lcnr's PR actually did signal a shortcoming in the current normalize call -- we don't really have a way to signal failures due to ambiguity, since right now all we return is a `Result<T, NoSolution>`.