### PR TITLE
Make is_ascii_hexdigit branchless

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1510,8 +1510,10 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        // Bitwise or can avoid need for branches in compiled code.
-        matches!(*self, '0'..='9') || matches!(*self as u32 | 0x20, 0x61..=0x66)
+        // Bitwise or converts A-Z to a-z, avoiding need for branches in compiled code.
+        const A: u32 = 'a' as u32;
+        const F: u32 = 'f' as u32;
+        matches!(*self, '0'..='9') || matches!(*self as u32 | 0x20, A..=F)
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1511,7 +1511,7 @@ impl char {
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         // Bitwise or can avoid need for branches in compiled code.
-        matches!(*self, '0'..='9') || matches!(*self as u32 | 0x20, 0x61..=0x7a)
+        matches!(*self, '0'..='9') || matches!(*self as u32 | 0x20, 0x61..=0x66)
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1511,9 +1511,8 @@ impl char {
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         // Bitwise or converts A-Z to a-z, avoiding need for branches in compiled code.
-        const A: u32 = 'a' as u32;
-        const F: u32 = 'f' as u32;
-        matches!(*self, '0'..='9') || matches!(*self as u32 | 0x20, A..=F)
+        ((*self as u32).wrapping_sub('0' as u32) < 10)
+            | ((*self as u32 | 0x20).wrapping_sub('a' as u32) < 6)
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1510,7 +1510,8 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        matches!(*self, '0'..='9' | 'A'..='F' | 'a'..='f')
+        // Bitwise or can avoid need for branches in compiled code.
+        matches!(*self, '0'..='9') || matches!(*self as u32 | 0x20, 0x61..=0x7a)
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -689,7 +689,7 @@ impl u8 {
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         // Bitwise or can avoid need for branches in compiled code.
-        matches!(*self, b'0'..=b'9') || matches!(*self | 0x20, b'a'..=b'z')
+        matches!(*self, b'0'..=b'9') || matches!(*self | 0x20, b'a'..=b'f')
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -689,7 +689,7 @@ impl u8 {
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         // Bitwise or converts A-Z to a-z, avoiding need for branches in compiled code.
-        matches!(*self, b'0'..=b'9') || matches!(*self | 0x20, b'a'..=b'f')
+        (self.wrapping_sub(b'0') < 10) | ((*self | 0x20).wrapping_sub(b'a') < 6)
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -688,7 +688,7 @@ impl u8 {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        // Bitwise or can avoid need for branches in compiled code.
+        // Bitwise or converts A-Z to a-z, avoiding need for branches in compiled code.
         matches!(*self, b'0'..=b'9') || matches!(*self | 0x20, b'a'..=b'f')
     }
 

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -688,7 +688,8 @@ impl u8 {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        matches!(*self, b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f')
+        // Bitwise or can avoid need for branches in compiled code.
+        matches!(*self, b'0'..=b'9') || matches!(*self | 0x20, b'a'..=b'z')
     }
 
     /// Checks if the value is an ASCII punctuation character:


### PR DESCRIPTION
Relevant issue #72895.

Use a bitwise or with `0x20` to make uppercase letters lowercase before comparing against the range `'a'..='f'`. This offers a significant speedup on my machine in a simple benchmark.

```rust
#![feature(test)]

extern crate test;

const RAND: &'static [u8; 500000] = include_bytes!("random.dat");

#[bench]
fn is_ascii_hex_current(bench: &mut test::Bencher) {
    bench.iter(|| {
        let mut total = 0;
        for byte in RAND.iter() {
            if byte.is_ascii_hexdigit() { total += 1; }
        }
        total
    });
}

#[bench]
fn is_ascii_hex_bitor(bench: &mut test::Bencher) {
    bench.iter(|| {
        let mut total = 0;
        for byte in RAND.iter() {
            if matches!(*byte, b'0'..=b'9') || matches!(*byte | 0x20, b'a'..=b'f') { total += 1; }
        }
        total
    });
}
```

```
test is_ascii_hex_bitor   ... bench:     222,629 ns/iter (+/- 1,426)
test is_ascii_hex_current ... bench:   1,531,543 ns/iter (+/- 25,991)
```

The generated code can also be seen to be branch-free: https://rust.godbolt.org/z/T57hG18hc.

(For reasons which aren't clear to me, `is_ascii_alphanumeric` gets optimized better despite looking very similar so I haven't made the corresponding change there.)