### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
- "clap 4.0.9",
+ "clap 4.0.15",
  "crates-io",
  "curl",
  "curl-sys",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.9"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",

--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -145,6 +145,9 @@ passes_doc_test_takes_list =
 passes_doc_primitive =
     `doc(primitive)` should never have been stable
 
+passes_doc_cfg_hide_takes_list =
+    `#[doc(cfg_hide(...)]` takes a list of attributes
+
 passes_doc_test_unknown_any =
     unknown `doc` attribute `{$path}`
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -272,6 +272,10 @@ pub struct DocTestUnknown {
 pub struct DocTestTakesList;
 
 #[derive(LintDiagnostic)]
+#[diag(passes::doc_cfg_hide_takes_list)]
+pub struct DocCfgHideTakesList;
+
+#[derive(LintDiagnostic)]
 #[diag(passes::doc_primitive)]
 pub struct DocPrimitive;
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2937,19 +2937,15 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             ObligationCauseCode::BinOp { rhs_span: Some(span), is_lit, .. } if *is_lit => span,
             _ => return,
         };
-        match (
-            trait_ref.skip_binder().self_ty().kind(),
-            trait_ref.skip_binder().substs.type_at(1).kind(),
-        ) {
-            (ty::Float(_), ty::Infer(InferTy::IntVar(_))) => {
-                err.span_suggestion_verbose(
-                    rhs_span.shrink_to_hi(),
-                    "consider using a floating-point literal by writing it with `.0`",
-                    ".0",
-                    Applicability::MaybeIncorrect,
-                );
-            }
-            _ => {}
+        if let ty::Float(_) = trait_ref.skip_binder().self_ty().kind()
+            && let ty::Infer(InferTy::IntVar(_)) = trait_ref.skip_binder().substs.type_at(1).kind()
+        {
+            err.span_suggestion_verbose(
+                rhs_span.shrink_to_hi(),
+                "consider using a floating-point literal by writing it with `.0`",
+                ".0",
+                Applicability::MaybeIncorrect,
+            );
         }
     }
 

