### PR TITLE
Add basename and dirname aliases

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1670,6 +1670,7 @@ impl DirEntry {
     /// }
     /// ```
     #[must_use]
+    #[doc(alias = "basename")]
     #[stable(feature = "dir_entry_ext", since = "1.1.0")]
     pub fn file_name(&self) -> OsString {
         self.0.file_name()

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1670,7 +1670,6 @@ impl DirEntry {
     /// }
     /// ```
     #[must_use]
-    #[doc(alias = "basename")]
     #[stable(feature = "dir_entry_ext", since = "1.1.0")]
     pub fn file_name(&self) -> OsString {
         self.0.file_name()

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2158,6 +2158,7 @@ impl Path {
     /// assert_eq!(grand_parent.parent(), None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "dirname")]
     #[must_use]
     pub fn parent(&self) -> Option<&Path> {
         let mut comps = self.components();
@@ -2225,6 +2226,7 @@ impl Path {
     /// assert_eq!(None, Path::new("/").file_name());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "basename")]
     #[must_use]
     pub fn file_name(&self) -> Option<&OsStr> {
         self.components().next_back().and_then(|p| match p {


### PR DESCRIPTION
Users might be used to the POSIX names of these functions. In fact, here's a [blog post][1] about this very thing.

[1]: https://boinkor.net/2019/07/basename-and-dirname-in-rust/