### PR TITLE
Mark `std::os::wasi::io::AsFd` etc. as stable.

### DIFF
--- a/library/std/src/os/wasi/io/mod.rs
+++ b/library/std/src/os/wasi/io/mod.rs
@@ -1,6 +1,6 @@
 //! WASI-specific extensions to general I/O primitives.
 
-#![unstable(feature = "wasi_ext", issue = "71213")]
+#![stable(feature = "io_safety", since = "1.63.0")]
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 pub use crate::os::fd::*;

--- a/library/std/src/os/wasi/io/mod.rs
+++ b/library/std/src/os/wasi/io/mod.rs
@@ -2,5 +2,5 @@
 
 #![unstable(feature = "wasi_ext", issue = "71213")]
 
-#[unstable(feature = "wasi_ext", issue = "71213")]
+#[stable(feature = "io_safety", since = "1.63.0")]
 pub use crate::os::fd::*;


### PR DESCRIPTION
io_safety was stabilized in Rust 1.63, so mark the io_safety exports in `std::os::wasi::io` as stable.

Fixes #103306.