### PR TITLE
Allow Or patterns in IfLet guard

### DIFF
--- a/src/test/ui/rfc-2294-if-let-guard/run-pass.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/run-pass.rs
@@ -30,4 +30,10 @@ fn main() {
         Some(x) if let Foo::Qux(y) = qux(x) => assert_eq!(y, 84),
         _ => panic!(),
     }
+    match () {
+        () | () if let x = 0 => {
+            x;
+        },
+        _ => {}
+    };
 }


### PR DESCRIPTION
As mentioned in #88015 each subpattern creates a new local for 'x' which confuses the borrow checker about its initialization.

Fixes #88015
