### PR TITLE
interpret: remove an incorrect assertion

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -35,7 +35,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 assert_eq!(discr.layout.ty, switch_ty);
 
                 // Branch to the `otherwise` case by default, if no match is found.
-                assert!(!targets.iter().is_empty());
                 let mut target_block = targets.otherwise();
 
                 for (const_int, target) in targets.iter() {


### PR DESCRIPTION
This fixes an ICE in Miri, [reported](https://rust-lang.zulipchat.com/#narrow/stream/269128-miri/topic/SwitchInt.20with.20no.20targets.3F) by @saethlin. The faulty assertion was introduced by https://github.com/rust-lang/rust/commit/432535da2b5144d467056efcfa6864d35ba2de0f, when a previously correct assertion checking that the `otherwise` target exists got replaced by this assertion checking that at least one more target beyond `otherwise` exists.

Sadly we don't have a small reproducer so I don't think we can easily add a testcase.