### PR TITLE
remove HRTB from `[T]::is_sorted_by{,_key}`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3724,9 +3724,9 @@ impl<T> [T] {
     /// [`is_sorted`]: slice::is_sorted
     #[unstable(feature = "is_sorted", reason = "new API", issue = "53485")]
     #[must_use]
-    pub fn is_sorted_by<F>(&self, mut compare: F) -> bool
+    pub fn is_sorted_by<'a, F>(&'a self, mut compare: F) -> bool
     where
-        F: FnMut(&T, &T) -> Option<Ordering>,
+        F: FnMut(&'a T, &'a T) -> Option<Ordering>,
     {
         self.iter().is_sorted_by(|a, b| compare(*a, *b))
     }
@@ -3750,9 +3750,9 @@ impl<T> [T] {
     #[inline]
     #[unstable(feature = "is_sorted", reason = "new API", issue = "53485")]
     #[must_use]
-    pub fn is_sorted_by_key<F, K>(&self, f: F) -> bool
+    pub fn is_sorted_by_key<'a, F, K>(&'a self, f: F) -> bool
     where
-        F: FnMut(&T) -> K,
+        F: FnMut(&'a T) -> K,
         K: PartialOrd,
     {
         self.iter().is_sorted_by_key(f)

--- a/src/test/ui/array-slice-vec/slice_is_sorted_by_borrow.rs
+++ b/src/test/ui/array-slice-vec/slice_is_sorted_by_borrow.rs
@@ -1,0 +1,20 @@
+// check-pass
+// regression test for https://github.com/rust-lang/rust/issues/53485#issuecomment-885393452
+
+#![feature(is_sorted)]
+
+struct A {
+    name: String,
+}
+
+fn main() {
+    let a = &[
+        A {
+            name: "1".to_string(),
+        },
+        A {
+            name: "2".to_string(),
+        },
+    ];
+    assert!(a.is_sorted_by_key(|a| a.name.as_str()));
+}


### PR DESCRIPTION
Changes the signature of `[T]::is_sorted_by{,_key}` to match `[T]::binary_search_by{,_key}` and make code like https://github.com/rust-lang/rust/issues/53485#issuecomment-885393452 compile.

Tracking issue: https://github.com/rust-lang/rust/issues/53485

~~Do we need an ACP for something like this?~~ Edit: Filed ACP here: https://github.com/rust-lang/libs-team/issues/121