### PR TITLE
rustc_codegen_ssa: Use `llvm.invariant` intrinsics on arguments that are immutable references; off by default.

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1235,6 +1235,16 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         // TODO(antoyo)
     }
 
+    fn invariant_start(&mut self, _value_ptr: RValue<'gcc>, _size: Size) -> RValue<'gcc> {
+        // TODO
+        unimplemented!()
+    }
+
+    fn invariant_end(&mut self, _marker_ptr: RValue<'gcc>, _value_ptr: RValue<'gcc>, _size: Size) {
+        // TODO
+        unimplemented!()
+    }
+
     fn call(
         &mut self,
         _typ: Type<'gcc>,

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1113,6 +1113,21 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         self.call_lifetime_intrinsic("llvm.lifetime.end.p0i8", ptr, size);
     }
 
+    fn invariant_start(&mut self, value_ptr: &'ll Value, size: Size) -> &'ll Value {
+        let size = size.bytes();
+        let value_ptr = self.pointercast(value_ptr, self.cx.type_i8p());
+        self.call_intrinsic("llvm.invariant.start.p0i8", &[self.cx.const_u64(size), value_ptr])
+    }
+
+    fn invariant_end(&mut self, marker_ptr: &'ll Value, value_ptr: &'ll Value, size: Size) {
+        let size = size.bytes();
+        let value_ptr = self.pointercast(value_ptr, self.cx.type_i8p());
+        self.call_intrinsic(
+            "llvm.invariant.end.p0i8",
+            &[marker_ptr, self.cx.const_u64(size), value_ptr],
+        );
+    }
+
     fn instrprof_increment(
         &mut self,
         fn_name: &'ll Value,

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -629,6 +629,7 @@ impl<'ll> CodegenCx<'ll, '_> {
         }
 
         let i8p = self.type_i8p();
+        let unitp = self.type_ptr_to(self.type_struct(&[], false));
         let void = self.type_void();
         let i1 = self.type_i1();
         let t_i8 = self.type_i8();
@@ -839,6 +840,9 @@ impl<'ll> CodegenCx<'ll, '_> {
 
         ifn!("llvm.lifetime.start.p0i8", fn(t_i64, i8p) -> void);
         ifn!("llvm.lifetime.end.p0i8", fn(t_i64, i8p) -> void);
+
+        ifn!("llvm.invariant.start.p0i8", fn(t_i64, i8p) -> unitp);
+        ifn!("llvm.invariant.end.p0i8", fn(unitp, t_i64, i8p) -> void);
 
         ifn!("llvm.expect.i1", fn(i1, i1) -> i1);
         ifn!("llvm.eh.typeid.for", fn(i8p) -> t_i32);

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -310,6 +310,9 @@ pub trait BuilderMethods<'a, 'tcx>:
     /// Called for `StorageDead`
     fn lifetime_end(&mut self, ptr: Self::Value, size: Size);
 
+    fn invariant_start(&mut self, ptr: Self::Value, size: Size) -> Self::Value;
+    fn invariant_end(&mut self, marker_ptr: Self::Value, value_ptr: Self::Value, size: Size);
+
     fn instrprof_increment(
         &mut self,
         fn_name: Self::Value,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1295,6 +1295,8 @@ options! {
         an additional `.html` file showing the computed coverage spans."),
     dwarf_version: Option<u32> = (None, parse_opt_number, [TRACKED],
         "version of DWARF debug information to emit (default: 2 or 4, depending on platform)"),
+    emit_invariant_markers: bool = (false, parse_bool, [UNTRACKED],
+        "emit `llvm.invariant` markers, which may enable better optimization (default: no)"),
     emit_stack_sizes: bool = (false, parse_bool, [UNTRACKED],
         "emit a section containing stack size metadata (default: no)"),
     emit_thin_lto: bool = (true, parse_bool, [TRACKED],

--- a/src/test/codegen/invariant-basic.rs
+++ b/src/test/codegen/invariant-basic.rs
@@ -1,0 +1,12 @@
+// compile-flags: -C opt-level=0 -Z emit-invariant-markers=yes
+#![crate_type="lib"]
+
+#[no_mangle]
+pub fn foo(x: &i32) {
+    // CHECK-LABEL: @foo
+    // CHECK: call {{.*}} @llvm.invariant.start{{[^(]*}}(i64 4
+    // CHECK: call void @{{.*}}drop{{.*}}
+    // CHECK: call void @llvm.invariant.end
+    // CHECK: ret void
+    drop(x);
+}

--- a/src/test/rustdoc-ui/z-help.stdout
+++ b/src/test/rustdoc-ui/z-help.stdout
@@ -36,6 +36,7 @@
     -Z                       dump-mir-graphviz=val -- in addition to `.mir` files, create graphviz `.dot` files (and with `-Z instrument-coverage`, also create a `.dot` file for the MIR-derived coverage graph) (default: no)
     -Z                       dump-mir-spanview=val -- in addition to `.mir` files, create `.html` files to view spans for all `statement`s (including terminators), only `terminator` spans, or computed `block` spans (one span encompassing a block's terminator and all statements). If `-Z instrument-coverage` is also enabled, create an additional `.html` file showing the computed coverage spans.
     -Z                           dwarf-version=val -- version of DWARF debug information to emit (default: 2 or 4, depending on platform)
+    -Z                  emit-invariant-markers=val -- emit `llvm.invariant` markers, which may enable better optimization (default: no)
     -Z                        emit-stack-sizes=val -- emit a section containing stack size metadata (default: no)
     -Z                           emit-thin-lto=val -- emit the bc module with thin LTO info (default: yes)
     -Z               export-executable-symbols=val -- export symbols from executables, as if they were dynamic libraries


### PR DESCRIPTION
Optimization failures around reloads and memcpy optimizations are frequently traceable to LLVM's failure to prove that memory can't be mutated by a call or store. This problem is especially acute in Rust, where large values tend to be memcpy'd more often than in C++. Thankfully, Rust has stronger guarantees on mutability available than C++ does, via the strong immutability of `&` references. This should allow LLVM to prove that memory can't be modified by stores and calls in more cases.

We're already using LLVM's `readonly` parameter attribute on such calls. However, the semantics of `readonly` are akin to `const` in C++, in that they only promise to LLVM that the function won't mutate the parameter *through that pointer*, not that the pointed-to memory is immutable for the entire duration of the function. These weak semantics limit the applicability of `readonly` to LLVM's alias analysis. Instead of `readonly`, the correct way to express strong immutability guarantees on memory is through the `llvm.invariant.start` and `llvm.invariant.end` intrinsics. These enable a frontend like `rustc` to describe immutability of memory regions in an expressive, flow-sensitive manner.

Unfortunately, LLVM doesn't use the `llvm.invariant.start` and `llvm.invariant.end` intrinsics for much at the moment. It's only used in one optimization in loop-invariant code motion at this time. Follow-up work will need to be done in LLVM to integrate these intrinsics into alias analysis. Possibly there will need to be some sort of "MemoryInvarianceAnalysis" that uses graph reachability algorithms to analyze the extent of the guarantees provided by these intrinsics to the control flow graph.

Regardless, this front-end work needs to happen as a prerequisite for any LLVM work, so that the improvements to LLVM can be measured and tested. So this commit makes `rustc` use `llvm.invariant` in a minimal way: on immutable references to "freeze" types (i.e. not transitively containing UnsafeCell) passed directly as parameters to functions. This is off by default, gated behind the non-default `-Z emit-invariant-markers=yes` flag.

Obviously, a lot more can be done to use `llvm.invariant` more liberally in the future, but this can be added over time, especially once more LLVM optimization passes use that infrastructure. This is simply the bare minimum for now. Once LLVM uses those intrinsics for more optimizations, the effects of more `llvm.invariant` use can be measured more precisely.