### PR TITLE
Support DirEntry metadata calls in miri

### DIFF
--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -674,7 +674,10 @@ impl DirEntry {
         self.file_name_os_str().to_os_string()
     }
 
-    #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "android"))]
+    #[cfg(all(
+        any(target_os = "linux", target_os = "emscripten", target_os = "android"),
+        not(miri)
+    ))]
     pub fn metadata(&self) -> io::Result<FileAttr> {
         let fd = cvt(unsafe { dirfd(self.dir.dirp.0) })?;
         let name = self.name_cstr().as_ptr();
@@ -695,7 +698,10 @@ impl DirEntry {
         Ok(FileAttr::from_stat64(stat))
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "emscripten", target_os = "android")))]
+    #[cfg(any(
+        not(any(target_os = "linux", target_os = "emscripten", target_os = "android")),
+        miri
+    ))]
     pub fn metadata(&self) -> io::Result<FileAttr> {
         lstat(&self.path())
     }

--- a/src/tools/miri/tests/pass-dep/shims/fs.rs
+++ b/src/tools/miri/tests/pass-dep/shims/fs.rs
@@ -404,6 +404,14 @@ fn test_directory() {
     let mut file_names = dir_iter.map(|e| e.unwrap().file_name()).collect::<Vec<_>>();
     file_names.sort_unstable();
     assert_eq!(file_names, vec!["test_file_1", "test_file_2"]);
+    // Test that read_dir metadata calls succeed
+    assert_eq!(
+        &[true, true],
+        &*read_dir(&dir_path)
+            .unwrap()
+            .map(|e| e.unwrap().metadata().unwrap().is_file())
+            .collect::<Vec<_>>()
+    );
     // Deleting the directory should fail, since it is not empty.
     assert_eq!(ErrorKind::DirectoryNotEmpty, remove_dir(&dir_path).unwrap_err().kind());
     // Clean up the files in the directory


### PR DESCRIPTION
This should work as it uses lstat64 which is supported here: ~https://github.com/rust-lang/miri/blob/d9ad25ee4bbd9364c498959cdc82b5fa6c41e63c/src/shims/unix/macos/foreign_items.rs#L42~ just noticed that's macos, linux would be using statx: https://github.com/rust-lang/miri/blob/86f0e63b21721fe2c14608644f467b9cb21945eb/src/shims/unix/linux/foreign_items.rs#L112

The failing syscall is `dirfd`, so maybe that should actually be added to the shims?