### PR TITLE
Handle core dumps output in QEMU user mode

### DIFF
--- a/src/test/ui/alloc-error/default-alloc-error-hook.rs
+++ b/src/test/ui/alloc-error/default-alloc-error-hook.rs
@@ -15,5 +15,14 @@ fn main() {
     let me = env::current_exe().unwrap();
     let output = Command::new(&me).arg("next").output().unwrap();
     assert!(!output.status.success(), "{:?} is a success", output.status);
-    assert_eq!(str::from_utf8(&output.stderr).unwrap(), "memory allocation of 42 bytes failed\n");
+
+    let mut stderr = str::from_utf8(&output.stderr).unwrap();
+
+    // When running inside QEMU user-mode emulation, there will be an extra message printed by QEMU
+    // in the stderr whenever a core dump happens. Remove it before the check.
+    stderr = stderr
+        .strip_suffix("qemu: uncaught target signal 6 (Aborted) - core dumped\n")
+        .unwrap_or(stderr);
+
+    assert_eq!(stderr, "memory allocation of 42 bytes failed\n");
 }

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -22,7 +22,12 @@ fn main() {
     }.expect("running the command should have succeeded");
     println!("{:#?}", output);
     let stderr = std::str::from_utf8(&output.stderr);
-    assert!(stderr.map(|v| {
-        v.ends_with("fatal runtime error: drop of the panic payload panicked\n")
-    }).unwrap_or(false));
+    assert!(stderr
+        .map(|v| {
+            // When running inside QEMU user-mode emulation, there will be an extra message printed
+            // by QEMU in the stderr whenever a core dump happens. Remove it before the check.
+            v.strip_suffix("qemu: uncaught target signal 6 (Aborted) - core dumped\n").unwrap_or(v)
+        })
+        .map(|v| { v.ends_with("fatal runtime error: drop of the panic payload panicked\n") })
+        .unwrap_or(false));
 }


### PR DESCRIPTION
In addition to the whole-system emulation/virtualization, QEMU also supports user-mode emulation, where the emulation happens as a normal process inside the parent system. This allows running most tests by simply spawning remote-test-server inside user-mode emulation.

Unfortunately, QEMU always writes its own message in addition to the system one when a core dump happens, which breaks a few tests which match on the exact output of the system.

This PR changes those tests to strip the (possible) QEMU output before checking if the output is expected.