### PR TITLE
rustdoc: don't ICE on `TyKind::Typeof`

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1543,8 +1543,7 @@ pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> T
         }
         TyKind::BareFn(barefn) => BareFunction(Box::new(clean_bare_fn_ty(barefn, cx))),
         // Rustdoc handles `TyKind::Err`s by turning them into `Type::Infer`s.
-        TyKind::Infer | TyKind::Err => Infer,
-        TyKind::Typeof(..) => panic!("unimplemented type {:?}", ty.kind),
+        TyKind::Infer | TyKind::Err | TyKind::Typeof(..) => Infer,
     }
 }
 

--- a/src/test/rustdoc-ui/issue-102986.rs
+++ b/src/test/rustdoc-ui/issue-102986.rs
@@ -1,0 +1,4 @@
+struct Struct {
+    y: (typeof("hey"),),
+    //~^ `typeof` is a reserved keyword but unimplemented
+}

--- a/src/test/rustdoc-ui/issue-102986.stderr
+++ b/src/test/rustdoc-ui/issue-102986.stderr
@@ -1,0 +1,14 @@
+error[E0516]: `typeof` is a reserved keyword but unimplemented
+  --> $DIR/issue-102986.rs:2:9
+   |
+LL |     y: (typeof("hey"),),
+   |         ^^^^^^^^^^^^^ reserved keyword
+   |
+help: consider replacing `typeof(...)` with an actual type
+   |
+LL |     y: (&'static str,),
+   |         ~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0516`.


### PR DESCRIPTION
Fixes #102986

I'm not sure why rustdoc started seeing `TyKind::Typeof` all of a sudden (the code being editted was last touched 3 months ago), probably something to do with error recovery? idk.