### PR TITLE
Nuke slice_as{,_mut}_ptr methods of MaybeUninit

### DIFF
--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -182,7 +182,7 @@ impl FileEncoder {
             // room to write the input to the buffer.
             unsafe {
                 let src = buf.as_ptr();
-                let dst = self.buf.as_mut_ptr().add(buffered).into_inner();
+                let dst = self.buf.as_mut_ptr().add(buffered).cast::<u8>();
                 ptr::copy_nonoverlapping(src, dst, buf_len);
             }
 

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -160,7 +160,7 @@ impl FileEncoder {
         // SAFETY: The above check and `flush` ensures that there is enough
         // room to write the input to the buffer.
         unsafe {
-            *MaybeUninit::slice_as_mut_ptr(&mut self.buf).add(buffered) = value;
+            self.buf.get_unchecked_mut(buffered).write(value);
         }
 
         self.buffered = buffered + 1;
@@ -182,7 +182,7 @@ impl FileEncoder {
             // room to write the input to the buffer.
             unsafe {
                 let src = buf.as_ptr();
-                let dst = MaybeUninit::slice_as_mut_ptr(&mut self.buf).add(buffered);
+                let dst = self.buf.get_unchecked_mut(buffered).as_mut_ptr();
                 ptr::copy_nonoverlapping(src, dst, buf_len);
             }
 

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -182,7 +182,7 @@ impl FileEncoder {
             // room to write the input to the buffer.
             unsafe {
                 let src = buf.as_ptr();
-                let dst = self.buf.get_unchecked_mut(buffered).as_mut_ptr();
+                let dst = self.buf.as_mut_ptr().add(buffered).into_inner();
                 ptr::copy_nonoverlapping(src, dst, buf_len);
             }
 

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -397,7 +397,7 @@ macro_rules! impl_Exp {
                 } else {
                     let off = exponent << 1;
                     // SAFETY: 1 + 2 <= 3
-                    unsafe { ptr::copy_nonoverlapping(lut_ptr.add(off), exp_buf[1].as_mut_ptr(), 2); }
+                    unsafe { ptr::copy_nonoverlapping(lut_ptr.add(off), exp_buf.as_mut_ptr().into_inner().add(1), 2); }
                     3
                 };
                 // SAFETY: max(2, 3) <= 3
@@ -605,7 +605,7 @@ fn fmt_u128(n: u128, is_nonnegative: bool, f: &mut fmt::Formatter<'_>) -> fmt::R
         // SAFETY: Guaranteed that we wrote at most 19 bytes, and there must be space
         // remaining since it has length 39
         unsafe {
-            ptr::write_bytes(buf[target].as_mut_ptr(), b'0', curr - target);
+            ptr::write_bytes(buf.as_mut_ptr().add(target), b'0', curr - target);
         }
         curr = target;
 
@@ -617,7 +617,7 @@ fn fmt_u128(n: u128, is_nonnegative: bool, f: &mut fmt::Formatter<'_>) -> fmt::R
             // SAFETY: At this point we wrote at most 38 bytes, pad up to that point,
             // There can only be at most 1 digit remaining.
             unsafe {
-                ptr::write_bytes(buf[target].as_mut_ptr(), b'0', curr - target);
+                ptr::write_bytes(buf.as_mut_ptr().add(target), b'0', curr - target);
             }
             curr = target - 1;
             buf[curr].write((n as u8) + b'0');
@@ -628,7 +628,7 @@ fn fmt_u128(n: u128, is_nonnegative: bool, f: &mut fmt::Formatter<'_>) -> fmt::R
     // UTF-8 since `DEC_DIGITS_LUT` is
     let buf_slice = unsafe {
         str::from_utf8_unchecked(slice::from_raw_parts(
-            buf.get_unchecked_mut(curr).as_mut_ptr(),
+            buf.as_mut_ptr().add(curr).into_inner(),
             buf.len() - curr,
         ))
     };

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1294,25 +1294,3 @@ impl<T, const N: usize> [MaybeUninit<T>; N] {
         unsafe { intrinsics::transmute_unchecked(self) }
     }
 }
-
-impl<T> *const MaybeUninit<T> {
-    /// Converts a MaybeUninit pointer to its underlying type.
-    ///
-    /// See [`MaybeUninit::as_ptr`] for caveats.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    pub const fn into_inner(self) -> *const T {
-        self.cast()
-    }
-}
-
-impl<T> *mut MaybeUninit<T> {
-    /// Converts mutable a MaybeUninit pointer to its underlying type.
-    ///
-    /// See [`MaybeUninit::as_mut_ptr`] for caveats.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    pub const fn into_inner(self) -> *mut T {
-        self.cast()
-    }
-}

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -993,22 +993,6 @@ impl<T> MaybeUninit<T> {
         unsafe { &mut *(slice as *mut [Self] as *mut [T]) }
     }
 
-    /// Gets a pointer to the first element of the array.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[inline(always)]
-    pub const fn slice_as_ptr(this: &[MaybeUninit<T>]) -> *const T {
-        this.as_ptr() as *const T
-    }
-
-    /// Gets a mutable pointer to the first element of the array.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[inline(always)]
-    pub const fn slice_as_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T {
-        this.as_mut_ptr() as *mut T
-    }
-
     /// Copies the elements from `src` to `this`, returning a mutable reference to the now initialized contents of `this`.
     ///
     /// If `T` does not implement `Copy`, use [`write_slice_cloned`]
@@ -1308,5 +1292,27 @@ impl<T, const N: usize> [MaybeUninit<T>; N] {
     pub const fn transpose(self) -> MaybeUninit<[T; N]> {
         // SAFETY: T and MaybeUninit<T> have the same layout
         unsafe { intrinsics::transmute_unchecked(self) }
+    }
+}
+
+impl<T> *const MaybeUninit<T> {
+    /// Converts a MaybeUninit pointer to its underlying type.
+    ///
+    /// See [`MaybeUninit::as_ptr`] for caveats.
+    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
+    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
+    pub const fn into_inner(self) -> *const T {
+        self.cast()
+    }
+}
+
+impl<T> *mut MaybeUninit<T> {
+    /// Converts mutable a MaybeUninit pointer to its underlying type.
+    ///
+    /// See [`MaybeUninit::as_mut_ptr`] for caveats.
+    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
+    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
+    pub const fn into_inner(self) -> *mut T {
+        self.cast()
     }
 }

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -376,7 +376,7 @@ where
 
         if start_l == end_l {
             // Trace `block_l` elements from the left side.
-            start_l = offsets_l.as_mut_ptr().into_inner();
+            start_l = offsets_l.as_mut_ptr().cast::<u8>();
             end_l = start_l;
             let mut elem = l;
 
@@ -402,7 +402,7 @@ where
 
         if start_r == end_r {
             // Trace `block_r` elements from the right side.
-            start_r = offsets_r.as_mut_ptr().into_inner();
+            start_r = offsets_r.as_mut_ptr().cast::<u8>();
             end_r = start_r;
             let mut elem = r;
 

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -376,7 +376,7 @@ where
 
         if start_l == end_l {
             // Trace `block_l` elements from the left side.
-            start_l = MaybeUninit::slice_as_mut_ptr(&mut offsets_l);
+            start_l = offsets_l.as_mut_ptr().into_inner();
             end_l = start_l;
             let mut elem = l;
 
@@ -402,7 +402,7 @@ where
 
         if start_r == end_r {
             // Trace `block_r` elements from the right side.
-            start_r = MaybeUninit::slice_as_mut_ptr(&mut offsets_r);
+            start_r = offsets_r.as_mut_ptr().into_inner();
             end_r = start_r;
             let mut elem = r;
 


### PR DESCRIPTION
These methods are of questionable value: they mix together removing bounds checks with converting the MaybeUninit slice into a raw pointer. These two behaviors should be explicitly invoked separately to improve code clarity and safety. There is evidence of unnecessary bounds checking removal in the stdlib uses that are updated in this PR.

In https://github.com/rust-lang/libs-team/issues/122, there is discussion of a need for generalized containers. However, that's going to be a long ways off, so in the meantime this PR adds an `into_inner` method on MaybeUninit raw pointers to unwrap the raw pointer. These aren't strictly necessary and could be replaced by `cast`, but then you don't get and type system guarentees.