--- a/library/std/src/sys/unix/thread_parker/darwin.rs
+++ b/library/std/src/sys/unix/thread_parker/darwin.rs
@@ -1,0 +1,131 @@
+//! Thread parking for Darwin-based systems.
+//!
+//! Darwin actually has futex syscalls (`__ulock_wait`/`__ulock_wake`), but they
+//! cannot be used in `std` because they are non-public (their use will lead to
+//! rejection from the App Store) and because they are only available starting
+//! with macOS version 10.12, even though the minimum target version is 10.7.
+//!
+//! Therefore, we need to look for other synchronization primitives. Luckily, Darwin
+//! supports semaphores, which allow us to implement the behaviour we need with
+//! only one primitive (as opposed to a mutex-condvar pair). We use the semaphore
+//! provided by libdispatch, as the underlying Mach semaphore is only dubiously
+//! public.
+
+use crate::pin::Pin;
+use crate::sync::atomic::{
+    AtomicI8,
+    Ordering::{Acquire, Release},
+};
+use crate::time::Duration;
+
+type dispatch_semaphore_t = *mut crate::ffi::c_void;
+type dispatch_time_t = u64;
+
+const DISPATCH_TIME_NOW: dispatch_time_t = 0;
+const DISPATCH_TIME_FOREVER: dispatch_time_t = !0;
+
+#[link(name = "System", kind = "dylib")]
+extern "C" {
+    fn dispatch_time(when: dispatch_time_t, delta: i64) -> dispatch_time_t;
+    fn dispatch_semaphore_create(val: isize) -> dispatch_semaphore_t;
+    fn dispatch_semaphore_wait(dsema: dispatch_semaphore_t, timeout: dispatch_time_t) -> isize;
+    fn dispatch_semaphore_signal(dsema: dispatch_semaphore_t) -> isize;
+    fn dispatch_release(object: *mut crate::ffi::c_void);
+}
+
+const EMPTY: i8 = 0;
+const NOTIFIED: i8 = 1;
+const PARKED: i8 = -1;
+
+pub struct Parker {
+    semaphore: dispatch_semaphore_t,
+    state: AtomicI8,
+}
+
+unsafe impl Sync for Parker {}
+unsafe impl Send for Parker {}
+
+impl Parker {
+    pub unsafe fn new(parker: *mut Parker) {
+        let semaphore = dispatch_semaphore_create(0);
+        assert!(
+            !semaphore.is_null(),
+            "failed to create dispatch semaphore for thread synchronization"
+        );
+        parker.write(Parker { semaphore, state: AtomicI8::new(EMPTY) })
+    }
+
+    // Does not need `Pin`, but other implementation do.
+    pub unsafe fn park(self: Pin<&Self>) {
+        // The semaphore counter must be zero at this point, because unparking
+        // threads will not actually increase it until we signalled that we
+        // are waiting.
+
+        // Change NOTIFIED to EMPTY and EMPTY to PARKED.
+        if self.state.fetch_sub(1, Acquire) == NOTIFIED {
+            return;
+        }
+
+        // Another thread may increase the semaphore counter from this point on.
+        // If it is faster than us, we will decrement it again immediately below.
+        // If we are faster, we wait.
+
+        // Ensure that the semaphore counter has actually been decremented, even
+        // if the call timed out for some reason.
+        while dispatch_semaphore_wait(self.semaphore, DISPATCH_TIME_FOREVER) != 0 {}
+
+        // At this point, the semaphore counter is zero again.
+
+        // We were definitely woken up, so we don't need to check the state.
+        // Still, we need to reset the state using a swap to observe the state
+        // change with acquire ordering.
+        self.state.swap(EMPTY, Acquire);
+    }
+
+    // Does not need `Pin`, but other implementation do.
+    pub unsafe fn park_timeout(self: Pin<&Self>, dur: Duration) {
+        if self.state.fetch_sub(1, Acquire) == NOTIFIED {
+            return;
+        }
+
+        let nanos = dur.as_nanos().try_into().unwrap_or(i64::MAX);
+        let timeout = dispatch_time(DISPATCH_TIME_NOW, nanos);
+
+        let timeout = dispatch_semaphore_wait(self.semaphore, timeout) != 0;
+
+        let state = self.state.swap(EMPTY, Acquire);
+        if state == NOTIFIED && timeout {
+            // If the state was NOTIFIED but semaphore_wait returned without
+            // decrementing the count because of a timeout, it means another
+            // thread is about to call semaphore_signal. We must wait for that
+            // to happen to ensure the semaphore count is reset.
+            while dispatch_semaphore_wait(self.semaphore, DISPATCH_TIME_FOREVER) != 0 {}
+        } else {
+            // Either a timeout occurred and we reset the state before any thread
+            // tried to wake us up, or we were woken up and reset the state,
+            // making sure to observe the state change with acquire ordering.
+            // Either way, the semaphore counter is now zero again.
+        }
+    }
+
+    // Does not need `Pin`, but other implementation do.
+    pub fn unpark(self: Pin<&Self>) {
+        let state = self.state.swap(NOTIFIED, Release);
+        if state == PARKED {
+            unsafe {
+                dispatch_semaphore_signal(self.semaphore);
+            }
+        }
+    }
+}
+
+impl Drop for Parker {
+    fn drop(&mut self) {
+        // SAFETY:
+        // We always ensure that the semaphore count is reset, so this will
+        // never cause an exception.
+        unsafe {
+            dispatch_release(self.semaphore);
+        }
+    }
+}

--- a/library/std/src/sys/unix/thread_parker/darwin.rs
+++ b/library/std/src/sys/unix/thread_parker/darwin.rs
@@ -24,7 +24,7 @@ type dispatch_time_t = u64;
 const DISPATCH_TIME_NOW: dispatch_time_t = 0;
 const DISPATCH_TIME_FOREVER: dispatch_time_t = !0;
 
