### PR TITLE
[rustdoc / JSON output] Document private items when generating JSON docs.

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -509,7 +509,11 @@ impl Step for JsonStd {
         let target = self.target;
         let out = builder.json_doc_out(target);
         t!(fs::create_dir_all(&out));
-        let extra_args = [OsStr::new("--output-format"), OsStr::new("json")];
+        let extra_args = [
+            OsStr::new("--document-private-items"),
+            OsStr::new("--output-format"),
+            OsStr::new("json"),
+        ];
         doc_std(builder, DocumentationFormat::JSON, stage, target, &out, &extra_args, &[])
     }
 }


### PR DESCRIPTION
This provides consumers of the distributed `rust-docs-json` component with the full set of information about toolchain crates. 
In particular, it allows them to process public re-exports which currently require access to the private items that are then exposed via `pub use` statements.