### PR TITLE
Mark `rust-analyzer` as a host-only tool

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -698,7 +698,7 @@ pub struct RustAnalyzer {
 impl Step for RustAnalyzer {
     type Output = Option<PathBuf>;
     const DEFAULT: bool = true;
-    const ONLY_HOSTS: bool = false;
+    const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
@@ -742,7 +742,7 @@ pub struct RustAnalyzerProcMacroSrv {
 impl Step for RustAnalyzerProcMacroSrv {
     type Output = Option<PathBuf>;
     const DEFAULT: bool = true;
-    const ONLY_HOSTS: bool = false;
+    const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;


### PR DESCRIPTION
All tools meant to be shipped with host toolchains only should be marked as `ONLY_HOSTS = true`, but rust-analyzer was marked as `ONLY_HOSTS = false` incorrectly. This meant that bootstrap attempted to build rust-analyzer for cross-compilation-only targets, causing errors because libstd is not present on some of them.

It will still be possible to cross-compile rust-analyzer by passing a different `--host` flag to `./x`, like you can cross-compile other tools.

The problem can be reproduced by running:

```
./x build src/tools/rust-analyzer --target x86_64-unknown-linux-gnu,aarch64-unknown-none
```