### PR TITLE
Add suggestion to the "missing native library" error

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/metadata.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/metadata.ftl
@@ -165,6 +165,8 @@ metadata_failed_write_error =
 metadata_missing_native_library =
     could not find native static library `{$libname}`, perhaps an -L flag is missing?
 
+metadata_only_provide_library_name = only provide the library name `{$suggested_name}`, not the full filename
+
 metadata_failed_create_tempdir =
     couldn't create a temp dir: {$err}
 

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -52,7 +52,7 @@ pub fn find_native_static_library(
         }
     }
 
-    sess.emit_fatal(MissingNativeLibrary { libname: name });
+    sess.emit_fatal(MissingNativeLibrary::new(name, verbatim.unwrap_or(false)));
 }
 
 fn find_bundled_library(

--- a/src/test/ui/native-library-link-flags/suggest-libname-only-1.rs
+++ b/src/test/ui/native-library-link-flags/suggest-libname-only-1.rs
@@ -1,0 +1,9 @@
+// build-fail
+// compile-flags: --crate-type rlib
+// error-pattern: could not find native static library `libfoo.a`
+// error-pattern: only provide the library name `foo`, not the full filename
+
+#[link(name = "libfoo.a", kind = "static")]
+extern { }
+
+pub fn main() { }

--- a/src/test/ui/native-library-link-flags/suggest-libname-only-1.stderr
+++ b/src/test/ui/native-library-link-flags/suggest-libname-only-1.stderr
@@ -1,0 +1,6 @@
+error: could not find native static library `libfoo.a`, perhaps an -L flag is missing?
+   |
+   = help: only provide the library name `foo`, not the full filename
+
+error: aborting due to previous error
+

--- a/src/test/ui/native-library-link-flags/suggest-libname-only-2.rs
+++ b/src/test/ui/native-library-link-flags/suggest-libname-only-2.rs
@@ -1,0 +1,9 @@
+// build-fail
+// compile-flags: --crate-type rlib
+// error-pattern: could not find native static library `bar.lib`
+// error-pattern: only provide the library name `bar`, not the full filename
+
+#[link(name = "bar.lib", kind = "static")]
+extern { }
+
+pub fn main() { }

--- a/src/test/ui/native-library-link-flags/suggest-libname-only-2.stderr
+++ b/src/test/ui/native-library-link-flags/suggest-libname-only-2.stderr
@@ -1,0 +1,6 @@
+error: could not find native static library `bar.lib`, perhaps an -L flag is missing?
+   |
+   = help: only provide the library name `bar`, not the full filename
+
+error: aborting due to previous error
+


### PR DESCRIPTION
If we fail to locate a native library that we are linking with, it could be the case the user entered a complete file name like `foo.lib` or `libfoo.a` when we expect them to simply provide `foo`.

In this situation, we now detect that case and suggest the user only provide the library name itself.