### PR TITLE
Allow #[unstable] impls for fn() with unstable abi.

### DIFF
--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -888,10 +888,15 @@ impl<'tcx> Visitor<'tcx> for CheckTraitImplStable<'tcx> {
     }
 
     fn visit_ty(&mut self, t: &'tcx Ty<'tcx>) {
-        if let TyKind::Never = t.kind {
-            self.fully_stable = false;
+        match t.kind {
+            TyKind::Never => self.fully_stable = false,
+            TyKind::BareFn(f) => {
+                if rustc_target::spec::abi::is_stable(f.abi.name()).is_err() {
+                    self.fully_stable = false;
+                }
+            }
+            _ => intravisit::walk_ty(self, t),
         }
-        intravisit::walk_ty(self, t)
     }
 }
 

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -888,14 +888,26 @@ impl<'tcx> Visitor<'tcx> for CheckTraitImplStable<'tcx> {
     }
 
     fn visit_ty(&mut self, t: &'tcx Ty<'tcx>) {
-        match t.kind {
-            TyKind::Never => self.fully_stable = false,
-            TyKind::BareFn(f) => {
-                if rustc_target::spec::abi::is_stable(f.abi.name()).is_err() {
-                    self.fully_stable = false;
-                }
+        if let TyKind::Never = t.kind {
+            self.fully_stable = false;
+        }
+        if let TyKind::BareFn(f) = t.kind {
+            if rustc_target::spec::abi::is_stable(f.abi.name()).is_err() {
+                self.fully_stable = false;
             }
-            _ => intravisit::walk_ty(self, t),
+        }
+        intravisit::walk_ty(self, t)
+    }
+
+    fn visit_fn_decl(&mut self, fd: &'tcx hir::FnDecl<'tcx>) {
+        for ty in fd.inputs {
+            self.visit_ty(ty)
+        }
+        if let hir::FnRetTy::Return(output_ty) = fd.output {
+            match output_ty.kind {
+                TyKind::Never => {} // `-> !` is stable
+                _ => self.visit_ty(output_ty),
+            }
         }
     }
 }

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -37,4 +37,7 @@ impl StableTrait for StableType {}
 //~^ ERROR an `#[unstable]` annotation here has no effect [ineffective_unstable_trait_impl]
 impl StableTrait for fn() -> ! {}
 
+#[unstable(feature = "l", issue = "none")]
+impl StableTrait for fn() -> UnstableType {}
+
 fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -33,4 +33,8 @@ impl StableTrait for extern "C-unwind" fn() {}
 //~^ ERROR an `#[unstable]` annotation here has no effect [ineffective_unstable_trait_impl]
 impl StableTrait for StableType {}
 
+#[unstable(feature = "k", issue = "none")]
+//~^ ERROR an `#[unstable]` annotation here has no effect [ineffective_unstable_trait_impl]
+impl StableTrait for fn() -> ! {}
+
 fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -1,4 +1,4 @@
-#![feature(staged_api)]
+#![feature(staged_api, never_type, c_unwind)]
 //~^ ERROR module has missing stability attribute
 
 #[stable(feature = "a", since = "1")]
@@ -23,6 +23,13 @@ impl StableTrait for UnstableType {}
 impl UnstableTrait for StableType {}
 
 #[unstable(feature = "h", issue = "none")]
+impl StableTrait for ! {}
+
+// Note: If C-unwind is stabilized, switch this to another (unstable) ABI.
+#[unstable(feature = "i", issue = "none")]
+impl StableTrait for extern "C-unwind" fn() {}
+
+#[unstable(feature = "j", issue = "none")]
 //~^ ERROR an `#[unstable]` annotation here has no effect [ineffective_unstable_trait_impl]
 impl StableTrait for StableType {}
 

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
@@ -1,7 +1,7 @@
 error: an `#[unstable]` annotation here has no effect
-  --> $DIR/stability-attribute-trait-impl.rs:25:1
+  --> $DIR/stability-attribute-trait-impl.rs:32:1
    |
-LL | #[unstable(feature = "h", issue = "none")]
+LL | #[unstable(feature = "j", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
@@ -10,7 +10,7 @@ LL | #[unstable(feature = "h", issue = "none")]
 error: module has missing stability attribute
   --> $DIR/stability-attribute-trait-impl.rs:1:1
    |
-LL | / #![feature(staged_api)]
+LL | / #![feature(staged_api, never_type, c_unwind)]
 LL | |
 LL | |
 LL | | #[stable(feature = "a", since = "1")]

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
@@ -7,6 +7,14 @@ LL | #[unstable(feature = "j", issue = "none")]
    = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
    = note: `#[deny(ineffective_unstable_trait_impl)]` on by default
 
+error: an `#[unstable]` annotation here has no effect
+  --> $DIR/stability-attribute-trait-impl.rs:36:1
+   |
+LL | #[unstable(feature = "k", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
+
 error: module has missing stability attribute
   --> $DIR/stability-attribute-trait-impl.rs:1:1
    |
@@ -19,5 +27,5 @@ LL | |
 LL | | fn main() {}
    | |____________^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This allows `#[unstable]` trait impls for `extern "unwind-C" fn()`, based on the fact that that abi and therefore that type is unstable.

See https://github.com/rust-lang/rust/pull/101263#issuecomment-1283099947