### PR TITLE
Fix `Duration::{try_,}from_secs_f{32,64}(-0.0)`

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -1279,7 +1279,7 @@ macro_rules! try_from_secs {
         const MANT_MASK: $bits_ty = (1 << $mant_bits) - 1;
         const EXP_MASK: $bits_ty = (1 << $exp_bits) - 1;
 
-        if $secs.is_sign_negative() {
+        if $secs < 0.0 {
             return Err(FromFloatSecsError { kind: FromFloatSecsErrorKind::Negative });
         }
 

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -101,6 +101,7 @@
 #![feature(provide_any)]
 #![feature(utf8_chunks)]
 #![feature(is_ascii_octdigit)]
+#![feature(duration_checked_float)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate test;

--- a/library/core/tests/time.rs
+++ b/library/core/tests/time.rs
@@ -467,3 +467,11 @@ fn duration_const() {
     const SATURATING_MUL: Duration = MAX.saturating_mul(2);
     assert_eq!(SATURATING_MUL, MAX);
 }
+
+#[test]
+fn from_neg_zero() {
+    assert_eq!(Duration::try_from_secs_f32(-0.0), Ok(Duration::ZERO));
+    assert_eq!(Duration::try_from_secs_f64(-0.0), Ok(Duration::ZERO));
+    assert_eq!(Duration::from_secs_f32(-0.0), Duration::ZERO);
+    assert_eq!(Duration::from_secs_f64(-0.0), Duration::ZERO);
+}


### PR DESCRIPTION
Make `Duration::{try_,}from_secs_f{32,64}(-0.0)` return `Duration::ZERO` (as they did before #90247) instead of erroring/panicking.

I'll update this PR to remove the `#![feature(duration_checked_float)]` if #102271 is merged before this PR.

Tracking issue for `try_from_secs_f{32,64}`: #83400