### PR TITLE
Fix stabilization of `feature(half_open_range_patterns)`

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -412,8 +412,6 @@ declare_features! (
     (incomplete, generic_associated_types_extended, "1.61.0", Some(95451), None),
     /// Allows non-trivial generic constants which have to have wfness manually propagated to callers
     (incomplete, generic_const_exprs, "1.56.0", Some(76560), None),
-    /// Allows using `..X`, `..=X`, `...X`, and `X..` as a pattern.
-    (active, half_open_range_patterns, "1.41.0", Some(67264), None),
     /// Allows using `..=X` as a patterns in slices.
     (active, half_open_range_patterns_in_slices, "CURRENT_RUSTC_VERSION", Some(67264), None),
     /// Allows `if let` guard in match arms.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/pull/102275/files#r991292215 by removing the relevant code that was [already partial moved](https://github.com/rust-lang/rust/pull/102275/files#diff-307e0d3a2037c11a3fa16822fbaa0fec08e57ac7d0d6e7354f6005c9482a9e26).

cc @Undin 