### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
- "clap 4.0.9",
+ "clap 4.0.15",
  "crates-io",
  "curl",
  "curl-sys",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.9"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",


### PR DESCRIPTION
12 commits in b8f30cb23c4e5f20854a4f683325782b7cff9837..b332991a57c9d055f1864de1eed93e2178d49440 2022-10-10 19:16:06 +0000 to 2022-10-13 22:05:28 +0000
- Differentiate the warning when an alias (built-in or user-defined) shadows an external subcommand (rust-lang/cargo#11170)
- chore: Update tests for latest clap (rust-lang/cargo#11235)
- feat(publish): Support 'publish.timeout' config behind '-Zpublish-timeout' (rust-lang/cargo#11230)
- Add missing edition (rust-lang/cargo#11231)
- doc(profiles): add module level doc (rust-lang/cargo#11219)
- refactor(publish): Clarify which SourceId is being used (rust-lang/cargo#11216)
- Add new SourceKind::SparseRegistry to differentiate sparse registries (rust-lang/cargo#11209)
- Fix deadlock when build scripts are waiting for input on stdin (rust-lang/cargo#11205)
- refactor: New variant `FeaturesFor::ArtifactDep` (rust-lang/cargo#11184)
- Fix rustdoc warning about unclosed HTML tag (rust-lang/cargo#11221)
- refactor(tests): Prepare for wait-for-publish test changes (rust-lang/cargo#11210)
- Add configuration option for controlling crates.io protocol (rust-lang/cargo#11215)