### PR TITLE
rustdoc: merge separate `.item-info` CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -694,14 +694,11 @@ pre, .rustdoc.source .example-wrap {
 
 .item-info {
 	display: block;
-}
-
-.content .item-info code {
-	font-size: 0.875rem;
-}
-
-.content .item-info {
 	margin-left: 24px;
+}
+
+.item-info code {
+	font-size: 0.875rem;
 }
 
 #main-content > .item-info {
@@ -1948,7 +1945,7 @@ in storage.js plus the media query with (min-width: 701px)
 	}
 
 	/* Align summary-nested and unnested item-info gizmos. */
-	.content .impl-items > .item-info {
+	.impl-items > .item-info {
 		margin-left: 34px;
 	}
 }


### PR DESCRIPTION
Rough timeline:

* The longer `.content .item-info` selector originated in 110e7270ab7b0700ce714b8b1c7e509195dea2c4. No reason seems to be given in the PR why it needed the `.content` part, but it was probably added because of <https://github.com/rust-lang/rust/blob/110e7270ab7b0700ce714b8b1c7e509195dea2c4/src/librustdoc/html/static/rustdoc.css#L476-L478>. That selector with the margin-bottom was removed when CSS containment was added in 8846c0853d8687fda0e5f23f6687b03b243980ee.
* `.stability` was renamed `.item-info` in caf6c5790a858893c1d32ed2054c9577d12e7493.
* The selector without the `.content` was added in d48a39a5e24ab08f727d1c919dc2af98c333ad14.