### PR TITLE
Move lifetime resolution module to rustc_hir_analysis.

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -46,6 +46,7 @@ use std::iter;
 
 mod generics_of;
 mod item_bounds;
+mod lifetimes;
 mod predicates_of;
 mod type_of;
 
@@ -57,6 +58,7 @@ fn collect_mod_item_types(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {
 }
 
 pub fn provide(providers: &mut Providers) {
+    lifetimes::provide(providers);
     *providers = Providers {
         opt_const_param_of: type_of::opt_const_param_of,
         type_of: type_of::type_of,

--- a/compiler/rustc_hir_analysis/src/collect/lifetimes.rs
+++ b/compiler/rustc_hir_analysis/src/collect/lifetimes.rs
@@ -32,8 +32,6 @@ trait RegionExt {
     fn id(&self) -> Option<DefId>;
 
     fn shifted(self, amount: u32) -> Region;
-
-    fn shifted_out_to_binder(self, binder: ty::DebruijnIndex) -> Region;
 }
 
 impl RegionExt for Region {
@@ -69,15 +67,6 @@ impl RegionExt for Region {
             _ => self,
         }
     }
-
-    fn shifted_out_to_binder(self, binder: ty::DebruijnIndex) -> Region {
-        match self {
-            Region::LateBound(debruijn, index, id) => {
-                Region::LateBound(debruijn.shifted_out_to_binder(binder), index, id)
-            }
-            _ => self,
-        }
-    }
 }
 
 /// Maps the id of each lifetime reference to the lifetime decl
@@ -101,8 +90,8 @@ struct NamedRegionMap {
     late_bound_vars: HirIdMap<Vec<ty::BoundVariableKind>>,
 }
 
-pub(crate) struct LifetimeContext<'a, 'tcx> {
-    pub(crate) tcx: TyCtxt<'tcx>,
+struct LifetimeContext<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
     map: &'a mut NamedRegionMap,
     scope: ScopeRef<'a>,
 
@@ -234,7 +223,7 @@ type ScopeRef<'a> = &'a Scope<'a>;
 
 const ROOT_SCOPE: ScopeRef<'static> = &Scope::Root;
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub(crate) fn provide(providers: &mut ty::query::Providers) {
     *providers = ty::query::Providers {
         resolve_lifetimes_trait_definition,
         resolve_lifetimes,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -739,7 +739,6 @@ pub static DEFAULT_QUERY_PROVIDERS: LazyLock<Providers> = LazyLock::new(|| {
     ty::provide(providers);
     traits::provide(providers);
     rustc_passes::provide(providers);
-    rustc_resolve::provide(providers);
     rustc_traits::provide(providers);
     rustc_ty_utils::provide(providers);
     rustc_metadata::provide(providers);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -34,7 +34,6 @@ use std::collections::{hash_map::Entry, BTreeSet};
 use std::mem::{replace, take};
 
 mod diagnostics;
-pub(crate) mod lifetimes;
 
 type Res = def::Res<NodeId>;
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -42,7 +42,6 @@ use rustc_metadata::creader::{CStore, CrateLoader};
 use rustc_middle::metadata::ModChild;
 use rustc_middle::middle::privacy::AccessLevels;
 use rustc_middle::span_bug;
-use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, DefIdTree, MainDefinition, RegisteredTools, ResolverOutputs};
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::cstore::{CrateStore, CrateStoreDyn, MetadataLoaderDyn};
@@ -2081,8 +2080,4 @@ impl Finalize {
     fn with_root_span(node_id: NodeId, path_span: Span, root_span: Span) -> Finalize {
         Finalize { node_id, path_span, root_span, report_private: true }
     }
-}
-
-pub fn provide(providers: &mut Providers) {
-    late::lifetimes::provide(providers);
 }


### PR DESCRIPTION
Now that lifetime resolution has been removed from it, this file has nothing to do in `rustc_resolve`.  It's purpose is to compute Debruijn indices for lifetimes, so let's put it in type collection.