### PR TITLE
suggest type annotation for local statement initialed by ref expression

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -714,7 +714,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &hir::Expr<'tcx>,
         checked_ty: Ty<'tcx>,
         expected: Ty<'tcx>,
-    ) -> Option<(Span, String, String, Applicability, bool /* verbose */)> {
+    ) -> Option<(
+        Span,
+        String,
+        String,
+        Applicability,
+        bool, /* verbose */
+        bool, /* suggest `&` or `&mut` type annotation */
+    )> {
         let sess = self.sess();
         let sp = expr.span;
 
@@ -746,6 +753,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     String::new(),
                                     Applicability::MachineApplicable,
                                     true,
+                                    false,
                                 ));
                             }
                         }
@@ -760,6 +768,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     "b".to_string(),
                                     Applicability::MachineApplicable,
                                     true,
+                                    false,
                                 ));
                     }
                 }
@@ -817,6 +826,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 sugg.2,
                                 Applicability::MachineApplicable,
                                 false,
+                                false,
                             ));
                         }
 
@@ -844,12 +854,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 format!("{prefix}&mut {sugg_expr}"),
                                 Applicability::MachineApplicable,
                                 false,
+                                false,
                             ),
                             hir::Mutability::Not => (
                                 sp,
                                 "consider borrowing here".to_string(),
                                 format!("{prefix}&{sugg_expr}"),
                                 Applicability::MachineApplicable,
+                                false,
                                 false,
                             ),
                         });
@@ -880,6 +892,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             String::new(),
                             Applicability::MachineApplicable,
                             true,
+                            true
                         ));
                     }
                     return None;
@@ -892,6 +905,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         "consider removing the borrow".to_string(),
                         String::new(),
                         Applicability::MachineApplicable,
+                        true,
                         true,
                     ));
                 }
@@ -959,6 +973,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             src,
                             applicability,
                             true,
+                            false,
                         ));
                     }
                 }
@@ -999,6 +1014,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 Applicability::MachineApplicable
                             },
                             true,
+                            false,
                         ));
                     }
 
@@ -1050,6 +1066,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             suggestion,
                             Applicability::MachineApplicable,
                             true,
+                            false,
                         ));
                     }
                 }

--- a/src/test/ui/suggestions/format-borrow.stderr
+++ b/src/test/ui/suggestions/format-borrow.stderr
@@ -11,6 +11,10 @@ help: consider removing the borrow
 LL -     let a: String = &String::from("a");
 LL +     let a: String = String::from("a");
    |
+help: alternatively, consider changing the type annotation
+   |
+LL |     let a: &String = &String::from("a");
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/format-borrow.rs:4:21
@@ -25,6 +29,10 @@ help: consider removing the borrow
 LL -     let b: String = &format!("b");
 LL +     let b: String = format!("b");
    |
+help: alternatively, consider changing the type annotation
+   |
+LL |     let b: &String = &format!("b");
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/format-borrow.rs:6:21
@@ -39,6 +47,10 @@ help: consider removing the borrow
 LL -     let c: String = &mut format!("c");
 LL +     let c: String = format!("c");
    |
+help: alternatively, consider changing the type annotation
+   |
+LL |     let c: &mut String = &mut format!("c");
+   |            ++++
 
 error[E0308]: mismatched types
   --> $DIR/format-borrow.rs:8:21
@@ -53,6 +65,10 @@ help: consider removing the borrow
 LL -     let d: String = &mut (format!("d"));
 LL +     let d: String = format!("d"));
    |
+help: alternatively, consider changing the type annotation
+   |
+LL |     let d: &mut String = &mut (format!("d"));
+   |            ++++
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/issue-102892.rs
+++ b/src/test/ui/suggestions/issue-102892.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code, unused_variables)]
+
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct A;
+#[derive(Debug)]
+struct B;
+
+fn process_without_annot(arc: &Arc<(A, B)>) {
+    let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+}
+
+fn process_with_annot(arc: &Arc<(A, B)>) {
+    let (a, b): (A, B) = &**arc; // suggests putting `&**arc` here too
+    //~^ ERROR mismatched types
+}
+
+fn process_with_tuple_annot(mutation: &mut (A, B), arc: &Arc<(A, B)>) {
+    let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-102892.stderr
+++ b/src/test/ui/suggestions/issue-102892.stderr
@@ -1,0 +1,57 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-102892.rs:15:26
+   |
+LL |     let (a, b): (A, B) = &**arc; // suggests putting `&**arc` here too
+   |                 ------   ^^^^^^ expected tuple, found `&(A, B)`
+   |                 |
+   |                 expected due to this
+   |
+   = note:  expected tuple `(A, B)`
+           found reference `&(A, B)`
+help: consider removing the borrow
+   |
+LL -     let (a, b): (A, B) = &**arc; // suggests putting `&**arc` here too
+LL +     let (a, b): (A, B) = **arc; // suggests putting `&**arc` here too
+   |
+help: alternatively, consider changing the type annotation
+   |
+LL |     let (a, b): &(A, B) = &**arc; // suggests putting `&**arc` here too
+   |                 +
+
+error[E0308]: mismatched types
+  --> $DIR/issue-102892.rs:20:32
+   |
+LL |     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
+   |                                ^^^^^^^^^^^^^^ expected tuple, found `&mut (A, B)`
+   |
+   = note:          expected tuple `(A, B)`
+           found mutable reference `&mut (A, B)`
+help: consider removing the borrow
+   |
+LL -     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
+LL +     let (a, b): ((A, B), A) = (*mutation, &(**arc).0); // suggests putting `&**arc` here too
+   |
+help: alternatively, consider changing the type annotation
+   |
+LL |     let (a, b): (&mut (A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
+   |                  ++++
+
+error[E0308]: mismatched types
+  --> $DIR/issue-102892.rs:20:48
+   |
+LL |     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
+   |                                                ^^^^^^^^^^ expected struct `A`, found `&A`
+   |
+help: consider removing the borrow
+   |
+LL -     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
+LL +     let (a, b): ((A, B), A) = (&mut *mutation, (**arc).0); // suggests putting `&**arc` here too
+   |
+help: alternatively, consider changing the type annotation
+   |
+LL |     let (a, b): ((A, B), &A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
+   |                          +
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
In a local statement with a type declaration, if a ref expression is used on the right side and not used on the left side, in addition to removing the `&` and `&mut` on the right side, we can add them on the left side alternatively
Fixes #102892