### PR TITLE
rustdoc: do not filter out cross-crate `Self: Sized` bounds

### DIFF
--- a/src/test/rustdoc/inline_cross/auxiliary/issue-24183.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/issue-24183.rs
@@ -1,0 +1,14 @@
+#![crate_type = "lib"]
+
+pub trait U/*: ?Sized */ {
+    fn modified(self) -> Self
+    where
+        Self: Sized
+    {
+        self
+    }
+
+    fn touch(&self)/* where Self: ?Sized */{}
+}
+
+pub trait S: Sized {}

--- a/src/test/rustdoc/inline_cross/issue-24183.method_no_where_self_sized.html
+++ b/src/test/rustdoc/inline_cross/issue-24183.method_no_where_self_sized.html
@@ -1,0 +1,1 @@
+<h4 class="code-header">fn <a href="#method.touch" class="fnname">touch</a>(&amp;self)</h4>

--- a/src/test/rustdoc/inline_cross/issue-24183.rs
+++ b/src/test/rustdoc/inline_cross/issue-24183.rs
@@ -1,0 +1,18 @@
+#![crate_type = "lib"]
+#![crate_name = "usr"]
+
+// aux-crate:issue_24183=issue-24183.rs
+// edition: 2021
+
+// @has usr/trait.U.html
+// @has - '//*[@class="item-decl"]' "pub trait U {"
+// @has - '//*[@id="method.modified"]' \
+// "fn modified(self) -> Self\
+// where \
+//     Self: Sized"
+// @snapshot method_no_where_self_sized - '//*[@id="method.touch"]/*[@class="code-header"]'
+pub use issue_24183::U;
+
+// @has usr/trait.S.html
+// @has - '//*[@class="item-decl"]' 'pub trait S: Sized {'
+pub use issue_24183::S;


### PR DESCRIPTION
All type parameters **except `Self`** are implicitly `Sized` ([via](https://doc.rust-lang.org/nightly/std/marker/trait.Sized.html)). Previously, we disregarded the exception of `Self` and omitted cross-crate `Sized` bounds of *any* type parameter *including* `Self` when rendering.
From now on, we *do* render cross-crate `Self: Sized` bounds.

Most notably, in `std` we now finally properly render the `Sized` bound of the `Clone` trait as well as the `Self: Sized` bound on `Iterator::map`.

Fixes #24183.

@rustbot label T-rustdoc A-cross-crate-reexports
r? rustdoc