### PR TITLE
Add missing checks for `doc(cfg_hide(...))`

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -145,6 +145,9 @@ passes_doc_test_takes_list =
 passes_doc_primitive =
     `doc(primitive)` should never have been stable
 
+passes_doc_cfg_hide_takes_list =
+    `#[doc(cfg_hide(...)]` takes a list of attributes
+
 passes_doc_test_unknown_any =
     unknown `doc` attribute `{$path}`
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -272,6 +272,10 @@ pub struct DocTestUnknown {
 pub struct DocTestTakesList;
 
 #[derive(LintDiagnostic)]
+#[diag(passes::doc_cfg_hide_takes_list)]
+pub struct DocCfgHideTakesList;
+
+#[derive(LintDiagnostic)]
 #[diag(passes::doc_primitive)]
 pub struct DocPrimitive;
 

--- a/src/test/rustdoc-ui/doc_cfg_hide.rs
+++ b/src/test/rustdoc-ui/doc_cfg_hide.rs
@@ -1,0 +1,11 @@
+#![feature(doc_cfg_hide)]
+#![deny(warnings)]
+
+#![doc(cfg_hide = "test")] //~ ERROR
+//~^ WARN
+#![doc(cfg_hide)] //~ ERROR
+//~^ WARN
+
+#[doc(cfg_hide(doc))] //~ ERROR
+//~^ WARN
+pub fn foo() {}

--- a/src/test/rustdoc-ui/doc_cfg_hide.stderr
+++ b/src/test/rustdoc-ui/doc_cfg_hide.stderr
@@ -1,0 +1,40 @@
+error: this attribute can only be applied at the crate level
+  --> $DIR/doc_cfg_hide.rs:9:7
+   |
+LL | #[doc(cfg_hide(doc))]
+   |       ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
+note: the lint level is defined here
+  --> $DIR/doc_cfg_hide.rs:2:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+help: to apply to the crate, use an inner attribute
+   |
+LL | #![doc(cfg_hide(doc))]
+   | ~~~~~~~~~~~~~~~~~~~~~~
+
+error: `#[doc(cfg_hide(...)]` takes a list of attributes
+  --> $DIR/doc_cfg_hide.rs:4:8
+   |
+LL | #![doc(cfg_hide = "test")]
+   |        ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: `#[doc(cfg_hide(...)]` takes a list of attributes
+  --> $DIR/doc_cfg_hide.rs:6:8
+   |
+LL | #![doc(cfg_hide)]
+   |        ^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Part of  #43781.

The `doc(cfg_hide(...))` attribute can only be used at the crate level and takes a list of attributes as argument.

r? @Manishearth 