### PR TITLE
[experiment] Execute queries through a single function in `QueryEngine`

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -297,7 +297,7 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
     let mut query_description_stream = quote! {};
     let mut query_cached_stream = quote! {};
 
-    for query in queries.0 {
+    for (query_id, query) in queries.0.into_iter().enumerate() {
         let Query { name, arg, modifiers, .. } = &query;
         let result_full = &query.result;
         let result = match query.result {
@@ -344,10 +344,13 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
         let span = name.span();
         let attribute_stream = quote_spanned! {span=> #(#attributes),*};
         let doc_comments = &query.doc_comments;
+
+        let query_id = u16::try_from(query_id).unwrap();
+
         // Add the query to the group
         query_stream.extend(quote! {
             #(#doc_comments)*
-            [#attribute_stream] fn #name(#arg) #result,
+            [#attribute_stream] fn #name #query_id(#arg) #result,
         });
 
         add_query_desc_cached_impl(&query, &mut query_description_stream, &mut query_cached_stream);

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -72,7 +72,7 @@ pub use rustc_query_system::dep_graph::{DepContext, DepNodeParams};
 macro_rules! define_dep_nodes {
     (
      $($(#[$attr:meta])*
-        [$($modifiers:tt)*] fn $variant:ident($($K:tt)*) -> $V:ty,)*) => {
+        [$($modifiers:tt)*] fn $variant:ident $query_id:literal($($K:tt)*) -> $V:ty,)*) => {
 
         #[macro_export]
         macro_rules! make_dep_kind_array {
@@ -104,14 +104,15 @@ macro_rules! define_dep_nodes {
     };
 }
 
+// We ignore the query ID here so pass a sentinel
 rustc_query_append!(define_dep_nodes![
     /// We use this for most things when incr. comp. is turned off.
-    [] fn Null() -> (),
+    [] fn Null 0() -> (),
     /// We use this to create a forever-red node.
-    [] fn Red() -> (),
-    [] fn TraitSelect() -> (),
-    [] fn CompileCodegenUnit() -> (),
-    [] fn CompileMonoItem() -> (),
+    [] fn Red 0() -> (),
+    [] fn TraitSelect 0() -> (),
+    [] fn CompileCodegenUnit 0() -> (),
+    [] fn CompileMonoItem 0() -> (),
 ]);
 
 // WARNING: `construct` is generic and does not know that `CompileCodegenUnit` takes `Symbol`s as keys.

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -230,11 +230,11 @@ macro_rules! define_callbacks {
                     Err(()) => (),
                 }
 
-                // self.tcx.queries.$name(self.tcx, DUMMY_SP, key, QueryMode::Ensure).unwrap()
+                // self.tcx.queries.$name(self.tcx, DUMMY_SP, key, QueryMode::Ensure);
                 let key = &key as *const query_keys::$name<'tcx>;
                 let mut out = MaybeUninit::<query_stored::$name<'tcx>>::uninit();
                 unsafe {
-                    let success = self.tcx.queries.execute(
+                    self.tcx.queries.execute(
                         self.tcx,
                         DUMMY_SP,
                         $query_id,
@@ -242,9 +242,6 @@ macro_rules! define_callbacks {
                         out.as_mut_ptr().cast::<()>(),
                         QueryMode::Ensure,
                     );
-                    if !success {
-                        panic!("Failed to executed query");
-                    }
                 }
             })*
         }
@@ -278,17 +275,14 @@ macro_rules! define_callbacks {
                 let key = &key as *const query_keys::$name<'tcx>;
                 let mut out = MaybeUninit::<query_stored::$name<'tcx>>::uninit();
                 unsafe {
-                    let success = self.tcx.queries.execute(
+                    self.tcx.queries.execute(
                         self.tcx,
                         self.span,
                         $query_id,
                         key.cast::<()>(),
                         out.as_mut_ptr().cast::<()>(),
                         QueryMode::Get,
-                    );
-                    if !success {
-                        panic!("Failed to executed query");
-                    }
+                    ).unwrap();
                     out.assume_init()
                 }
             })*
@@ -352,7 +346,7 @@ macro_rules! define_callbacks {
                 key: *const (),
                 out: *mut (),
                 mode: QueryMode,
-            ) -> bool;
+            ) -> Option<()>;
 
             /*
             $($(#[$attr])*

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -705,7 +705,7 @@ macro_rules! define_queries_struct {
                 key: *const (),
                 out: *mut (),
                 mode: QueryMode,
-            ) -> bool {
+            ) -> Option<()> {
                 let qcx = QueryCtxt { tcx, queries: self };
 
                 match query_id {
@@ -716,7 +716,7 @@ macro_rules! define_queries_struct {
                                 key.read()
                             };
                             let result = get_query::<queries::$name<'tcx>, _>(qcx, span, key, mode);
-                            result.map(|result| unsafe { out.cast::<<queries::$name<'tcx> as QueryConfig>::Stored>().write(result) }).is_some()
+                            result.map(|result| unsafe { out.cast::<<queries::$name<'tcx> as QueryConfig>::Stored>().write(result) })
                         }
                     )*
                     id => bug!("Found invalid query id {id}"),

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -14,7 +14,7 @@ use std::hash::Hash;
 pub trait QueryConfig {
     const NAME: &'static str;
 
-    type Key: Eq + Hash + Clone + Debug;
+    type Key: Eq + Hash + Clone + Debug + Copy + Sized;
     type Value;
     type Stored: Clone;
 }


### PR DESCRIPTION
Using a bunch of type erasure, we can get rid of almost 300 functions on the trait.

I want to see whether this has an effect on compile perf and the bootstrap timings for query_impl and middle.

r? @ghost