### PR TITLE
pretty: fix to print some lifetimes on HIR pretty-print

### DIFF
--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1687,7 +1687,11 @@ impl<'a> State<'a> {
 
             let mut nonelided_generic_args: bool = false;
             let elide_lifetimes = generic_args.args.iter().all(|arg| match arg {
-                GenericArg::Lifetime(lt) => lt.is_elided(),
+                GenericArg::Lifetime(lt) if lt.is_elided() => true,
+                GenericArg::Lifetime(_) => {
+                    nonelided_generic_args = true;
+                    false
+                }
                 _ => {
                     nonelided_generic_args = true;
                     true

--- a/src/test/pretty/issue-85089.pp
+++ b/src/test/pretty/issue-85089.pp
@@ -1,0 +1,20 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// Test to print lifetimes on HIR pretty-printing.
+
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:issue-85089.pp
+
+trait A<'x> { }
+trait B<'x> { }
+
+struct Foo<'b> {
+    bar: &'b dyn for<'a> A<'a>,
+}
+
+impl <'a> B<'a> for dyn for<'b> A<'b> { }
+
+impl <'a> A<'a> for Foo<'a> { }

--- a/src/test/pretty/issue-85089.rs
+++ b/src/test/pretty/issue-85089.rs
@@ -1,0 +1,16 @@
+// Test to print lifetimes on HIR pretty-printing.
+
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:issue-85089.pp
+
+trait A<'x> {}
+trait B<'x> {}
+
+struct Foo<'b> {
+    pub bar: &'b dyn for<'a> A<'a>,
+}
+
+impl<'a> B<'a> for dyn for<'b> A<'b> {}
+
+impl<'a> A<'a> for Foo<'a> {}


### PR DESCRIPTION
HIR pretty-printer doesn't seem to print some lifetimes in types. This PR fixes that.

Closes https://github.com/rust-lang/rust/issues/85089