### PR TITLE
Properly bubble up ambiguity in normalize query

### DIFF
--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -109,6 +109,33 @@ impl<'tcx> From<TypeError<'tcx>> for NoSolution {
     }
 }
 
+#[derive(Copy, Clone, Debug, HashStable)]
+pub enum NoSolutionOrAmbiguous {
+    NoSolution,
+    Ambiguous,
+}
+
+impl NoSolutionOrAmbiguous {
+    pub fn expect_unambiguous(self) -> NoSolution {
+        match self {
+            NoSolutionOrAmbiguous::NoSolution => NoSolution,
+            NoSolutionOrAmbiguous::Ambiguous => bug!("unexpected ambiguity"),
+        }
+    }
+}
+
+impl From<NoSolution> for NoSolutionOrAmbiguous {
+    fn from(_: NoSolution) -> NoSolutionOrAmbiguous {
+        NoSolutionOrAmbiguous::NoSolution
+    }
+}
+
+impl<'tcx> From<TypeError<'tcx>> for NoSolutionOrAmbiguous {
+    fn from(_: TypeError<'tcx>) -> NoSolutionOrAmbiguous {
+        NoSolutionOrAmbiguous::NoSolution
+    }
+}
+
 #[derive(Clone, Debug, Default, HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct DropckOutlivesResult<'tcx> {
     pub kinds: Vec<GenericArg<'tcx>>,

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -116,10 +116,22 @@ pub enum NoSolutionOrAmbiguous {
 }
 
 impl NoSolutionOrAmbiguous {
+    // Expect unambiguous errors only
     pub fn expect_unambiguous(self) -> NoSolution {
         match self {
             NoSolutionOrAmbiguous::NoSolution => NoSolution,
             NoSolutionOrAmbiguous::Ambiguous => bug!("unexpected ambiguity"),
+        }
+    }
+
+    /// Delay an ambiguity as a `delay_span_bug`.
+    pub fn delay_ambiguous(self, tcx: TyCtxt<'_>, span: Span) -> NoSolution {
+        match self {
+            NoSolutionOrAmbiguous::NoSolution => NoSolution,
+            NoSolutionOrAmbiguous::Ambiguous => {
+                tcx.sess.delay_span_bug(span, "unexpected ambiguity");
+                NoSolution
+            }
         }
     }
 }

--- a/compiler/rustc_traits/src/dropck_outlives.rs
+++ b/compiler/rustc_traits/src/dropck_outlives.rs
@@ -131,8 +131,8 @@ fn dropck_outlives<'tcx>(
 
                 // We don't actually expect to fail to normalize.
                 // That implies a WF error somewhere else.
-                Err(NoSolution) => {
-                    return Err(NoSolution);
+                Err(err) => {
+                    return Err(err.expect_unambiguous());
                 }
             }
         }

--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -48,7 +48,7 @@ fn try_normalize_after_erasing_regions<'tcx, T: TypeFoldable<'tcx> + PartialEq +
             debug_assert!(!erased.needs_infer(), "{:?}", erased);
             Ok(erased)
         }
-        Err(NoSolution) => Err(NoSolution),
+        Err(err) => Err(err.expect_unambiguous()),
     }
 }
 

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -218,8 +218,10 @@ where
     T: fmt::Debug + TypeFoldable<'tcx> + Lift<'tcx>,
 {
     let (param_env, Normalize { value }) = key.into_parts();
-    let Normalized { value, obligations } =
-        infcx.at(&ObligationCause::dummy(), param_env).normalize(value)?;
+    let Normalized { value, obligations } = infcx
+        .at(&ObligationCause::dummy(), param_env)
+        .normalize(value)
+        .map_err(|err| err.expect_unambiguous())?;
     fulfill_cx.register_predicate_obligations(infcx, obligations);
     Ok(value)
 }

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -221,7 +221,7 @@ where
     let Normalized { value, obligations } = infcx
         .at(&ObligationCause::dummy(), param_env)
         .normalize(value)
-        .map_err(|err| err.expect_unambiguous())?;
+        .map_err(|err| err.delay_ambiguous(infcx.tcx, DUMMY_SP))?;
     fulfill_cx.register_predicate_obligations(infcx, obligations);
     Ok(value)
 }

