### PR TITLE
rustdoc: remove redundant CSS `#crate-search { border-radius }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1994,10 +1994,6 @@ in storage.js plus the media query with (min-width: 701px)
 }
 
 @media (max-width: 464px) {
-	#crate-search {
-		border-radius: 4px;
-	}
-
 	.docblock {
 		margin-left: 12px;
 	}


### PR DESCRIPTION
This is the same border-radius that's always set on that ID:

https://github.com/rust-lang/rust/blob/a9d1cafa878ecc04a4aa7aaa7df0414a29a2bd0b/src/librustdoc/html/static/css/rustdoc.css#L825-L836