### PR TITLE
Fix `src/test/run-make/issue-36710` on cross-compiled targets

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -15,8 +15,8 @@ use std::str::FromStr;
 
 use crate::builder::TaskPath;
 use crate::cache::{Interned, INTERNER};
-use crate::channel::{self, GitInfo};
 use crate::cc_detect::{ndk_compiler, Language};
+use crate::channel::{self, GitInfo};
 pub use crate::flags::Subcommand;
 use crate::flags::{Color, Flags};
 use crate::util::{exe, output, t};

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 use crate::builder::TaskPath;
 use crate::cache::{Interned, INTERNER};
 use crate::channel::{self, GitInfo};
+use crate::cc_detect::{ndk_compiler, Language};
 pub use crate::flags::Subcommand;
 use crate::flags::{Color, Flags};
 use crate::util::{exe, output, t};
@@ -1237,8 +1238,12 @@ impl Config {
                 if let Some(s) = cfg.no_std {
                     target.no_std = s;
                 }
-                target.cc = cfg.cc.map(PathBuf::from);
-                target.cxx = cfg.cxx.map(PathBuf::from);
+                target.cc = cfg.cc.map(PathBuf::from).or_else(|| {
+                    target.ndk.as_ref().map(|ndk| ndk_compiler(Language::C, &triple, ndk))
+                });
+                target.cxx = cfg.cxx.map(PathBuf::from).or_else(|| {
+                    target.ndk.as_ref().map(|ndk| ndk_compiler(Language::CPlusPlus, &triple, ndk))
+                });
                 target.ar = cfg.ar.map(PathBuf::from);
                 target.ranlib = cfg.ranlib.map(PathBuf::from);
                 target.linker = cfg.linker.map(PathBuf::from);

--- a/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-
       curl \
       file \
       g++ \
-      gcc-arm-linux-gnueabihf \
+      g++-arm-linux-gnueabihf \
       git \
       libc6-dev \
       libc6-dev-armhf-cross \

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -40,6 +40,17 @@ endif
 # e.g. for `$(CC) -o $(RUN_BINFILE)`.
 RUN_BINFILE = $(TMPDIR)/$(1)
 
+# Invoke the generated binary on the remote machine if a test address is
+# provided, otherwise run it on the current host.
+ifdef TEST_DEVICE_ADDR
+# FIXME: if a test requires additional files, this will need to be changed to
+# also push them (by changing the 0 to the number of additional files, and
+# providing the path of the additional files as the last arguments).
+EXECUTE = $(REMOTE_TEST_CLIENT) run 0 $(RUN_BINFILE)
+else
+EXECUTE = $(RUN_BINFILE)
+endif
+
 # RUN and FAIL are basic way we will invoke the generated binary.  On
 # non-windows platforms, they set the LD_LIBRARY_PATH environment
 # variable before running the binary.
@@ -50,16 +61,16 @@ BIN = $(1)
 UNAME = $(shell uname)
 
 ifeq ($(UNAME),Darwin)
-RUN = $(TARGET_RPATH_ENV) $(RUN_BINFILE)
-FAIL = $(TARGET_RPATH_ENV) $(RUN_BINFILE) && exit 1 || exit 0
+RUN = $(TARGET_RPATH_ENV) $(EXECUTE)
+FAIL = $(TARGET_RPATH_ENV) $(EXECUTE) && exit 1 || exit 0
 DYLIB_GLOB = lib$(1)*.dylib
 DYLIB = $(TMPDIR)/lib$(1).dylib
 STATICLIB = $(TMPDIR)/lib$(1).a
 STATICLIB_GLOB = lib$(1)*.a
 else
 ifdef IS_WINDOWS
-RUN = PATH="$(PATH):$(TARGET_RPATH_DIR)" $(RUN_BINFILE)
-FAIL = PATH="$(PATH):$(TARGET_RPATH_DIR)" $(RUN_BINFILE) && exit 1 || exit 0
+RUN = PATH="$(PATH):$(TARGET_RPATH_DIR)" $(EXECUTE)
+FAIL = PATH="$(PATH):$(TARGET_RPATH_DIR)" $(EXECUTE) && exit 1 || exit 0
 DYLIB_GLOB = $(1)*.dll
 DYLIB = $(TMPDIR)/$(1).dll
 ifdef IS_MSVC
@@ -73,8 +84,8 @@ endif
 BIN = $(1).exe
 LLVM_FILECHECK := $(shell cygpath -u "$(LLVM_FILECHECK)")
 else
-RUN = $(TARGET_RPATH_ENV) $(RUN_BINFILE)
-FAIL = $(TARGET_RPATH_ENV) $(RUN_BINFILE) && exit 1 || exit 0
+RUN = $(TARGET_RPATH_ENV) $(EXECUTE)
+FAIL = $(TARGET_RPATH_ENV) $(EXECUTE) && exit 1 || exit 0
 DYLIB_GLOB = lib$(1)*.so
 DYLIB = $(TMPDIR)/lib$(1).so
 STATICLIB = $(TMPDIR)/lib$(1).a

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -40,9 +40,9 @@ endif
 # e.g. for `$(CC) -o $(RUN_BINFILE)`.
 RUN_BINFILE = $(TMPDIR)/$(1)
 
-# Invoke the generated binary on the remote machine if a test address is
-# provided, otherwise run it on the current host.
-ifdef TEST_DEVICE_ADDR
+# Invoke the generated binary on the remote machine if compiletest was
+# configured to use a remote test device, otherwise run it on the current host.
+ifdef REMOTE_TEST_CLIENT
 # FIXME: if a test requires additional files, this will need to be changed to
 # also push them (by changing the 0 to the number of additional files, and
 # providing the path of the additional files as the last arguments).

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,6 +1,10 @@
-# ignore-cross-compile $(call RUN,foo) expects to run the target executable natively
+# ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
 #                              so it won't work with remote-test-server
+# ignore-arm Another build using remote-test-server
 # ignore-none no-std is not supported
+# ignore-wasm32 FIXME: don't attempt to compile C++ to WASM
+# ignore-wasm64 FIXME: don't attempt to compile C++ to WASM
+# ignore-nvptx64-nvidia-cuda FIXME: can't find crate for `std`
 # ignore-musl FIXME: this makefile needs teaching how to use a musl toolchain
 #                    (see dist-i586-gnu-i586-i686-musl Dockerfile)
 

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,6 +1,3 @@
-# ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
-#                              so it won't work with remote-test-server
-# ignore-arm Another build using remote-test-server
 # ignore-none no-std is not supported
 # ignore-wasm32 FIXME: don't attempt to compile C++ to WASM
 # ignore-wasm64 FIXME: don't attempt to compile C++ to WASM

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2987,6 +2987,10 @@ impl<'test> TestCx<'test> {
             cmd.env("LLVM_BIN_DIR", llvm_bin_dir);
         }
 
+        if let Some(ref remote_test_client) = self.config.remote_test_client {
+            cmd.env("REMOTE_TEST_CLIENT", remote_test_client);
+        }
+
         // We don't want RUSTFLAGS set from the outside to interfere with
         // compiler flags set in the test cases:
         cmd.env_remove("RUSTFLAGS");


### PR DESCRIPTION
This PR fixes the `src/test/run-make/issue-36710` test not working on cross-compiled targets by telling the make infra how to run tests remotely with `remote-test-server`.

This PR includes a revert of #102723 (cc @pcc), which disabled that test on all cross-compiled targets.