### PR TITLE
Track where diagnostics were created.

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1211,6 +1211,7 @@ pub fn report_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
         false,
         None,
         false,
+        false,
     ));
     let handler = rustc_errors::Handler::with_emitter(true, None, emitter);
 

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -133,6 +133,7 @@ mod sealed_level_is_error {
 impl<'a> DiagnosticBuilder<'a, ErrorGuaranteed> {
     /// Convenience function for internal use, clients should use one of the
     /// `struct_*` methods on [`Handler`].
+    #[track_caller]
     pub(crate) fn new_guaranteeing_error<M: Into<DiagnosticMessage>, const L: Level>(
         handler: &'a Handler,
         message: M,
@@ -196,6 +197,7 @@ impl EmissionGuarantee for ErrorGuaranteed {
         }
     }
 
+    #[track_caller]
     fn make_diagnostic_builder(
         handler: &Handler,
         msg: impl Into<DiagnosticMessage>,
@@ -209,6 +211,7 @@ impl EmissionGuarantee for ErrorGuaranteed {
 impl<'a> DiagnosticBuilder<'a, ()> {
     /// Convenience function for internal use, clients should use one of the
     /// `struct_*` methods on [`Handler`].
+    #[track_caller]
     pub(crate) fn new<M: Into<DiagnosticMessage>>(
         handler: &'a Handler,
         level: Level,
@@ -220,6 +223,7 @@ impl<'a> DiagnosticBuilder<'a, ()> {
 
     /// Creates a new `DiagnosticBuilder` with an already constructed
     /// diagnostic.
+    #[track_caller]
     pub(crate) fn new_diagnostic(handler: &'a Handler, diagnostic: Diagnostic) -> Self {
         debug!("Created new diagnostic");
         Self {
@@ -308,6 +312,7 @@ impl EmissionGuarantee for Noted {
 impl<'a> DiagnosticBuilder<'a, !> {
     /// Convenience function for internal use, clients should use one of the
     /// `struct_*` methods on [`Handler`].
+    #[track_caller]
     pub(crate) fn new_fatal(handler: &'a Handler, message: impl Into<DiagnosticMessage>) -> Self {
         let diagnostic = Diagnostic::new_with_code(Level::Fatal, None, message);
         Self::new_diagnostic_fatal(handler, diagnostic)

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -16,10 +16,10 @@ use crate::snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, Styl
 use crate::styled_buffer::StyledBuffer;
 use crate::translation::{to_fluent_args, Translate};
 use crate::{
-    CodeSuggestion, Diagnostic, DiagnosticId, DiagnosticMessage, FluentBundle, Handler,
-    LazyFallbackBundle, Level, MultiSpan, SubDiagnostic, SubstitutionHighlight, SuggestionStyle,
+    diagnostic::DiagnosticLocation, CodeSuggestion, Diagnostic, DiagnosticId, DiagnosticMessage,
+    FluentBundle, Handler, LazyFallbackBundle, Level, MultiSpan, SubDiagnostic,
+    SubstitutionHighlight, SuggestionStyle,
 };
-
 use rustc_lint_defs::pluralize;
 
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
@@ -64,6 +64,7 @@ impl HumanReadableErrorType {
         teach: bool,
         diagnostic_width: Option<usize>,
         macro_backtrace: bool,
+        track_diagnostics: bool,
     ) -> EmitterWriter {
         let (short, color_config) = self.unzip();
         let color = color_config.suggests_using_colors();
@@ -77,6 +78,7 @@ impl HumanReadableErrorType {
             color,
             diagnostic_width,
             macro_backtrace,
+            track_diagnostics,
         )
     }
 }
@@ -557,6 +559,7 @@ impl Emitter for EmitterWriter {
             &primary_span,
             &children,
             &suggestions,
+            Some(&diag.emitted_at),
         );
     }
 
@@ -650,6 +653,7 @@ pub struct EmitterWriter {
     diagnostic_width: Option<usize>,
 
     macro_backtrace: bool,
+    track_diagnostics: bool,
 }
 
 #[derive(Debug)]
@@ -669,6 +673,7 @@ impl EmitterWriter {
         teach: bool,
         diagnostic_width: Option<usize>,
         macro_backtrace: bool,
+        track_diagnostics: bool,
     ) -> EmitterWriter {
         let dst = Destination::from_stderr(color_config);
         EmitterWriter {
@@ -681,6 +686,7 @@ impl EmitterWriter {
             ui_testing: false,
             diagnostic_width,
             macro_backtrace,
+            track_diagnostics,
         }
     }
 
@@ -694,6 +700,7 @@ impl EmitterWriter {
         colored: bool,
         diagnostic_width: Option<usize>,
         macro_backtrace: bool,
+        track_diagnostics: bool,
     ) -> EmitterWriter {
         EmitterWriter {
             dst: Raw(dst, colored),
@@ -705,6 +712,7 @@ impl EmitterWriter {
             ui_testing: false,
             diagnostic_width,
             macro_backtrace,
+            track_diagnostics,
         }
     }
 
@@ -1327,6 +1335,7 @@ impl EmitterWriter {
         level: &Level,
         max_line_num_len: usize,
         is_secondary: bool,
+        emitted_at: Option<&DiagnosticLocation>,
     ) -> io::Result<()> {
         let mut buffer = StyledBuffer::new();
 
@@ -1377,7 +1386,6 @@ impl EmitterWriter {
                 }
             }
         }
-
         let mut annotated_files = FileWithAnnotatedLines::collect_annotations(self, args, msp);
 
         // Make sure our primary file comes first
@@ -1651,6 +1659,12 @@ impl EmitterWriter {
                     multilines.extend(&to_add);
                 }
             }
+        }
+
+        if self.track_diagnostics && let Some(tracked) = emitted_at {
+            let track = format!("-Ztrack-diagnostics: created at {tracked}");
+            let len = buffer.num_lines();
+            buffer.append(len, &track, Style::NoStyle);
         }
 
         // final step: take our styled buffer, render it, then output it
@@ -1977,6 +1991,7 @@ impl EmitterWriter {
         span: &MultiSpan,
         children: &[SubDiagnostic],
         suggestions: &[CodeSuggestion],
+        emitted_at: Option<&DiagnosticLocation>,
     ) {
         let max_line_num_len = if self.ui_testing {
             ANONYMIZED_LINE_NUM.len()
@@ -1985,7 +2000,16 @@ impl EmitterWriter {
             num_decimal_digits(n)
         };
 
-        match self.emit_message_default(span, message, args, code, level, max_line_num_len, false) {
+        match self.emit_message_default(
+            span,
+            message,
+            args,
+            code,
+            level,
+            max_line_num_len,
+            false,
+            emitted_at,
+        ) {
             Ok(()) => {
                 if !children.is_empty()
                     || suggestions.iter().any(|s| s.style != SuggestionStyle::CompletelyHidden)
@@ -2014,6 +2038,7 @@ impl EmitterWriter {
                             &child.level,
                             max_line_num_len,
                             true,
+                            None,
                         ) {
                             panic!("failed to emit error: {}", err);
                         }
@@ -2030,6 +2055,7 @@ impl EmitterWriter {
                                 &Level::Help,
                                 max_line_num_len,
                                 true,
+                                None,
                             ) {
                                 panic!("failed to emit error: {}", e);
                             }

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -559,7 +559,7 @@ impl Emitter for EmitterWriter {
             &primary_span,
             &children,
             &suggestions,
-            Some(&diag.emitted_at),
+            self.track_diagnostics.then_some(&diag.emitted_at),
         );
     }
 
@@ -1661,7 +1661,7 @@ impl EmitterWriter {
             }
         }
 
-        if self.track_diagnostics && let Some(tracked) = emitted_at {
+        if let Some(tracked) = emitted_at {
             let track = format!("-Ztrack-diagnostics: created at {tracked}");
             let len = buffer.num_lines();
             buffer.append(len, &track, Style::NoStyle);

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -45,6 +45,7 @@ pub struct JsonEmitter {
     json_rendered: HumanReadableErrorType,
     diagnostic_width: Option<usize>,
     macro_backtrace: bool,
+    track_diagnostics: bool,
 }
 
 impl JsonEmitter {
@@ -57,6 +58,7 @@ impl JsonEmitter {
         json_rendered: HumanReadableErrorType,
         diagnostic_width: Option<usize>,
         macro_backtrace: bool,
+        track_diagnostics: bool,
     ) -> JsonEmitter {
         JsonEmitter {
             dst: Box::new(io::BufWriter::new(io::stderr())),
@@ -69,6 +71,7 @@ impl JsonEmitter {
             json_rendered,
             diagnostic_width,
             macro_backtrace,
+            track_diagnostics,
         }
     }
 
@@ -79,6 +82,7 @@ impl JsonEmitter {
         fallback_bundle: LazyFallbackBundle,
         diagnostic_width: Option<usize>,
         macro_backtrace: bool,
+        track_diagnostics: bool,
     ) -> JsonEmitter {
         let file_path_mapping = FilePathMapping::empty();
         JsonEmitter::stderr(
@@ -90,6 +94,7 @@ impl JsonEmitter {
             json_rendered,
             diagnostic_width,
             macro_backtrace,
+            track_diagnostics,
         )
     }
 
@@ -103,6 +108,7 @@ impl JsonEmitter {
         json_rendered: HumanReadableErrorType,
         diagnostic_width: Option<usize>,
         macro_backtrace: bool,
+        track_diagnostics: bool,
     ) -> JsonEmitter {
         JsonEmitter {
             dst,
@@ -115,6 +121,7 @@ impl JsonEmitter {
             json_rendered,
             diagnostic_width,
             macro_backtrace,
+            track_diagnostics,
         }
     }
 
@@ -350,6 +357,7 @@ impl Diagnostic {
                 false,
                 je.diagnostic_width,
                 je.macro_backtrace,
+                je.track_diagnostics,
             )
             .ui_testing(je.ui_testing)
             .emit_diagnostic(diag);

--- a/compiler/rustc_errors/src/json/tests.rs
+++ b/compiler/rustc_errors/src/json/tests.rs
@@ -59,6 +59,7 @@ fn test_positions(code: &str, span: (u32, u32), expected_output: SpanTestData) {
             HumanReadableErrorType::Short(ColorConfig::Never),
             None,
             false,
+            false,
         );
 
         let span = Span::with_root_ctxt(BytePos(span.0), BytePos(span.1));

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -489,6 +489,8 @@ pub struct HandlerFlags {
     pub macro_backtrace: bool,
     /// If true, identical diagnostics are reported only once.
     pub deduplicate_diagnostics: bool,
+    /// Track where errors are created. Enabled with `-Ztrack-diagnostics`.
+    pub track_diagnostics: bool,
 }
 
 impl Drop for HandlerInner {
@@ -556,6 +558,7 @@ impl Handler {
             false,
             None,
             flags.macro_backtrace,
+            flags.track_diagnostics,
         ));
         Self::with_emitter_and_flags(emitter, flags)
     }
@@ -661,6 +664,7 @@ impl Handler {
 
     /// Construct a builder with the `msg` at the level appropriate for the specific `EmissionGuarantee`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_diagnostic<G: EmissionGuarantee>(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -674,6 +678,7 @@ impl Handler {
     /// * `can_emit_warnings` is `true`
     /// * `is_force_warn` was set in `DiagnosticId::Lint`
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_warn(
         &self,
         span: impl Into<MultiSpan>,
@@ -690,6 +695,7 @@ impl Handler {
     /// Attempting to `.emit()` the builder will only emit if either:
     /// * `can_emit_warnings` is `true`
     /// * `is_force_warn` was set in `DiagnosticId::Lint`
+    #[track_caller]
     pub fn struct_span_warn_with_expectation(
         &self,
         span: impl Into<MultiSpan>,
@@ -703,6 +709,7 @@ impl Handler {
 
     /// Construct a builder at the `Allow` level at the given `span` and with the `msg`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_allow(
         &self,
         span: impl Into<MultiSpan>,
@@ -716,6 +723,7 @@ impl Handler {
     /// Construct a builder at the `Warning` level at the given `span` and with the `msg`.
     /// Also include a code.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_warn_with_code(
         &self,
         span: impl Into<MultiSpan>,
@@ -733,6 +741,7 @@ impl Handler {
     /// * `can_emit_warnings` is `true`
     /// * `is_force_warn` was set in `DiagnosticId::Lint`
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_warn(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         DiagnosticBuilder::new(self, Level::Warning(None), msg)
     }
@@ -743,6 +752,7 @@ impl Handler {
     /// Attempting to `.emit()` the builder will only emit if either:
     /// * `can_emit_warnings` is `true`
     /// * `is_force_warn` was set in `DiagnosticId::Lint`
+    #[track_caller]
     pub fn struct_warn_with_expectation(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -759,6 +769,7 @@ impl Handler {
 
     /// Construct a builder at the `Expect` level with the `msg`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_expect(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -769,6 +780,7 @@ impl Handler {
 
     /// Construct a builder at the `Error` level at the given `span` and with the `msg`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_err(
         &self,
         span: impl Into<MultiSpan>,
@@ -781,6 +793,7 @@ impl Handler {
 
     /// Construct a builder at the `Error` level at the given `span`, with the `msg`, and `code`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_err_with_code(
         &self,
         span: impl Into<MultiSpan>,
@@ -795,6 +808,7 @@ impl Handler {
     /// Construct a builder at the `Error` level with the `msg`.
     // FIXME: This method should be removed (every error should have an associated error code).
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_err(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -804,12 +818,14 @@ impl Handler {
 
     /// This should only be used by `rustc_middle::lint::struct_lint_level`. Do not use it for hard errors.
     #[doc(hidden)]
+    #[track_caller]
     pub fn struct_err_lint(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         DiagnosticBuilder::new(self, Level::Error { lint: true }, msg)
     }
 
     /// Construct a builder at the `Error` level with the `msg` and the `code`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_err_with_code(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -822,6 +838,7 @@ impl Handler {
 
     /// Construct a builder at the `Warn` level with the `msg` and the `code`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_warn_with_code(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -834,6 +851,7 @@ impl Handler {
 
     /// Construct a builder at the `Fatal` level at the given `span` and with the `msg`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_fatal(
         &self,
         span: impl Into<MultiSpan>,
@@ -871,6 +889,7 @@ impl Handler {
 
     /// Construct a builder at the `Note` level with the `msg`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_note_without_error(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -885,6 +904,7 @@ impl Handler {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_fatal_with_code(
         &self,
         span: impl Into<MultiSpan>,
@@ -896,6 +916,7 @@ impl Handler {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_err(
         &self,
         span: impl Into<MultiSpan>,
@@ -905,6 +926,7 @@ impl Handler {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_err_with_code(
         &self,
         span: impl Into<MultiSpan>,
@@ -918,11 +940,13 @@ impl Handler {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_warn(&self, span: impl Into<MultiSpan>, msg: impl Into<DiagnosticMessage>) {
         self.emit_diag_at_span(Diagnostic::new(Warning(None), msg), span);
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_warn_with_code(
         &self,
         span: impl Into<MultiSpan>,
@@ -932,6 +956,7 @@ impl Handler {
         self.emit_diag_at_span(Diagnostic::new_with_code(Warning(None), Some(code), msg), span);
     }
 
+    #[track_caller]
     pub fn span_bug(&self, span: impl Into<MultiSpan>, msg: impl Into<DiagnosticMessage>) -> ! {
         self.inner.borrow_mut().span_bug(span, msg)
     }
@@ -947,14 +972,17 @@ impl Handler {
 
     // FIXME(eddyb) note the comment inside `impl Drop for HandlerInner`, that's
     // where the explanation of what "good path" is (also, it should be renamed).
+    #[track_caller]
     pub fn delay_good_path_bug(&self, msg: impl Into<DiagnosticMessage>) {
         self.inner.borrow_mut().delay_good_path_bug(msg)
     }
 
+    #[track_caller]
     pub fn span_bug_no_panic(&self, span: impl Into<MultiSpan>, msg: impl Into<DiagnosticMessage>) {
         self.emit_diag_at_span(Diagnostic::new(Bug, msg), span);
     }
 
+    #[track_caller]
     pub fn span_note_without_error(
         &self,
         span: impl Into<MultiSpan>,
@@ -963,6 +991,7 @@ impl Handler {
         self.emit_diag_at_span(Diagnostic::new(Note, msg), span);
     }
 
+    #[track_caller]
     pub fn span_note_diag(
         &self,
         span: Span,
@@ -1449,6 +1478,7 @@ impl HandlerInner {
         }
     }
 
+    #[track_caller]
     fn span_bug(&mut self, sp: impl Into<MultiSpan>, msg: impl Into<DiagnosticMessage>) -> ! {
         self.emit_diag_at_span(Diagnostic::new(Bug, msg), sp);
         panic::panic_any(ExplicitBug);

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -763,6 +763,7 @@ impl Handler {
 
     /// Construct a builder at the `Allow` level with the `msg`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_allow(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         DiagnosticBuilder::new(self, Level::Allow, msg)
     }
@@ -864,6 +865,7 @@ impl Handler {
 
     /// Construct a builder at the `Fatal` level at the given `span`, with the `msg`, and `code`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_fatal_with_code(
         &self,
         span: impl Into<MultiSpan>,
@@ -877,6 +879,7 @@ impl Handler {
 
     /// Construct a builder at the `Error` level with the `msg`.
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_fatal(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, !> {
         DiagnosticBuilder::new_fatal(self, msg)
     }
@@ -898,6 +901,7 @@ impl Handler {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_fatal(&self, span: impl Into<MultiSpan>, msg: impl Into<DiagnosticMessage>) -> ! {
         self.emit_diag_at_span(Diagnostic::new(Fatal, msg), span);
         FatalError.raise()
@@ -956,7 +960,6 @@ impl Handler {
         self.emit_diag_at_span(Diagnostic::new_with_code(Warning(None), Some(code), msg), span);
     }
 
-    #[track_caller]
     pub fn span_bug(&self, span: impl Into<MultiSpan>, msg: impl Into<DiagnosticMessage>) -> ! {
         self.inner.borrow_mut().span_bug(span, msg)
     }
@@ -972,7 +975,6 @@ impl Handler {
 
     // FIXME(eddyb) note the comment inside `impl Drop for HandlerInner`, that's
     // where the explanation of what "good path" is (also, it should be renamed).
-    #[track_caller]
     pub fn delay_good_path_bug(&self, msg: impl Into<DiagnosticMessage>) {
         self.inner.borrow_mut().delay_good_path_bug(msg)
     }

--- a/compiler/rustc_expand/src/tests.rs
+++ b/compiler/rustc_expand/src/tests.rs
@@ -151,6 +151,7 @@ fn test_harness(file_text: &str, span_labels: Vec<SpanLabel>, expected_output: &
             false,
             None,
             false,
+            false,
         );
         let handler = Handler::with_emitter(true, None, Box::new(emitter));
         handler.span_err(msp, "foo");

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -252,6 +252,7 @@ pub struct MissingTypeParams {
 
 // Manual implementation of `IntoDiagnostic` to be able to call `span_to_snippet`.
 impl<'a> IntoDiagnostic<'a> for MissingTypeParams {
+    #[track_caller]
     fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut err = handler.struct_span_err_with_code(
             self.span,

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -689,6 +689,7 @@ fn test_unstable_options_tracking_hash() {
     untracked!(time_llvm_passes, true);
     untracked!(time_passes, true);
     untracked!(trace_macros, true);
+    untracked!(track_diagnostics, false);
     untracked!(trim_diagnostic_paths, false);
     untracked!(ui_testing, true);
     untracked!(unpretty, Some("expanded".to_string()));

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -689,7 +689,7 @@ fn test_unstable_options_tracking_hash() {
     untracked!(time_llvm_passes, true);
     untracked!(time_passes, true);
     untracked!(trace_macros, true);
-    untracked!(track_diagnostics, false);
+    untracked!(track_diagnostics, true);
     untracked!(trim_diagnostic_paths, false);
     untracked!(ui_testing, true);
     untracked!(unpretty, Some("expanded".to_string()));

--- a/compiler/rustc_macros/src/diagnostics/diagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic.rs
@@ -69,6 +69,8 @@ impl<'a> DiagnosticDerive<'a> {
                     for @Self
                 where G: rustc_errors::EmissionGuarantee
             {
+
+                #[track_caller]
                 fn into_diagnostic(
                     self,
                     #handler: &'__diagnostic_handler_sess rustc_errors::Handler
@@ -133,6 +135,7 @@ impl<'a> LintDiagnosticDerive<'a> {
         let diag = &builder.diag;
         structure.gen_impl(quote! {
             gen impl<'__a> rustc_errors::DecorateLint<'__a, ()> for @Self {
+                #[track_caller]
                 fn decorate_lint<'__b>(
                     self,
                     #diag: &'__b mut rustc_errors::DiagnosticBuilder<'__a, ()>

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -578,6 +578,7 @@ pub struct InvalidMetadataFiles {
 }
 
 impl IntoDiagnostic<'_> for InvalidMetadataFiles {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'_ rustc_errors::Handler,
@@ -606,6 +607,7 @@ pub struct CannotFindCrate {
 }
 
 impl IntoDiagnostic<'_> for CannotFindCrate {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'_ rustc_errors::Handler,

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -45,6 +45,7 @@ pub struct UnusedGenericParams {
 }
 
 impl IntoDiagnostic<'_> for UnusedGenericParams {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'_ rustc_errors::Handler,

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -930,6 +930,7 @@ pub(crate) struct ExpectedIdentifier {
 }
 
 impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedIdentifier {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'a rustc_errors::Handler,
@@ -977,6 +978,7 @@ pub(crate) struct ExpectedSemi {
 }
 
 impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedSemi {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'a rustc_errors::Handler,

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -744,6 +744,7 @@ pub struct InvalidAttrAtCrateLevel {
 }
 
 impl IntoDiagnostic<'_> for InvalidAttrAtCrateLevel {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'_ rustc_errors::Handler,
@@ -877,6 +878,7 @@ pub struct BreakNonLoop<'a> {
 }
 
 impl<'a> IntoDiagnostic<'_> for BreakNonLoop<'a> {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &rustc_errors::Handler,
@@ -1014,6 +1016,7 @@ pub struct NakedFunctionsAsmBlock {
 }
 
 impl IntoDiagnostic<'_> for NakedFunctionsAsmBlock {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &rustc_errors::Handler,
@@ -1137,6 +1140,7 @@ pub struct NoMainErr {
 }
 
 impl<'a> IntoDiagnostic<'a> for NoMainErr {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'a rustc_errors::Handler,
@@ -1197,6 +1201,7 @@ pub struct DuplicateLangItem {
 }
 
 impl IntoDiagnostic<'_> for DuplicateLangItem {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &rustc_errors::Handler,

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -794,6 +794,7 @@ impl UnstableOptions {
             report_delayed_bugs: self.report_delayed_bugs,
             macro_backtrace: self.macro_backtrace,
             deduplicate_diagnostics: self.deduplicate_diagnostics,
+            track_diagnostics: self.track_diagnostics,
         }
     }
 }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1585,6 +1585,8 @@ options! {
         "choose the TLS model to use (`rustc --print tls-models` for details)"),
     trace_macros: bool = (false, parse_bool, [UNTRACKED],
         "for every macro invocation, print its name and arguments (default: no)"),
+    track_diagnostics: bool = (false, parse_bool, [TRACKED],
+        "Tracks where in rustc a diagnostic was emitted"),
     // Diagnostics are considered side-effects of a query (see `QuerySideEffects`) and are saved
     // alongside query results and changes to translation options can affect diagnostics - so
     // translation options should be tracked.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1585,8 +1585,8 @@ options! {
         "choose the TLS model to use (`rustc --print tls-models` for details)"),
     trace_macros: bool = (false, parse_bool, [UNTRACKED],
         "for every macro invocation, print its name and arguments (default: no)"),
-    track_diagnostics: bool = (false, parse_bool, [TRACKED],
-        "Tracks where in rustc a diagnostic was emitted"),
+    track_diagnostics: bool = (false, parse_bool, [UNTRACKED],
+        "tracks where in rustc a diagnostic was emitted"),
     // Diagnostics are considered side-effects of a query (see `QuerySideEffects`) and are saved
     // alongside query results and changes to translation options can affect diagnostics - so
     // translation options should be tracked.

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -97,6 +97,7 @@ pub fn feature_err<'a>(
 ///
 /// This variant allows you to control whether it is a library or language feature.
 /// Almost always, you want to use this for a language feature. If so, prefer `feature_err`.
+#[track_caller]
 pub fn feature_err_issue<'a>(
     sess: &'a ParseSess,
     feature: Symbol,
@@ -332,6 +333,7 @@ impl ParseSess {
         self.proc_macro_quoted_spans.lock().clone()
     }
 
+    #[track_caller]
     pub fn create_err<'a>(
         &'a self,
         err: impl IntoDiagnostic<'a>,
@@ -339,10 +341,12 @@ impl ParseSess {
         err.into_diagnostic(&self.span_diagnostic)
     }
 
+    #[track_caller]
     pub fn emit_err<'a>(&'a self, err: impl IntoDiagnostic<'a>) -> ErrorGuaranteed {
         self.create_err(err).emit()
     }
 
+    #[track_caller]
     pub fn create_warning<'a>(
         &'a self,
         warning: impl IntoDiagnostic<'a, ()>,
@@ -350,6 +354,7 @@ impl ParseSess {
         warning.into_diagnostic(&self.span_diagnostic)
     }
 
+    #[track_caller]
     pub fn emit_warning<'a>(&'a self, warning: impl IntoDiagnostic<'a, ()>) {
         self.create_warning(warning).emit()
     }
@@ -377,6 +382,7 @@ impl ParseSess {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_err(
         &self,
         msg: impl Into<DiagnosticMessage>,

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -330,6 +330,7 @@ impl Session {
         self.diagnostic().struct_warn_with_expectation(msg, id)
     }
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_allow<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -338,10 +339,12 @@ impl Session {
         self.diagnostic().struct_span_allow(sp, msg)
     }
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_allow(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         self.diagnostic().struct_allow(msg)
     }
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_expect(
         &self,
         msg: impl Into<DiagnosticMessage>,
@@ -396,6 +399,7 @@ impl Session {
         self.diagnostic().struct_warn_with_code(msg, code)
     }
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_fatal<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -418,6 +422,7 @@ impl Session {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_fatal<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) -> ! {
         self.diagnostic().span_fatal(sp, msg)
     }
@@ -490,33 +495,40 @@ impl Session {
         add_feature_diagnostics(&mut err, &self.parse_sess, feature);
         err
     }
+    #[track_caller]
     pub fn emit_err<'a>(&'a self, err: impl IntoDiagnostic<'a>) -> ErrorGuaranteed {
         self.parse_sess.emit_err(err)
     }
+    #[track_caller]
     pub fn create_warning<'a>(
         &'a self,
         err: impl IntoDiagnostic<'a, ()>,
     ) -> DiagnosticBuilder<'a, ()> {
         self.parse_sess.create_warning(err)
     }
+    #[track_caller]
     pub fn emit_warning<'a>(&'a self, warning: impl IntoDiagnostic<'a, ()>) {
         self.parse_sess.emit_warning(warning)
     }
+    #[track_caller]
     pub fn create_note<'a>(
         &'a self,
         note: impl IntoDiagnostic<'a, Noted>,
     ) -> DiagnosticBuilder<'a, Noted> {
         self.parse_sess.create_note(note)
     }
+    #[track_caller]
     pub fn emit_note<'a>(&'a self, note: impl IntoDiagnostic<'a, Noted>) -> Noted {
         self.parse_sess.emit_note(note)
     }
+    #[track_caller]
     pub fn create_fatal<'a>(
         &'a self,
         fatal: impl IntoDiagnostic<'a, !>,
     ) -> DiagnosticBuilder<'a, !> {
         self.parse_sess.create_fatal(fatal)
     }
+    #[track_caller]
     pub fn emit_fatal<'a>(&'a self, fatal: impl IntoDiagnostic<'a, !>) -> ! {
         self.parse_sess.emit_fatal(fatal)
     }
@@ -556,6 +568,7 @@ impl Session {
     }
     #[allow(rustc::untranslatable_diagnostic)]
     #[allow(rustc::diagnostic_outside_of_impl)]
+    #[track_caller]
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) {
         self.diagnostic().span_warn(sp, msg)
     }
@@ -602,6 +615,8 @@ impl Session {
     pub fn note_without_error(&self, msg: impl Into<DiagnosticMessage>) {
         self.diagnostic().note_without_error(msg)
     }
+
+    #[track_caller]
     pub fn span_note_without_error<S: Into<MultiSpan>>(
         &self,
         sp: S,

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -67,6 +67,7 @@ pub struct NegativePositiveConflict<'a> {
 }
 
 impl IntoDiagnostic<'_> for NegativePositiveConflict<'_> {
+    #[track_caller]
     fn into_diagnostic(
         self,
         handler: &Handler,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -172,7 +172,7 @@ pub(crate) fn new_handler(
                     unstable_opts.teach,
                     diagnostic_width,
                     false,
-                    false,
+                    unstable_opts.track_diagnostics,
                 )
                 .ui_testing(unstable_opts.ui_testing),
             )
@@ -191,7 +191,7 @@ pub(crate) fn new_handler(
                     json_rendered,
                     diagnostic_width,
                     false,
-                    false,
+                    unstable_opts.track_diagnostics,
                 )
                 .ui_testing(unstable_opts.ui_testing),
             )

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -172,6 +172,7 @@ pub(crate) fn new_handler(
                     unstable_opts.teach,
                     diagnostic_width,
                     false,
+                    false,
                 )
                 .ui_testing(unstable_opts.ui_testing),
             )
@@ -189,6 +190,7 @@ pub(crate) fn new_handler(
                     pretty,
                     json_rendered,
                     diagnostic_width,
+                    false,
                     false,
                 )
                 .ui_testing(unstable_opts.ui_testing),

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -551,6 +551,7 @@ pub(crate) fn make_test(
                 false,
                 Some(80),
                 false,
+                false,
             )
             .supports_color();
 
@@ -563,6 +564,7 @@ pub(crate) fn make_test(
                 false,
                 false,
                 None,
+                false,
                 false,
             );
 
@@ -747,6 +749,7 @@ fn check_if_attr_is_complete(source: &str, edition: Edition) -> bool {
                 false,
                 false,
                 None,
+                false,
                 false,
             );
 

--- a/src/test/rustdoc-ui/track-diagnostics.rs
+++ b/src/test/rustdoc-ui/track-diagnostics.rs
@@ -1,6 +1,10 @@
 // compile-flags: -Z track-diagnostics
 // error-pattern: created at
 
+// Normalize the emitted location so this doesn't need
+// updating everytime someone adds or removes a line.
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+
 struct A;
 struct B;
 const S: A = B;

--- a/src/test/rustdoc-ui/track-diagnostics.rs
+++ b/src/test/rustdoc-ui/track-diagnostics.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 struct A;
 struct B;

--- a/src/test/rustdoc-ui/track-diagnostics.rs
+++ b/src/test/rustdoc-ui/track-diagnostics.rs
@@ -1,0 +1,6 @@
+// compile-flags: -Z track-diagnostics
+// error-pattern: created at
+
+struct A;
+struct B;
+const S: A = B;

--- a/src/test/rustdoc-ui/track-diagnostics.stderr
+++ b/src/test/rustdoc-ui/track-diagnostics.stderr
@@ -1,0 +1,10 @@
+error[E0308]: mismatched types
+  --> $DIR/track-diagnostics.rs:6:14
+   |
+LL | const S: A = B;
+   |              ^ expected struct `A`, found struct `B`
+-Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:2275:31
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/rustdoc-ui/track-diagnostics.stderr
+++ b/src/test/rustdoc-ui/track-diagnostics.stderr
@@ -1,9 +1,9 @@
 error[E0308]: mismatched types
-  --> $DIR/track-diagnostics.rs:$LINE::$COL
+  --> $DIR/track-diagnostics.rs:LL:CC
    |
 LL | const S: A = B;
    |              ^ expected struct `A`, found struct `B`
--Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:LL:CC
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/track-diagnostics.stderr
+++ b/src/test/rustdoc-ui/track-diagnostics.stderr
@@ -1,9 +1,9 @@
 error[E0308]: mismatched types
-  --> $DIR/track-diagnostics.rs:6:14
+  --> $DIR/track-diagnostics.rs:$LINE::$COL
    |
 LL | const S: A = B;
    |              ^ expected struct `A`, found struct `B`
--Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:2275:31
+-Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:$LINE::$COL
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/z-help.stdout
+++ b/src/test/rustdoc-ui/z-help.stdout
@@ -170,6 +170,7 @@
     -Z                             time-passes=val -- measure time of each rustc pass (default: no)
     -Z                               tls-model=val -- choose the TLS model to use (`rustc --print tls-models` for details)
     -Z                            trace-macros=val -- for every macro invocation, print its name and arguments (default: no)
+    -Z                       track-diagnostics=val -- Tracks where in rustc a diagnostic was emitted
     -Z                translate-additional-ftl=val -- additional fluent translation to preferentially use (for testing translation)
     -Z        translate-directionality-markers=val -- emit directionality isolation markers in translated diagnostics
     -Z                          translate-lang=val -- language identifier for diagnostic output

--- a/src/test/rustdoc-ui/z-help.stdout
+++ b/src/test/rustdoc-ui/z-help.stdout
@@ -170,7 +170,7 @@
     -Z                             time-passes=val -- measure time of each rustc pass (default: no)
     -Z                               tls-model=val -- choose the TLS model to use (`rustc --print tls-models` for details)
     -Z                            trace-macros=val -- for every macro invocation, print its name and arguments (default: no)
-    -Z                       track-diagnostics=val -- Tracks where in rustc a diagnostic was emitted
+    -Z                       track-diagnostics=val -- tracks where in rustc a diagnostic was emitted
     -Z                translate-additional-ftl=val -- additional fluent translation to preferentially use (for testing translation)
     -Z        translate-directionality-markers=val -- emit directionality isolation markers in translated diagnostics
     -Z                          translate-lang=val -- language identifier for diagnostic output

--- a/src/test/ui/track-diagnostics/track.rs
+++ b/src/test/ui/track-diagnostics/track.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
 // normalize-stderr-test "note: rustc .+ running on .+" -> "note: rustc $$VERSION running on $$TARGET"
 
 fn main() {

--- a/src/test/ui/track-diagnostics/track.rs
+++ b/src/test/ui/track-diagnostics/track.rs
@@ -1,0 +1,6 @@
+// compile-flags: -Z track-diagnostics
+// error-pattern: created at
+
+fn main() {
+    break rust
+}

--- a/src/test/ui/track-diagnostics/track.stderr
+++ b/src/test/ui/track-diagnostics/track.stderr
@@ -1,0 +1,26 @@
+error[E0425]: cannot find value `rust` in this scope
+  --> $DIR/track.rs:5:11
+   |
+LL |     break rust
+   |           ^^^^ not found in this scope
+-Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:289:28
+
+error[E0268]: `break` outside of a loop
+  --> $DIR/track.rs:5:5
+   |
+LL |     break rust
+   |     ^^^^^^^^^^ cannot `break` outside of a loop
+-Ztrack-diagnostics: created at compiler/rustc_passes/src/errors.rs:957:10
+
+error: internal compiler error: It looks like you're trying to break rust; would you like some ICE?
+
+note: the compiler expectedly panicked. this is a feature.
+
+note: we would appreciate a joke overview: https://github.com/rust-lang/rust/issues/43162#issuecomment-320764675
+
+note: rustc 1.66.0-dev running on x86_64-pc-windows-msvc
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0268, E0425.
+For more information about an error, try `rustc --explain E0268`.

--- a/src/test/ui/track-diagnostics/track.stderr
+++ b/src/test/ui/track-diagnostics/track.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find value `rust` in this scope
-  --> $DIR/track.rs:$LINE::$COL
+  --> $DIR/track.rs:LL:CC
    |
 LL |     break rust
    |           ^^^^ not found in this scope
--Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:LL:CC
 
 error[E0268]: `break` outside of a loop
-  --> $DIR/track.rs:$LINE::$COL
+  --> $DIR/track.rs:LL:CC
    |
 LL |     break rust
    |     ^^^^^^^^^^ cannot `break` outside of a loop
--Ztrack-diagnostics: created at compiler/rustc_passes/src/errors.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_passes/src/errors.rs:LL:CC
 
 error: internal compiler error: It looks like you're trying to break rust; would you like some ICE?
 

--- a/src/test/ui/track-diagnostics/track.stderr
+++ b/src/test/ui/track-diagnostics/track.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find value `rust` in this scope
-  --> $DIR/track.rs:5:11
+  --> $DIR/track.rs:$LINE::$COL
    |
 LL |     break rust
    |           ^^^^ not found in this scope
--Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:289:28
+-Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:$LINE::$COL
 
 error[E0268]: `break` outside of a loop
-  --> $DIR/track.rs:5:5
+  --> $DIR/track.rs:$LINE::$COL
    |
 LL |     break rust
    |     ^^^^^^^^^^ cannot `break` outside of a loop
--Ztrack-diagnostics: created at compiler/rustc_passes/src/errors.rs:957:10
+-Ztrack-diagnostics: created at compiler/rustc_passes/src/errors.rs:$LINE::$COL
 
 error: internal compiler error: It looks like you're trying to break rust; would you like some ICE?
 
@@ -18,7 +18,7 @@ note: the compiler expectedly panicked. this is a feature.
 
 note: we would appreciate a joke overview: https://github.com/rust-lang/rust/issues/43162#issuecomment-320764675
 
-note: rustc 1.66.0-dev running on x86_64-pc-windows-msvc
+note: rustc $VERSION running on $TARGET
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/track-diagnostics/track.stderr
+++ b/src/test/ui/track-diagnostics/track.stderr
@@ -10,7 +10,7 @@ error[E0268]: `break` outside of a loop
    |
 LL |     break rust
    |     ^^^^^^^^^^ cannot `break` outside of a loop
--Ztrack-diagnostics: created at compiler/rustc_passes/src/errors.rs:LL:CC
+-Ztrack-diagnostics: created at compiler/rustc_passes/src/loops.rs:LL:CC
 
 error: internal compiler error: It looks like you're trying to break rust; would you like some ICE?
 

--- a/src/test/ui/track-diagnostics/track2.rs
+++ b/src/test/ui/track-diagnostics/track2.rs
@@ -4,8 +4,7 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 // normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
-// normalize-stderr-test "note: rustc .+ running on .+" -> "note: rustc $$VERSION running on $$TARGET"
 
 fn main() {
-    break rust
+    let _moved @ _from = String::from("foo");
 }

--- a/src/test/ui/track-diagnostics/track2.rs
+++ b/src/test/ui/track-diagnostics/track2.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 fn main() {
     let _moved @ _from = String::from("foo");

--- a/src/test/ui/track-diagnostics/track2.stderr
+++ b/src/test/ui/track-diagnostics/track2.stderr
@@ -1,12 +1,12 @@
 error[E0382]: use of moved value
-  --> $DIR/track2.rs:$LINE::$COL
+  --> $DIR/track2.rs:LL:CC
    |
 LL |     let _moved @ _from = String::from("foo");
    |         ^^^^^^   -----   ------------------- move occurs because value has type `String`, which does not implement the `Copy` trait
    |         |        |
    |         |        value moved here
    |         value used here after move
--Ztrack-diagnostics: created at compiler/rustc_borrowck/src/borrowck_errors.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_borrowck/src/borrowck_errors.rs:LL:CC
 
 error: aborting due to previous error
 

--- a/src/test/ui/track-diagnostics/track2.stderr
+++ b/src/test/ui/track-diagnostics/track2.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value
+  --> $DIR/track2.rs:$LINE::$COL
+   |
+LL |     let _moved @ _from = String::from("foo");
+   |         ^^^^^^   -----   ------------------- move occurs because value has type `String`, which does not implement the `Copy` trait
+   |         |        |
+   |         |        value moved here
+   |         value used here after move
+-Ztrack-diagnostics: created at compiler/rustc_borrowck/src/borrowck_errors.rs:$LINE::$COL
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/track-diagnostics/track3.rs
+++ b/src/test/ui/track-diagnostics/track3.rs
@@ -4,8 +4,7 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 // normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
-// normalize-stderr-test "note: rustc .+ running on .+" -> "note: rustc $$VERSION running on $$TARGET"
 
 fn main() {
-    break rust
+    let _unimported = Blah { field: u8 };
 }

--- a/src/test/ui/track-diagnostics/track3.rs
+++ b/src/test/ui/track-diagnostics/track3.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 fn main() {
     let _unimported = Blah { field: u8 };

--- a/src/test/ui/track-diagnostics/track3.stderr
+++ b/src/test/ui/track-diagnostics/track3.stderr
@@ -1,16 +1,16 @@
 error[E0422]: cannot find struct, variant or union type `Blah` in this scope
-  --> $DIR/track3.rs:$LINE::$COL
+  --> $DIR/track3.rs:LL:CC
    |
 LL |     let _unimported = Blah { field: u8 };
    |                       ^^^^ not found in this scope
--Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:LL:CC
 
 error[E0423]: expected value, found builtin type `u8`
-  --> $DIR/track3.rs:$LINE::$COL
+  --> $DIR/track3.rs:LL:CC
    |
 LL |     let _unimported = Blah { field: u8 };
    |                                     ^^ not a value
--Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:LL:CC
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/track-diagnostics/track3.stderr
+++ b/src/test/ui/track-diagnostics/track3.stderr
@@ -1,0 +1,18 @@
+error[E0422]: cannot find struct, variant or union type `Blah` in this scope
+  --> $DIR/track3.rs:$LINE::$COL
+   |
+LL |     let _unimported = Blah { field: u8 };
+   |                       ^^^^ not found in this scope
+-Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:$LINE::$COL
+
+error[E0423]: expected value, found builtin type `u8`
+  --> $DIR/track3.rs:$LINE::$COL
+   |
+LL |     let _unimported = Blah { field: u8 };
+   |                                     ^^ not a value
+-Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:$LINE::$COL
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0422, E0423.
+For more information about an error, try `rustc --explain E0422`.

--- a/src/test/ui/track-diagnostics/track4.rs
+++ b/src/test/ui/track-diagnostics/track4.rs
@@ -4,8 +4,10 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 // normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
-// normalize-stderr-test "note: rustc .+ running on .+" -> "note: rustc $$VERSION running on $$TARGET"
 
-fn main() {
-    break rust
+pub onion {
+    Owo(u8),
+    Uwu(i8),
 }
+
+fn main() {}

--- a/src/test/ui/track-diagnostics/track4.rs
+++ b/src/test/ui/track-diagnostics/track4.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 pub onion {
     Owo(u8),

--- a/src/test/ui/track-diagnostics/track4.stderr
+++ b/src/test/ui/track-diagnostics/track4.stderr
@@ -1,9 +1,9 @@
 error: missing `struct` for struct definition
-  --> $DIR/track4.rs:$LINE::$COL
+  --> $DIR/track4.rs:LL:CC
    |
 LL | pub onion {
    |    ^
--Ztrack-diagnostics: created at compiler/rustc_parse/src/parser/diagnostics.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_parse/src/parser/diagnostics.rs:LL:CC
    |
 help: add `struct` here to parse `onion` as a public struct
    |

--- a/src/test/ui/track-diagnostics/track4.stderr
+++ b/src/test/ui/track-diagnostics/track4.stderr
@@ -1,0 +1,14 @@
+error: missing `struct` for struct definition
+  --> $DIR/track4.rs:$LINE::$COL
+   |
+LL | pub onion {
+   |    ^
+-Ztrack-diagnostics: created at compiler/rustc_parse/src/parser/diagnostics.rs:$LINE::$COL
+   |
+help: add `struct` here to parse `onion` as a public struct
+   |
+LL | pub struct onion {
+   |     ++++++
+
+error: aborting due to previous error
+

--- a/src/test/ui/track-diagnostics/track5.rs
+++ b/src/test/ui/track-diagnostics/track5.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Z track-diagnostics
+// error-pattern: created at
+
+// Normalize the emitted location so this doesn't need
+// updating everytime someone adds or removes a line.
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+
+}

--- a/src/test/ui/track-diagnostics/track5.stderr
+++ b/src/test/ui/track-diagnostics/track5.stderr
@@ -1,0 +1,9 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/track5.rs:LL:CC
+   |
+LL | }
+   | ^ unexpected closing delimiter
+-Ztrack-diagnostics: created at compiler/rustc_parse/src/lexer/tokentrees.rs:LL:CC
+
+error: aborting due to previous error
+

--- a/src/test/ui/track-diagnostics/track6.rs
+++ b/src/test/ui/track-diagnostics/track6.rs
@@ -1,0 +1,14 @@
+// compile-flags: -Z track-diagnostics
+// error-pattern: created at
+
+
+
+pub trait Foo {
+    fn bar();
+}
+
+impl <T> Foo for T {
+    default fn bar() {}
+}
+
+fn main() {}

--- a/src/test/ui/track-diagnostics/track6.stderr
+++ b/src/test/ui/track-diagnostics/track6.stderr
@@ -1,0 +1,13 @@
+error[E0658]: specialization is unstable
+  --> $DIR/track6.rs:11:5
+   |
+LL |     default fn bar() {}
+   |     ^^^^^^^^^^^^^^^^^^^
+-Ztrack-diagnostics: created at $COMPILER_DIR/rustc_session/src/parse.rs:93:5
+   |
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
+   = help: add `#![feature(specialization)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/tools/clippy/clippy_lints/src/doc.rs
+++ b/src/tools/clippy/clippy_lints/src/doc.rs
@@ -691,6 +691,7 @@ fn check_code(cx: &LateContext<'_>, text: &str, edition: Edition, span: Span) {
                     false,
                     None,
                     false,
+                    false,
                 );
                 let handler = Handler::with_emitter(false, None, Box::new(emitter));
                 let sess = ParseSess::with_span_handler(handler, sm);

--- a/src/tools/clippy/src/driver.rs
+++ b/src/tools/clippy/src/driver.rs
@@ -179,6 +179,7 @@ fn report_clippy_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
         false,
         None,
         false,
+        false,
     ));
     let handler = rustc_errors::Handler::with_emitter(true, None, emitter);
 

--- a/src/tools/clippy/tests/ui/track-diagnostics.rs
+++ b/src/tools/clippy/tests/ui/track-diagnostics.rs
@@ -1,6 +1,10 @@
 // compile-flags: -Z track-diagnostics
 // error-pattern: created at
 
+// Normalize the emitted location so this doesn't need
+// updating everytime someone adds or removes a line.
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+
 struct A;
 struct B;
 const S: A = B;

--- a/src/tools/clippy/tests/ui/track-diagnostics.rs
+++ b/src/tools/clippy/tests/ui/track-diagnostics.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:$$LINE::$$COL"
+// normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 struct A;
 struct B;

--- a/src/tools/clippy/tests/ui/track-diagnostics.rs
+++ b/src/tools/clippy/tests/ui/track-diagnostics.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Z track-diagnostics
+// error-pattern: created at
+
+struct A;
+struct B;
+const S: A = B;
+
+fn main() {}

--- a/src/tools/clippy/tests/ui/track-diagnostics.stderr
+++ b/src/tools/clippy/tests/ui/track-diagnostics.stderr
@@ -1,0 +1,10 @@
+error[E0308]: mismatched types
+  --> $DIR/track-diagnostics.rs:6:14
+   |
+LL | const S: A = B;
+   |              ^ expected struct `A`, found struct `B`
+-Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:2275:31
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/tools/clippy/tests/ui/track-diagnostics.stderr
+++ b/src/tools/clippy/tests/ui/track-diagnostics.stderr
@@ -1,9 +1,9 @@
 error[E0308]: mismatched types
-  --> $DIR/track-diagnostics.rs:$LINE::$COL
+  --> $DIR/track-diagnostics.rs:LL:CC
    |
 LL | const S: A = B;
    |              ^ expected struct `A`, found struct `B`
--Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:$LINE::$COL
+-Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:LL:CC
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui/track-diagnostics.stderr
+++ b/src/tools/clippy/tests/ui/track-diagnostics.stderr
@@ -1,9 +1,9 @@
 error[E0308]: mismatched types
-  --> $DIR/track-diagnostics.rs:6:14
+  --> $DIR/track-diagnostics.rs:$LINE::$COL
    |
 LL | const S: A = B;
    |              ^ expected struct `A`, found struct `B`
--Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:2275:31
+-Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:$LINE::$COL
 
 error: aborting due to previous error
 

--- a/src/tools/rustfmt/src/parse/session.rs
+++ b/src/tools/rustfmt/src/parse/session.rs
@@ -134,6 +134,7 @@ fn default_handler(
             false,
             None,
             false,
+            false,
         ))
     };
     Handler::with_emitter(


### PR DESCRIPTION
This implements the `-Ztrack-diagnostics` flag, which uses `#[track_caller]` to track where diagnostics are created. It is meant as a debugging tool much like `-Ztreat-err-as-bug`.

For example, the following code...

```rust
struct A;
struct B;

fn main(){
    let _: A = B;
}
```
...now emits the following error message:

```
error[E0308]: mismatched types
 --> src\main.rs:5:16
  |
5 |     let _: A = B;
  |            -   ^ expected struct `A`, found struct `B`
  |            |
  |            expected due to this
-Ztrack-diagnostics: created at compiler\rustc_infer\src\infer\error_reporting\mod.rs:2275:31
```
