### PR TITLE
compiletest: set the dylib path when gathering target cfg

### DIFF
--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -2,6 +2,7 @@ use crate::common::Config;
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
+use std::process::Command;
 
 use tracing::*;
 
@@ -110,4 +111,26 @@ impl PathBufExt for PathBuf {
             self.with_file_name(fname)
         }
     }
+}
+
+/// The name of the environment variable that holds dynamic library locations.
+pub fn dylib_env_var() -> &'static str {
+    if cfg!(windows) {
+        "PATH"
+    } else if cfg!(target_os = "macos") {
+        "DYLD_LIBRARY_PATH"
+    } else if cfg!(target_os = "haiku") {
+        "LIBRARY_PATH"
+    } else {
+        "LD_LIBRARY_PATH"
+    }
+}
+
+/// Adds a list of lookup paths to `cmd`'s dynamic library lookup path.
+/// If the dylib_path_var is already set for this cmd, the old value will be overwritten!
+pub fn add_dylib_path(cmd: &mut Command, paths: impl Iterator<Item = impl Into<PathBuf>>) {
+    let path_env = env::var_os(dylib_env_var());
+    let old_paths = path_env.as_ref().map(env::split_paths);
+    let new_paths = paths.map(Into::into).chain(old_paths.into_iter().flatten());
+    cmd.env(dylib_env_var(), env::join_paths(new_paths).unwrap());
 }


### PR DESCRIPTION
If the compiler is built with `rpath = false`, then it won't find its
own libraries unless the library search path is set. We already do that
while running the actual compiletests, but #100260 added another rustc
command for getting the target cfg.

    Check compiletest suite=codegen mode=codegen (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    thread 'main' panicked at 'error: failed to get cfg info from "[...]/build/x86_64-unknown-linux-gnu/stage1/bin/rustc"
    --- stdout

    --- stderr
    [...]/build/x86_64-unknown-linux-gnu/stage1/bin/rustc: error while loading shared libraries: librustc_driver-a2a76dc626cd02d2.so: cannot open shared object file: No such file or directory
    ', src/tools/compiletest/src/common.rs:476:13

Now the library path is set here as well, so it works without rpath.
