### PR TITLE
rustdoc: remove unused CSS `.search-container > *`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -808,9 +808,6 @@ table,
 	height: 34px;
 	margin-top: 4px;
 }
-.search-container > * {
-	height: 100%;
-}
 .search-results-title {
 	margin-top: 0;
 	white-space: nowrap;


### PR DESCRIPTION
The two items it was really intended to target were the buttons, and those both need to have the style set directly on them anyway because the buttons are both child elements of wrappers.

https://github.com/rust-lang/rust/blob/6b3ede3f7bc502eba7bbd202b4b9312d812adcd7/src/librustdoc/html/static/css/rustdoc.css#L1406-L1411