### PR TITLE
(#102929) Implement `String:leak`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,7 +146,6 @@
 #![feature(slice_ptr_len)]
 #![feature(slice_range)]
 #![feature(str_internals)]
-#![feature(string_leak)]
 #![feature(strict_provenance)]
 #![feature(trusted_len)]
 #![feature(trusted_random_access)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,6 +146,7 @@
 #![feature(slice_ptr_len)]
 #![feature(slice_range)]
 #![feature(str_internals)]
+#![feature(string_leak)]
 #![feature(strict_provenance)]
 #![feature(trusted_len)]
 #![feature(trusted_random_access)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1862,9 +1862,13 @@ impl String {
     /// Simple usage:
     ///
     /// ```
-    /// let x = String::from("bucket");
-    /// let static_ref: &'static mut str = x.leak();
-    /// assert_eq!(static_ref, "bucket");
+    /// #![feature(string_leak)]
+    ///
+    /// pub fn main() {
+    ///     let x = String::from("bucket");
+    ///     let static_ref: &'static mut str = x.leak();
+    ///     assert_eq!(static_ref, "bucket");
+    /// }
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "string_leak", issue = "102929")]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1872,7 +1872,6 @@ impl String {
     /// let static_ref: &'static mut str = x.leak();
     /// assert_eq!(static_ref, "bucket");
     /// ```
-    #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "string_leak", issue = "102929")]
     #[inline]
     pub fn leak(self) -> &'static mut str {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1853,9 +1853,13 @@ impl String {
     /// Consumes and leaks the `String`, returning a mutable reference to the contents,
     /// `&'a mut str`.
     ///
-    /// This function is mainly useful for data that lives for the remainder of
+    /// This is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory
     /// leak.
+    ///
+    /// It does not reallocate or shrink the `String`,
+    /// so the leaked allocation may include unused capacity that is not part
+    /// of the returned slice.
     ///
     /// # Examples
     ///
@@ -1864,17 +1868,15 @@ impl String {
     /// ```
     /// #![feature(string_leak)]
     ///
-    /// pub fn main() {
-    ///     let x = String::from("bucket");
-    ///     let static_ref: &'static mut str = x.leak();
-    ///     assert_eq!(static_ref, "bucket");
-    /// }
+    /// let x = String::from("bucket");
+    /// let static_ref: &'static mut str = x.leak();
+    /// assert_eq!(static_ref, "bucket");
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "string_leak", issue = "102929")]
     #[inline]
-    pub fn leak<'a>(self) -> &'a mut str {
-        let slice = self.into_bytes().leak();
+    pub fn leak(self) -> &'static mut str {
+        let slice = self.vec.leak();
         unsafe { from_utf8_unchecked_mut(slice) }
     }
 }


### PR DESCRIPTION
Implementation of `String::leak` (#102929)

ACP: https://github.com/rust-lang/libs-team/issues/109

**Superseded by: #103280**