### PR TITLE
Migrate css highlight without change

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1096,8 +1096,55 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	color: var(--right-side-color);
 }
 
+pre.rust {
+	tab-size: 4;
+	-moz-tab-size: 4;
+}
+
+/* Code highlighting */
+pre.rust .kw {
+	color: var(--code-highlight-kw-color);
+}
+pre.rust .kw-2 {
+	color: var(--code-highlight-kw-2-color);
+}
+pre.rust .lifetime {
+	color: var(--code-highlight-lifetime-color);
+}
+pre.rust .prelude-ty {
+	color: var(--code-highlight-prelude-color);
+}
+pre.rust .prelude-val {
+	color: var(--code-highlight-prelude-val-color);
+}
+pre.rust .string {
+	color: var(--code-highlight-string-color);
+}
+pre.rust .number {
+	color: var(--code-highlight-number-color);
+}
+pre.rust .bool-val {
+	color: var(--code-highlight-literal-color);
+}
+pre.rust .self {
+	color: var(--code-highlight-self-color);
+}
+pre.rust .attribute {
+	color: var(--code-highlight-attribute-color);
+}
+pre.rust .macro,
+pre.rust .macro-nonterminal {
+	color: var(--code-highlight-macro-color);
+}
 pre.rust .question-mark {
 	font-weight: bold;
+	color: var(--code-highlight-question-mark-color);
+}
+pre.rust .comment {
+	color: var(--code-highlight-comment-color);
+}
+pre.rust .doccomment {
+	color: var(--code-highlight-doc-comment-color);
 }
 
 .example-wrap.compile_fail,
