### PR TITLE
resolve: Shadow erroneous glob imports with erroneous single imports

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -252,7 +252,7 @@ impl<'a> Resolver<'a> {
         self.set_binding_parent_module(binding, module);
         self.update_resolution(module, key, |this, resolution| {
             if let Some(old_binding) = resolution.binding {
-                if res == Res::Err {
+                if res == Res::Err && old_binding.res() != Res::Err {
                     // Do not override real bindings with `Res::Err`s from error recovery.
                     return Ok(());
                 }

--- a/src/test/rustdoc/issue-100241.rs
+++ b/src/test/rustdoc/issue-100241.rs
@@ -1,0 +1,12 @@
+//! See [`S`].
+
+// Check that this isn't an ICE
+// should-fail
+
+mod foo {
+    pub use inner::S;
+    //~^ ERROR unresolved imports `inner`, `foo::S`
+}
+
+use foo::*;
+use foo::S;


### PR DESCRIPTION
If such shadowing doesn't happen we end up in a weird state that may cause ICEs.
(In non-erroneous cases single imports always shadow glob imports too.)

Fixes https://github.com/rust-lang/rust/issues/100047
Fixes https://github.com/rust-lang/rust/issues/100241