### PR TITLE
(#102929) Implement `String::leak` (attempt 2)

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -67,7 +67,7 @@ use core::str::Utf8Chunks;
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 use crate::collections::TryReserveError;
-use crate::str::{self, Chars, Utf8Error};
+use crate::str::{self, from_utf8_unchecked_mut, Chars, Utf8Error};
 #[cfg(not(no_global_oom_handling))]
 use crate::str::{from_boxed_utf8_unchecked, FromStr};
 use crate::vec::Vec;
@@ -2690,6 +2690,35 @@ impl From<String> for Box<str> {
     /// ```
     fn from(s: String) -> Box<str> {
         s.into_boxed_str()
+    }
+
+    /// Consumes and leaks the `String`, returning a mutable reference to the contents,
+    /// `&'a mut str`.
+    ///
+    /// This is mainly useful for data that lives for the remainder of
+    /// the program's life. Dropping the returned reference will cause a memory
+    /// leak.
+    ///
+    /// It does not reallocate or shrink the `String`,
+    /// so the leaked allocation may include unused capacity that is not part
+    /// of the returned slice.
+    ///
+    /// # Examples
+    ///
+    /// Simple usage:
+    ///
+    /// ```
+    /// #![feature(string_leak)]
+    ///
+    /// let x = String::from("bucket");
+    /// let static_ref: &'static mut str = x.leak();
+    /// assert_eq!(static_ref, "bucket");
+    /// ```
+    #[unstable(feature = "string_leak", issue = "102929")]
+    #[inline]
+    pub fn leak(self) -> &'static mut str {
+        let slice = self.vec.leak();
+        unsafe { from_utf8_unchecked_mut(slice) }
     }
 }
 

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1849,6 +1849,35 @@ impl String {
         let slice = self.vec.into_boxed_slice();
         unsafe { from_boxed_utf8_unchecked(slice) }
     }
+
+    /// Consumes and leaks the `String`, returning a mutable reference to the contents,
+    /// `&'a mut str`.
+    ///
+    /// This is mainly useful for data that lives for the remainder of
+    /// the program's life. Dropping the returned reference will cause a memory
+    /// leak.
+    ///
+    /// It does not reallocate or shrink the `String`,
+    /// so the leaked allocation may include unused capacity that is not part
+    /// of the returned slice.
+    ///
+    /// # Examples
+    ///
+    /// Simple usage:
+    ///
+    /// ```
+    /// #![feature(string_leak)]
+    ///
+    /// let x = String::from("bucket");
+    /// let static_ref: &'static mut str = x.leak();
+    /// assert_eq!(static_ref, "bucket");
+    /// ```
+    #[unstable(feature = "string_leak", issue = "102929")]
+    #[inline]
+    pub fn leak(self) -> &'static mut str {
+        let slice = self.vec.leak();
+        unsafe { from_utf8_unchecked_mut(slice) }
+    }
 }
 
 impl FromUtf8Error {
@@ -2690,35 +2719,6 @@ impl From<String> for Box<str> {
     /// ```
     fn from(s: String) -> Box<str> {
         s.into_boxed_str()
-    }
-
-    /// Consumes and leaks the `String`, returning a mutable reference to the contents,
-    /// `&'a mut str`.
-    ///
-    /// This is mainly useful for data that lives for the remainder of
-    /// the program's life. Dropping the returned reference will cause a memory
-    /// leak.
-    ///
-    /// It does not reallocate or shrink the `String`,
-    /// so the leaked allocation may include unused capacity that is not part
-    /// of the returned slice.
-    ///
-    /// # Examples
-    ///
-    /// Simple usage:
-    ///
-    /// ```
-    /// #![feature(string_leak)]
-    ///
-    /// let x = String::from("bucket");
-    /// let static_ref: &'static mut str = x.leak();
-    /// assert_eq!(static_ref, "bucket");
-    /// ```
-    #[unstable(feature = "string_leak", issue = "102929")]
-    #[inline]
-    pub fn leak(self) -> &'static mut str {
-        let slice = self.vec.leak();
-        unsafe { from_utf8_unchecked_mut(slice) }
     }
 }
 


### PR DESCRIPTION
Implementation of `String::leak` (#102929)

ACP: https://github.com/rust-lang/libs-team/issues/109

Supersedes #102941 (see previous reviews there)

@rustbot label +T-libs-api -T-libs