### PR TITLE
Assert if inference vars are leaking from `InferCtxt::fully_resolve`

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1469,7 +1469,12 @@ impl<'tcx> InferCtxt<'tcx> {
          * except during the writeback phase.
          */
 
-        resolve::fully_resolve(self, value)
+        let value = resolve::fully_resolve(self, value);
+        assert!(
+            value.as_ref().map_or(true, |value| !value.needs_infer()),
+            "`{value:?}` is not fully resolved"
+        );
+        value
     }
 
     pub fn replace_bound_vars_with_fresh_vars<T>(


### PR DESCRIPTION
`InferCtxt::fully_resolve` shouldn't return unresolved inference vars without us at least being aware of it, so make it an assertion now. This should only happen in cases where we used to be returning `ReEmpty`...

cc @jackh726 