### PR TITLE
Add eval hack in `super_relate_consts` back

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -554,6 +554,13 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         val: &mir::ConstantKind<'tcx>,
         layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
+        // FIXME(const_prop): normalization needed b/c const prop lint in
+        // `mir_drops_elaborated_and_const_checked`, which happens before
+        // optimized MIR. Only after optimizing the MIR can we guarantee
+        // that the `RevealAll` pass has happened and that the body's consts
+        // are normalized, so any call to resolve before that needs to be
+        // manually normalized.
+        let val = self.tcx.normalize_erasing_regions(self.param_env, *val);
         match val {
             mir::ConstantKind::Ty(ct) => {
                 match ct.kind() {
@@ -585,7 +592,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     }
                 }
             }
-            mir::ConstantKind::Val(val, ty) => self.const_val_to_op(*val, *ty, layout),
+            mir::ConstantKind::Val(val, ty) => self.const_val_to_op(val, ty, layout),
             mir::ConstantKind::Unevaluated(uv, _) => {
                 let instance = self.resolve(uv.def, uv.substs)?;
                 Ok(self.eval_to_allocation(GlobalId { instance, promoted: uv.promoted })?.into())

--- a/src/test/ui/consts/unnormalized-param-env.rs
+++ b/src/test/ui/consts/unnormalized-param-env.rs
@@ -1,0 +1,31 @@
+// check-pass
+
+pub trait CSpace<const N: usize> {
+    type Traj;
+}
+
+pub struct Const<const R: usize>;
+
+pub trait Obstacle<CS, const N: usize> {
+    fn trajectory_free<FT, S1>(&self, t: &FT)
+    where
+        CS::Traj: Sized,
+        CS: CSpace<N>;
+}
+
+// -----
+
+const N: usize = 4;
+
+struct ObstacleSpace2df32;
+
+impl<CS> Obstacle<CS, N> for ObstacleSpace2df32 {
+    fn trajectory_free<TF, S1>(&self, t: &TF)
+    where
+        CS::Traj: Sized,
+        CS: CSpace<N>,
+    {
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Partially reverts 01adb7e98d5656c06497f33dd2747df144e78356.

This extra eval call *still* needs to happen, for example, in `normalize_param_env_or_error` when a param-env predicate has an unnormalized constant, since the param-env candidates never get normalized during candidate assembly (everywhere else we can assume that they are normalized fully).

r? @lcnr, though I feel like I've assigned quite a few PRs to you in the last few days, so feel free to reassign to someone else familiar with this code if you're busy!
 
cc #103243 (fixes the issue, but don't want to auto-close that until a backport is performed).