### PR TITLE
Erase integer and float variables before `needs_drop` calls in HIR generator analysis

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/generator_interior.rs
+++ b/compiler/rustc_hir_analysis/src/check/generator_interior.rs
@@ -378,9 +378,11 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
 
         let ty = self.fcx.typeck_results.borrow().expr_ty_adjusted_opt(expr);
         let may_need_drop = |ty: Ty<'tcx>| {
-            // Avoid ICEs in needs_drop.
             let ty = self.fcx.resolve_vars_if_possible(ty);
+            // Regions are not needed to prove if something needs drop
             let ty = self.fcx.tcx.erase_regions(ty);
+            // All int/float types are trivially drop, so those infer variables can be erased
+            let ty = self.fcx.resolve_numeric_literals_with_default(ty);
             if ty.needs_infer() {
                 return true;
             }

--- a/compiler/rustc_hir_analysis/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
+++ b/compiler/rustc_hir_analysis/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
@@ -198,6 +198,10 @@ impl<'tcx> expr_use_visitor::Delegate<'tcx> for ExprUseDelegate<'tcx> {
 
         // If the type being assigned needs dropped, then the mutation counts as a borrow
         // since it is essentially doing `Drop::drop(&mut x); x = new_value;`.
+        //
+        // FIXME(drop-tracking): We need to be more responsible about inference
+        // variables here, since `needs_drop` is a "raw" type query, i.e. it
+        // basically requires types to have been fully resolved.
         if assignee_place.place.base_ty.needs_drop(self.tcx, self.param_env) {
             self.places
                 .borrowed

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1840,9 +1840,8 @@ impl<'tcx> TyOrConstInferVar<'tcx> {
 }
 
 /// Replace `{integer}` with `i32` and `{float}` with `f64`.
-/// Used only for diagnostics.
-struct InferenceLiteralEraser<'tcx> {
-    tcx: TyCtxt<'tcx>,
+pub struct InferenceLiteralEraser<'tcx> {
+    pub tcx: TyCtxt<'tcx>,
 }
 
 impl<'tcx> TypeFolder<'tcx> for InferenceLiteralEraser<'tcx> {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2205,7 +2205,10 @@ impl<'tcx> Ty<'tcx> {
             // These aren't even `Clone`
             ty::Str | ty::Slice(..) | ty::Foreign(..) | ty::Dynamic(..) => false,
 
-            ty::Int(..) | ty::Uint(..) | ty::Float(..) => true,
+            ty::Infer(ty::InferTy::FloatVar(_) | ty::InferTy::IntVar(_))
+            | ty::Int(..)
+            | ty::Uint(..)
+            | ty::Float(..) => true,
 
             // The voldemort ZSTs are fine.
             ty::FnDef(..) => true,

--- a/src/test/ui/generator/issue-102645.rs
+++ b/src/test/ui/generator/issue-102645.rs
@@ -1,0 +1,23 @@
+// compile-flags: -Zdrop-tracking
+
+#![feature(generators, generator_trait)]
+
+use std::ops::Generator;
+use std::pin::Pin;
+
+fn main() {
+    let mut a = 5;
+    let mut b = || {
+        let d = 6;
+        yield;
+        _zzz(); // #break
+        a = d;
+    };
+    Pin::new(&mut b).resume();
+    //~^ ERROR this function takes 1 argument but 0 arguments were supplied
+    // This type error is required to reproduce the ICE...
+}
+
+fn _zzz() {
+    ()
+}

--- a/src/test/ui/generator/issue-102645.stderr
+++ b/src/test/ui/generator/issue-102645.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> $DIR/issue-102645.rs:16:22
+   |
+LL |     Pin::new(&mut b).resume();
+   |                      ^^^^^^-- an argument of type `()` is missing
+   |
+note: associated function defined here
+  --> $SRC_DIR/core/src/ops/generator.rs:LL:COL
+   |
+LL |     fn resume(self: Pin<&mut Self>, arg: R) -> GeneratorState<Self::Yield, Self::Return>;
+   |        ^^^^^^
+help: provide the argument
+   |
+LL |     Pin::new(&mut b).resume(());
+   |                            ~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
This is kinda a follow-up to #102695, which only coincidentally fixes #102645. 

This is a more proper fix, but it may be a "misuse" of the `InferenceLiteralEraser` and `InferCtxt::resolve_numeric_literals_with_default`, which was originally intended only for diagnostics. However, I do feel like this usage is legitimate. For the purposes of drop tracking, we don't care that an int/float infer variable is unresolved, since all builtin int/float types are trivially drop and copy.

Given that there may be a legitimate desire not to use `InferenceLiteralEraser`, that's why I split it up -- only need a review on the last commit in the stack.

r? @lcnr since you reviewed #102695, feel free to reassign.