### PR TITLE
Update pkg-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,9 +2652,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polonius-engine"


### PR DESCRIPTION
I'd like to be able to cross-compile rustc in a scenario where it'd be really helpful to have https://github.com/rust-lang/pkg-config-rs/commit/cd3ccca7c3b89644e74b0217ef93c632efd8ed2a.  I've done some test builds of the compiler on x86_64 linux, targeting x86_64 linux and aarch64 linux.