### PR TITLE
Optimize ReadDir iterator

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1542,6 +1542,10 @@ impl Iterator for ReadDir {
     fn next(&mut self) -> Option<io::Result<DirEntry>> {
         self.0.next().map(|entry| entry.map(DirEntry))
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
 }
 
 impl DirEntry {


### PR DESCRIPTION
I was recently dealing with a directory containing a large number of files and tried to see if there was any room for optimizing `std::fs::ReadDir` for this situation. This commit ended up improving `count()` by only **8.5%** which I didn't find to be enough to justify merging after taking into account how often anybody else would care about this operation. However I think some of the changes to `next()` are an improvement independent of performance so I am going to move those into a separate PR.

```rust
use std::{env, fs};

fn main() {
    let mut args_os = env::args_os();
    args_os.next().unwrap();
    let read_dir = fs::read_dir(args_os.next().unwrap()).unwrap();

    // Before: 4.718 sec
    // After: 4.676 sec (-0.9%)
    let count = read_dir.fold(0, |count, _| count + 1);

    // Before: 4.718 sec
    // After: 4.296 sec (-8.5%)
    let count = read_dir.count();

    println!("{}", count);
}
```

r? @ghost