### PR TITLE
Adjusting test to needs-unwind, with linking issue

### DIFF
--- a/src/test/ui/test-attrs/test-fn-signature-verification-for-explicit-return-type.rs
+++ b/src/test/ui/test-attrs/test-fn-signature-verification-for-explicit-return-type.rs
@@ -1,5 +1,5 @@
 // run-pass
-// ignore-fuchsia Test must be run out-of-process
+// needs-unwind (#73509)
 
 #![feature(test)]
 


### PR DESCRIPTION
Test requires `needs-unwind` (see linked issue #103261)