### PR TITLE
Allow `Vec::leak` when using `no_global_oom_handling`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2193,7 +2193,6 @@ impl<T, A: Allocator> Vec<T, A> {
     /// static_ref[0] += 1;
     /// assert_eq!(static_ref, &[2, 2, 3]);
     /// ```
-    #[cfg(not(no_global_oom_handling))]
     #[stable(feature = "vec_leak", since = "1.47.0")]
     #[inline]
     pub fn leak<'a>(self) -> &'a mut [T]


### PR DESCRIPTION
As [the documentation notes](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.leak), `Vec::leak` hasn't allocated since 1.57.

cc @Ericson2314 in case I'm missing something.