### PR TITLE
New macro: `pdbg!` (pretty debug)

### DIFF
--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -362,7 +362,7 @@ macro_rules! dbg {
 
 #[macro_export]
 #[cfg_attr(not(test), rustc_diagnostic_item = "dbg_macro")]
-#[unstable(feature = "dbg_macro")]
+#[feature(pdbg)]
 macro_rules! pdbg {
     () => {
         $crate::eprintln!()

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -360,6 +360,29 @@ macro_rules! dbg {
     };
 }
 
+#[macro_export]
+#[cfg_attr(not(test), rustc_diagnostic_item = "dbg_macro")]
+#[unstable(feature = "dbg_macro")]
+macro_rules! pdbg {
+    () => {
+        $crate::eprintln!()
+    };
+    ($val:expr $(,)?) => {
+        // Use of `match` here is intentional because it affects the lifetimes
+        // of temporaries - https://stackoverflow.com/a/48732525/1063961
+        match $val {
+            tmp => {
+                $crate::eprintln!("{} = {:#?}\n",
+                    $crate::stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::pdbg!($val)),+,)
+    };
+}
+
 #[cfg(test)]
 macro_rules! assert_approx_eq {
     ($a:expr, $b:expr) => {{


### PR DESCRIPTION
ACP: https://github.com/rust-lang/libs-team/issues/125

The main intended use-case of this new macro is to relieve the user from having to choose between writing long boilerplate (`println!`) and having a messy output (`dbg!`). 

This new macro may be helpful especially when exploring new Rust features (for example in Rust playground) for educational purposes to understand how the feature works. It's modeled after the existing `dbg!` macro, except that it skips the (in some situations) redundant and distracting info about file name and line number. Another difference is that the new `pdbg!`macro will insert a new line at the end to make it easier for the user to identify where each output begins and ends at a quick glance, which may be helpful for example when outputting an enum or a struct, or some other multi-line output.