### PR TITLE
[beta] Cargo backport 1.65.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "core-foundation",


### PR DESCRIPTION
1 commits in 082503982ea0fb7a8fd72210427d43a2e2128a63..4bc8f24d3e899462e43621aab981f6383a370365 2022-09-13 17:49:38 +0000 to 2022-10-20 06:00:42 +0000

- [BETA-1.65] Fix deadlock when build scripts are waiting for input on stdin (rust-lang/cargo#11257)