### PR TITLE
suggest candidates for unresolved import

### DIFF
--- a/src/test/ui/extenv/issue-55897.stderr
+++ b/src/test/ui/extenv/issue-55897.stderr
@@ -26,6 +26,11 @@ error[E0432]: unresolved import `env`
    |
 LL |     use env;
    |         ^^^ no `env` in the root
+   |
+help: consider importing this module instead
+   |
+LL |     use std::env;
+   |         ~~~~~~~~~
 
 error: cannot determine resolution for the macro `env`
   --> $DIR/issue-55897.rs:6:22

--- a/src/test/ui/imports/issue-56125.stderr
+++ b/src/test/ui/imports/issue-56125.stderr
@@ -3,6 +3,18 @@ error[E0432]: unresolved import `empty::issue_56125`
    |
 LL |     use empty::issue_56125;
    |         ^^^^^^^^^^^^^^^^^^ no `issue_56125` in `m3::empty`
+   |
+help: consider importing one of these items instead
+   |
+LL |     use crate::m3::last_segment::issue_56125;
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     use crate::m3::non_last_segment::non_last_segment::issue_56125;
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     use issue_56125::issue_56125;
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     use issue_56125::last_segment::issue_56125;
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     and 1 other candidate
 
 error[E0659]: `issue_56125` is ambiguous
   --> $DIR/issue-56125.rs:6:9

--- a/src/test/ui/imports/issue-57015.stderr
+++ b/src/test/ui/imports/issue-57015.stderr
@@ -3,6 +3,11 @@ error[E0432]: unresolved import `single_err::something`
    |
 LL | use single_err::something;
    |     ^^^^^^^^^^^^^^^^^^^^^ no `something` in `single_err`
+   |
+help: consider importing this module instead
+   |
+LL | use glob_ok::something;
+   |     ~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2126-extern-absolute-paths/not-allowed.stderr
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/not-allowed.stderr
@@ -3,6 +3,13 @@ error[E0432]: unresolved import `alloc`
    |
 LL | use alloc;
    |     ^^^^^ no external crate `alloc`
+   |
+help: consider importing one of these items instead
+   |
+LL | use core::alloc;
+   |     ~~~~~~~~~~~~
+LL | use std::alloc;
+   |     ~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/simd/portable-intrinsics-arent-exposed.stderr
+++ b/src/test/ui/simd/portable-intrinsics-arent-exposed.stderr
@@ -11,6 +11,11 @@ error[E0432]: unresolved import `std::simd::intrinsics`
    |
 LL | use std::simd::intrinsics;
    |     ^^^^^^^^^^^^^^^^^^^^^ no `intrinsics` in `simd`
+   |
+help: consider importing this module instead
+   |
+LL | use std::intrinsics;
+   |     ~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/src/test/ui/test-attrs/inaccessible-test-modules.stderr
@@ -11,10 +11,16 @@ error[E0432]: unresolved import `test`
   --> $DIR/inaccessible-test-modules.rs:6:5
    |
 LL | use test as y;
-   |     ----^^^^^
-   |     |
-   |     no `test` in the root
-   |     help: a similar name exists in the module: `test`
+   |     ^^^^^^^^^ no `test` in the root
+   |
+help: a similar name exists in the module
+   |
+LL | use test as y;
+   |     ~~~~
+help: consider importing this module instead
+   |
+LL | use test::test;
+   |     ~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unresolved/unresolved-candidates.rs
+++ b/src/test/ui/unresolved/unresolved-candidates.rs
@@ -1,0 +1,13 @@
+mod a {
+    pub trait Trait {}
+}
+
+mod b {
+    use Trait; //~ ERROR unresolved import `Trait`
+}
+
+mod c {
+    impl Trait for () {} //~ ERROR cannot find trait `Trait` in this scope
+}
+
+fn main() {}

--- a/src/test/ui/unresolved/unresolved-candidates.stderr
+++ b/src/test/ui/unresolved/unresolved-candidates.stderr
@@ -1,0 +1,26 @@
+error[E0432]: unresolved import `Trait`
+  --> $DIR/unresolved-candidates.rs:6:9
+   |
+LL |     use Trait;
+   |         ^^^^^ no `Trait` in the root
+   |
+help: consider importing this trait instead
+   |
+LL |     use a::Trait;
+   |         ~~~~~~~~~
+
+error[E0405]: cannot find trait `Trait` in this scope
+  --> $DIR/unresolved-candidates.rs:10:10
+   |
+LL |     impl Trait for () {}
+   |          ^^^^^ not found in this scope
+   |
+help: consider importing this trait
+   |
+LL |     use a::Trait;
+   |
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0405, E0432.
+For more information about an error, try `rustc --explain E0405`.


### PR DESCRIPTION
Currently we prompt suggestion of candidates(help notes of `use xxx::yyy`) for names which cannot be resolved, but we don't do that for import statements themselves that couldn't be resolved. It seems reasonable to add candidate help information for these statements as well.
Fixes #102711 