### PR TITLE
Properly support LUB for ReErased

### DIFF
--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -532,9 +532,12 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
     #[instrument(level = "trace", skip(self), ret)]
     fn lub_concrete_regions(&self, a: Region<'tcx>, b: Region<'tcx>) -> Region<'tcx> {
         match (*a, *b) {
-            (ReLateBound(..), _) | (_, ReLateBound(..)) | (ReErased, _) | (_, ReErased) => {
+            (ReLateBound(..), _) | (_, ReLateBound(..)) => {
                 bug!("cannot relate region: LUB({:?}, {:?})", a, b);
             }
+
+            (_, ReErased) => a,
+            (ReErased, _) => b,
 
             (ReVar(v_id), _) | (_, ReVar(v_id)) => {
                 span_bug!(

--- a/src/test/ui/impl-trait/unconstrained-tait-region-2.rs
+++ b/src/test/ui/impl-trait/unconstrained-tait-region-2.rs
@@ -1,0 +1,29 @@
+// check-pass
+// edition:2021
+
+#![feature(type_alias_impl_trait)]
+
+use std::future::Future;
+
+pub trait Ctx {}
+
+pub trait MyTrait {
+    type AssocT<'m, C>: Future<Output = ()> + 'm
+    where
+        Self: 'm,
+        C: Ctx + 'm;
+    fn run<'d, C: Ctx + 'd>(&mut self, c: C) -> Self::AssocT<'_, C>;
+}
+
+pub struct MyType;
+
+impl MyTrait for MyType {
+    type AssocT<'m, C> = impl Future<Output = ()> + 'm where Self: 'm, C: Ctx + 'm;
+    fn run<'d, C: Ctx + 'd>(&mut self, c: C) -> Self::AssocT<'_, C> {
+        async move {}
+    }
+}
+
+fn main() {
+    let t = MyType;
+}

--- a/src/test/ui/impl-trait/unconstrained-tait-region.rs
+++ b/src/test/ui/impl-trait/unconstrained-tait-region.rs
@@ -1,0 +1,38 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct Output;
+
+trait Service {
+    type OutputStream;
+
+    fn stream<'l, 'a>(&'l self) -> Self::OutputStream
+    where
+        Self: 'a,
+        'l: 'a;
+}
+
+trait Stream {
+    type Item;
+}
+
+struct ImplStream<F: Fn()>(F);
+
+impl<F: Fn()> Stream for ImplStream<F> {
+    type Item = Output;
+}
+
+impl Service for () {
+    type OutputStream = impl Stream<Item = Output>;
+
+    fn stream<'l, 'a>(&'l self) -> Self::OutputStream
+    where
+        Self: 'a,
+        'l: 'a,
+    {
+        ImplStream(|| ())
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This is needed to properly [check obligations](https://github.com/rust-lang/rust/blob/3e01d072f7db1279a5d6e15b107040a9a2c78831/compiler/rustc_hir_analysis/src/check/check.rs#L746) on opaque types, since instead of returning ReEmpty, we now return ReErased for [unconstrained regions](https://github.com/rust-lang/rust/blob/3e01d072f7db1279a5d6e15b107040a9a2c78831/compiler/rustc_borrowck/src/region_infer/opaque_types.rs#L112) in MIR borrowck.

This shouldn't be unsafe for now, but it does kinda risk future bugs if we accidentally allow `ReEmpty` to leak into other inference contexts, since LUB would cause an ICE that is very obvious to see otherwise. I'm not really certain how to fix this other than reintroducing a `ReRootEmpty` region for opaque type inference that properly represents an unconstrained opaque lifetime..

cc @oli-obk and @jackh726 
not sure which of y'all to request review from, so I flipped a coin and it landed on heads. therefore r? @oli-obk, feel free to reassign though.

Fixes #102649
Fixes #102510

Originally caused by #98559