### PR TITLE
Fix bootstrap issue w/ Apple M1 processor

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -318,6 +318,11 @@ def default_build_triple(verbose):
         'x86_64': 'x86_64'
     }
 
+    if (ostype == 'apple-darwin'
+        and cputype == 'x86_64'
+        and 'ARM64' in os.uname().version):
+        cputype = 'aarch64'
+
     # Consider the direct transformation first and then the special cases
     if cputype in cputype_mapper:
         cputype = cputype_mapper[cputype]


### PR DESCRIPTION
My version of Python (`Python 3.9.5 (default, May 18 2021, 12:31:01)`) has this interesting feature where the following happens:
```python
>>> import subprocess
>>> subprocess.check_output(["uname", "-m"]).strip()
b'x86_64'
```
But in my shell:
```shell
$ uname -m
arm64
```

This causes `default_build_triple` in `src/bootstrap/bootstrap.py` to return the wrong value ("x86_64-apple-darwin" vs the desired "aarch64-apple-darwin"). As a result, `$ ./x.py --help` fails with:
```shell
$ ./x.py --help
...
Building rustbuild
   Compiling bootstrap v0.0.0 (/Users/carson/git/rust/src/bootstrap)
error: linking with `cc` failed: exit status: 1
...
  = note: ld: warning: ignoring file /opt/homebrew/Cellar/xz/5.2.6/lib/liblzma.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
```

This PR attempt to resolve this issue by using `os.uname().version` which, in my case, returns something like "'Darwin Kernel Version 21.6.0: Mon Aug 22 20:20:05 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T8101'". So I use the "ARM64" substring to determine that "x86_64"  isn't the correct value for `cputype`.

In case it is interesting:
```shell
$ sw_vers
ProductName:    macOS
ProductVersion: 12.6
BuildVersion:   21G115
```