### PR TITLE
ci: Bring back ninja for dist builders

### DIFF
--- a/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
@@ -23,6 +23,7 @@ RUN yum upgrade -y && \
       libstdc++-devel.x86_64 \
       make \
       ncurses-devel \
+      ninja-build \
       openssl-devel \
       patch \
       perl \
@@ -64,7 +65,6 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-profiler \
       --set target.i686-unknown-linux-gnu.linker=clang \
       --build=i686-unknown-linux-gnu \
-      --set llvm.ninja=false \
       --set rust.jemalloc
 ENV SCRIPT python3 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS
 ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=clang

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -23,6 +23,7 @@ RUN yum upgrade -y && \
       libstdc++-devel.x86_64 \
       make \
       ncurses-devel \
+      ninja-build \
       openssl-devel \
       patch \
       perl \
@@ -76,7 +77,6 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ar=/rustroot/bin/llvm-ar \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
-      --set llvm.ninja=false \
       --set rust.jemalloc \
       --set rust.use-lld=true
 ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -25,6 +25,7 @@ INC="/rustroot/include:/usr/include"
 # disable them. BOLT is used for optimizing LLVM.
 hide_output \
     cmake ../llvm \
+      -GNinja \
       -DCMAKE_C_COMPILER=/rustroot/bin/gcc \
       -DCMAKE_CXX_COMPILER=/rustroot/bin/g++ \
       -DCMAKE_BUILD_TYPE=Release \
@@ -39,8 +40,8 @@ hide_output \
       -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt;bolt" \
       -DC_INCLUDE_DIRS="$INC"
 
-hide_output make -j$(nproc)
-hide_output make install
+hide_output ninja
+hide_output ninja install
 
 cd ../..
 rm -rf llvm-project


### PR DESCRIPTION
The primary reason for this is that make can result in a substantial under utilization of parallelism (noticed while testing on a workstation), mostly due to the submake structure preventing good dependency tracking and scheduling.

In f758c7b2a78 (Debian 6 doesn't have ninja, so use make for the dist builds) llvm.ninja was disabled due to lack of distro package. This is no longer the case with the CentOS 7 base, so bring ninja back for a performance boost.