### PR TITLE
rustdoc: remove no-op CSS `nav.sub { font-size: 1rem }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -703,7 +703,6 @@ pre, .rustdoc.source .example-wrap {
 
 nav.sub {
 	position: relative;
-	font-size: 1rem;
 	flex-grow: 1;
 	margin-bottom: 25px;
 }


### PR DESCRIPTION
This rule originated as a `font-size: 16px`, when body had `font-size: 13px` set in 4fd061c426902b0904c65e64a3780b21f9ab3afb.

It remained even when body's font size was bumped up to 16px, 4d5f4ff5e9297dcad21612f9dd20ae4598b5b7e2, making the rule a no-op, and was carried forward when it was converted to 1rem in cc18120425a5c571a968d850c75cc935a8321136.