### PR TITLE
rustdoc: remove unused CSS `nav.sum`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -563,8 +563,6 @@ h2.location a {
 .rustdoc .example-wrap {
 	display: flex;
 	position: relative;
-}
-.rustdoc .example-wrap {
 	margin-bottom: 10px;
 }
 /* For the last child of a div, the margin will be taken care of

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -718,7 +718,6 @@ nav.sub {
 .source nav.sub {
 	margin-left: 32px;
 }
-nav.sum { text-align: right; }
 nav.sub form { display: inline; }
 
 a {


### PR DESCRIPTION
This was added in 4fd061c426902b0904c65e64a3780b21f9ab3afb, but never actually used.