### PR TITLE
Avoid dropping TLS Key on sgx

### DIFF
--- a/library/std/src/sys/sgx/abi/tls/mod.rs
+++ b/library/std/src/sys/sgx/abi/tls/mod.rs
@@ -111,6 +111,7 @@ impl Tls {
             rtabort!("TLS limit exceeded")
         };
         TLS_DESTRUCTOR[index].store(dtor.map_or(0, |f| f as usize), Ordering::Relaxed);
+        unsafe { Self::current() }.data[index].set(ptr::null_mut());
         Key::from_index(index)
     }
 


### PR DESCRIPTION
#102655 reenabled dropping thread local `Key` on every platform ([library/std/src/sys_common/thread_local_key.rs](https://github.com/rust-lang-ci/rust/commit/fa0ca783f89a83046e6ce0383385ba5b28296435#diff-5cb9acf9e243f35c975fa9fbac4885519dc104626bc03610dfa7a20bc79641ceL237-R215)). That's causing problems at least for sgx.

cc: @jethrogb @ChrisDenton 