### PR TITLE
Retrieve LLVM version from llvm-filecheck binary if it is not set yet

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use tracing::*;
 
@@ -841,6 +842,20 @@ pub fn extract_llvm_version(version: &str) -> Option<u32> {
         _ => panic!("Malformed version"),
     };
     Some(version)
+}
+
+pub fn extract_llvm_version_from_binary(binary_path: &str) -> Option<u32> {
+    let output = Command::new(binary_path).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let version = String::from_utf8(output.stdout).ok()?;
+    for line in version.lines() {
+        if let Some(version) = line.split("LLVM version ").skip(1).next() {
+            return extract_llvm_version(version);
+        }
+    }
+    None
 }
 
 /// Takes a directive of the form "<version1> [- <version2>]",

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -200,7 +200,9 @@ pub fn parse_config(args: Vec<String>) -> Config {
         Some(x) => panic!("argument for --color must be auto, always, or never, but found `{}`", x),
     };
     let llvm_version =
-        matches.opt_str("llvm-version").as_deref().and_then(header::extract_llvm_version);
+        matches.opt_str("llvm-version").as_deref().and_then(header::extract_llvm_version).or_else(
+            || header::extract_llvm_version_from_binary(&matches.opt_str("llvm-filecheck")?),
+        );
 
     let src_base = opt_path(matches, "src-base");
     let run_ignored = matches.opt_present("ignored");


### PR DESCRIPTION
In `rustc_codegen_gcc`, we run the `ASM` test suite. The problem is that, if a too recent version of the `llvm-filecheck` binary is provided, an extra argument needs to be passed and the to detect this version, it currently only expects a `--llvm-version` argument. With this, the version can be determined directly from the `llvm-filecheck` binary.

r? @Amanieu 