### PR TITLE
Simplify codegen for niche-encoded enums in simple cases

### DIFF
--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -819,6 +819,11 @@ impl WrappingRange {
         debug_assert!(self.start <= max_value && self.end <= max_value);
         self.start == (self.end.wrapping_add(1) & max_value)
     }
+
+    #[inline]
+    pub fn wraps(&self) -> bool {
+        return self.start > self.end;
+    }
 }
 
 impl fmt::Debug for WrappingRange {


### PR DESCRIPTION
Vast majority of niche-encoded enums have either a single niche-encoded variant or all their niche-encoded tags are greater than the whole untagged range, eg. with `enum E { A(bool), B, C }`  we have 0 | 1 → A, 2 → B, 3  → C. Currently get_discriminant accounts for various edgecases, like wrapping ranges, etc., but for such simple enum, we should be able to just determine whether an untagged value is stored by simple `<` comparison.

In pseudocode, before:
```rust
let relative_discr = tag.wrapping_sub(X);
if relative_discr < Y { Z } else { relative_discr + A }
```

after:
```rust
if tag < X { Z } else { tag - B }
```

Also:
* Noticed that doing all computation before cast to `cast_to` yields better codegen (perhaps LLVM has problems with `range` propagation when casting?).
* Adding `assume` that niche-encoded discriminant will never be the same as untagged discriminant helps a lot in cases when untagged variant is not the first one. Eg. in `enum E { A, B(bool), C }` LLVM would have to consider 0 | 1 | 3 as valid values for B) if not for this assumption.
* I remember trying slight variant of `tag < X` condition (`<=` or  just inverting the boolean? not sure now), but it resulted in LLVM getting too smart and recognizing the `if tag > X { 0 } else { tag - X }` as saturating-sub intrinsic too early in the process, which resulted in nice codegen, but stopped further optimization.

Despite some nice wins in generated assembly – [see the "enum-fair-opt" file in this gist][gist], I've seen only tiny (~0.03%) improvements on check scenarios in local perf testing on instr counts. The wins were quite consistent though, so I'd be happy to see a perf run – perhaps there's an improvement in cycles? (I couldn't get reliable values for cycles on local setup)

Pushing it as draft, because TODO
- [ ] ~~Cranelift~~ It could be done in followup PR, I guess
- [ ] Add test for non-simple cases (they are so rare now, so that this codepath is basically untested)
- [ ] Compare with https://github.com/rust-lang/rust/pull/102872 – perhaps combine the best of both approaches?

May help with https://github.com/rust-lang/rust/issues/101872

[gist]: https://gist.github.com/krdln/cefbb4a14d7ddfb5014099d1a0060916