### PR TITLE
Diagnostic derives: allow specifying multiple alternative suggestions

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -691,6 +691,24 @@ impl Diagnostic {
         suggestions: impl Iterator<Item = String>,
         applicability: Applicability,
     ) -> &mut Self {
+        self.span_suggestions_with_style(
+            sp,
+            msg,
+            suggestions,
+            applicability,
+            SuggestionStyle::ShowCode,
+        )
+    }
+
+    /// [`Diagnostic::span_suggestions()`] but you can set the [`SuggestionStyle`].
+    pub fn span_suggestions_with_style(
+        &mut self,
+        sp: Span,
+        msg: impl Into<SubdiagnosticMessage>,
+        suggestions: impl Iterator<Item = String>,
+        applicability: Applicability,
+        style: SuggestionStyle,
+    ) -> &mut Self {
         let mut suggestions: Vec<_> = suggestions.collect();
         suggestions.sort();
 
@@ -706,14 +724,15 @@ impl Diagnostic {
         self.push_suggestion(CodeSuggestion {
             substitutions,
             msg: self.subdiagnostic_message_to_diagnostic_message(msg),
-            style: SuggestionStyle::ShowCode,
+            style,
             applicability,
         });
         self
     }
 
-    /// Prints out a message with multiple suggested edits of the code.
-    /// See also [`Diagnostic::span_suggestion()`].
+    /// Prints out a message with multiple suggested edits of the code, where each edit consists of
+    /// multiple parts.
+    /// See also [`Diagnostic::multipart_suggestion()`].
     pub fn multipart_suggestions(
         &mut self,
         msg: impl Into<SubdiagnosticMessage>,
@@ -745,6 +764,7 @@ impl Diagnostic {
         });
         self
     }
+
     /// Prints out a message with a suggested edit of the code. If the suggestion is presented
     /// inline, it will only show the message and not the suggestion.
     ///

--- a/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
@@ -454,7 +454,7 @@ impl<'a> DiagnosticDeriveVariantBuilder<'a> {
 
                 self.formatting_init.extend(code_init);
                 Ok(quote! {
-                    #diag.span_suggestion_with_style(
+                    #diag.span_suggestions_with_style(
                         #span_field,
                         rustc_errors::fluent::#slug,
                         #code_field,

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -758,3 +758,41 @@ struct WithDocComment {
     #[primary_span]
     span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(compiletest_example)]
+struct SuggestionsGood {
+    #[suggestion(code("foo", "bar"))]
+    sub: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(compiletest_example)]
+struct SuggestionsSingleItem {
+    #[suggestion(code("foo"))]
+    sub: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(compiletest_example)]
+struct SuggestionsNoItem {
+    #[suggestion(code())]
+    //~^ ERROR expected at least one string literal for `code(...)`
+    sub: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(compiletest_example)]
+struct SuggestionsInvalidItem {
+    #[suggestion(code(foo))]
+    //~^ ERROR `code(...)` must contain only string literals
+    sub: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(compiletest_example)]
+struct SuggestionsInvalidLiteral {
+    #[suggestion(code = 3)]
+    //~^ ERROR `code = "..."`/`code(...)` must contain only string literals
+    sub: Span,
+}

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -573,6 +573,24 @@ LL |     #[subdiagnostic(eager)]
    |
    = help: eager subdiagnostics are not supported on lints
 
+error: expected at least one string literal for `code(...)`
+  --> $DIR/diagnostic-derive.rs:779:18
+   |
+LL |     #[suggestion(code())]
+   |                  ^^^^^^
+
+error: `code(...)` must contain only string literals
+  --> $DIR/diagnostic-derive.rs:787:23
+   |
+LL |     #[suggestion(code(foo))]
+   |                       ^^^
+
+error: `code = "..."`/`code(...)` must contain only string literals
+  --> $DIR/diagnostic-derive.rs:795:18
+   |
+LL |     #[suggestion(code = 3)]
+   |                  ^^^^^^^^
+
 error: cannot find attribute `nonsense` in this scope
   --> $DIR/diagnostic-derive.rs:55:3
    |
@@ -647,7 +665,7 @@ LL |         arg: impl IntoDiagnosticArg,
    |                   ^^^^^^^^^^^^^^^^^ required by this bound in `DiagnosticBuilder::<'a, G>::set_arg`
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 80 previous errors
+error: aborting due to 83 previous errors
 
 Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -661,3 +661,48 @@ enum BL {
         span: Span,
     }
 }
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parser_add_paren)]
+struct BM {
+    #[suggestion_part(code("foo"))]
+    //~^ ERROR expected exactly one string literal for `code = ...`
+    span: Span,
+    r#type: String,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parser_add_paren)]
+struct BN {
+    #[suggestion_part(code("foo", "bar"))]
+    //~^ ERROR expected exactly one string literal for `code = ...`
+    span: Span,
+    r#type: String,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parser_add_paren)]
+struct BO {
+    #[suggestion_part(code(3))]
+    //~^ ERROR expected exactly one string literal for `code = ...`
+    span: Span,
+    r#type: String,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parser_add_paren)]
+struct BP {
+    #[suggestion_part(code())]
+    //~^ ERROR expected exactly one string literal for `code = ...`
+    span: Span,
+    r#type: String,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parser_add_paren)]
+struct BQ {
+    #[suggestion_part(code = 3)]
+    //~^ ERROR `code = "..."`/`code(...)` must contain only string literals
+    span: Span,
+    r#type: String,
+}

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -415,6 +415,36 @@ error: `#[applicability]` has no effect if all `#[suggestion]`/`#[multipart_sugg
 LL |     #[applicability]
    |     ^^^^^^^^^^^^^^^^
 
+error: expected exactly one string literal for `code = ...`
+  --> $DIR/subdiagnostic-derive.rs:668:23
+   |
+LL |     #[suggestion_part(code("foo"))]
+   |                       ^^^^^^^^^^^
+
+error: expected exactly one string literal for `code = ...`
+  --> $DIR/subdiagnostic-derive.rs:677:23
+   |
+LL |     #[suggestion_part(code("foo", "bar"))]
+   |                       ^^^^^^^^^^^^^^^^^^
+
+error: expected exactly one string literal for `code = ...`
+  --> $DIR/subdiagnostic-derive.rs:686:23
+   |
+LL |     #[suggestion_part(code(3))]
+   |                       ^^^^^^^
+
+error: expected exactly one string literal for `code = ...`
+  --> $DIR/subdiagnostic-derive.rs:695:23
+   |
+LL |     #[suggestion_part(code())]
+   |                       ^^^^^^
+
+error: `code = "..."`/`code(...)` must contain only string literals
+  --> $DIR/subdiagnostic-derive.rs:704:23
+   |
+LL |     #[suggestion_part(code = 3)]
+   |                       ^^^^^^^^
+
 error: cannot find attribute `foo` in this scope
   --> $DIR/subdiagnostic-derive.rs:63:3
    |
@@ -475,6 +505,6 @@ error[E0425]: cannot find value `slug` in module `rustc_errors::fluent`
 LL | #[label(slug)]
    |         ^^^^ not found in `rustc_errors::fluent`
 
-error: aborting due to 67 previous errors
+error: aborting due to 72 previous errors
 
 For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
This allows porting `span_suggestions()` to diagnostic structs.

Doesn't work for `multipart_suggestions()` because the rank would be reversed - the struct would specify multiple spans, each of which has multiple possible replacements, while `multipart_suggestions()` creates multiple possible replacements, each with multiple spans.