### PR TITLE
Don't label `src/test` tests as `A-testsuite`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -217,7 +217,6 @@ trigger_files = [
 
 [autolabel."A-testsuite"]
 trigger_files = [
-    "src/test",
     "src/ci",
     "src/tools/compiletest",
     "src/tools/cargotest",


### PR DESCRIPTION
Nearly every PR modifies `src/test`; A-testsuite is meant to be for things affecting the test runners themselves.

cc https://github.com/rust-lang/rust/pull/103204#discussion_r1000868781

r? @jyn514