### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,9 +2652,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polonius-engine"

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -284,7 +284,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         this.fail(
                         location,
                         format!(
-                            "Field projection `{:?}.{:?}` specified type `{:?}`, but actual type is {:?}",
+                            "Field projection `{:?}.{:?}` specified type `{:?}`, but actual type is `{:?}`",
                             parent, f, ty, f_ty
                         )
                     )

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1687,7 +1687,11 @@ impl<'a> State<'a> {
 
             let mut nonelided_generic_args: bool = false;
             let elide_lifetimes = generic_args.args.iter().all(|arg| match arg {
-                GenericArg::Lifetime(lt) => lt.is_elided(),
+                GenericArg::Lifetime(lt) if lt.is_elided() => true,
+                GenericArg::Lifetime(_) => {
+                    nonelided_generic_args = true;
+                    false
+                }
                 _ => {
                     nonelided_generic_args = true;
                     true

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -451,14 +451,12 @@ macro_rules! tool_check_step {
 }
 
 tool_check_step!(Rustdoc, "src/tools/rustdoc", "src/librustdoc", SourceType::InTree);
-// Clippy and Rustfmt are hybrids. They are external tools, but use a git subtree instead
+// Clippy, miri and Rustfmt are hybrids. They are external tools, but use a git subtree instead
 // of a submodule. Since the SourceType only drives the deny-warnings
 // behavior, treat it as in-tree so that any new warnings in clippy will be
 // rejected.
 tool_check_step!(Clippy, "src/tools/clippy", SourceType::InTree);
-// Miri on the other hand is treated as out of tree, since InTree also causes it to
-// be run as part of `check`, which can fail on platforms which libffi-sys has no support for.
-tool_check_step!(Miri, "src/tools/miri", SourceType::Submodule);
+tool_check_step!(Miri, "src/tools/miri", SourceType::InTree);
 tool_check_step!(Rls, "src/tools/rls", SourceType::InTree);
 tool_check_step!(Rustfmt, "src/tools/rustfmt", SourceType::InTree);
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -734,7 +734,7 @@ impl Step for Rustc {
 }
 
 macro_rules! tool_doc {
-    ($tool: ident, $should_run: literal, $path: literal, [$($krate: literal),+ $(,)?], in_tree = $in_tree:expr $(,)?) => {
+    ($tool: ident, $should_run: literal, $path: literal, [$($krate: literal),+ $(,)?] $(,)?) => {
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct $tool {
             target: TargetSelection,
@@ -790,12 +790,6 @@ macro_rules! tool_doc {
                 t!(fs::create_dir_all(&out_dir));
                 t!(symlink_dir_force(&builder.config, &out, &out_dir));
 
-                let source_type = if $in_tree == true {
-                    SourceType::InTree
-                } else {
-                    SourceType::Submodule
-                };
-
                 // Build cargo command.
                 let mut cargo = prepare_tool_cargo(
                     builder,
@@ -804,7 +798,7 @@ macro_rules! tool_doc {
                     target,
                     "doc",
                     $path,
-                    source_type,
+                    SourceType::InTree,
                     &[],
                 );
 
@@ -820,38 +814,21 @@ macro_rules! tool_doc {
                 cargo.rustdocflag("--show-type-layout");
                 cargo.rustdocflag("--generate-link-to-definition");
                 cargo.rustdocflag("-Zunstable-options");
-                if $in_tree == true {
-                    builder.run(&mut cargo.into());
-                } else {
-                    // Allow out-of-tree docs to fail (since the tool might be in a broken state).
-                    if !builder.try_run(&mut cargo.into()) {
-                        builder.info(&format!(
-                            "WARNING: tool {} failed to document; ignoring failure because it is an out-of-tree tool",
-                            stringify!($tool).to_lowercase(),
-                        ));
-                    }
-                }
+                builder.run(&mut cargo.into());
             }
         }
     }
 }
 
-tool_doc!(
-    Rustdoc,
-    "rustdoc-tool",
-    "src/tools/rustdoc",
-    ["rustdoc", "rustdoc-json-types"],
-    in_tree = true
-);
+tool_doc!(Rustdoc, "rustdoc-tool", "src/tools/rustdoc", ["rustdoc", "rustdoc-json-types"],);
 tool_doc!(
     Rustfmt,
     "rustfmt-nightly",
     "src/tools/rustfmt",
     ["rustfmt-nightly", "rustfmt-config_proc_macro"],
-    in_tree = true
 );
-tool_doc!(Clippy, "clippy", "src/tools/clippy", ["clippy_utils"], in_tree = true);
-tool_doc!(Miri, "miri", "src/tools/miri", ["miri"], in_tree = false);
+tool_doc!(Clippy, "clippy", "src/tools/clippy", ["clippy_utils"]);
+tool_doc!(Miri, "miri", "src/tools/miri", ["miri"]);
 
 #[derive(Ord, PartialOrd, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -503,7 +503,7 @@ impl Step for Miri {
             host,
             "run",
             "src/tools/miri/cargo-miri",
-            SourceType::Submodule,
+            SourceType::InTree,
             &[],
         );
         cargo.add_rustc_lib_path(builder, compiler);
@@ -550,7 +550,7 @@ impl Step for Miri {
             host,
             "test",
             "src/tools/miri",
-            SourceType::Submodule,
+            SourceType::InTree,
             &[],
         );
         cargo.add_rustc_lib_path(builder, compiler);

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -794,9 +794,9 @@ macro_rules! tool_extended {
        $($name:ident,
        $path:expr,
        $tool_name:expr,
-       stable = $stable:expr,
-       $(tool_std = $tool_std:literal,)?
-       $extra_deps:block;)+) => {
+       stable = $stable:expr
+       $(,tool_std = $tool_std:literal)?
+       ;)+) => {
         $(
             #[derive(Debug, Clone, Hash, PartialEq, Eq)]
         pub struct $name {
@@ -838,7 +838,6 @@ macro_rules! tool_extended {
 
             #[allow(unused_mut)]
             fn run(mut $sel, $builder: &Builder<'_>) -> Option<PathBuf> {
-                $extra_deps
                 $builder.ensure(ToolBuild {
                     compiler: $sel.compiler,
                     target: $sel.target,
@@ -860,17 +859,17 @@ macro_rules! tool_extended {
 // Note: Most submodule updates for tools are handled by bootstrap.py, since they're needed just to
 // invoke Cargo to build bootstrap. See the comment there for more details.
 tool_extended!((self, builder),
-    Cargofmt, "src/tools/rustfmt", "cargo-fmt", stable=true, {};
-    CargoClippy, "src/tools/clippy", "cargo-clippy", stable=true, {};
-    Clippy, "src/tools/clippy", "clippy-driver", stable=true, {};
-    Miri, "src/tools/miri", "miri", stable=false, {};
-    CargoMiri, "src/tools/miri/cargo-miri", "cargo-miri", stable=true, {};
+    Cargofmt, "src/tools/rustfmt", "cargo-fmt", stable=true;
+    CargoClippy, "src/tools/clippy", "cargo-clippy", stable=true;
+    Clippy, "src/tools/clippy", "clippy-driver", stable=true;
+    Miri, "src/tools/miri", "miri", stable=false;
+    CargoMiri, "src/tools/miri/cargo-miri", "cargo-miri", stable=true;
     // FIXME: tool_std is not quite right, we shouldn't allow nightly features.
     // But `builder.cargo` doesn't know how to handle ToolBootstrap in stages other than 0,
     // and this is close enough for now.
-    Rls, "src/tools/rls", "rls", stable=true, tool_std=true, {};
-    RustDemangler, "src/tools/rust-demangler", "rust-demangler", stable=false, tool_std=true, {};
-    Rustfmt, "src/tools/rustfmt", "rustfmt", stable=true, {};
+    Rls, "src/tools/rls", "rls", stable=true, tool_std=true;
+    RustDemangler, "src/tools/rust-demangler", "rust-demangler", stable=false, tool_std=true;
+    Rustfmt, "src/tools/rustfmt", "rustfmt", stable=true;
 );
 
 impl<'a> Builder<'a> {

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -795,7 +795,6 @@ macro_rules! tool_extended {
        $path:expr,
        $tool_name:expr,
        stable = $stable:expr,
-       $(in_tree = $in_tree:expr,)?
        $(tool_std = $tool_std:literal,)?
        $extra_deps:block;)+) => {
         $(
@@ -848,11 +847,7 @@ macro_rules! tool_extended {
                     path: $path,
                     extra_features: $sel.extra_features,
                     is_optional_tool: true,
-                    source_type: if false $(|| $in_tree)* {
-                        SourceType::InTree
-                    } else {
-                        SourceType::Submodule
-                    },
+                    source_type: SourceType::InTree,
                 })
             }
         }
@@ -865,17 +860,17 @@ macro_rules! tool_extended {
 // Note: Most submodule updates for tools are handled by bootstrap.py, since they're needed just to
 // invoke Cargo to build bootstrap. See the comment there for more details.
 tool_extended!((self, builder),
-    Cargofmt, "src/tools/rustfmt", "cargo-fmt", stable=true, in_tree=true, {};
-    CargoClippy, "src/tools/clippy", "cargo-clippy", stable=true, in_tree=true, {};
-    Clippy, "src/tools/clippy", "clippy-driver", stable=true, in_tree=true, {};
-    Miri, "src/tools/miri", "miri", stable=false, in_tree=true, {};
-    CargoMiri, "src/tools/miri/cargo-miri", "cargo-miri", stable=false, in_tree=true, {};
+    Cargofmt, "src/tools/rustfmt", "cargo-fmt", stable=true, {};
+    CargoClippy, "src/tools/clippy", "cargo-clippy", stable=true, {};
+    Clippy, "src/tools/clippy", "clippy-driver", stable=true, {};
+    Miri, "src/tools/miri", "miri", stable=false, {};
+    CargoMiri, "src/tools/miri/cargo-miri", "cargo-miri", stable=true, {};
     // FIXME: tool_std is not quite right, we shouldn't allow nightly features.
     // But `builder.cargo` doesn't know how to handle ToolBootstrap in stages other than 0,
     // and this is close enough for now.
-    Rls, "src/tools/rls", "rls", stable=true, in_tree=true, tool_std=true, {};
-    RustDemangler, "src/tools/rust-demangler", "rust-demangler", stable=false, in_tree=true, tool_std=true, {};
-    Rustfmt, "src/tools/rustfmt", "rustfmt", stable=true, in_tree=true, {};
+    Rls, "src/tools/rls", "rls", stable=true, tool_std=true, {};
+    RustDemangler, "src/tools/rust-demangler", "rust-demangler", stable=false, tool_std=true, {};
+    Rustfmt, "src/tools/rustfmt", "rustfmt", stable=true, {};
 );
 
 impl<'a> Builder<'a> {

--- a/src/test/pretty/issue-85089.pp
+++ b/src/test/pretty/issue-85089.pp
@@ -1,0 +1,20 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// Test to print lifetimes on HIR pretty-printing.
+
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:issue-85089.pp
+
+trait A<'x> { }
+trait B<'x> { }
+
+struct Foo<'b> {
+    bar: &'b dyn for<'a> A<'a>,
+}
+
+impl <'a> B<'a> for dyn for<'b> A<'b> { }
+
+impl <'a> A<'a> for Foo<'a> { }

--- a/src/test/pretty/issue-85089.rs
+++ b/src/test/pretty/issue-85089.rs
@@ -1,0 +1,16 @@
+// Test to print lifetimes on HIR pretty-printing.
+
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:issue-85089.pp
+
+trait A<'x> {}
+trait B<'x> {}
+
+struct Foo<'b> {
+    pub bar: &'b dyn for<'a> A<'a>,
+}
+
+impl<'a> B<'a> for dyn for<'b> A<'b> {}
+
+impl<'a> A<'a> for Foo<'a> {}

--- a/src/test/ui/borrowck/borrowck-mut-borrow-linear-errors.stderr
+++ b/src/test/ui/borrowck/borrowck-mut-borrow-linear-errors.stderr
@@ -25,7 +25,10 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-linear-errors.rs:12:30
    |
 LL |             _ => { addr.push(&mut x); }
-   |                              ^^^^^^ `x` was mutably borrowed here in the previous iteration of the loop
+   |                    ----------^^^^^^-
+   |                    |         |
+   |                    |         `x` was mutably borrowed here in the previous iteration of the loop
+   |                    first borrow used here, in later iteration of loop
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/two-phase-across-loop.stderr
+++ b/src/test/ui/borrowck/two-phase-across-loop.stderr
@@ -2,7 +2,10 @@ error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/two-phase-across-loop.rs:17:22
    |
 LL |         strings.push(foo.get_string());
-   |                      ^^^^^^^^^^^^^^^^ `foo` was mutably borrowed here in the previous iteration of the loop
+   |         -------------^^^^^^^^^^^^^^^^-
+   |         |            |
+   |         |            `foo` was mutably borrowed here in the previous iteration of the loop
+   |         first borrow used here, in later iteration of loop
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closures-in-loops.stderr
+++ b/src/test/ui/nll/closures-in-loops.stderr
@@ -13,17 +13,21 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/closures-in-loops.rs:13:16
    |
 LL |         v.push(|| x = String::new());
-   |                ^^ - borrows occur due to use of `x` in closure
-   |                |
-   |                `x` was mutably borrowed here in the previous iteration of the loop
+   |         -------^^-------------------
+   |         |      |  |
+   |         |      |  borrows occur due to use of `x` in closure
+   |         |      `x` was mutably borrowed here in the previous iteration of the loop
+   |         first borrow used here, in later iteration of loop
 
 error[E0524]: two closures require unique access to `x` at the same time
   --> $DIR/closures-in-loops.rs:20:16
    |
 LL |         v.push(|| *x = String::new());
-   |                ^^ -- borrows occur due to use of `x` in closure
-   |                |
-   |                closures are constructed here in different iterations of loop
+   |         -------^^--------------------
+   |         |      |  |
+   |         |      |  borrows occur due to use of `x` in closure
+   |         |      closures are constructed here in different iterations of loop
+   |         first borrow used here, in later iteration of loop
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #102080 (Fix missing explanation of where the borrowed reference is used when the same borrow occurs multiple times due to loop iterations)
 - #102950 (Enable `x.py check` for miri)
 - #103033 (Update pkg-config)
 - #103080 (pretty: fix to print some lifetimes on HIR pretty-print)
 - #103082 (Surround type with backticks)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102080,102950,103033,103080,103082)
<!-- homu-ignore:end -->