### PR TITLE
Use already checked RHS ty for LHS deref suggestions

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/expr.rs
+++ b/compiler/rustc_hir_analysis/src/check/expr.rs
@@ -1130,11 +1130,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         };
 
-        self.check_lhs_assignable(lhs, "E0070", span, |err| {
-            let rhs_ty = self.check_expr(&rhs);
-            suggest_deref_binop(err, rhs_ty);
-        });
-
         // This is (basically) inlined `check_expr_coercable_to_type`, but we want
         // to suggest an additional fixup here in `suggest_deref_binop`.
         let rhs_ty = self.check_expr_with_hint(&rhs, lhs_ty);
@@ -1144,6 +1139,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             suggest_deref_binop(&mut diag, rhs_ty);
             diag.emit();
         }
+
+        self.check_lhs_assignable(lhs, "E0070", span, |err| {
+            if let Some(rhs_ty) = self.typeck_results.borrow().expr_ty_opt(rhs) {
+                suggest_deref_binop(err, rhs_ty);
+            }
+        });
 
         self.require_type_is_sized(lhs_ty, lhs.span, traits::AssignmentLhsSized);
 

--- a/src/test/ui/typeck/slow-lhs-suggestion.rs
+++ b/src/test/ui/typeck/slow-lhs-suggestion.rs
@@ -1,0 +1,26 @@
+fn main() {
+    1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+    //~^ ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
+}

--- a/src/test/ui/typeck/slow-lhs-suggestion.stderr
+++ b/src/test/ui/typeck/slow-lhs-suggestion.stderr
@@ -1,0 +1,187 @@
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:95
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                                             - ^
+   |                                                                                             |
+   |                                                                                             cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:91
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                                         - ^
+   |                                                                                         |
+   |                                                                                         cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:87
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                                     - ^
+   |                                                                                     |
+   |                                                                                     cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:83
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                                 - ^
+   |                                                                                 |
+   |                                                                                 cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:79
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                             - ^
+   |                                                                             |
+   |                                                                             cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:75
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                         - ^
+   |                                                                         |
+   |                                                                         cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:71
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                     - ^
+   |                                                                     |
+   |                                                                     cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:67
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                                 - ^
+   |                                                                 |
+   |                                                                 cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:63
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                             - ^
+   |                                                             |
+   |                                                             cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:59
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                         - ^
+   |                                                         |
+   |                                                         cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:55
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                     - ^
+   |                                                     |
+   |                                                     cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:51
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                                 - ^
+   |                                                 |
+   |                                                 cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:47
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                             - ^
+   |                                             |
+   |                                             cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:43
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                         - ^
+   |                                         |
+   |                                         cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:39
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                     - ^
+   |                                     |
+   |                                     cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:35
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                                 - ^
+   |                                 |
+   |                                 cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:31
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                             - ^
+   |                             |
+   |                             cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:27
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                         - ^
+   |                         |
+   |                         cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:23
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                     - ^
+   |                     |
+   |                     cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:19
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |                 - ^
+   |                 |
+   |                 cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:15
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |             - ^
+   |             |
+   |             cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:11
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |         - ^
+   |         |
+   |         cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/slow-lhs-suggestion.rs:2:7
+   |
+LL |     1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1 = 1;
+   |     - ^
+   |     |
+   |     cannot assign to this expression
+
+error: aborting due to 23 previous errors
+
+For more information about this error, try `rustc --explain E0070`.


### PR DESCRIPTION
There's no reason to do the `check_lhs_assignable` and RHS `check_expr_with_hint` in that order, so invert them and use the typeck results to avoid exponential blowup on error.

Fixes #103219