@@ -1301,11 +1348,6 @@ h3.variant {
 	margin: 0;
 	padding: 0;
 	font-size: 1.25rem;
-}
-
-pre.rust {
-	tab-size: 4;
-	-moz-tab-size: 4;
 }
 
 .search-failed {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -41,6 +41,20 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--search-color: #fff;
+	--code-highlight-kw-color: #ff7733;
+	--code-highlight-kw-2-color: #ff7733;
+	--code-highlight-lifetime-color: #ff7733;
+	--code-highlight-prelude-color: #69f2df;
+	--code-highlight-prelude-val-color: #ff7733;
+	--code-highlight-number-color: #b8cc52;
+	--code-highlight-string-color: #b8cc52;
+	--code-highlight-literal-color: #ff7733;
+	--code-highlight-attribute-color: #e6e1cf;
+	--code-highlight-self-color: #36a3d9;
+	--code-highlight-macro-color: #a37acc;
+	--code-highlight-question-mark-color: #ff9011;
+	--code-highlight-comment-color: #788797;
+	--code-highlight-doc-comment-color: #a1ac88;
 }
 
 .slider {
@@ -124,9 +138,6 @@ pre, .rustdoc.source .example-wrap {
 
 .content .item-info::before { color: #ccc; }
 
-pre.rust .comment { color: #788797; }
-pre.rust .doccomment { color: #a1ac88; }
-
 .sidebar h2 a,
 .sidebar h3 a {
 	color: white;
@@ -160,23 +171,6 @@ details.rustdoc-toggle > summary::before {
 }
 
 .src-line-numbers :target { background-color: transparent; }
-
-/* Code highlighting */
-pre.rust .number, pre.rust .string { color: #b8cc52; }
-pre.rust .kw, pre.rust .kw-2, pre.rust .prelude-ty,
-pre.rust .bool-val, pre.rust .prelude-val,
-pre.rust .lifetime { color: #ff7733; }
-pre.rust .macro, pre.rust .macro-nonterminal { color: #a37acc; }
-pre.rust .question-mark {
-	color: #ff9011;
-}
-pre.rust .self {
-	color: #36a3d9;
-	font-style: italic;
-}
-pre.rust .attribute {
-	color: #e6e1cf;
-}
 
 pre.example-line-numbers {
 	color: #5c67736e;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -36,6 +36,20 @@
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--search-color: #111;
+	--code-highlight-kw-color: #ab8ac1;
+	--code-highlight-kw-2-color: #769acb;
+	--code-highlight-lifetime-color: #d97f26;
+	--code-highlight-prelude-color: #769acb;
+	--code-highlight-prelude-val-color: #ee6868;
+	--code-highlight-number-color: #83a300;
+	--code-highlight-string-color: #83a300;
+	--code-highlight-literal-color: #ee6868;
+	--code-highlight-attribute-color: #ee6868;
+	--code-highlight-self-color: #ee6868;
+	--code-highlight-macro-color: #3e999f;
+	--code-highlight-question-mark-color: #ff9011;
+	--code-highlight-comment-color: #8d8d8b;
+	--code-highlight-doc-comment-color: #8ca375;
 }
 
 .slider {
@@ -62,9 +76,6 @@ input:focus + .slider {
 
 .content .item-info::before { color: #ccc; }
 
-pre.rust .comment { color: #8d8d8b; }
-pre.rust .doccomment { color: #8ca375; }
-
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
@@ -85,18 +96,6 @@ details.rustdoc-toggle > summary::before {
 }
 
 .src-line-numbers :target { background-color: transparent; }
-
-/* Code highlighting */
-pre.rust .kw { color: #ab8ac1; }
-pre.rust .kw-2, pre.rust .prelude-ty { color: #769acb; }
-pre.rust .number, pre.rust .string { color: #83a300; }
-pre.rust .self, pre.rust .bool-val, pre.rust .prelude-val,
-pre.rust .attribute { color: #ee6868; }
-pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
-pre.rust .lifetime { color: #d97f26; }
-pre.rust .question-mark {
-	color: #ff9011;
-}
 
 pre.example-line-numbers {
 	border-color: #4a4949;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -36,6 +36,20 @@
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--search-color: #000;
+	--code-highlight-kw-color: #8959a8;
+	--code-highlight-kw-2-color: #4271ae;
+	--code-highlight-lifetime-color: #b76514;
+	--code-highlight-prelude-color: #4271ae;
+	--code-highlight-prelude-val-color: #c82829;
+	--code-highlight-number-color: #718c00;
+	--code-highlight-string-color: #718c00;
+	--code-highlight-literal-color: #c82829;
+	--code-highlight-attribute-color: #c82829;
+	--code-highlight-self-color: #c82829;
+	--code-highlight-macro-color: #3e999f;
+	--code-highlight-question-mark-color: #ff9011;
+	--code-highlight-comment-color: #8e908c;
+	--code-highlight-doc-comment-color: #4d4d4c;
 }
 
 .slider {
@@ -77,20 +91,6 @@ body.source .example-wrap pre.rust a {
 }
 
 .src-line-numbers :target { background-color: transparent; }
-
-/* Code highlighting */
-pre.rust .kw { color: #8959A8; }
-pre.rust .kw-2, pre.rust .prelude-ty { color: #4271AE; }
-pre.rust .number, pre.rust .string { color: #718C00; }
-pre.rust .self, pre.rust .bool-val, pre.rust .prelude-val,
-pre.rust .attribute { color: #C82829; }
-pre.rust .comment { color: #8E908C; }
-pre.rust .doccomment { color: #4D4D4C; }
-pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
-pre.rust .lifetime { color: #B76514; }
-pre.rust .question-mark {
-	color: #ff9011;
-}
 
 pre.example-line-numbers {
 	border-color: #c7c7c7;

--- a/src/test/rustdoc-gui/highlight-colors.goml
+++ b/src/test/rustdoc-gui/highlight-colors.goml
@@ -1,0 +1,57 @@
+// This test checks the highlight colors in the source code pages.
+goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
+show-text: true
+
+local-storage: {"rustdoc-theme": "ayu", "rustdoc-use-system-theme": "false"}
+reload:
+
+assert-css: ("pre.rust .kw", {"color": "rgb(255, 119, 51)"}, ALL)
+assert-css: ("pre.rust .kw-2", {"color": "rgb(255, 119, 51)"}, ALL)
+assert-css: ("pre.rust .prelude-ty", {"color": "rgb(105, 242, 223)"}, ALL)
+assert-css: ("pre.rust .prelude-val", {"color": "rgb(255, 119, 51)"}, ALL)
+assert-css: ("pre.rust .lifetime", {"color": "rgb(255, 119, 51)"}, ALL)
+assert-css: ("pre.rust .number", {"color": "rgb(184, 204, 82)"}, ALL)
+assert-css: ("pre.rust .string", {"color": "rgb(184, 204, 82)"}, ALL)
+assert-css: ("pre.rust .bool-val", {"color": "rgb(255, 119, 51)"}, ALL)
+assert-css: ("pre.rust .self", {"color": "rgb(54, 163, 217)"}, ALL)
+assert-css: ("pre.rust .attribute", {"color": "rgb(230, 225, 207)"}, ALL)
+assert-css: ("pre.rust .macro", {"color": "rgb(163, 122, 204)"}, ALL)
+assert-css: ("pre.rust .question-mark", {"color": "rgb(255, 144, 17)"}, ALL)
+assert-css: ("pre.rust .comment", {"color": "rgb(120, 135, 151)"}, ALL)
+assert-css: ("pre.rust .doccomment", {"color": "rgb(161, 172, 136)"}, ALL)
+
+local-storage: {"rustdoc-theme": "dark"}
+reload:
+
+assert-css: ("pre.rust .kw", {"color": "rgb(171, 138, 193)"}, ALL)
+assert-css: ("pre.rust .kw-2", {"color": "rgb(118, 154, 203)"}, ALL)
+assert-css: ("pre.rust .prelude-ty", {"color": "rgb(118, 154, 203)"}, ALL)
+assert-css: ("pre.rust .prelude-val", {"color": "rgb(238, 104, 104)"}, ALL)
+assert-css: ("pre.rust .lifetime", {"color": "rgb(217, 127, 38)"}, ALL)
+assert-css: ("pre.rust .number", {"color": "rgb(131, 163, 0)"}, ALL)
+assert-css: ("pre.rust .string", {"color": "rgb(131, 163, 0)"}, ALL)
+assert-css: ("pre.rust .bool-val", {"color": "rgb(238, 104, 104)"}, ALL)
+assert-css: ("pre.rust .self", {"color": "rgb(238, 104, 104)"}, ALL)
+assert-css: ("pre.rust .attribute", {"color": "rgb(238, 104, 104)"}, ALL)
+assert-css: ("pre.rust .macro", {"color": "rgb(62, 153, 159)"}, ALL)
+assert-css: ("pre.rust .question-mark", {"color": "rgb(255, 144, 17)"}, ALL)
+assert-css: ("pre.rust .comment", {"color": "rgb(141, 141, 139)"}, ALL)
+assert-css: ("pre.rust .doccomment", {"color": "rgb(140, 163, 117)"}, ALL)
+
+local-storage: {"rustdoc-theme": "light"}
+reload:
+
+assert-css: ("pre.rust .kw", {"color": "rgb(137, 89, 168)"}, ALL)
+assert-css: ("pre.rust .kw-2", {"color": "rgb(66, 113, 174)"}, ALL)
+assert-css: ("pre.rust .prelude-ty", {"color": "rgb(66, 113, 174)"}, ALL)
+assert-css: ("pre.rust .prelude-val", {"color": "rgb(200, 40, 41)"}, ALL)
+assert-css: ("pre.rust .lifetime", {"color": "rgb(183, 101, 20)"}, ALL)
+assert-css: ("pre.rust .number", {"color": "rgb(113, 140, 0)"}, ALL)
+assert-css: ("pre.rust .string", {"color": "rgb(113, 140, 0)"}, ALL)
+assert-css: ("pre.rust .bool-val", {"color": "rgb(200, 40, 41)"}, ALL)
+assert-css: ("pre.rust .self", {"color": "rgb(200, 40, 41)"}, ALL)
+assert-css: ("pre.rust .attribute", {"color": "rgb(200, 40, 41)"}, ALL)
+assert-css: ("pre.rust .macro", {"color": "rgb(62, 153, 159)"}, ALL)
+assert-css: ("pre.rust .question-mark", {"color": "rgb(255, 144, 17)"}, ALL)
+assert-css: ("pre.rust .comment", {"color": "rgb(142, 144, 140)"}, ALL)
+assert-css: ("pre.rust .doccomment", {"color": "rgb(77, 77, 76)"}, ALL)

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -364,8 +364,23 @@ pub trait TraitWithNoDocblocks {
 pub struct TypeWithNoDocblocks;
 
 impl TypeWithNoDocblocks {
+    fn x() -> Option<Self> {
+        Some(Self)
+    }
+    fn y() -> Option<u32> {
+        // code comment
+        let t = Self::x()?;
+        Some(0)
+    }
+}
+
+impl TypeWithNoDocblocks {
     pub fn first_fn(&self) {}
-    pub fn second_fn(&self) {}
+    pub fn second_fn<'a>(&'a self) {
+        let x = 12;
+        let y = "a";
+        let z = false;
+    }
 }
 
 pub unsafe fn unsafe_fn() {}


### PR DESCRIPTION
This is a "previous" version of https://github.com/rust-lang/rust/pull/102663: only migrating to CSS variables, no changes. It's a bit more verbose because rules are not coherent between themes.

Part of https://github.com/rust-lang/rust/pull/98460.

r? @notriddle 