### PR TITLE
Make transpose const and inline

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -217,6 +217,7 @@
 #![feature(unboxed_closures)]
 #![feature(unsized_fn_params)]
 #![feature(asm_const)]
+#![feature(const_transmute_copy)]
 //
 // Target features:
 #![feature(arm_target_feature)]

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1297,7 +1297,8 @@ impl<T, const N: usize> MaybeUninit<[T; N]> {
     /// let data: [MaybeUninit<u8>; 1000] = MaybeUninit::uninit().transpose();
     /// ```
     #[unstable(feature = "maybe_uninit_uninit_array_transpose", issue = "96097")]
-    pub fn transpose(self) -> [MaybeUninit<T>; N] {
+    #[inline]
+    pub const fn transpose(self) -> [MaybeUninit<T>; N] {
         // SAFETY: T and MaybeUninit<T> have the same layout
         unsafe { super::transmute_copy(&ManuallyDrop::new(self)) }
     }
@@ -1316,7 +1317,8 @@ impl<T, const N: usize> [MaybeUninit<T>; N] {
     /// let data: MaybeUninit<[u8; 1000]> = data.transpose();
     /// ```
     #[unstable(feature = "maybe_uninit_uninit_array_transpose", issue = "96097")]
-    pub fn transpose(self) -> MaybeUninit<[T; N]> {
+    #[inline]
+    pub const fn transpose(self) -> MaybeUninit<[T; N]> {
         // SAFETY: T and MaybeUninit<T> have the same layout
         unsafe { super::transmute_copy(&ManuallyDrop::new(self)) }
     }


### PR DESCRIPTION
r? @scottmcm 

- These should have been const from the beginning since we're never going to do more than a transmute.
- Inline these always because that's what every other method in MaybeUninit which simply casts does. :) Ok, but a stronger justification is that because we're taking in arrays by `self`, not inlining would defeat the whole purpose of using `MaybeUninit` due to the copying.