### PR TITLE
Elaborate trait ref to compute object safety.

### DIFF
--- a/src/test/ui/object-safety/object-safety-supertrait-mentions-GAT.rs
+++ b/src/test/ui/object-safety/object-safety-supertrait-mentions-GAT.rs
@@ -1,0 +1,15 @@
+//~ ERROR the parameter type `Self` may not live long enough
+
+trait GatTrait {
+    type Gat<'a>
+    where
+        Self: 'a;
+}
+
+trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
+    fn c(&self) -> dyn SuperTrait<T>;
+    //~^ ERROR associated item referring to unboxed trait object for its own trait
+    //~| ERROR the trait `SuperTrait` cannot be made into an object
+}
+
+fn main() {}

--- a/src/test/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
+++ b/src/test/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
@@ -1,0 +1,43 @@
+error[E0311]: the parameter type `Self` may not live long enough
+   |
+   = help: consider adding an explicit lifetime bound `Self: 'a`...
+   = note: ...so that the type `Self` will meet its required lifetime bounds...
+note: ...that is required by this bound
+  --> $DIR/object-safety-supertrait-mentions-GAT.rs:9:39
+   |
+LL | trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
+   |                                       ^^^^^^^^^^^
+
+error: associated item referring to unboxed trait object for its own trait
+  --> $DIR/object-safety-supertrait-mentions-GAT.rs:10:20
+   |
+LL | trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
+   |       ---------- in this trait
+LL |     fn c(&self) -> dyn SuperTrait<T>;
+   |                    ^^^^^^^^^^^^^^^^^
+   |
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL |     fn c(&self) -> Self;
+   |                    ~~~~
+
+error[E0038]: the trait `SuperTrait` cannot be made into an object
+  --> $DIR/object-safety-supertrait-mentions-GAT.rs:10:20
+   |
+LL |     fn c(&self) -> dyn SuperTrait<T>;
+   |                    ^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-supertrait-mentions-GAT.rs:4:10
+   |
+LL |     type Gat<'a>
+   |          ^^^ ...because it contains the generic associated type `Gat`
+...
+LL | trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
+   |       ---------- this trait cannot be made into an object...
+   = help: consider moving `Gat` to another trait
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0311.
+For more information about an error, try `rustc --explain E0038`.


### PR DESCRIPTION
instead of building them manually from supertraits and associated items.

This allows to have the correct substs for GATs.

Fixes https://github.com/rust-lang/rust/issues/102751