### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -909,8 +909,6 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     return;
                 }
 
-                let is_intrinsic = tcx.is_intrinsic(callee);
-
                 if !tcx.is_const_fn_raw(callee) {
                     if !tcx.is_const_default_method(callee) {
                         // To get to here we must have already found a const impl for the
@@ -970,7 +968,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     // We do not use `const` modifiers for intrinsic "functions", as intrinsics are
                     // `extern` functions, and these have no way to get marked `const`. So instead we
                     // use `rustc_const_(un)stable` attributes to mean that the intrinsic is `const`
-                    if self.ccx.is_const_stable_const_fn() || is_intrinsic {
+                    if self.ccx.is_const_stable_const_fn() || tcx.is_intrinsic(callee) {
                         self.check_op(ops::FnCallUnstable(callee, None));
                         return;
                     }

--- a/compiler/rustc_hir_analysis/src/check/expr.rs
+++ b/compiler/rustc_hir_analysis/src/check/expr.rs
@@ -1051,8 +1051,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 rhs_expr,
             ) = lhs.kind
             {
+                // if x == 1 && y == 2 { .. }
+                //                 +
                 let actual_lhs_ty = self.check_expr(&rhs_expr);
                 (Applicability::MaybeIncorrect, self.can_coerce(rhs_ty, actual_lhs_ty))
+            } else if let ExprKind::Binary(
+                Spanned { node: hir::BinOpKind::And | hir::BinOpKind::Or, .. },
+                lhs_expr,
+                _,
+            ) = rhs.kind
+            {
+                // if x == 1 && y == 2 { .. }
+                //       +
+                let actual_rhs_ty = self.check_expr(&lhs_expr);
+                (Applicability::MaybeIncorrect, self.can_coerce(actual_rhs_ty, lhs_ty))
             } else {
                 (Applicability::MaybeIncorrect, false)
             };

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -637,7 +637,9 @@ pub trait PrettyPrinter<'tcx>:
                 p!(print_def_path(def_id, &[]));
             }
             ty::Projection(ref data) => {
-                if self.tcx().def_kind(data.item_def_id) == DefKind::ImplTraitPlaceholder {
+                if !(self.tcx().sess.verbose() || NO_QUERIES.with(|q| q.get()))
+                    && self.tcx().def_kind(data.item_def_id) == DefKind::ImplTraitPlaceholder
+                {
                     return self.pretty_print_opaque_impl_type(data.item_def_id, data.substs);
                 } else {
                     p!(print(data))

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1969,7 +1969,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                     None
                 }
             })
-            .map(|res| res.expect_full_res())
+            .and_then(|res| res.full_res())
             .filter(|res| {
                 // Permit the types that unambiguously always
                 // result in the same type constructor being used

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -767,6 +767,16 @@ pub mod guard {
             const GUARD_PAGES: usize = 1;
             let guard = guardaddr..guardaddr + GUARD_PAGES * page_size;
             Some(guard)
+        } else if cfg!(target_os = "openbsd") {
+            // OpenBSD stack already includes a guard page, and stack is
+            // immutable.
+            //
+            // We'll just note where we expect rlimit to start
+            // faulting, so our handler can report "stack overflow", and
+            // trust that the kernel's own stack guard will work.
+            let stackptr = get_stack_start_aligned()?;
+            let stackaddr = stackptr.addr();
+            Some(stackaddr - page_size..stackaddr)
         } else {
             // Reallocate the last page of the stack.
             // This ensures SIGBUS will be raised on

--- a/src/test/ui/object-safety/issue-102933.rs
+++ b/src/test/ui/object-safety/issue-102933.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+use std::future::Future;
+
+pub trait Service {
+    type Response;
+    type Future: Future<Output = Self::Response>;
+}
+
+pub trait A1: Service<Response = i32> {}
+
+pub trait A2: Service<Future = Box<dyn Future<Output = i32>>> + A1 {
+    fn foo(&self) {}
+}
+
+pub trait B1: Service<Future = Box<dyn Future<Output = i32>>> {}
+
+pub trait B2: Service<Response = i32> + B1 {
+    fn foo(&self) {}
+}
+
+fn main() {
+    let x: &dyn A2 = todo!();
+    let x: &dyn B2 = todo!();
+}

--- a/src/test/ui/resolve/issue-102946.rs
+++ b/src/test/ui/resolve/issue-102946.rs
@@ -1,0 +1,7 @@
+impl Error for str::Utf8Error {
+    //~^ ERROR cannot find trait `Error` in this scope
+    //~| ERROR ambiguous associated type
+    fn description(&self)  {}
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-102946.stderr
+++ b/src/test/ui/resolve/issue-102946.stderr
@@ -1,0 +1,26 @@
+error[E0405]: cannot find trait `Error` in this scope
+  --> $DIR/issue-102946.rs:1:6
+   |
+LL | impl Error for str::Utf8Error {
+   |      ^^^^^ not found in this scope
+   |
+help: consider importing this trait
+   |
+LL | use std::error::Error;
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/issue-102946.rs:1:16
+   |
+LL | impl Error for str::Utf8Error {
+   |                ^^^^^^^^^^^^^^
+   |
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL | impl Error for std::str::Utf8Error {
+   |                +++++
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0223, E0405.
+For more information about an error, try `rustc --explain E0223`.

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-102985.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-102985.rs
@@ -1,0 +1,11 @@
+#![feature(const_trait_impl)]
+
+struct Bug {
+    inner: [(); match || 1 {
+        n => n(),
+        //~^ ERROR the trait bound
+        //~| ERROR cannot call non-const fn `Bug::inner::{constant#0}::{closure#0}` in constants
+    }],
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-102985.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-102985.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `[closure@$DIR/issue-102985.rs:4:23: 4:25]: ~const Fn<()>` is not satisfied
+  --> $DIR/issue-102985.rs:5:14
+   |
+LL |         n => n(),
+   |              ^^^ expected an `Fn<()>` closure, found `[closure@$DIR/issue-102985.rs:4:23: 4:25]`
+   |
+   = help: the trait `~const Fn<()>` is not implemented for closure `[closure@$DIR/issue-102985.rs:4:23: 4:25]`
+note: the trait `Fn<()>` is implemented for `[closure@$DIR/issue-102985.rs:4:23: 4:25]`, but that implementation is not `const`
+  --> $DIR/issue-102985.rs:5:14
+   |
+LL |         n => n(),
+   |              ^^^
+   = note: wrap the `[closure@$DIR/issue-102985.rs:4:23: 4:25]` in a closure with no arguments: `|| { /* code */ }`
+
+error[E0015]: cannot call non-const fn `Bug::inner::{constant#0}::{closure#0}` in constants
+  --> $DIR/issue-102985.rs:5:14
+   |
+LL |         n => n(),
+   |              ^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/type/type-check/assignment-in-if.rs
+++ b/src/test/ui/type/type-check/assignment-in-if.rs
@@ -53,4 +53,10 @@ fn main() {
         //~| ERROR mismatched types
         println!("{}", x);
     }
+
+    if x = 1 && x == 1 {
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        println!("{}", x);
+    }
 }

--- a/src/test/ui/type/type-check/assignment-in-if.stderr
+++ b/src/test/ui/type/type-check/assignment-in-if.stderr
@@ -104,6 +104,23 @@ help: you might have meant to compare for equality
 LL |     if x == x && x == x && x == x {
    |                               +
 
-error: aborting due to 11 previous errors
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:57:12
+   |
+LL |     if x = 1 && x == 1 {
+   |            ^ expected `bool`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/assignment-in-if.rs:57:8
+   |
+LL |     if x = 1 && x == 1 {
+   |        ^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == 1 && x == 1 {
+   |           +
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #102765 (Suggest `==` to the first expr which has `ExprKind::Assign` kind)
 - #102854 (openbsd: don't reallocate a guard page on the stack.)
 - #102904 (Print return-position `impl Trait` in trait verbosely if `-Zverbose`)
 - #102947 (Sort elaborated existential predicates in `object_ty_for_trait`)
 - #102956 (Use `full_res` instead of `expect_full_res`)
 - #102999 (Delay `is_intrinsic` query until after we've determined the callee is a function)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102765,102854,102904,102947,102956,102999)
<!-- homu-ignore:end -->