### PR TITLE
Remove byte swap of valtree hash on big endian

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -666,10 +666,8 @@ fn push_const_param<'tcx>(tcx: TyCtxt<'tcx>, ct: ty::Const<'tcx>, output: &mut S
                     hcx.while_hashing_spans(false, |hcx| {
                         ct.to_valtree().hash_stable(hcx, &mut hasher)
                     });
-                    // Note: Don't use `StableHashResult` impl of `u64` here directly, since that
-                    // would lead to endianness problems.
-                    let hash: u128 = hasher.finish();
-                    (hash.to_le() as u64).to_le()
+                    let hash: u64 = hasher.finish();
+                    hash
                 });
 
                 if cpp_like_debuginfo(tcx) {


### PR DESCRIPTION
This addresses problem reported in #103183. The code was originally introduced in https://github.com/rust-lang/rust/commit/e14b34c386ad2809e937e0e6e0379c5cc5474954. (see https://github.com/rust-lang/rust/pull/96591)

On big-endian environment, this operation sequence actually put the other half from 128-bit result, thus we got different hash result on LE and BE.