### PR TITLE
Derive `Eq` and `Hash` for `ControlFlow`

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -79,7 +79,9 @@ use crate::{convert, ops};
 /// [`Break`]: ControlFlow::Break
 /// [`Continue`]: ControlFlow::Continue
 #[stable(feature = "control_flow_enum_type", since = "1.55.0")]
-#[derive(Debug, Clone, Copy, PartialEq)]
+// ControlFlow should not implement PartialOrd or Ord, per RFC 3058:
+// https://rust-lang.github.io/rfcs/3058-try-trait-v2.html#traits-for-controlflow
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ControlFlow<B, C = ()> {
     /// Move on to the next phase of the operation as normal.
     #[stable(feature = "control_flow_enum_type", since = "1.55.0")]


### PR DESCRIPTION
There's really no reason for `ControlFlow` not to derive these traits. This is the part of #96416 that no one objected to, but that PR seems stale. The `Eq` derive was also [requested](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/.60ControlFlow.3A.20Eq.60/near/303610659) by @lcnr on Zulip to allow for pattern matching.

This change requires an FCP because it's insta-stable.

Closes #96416.