### PR TITLE
Remove `ptr` from `AtomicPtr::fetch_{add,sub}` method names

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1477,7 +1477,7 @@ impl<T> AtomicPtr<T> {
     /// work with a deliberately misaligned pointer. In such cases, you may use
     /// the [`fetch_byte_add`](Self::fetch_byte_add) method instead.
     ///
-    /// `fetch_ptr_add` takes an [`Ordering`] argument which describes the
+    /// `fetch_add` takes an [`Ordering`] argument which describes the
     /// memory ordering of this operation. All ordering modes are possible. Note
     /// that using [`Acquire`] makes the store part of this operation
     /// [`Relaxed`], and using [`Release`] makes the load part [`Relaxed`].
@@ -1494,7 +1494,7 @@ impl<T> AtomicPtr<T> {
     /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let atom = AtomicPtr::<i64>::new(core::ptr::null_mut());
-    /// assert_eq!(atom.fetch_ptr_add(1, Ordering::Relaxed).addr(), 0);
+    /// assert_eq!(atom.fetch_add(1, Ordering::Relaxed).addr(), 0);
     /// // Note: units of `size_of::<i64>()`.
     /// assert_eq!(atom.load(Ordering::Relaxed).addr(), 8);
     /// ```
@@ -1502,7 +1502,7 @@ impl<T> AtomicPtr<T> {
     #[cfg(target_has_atomic = "ptr")]
     #[unstable(feature = "strict_provenance_atomic_ptr", issue = "99108")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    pub fn fetch_ptr_add(&self, val: usize, order: Ordering) -> *mut T {
+    pub fn fetch_add(&self, val: usize, order: Ordering) -> *mut T {
         self.fetch_byte_add(val.wrapping_mul(core::mem::size_of::<T>()), order)
     }
 
@@ -1518,7 +1518,7 @@ impl<T> AtomicPtr<T> {
     /// work with a deliberately misaligned pointer. In such cases, you may use
     /// the [`fetch_byte_sub`](Self::fetch_byte_sub) method instead.
     ///
-    /// `fetch_ptr_sub` takes an [`Ordering`] argument which describes the memory
+    /// `fetch_sub` takes an [`Ordering`] argument which describes the memory
     /// ordering of this operation. All ordering modes are possible. Note that
     /// using [`Acquire`] makes the store part of this operation [`Relaxed`],
     /// and using [`Release`] makes the load part [`Relaxed`].
@@ -1538,7 +1538,7 @@ impl<T> AtomicPtr<T> {
     /// let atom = AtomicPtr::new(array.as_ptr().wrapping_add(1) as *mut _);
     ///
     /// assert!(core::ptr::eq(
-    ///     atom.fetch_ptr_sub(1, Ordering::Relaxed),
+    ///     atom.fetch_sub(1, Ordering::Relaxed),
     ///     &array[1],
     /// ));
     /// assert!(core::ptr::eq(atom.load(Ordering::Relaxed), &array[0]));
@@ -1547,7 +1547,7 @@ impl<T> AtomicPtr<T> {
     #[cfg(target_has_atomic = "ptr")]
     #[unstable(feature = "strict_provenance_atomic_ptr", issue = "99108")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    pub fn fetch_ptr_sub(&self, val: usize, order: Ordering) -> *mut T {
+    pub fn fetch_sub(&self, val: usize, order: Ordering) -> *mut T {
         self.fetch_byte_sub(val.wrapping_mul(core::mem::size_of::<T>()), order)
     }
 

--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -131,13 +131,13 @@ fn int_max() {
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
 fn ptr_add_null() {
     let atom = AtomicPtr::<i64>::new(core::ptr::null_mut());
-    assert_eq!(atom.fetch_ptr_add(1, SeqCst).addr(), 0);
+    assert_eq!(atom.fetch_add(1, SeqCst).addr(), 0);
     assert_eq!(atom.load(SeqCst).addr(), 8);
 
     assert_eq!(atom.fetch_byte_add(1, SeqCst).addr(), 8);
     assert_eq!(atom.load(SeqCst).addr(), 9);
 
-    assert_eq!(atom.fetch_ptr_sub(1, SeqCst).addr(), 9);
+    assert_eq!(atom.fetch_sub(1, SeqCst).addr(), 9);
     assert_eq!(atom.load(SeqCst).addr(), 1);
 
     assert_eq!(atom.fetch_byte_sub(1, SeqCst).addr(), 1);
@@ -150,10 +150,10 @@ fn ptr_add_data() {
     let num = 0i64;
     let n = &num as *const i64 as *mut _;
     let atom = AtomicPtr::<i64>::new(n);
-    assert_eq!(atom.fetch_ptr_add(1, SeqCst), n);
+    assert_eq!(atom.fetch_add(1, SeqCst), n);
     assert_eq!(atom.load(SeqCst), n.wrapping_add(1));
 
-    assert_eq!(atom.fetch_ptr_sub(1, SeqCst), n.wrapping_add(1));
+    assert_eq!(atom.fetch_sub(1, SeqCst), n.wrapping_add(1));
     assert_eq!(atom.load(SeqCst), n);
     let bytes_from_n = |b| n.wrapping_byte_add(b);
 

--- a/src/tools/miri/tests/pass/atomic.rs
+++ b/src/tools/miri/tests/pass/atomic.rs
@@ -164,9 +164,9 @@ fn atomic_ptr() {
     );
     ptr.store(x, Relaxed);
 
-    assert_eq!(ptr.fetch_ptr_add(13, AcqRel).addr(), x.addr());
+    assert_eq!(ptr.fetch_add(13, AcqRel).addr(), x.addr());
     unsafe { assert_eq!(*ptr.load(SeqCst), 13) }; // points to index 13 now
-    assert_eq!(ptr.fetch_ptr_sub(4, AcqRel).addr(), x.addr() + 13 * 4);
+    assert_eq!(ptr.fetch_sub(4, AcqRel).addr(), x.addr() + 13 * 4);
     unsafe { assert_eq!(*ptr.load(SeqCst), 9) };
     assert_eq!(ptr.fetch_or(3, AcqRel).addr(), x.addr() + 9 * 4); // ptr is 4-aligned, so set the last 2 bits
     assert_eq!(ptr.fetch_and(!3, AcqRel).addr(), (x.addr() + 9 * 4) | 3); // and unset them again


### PR DESCRIPTION
Rename `AtomicPtr::{fetch_ptr_add => fetch_add, fetch_ptr_sub => fetch_sub}`.

Reasoning TL;DR: new naming is consistent with other `Atomic*` and `pointer` methods, see https://github.com/rust-lang/rust/issues/99108#issuecomment-1272332432

r? @thomcc 