### PR TITLE
Remove structural match from `TypeId`

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -662,10 +662,18 @@ impl dyn Any + Send + Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialOrd, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
     t: u64,
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl PartialEq for TypeId {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.t == other.t
+    }
 }
 
 impl TypeId {

--- a/tests/ui/const-generics/generic_const_exprs/typeid-equality-by-subtyping.rs
+++ b/tests/ui/const-generics/generic_const_exprs/typeid-equality-by-subtyping.rs
@@ -1,7 +1,7 @@
-// check-pass
+// known-bug: #110395
 // known-bug: #97156
 
-#![feature(const_type_id, generic_const_exprs)]
+#![feature(const_type_id, const_trait_impl, generic_const_exprs)]
 #![allow(incomplete_features)]
 
 use std::any::TypeId;
@@ -26,7 +26,10 @@ impl<T: 'static> AssocCt for T {
 trait WithAssoc<U> {
     type Assoc;
 }
-impl<T: 'static> WithAssoc<()> for T where [(); <T as AssocCt>::ASSOC]: {
+impl<T: 'static> WithAssoc<()> for T
+where
+    [(); <T as AssocCt>::ASSOC]:,
+{
     type Assoc = [u8; <T as AssocCt>::ASSOC];
 }
 
@@ -37,7 +40,6 @@ where
 {
     x
 }
-
 
 fn unsound<T>(x: <One as WithAssoc<T>>::Assoc) -> <Two as WithAssoc<T>>::Assoc
 where

--- a/tests/ui/const-generics/generic_const_exprs/typeid-equality-by-subtyping.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/typeid-equality-by-subtyping.stderr
@@ -1,0 +1,11 @@
+error: to use a constant of type `TypeId` in a pattern, `TypeId` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/typeid-equality-by-subtyping.rs:18:9
+   |
+LL |         WHAT_A_TYPE => 0,
+   |         ^^^^^^^^^^^
+   |
+   = note: the traits must be derived, manual `impl`s are not sufficient
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
+
+error: aborting due to previous error
+

--- a/tests/ui/consts/const_cmp_type_id.stderr
+++ b/tests/ui/consts/const_cmp_type_id.stderr
@@ -20,7 +20,6 @@ LL |     assert!(TypeId::of::<u8>() == TypeId::of::<u8>());
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `TypeId` with `TypeId` in const contexts
   --> $DIR/const_cmp_type_id.rs:9:13
@@ -44,7 +43,6 @@ LL |     assert!(TypeId::of::<()>() != TypeId::of::<u8>());
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `TypeId` with `TypeId` in const contexts
   --> $DIR/const_cmp_type_id.rs:10:22

--- a/tests/ui/consts/issue-73976-monomorphic.stderr
+++ b/tests/ui/consts/issue-73976-monomorphic.stderr
@@ -20,7 +20,6 @@ LL |     GetTypeId::<T>::VALUE == GetTypeId::<usize>::VALUE
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/pull/99189#issuecomment-1203720442.

> Removing the structural equality might make sense, but is a breaking change that'd require a libs-api FCP.

https://github.com/rust-lang/rust/pull/99189#issuecomment-1197545482

> Landing this PR now (well, mainly the "remove structural equality" part) would unblock `const fn` `TypeId::of`, since we only postponed that because we were guaranteeing too much.

See also #99189, #101698