### PR TITLE
Sort elaborated existential predicates in `object_ty_for_trait`

### DIFF
--- a/src/test/ui/object-safety/issue-102933.rs
+++ b/src/test/ui/object-safety/issue-102933.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+use std::future::Future;
+
+pub trait Service {
+    type Response;
+    type Future: Future<Output = Self::Response>;
+}
+
+pub trait A1: Service<Response = i32> {}
+
+pub trait A2: Service<Future = Box<dyn Future<Output = i32>>> + A1 {
+    fn foo(&self) {}
+}
+
+pub trait B1: Service<Future = Box<dyn Future<Output = i32>>> {}
+
+pub trait B2: Service<Response = i32> + B1 {
+    fn foo(&self) {}
+}
+
+fn main() {
+    let x: &dyn A2 = todo!();
+    let x: &dyn B2 = todo!();
+}


### PR DESCRIPTION
r? @cjgillot 

I think that #102845 caused #102933. Depending on the order that we elaborate these existential projection predicates, there's no guarantee that they'll be sorted by def id, which is what is failing the assertion in the issue.

Fixes #102933
Fixes #102973