### PR TITLE
Stabilize proc_macro::Span::source_text

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -546,7 +546,7 @@ impl Span {
     /// Note: The observable result of a macro should only rely on the tokens and
     /// not on this source text. The result of this function is a best effort to
     /// be used for diagnostics only.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_source_text", since = "CURRENT_RUSTC_VERSION")]
     pub fn source_text(&self) -> Option<String> {
         self.0.source_text()
     }


### PR DESCRIPTION
Splits `proc_macro::Span::source_text` into a new feature gate and stabilizes it. The [FCP is complete](https://github.com/rust-lang/rust/issues/101991#issuecomment-1279393265).

```Rust
impl Span {
    pub fn source_text(&self) -> Option<String>;
}
```

Closes #101991