### PR TITLE
Skip chained OpaqueCast when building captures.

### DIFF
--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This crate also contains the match exhaustiveness and usefulness checking.
 #![allow(rustc::potential_query_instability)]
+#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(if_let_guard)]

--- a/src/test/ui/closures/issue-102089-multiple-opaque-cast.rs
+++ b/src/test/ui/closures/issue-102089-multiple-opaque-cast.rs
@@ -1,0 +1,17 @@
+// edition:2021
+// check-pass
+
+pub struct Example<'a, T> {
+  a: T,
+  b: &'a T,
+}
+
+impl<'a, T> Example<'a, T> {
+  pub fn error_trying_to_destructure_self_in_closure(self) {
+    let closure = || {
+      let Self { a, b } = self;
+    };
+  }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/102089