--- a/src/test/rustdoc/issue-102835.rs
+++ b/src/test/rustdoc/issue-102835.rs
@@ -1,0 +1,21 @@
+// compile-flags: -Znormalize-docs
+
+#![feature(type_alias_impl_trait)]
+
+trait Allocator {
+    type Buffer;
+}
+
+struct DefaultAllocator;
+
+impl<T> Allocator for DefaultAllocator {
+    type Buffer = ();
+}
+
+type A = impl Fn(<DefaultAllocator as Allocator>::Buffer);
+
+fn foo() -> A {
+    |_| ()
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issue-103181-1.rs
+++ b/src/test/ui/impl-trait/issue-103181-1.rs
@@ -1,0 +1,85 @@
+// edition:2021
+
+mod hyper {
+    use std::{fmt::Debug, future::Future, marker::PhantomData, pin::Pin, task::Poll};
+
+    pub trait HttpBody {
+        type Error;
+    }
+    impl HttpBody for () {
+        //~^ ERROR not all trait items implemented, missing: `Error`
+        // don't implement `Error` here for the ICE
+    }
+
+    pub struct Server<I, S>(I, S);
+
+    pub fn serve<I, S>(_: S) -> Server<I, S> {
+        todo!()
+    }
+
+    impl<S, B> Future for Server<(), S>
+    where
+        S: MakeServiceRef<(), (), ResBody = B>,
+        B: HttpBody,
+        B::Error: Debug,
+    {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+            todo!()
+        }
+    }
+
+    pub trait MakeServiceRef<Target, ReqBody> {
+        type ResBody;
+    }
+
+    impl<T, S> MakeServiceRef<(), ()> for T
+    where
+        T: for<'a> Service<&'a (), Response = S>,
+        S: Service<()>,
+    {
+        type ResBody = ();
+    }
+
+    pub struct MakeServiceFn<F>(pub F);
+    pub struct ServiceFn<F, R>(pub PhantomData<(F, R)>);
+
+    pub trait Service<Request> {
+        type Response;
+    }
+
+    impl<'t, F, Ret, Target, Svc> Service<&'t Target> for MakeServiceFn<F>
+    where
+        F: Fn() -> Ret,
+        Ret: Future<Output = Result<Svc, ()>>,
+    {
+        type Response = Svc;
+    }
+
+    impl<F, ReqBody, Ret, ResBody, E> Service<ReqBody> for ServiceFn<F, ReqBody>
+    where
+        F: Fn() -> Ret,
+        Ret: Future<Output = Result<ResBody, E>>,
+    {
+        type Response = ResBody;
+    }
+}
+
+async fn smarvice() -> Result<(), ()> {
+    Ok(())
+}
+
+fn service_fn<F, R, S>(f: F) -> hyper::ServiceFn<F, R>
+where
+    F: Fn() -> S,
+{
+    hyper::ServiceFn(std::marker::PhantomData)
+}
+
+async fn iceice() {
+    let service = hyper::MakeServiceFn(|| async { Ok::<_, ()>(service_fn(|| smarvice())) });
+    hyper::serve::<(), _>(service).await;
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issue-103181-1.stderr
+++ b/src/test/ui/impl-trait/issue-103181-1.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Error`
+  --> $DIR/issue-103181-1.rs:9:5
+   |
+LL |         type Error;
+   |         ---------- `Error` from trait
+LL |     }
+LL |     impl HttpBody for () {
+   |     ^^^^^^^^^^^^^^^^^^^^ missing `Error` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/src/test/ui/impl-trait/issue-103181-2.rs
+++ b/src/test/ui/impl-trait/issue-103181-2.rs
@@ -1,0 +1,29 @@
+// edition:2021
+
+trait SendFuture: Send {
+    type Output;
+}
+
+impl<Fut: Send> SendFuture for Fut {
+    type Output = ();
+}
+
+async fn broken_fut() {
+    ident_error;
+    //~^ ERROR cannot find value `ident_error` in this scope
+}
+
+// triggers normalization of `<Fut as SendFuture>::Output`,
+// which requires `Fut: Send`.
+fn normalize<Fut: SendFuture>(_: Fut, _: Fut::Output) {}
+
+async fn iceice<A, B>()
+// <- async fn is necessary
+where
+    A: Send,
+    B: Send, // <- a second bound
+{
+    normalize(broken_fut(), ());
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issue-103181-2.stderr
+++ b/src/test/ui/impl-trait/issue-103181-2.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `ident_error` in this scope
+  --> $DIR/issue-103181-2.rs:12:5
+   |
+LL |     ident_error;
+   |     ^^^^^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Alternative approach to fix #102827.

Returns a `NoSolutionOrAmbiguous` enum from the normalization query, and then we can deal with the unexpected ambiguity in places where we actually expect it to not occur, such as the `normalize_erasing_..` queries, while also silently swallowing it in places where we can afford to be more fallible, such as normalizing in rustdoc.

---

Edit: This also fixes #103181, which also ends up ICEing while normalizing types that have nested normalization obligations involving `[type error]`, which is always ambiguous as far as I can tell. Therefore we delay a bug when we see ambiguity while normalizing in `type_op_normalize` during MIR typeck.