### PR TITLE
Do not register placeholder `RegionOutlives` obligations when `considering_regions` is false

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -355,7 +355,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                 }
 
                 ty::PredicateKind::RegionOutlives(data) => {
-                    if infcx.considering_regions || data.has_placeholders() {
+                    if infcx.considering_regions {
                         infcx.region_outlives_predicate(&obligation.cause, Binder::dummy(data));
                     }
 

--- a/src/test/ui/higher-rank-trait-bounds/issue-100689.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-100689.rs
@@ -1,0 +1,29 @@
+// check-pass
+
+struct Foo<'a> {
+    foo: &'a mut usize,
+}
+
+trait Bar<'a> {
+    type FooRef<'b>
+    where
+        'a: 'b;
+    fn uwu(foo: Foo<'a>, f: impl for<'b> FnMut(Self::FooRef<'b>));
+}
+impl<'a> Bar<'a> for () {
+    type FooRef<'b>
+    =
+        &'b Foo<'a>
+    where
+        'a : 'b,
+    ;
+
+    fn uwu(
+        foo: Foo<'a>,
+        mut f: impl for<'b> FnMut(&'b Foo<'a>), //relevant part
+    ) {
+        f(&foo);
+    }
+}
+
+fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/issue-102899.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-102899.rs
@@ -1,0 +1,32 @@
+// check-pass
+
+pub trait BufferTrait<'buffer> {
+    type Subset<'channel>
+    where
+        'buffer: 'channel;
+
+    fn for_each_subset<F>(&self, f: F)
+    where
+        F: for<'channel> Fn(Self::Subset<'channel>);
+}
+
+pub struct SomeBuffer<'buffer> {
+    samples: &'buffer [()],
+}
+
+impl<'buffer> BufferTrait<'buffer> for SomeBuffer<'buffer> {
+    type Subset<'subset> = Subset<'subset> where 'buffer: 'subset;
+
+    fn for_each_subset<F>(&self, _f: F)
+    where
+        F: for<'subset> Fn(Subset<'subset>),
+    {
+        todo!()
+    }
+}
+
+pub struct Subset<'subset> {
+    buffer: &'subset [()],
+}
+
+fn main() {}


### PR DESCRIPTION
**NOTE:** I'm kinda just putting this up for discussion. I'm not certain this is correct...?

This was introduced in [`608625d`](https://github.com/rust-lang/rust/commit/608625dae95cde00e4570eb6c2d63b2244bbf34c#diff-6e54b18681342ec725d75591dbf384ad08cd73df29db00485fe51b4e90f76ff7R361). 

Interestingly, we only check `data.has_placeholders()` for `RegionOutlives`, and not for `TypeOutlives`... why? For the record, that different treatment between `RegionOutlives` and `TypeOutlives` is why the fix "The compiling succeeds when all `'a : 'b` are replaced with `&'a () : 'b`" in #100689 _"works"_, but it seems like an implementation detail considering this.

Also, why do we care about placeholder regions being registered if `considering_regions` is false? It doesn't seem to affect any UI tests, for example.

r? @lcnr

Fixes #102899
Fixes #100689