### PR TITLE
Optimize `slice_iter.copied().next_chunk()`

### DIFF
--- a/library/core/benches/lib.rs
+++ b/library/core/benches/lib.rs
@@ -4,6 +4,7 @@
 #![feature(int_log)]
 #![feature(test)]
 #![feature(trusted_random_access)]
+#![feature(iter_array_chunks)]
 
 extern crate test;
 


### PR DESCRIPTION
```
OLD: 
test iter::bench_copied_array_chunks                               ... bench:         371 ns/iter (+/- 7)
NEW:
test iter::bench_copied_array_chunks                               ... bench:          31 ns/iter (+/- 0)
```

The default `next_chunk` implementation suffers from having to assemble the array byte by byte via `next()`, checking the `Option<&T>` and then dereferencing `&T`. The specialization copies the chunk directly from the slice.