### PR TITLE
rustdoc: remove unused classes from sidebar links

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -218,55 +218,55 @@ pre.rust a,
 .sidebar h2 a,
 .sidebar h3 a,
 .mobile-topbar h2 a,
-h1.fqn a,
+h1 a,
 .search-results a,
 .module-item .stab,
 .import-item .stab,
 .result-name .primitive > i, .result-name .keyword > i,
-.content .method .where,
-.content .fn .where,
-.content .where.fmt-newline {
+.method .where,
+.fn .where,
+.where.fmt-newline {
 	color: var(--main-color);
 }
 
-.content span.enum, .content a.enum,
-.content span.struct, .content a.struct,
-.content span.union, .content a.union,
-.content span.primitive, .content a.primitive,
-.content span.type, .content a.type,
-.content span.foreigntype, .content a.foreigntype {
+span.enum, a.enum,
+span.struct, a.struct,
+span.union, a.union,
+span.primitive, a.primitive,
+span.type, a.type,
+span.foreigntype, a.foreigntype {
 	color: var(--type-link-color);
 }
 
-.content span.trait, .content a.trait,
-.content span.traitalias, .content a.traitalias {
+span.trait, a.trait,
+span.traitalias, a.traitalias {
 	color: var(--trait-link-color);
 }
 
-.content span.associatedtype, .content a.associatedtype,
-.content span.constant, .content a.constant,
-.content span.static, .content a.static {
+span.associatedtype, a.associatedtype,
+span.constant, a.constant,
+span.static, a.static {
 	color: var(--assoc-item-link-color);
 }
 
-.content span.fn, .content a.fn,
-.content .fnname,
-.content span.method, .content a.method,
-.content span.tymethod, .content a.tymethod {
+span.fn, a.fn,
+.fnname,
+span.method, a.method,
+span.tymethod, a.tymethod {
 	color: var(--function-link-color);
 }
 
-.content span.attr, .content a.attr,
-.content span.derive, .content a.derive,
-.content span.macro, .content a.macro {
+span.attr, a.attr,
+span.derive, a.derive,
+span.macro, a.macro {
 	color: var(--macro-link-color);
 }
 
-.content span.mod, .content a.mod, .block a.current.mod {
+span.mod, a.mod {
 	color: var(--mod-link-color);
 }
 
-.content span.keyword, .content a.keyword {
+span.keyword, a.keyword {
 	color: var(--keyword-link-color);
 }
 
@@ -685,9 +685,9 @@ pre, .rustdoc.source .example-wrap {
 }
 
 /* Shift "where ..." part of method or fn definition down a line */
-.content .method .where,
-.content .fn .where,
-.content .where.fmt-newline {
+.method .where,
+.fn .where,
+.where.fmt-newline {
 	display: block;
 	font-size: 0.875rem;
 }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -56,7 +56,7 @@ input:focus + .slider {
 h1, h2, h3, h4 {
 	color: white;
 }
-h1.fqn  a {
+h1 a {
 	color: #fff;
 }
 h4 {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -451,7 +451,6 @@ function loadCss(cssFileName) {
                 const name = item[0];
                 const desc = item[1]; // can be null
 
-                let klass = shortty;
                 let path;
                 if (shortty === "mod") {
                     path = name + "/index.html";
@@ -459,13 +458,12 @@ function loadCss(cssFileName) {
                     path = shortty + "." + name + ".html";
                 }
                 const current_page = document.location.href.split("/").pop();
-                if (path === current_page) {
-                    klass += " current";
-                }
                 const link = document.createElement("a");
                 link.href = path;
                 link.title = desc;
-                link.className = klass;
+                if (path === current_page) {
+                    link.className = "current";
+                }
                 link.textContent = name;
                 const li = document.createElement("li");
                 li.appendChild(link);

--- a/src/test/rustdoc-gui/sidebar-links-color.goml
+++ b/src/test/rustdoc-gui/sidebar-links-color.goml
@@ -13,72 +13,72 @@ reload:
 
 // Struct
 assert-css: (
-    ".sidebar a.struct:not(.current)",
+    ".sidebar .block.struct a:not(.current)",
     {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.struct:not(.current)"
+move-cursor-to: ".sidebar .block.struct a:not(.current)"
 assert-css: (
-    ".sidebar a.struct:hover",
+    ".sidebar .block.struct a:hover",
     {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)"},
 )
 // Enum
 assert-css: (
-    ".sidebar a.enum",
+    ".sidebar .block.enum a",
     {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.enum"
+move-cursor-to: ".sidebar .block.enum a"
 assert-css: (
-    ".sidebar a.enum:hover",
+    ".sidebar .block.enum a:hover",
     {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)"},
 )
 // Union
 assert-css: (
-    ".sidebar a.union",
+    ".sidebar .block.union a",
     {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.union"
+move-cursor-to: ".sidebar .block.union a"
 assert-css: (
-    ".sidebar a.union:hover",
+    ".sidebar .block.union a:hover",
     {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)"},
 )
 // Trait
 assert-css: (
-    ".sidebar a.trait",
+    ".sidebar .block.trait a",
     {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.trait"
+move-cursor-to: ".sidebar .block.trait a"
 assert-css: (
-    ".sidebar a.trait:hover",
+    ".sidebar .block.trait a:hover",
     {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)"},
 )
 // Function
 assert-css: (
-    ".sidebar a.fn",
+    ".sidebar .block.fn a",
     {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.fn"
+move-cursor-to: ".sidebar .block.fn a"
 assert-css: (
-    ".sidebar a.fn:hover",
+    ".sidebar .block.fn a:hover",
     {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)"},
 )
 // Type definition
 assert-css: (
-    ".sidebar a.type",
+    ".sidebar .block.type a",
     {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.type"
+move-cursor-to: ".sidebar .block.type a"
 assert-css: (
-    ".sidebar a.type:hover",
+    ".sidebar .block.type a:hover",
     {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)"},
 )
 // Keyword
 assert-css: (
-    ".sidebar a.keyword",
+    ".sidebar .block.keyword a",
     {"color": "rgb(83, 177, 219)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.keyword"
+move-cursor-to: ".sidebar .block.keyword a"
 assert-css: (
-    ".sidebar a.keyword:hover",
+    ".sidebar .block.keyword a:hover",
     {"color": "rgb(255, 180, 76)", "background-color": "rgba(0, 0, 0, 0)"},
 )
 
@@ -88,72 +88,72 @@ reload:
 
 // Struct
 assert-css: (
-    ".sidebar a.struct:not(.current)",
+    ".sidebar .block.struct a:not(.current)",
     {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.struct:not(.current)"
+move-cursor-to: ".sidebar .block.struct a:not(.current)"
 assert-css: (
-    ".sidebar a.struct:hover",
+    ".sidebar .block.struct a:hover",
     {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)"},
 )
 // Enum
 assert-css: (
-    ".sidebar a.enum",
+    ".sidebar .block.enum a",
     {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.enum"
+move-cursor-to: ".sidebar .block.enum a"
 assert-css: (
-    ".sidebar a.enum:hover",
+    ".sidebar .block.enum a:hover",
     {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)"},
 )
 // Union
 assert-css: (
-    ".sidebar a.union",
+    ".sidebar .block.union a",
     {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.union"
+move-cursor-to: ".sidebar .block.union a"
 assert-css: (
-    ".sidebar a.union:hover",
+    ".sidebar .block.union a:hover",
     {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)"},
 )
 // Trait
 assert-css: (
-    ".sidebar a.trait",
+    ".sidebar .block.trait a",
     {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.trait"
+move-cursor-to: ".sidebar .block.trait a"
 assert-css: (
-    ".sidebar a.trait:hover",
+    ".sidebar .block.trait a:hover",
     {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)"},
 )
 // Function
 assert-css: (
-    ".sidebar a.fn",
+    ".sidebar .block.fn a",
     {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.fn"
+move-cursor-to: ".sidebar .block.fn a"
 assert-css: (
-    ".sidebar a.fn:hover",
+    ".sidebar .block.fn a:hover",
     {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)"},
 )
 // Type definition
 assert-css: (
-    ".sidebar a.type",
+    ".sidebar .block.type a",
     {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.type"
+move-cursor-to: ".sidebar .block.type a"
 assert-css: (
-    ".sidebar a.type:hover",
+    ".sidebar .block.type a:hover",
     {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)"},
 )
 // Keyword
 assert-css: (
-    ".sidebar a.keyword",
+    ".sidebar .block.keyword a",
     {"color": "rgb(253, 191, 53)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.keyword"
+move-cursor-to: ".sidebar .block.keyword a"
 assert-css: (
-    ".sidebar a.keyword:hover",
+    ".sidebar .block.keyword a:hover",
     {"color": "rgb(253, 191, 53)", "background-color": "rgb(68, 68, 68)"},
 )
 
@@ -163,71 +163,71 @@ reload:
 
 // Struct
 assert-css: (
-    ".sidebar a.struct:not(.current)",
+    ".sidebar .block.struct a:not(.current)",
     {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.struct:not(.current)"
+move-cursor-to: ".sidebar .block.struct a:not(.current)"
 assert-css: (
-    ".sidebar a.struct:hover",
+    ".sidebar .block.struct a:hover",
     {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)"},
 )
 // Enum
 assert-css: (
-    ".sidebar a.enum",
+    ".sidebar .block.enum a",
     {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.enum"
+move-cursor-to: ".sidebar .block.enum a"
 assert-css: (
-    ".sidebar a.enum:hover",
+    ".sidebar .block.enum a:hover",
     {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)"},
 )
 // Union
 assert-css: (
-    ".sidebar a.union",
+    ".sidebar .block.union a",
     {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.union"
+move-cursor-to: ".sidebar .block.union a"
 assert-css: (
-    ".sidebar a.union:hover",
+    ".sidebar .block.union a:hover",
     {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)"},
 )
 // Trait
 assert-css: (
-    ".sidebar a.trait",
+    ".sidebar .block.trait a",
     {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.trait"
+move-cursor-to: ".sidebar .block.trait a"
 assert-css: (
-    ".sidebar a.trait:hover",
+    ".sidebar .block.trait a:hover",
     {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)"},
 )
 // Function
 assert-css: (
-    ".sidebar a.fn",
+    ".sidebar .block.fn a",
     {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.fn"
+move-cursor-to: ".sidebar .block.fn a"
 assert-css: (
-    ".sidebar a.fn:hover",
+    ".sidebar .block.fn a:hover",
     {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)"},
 )
 // Type definition
 assert-css: (
-    ".sidebar a.type",
+    ".sidebar .block.type a",
     {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.type"
+move-cursor-to: ".sidebar .block.type a"
 assert-css: (
-    ".sidebar a.type:hover",
+    ".sidebar .block.type a:hover",
     {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)"},
 )
 // Keyword
 assert-css: (
-    ".sidebar a.keyword",
+    ".sidebar .block.keyword a",
     {"color": "rgb(53, 109, 164)", "background-color": "rgba(0, 0, 0, 0)"},
 )
-move-cursor-to: ".sidebar a.keyword"
+move-cursor-to: ".sidebar .block.keyword a"
 assert-css: (
-    ".sidebar a.keyword:hover",
+    ".sidebar .block.keyword a:hover",
     {"color": "rgb(53, 109, 164)", "background-color": "rgb(255, 255, 255)"},
 )

--- a/src/test/rustdoc-gui/sidebar-macro-reexport.goml
+++ b/src/test/rustdoc-gui/sidebar-macro-reexport.goml
@@ -1,5 +1,5 @@
 // This test ensures that the reexport of a macro doesn't make the original macro
 // displayed twice in the sidebar.
 goto: "file://" + |DOC_PATH| + "/test_docs/macro.repro.html"
-wait-for: ".sidebar-elems .macro .macro"
+wait-for: ".sidebar-elems .block.macro a"
 assert-count: ("//*[@class='sidebar-elems']//*[@class='block macro']//a[text()='repro']", 1)


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/commit/98f05a0282625a5fda6e90ebf3b05a4bd7608f65 removed separate colors from the currently-selected item, there's no need to have item classes on sidebar links.

Preview: https://notriddle.com/notriddle-rustdoc-demos/sidebar-link-class/std/vec/struct.Vec.html

While cleaning up the CSS to remove unneeded `.content` selectors, this PR changes the `h1.fqn a` CSS selector to just be `h1 a`, so that the header link color selector is less specific than the typed link at the end. Since https://github.com/rust-lang/rust/pull/89506 made docblocks start at `h2`, the main page link header should be the only h1 in the page now.