### PR TITLE
[rustdoc-json] Partially remove `paths` and introduce `external_index`

### DIFF
--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -292,15 +292,14 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
             crate_version: self.cache.crate_version.clone(),
             includes_private: self.cache.document_private,
             index: index.into_iter().collect(),
-            paths: self
+            external_index: self
                 .cache
-                .paths
+                .external_paths
                 .iter()
-                .chain(&self.cache.external_paths)
                 .map(|(&k, &(ref path, kind))| {
                     (
                         from_item_id(k.into(), self.tcx),
-                        types::ItemSummary {
+                        types::ExternalItem {
                             crate_id: k.krate.as_u32(),
                             path: path.iter().map(|s| s.to_string()).collect(),
                             kind: kind.into_tcx(self.tcx),

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 22;
+pub const FORMAT_VERSION: u32 = 23;
 
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
@@ -25,8 +25,8 @@ pub struct Crate {
     /// A collection of all items in the local crate as well as some external traits and their
     /// items that are referenced locally.
     pub index: HashMap<Id, Item>,
-    /// Maps IDs to fully qualified paths and other info helpful for generating links.
-    pub paths: HashMap<Id, ItemSummary>,
+    /// Maps external IDs to basic informations.
+    pub external_index: HashMap<Id, ExternalItem>,
     /// Maps `crate_id` of items to a crate name and html_root_url if it exists.
     pub external_crates: HashMap<u32, ExternalCrate>,
     /// A single version number to be used in the future when making backwards incompatible changes
@@ -45,7 +45,7 @@ pub struct ExternalCrate {
 /// question, or can be used by a tool that takes the json output of multiple crates to find
 /// the actual item definition with all the relevant info.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ItemSummary {
+pub struct ExternalItem {
     /// Can be used to look up the name and html_root_url of the crate this item came from in the
     /// `external_crates` map.
     pub crate_id: u32,
@@ -56,6 +56,10 @@ pub struct ItemSummary {
     /// defined. Currenty, this is the full path to where the item was defined. Eg
     /// [`String`] is currently `["alloc", "string", "String"]` and [`HashMap`] is
     /// `["std", "collections", "hash", "map", "HashMap"]`, but this is subject to change.
+    ///
+    /// Be aware that this field maybe be subject to change (like complete removal) in the
+    /// future, see issue <https://github.com/rust-lang/rust/issues/93522> and
+    /// <https://github.com/rust-lang/rust/pull/103085> for more information.
     pub path: Vec<String>,
     /// Whether this item is a struct, trait, macro, etc.
     pub kind: ItemKind,

--- a/src/tools/jsondoclint/src/item_kind.rs
+++ b/src/tools/jsondoclint/src/item_kind.rs
@@ -1,4 +1,4 @@
-use rustdoc_json_types::{Item, ItemEnum, ItemKind, ItemSummary};
+use rustdoc_json_types::{ExternalItem, Item, ItemEnum, ItemKind};
 
 /// A univeral way to represent an [`ItemEnum`] or [`ItemKind`]
 #[derive(Debug)]
@@ -150,7 +150,7 @@ impl Kind {
         }
     }
 
-    pub fn from_summary(s: &ItemSummary) -> Self {
+    pub fn from_summary(s: &ExternalItem) -> Self {
         use Kind::*;
         match s.kind {
             ItemKind::AssocConst => AssocConst,

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -90,7 +90,7 @@ impl<'a> Validator<'a> {
                 }
             }
         } else {
-            assert!(self.krate.paths.contains_key(id));
+            assert!(self.krate.external_index.contains_key(id));
         }
     }
 
@@ -424,7 +424,7 @@ impl<'a> Validator<'a> {
     fn kind_of(&mut self, id: &Id) -> Option<Kind> {
         if let Some(item) = self.krate.index.get(id) {
             Some(Kind::from_item(item))
-        } else if let Some(summary) = self.krate.paths.get(id) {
+        } else if let Some(summary) = self.krate.external_index.get(id) {
             Some(Kind::from_summary(summary))
         } else {
             None


### PR DESCRIPTION
From [`[rustdoc-json] paths is inconsistent and questionably useful`](https://github.com/rust-lang/rust/issues/93522):

> **Problem:** Currently, the items `paths` includes is just the list of paths used in the rustdoc cache. This is implementation-dependent, misses some items that should possibly be included such as re-export source items, and generally imperfect.
> 
> **Solution:** `paths` inclusion should be standardized, and separated from the internal cache implementation.

To solve this issue this PR introduce a new `external_index` that only contains a `ExternalItem` struct from the previous `ItemSummary`. This "new" index only contains external item and is here so that no ID are not dangling and to still provide a minimum of informations to those external IDs (crate_id, name, kind).

~~This PR also rename `path` to `name` (from `ExternalItem`) because it's not clear at all what `path` represent (is it one of the public paths but which one or is it a private one but why) so to simplify all this we will now just give the first external name of the item.~~

r? @aDotInTheVoid
cc @Enselic 