### PR TITLE
mark sys_common::once::generic::Once::new const-stable

### DIFF
--- a/library/std/src/sys_common/once/generic.rs
+++ b/library/std/src/sys_common/once/generic.rs
@@ -107,6 +107,7 @@ struct WaiterQueue<'a> {
 
 impl Once {
     #[inline]
+    #[rustc_const_stable(feature = "const_once_new", since = "1.32.0")]
     pub const fn new() -> Once {
         Once { state_and_queue: AtomicPtr::new(ptr::invalid_mut(INCOMPLETE)) }
     }


### PR DESCRIPTION
Attempt to address https://github.com/rust-lang/rust/issues/103191 by marking the impl const-stable.
Picked the declaration from the callsite:
https://github.com/rust-lang/rust/blob/21b246587c2687935bd6004ffa5dcc4f4dd6600d/library/std/src/sync/once.rs#L67

This is similar to https://github.com/rust-lang/rust/pull/98457.

With this in, `python3 x.py build library/std --target x86_64-unknown-none` succeeds.