### PR TITLE
Erase regions before checking for `Default` in uninitialized binding error

### DIFF
--- a/src/test/ui/borrowck/issue-103250.rs
+++ b/src/test/ui/borrowck/issue-103250.rs
@@ -1,0 +1,37 @@
+// edition:2021
+
+type TranslateFn = Box<dyn Fn(String, String) -> String>;
+
+pub struct DeviceCluster {
+    devices: Vec<Device>,
+}
+
+impl DeviceCluster {
+    pub async fn do_something(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut last_error: Box<dyn std::error::Error>;
+
+        for device in &mut self.devices {
+            match device.do_something().await {
+                Ok(info) => {
+                    return Ok(info);
+                }
+                Err(e) => {}
+            }
+        }
+
+        Err(last_error)
+        //~^ ERROR used binding `last_error` isn't initialized
+    }
+}
+
+pub struct Device {
+    translate_fn: Option<TranslateFn>,
+}
+
+impl Device {
+    pub async fn do_something(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        Ok(String::from(""))
+    }
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/issue-103250.stderr
+++ b/src/test/ui/borrowck/issue-103250.stderr
@@ -1,0 +1,17 @@
+error[E0381]: used binding `last_error` isn't initialized
+  --> $DIR/issue-103250.rs:22:13
+   |
+LL |         let mut last_error: Box<dyn std::error::Error>;
+   |             -------------- binding declared here but left uninitialized
+...
+LL |         Err(last_error)
+   |             ^^^^^^^^^^ `last_error` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |         let mut last_error: Box<dyn std::error::Error> = todo!();
+   |                                                        +++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0381`.


### PR DESCRIPTION
Fixes #103250