-#[link(name = "System", kind = "dylib")]
+// Contained in libSystem.dylib, which is linked by default.
 extern "C" {
     fn dispatch_time(when: dispatch_time_t, delta: i64) -> dispatch_time_t;
     fn dispatch_semaphore_create(val: isize) -> dispatch_semaphore_t;

--- a/library/std/src/sys/unix/thread_parker/mod.rs
+++ b/library/std/src/sys/unix/thread_parker/mod.rs
@@ -11,7 +11,15 @@
 )))]
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "netbsd")] {
+    if #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+    ))] {
+        mod darwin;
+        pub use darwin::Parker;
+    } else if #[cfg(target_os = "netbsd")] {
         mod netbsd;
         pub use netbsd::Parker;
     } else {

--- a/library/std/src/sys/unix/thread_parker/mod.rs
+++ b/library/std/src/sys/unix/thread_parker/mod.rs
@@ -11,11 +11,14 @@
 )))]
 
 cfg_if::cfg_if! {
-    if #[cfg(any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "watchos",
-        target_os = "tvos",
+    if #[cfg(all(
+        any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "watchos",
+            target_os = "tvos",
+        ),
+        not(miri),
     ))] {
         mod darwin;
         pub use darwin::Parker;

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -245,6 +245,28 @@ fn test_try_panic_any_message_unit_struct() {
 }
 
 #[test]
+fn test_park_unpark_before() {
+    for _ in 0..10 {
+        thread::current().unpark();
+        thread::park();
+    }
+}
+
+#[test]
+fn test_park_unpark_called_other_thread() {
+    for _ in 0..10 {
+        let th = thread::current();
+
+        let _guard = thread::spawn(move || {
+            super::sleep(Duration::from_millis(50));
+            th.unpark();
+        });
+
+        thread::park();
+    }
+}
+
+#[test]
 fn test_park_timeout_unpark_before() {
     for _ in 0..10 {
         thread::current().unpark();

--- a/src/test/rustdoc-ui/doc_cfg_hide.rs
+++ b/src/test/rustdoc-ui/doc_cfg_hide.rs
@@ -1,0 +1,11 @@
+#![feature(doc_cfg_hide)]
+#![deny(warnings)]
+
+#![doc(cfg_hide = "test")] //~ ERROR
+//~^ WARN
+#![doc(cfg_hide)] //~ ERROR
+//~^ WARN
+
+#[doc(cfg_hide(doc))] //~ ERROR
+//~^ WARN
+pub fn foo() {}

--- a/src/test/rustdoc-ui/doc_cfg_hide.stderr
+++ b/src/test/rustdoc-ui/doc_cfg_hide.stderr
@@ -1,0 +1,40 @@
+error: this attribute can only be applied at the crate level
+  --> $DIR/doc_cfg_hide.rs:9:7
+   |
+LL | #[doc(cfg_hide(doc))]
+   |       ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
+note: the lint level is defined here
+  --> $DIR/doc_cfg_hide.rs:2:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+help: to apply to the crate, use an inner attribute
+   |
+LL | #![doc(cfg_hide(doc))]
+   | ~~~~~~~~~~~~~~~~~~~~~~
+
+error: `#[doc(cfg_hide(...)]` takes a list of attributes
+  --> $DIR/doc_cfg_hide.rs:4:8
+   |
+LL | #![doc(cfg_hide = "test")]
+   |        ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: `#[doc(cfg_hide(...)]` takes a list of attributes
+  --> $DIR/doc_cfg_hide.rs:6:8
+   |
+LL | #![doc(cfg_hide)]
+   |        ^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/drop/drop_order.rs
+++ b/src/test/ui/drop/drop_order.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![feature(let_chains)]
 
 use std::cell::RefCell;
 use std::convert::TryInto;
@@ -116,6 +117,58 @@ impl DropOrderCollector {
         }
     }
 
+    fn let_chain(&self) {
+        // take the "then" branch
+        if self.option_loud_drop(2).is_some() // 2
+            && self.option_loud_drop(1).is_some() // 1
+            && let Some(_d) = self.option_loud_drop(4) { // 4
+            self.print(3); // 3
+        }
+
+        // take the "else" branch
+        if self.option_loud_drop(6).is_some() // 2
+            && self.option_loud_drop(5).is_some() // 1
+            && let None = self.option_loud_drop(7) { // 3
+            unreachable!();
+        } else {
+            self.print(8); // 4
+        }
+
+        // let exprs interspersed
+        if self.option_loud_drop(9).is_some() // 1
+            && let Some(_d) = self.option_loud_drop(13) // 5
+            && self.option_loud_drop(10).is_some() // 2
+            && let Some(_e) = self.option_loud_drop(12) { // 4
+            self.print(11); // 3
+        }
+
+        // let exprs first
+        if let Some(_d) = self.option_loud_drop(18) // 5
+            && let Some(_e) = self.option_loud_drop(17) // 4
+            && self.option_loud_drop(14).is_some() // 1
+            && self.option_loud_drop(15).is_some() { // 2
+                self.print(16); // 3
+            }
+
+        // let exprs last
+        if self.option_loud_drop(20).is_some() // 2
+            && self.option_loud_drop(19).is_some() // 1
+            && let Some(_d) = self.option_loud_drop(23) // 5
+            && let Some(_e) = self.option_loud_drop(22) { // 4
+                self.print(21); // 3
+        }
+    }
+
+    fn while_(&self) {
+        let mut v = self.option_loud_drop(4);
+        while let Some(_d) = v
+            && self.option_loud_drop(1).is_some()
+            && self.option_loud_drop(2).is_some() {
+            self.print(3);
+            v = None;
+        }
+    }
+
     fn assert_sorted(self) {
         assert!(
             self.0
@@ -141,5 +194,15 @@ fn main() {
     println!("-- match --");
     let collector = DropOrderCollector::default();
     collector.match_();
+    collector.assert_sorted();
+
+    println!("-- let chain --");
+    let collector = DropOrderCollector::default();
+    collector.let_chain();
+    collector.assert_sorted();
+
+    println!("-- while --");
+    let collector = DropOrderCollector::default();
+    collector.while_();
     collector.assert_sorted();
 }

--- a/src/test/ui/drop/drop_order.rs
+++ b/src/test/ui/drop/drop_order.rs
@@ -1,4 +1,5 @@
 // run-pass
+// compile-flags: -Z validate-mir
 #![feature(let_chains)]
 
 use std::cell::RefCell;

--- a/src/test/ui/lifetimes/unusual-rib-combinations.rs
+++ b/src/test/ui/lifetimes/unusual-rib-combinations.rs
@@ -1,0 +1,28 @@
+#![feature(inline_const)]
+
+struct S<'a>(&'a u8);
+fn foo() {}
+
+// Paren generic args in AnonConst
+fn a() -> [u8; foo::()] {
+//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
+//~| ERROR mismatched types
+    panic!()
+}
+
+// Paren generic args in ConstGeneric
+fn b<const C: u8()>() {}
+//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
+
+// Paren generic args in AnonymousReportError
+fn c<T = u8()>() {}
+//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
+//~| ERROR defaults for type parameters are only allowed in
+//~| WARN this was previously accepted
+
+// Elided lifetime in path in ConstGeneric
+fn d<const C: S>() {}
+//~^ ERROR missing lifetime specifier
+//~| ERROR `S<'static>` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/src/test/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/src/test/ui/lifetimes/unusual-rib-combinations.stderr
@@ -1,0 +1,61 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/unusual-rib-combinations.rs:24:15
+   |
+LL | fn d<const C: S>() {}
+   |               ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn d<'a, const C: S<'a>>() {}
+   |      +++           ++++
+
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/unusual-rib-combinations.rs:7:16
+   |
+LL | fn a() -> [u8; foo::()] {
+   |                ^^^^^^^ only `Fn` traits may use parentheses
+
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/unusual-rib-combinations.rs:14:15
+   |
+LL | fn b<const C: u8()>() {}
+   |               ^^^^ only `Fn` traits may use parentheses
+
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/unusual-rib-combinations.rs:18:10
+   |
+LL | fn c<T = u8()>() {}
+   |          ^^^^ only `Fn` traits may use parentheses
+
+error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/unusual-rib-combinations.rs:18:6
+   |
+LL | fn c<T = u8()>() {}
+   |      ^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
+   = note: `#[deny(invalid_type_param_default)]` on by default
+
+error[E0308]: mismatched types
+  --> $DIR/unusual-rib-combinations.rs:7:16
+   |
+LL | fn a() -> [u8; foo::()] {
+   |                ^^^^^^^ expected `usize`, found fn item
+   |
+   = note: expected type `usize`
+           found fn item `fn() {foo}`
+
+error: `S<'static>` is forbidden as the type of a const generic parameter
+  --> $DIR/unusual-rib-combinations.rs:24:15
+   |
+LL | fn d<const C: S>() {}
+   |               ^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: more complex types are supported with `#![feature(adt_const_params)]`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0106, E0214, E0308.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/traits/issue-102989.rs
+++ b/src/test/ui/traits/issue-102989.rs
@@ -1,9 +1,6 @@
-//~ ERROR can't find crate for `profiler_builtins`
-// compile-flags: -Cinstrument-coverage
 // normalize-stderr-test "loaded from .*libcore-.*.rlib" -> "loaded from SYSROOT/libcore-*.rlib"
 
-#![no_core]
-#![feature(no_core, lang_items)]
+#![feature(lang_items)]
 #[lang="sized"]
 trait Sized { } //~ ERROR found duplicate lang item `sized`
 

--- a/src/test/ui/traits/issue-102989.rs
+++ b/src/test/ui/traits/issue-102989.rs
@@ -1,5 +1,6 @@
+//~ ERROR can't find crate for `profiler_builtins`
 // compile-flags: -Cinstrument-coverage
-//~^ ERROR can't find crate for `profiler_builtins`
+// normalize-stderr-test "loaded from .*libcore-.*.rlib" -> "loaded from SYSROOT/libcore-*.rlib"
 
 #![no_core]
 #![feature(no_core, lang_items)]

--- a/src/test/ui/traits/issue-102989.rs
+++ b/src/test/ui/traits/issue-102989.rs
@@ -1,0 +1,18 @@
+// compile-flags: -Cinstrument-coverage
+//~^ ERROR can't find crate for `profiler_builtins`
+
+#![no_core]
+#![feature(no_core, lang_items)]
+#[lang="sized"]
+trait Sized { } //~ ERROR found duplicate lang item `sized`
+
+fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    //~| ERROR cannot find type `Struct` in this scope
+    //~| ERROR mismatched types
+    let x = x << 1;
+    //~^ ERROR the size for values of type `{integer}` cannot be known at compilation time
+    //~| ERROR cannot find value `x` in this scope
+}
+
+fn main() {}

--- a/src/test/ui/traits/issue-102989.stderr
+++ b/src/test/ui/traits/issue-102989.stderr
@@ -1,5 +1,5 @@
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/issue-102989.rs:10:15
+  --> $DIR/issue-102989.rs:7:15
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |               ^^^^ not semantically valid as function parameter
@@ -7,50 +7,37 @@ LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    = note: associated functions are those in `impl` or `trait` definitions
 
 error[E0412]: cannot find type `Struct` in this scope
-  --> $DIR/issue-102989.rs:10:22
+  --> $DIR/issue-102989.rs:7:22
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                      ^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/issue-102989.rs:14:13
+  --> $DIR/issue-102989.rs:11:13
    |
 LL |     let x = x << 1;
    |             ^ help: a local variable with a similar name exists: `f`
 
-error: `profiler_builtins` crate (required by compiler options) is not compatible with crate attribute `#![no_core]`
-
-error[E0463]: can't find crate for `profiler_builtins`
-   |
-   = note: the compiler may have been built without the profiler runtime
-
 error[E0152]: found duplicate lang item `sized`
-  --> $DIR/issue-102989.rs:8:1
+  --> $DIR/issue-102989.rs:5:1
    |
 LL | trait Sized { }
    | ^^^^^^^^^^^
    |
-   = note: the lang item is first defined in crate `core`.
+   = note: the lang item is first defined in crate `core` (which `std` depends on)
    = note: first definition in `core` loaded from SYSROOT/libcore-*.rlib
    = note: second definition in the local crate (`issue_102989`)
 
-error: `#[panic_handler]` function required, but not found
-
-error: language item required, but not found: `eh_personality`
-   |
-   = note: this can occur when a binary crate with `#![no_std]` is compiled for a target where `eh_personality` is defined in the standard library
-   = help: you may be able to compile for a target that doesn't need `eh_personality`, specify a target with `--target` or in `.cargo/config`
-
 error[E0277]: the size for values of type `{integer}` cannot be known at compilation time
-  --> $DIR/issue-102989.rs:14:15
+  --> $DIR/issue-102989.rs:11:15
    |
 LL |     let x = x << 1;
    |               ^^ doesn't have a size known at compile-time
    |
-   = help: the trait `core::marker::Sized` is not implemented for `{integer}`
+   = help: the trait `std::marker::Sized` is not implemented for `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-102989.rs:10:42
+  --> $DIR/issue-102989.rs:7:42
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |    ----------                            ^^^^ expected `&u32`, found `()`
@@ -58,7 +45,7 @@ LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
    |
 note: consider returning one of these bindings
-  --> $DIR/issue-102989.rs:10:30
+  --> $DIR/issue-102989.rs:7:30
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                              ^
@@ -66,7 +53,7 @@ LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
 LL |     let x = x << 1;
    |         ^
 
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0152, E0277, E0308, E0412, E0425, E0463.
+Some errors have detailed explanations: E0152, E0277, E0308, E0412, E0425.
 For more information about an error, try `rustc --explain E0152`.

--- a/src/test/ui/traits/issue-102989.stderr
+++ b/src/test/ui/traits/issue-102989.stderr
@@ -1,0 +1,72 @@
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/issue-102989.rs:9:15
+   |
+LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |               ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0412]: cannot find type `Struct` in this scope
+  --> $DIR/issue-102989.rs:9:22
+   |
+LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |                      ^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/issue-102989.rs:13:13
+   |
+LL |     let x = x << 1;
+   |             ^ help: a local variable with a similar name exists: `f`
+
+error: `profiler_builtins` crate (required by compiler options) is not compatible with crate attribute `#![no_core]`
+
+error[E0463]: can't find crate for `profiler_builtins`
+   |
+   = note: the compiler may have been built without the profiler runtime
+
+error[E0152]: found duplicate lang item `sized`
+  --> $DIR/issue-102989.rs:7:1
+   |
+LL | trait Sized { }
+   | ^^^^^^^^^^^
+   |
+   = note: the lang item is first defined in crate `core`.
+   = note: first definition in `core` loaded from $BUILD_DIR/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib/libcore-500f4c12402b1108.rlib
+   = note: second definition in the local crate (`issue_102989`)
+
+error: `#[panic_handler]` function required, but not found
+
+error: language item required, but not found: `eh_personality`
+   |
+   = note: this can occur when a binary crate with `#![no_std]` is compiled for a target where `eh_personality` is defined in the standard library
+   = help: you may be able to compile for a target that doesn't need `eh_personality`, specify a target with `--target` or in `.cargo/config`
+
+error[E0277]: the size for values of type `{integer}` cannot be known at compilation time
+  --> $DIR/issue-102989.rs:13:15
+   |
+LL |     let x = x << 1;
+   |               ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `core::marker::Sized` is not implemented for `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-102989.rs:9:42
+   |
+LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |    ----------                            ^^^^ expected `&u32`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+   |
+note: consider returning one of these bindings
+  --> $DIR/issue-102989.rs:9:30
+   |
+LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |                              ^
+...
+LL |     let x = x << 1;
+   |         ^
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0152, E0277, E0308, E0412, E0425, E0463.
+For more information about an error, try `rustc --explain E0152`.

--- a/src/test/ui/traits/issue-102989.stderr
+++ b/src/test/ui/traits/issue-102989.stderr
@@ -1,5 +1,5 @@
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/issue-102989.rs:9:15
+  --> $DIR/issue-102989.rs:10:15
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |               ^^^^ not semantically valid as function parameter
@@ -7,13 +7,13 @@ LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    = note: associated functions are those in `impl` or `trait` definitions
 
 error[E0412]: cannot find type `Struct` in this scope
-  --> $DIR/issue-102989.rs:9:22
+  --> $DIR/issue-102989.rs:10:22
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                      ^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/issue-102989.rs:13:13
+  --> $DIR/issue-102989.rs:14:13
    |
 LL |     let x = x << 1;
    |             ^ help: a local variable with a similar name exists: `f`
@@ -25,13 +25,13 @@ error[E0463]: can't find crate for `profiler_builtins`
    = note: the compiler may have been built without the profiler runtime
 
 error[E0152]: found duplicate lang item `sized`
-  --> $DIR/issue-102989.rs:7:1
+  --> $DIR/issue-102989.rs:8:1
    |
 LL | trait Sized { }
    | ^^^^^^^^^^^
    |
    = note: the lang item is first defined in crate `core`.
-   = note: first definition in `core` loaded from $BUILD_DIR/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib/libcore-500f4c12402b1108.rlib
+   = note: first definition in `core` loaded from SYSROOT/libcore-*.rlib
    = note: second definition in the local crate (`issue_102989`)
 
 error: `#[panic_handler]` function required, but not found
@@ -42,7 +42,7 @@ error: language item required, but not found: `eh_personality`
    = help: you may be able to compile for a target that doesn't need `eh_personality`, specify a target with `--target` or in `.cargo/config`
 
 error[E0277]: the size for values of type `{integer}` cannot be known at compilation time
-  --> $DIR/issue-102989.rs:13:15
+  --> $DIR/issue-102989.rs:14:15
    |
 LL |     let x = x << 1;
    |               ^^ doesn't have a size known at compile-time
@@ -50,7 +50,7 @@ LL |     let x = x << 1;
    = help: the trait `core::marker::Sized` is not implemented for `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-102989.rs:9:42
+  --> $DIR/issue-102989.rs:10:42
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |    ----------                            ^^^^ expected `&u32`, found `()`
@@ -58,7 +58,7 @@ LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |    implicitly returns `()` as its body has no tail or `return` expression
    |
 note: consider returning one of these bindings
-  --> $DIR/issue-102989.rs:9:30
+  --> $DIR/issue-102989.rs:10:30
    |
 LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                              ^


### PR DESCRIPTION
Successful merges:

 - #102773 (Use semaphores for thread parking on Apple platforms)
 - #102884 (resolve: Some cleanup, asserts and tests for lifetime ribs)
 - #102954 (Add missing checks for `doc(cfg_hide(...))`)
 - #102998 (Drop temporaries created in a condition, even if it's a let chain)
 - #103003 (Fix `suggest_floating_point_literal` ICE)
 - #103041 (Update cargo)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102773,102884,102954,102998,103003,103041)
<!-- homu-ignore:end -->