### PR TITLE
Fix `let` keyword removal suggestion in structs

### DIFF
--- a/src/test/ui/parser/bad-let-as-field.rs
+++ b/src/test/ui/parser/bad-let-as-field.rs
@@ -1,0 +1,6 @@
+struct Foo {
+    let: i32,
+    //~^ ERROR expected identifier, found keyword
+}
+
+fn main() {}

--- a/src/test/ui/parser/bad-let-as-field.stderr
+++ b/src/test/ui/parser/bad-let-as-field.stderr
@@ -1,0 +1,15 @@
+error: expected identifier, found keyword `let`
+  --> $DIR/bad-let-as-field.rs:2:5
+   |
+LL | struct Foo {
+   |        --- while parsing this struct
+LL |     let: i32,
+   |     ^^^ expected identifier, found keyword
+   |
+help: escape `let` to use it as an identifier
+   |
+LL |     r#let: i32,
+   |     ++
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/removed-syntax-field-let-2.rs
+++ b/src/test/ui/parser/removed-syntax-field-let-2.rs
@@ -1,0 +1,12 @@
+struct Foo {
+    let x: i32,
+    //~^ ERROR expected identifier, found keyword
+    let y: i32,
+    //~^ ERROR expected identifier, found keyword
+}
+
+fn main() {
+    let _ = Foo {
+        //~^ ERROR missing fields `x` and `y` in initializer of `Foo`
+    };
+}

--- a/src/test/ui/parser/removed-syntax-field-let-2.stderr
+++ b/src/test/ui/parser/removed-syntax-field-let-2.stderr
@@ -1,0 +1,33 @@
+error: expected identifier, found keyword `let`
+  --> $DIR/removed-syntax-field-let-2.rs:2:5
+   |
+LL |     let x: i32,
+   |     ^^^-
+   |     |
+   |     expected identifier, found keyword
+   |     help: remove this `let` keyword
+   |
+   = note: the `let` keyword is not allowed in `struct` fields
+   = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
+
+error: expected identifier, found keyword `let`
+  --> $DIR/removed-syntax-field-let-2.rs:4:5
+   |
+LL |     let y: i32,
+   |     ^^^-
+   |     |
+   |     expected identifier, found keyword
+   |     help: remove this `let` keyword
+   |
+   = note: the `let` keyword is not allowed in `struct` fields
+   = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
+
+error[E0063]: missing fields `x` and `y` in initializer of `Foo`
+  --> $DIR/removed-syntax-field-let-2.rs:9:13
+   |
+LL |     let _ = Foo {
+   |             ^^^ missing `x` and `y`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/parser/removed-syntax-field-let.stderr
+++ b/src/test/ui/parser/removed-syntax-field-let.stderr
@@ -2,15 +2,13 @@ error: expected identifier, found keyword `let`
   --> $DIR/removed-syntax-field-let.rs:2:5
    |
 LL |     let foo: (),
-   |     ^^^ expected identifier, found keyword
+   |     ^^^-
+   |     |
+   |     expected identifier, found keyword
+   |     help: remove this `let` keyword
    |
    = note: the `let` keyword is not allowed in `struct` fields
    = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
-help: remove the let, the `let` keyword is not allowed in struct field definitions
-   |
-LL -     let foo: (),
-LL +     foo: (),
-   |
 
 error: aborting due to previous error
 


### PR DESCRIPTION
(1.) Fixes a bug where, given this code:
```rust
struct Foo {
  let x: i32,
}
```

We were parsing the field name as `let` instead of `x`, which causes issues later on in the type-checking phase.

(2.) Also, suggestions for `let: i32` as a field regressed, displaying this extra `help:` which is removed by this PR

```
help: remove the let, the `let` keyword is not allowed in struct field definitions
  |
2 -     let: i32,
2 +     : i32,
```

(3.) Makes the suggestion text a bit more succinct, since we don't need to re-explain that `let` is not allowed in this position (since it's in a note that follows). This causes the suggestion to render inline as well.

cc @gimbles, this addresses a few nits I mentioned in your PR.