### PR TITLE
Flatten diagnostic slug modules

### DIFF
--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -3,7 +3,7 @@ use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::generic_type_with_parentheses, code = "E0214")]
+#[diag(ast_lowering_generic_type_with_parentheses, code = "E0214")]
 pub struct GenericTypeWithParentheses {
     #[primary_span]
     #[label]
@@ -13,7 +13,7 @@ pub struct GenericTypeWithParentheses {
 }
 
 #[derive(Clone, Copy, Subdiagnostic)]
-#[multipart_suggestion(ast_lowering::use_angle_brackets, applicability = "maybe-incorrect")]
+#[multipart_suggestion(ast_lowering_use_angle_brackets, applicability = "maybe-incorrect")]
 pub struct UseAngleBrackets {
     #[suggestion_part(code = "<")]
     pub open_param: Span,
@@ -22,7 +22,7 @@ pub struct UseAngleBrackets {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_lowering::invalid_abi, code = "E0703")]
+#[diag(ast_lowering_invalid_abi, code = "E0703")]
 #[note]
 pub struct InvalidAbi {
     #[primary_span]
@@ -36,7 +36,7 @@ pub struct InvalidAbi {
 
 #[derive(Subdiagnostic)]
 #[suggestion(
-    ast_lowering::invalid_abi_suggestion,
+    ast_lowering_invalid_abi_suggestion,
     code = "{suggestion}",
     applicability = "maybe-incorrect"
 )]
@@ -47,7 +47,7 @@ pub struct InvalidAbiSuggestion {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::assoc_ty_parentheses)]
+#[diag(ast_lowering_assoc_ty_parentheses)]
 pub struct AssocTyParentheses {
     #[primary_span]
     pub span: Span,
@@ -57,12 +57,12 @@ pub struct AssocTyParentheses {
 
 #[derive(Clone, Copy, Subdiagnostic)]
 pub enum AssocTyParenthesesSub {
-    #[multipart_suggestion(ast_lowering::remove_parentheses)]
+    #[multipart_suggestion(ast_lowering_remove_parentheses)]
     Empty {
         #[suggestion_part(code = "")]
         parentheses_span: Span,
     },
-    #[multipart_suggestion(ast_lowering::use_angle_brackets)]
+    #[multipart_suggestion(ast_lowering_use_angle_brackets)]
     NotEmpty {
         #[suggestion_part(code = "<")]
         open_param: Span,
@@ -72,7 +72,7 @@ pub enum AssocTyParenthesesSub {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_lowering::misplaced_impl_trait, code = "E0562")]
+#[diag(ast_lowering_misplaced_impl_trait, code = "E0562")]
 pub struct MisplacedImplTrait<'a> {
     #[primary_span]
     pub span: Span,
@@ -80,14 +80,14 @@ pub struct MisplacedImplTrait<'a> {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::rustc_box_attribute_error)]
+#[diag(ast_lowering_rustc_box_attribute_error)]
 pub struct RustcBoxAttributeError {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::underscore_expr_lhs_assign)]
+#[diag(ast_lowering_underscore_expr_lhs_assign)]
 pub struct UnderscoreExprLhsAssign {
     #[primary_span]
     #[label]
@@ -95,7 +95,7 @@ pub struct UnderscoreExprLhsAssign {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::base_expression_double_dot)]
+#[diag(ast_lowering_base_expression_double_dot)]
 pub struct BaseExpressionDoubleDot {
     #[primary_span]
     #[label]
@@ -103,24 +103,24 @@ pub struct BaseExpressionDoubleDot {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::await_only_in_async_fn_and_blocks, code = "E0728")]
+#[diag(ast_lowering_await_only_in_async_fn_and_blocks, code = "E0728")]
 pub struct AwaitOnlyInAsyncFnAndBlocks {
     #[primary_span]
     #[label]
     pub dot_await_span: Span,
-    #[label(ast_lowering::this_not_async)]
+    #[label(ast_lowering_this_not_async)]
     pub item_span: Option<Span>,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::generator_too_many_parameters, code = "E0628")]
+#[diag(ast_lowering_generator_too_many_parameters, code = "E0628")]
 pub struct GeneratorTooManyParameters {
     #[primary_span]
     pub fn_decl_span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::closure_cannot_be_static, code = "E0697")]
+#[diag(ast_lowering_closure_cannot_be_static, code = "E0697")]
 pub struct ClosureCannotBeStatic {
     #[primary_span]
     pub fn_decl_span: Span,
@@ -128,14 +128,14 @@ pub struct ClosureCannotBeStatic {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[help]
-#[diag(ast_lowering::async_non_move_closure_not_supported, code = "E0708")]
+#[diag(ast_lowering_async_non_move_closure_not_supported, code = "E0708")]
 pub struct AsyncNonMoveClosureNotSupported {
     #[primary_span]
     pub fn_decl_span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::functional_record_update_destructuring_assignment)]
+#[diag(ast_lowering_functional_record_update_destructuring_assignment)]
 pub struct FunctionalRecordUpdateDestructuringAssignemnt {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -143,28 +143,28 @@ pub struct FunctionalRecordUpdateDestructuringAssignemnt {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::async_generators_not_supported, code = "E0727")]
+#[diag(ast_lowering_async_generators_not_supported, code = "E0727")]
 pub struct AsyncGeneratorsNotSupported {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::inline_asm_unsupported_target, code = "E0472")]
+#[diag(ast_lowering_inline_asm_unsupported_target, code = "E0472")]
 pub struct InlineAsmUnsupportedTarget {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::att_syntax_only_x86)]
+#[diag(ast_lowering_att_syntax_only_x86)]
 pub struct AttSyntaxOnlyX86 {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::abi_specified_multiple_times)]
+#[diag(ast_lowering_abi_specified_multiple_times)]
 pub struct AbiSpecifiedMultipleTimes {
     #[primary_span]
     pub abi_span: Span,
@@ -176,7 +176,7 @@ pub struct AbiSpecifiedMultipleTimes {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::clobber_abi_not_supported)]
+#[diag(ast_lowering_clobber_abi_not_supported)]
 pub struct ClobberAbiNotSupported {
     #[primary_span]
     pub abi_span: Span,
@@ -184,7 +184,7 @@ pub struct ClobberAbiNotSupported {
 
 #[derive(Diagnostic)]
 #[note]
-#[diag(ast_lowering::invalid_abi_clobber_abi)]
+#[diag(ast_lowering_invalid_abi_clobber_abi)]
 pub struct InvalidAbiClobberAbi {
     #[primary_span]
     pub abi_span: Span,
@@ -192,7 +192,7 @@ pub struct InvalidAbiClobberAbi {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::invalid_register)]
+#[diag(ast_lowering_invalid_register)]
 pub struct InvalidRegister<'a> {
     #[primary_span]
     pub op_span: Span,
@@ -201,7 +201,7 @@ pub struct InvalidRegister<'a> {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::invalid_register_class)]
+#[diag(ast_lowering_invalid_register_class)]
 pub struct InvalidRegisterClass<'a> {
     #[primary_span]
     pub op_span: Span,
@@ -210,12 +210,12 @@ pub struct InvalidRegisterClass<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_lowering::invalid_asm_template_modifier_reg_class)]
+#[diag(ast_lowering_invalid_asm_template_modifier_reg_class)]
 pub struct InvalidAsmTemplateModifierRegClass {
     #[primary_span]
-    #[label(ast_lowering::template_modifier)]
+    #[label(ast_lowering_template_modifier)]
     pub placeholder_span: Span,
-    #[label(ast_lowering::argument)]
+    #[label(ast_lowering_argument)]
     pub op_span: Span,
     #[subdiagnostic]
     pub sub: InvalidAsmTemplateModifierRegClassSub,
@@ -223,34 +223,34 @@ pub struct InvalidAsmTemplateModifierRegClass {
 
 #[derive(Subdiagnostic)]
 pub enum InvalidAsmTemplateModifierRegClassSub {
-    #[note(ast_lowering::support_modifiers)]
+    #[note(ast_lowering_support_modifiers)]
     SupportModifier { class_name: Symbol, modifiers: String },
-    #[note(ast_lowering::does_not_support_modifiers)]
+    #[note(ast_lowering_does_not_support_modifiers)]
     DoesNotSupportModifier { class_name: Symbol },
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::invalid_asm_template_modifier_const)]
+#[diag(ast_lowering_invalid_asm_template_modifier_const)]
 pub struct InvalidAsmTemplateModifierConst {
     #[primary_span]
-    #[label(ast_lowering::template_modifier)]
+    #[label(ast_lowering_template_modifier)]
     pub placeholder_span: Span,
-    #[label(ast_lowering::argument)]
+    #[label(ast_lowering_argument)]
     pub op_span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::invalid_asm_template_modifier_sym)]
+#[diag(ast_lowering_invalid_asm_template_modifier_sym)]
 pub struct InvalidAsmTemplateModifierSym {
     #[primary_span]
-    #[label(ast_lowering::template_modifier)]
+    #[label(ast_lowering_template_modifier)]
     pub placeholder_span: Span,
-    #[label(ast_lowering::argument)]
+    #[label(ast_lowering_argument)]
     pub op_span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::register_class_only_clobber)]
+#[diag(ast_lowering_register_class_only_clobber)]
 pub struct RegisterClassOnlyClobber {
     #[primary_span]
     pub op_span: Span,
@@ -258,12 +258,12 @@ pub struct RegisterClassOnlyClobber {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::register_conflict)]
+#[diag(ast_lowering_register_conflict)]
 pub struct RegisterConflict<'a> {
     #[primary_span]
-    #[label(ast_lowering::register1)]
+    #[label(ast_lowering_register1)]
     pub op_span1: Span,
-    #[label(ast_lowering::register2)]
+    #[label(ast_lowering_register2)]
     pub op_span2: Span,
     pub reg1_name: &'a str,
     pub reg2_name: &'a str,
@@ -273,12 +273,12 @@ pub struct RegisterConflict<'a> {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[help]
-#[diag(ast_lowering::sub_tuple_binding)]
+#[diag(ast_lowering_sub_tuple_binding)]
 pub struct SubTupleBinding<'a> {
     #[primary_span]
     #[label]
     #[suggestion_verbose(
-        ast_lowering::sub_tuple_binding_suggestion,
+        ast_lowering_sub_tuple_binding_suggestion,
         code = "..",
         applicability = "maybe-incorrect"
     )]
@@ -289,56 +289,56 @@ pub struct SubTupleBinding<'a> {
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::extra_double_dot)]
+#[diag(ast_lowering_extra_double_dot)]
 pub struct ExtraDoubleDot<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(ast_lowering::previously_used_here)]
+    #[label(ast_lowering_previously_used_here)]
     pub prev_span: Span,
     pub ctx: &'a str,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
 #[note]
-#[diag(ast_lowering::misplaced_double_dot)]
+#[diag(ast_lowering_misplaced_double_dot)]
 pub struct MisplacedDoubleDot {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::misplaced_relax_trait_bound)]
+#[diag(ast_lowering_misplaced_relax_trait_bound)]
 pub struct MisplacedRelaxTraitBound {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::not_supported_for_lifetime_binder_async_closure)]
+#[diag(ast_lowering_not_supported_for_lifetime_binder_async_closure)]
 pub struct NotSupportedForLifetimeBinderAsyncClosure {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::arbitrary_expression_in_pattern)]
+#[diag(ast_lowering_arbitrary_expression_in_pattern)]
 pub struct ArbitraryExpressionInPattern {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::inclusive_range_with_no_end)]
+#[diag(ast_lowering_inclusive_range_with_no_end)]
 pub struct InclusiveRangeWithNoEnd {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic, Clone, Copy)]
-#[diag(ast_lowering::trait_fn_async, code = "E0706")]
+#[diag(ast_lowering_trait_fn_async, code = "E0706")]
 #[note]
-#[note(ast_lowering::note2)]
+#[note(note2)]
 pub struct TraitFnAsync {
     #[primary_span]
     pub fn_span: Span,

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -170,7 +170,7 @@ impl<'a> AstValidator<'a> {
                 DEPRECATED_WHERE_CLAUSE_LOCATION,
                 id,
                 where_clauses.0.1,
-                fluent::ast_passes::deprecated_where_clause_location,
+                fluent::ast_passes_deprecated_where_clause_location,
                 BuiltinLintDiagnostics::DeprecatedWhereclauseLocation(
                     where_clauses.1.1.shrink_to_hi(),
                     suggestion,
@@ -1765,12 +1765,12 @@ pub(crate) enum ForbiddenLetReason {
     /// `let` is not valid and the source environment is not important
     GenericForbidden,
     /// A let chain with the `||` operator
-    #[note(ast_passes::not_supported_or)]
+    #[note(not_supported_or)]
     NotSupportedOr(#[primary_span] Span),
     /// A let chain with invalid parentheses
     ///
     /// For example, `let 1 = 1 && (expr && expr)` is allowed
     /// but `(let 1 = 1 && (let 1 = 1 && (let 1 = 1))) && let a = 1` is not
-    #[note(ast_passes::not_supported_parentheses)]
+    #[note(not_supported_parentheses)]
     NotSupportedParentheses(#[primary_span] Span),
 }

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_span::{Span, Symbol};
 use crate::ast_validation::ForbiddenLetReason;
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::forbidden_let)]
+#[diag(ast_passes_forbidden_let)]
 #[note]
 pub struct ForbiddenLet {
     #[primary_span]
@@ -17,7 +17,7 @@ pub struct ForbiddenLet {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::forbidden_let_stable)]
+#[diag(ast_passes_forbidden_let_stable)]
 #[note]
 pub struct ForbiddenLetStable {
     #[primary_span]
@@ -25,21 +25,21 @@ pub struct ForbiddenLetStable {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::forbidden_assoc_constraint)]
+#[diag(ast_passes_forbidden_assoc_constraint)]
 pub struct ForbiddenAssocConstraint {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::keyword_lifetime)]
+#[diag(ast_passes_keyword_lifetime)]
 pub struct KeywordLifetime {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::invalid_label)]
+#[diag(ast_passes_invalid_label)]
 pub struct InvalidLabel {
     #[primary_span]
     pub span: Span,
@@ -47,11 +47,11 @@ pub struct InvalidLabel {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::invalid_visibility, code = "E0449")]
+#[diag(ast_passes_invalid_visibility, code = "E0449")]
 pub struct InvalidVisibility {
     #[primary_span]
     pub span: Span,
-    #[label(ast_passes::implied)]
+    #[label(implied)]
     pub implied: Option<Span>,
     #[subdiagnostic]
     pub note: Option<InvalidVisibilityNote>,
@@ -59,14 +59,14 @@ pub struct InvalidVisibility {
 
 #[derive(Subdiagnostic)]
 pub enum InvalidVisibilityNote {
-    #[note(ast_passes::individual_impl_items)]
+    #[note(individual_impl_items)]
     IndividualImplItems,
-    #[note(ast_passes::individual_foreign_items)]
+    #[note(individual_foreign_items)]
     IndividualForeignItems,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::trait_fn_const, code = "E0379")]
+#[diag(ast_passes_trait_fn_const, code = "E0379")]
 pub struct TraitFnConst {
     #[primary_span]
     #[label]
@@ -74,21 +74,21 @@ pub struct TraitFnConst {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::forbidden_lifetime_bound)]
+#[diag(ast_passes_forbidden_lifetime_bound)]
 pub struct ForbiddenLifetimeBound {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::forbidden_non_lifetime_param)]
+#[diag(ast_passes_forbidden_non_lifetime_param)]
 pub struct ForbiddenNonLifetimeParam {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::fn_param_too_many)]
+#[diag(ast_passes_fn_param_too_many)]
 pub struct FnParamTooMany {
     #[primary_span]
     pub span: Span,
@@ -96,21 +96,21 @@ pub struct FnParamTooMany {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::fn_param_c_var_args_only)]
+#[diag(ast_passes_fn_param_c_var_args_only)]
 pub struct FnParamCVarArgsOnly {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::fn_param_c_var_args_not_last)]
+#[diag(ast_passes_fn_param_c_var_args_not_last)]
 pub struct FnParamCVarArgsNotLast {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::fn_param_doc_comment)]
+#[diag(ast_passes_fn_param_doc_comment)]
 pub struct FnParamDocComment {
     #[primary_span]
     #[label]
@@ -118,14 +118,14 @@ pub struct FnParamDocComment {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::fn_param_forbidden_attr)]
+#[diag(ast_passes_fn_param_forbidden_attr)]
 pub struct FnParamForbiddenAttr {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::fn_param_forbidden_self)]
+#[diag(ast_passes_fn_param_forbidden_self)]
 #[note]
 pub struct FnParamForbiddenSelf {
     #[primary_span]
@@ -134,7 +134,7 @@ pub struct FnParamForbiddenSelf {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::forbidden_default)]
+#[diag(ast_passes_forbidden_default)]
 pub struct ForbiddenDefault {
     #[primary_span]
     pub span: Span,
@@ -143,7 +143,7 @@ pub struct ForbiddenDefault {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::assoc_const_without_body)]
+#[diag(ast_passes_assoc_const_without_body)]
 pub struct AssocConstWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -152,7 +152,7 @@ pub struct AssocConstWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::assoc_fn_without_body)]
+#[diag(ast_passes_assoc_fn_without_body)]
 pub struct AssocFnWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -161,7 +161,7 @@ pub struct AssocFnWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::assoc_type_without_body)]
+#[diag(ast_passes_assoc_type_without_body)]
 pub struct AssocTypeWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -170,7 +170,7 @@ pub struct AssocTypeWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::const_without_body)]
+#[diag(ast_passes_const_without_body)]
 pub struct ConstWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -179,7 +179,7 @@ pub struct ConstWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::static_without_body)]
+#[diag(ast_passes_static_without_body)]
 pub struct StaticWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -188,7 +188,7 @@ pub struct StaticWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::ty_alias_without_body)]
+#[diag(ast_passes_ty_alias_without_body)]
 pub struct TyAliasWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -197,7 +197,7 @@ pub struct TyAliasWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes::fn_without_body)]
+#[diag(ast_passes_fn_without_body)]
 pub struct FnWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -226,7 +226,7 @@ impl AddToDiagnostic for ExternBlockSuggestion {
         let end_suggestion = " }".to_owned();
 
         diag.multipart_suggestion(
-            fluent::ast_passes::extern_block_suggestion,
+            fluent::extern_block_suggestion,
             vec![(self.start_span, start_suggestion), (self.end_span, end_suggestion)],
             Applicability::MaybeIncorrect,
         );

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -10,14 +10,14 @@ use rustc_span::{Span, Symbol};
 use crate::UnsupportedLiteralReason;
 
 #[derive(Diagnostic)]
-#[diag(attr::expected_one_cfg_pattern, code = "E0536")]
+#[diag(attr_expected_one_cfg_pattern, code = "E0536")]
 pub(crate) struct ExpectedOneCfgPattern {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::invalid_predicate, code = "E0537")]
+#[diag(attr_invalid_predicate, code = "E0537")]
 pub(crate) struct InvalidPredicate {
     #[primary_span]
     pub span: Span,
@@ -26,7 +26,7 @@ pub(crate) struct InvalidPredicate {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::multiple_item, code = "E0538")]
+#[diag(attr_multiple_item, code = "E0538")]
 pub(crate) struct MultipleItem {
     #[primary_span]
     pub span: Span,
@@ -35,7 +35,7 @@ pub(crate) struct MultipleItem {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::incorrect_meta_item, code = "E0539")]
+#[diag(attr_incorrect_meta_item, code = "E0539")]
 pub(crate) struct IncorrectMetaItem {
     #[primary_span]
     pub span: Span,
@@ -54,39 +54,39 @@ impl<'a> IntoDiagnostic<'a> for UnknownMetaItem<'_> {
         let expected = self.expected.iter().map(|name| format!("`{}`", name)).collect::<Vec<_>>();
         let mut diag = handler.struct_span_err_with_code(
             self.span,
-            fluent::attr::unknown_meta_item,
+            fluent::attr_unknown_meta_item,
             error_code!(E0541),
         );
         diag.set_arg("item", self.item);
         diag.set_arg("expected", expected.join(", "));
-        diag.span_label(self.span, fluent::attr::label);
+        diag.span_label(self.span, fluent::label);
         diag
     }
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::missing_since, code = "E0542")]
+#[diag(attr_missing_since, code = "E0542")]
 pub(crate) struct MissingSince {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::missing_note, code = "E0543")]
+#[diag(attr_missing_note, code = "E0543")]
 pub(crate) struct MissingNote {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::multiple_stability_levels, code = "E0544")]
+#[diag(attr_multiple_stability_levels, code = "E0544")]
 pub(crate) struct MultipleStabilityLevels {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::invalid_issue_string, code = "E0545")]
+#[diag(attr_invalid_issue_string, code = "E0545")]
 pub(crate) struct InvalidIssueString {
     #[primary_span]
     pub span: Span,
@@ -99,31 +99,31 @@ pub(crate) struct InvalidIssueString {
 // translatable.
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidIssueStringCause {
-    #[label(attr::must_not_be_zero)]
+    #[label(must_not_be_zero)]
     MustNotBeZero {
         #[primary_span]
         span: Span,
     },
 
-    #[label(attr::empty)]
+    #[label(empty)]
     Empty {
         #[primary_span]
         span: Span,
     },
 
-    #[label(attr::invalid_digit)]
+    #[label(invalid_digit)]
     InvalidDigit {
         #[primary_span]
         span: Span,
     },
 
-    #[label(attr::pos_overflow)]
+    #[label(pos_overflow)]
     PosOverflow {
         #[primary_span]
         span: Span,
     },
 
-    #[label(attr::neg_overflow)]
+    #[label(neg_overflow)]
     NegOverflow {
         #[primary_span]
         span: Span,
@@ -144,21 +144,21 @@ impl InvalidIssueStringCause {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::missing_feature, code = "E0546")]
+#[diag(attr_missing_feature, code = "E0546")]
 pub(crate) struct MissingFeature {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::non_ident_feature, code = "E0546")]
+#[diag(attr_non_ident_feature, code = "E0546")]
 pub(crate) struct NonIdentFeature {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::missing_issue, code = "E0547")]
+#[diag(attr_missing_issue, code = "E0547")]
 pub(crate) struct MissingIssue {
     #[primary_span]
     pub span: Span,
@@ -167,7 +167,7 @@ pub(crate) struct MissingIssue {
 // FIXME: This diagnostic is identical to `IncorrectMetaItem`, barring the error code. Consider
 // changing this to `IncorrectMetaItem`. See #51489.
 #[derive(Diagnostic)]
-#[diag(attr::incorrect_meta_item, code = "E0551")]
+#[diag(attr_incorrect_meta_item, code = "E0551")]
 pub(crate) struct IncorrectMetaItem2 {
     #[primary_span]
     pub span: Span,
@@ -176,14 +176,14 @@ pub(crate) struct IncorrectMetaItem2 {
 // FIXME: Why is this the same error code as `InvalidReprHintNoParen` and `InvalidReprHintNoValue`?
 // It is more similar to `IncorrectReprFormatGeneric`.
 #[derive(Diagnostic)]
-#[diag(attr::incorrect_repr_format_packed_one_or_zero_arg, code = "E0552")]
+#[diag(attr_incorrect_repr_format_packed_one_or_zero_arg, code = "E0552")]
 pub(crate) struct IncorrectReprFormatPackedOneOrZeroArg {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::invalid_repr_hint_no_paren, code = "E0552")]
+#[diag(attr_invalid_repr_hint_no_paren, code = "E0552")]
 pub(crate) struct InvalidReprHintNoParen {
     #[primary_span]
     pub span: Span,
@@ -192,7 +192,7 @@ pub(crate) struct InvalidReprHintNoParen {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::invalid_repr_hint_no_value, code = "E0552")]
+#[diag(attr_invalid_repr_hint_no_value, code = "E0552")]
 pub(crate) struct InvalidReprHintNoValue {
     #[primary_span]
     pub span: Span,
@@ -213,13 +213,13 @@ impl<'a> IntoDiagnostic<'a> for UnsupportedLiteral {
         let mut diag = handler.struct_span_err_with_code(
             self.span,
             match self.reason {
-                UnsupportedLiteralReason::Generic => fluent::attr::unsupported_literal_generic,
-                UnsupportedLiteralReason::CfgString => fluent::attr::unsupported_literal_cfg_string,
+                UnsupportedLiteralReason::Generic => fluent::attr_unsupported_literal_generic,
+                UnsupportedLiteralReason::CfgString => fluent::attr_unsupported_literal_cfg_string,
                 UnsupportedLiteralReason::DeprecatedString => {
-                    fluent::attr::unsupported_literal_deprecated_string
+                    fluent::attr_unsupported_literal_deprecated_string
                 }
                 UnsupportedLiteralReason::DeprecatedKvPair => {
-                    fluent::attr::unsupported_literal_deprecated_kv_pair
+                    fluent::attr_unsupported_literal_deprecated_kv_pair
                 }
             },
             error_code!(E0565),
@@ -227,7 +227,7 @@ impl<'a> IntoDiagnostic<'a> for UnsupportedLiteral {
         if self.is_bytestr {
             diag.span_suggestion(
                 self.start_point_span,
-                fluent::attr::unsupported_literal_suggestion,
+                fluent::attr_unsupported_literal_suggestion,
                 "",
                 Applicability::MaybeIncorrect,
             );
@@ -237,7 +237,7 @@ impl<'a> IntoDiagnostic<'a> for UnsupportedLiteral {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::invalid_repr_align_need_arg, code = "E0589")]
+#[diag(attr_invalid_repr_align_need_arg, code = "E0589")]
 pub(crate) struct InvalidReprAlignNeedArg {
     #[primary_span]
     #[suggestion(code = "align(...)", applicability = "has-placeholders")]
@@ -245,7 +245,7 @@ pub(crate) struct InvalidReprAlignNeedArg {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::invalid_repr_generic, code = "E0589")]
+#[diag(attr_invalid_repr_generic, code = "E0589")]
 pub(crate) struct InvalidReprGeneric<'a> {
     #[primary_span]
     pub span: Span,
@@ -255,14 +255,14 @@ pub(crate) struct InvalidReprGeneric<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::incorrect_repr_format_align_one_arg, code = "E0693")]
+#[diag(attr_incorrect_repr_format_align_one_arg, code = "E0693")]
 pub(crate) struct IncorrectReprFormatAlignOneArg {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::incorrect_repr_format_generic, code = "E0693")]
+#[diag(attr_incorrect_repr_format_generic, code = "E0693")]
 pub(crate) struct IncorrectReprFormatGeneric<'a> {
     #[primary_span]
     pub span: Span,
@@ -275,7 +275,7 @@ pub(crate) struct IncorrectReprFormatGeneric<'a> {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum IncorrectReprFormatGenericCause<'a> {
-    #[suggestion(attr::suggestion, code = "{name}({int})", applicability = "machine-applicable")]
+    #[suggestion(suggestion, code = "{name}({int})", applicability = "machine-applicable")]
     Int {
         #[primary_span]
         span: Span,
@@ -287,11 +287,7 @@ pub(crate) enum IncorrectReprFormatGenericCause<'a> {
         int: u128,
     },
 
-    #[suggestion(
-        attr::suggestion,
-        code = "{name}({symbol})",
-        applicability = "machine-applicable"
-    )]
+    #[suggestion(suggestion, code = "{name}({symbol})", applicability = "machine-applicable")]
     Symbol {
         #[primary_span]
         span: Span,
@@ -317,28 +313,28 @@ impl<'a> IncorrectReprFormatGenericCause<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::rustc_promotable_pairing, code = "E0717")]
+#[diag(attr_rustc_promotable_pairing, code = "E0717")]
 pub(crate) struct RustcPromotablePairing {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::rustc_allowed_unstable_pairing, code = "E0789")]
+#[diag(attr_rustc_allowed_unstable_pairing, code = "E0789")]
 pub(crate) struct RustcAllowedUnstablePairing {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::cfg_predicate_identifier)]
+#[diag(attr_cfg_predicate_identifier)]
 pub(crate) struct CfgPredicateIdentifier {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::deprecated_item_suggestion)]
+#[diag(attr_deprecated_item_suggestion)]
 pub(crate) struct DeprecatedItemSuggestion {
     #[primary_span]
     pub span: Span,
@@ -351,21 +347,21 @@ pub(crate) struct DeprecatedItemSuggestion {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::expected_single_version_literal)]
+#[diag(attr_expected_single_version_literal)]
 pub(crate) struct ExpectedSingleVersionLiteral {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::expected_version_literal)]
+#[diag(attr_expected_version_literal)]
 pub(crate) struct ExpectedVersionLiteral {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::expects_feature_list)]
+#[diag(attr_expects_feature_list)]
 pub(crate) struct ExpectsFeatureList {
     #[primary_span]
     pub span: Span,
@@ -374,7 +370,7 @@ pub(crate) struct ExpectsFeatureList {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::expects_features)]
+#[diag(attr_expects_features)]
 pub(crate) struct ExpectsFeatures {
     #[primary_span]
     pub span: Span,
@@ -383,14 +379,14 @@ pub(crate) struct ExpectsFeatures {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::soft_no_args)]
+#[diag(attr_soft_no_args)]
 pub(crate) struct SoftNoArgs {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(attr::unknown_version_literal)]
+#[diag(attr_unknown_version_literal)]
 pub(crate) struct UnknownVersionLiteral {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -6,7 +6,7 @@ use rustc_span::Span;
 use crate::diagnostics::RegionName;
 
 #[derive(Diagnostic)]
-#[diag(borrowck::move_unsized, code = "E0161")]
+#[diag(borrowck_move_unsized, code = "E0161")]
 pub(crate) struct MoveUnsized<'tcx> {
     pub ty: Ty<'tcx>,
     #[primary_span]
@@ -15,7 +15,7 @@ pub(crate) struct MoveUnsized<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(borrowck::higher_ranked_lifetime_error)]
+#[diag(borrowck_higher_ranked_lifetime_error)]
 pub(crate) struct HigherRankedLifetimeError {
     #[subdiagnostic]
     pub cause: Option<HigherRankedErrorCause>,
@@ -25,21 +25,21 @@ pub(crate) struct HigherRankedLifetimeError {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum HigherRankedErrorCause {
-    #[note(borrowck::could_not_prove)]
+    #[note(borrowck_could_not_prove)]
     CouldNotProve { predicate: String },
-    #[note(borrowck::could_not_normalize)]
+    #[note(borrowck_could_not_normalize)]
     CouldNotNormalize { value: String },
 }
 
 #[derive(Diagnostic)]
-#[diag(borrowck::higher_ranked_subtype_error)]
+#[diag(borrowck_higher_ranked_subtype_error)]
 pub(crate) struct HigherRankedSubtypeError {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(borrowck::generic_does_not_live_long_enough)]
+#[diag(borrowck_generic_does_not_live_long_enough)]
 pub(crate) struct GenericDoesNotLiveLongEnough {
     pub kind: String,
     #[primary_span]
@@ -47,15 +47,15 @@ pub(crate) struct GenericDoesNotLiveLongEnough {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(borrowck::var_does_not_need_mut)]
+#[diag(borrowck_var_does_not_need_mut)]
 pub(crate) struct VarNeedNotMut {
     #[suggestion_short(applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
 #[derive(Diagnostic)]
-#[diag(borrowck::var_cannot_escape_closure)]
+#[diag(borrowck_var_cannot_escape_closure)]
 #[note]
-#[note(borrowck::cannot_escape)]
+#[note(cannot_escape)]
 pub(crate) struct FnMutError {
     #[primary_span]
     pub span: Span,
@@ -65,17 +65,17 @@ pub(crate) struct FnMutError {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum VarHereDenote {
-    #[label(borrowck::var_here_captured)]
+    #[label(borrowck_var_here_captured)]
     Captured {
         #[primary_span]
         span: Span,
     },
-    #[label(borrowck::var_here_defined)]
+    #[label(borrowck_var_here_defined)]
     Defined {
         #[primary_span]
         span: Span,
     },
-    #[label(borrowck::closure_inferred_mut)]
+    #[label(borrowck_closure_inferred_mut)]
     FnMutInferred {
         #[primary_span]
         span: Span,
@@ -84,17 +84,17 @@ pub(crate) enum VarHereDenote {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum FnMutReturnTypeErr {
-    #[label(borrowck::returned_closure_escaped)]
+    #[label(borrowck_returned_closure_escaped)]
     ReturnClosure {
         #[primary_span]
         span: Span,
     },
-    #[label(borrowck::returned_async_block_escaped)]
+    #[label(borrowck_returned_async_block_escaped)]
     ReturnAsyncBlock {
         #[primary_span]
         span: Span,
     },
-    #[label(borrowck::returned_ref_escaped)]
+    #[label(borrowck_returned_ref_escaped)]
     ReturnRef {
         #[primary_span]
         span: Span,
@@ -102,7 +102,7 @@ pub(crate) enum FnMutReturnTypeErr {
 }
 
 #[derive(Diagnostic)]
-#[diag(borrowck::lifetime_constraints_error)]
+#[diag(borrowck_lifetime_constraints_error)]
 pub(crate) struct LifetimeOutliveErr {
     #[primary_span]
     pub span: Span,
@@ -110,7 +110,7 @@ pub(crate) struct LifetimeOutliveErr {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum LifetimeReturnCategoryErr<'a> {
-    #[label(borrowck::returned_lifetime_wrong)]
+    #[label(borrowck_returned_lifetime_wrong)]
     WrongReturn {
         #[primary_span]
         span: Span,
@@ -118,7 +118,7 @@ pub(crate) enum LifetimeReturnCategoryErr<'a> {
         outlived_fr_name: RegionName,
         fr_name: &'a RegionName,
     },
-    #[label(borrowck::returned_lifetime_short)]
+    #[label(borrowck_returned_lifetime_short)]
     ShortReturn {
         #[primary_span]
         span: Span,
@@ -142,7 +142,7 @@ impl IntoDiagnosticArg for RegionName {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum RequireStaticErr {
-    #[note(borrowck::used_impl_require_static)]
+    #[note(borrowck_used_impl_require_static)]
     UsedImpl {
         #[primary_span]
         multi_span: MultiSpan,

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -36,7 +36,7 @@ pub fn expand_cfg(
 }
 
 #[derive(Diagnostic)]
-#[diag(builtin_macros::requires_cfg_pattern)]
+#[diag(builtin_macros_requires_cfg_pattern)]
 struct RequiresCfgPattern {
     #[primary_span]
     #[label]
@@ -44,7 +44,7 @@ struct RequiresCfgPattern {
 }
 
 #[derive(Diagnostic)]
-#[diag(builtin_macros::expected_one_cfg_pattern)]
+#[diag(builtin_macros_expected_one_cfg_pattern)]
 struct OneCfgPattern {
     #[primary_span]
     span: Span,

--- a/compiler/rustc_codegen_gcc/src/errors.rs
+++ b/compiler/rustc_codegen_gcc/src/errors.rs
@@ -17,7 +17,7 @@ impl IntoDiagnosticArg for ExitCode {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::ranlib_failure)]
+#[diag(codegen_gcc_ranlib_failure)]
 pub(crate) struct RanlibFailure {
     exit_code: ExitCode,
 }
@@ -29,7 +29,7 @@ impl RanlibFailure {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_basic_integer, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_basic_integer, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationBasicInteger<'a> {
     #[primary_span]
     pub span: Span,
@@ -38,7 +38,7 @@ pub(crate) struct InvalidMonomorphizationBasicInteger<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_invalid_float_vector, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_invalid_float_vector, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationInvalidFloatVector<'a> {
     #[primary_span]
     pub span: Span,
@@ -48,7 +48,7 @@ pub(crate) struct InvalidMonomorphizationInvalidFloatVector<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_not_float, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_not_float, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationNotFloat<'a> {
     #[primary_span]
     pub span: Span,
@@ -57,7 +57,7 @@ pub(crate) struct InvalidMonomorphizationNotFloat<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_unrecognized, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_unrecognized, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationUnrecognized {
     #[primary_span]
     pub span: Span,
@@ -65,7 +65,7 @@ pub(crate) struct InvalidMonomorphizationUnrecognized {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_expected_signed_unsigned, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_expected_signed_unsigned, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationExpectedSignedUnsigned<'a> {
     #[primary_span]
     pub span: Span,
@@ -75,7 +75,7 @@ pub(crate) struct InvalidMonomorphizationExpectedSignedUnsigned<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_unsupported_element, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_unsupported_element, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationUnsupportedElement<'a> {
     #[primary_span]
     pub span: Span,
@@ -86,7 +86,7 @@ pub(crate) struct InvalidMonomorphizationUnsupportedElement<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_invalid_bitmask, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_invalid_bitmask, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationInvalidBitmask<'a> {
     #[primary_span]
     pub span: Span,
@@ -97,7 +97,7 @@ pub(crate) struct InvalidMonomorphizationInvalidBitmask<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_simd_shuffle, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_simd_shuffle, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationSimdShuffle<'a> {
     #[primary_span]
     pub span: Span,
@@ -106,7 +106,7 @@ pub(crate) struct InvalidMonomorphizationSimdShuffle<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_expected_simd, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_expected_simd, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationExpectedSimd<'a> {
     #[primary_span]
     pub span: Span,
@@ -116,7 +116,7 @@ pub(crate) struct InvalidMonomorphizationExpectedSimd<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_mask_type, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_mask_type, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationMaskType<'a> {
     #[primary_span]
     pub span: Span,
@@ -125,7 +125,7 @@ pub(crate) struct InvalidMonomorphizationMaskType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_return_length, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_return_length, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationReturnLength<'a> {
     #[primary_span]
     pub span: Span,
@@ -136,7 +136,7 @@ pub(crate) struct InvalidMonomorphizationReturnLength<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_return_length_input_type, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_return_length_input_type, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationReturnLengthInputType<'a> {
     #[primary_span]
     pub span: Span,
@@ -148,7 +148,7 @@ pub(crate) struct InvalidMonomorphizationReturnLengthInputType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_return_element, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_return_element, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationReturnElement<'a> {
     #[primary_span]
     pub span: Span,
@@ -160,7 +160,7 @@ pub(crate) struct InvalidMonomorphizationReturnElement<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_return_type, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_return_type, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationReturnType<'a> {
     #[primary_span]
     pub span: Span,
@@ -171,7 +171,7 @@ pub(crate) struct InvalidMonomorphizationReturnType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_inserted_type, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_inserted_type, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationInsertedType<'a> {
     #[primary_span]
     pub span: Span,
@@ -182,7 +182,7 @@ pub(crate) struct InvalidMonomorphizationInsertedType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_return_integer_type, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_return_integer_type, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationReturnIntegerType<'a> {
     #[primary_span]
     pub span: Span,
@@ -192,7 +192,7 @@ pub(crate) struct InvalidMonomorphizationReturnIntegerType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_mismatched_lengths, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_mismatched_lengths, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationMismatchedLengths {
     #[primary_span]
     pub span: Span,
@@ -202,7 +202,7 @@ pub(crate) struct InvalidMonomorphizationMismatchedLengths {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_unsupported_cast, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_unsupported_cast, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationUnsupportedCast<'a> {
     #[primary_span]
     pub span: Span,
@@ -214,7 +214,7 @@ pub(crate) struct InvalidMonomorphizationUnsupportedCast<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::invalid_monomorphization_unsupported_operation, code = "E0511")]
+#[diag(codegen_gcc_invalid_monomorphization_unsupported_operation, code = "E0511")]
 pub(crate) struct InvalidMonomorphizationUnsupportedOperation<'a> {
     #[primary_span]
     pub span: Span,
@@ -224,18 +224,18 @@ pub(crate) struct InvalidMonomorphizationUnsupportedOperation<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::linkage_const_or_mut_type)]
+#[diag(codegen_gcc_linkage_const_or_mut_type)]
 pub(crate) struct LinkageConstOrMutType {
     #[primary_span]
     pub span: Span
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::lto_not_supported)]
+#[diag(codegen_gcc_lto_not_supported)]
 pub(crate) struct LTONotSupported;
 
 #[derive(Diagnostic)]
-#[diag(codegen_gcc::unwinding_inline_asm)]
+#[diag(codegen_gcc_unwinding_inline_asm)]
 pub(crate) struct UnwindingInlineAsm {
     #[primary_span]
     pub span: Span

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -13,43 +13,43 @@ use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::lib_def_write_failure)]
+#[diag(codegen_ssa_lib_def_write_failure)]
 pub struct LibDefWriteFailure {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::version_script_write_failure)]
+#[diag(codegen_ssa_version_script_write_failure)]
 pub struct VersionScriptWriteFailure {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::symbol_file_write_failure)]
+#[diag(codegen_ssa_symbol_file_write_failure)]
 pub struct SymbolFileWriteFailure {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::ld64_unimplemented_modifier)]
+#[diag(codegen_ssa_ld64_unimplemented_modifier)]
 pub struct Ld64UnimplementedModifier;
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::linker_unsupported_modifier)]
+#[diag(codegen_ssa_linker_unsupported_modifier)]
 pub struct LinkerUnsupportedModifier;
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::L4Bender_exporting_symbols_unimplemented)]
+#[diag(codegen_ssa_L4Bender_exporting_symbols_unimplemented)]
 pub struct L4BenderExportingSymbolsUnimplemented;
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::no_natvis_directory)]
+#[diag(codegen_ssa_no_natvis_directory)]
 pub struct NoNatvisDirectory {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::copy_path_buf)]
+#[diag(codegen_ssa_copy_path_buf)]
 pub struct CopyPathBuf {
     pub source_file: PathBuf,
     pub output_path: PathBuf,
@@ -58,7 +58,7 @@ pub struct CopyPathBuf {
 
 // Reports Paths using `Debug` implementation rather than Path's `Display` implementation.
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::copy_path)]
+#[diag(codegen_ssa_copy_path)]
 pub struct CopyPath<'a> {
     from: DebugArgPath<'a>,
     to: DebugArgPath<'a>,
@@ -80,36 +80,36 @@ impl IntoDiagnosticArg for DebugArgPath<'_> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::ignoring_emit_path)]
+#[diag(codegen_ssa_ignoring_emit_path)]
 pub struct IgnoringEmitPath {
     pub extension: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::ignoring_output)]
+#[diag(codegen_ssa_ignoring_output)]
 pub struct IgnoringOutput {
     pub extension: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::create_temp_dir)]
+#[diag(codegen_ssa_create_temp_dir)]
 pub struct CreateTempDir {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::incompatible_linking_modifiers)]
+#[diag(codegen_ssa_incompatible_linking_modifiers)]
 pub struct IncompatibleLinkingModifiers;
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::add_native_library)]
+#[diag(codegen_ssa_add_native_library)]
 pub struct AddNativeLibrary {
     pub library_path: PathBuf,
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa::multiple_external_func_decl)]
+#[diag(codegen_ssa_multiple_external_func_decl)]
 pub struct MultipleExternalFuncDecl<'a> {
     #[primary_span]
     pub span: Span,
@@ -119,13 +119,13 @@ pub struct MultipleExternalFuncDecl<'a> {
 
 #[derive(Diagnostic)]
 pub enum LinkRlibError {
-    #[diag(codegen_ssa::rlib_missing_format)]
+    #[diag(codegen_ssa_rlib_missing_format)]
     MissingFormat,
 
-    #[diag(codegen_ssa::rlib_only_rmeta_found)]
+    #[diag(codegen_ssa_rlib_only_rmeta_found)]
     OnlyRmetaFound { crate_name: Symbol },
 
-    #[diag(codegen_ssa::rlib_not_found)]
+    #[diag(codegen_ssa_rlib_not_found)]
     NotFound { crate_name: Symbol },
 }
 
@@ -136,188 +136,188 @@ impl IntoDiagnostic<'_> for ThorinErrorWrapper {
         let mut diag;
         match self.0 {
             thorin::Error::ReadInput(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_read_input_failure);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_read_input_failure);
                 diag
             }
             thorin::Error::ParseFileKind(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_input_file_kind);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_input_file_kind);
                 diag
             }
             thorin::Error::ParseObjectFile(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_input_object_file);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_input_object_file);
                 diag
             }
             thorin::Error::ParseArchiveFile(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_input_archive_file);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_input_archive_file);
                 diag
             }
             thorin::Error::ParseArchiveMember(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_archive_member);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_archive_member);
                 diag
             }
             thorin::Error::InvalidInputKind => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_invalid_input_kind);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_invalid_input_kind);
                 diag
             }
             thorin::Error::DecompressData(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_decompress_data);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_decompress_data);
                 diag
             }
             thorin::Error::NamelessSection(_, offset) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_section_without_name);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_section_without_name);
                 diag.set_arg("offset", format!("0x{:08x}", offset));
                 diag
             }
             thorin::Error::RelocationWithInvalidSymbol(section, offset) => {
                 diag =
-                    handler.struct_err(fluent::codegen_ssa::thorin_relocation_with_invalid_symbol);
+                    handler.struct_err(fluent::codegen_ssa_thorin_relocation_with_invalid_symbol);
                 diag.set_arg("section", section);
                 diag.set_arg("offset", format!("0x{:08x}", offset));
                 diag
             }
             thorin::Error::MultipleRelocations(section, offset) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_multiple_relocations);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_multiple_relocations);
                 diag.set_arg("section", section);
                 diag.set_arg("offset", format!("0x{:08x}", offset));
                 diag
             }
             thorin::Error::UnsupportedRelocation(section, offset) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_unsupported_relocation);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_unsupported_relocation);
                 diag.set_arg("section", section);
                 diag.set_arg("offset", format!("0x{:08x}", offset));
                 diag
             }
             thorin::Error::MissingDwoName(id) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_missing_dwo_name);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_missing_dwo_name);
                 diag.set_arg("id", format!("0x{:08x}", id));
                 diag
             }
             thorin::Error::NoCompilationUnits => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_no_compilation_units);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_no_compilation_units);
                 diag
             }
             thorin::Error::NoDie => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_no_die);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_no_die);
                 diag
             }
             thorin::Error::TopLevelDieNotUnit => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_top_level_die_not_unit);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_top_level_die_not_unit);
                 diag
             }
             thorin::Error::MissingRequiredSection(section) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_missing_required_section);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_missing_required_section);
                 diag.set_arg("section", section);
                 diag
             }
             thorin::Error::ParseUnitAbbreviations(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_unit_abbreviations);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_unit_abbreviations);
                 diag
             }
             thorin::Error::ParseUnitAttribute(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_unit_attribute);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_unit_attribute);
                 diag
             }
             thorin::Error::ParseUnitHeader(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_unit_header);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_unit_header);
                 diag
             }
             thorin::Error::ParseUnit(_) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_unit);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_unit);
                 diag
             }
             thorin::Error::IncompatibleIndexVersion(section, format, actual) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_incompatible_index_version);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_incompatible_index_version);
                 diag.set_arg("section", section);
                 diag.set_arg("actual", actual);
                 diag.set_arg("format", format);
                 diag
             }
             thorin::Error::OffsetAtIndex(_, index) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_offset_at_index);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_offset_at_index);
                 diag.set_arg("index", index);
                 diag
             }
             thorin::Error::StrAtOffset(_, offset) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_str_at_offset);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_str_at_offset);
                 diag.set_arg("offset", format!("0x{:08x}", offset));
                 diag
             }
             thorin::Error::ParseIndex(_, section) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_parse_index);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_parse_index);
                 diag.set_arg("section", section);
                 diag
             }
             thorin::Error::UnitNotInIndex(unit) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_unit_not_in_index);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_unit_not_in_index);
                 diag.set_arg("unit", format!("0x{:08x}", unit));
                 diag
             }
             thorin::Error::RowNotInIndex(_, row) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_row_not_in_index);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_row_not_in_index);
                 diag.set_arg("row", row);
                 diag
             }
             thorin::Error::SectionNotInRow => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_section_not_in_row);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_section_not_in_row);
                 diag
             }
             thorin::Error::EmptyUnit(unit) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_empty_unit);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_empty_unit);
                 diag.set_arg("unit", format!("0x{:08x}", unit));
                 diag
             }
             thorin::Error::MultipleDebugInfoSection => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_multiple_debug_info_section);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_multiple_debug_info_section);
                 diag
             }
             thorin::Error::MultipleDebugTypesSection => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_multiple_debug_types_section);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_multiple_debug_types_section);
                 diag
             }
             thorin::Error::NotSplitUnit => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_not_split_unit);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_not_split_unit);
                 diag
             }
             thorin::Error::DuplicateUnit(unit) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_duplicate_unit);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_duplicate_unit);
                 diag.set_arg("unit", format!("0x{:08x}", unit));
                 diag
             }
             thorin::Error::MissingReferencedUnit(unit) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_missing_referenced_unit);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_missing_referenced_unit);
                 diag.set_arg("unit", format!("0x{:08x}", unit));
                 diag
             }
             thorin::Error::NoOutputObjectCreated => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_not_output_object_created);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_not_output_object_created);
                 diag
             }
             thorin::Error::MixedInputEncodings => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_mixed_input_encodings);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_mixed_input_encodings);
                 diag
             }
             thorin::Error::Io(e) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_io);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_io);
                 diag.set_arg("error", format!("{e}"));
                 diag
             }
             thorin::Error::ObjectRead(e) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_object_read);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_object_read);
                 diag.set_arg("error", format!("{e}"));
                 diag
             }
             thorin::Error::ObjectWrite(e) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_object_write);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_object_write);
                 diag.set_arg("error", format!("{e}"));
                 diag
             }
             thorin::Error::GimliRead(e) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_gimli_read);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_gimli_read);
                 diag.set_arg("error", format!("{e}"));
                 diag
             }
             thorin::Error::GimliWrite(e) => {
-                diag = handler.struct_err(fluent::codegen_ssa::thorin_gimli_write);
+                diag = handler.struct_err(fluent::codegen_ssa_thorin_gimli_write);
                 diag.set_arg("error", format!("{e}"));
                 diag
             }
@@ -335,7 +335,7 @@ pub struct LinkingFailed<'a> {
 
 impl IntoDiagnostic<'_> for LinkingFailed<'_> {
     fn into_diagnostic(self, handler: &Handler) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = handler.struct_err(fluent::codegen_ssa::linking_failed);
+        let mut diag = handler.struct_err(fluent::codegen_ssa_linking_failed);
         diag.set_arg("linker_path", format!("{}", self.linker_path.display()));
         diag.set_arg("exit_status", format!("{}", self.exit_status));
 
@@ -344,9 +344,9 @@ impl IntoDiagnostic<'_> for LinkingFailed<'_> {
         // Trying to match an error from OS linkers
         // which by now we have no way to translate.
         if self.escaped_output.contains("undefined reference to") {
-            diag.note(fluent::codegen_ssa::extern_funcs_not_found)
-                .note(fluent::codegen_ssa::specify_libraries_to_link)
-                .note(fluent::codegen_ssa::use_cargo_directive);
+            diag.note(fluent::codegen_ssa_extern_funcs_not_found)
+                .note(fluent::codegen_ssa_specify_libraries_to_link)
+                .note(fluent::codegen_ssa_use_cargo_directive);
         }
         diag
     }

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -3,18 +3,18 @@ use rustc_macros::Diagnostic;
 use rustc_span::Span;
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unstable_in_stable)]
+#[diag(const_eval_unstable_in_stable)]
 pub(crate) struct UnstableInStable {
     pub gate: String,
     #[primary_span]
     pub span: Span,
     #[suggestion(
-        const_eval::unstable_sugg,
+        unstable_sugg,
         code = "#[rustc_const_unstable(feature = \"...\", issue = \"...\")]\n",
         applicability = "has-placeholders"
     )]
     #[suggestion(
-        const_eval::bypass_sugg,
+        bypass_sugg,
         code = "#[rustc_allow_const_fn_unstable({gate})]\n",
         applicability = "has-placeholders"
     )]
@@ -22,35 +22,35 @@ pub(crate) struct UnstableInStable {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::thread_local_access, code = "E0625")]
+#[diag(const_eval_thread_local_access, code = "E0625")]
 pub(crate) struct NonConstOpErr {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::static_access, code = "E0013")]
+#[diag(const_eval_static_access, code = "E0013")]
 #[help]
 pub(crate) struct StaticAccessErr {
     #[primary_span]
     pub span: Span,
     pub kind: ConstContext,
-    #[note(const_eval::teach_note)]
-    #[help(const_eval::teach_help)]
+    #[note(teach_note)]
+    #[help(teach_help)]
     pub teach: Option<()>,
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::raw_ptr_to_int)]
+#[diag(const_eval_raw_ptr_to_int)]
 #[note]
-#[note(const_eval::note2)]
+#[note(note2)]
 pub(crate) struct RawPtrToIntErr {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::raw_ptr_comparison)]
+#[diag(const_eval_raw_ptr_comparison)]
 #[note]
 pub(crate) struct RawPtrComparisonErr {
     #[primary_span]
@@ -58,14 +58,14 @@ pub(crate) struct RawPtrComparisonErr {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::panic_non_str)]
+#[diag(const_eval_panic_non_str)]
 pub(crate) struct PanicNonStrErr {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::mut_deref, code = "E0658")]
+#[diag(const_eval_mut_deref, code = "E0658")]
 pub(crate) struct MutDerefErr {
     #[primary_span]
     pub span: Span,
@@ -73,7 +73,7 @@ pub(crate) struct MutDerefErr {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::transient_mut_borrow, code = "E0658")]
+#[diag(const_eval_transient_mut_borrow, code = "E0658")]
 pub(crate) struct TransientMutBorrowErr {
     #[primary_span]
     pub span: Span,
@@ -81,7 +81,7 @@ pub(crate) struct TransientMutBorrowErr {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::transient_mut_borrow_raw, code = "E0658")]
+#[diag(const_eval_transient_mut_borrow_raw, code = "E0658")]
 pub(crate) struct TransientMutBorrowErrRaw {
     #[primary_span]
     pub span: Span,
@@ -89,7 +89,7 @@ pub(crate) struct TransientMutBorrowErrRaw {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::max_num_nodes_in_const)]
+#[diag(const_eval_max_num_nodes_in_const)]
 pub(crate) struct MaxNumNodesInConstErr {
     #[primary_span]
     pub span: Span,
@@ -97,7 +97,7 @@ pub(crate) struct MaxNumNodesInConstErr {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unallowed_fn_pointer_call)]
+#[diag(const_eval_unallowed_fn_pointer_call)]
 pub(crate) struct UnallowedFnPointerCall {
     #[primary_span]
     pub span: Span,
@@ -105,7 +105,7 @@ pub(crate) struct UnallowedFnPointerCall {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unstable_const_fn)]
+#[diag(const_eval_unstable_const_fn)]
 pub(crate) struct UnstableConstFn {
     #[primary_span]
     pub span: Span,
@@ -113,26 +113,26 @@ pub(crate) struct UnstableConstFn {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unallowed_mutable_refs, code = "E0764")]
+#[diag(const_eval_unallowed_mutable_refs, code = "E0764")]
 pub(crate) struct UnallowedMutableRefs {
     #[primary_span]
     pub span: Span,
     pub kind: ConstContext,
-    #[note(const_eval::teach_note)]
+    #[note(teach_note)]
     pub teach: Option<()>,
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unallowed_mutable_refs_raw, code = "E0764")]
+#[diag(const_eval_unallowed_mutable_refs_raw, code = "E0764")]
 pub(crate) struct UnallowedMutableRefsRaw {
     #[primary_span]
     pub span: Span,
     pub kind: ConstContext,
-    #[note(const_eval::teach_note)]
+    #[note(teach_note)]
     pub teach: Option<()>,
 }
 #[derive(Diagnostic)]
-#[diag(const_eval::non_const_fmt_macro_call, code = "E0015")]
+#[diag(const_eval_non_const_fmt_macro_call, code = "E0015")]
 pub(crate) struct NonConstFmtMacroCall {
     #[primary_span]
     pub span: Span,
@@ -140,7 +140,7 @@ pub(crate) struct NonConstFmtMacroCall {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::non_const_fn_call, code = "E0015")]
+#[diag(const_eval_non_const_fn_call, code = "E0015")]
 pub(crate) struct NonConstFnCall {
     #[primary_span]
     pub span: Span,
@@ -149,7 +149,7 @@ pub(crate) struct NonConstFnCall {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unallowed_op_in_const_context)]
+#[diag(const_eval_unallowed_op_in_const_context)]
 pub(crate) struct UnallowedOpInConstContext {
     #[primary_span]
     pub span: Span,
@@ -157,18 +157,18 @@ pub(crate) struct UnallowedOpInConstContext {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unallowed_heap_allocations, code = "E0010")]
+#[diag(const_eval_unallowed_heap_allocations, code = "E0010")]
 pub(crate) struct UnallowedHeapAllocations {
     #[primary_span]
     #[label]
     pub span: Span,
     pub kind: ConstContext,
-    #[note(const_eval::teach_note)]
+    #[note(teach_note)]
     pub teach: Option<()>,
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::unallowed_inline_asm, code = "E0015")]
+#[diag(const_eval_unallowed_inline_asm, code = "E0015")]
 pub(crate) struct UnallowedInlineAsm {
     #[primary_span]
     pub span: Span,
@@ -176,7 +176,7 @@ pub(crate) struct UnallowedInlineAsm {
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::interior_mutable_data_refer, code = "E0492")]
+#[diag(const_eval_interior_mutable_data_refer, code = "E0492")]
 pub(crate) struct InteriorMutableDataRefer {
     #[primary_span]
     #[label]
@@ -184,12 +184,12 @@ pub(crate) struct InteriorMutableDataRefer {
     #[help]
     pub opt_help: Option<()>,
     pub kind: ConstContext,
-    #[note(const_eval::teach_note)]
+    #[note(teach_note)]
     pub teach: Option<()>,
 }
 
 #[derive(Diagnostic)]
-#[diag(const_eval::interior_mutability_borrow)]
+#[diag(const_eval_interior_mutability_borrow)]
 pub(crate) struct InteriorMutabilityBorrow {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_driver/src/session_diagnostics.rs
+++ b/compiler/rustc_driver/src/session_diagnostics.rs
@@ -1,39 +1,39 @@
 use rustc_macros::Diagnostic;
 
 #[derive(Diagnostic)]
-#[diag(driver::rlink_unable_to_read)]
+#[diag(driver_rlink_unable_to_read)]
 pub(crate) struct RlinkUnableToRead {
     pub err: std::io::Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(driver::rlink_wrong_file_type)]
+#[diag(driver_rlink_wrong_file_type)]
 pub(crate) struct RLinkWrongFileType;
 
 #[derive(Diagnostic)]
-#[diag(driver::rlink_empty_version_number)]
+#[diag(driver_rlink_empty_version_number)]
 pub(crate) struct RLinkEmptyVersionNumber;
 
 #[derive(Diagnostic)]
-#[diag(driver::rlink_encoding_version_mismatch)]
+#[diag(driver_rlink_encoding_version_mismatch)]
 pub(crate) struct RLinkEncodingVersionMismatch {
     pub version_array: String,
     pub rlink_version: u32,
 }
 
 #[derive(Diagnostic)]
-#[diag(driver::rlink_rustc_version_mismatch)]
+#[diag(driver_rlink_rustc_version_mismatch)]
 pub(crate) struct RLinkRustcVersionMismatch<'a> {
     pub rustc_version: String,
     pub current_version: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(driver::rlink_no_a_file)]
+#[diag(driver_rlink_no_a_file)]
 pub(crate) struct RlinkNotAFile;
 
 #[derive(Diagnostic)]
-#[diag(driver::unpretty_dump_fail)]
+#[diag(driver_unpretty_dump_fail)]
 pub(crate) struct UnprettyDumpFail {
     pub path: String,
     pub err: String,

--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -175,14 +175,14 @@ impl IntoDiagnostic<'_, !> for TargetDataLayoutErrors<'_> {
         let mut diag;
         match self {
             TargetDataLayoutErrors::InvalidAddressSpace { addr_space, err, cause } => {
-                diag = handler.struct_fatal(fluent::errors::target_invalid_address_space);
+                diag = handler.struct_fatal(fluent::errors_target_invalid_address_space);
                 diag.set_arg("addr_space", addr_space);
                 diag.set_arg("cause", cause);
                 diag.set_arg("err", err);
                 diag
             }
             TargetDataLayoutErrors::InvalidBits { kind, bit, cause, err } => {
-                diag = handler.struct_fatal(fluent::errors::target_invalid_bits);
+                diag = handler.struct_fatal(fluent::errors_target_invalid_bits);
                 diag.set_arg("kind", kind);
                 diag.set_arg("bit", bit);
                 diag.set_arg("cause", cause);
@@ -190,30 +190,30 @@ impl IntoDiagnostic<'_, !> for TargetDataLayoutErrors<'_> {
                 diag
             }
             TargetDataLayoutErrors::MissingAlignment { cause } => {
-                diag = handler.struct_fatal(fluent::errors::target_missing_alignment);
+                diag = handler.struct_fatal(fluent::errors_target_missing_alignment);
                 diag.set_arg("cause", cause);
                 diag
             }
             TargetDataLayoutErrors::InvalidAlignment { cause, err } => {
-                diag = handler.struct_fatal(fluent::errors::target_invalid_alignment);
+                diag = handler.struct_fatal(fluent::errors_target_invalid_alignment);
                 diag.set_arg("cause", cause);
                 diag.set_arg("err", err);
                 diag
             }
             TargetDataLayoutErrors::InconsistentTargetArchitecture { dl, target } => {
-                diag = handler.struct_fatal(fluent::errors::target_inconsistent_architecture);
+                diag = handler.struct_fatal(fluent::errors_target_inconsistent_architecture);
                 diag.set_arg("dl", dl);
                 diag.set_arg("target", target);
                 diag
             }
             TargetDataLayoutErrors::InconsistentTargetPointerWidth { pointer_size, target } => {
-                diag = handler.struct_fatal(fluent::errors::target_inconsistent_pointer_width);
+                diag = handler.struct_fatal(fluent::errors_target_inconsistent_pointer_width);
                 diag.set_arg("pointer_size", pointer_size);
                 diag.set_arg("target", target);
                 diag
             }
             TargetDataLayoutErrors::InvalidBitsSize { err } => {
-                diag = handler.struct_fatal(fluent::errors::target_invalid_bits_size);
+                diag = handler.struct_fatal(fluent::errors_target_invalid_bits_size);
                 diag.set_arg("err", err);
                 diag
             }

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -3,28 +3,28 @@ use rustc_span::symbol::MacroRulesNormalizedIdent;
 use rustc_span::Span;
 
 #[derive(Diagnostic)]
-#[diag(expand::expr_repeat_no_syntax_vars)]
+#[diag(expand_expr_repeat_no_syntax_vars)]
 pub(crate) struct NoSyntaxVarsExprRepeat {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(expand::must_repeat_once)]
+#[diag(expand_must_repeat_once)]
 pub(crate) struct MustRepeatOnce {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(expand::count_repetition_misplaced)]
+#[diag(expand_count_repetition_misplaced)]
 pub(crate) struct CountRepetitionMisplaced {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(expand::meta_var_expr_unrecognized_var)]
+#[diag(expand_meta_var_expr_unrecognized_var)]
 pub(crate) struct MetaVarExprUnrecognizedVar {
     #[primary_span]
     pub span: Span,
@@ -32,7 +32,7 @@ pub(crate) struct MetaVarExprUnrecognizedVar {
 }
 
 #[derive(Diagnostic)]
-#[diag(expand::var_still_repeating)]
+#[diag(expand_var_still_repeating)]
 pub(crate) struct VarStillRepeating {
     #[primary_span]
     pub span: Span,
@@ -40,7 +40,7 @@ pub(crate) struct VarStillRepeating {
 }
 
 #[derive(Diagnostic)]
-#[diag(expand::meta_var_dif_seq_matchers)]
+#[diag(expand_meta_var_dif_seq_matchers)]
 pub(crate) struct MetaVarsDifSeqMatchers {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -598,12 +598,12 @@ pub fn compile_declarative_macro(
 
 #[derive(Subdiagnostic)]
 enum ExplainDocComment {
-    #[label(expand::explain_doc_comment_inner)]
+    #[label(expand_explain_doc_comment_inner)]
     Inner {
         #[primary_span]
         span: Span,
     },
-    #[label(expand::explain_doc_comment_outer)]
+    #[label(expand_explain_doc_comment_outer)]
     Outer {
         #[primary_span]
         span: Span,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_middle::ty::Ty;
 use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::unrecognized_atomic_operation, code = "E0092")]
+#[diag(hir_analysis_unrecognized_atomic_operation, code = "E0092")]
 pub struct UnrecognizedAtomicOperation<'a> {
     #[primary_span]
     #[label]
@@ -16,7 +16,7 @@ pub struct UnrecognizedAtomicOperation<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::wrong_number_of_generic_arguments_to_intrinsic, code = "E0094")]
+#[diag(hir_analysis_wrong_number_of_generic_arguments_to_intrinsic, code = "E0094")]
 pub struct WrongNumberOfGenericArgumentsToIntrinsic<'a> {
     #[primary_span]
     #[label]
@@ -27,7 +27,7 @@ pub struct WrongNumberOfGenericArgumentsToIntrinsic<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::unrecognized_intrinsic_function, code = "E0093")]
+#[diag(hir_analysis_unrecognized_intrinsic_function, code = "E0093")]
 pub struct UnrecognizedIntrinsicFunction {
     #[primary_span]
     #[label]
@@ -36,19 +36,19 @@ pub struct UnrecognizedIntrinsicFunction {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::lifetimes_or_bounds_mismatch_on_trait, code = "E0195")]
+#[diag(hir_analysis_lifetimes_or_bounds_mismatch_on_trait, code = "E0195")]
 pub struct LifetimesOrBoundsMismatchOnTrait {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(hir_analysis::generics_label)]
+    #[label(generics_label)]
     pub generics_span: Option<Span>,
     pub item_kind: &'static str,
     pub ident: Ident,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::drop_impl_on_wrong_item, code = "E0120")]
+#[diag(hir_analysis_drop_impl_on_wrong_item, code = "E0120")]
 pub struct DropImplOnWrongItem {
     #[primary_span]
     #[label]
@@ -56,18 +56,18 @@ pub struct DropImplOnWrongItem {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::field_already_declared, code = "E0124")]
+#[diag(hir_analysis_field_already_declared, code = "E0124")]
 pub struct FieldAlreadyDeclared {
     pub field_name: Ident,
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(hir_analysis::previous_decl_label)]
+    #[label(previous_decl_label)]
     pub prev_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::copy_impl_on_type_with_dtor, code = "E0184")]
+#[diag(hir_analysis_copy_impl_on_type_with_dtor, code = "E0184")]
 pub struct CopyImplOnTypeWithDtor {
     #[primary_span]
     #[label]
@@ -75,14 +75,14 @@ pub struct CopyImplOnTypeWithDtor {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::multiple_relaxed_default_bounds, code = "E0203")]
+#[diag(hir_analysis_multiple_relaxed_default_bounds, code = "E0203")]
 pub struct MultipleRelaxedDefaultBounds {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::copy_impl_on_non_adt, code = "E0206")]
+#[diag(hir_analysis_copy_impl_on_non_adt, code = "E0206")]
 pub struct CopyImplOnNonAdt {
     #[primary_span]
     #[label]
@@ -90,23 +90,23 @@ pub struct CopyImplOnNonAdt {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::trait_object_declared_with_no_traits, code = "E0224")]
+#[diag(hir_analysis_trait_object_declared_with_no_traits, code = "E0224")]
 pub struct TraitObjectDeclaredWithNoTraits {
     #[primary_span]
     pub span: Span,
-    #[label(hir_analysis::alias_span)]
+    #[label(alias_span)]
     pub trait_alias_span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::ambiguous_lifetime_bound, code = "E0227")]
+#[diag(hir_analysis_ambiguous_lifetime_bound, code = "E0227")]
 pub struct AmbiguousLifetimeBound {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::assoc_type_binding_not_allowed, code = "E0229")]
+#[diag(hir_analysis_assoc_type_binding_not_allowed, code = "E0229")]
 pub struct AssocTypeBindingNotAllowed {
     #[primary_span]
     #[label]
@@ -114,7 +114,7 @@ pub struct AssocTypeBindingNotAllowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::typeof_reserved_keyword_used, code = "E0516")]
+#[diag(hir_analysis_typeof_reserved_keyword_used, code = "E0516")]
 pub struct TypeofReservedKeywordUsed<'tcx> {
     pub ty: Ty<'tcx>,
     #[primary_span]
@@ -125,19 +125,19 @@ pub struct TypeofReservedKeywordUsed<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::value_of_associated_struct_already_specified, code = "E0719")]
+#[diag(hir_analysis_value_of_associated_struct_already_specified, code = "E0719")]
 pub struct ValueOfAssociatedStructAlreadySpecified {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(hir_analysis::previous_bound_label)]
+    #[label(previous_bound_label)]
     pub prev_span: Span,
     pub item_name: Ident,
     pub def_path: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::unconstrained_opaque_type)]
+#[diag(hir_analysis_unconstrained_opaque_type)]
 #[note]
 pub struct UnconstrainedOpaqueType {
     #[primary_span]
@@ -158,7 +158,7 @@ impl<'a> IntoDiagnostic<'a> for MissingTypeParams {
     fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut err = handler.struct_span_err_with_code(
             self.span,
-            rustc_errors::fluent::hir_analysis::missing_type_params,
+            rustc_errors::fluent::hir_analysis_missing_type_params,
             error_code!(E0393),
         );
         err.set_arg("parameterCount", self.missing_type_params.len());
@@ -171,7 +171,7 @@ impl<'a> IntoDiagnostic<'a> for MissingTypeParams {
                 .join(", "),
         );
 
-        err.span_label(self.def_span, rustc_errors::fluent::hir_analysis::label);
+        err.span_label(self.def_span, rustc_errors::fluent::label);
 
         let mut suggested = false;
         // Don't suggest setting the type params if there are some already: the order is
@@ -186,7 +186,7 @@ impl<'a> IntoDiagnostic<'a> for MissingTypeParams {
                 // least we can clue them to the correct syntax `Iterator<Type>`.
                 err.span_suggestion(
                     self.span,
-                    rustc_errors::fluent::hir_analysis::suggestion,
+                    rustc_errors::fluent::suggestion,
                     format!(
                         "{}<{}>",
                         snippet,
@@ -202,16 +202,16 @@ impl<'a> IntoDiagnostic<'a> for MissingTypeParams {
             }
         }
         if !suggested {
-            err.span_label(self.span, rustc_errors::fluent::hir_analysis::no_suggestion_label);
+            err.span_label(self.span, rustc_errors::fluent::no_suggestion_label);
         }
 
-        err.note(rustc_errors::fluent::hir_analysis::note);
+        err.note(rustc_errors::fluent::note);
         err
     }
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::manual_implementation, code = "E0183")]
+#[diag(hir_analysis_manual_implementation, code = "E0183")]
 #[help]
 pub struct ManualImplementation {
     #[primary_span]
@@ -221,21 +221,21 @@ pub struct ManualImplementation {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::substs_on_overridden_impl)]
+#[diag(hir_analysis_substs_on_overridden_impl)]
 pub struct SubstsOnOverriddenImpl {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(hir_analysis::unused_extern_crate)]
+#[diag(hir_analysis_unused_extern_crate)]
 pub struct UnusedExternCrate {
     #[suggestion(applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(hir_analysis::extern_crate_not_idiomatic)]
+#[diag(hir_analysis_extern_crate_not_idiomatic)]
 pub struct ExternCrateNotIdiomatic {
     #[suggestion_short(applicability = "machine-applicable", code = "{suggestion_code}")]
     pub span: Span,
@@ -244,7 +244,7 @@ pub struct ExternCrateNotIdiomatic {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::expected_used_symbol)]
+#[diag(hir_analysis_expected_used_symbol)]
 pub struct ExpectedUsedSymbol {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -4,36 +4,36 @@ use rustc_middle::ty::Ty;
 use rustc_span::{symbol::Ident, Span};
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::field_multiply_specified_in_initializer, code = "E0062")]
+#[diag(hir_analysis_field_multiply_specified_in_initializer, code = "E0062")]
 pub struct FieldMultiplySpecifiedInInitializer {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(hir_analysis::previous_use_label)]
+    #[label(previous_use_label)]
     pub prev_span: Span,
     pub ident: Ident,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::return_stmt_outside_of_fn_body, code = "E0572")]
+#[diag(hir_analysis_return_stmt_outside_of_fn_body, code = "E0572")]
 pub struct ReturnStmtOutsideOfFnBody {
     #[primary_span]
     pub span: Span,
-    #[label(hir_analysis::encl_body_label)]
+    #[label(encl_body_label)]
     pub encl_body_span: Option<Span>,
-    #[label(hir_analysis::encl_fn_label)]
+    #[label(encl_fn_label)]
     pub encl_fn_span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::yield_expr_outside_of_generator, code = "E0627")]
+#[diag(hir_analysis_yield_expr_outside_of_generator, code = "E0627")]
 pub struct YieldExprOutsideOfGenerator {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::struct_expr_non_exhaustive, code = "E0639")]
+#[diag(hir_analysis_struct_expr_non_exhaustive, code = "E0639")]
 pub struct StructExprNonExhaustive {
     #[primary_span]
     pub span: Span,
@@ -41,21 +41,21 @@ pub struct StructExprNonExhaustive {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::method_call_on_unknown_type, code = "E0699")]
+#[diag(hir_analysis_method_call_on_unknown_type, code = "E0699")]
 pub struct MethodCallOnUnknownType {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::functional_record_update_on_non_struct, code = "E0436")]
+#[diag(hir_analysis_functional_record_update_on_non_struct, code = "E0436")]
 pub struct FunctionalRecordUpdateOnNonStruct {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::address_of_temporary_taken, code = "E0745")]
+#[diag(hir_analysis_address_of_temporary_taken, code = "E0745")]
 pub struct AddressOfTemporaryTaken {
     #[primary_span]
     #[label]
@@ -65,7 +65,7 @@ pub struct AddressOfTemporaryTaken {
 #[derive(Subdiagnostic)]
 pub enum AddReturnTypeSuggestion {
     #[suggestion(
-        hir_analysis::add_return_type_add,
+        hir_analysis_add_return_type_add,
         code = "-> {found} ",
         applicability = "machine-applicable"
     )]
@@ -75,7 +75,7 @@ pub enum AddReturnTypeSuggestion {
         found: String,
     },
     #[suggestion(
-        hir_analysis::add_return_type_missing_here,
+        hir_analysis_add_return_type_missing_here,
         code = "-> _ ",
         applicability = "has-placeholders"
     )]
@@ -87,12 +87,12 @@ pub enum AddReturnTypeSuggestion {
 
 #[derive(Subdiagnostic)]
 pub enum ExpectedReturnTypeLabel<'tcx> {
-    #[label(hir_analysis::expected_default_return_type)]
+    #[label(hir_analysis_expected_default_return_type)]
     Unit {
         #[primary_span]
         span: Span,
     },
-    #[label(hir_analysis::expected_return_type)]
+    #[label(hir_analysis_expected_return_type)]
     Other {
         #[primary_span]
         span: Span,
@@ -101,21 +101,20 @@ pub enum ExpectedReturnTypeLabel<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis::missing_parentheses_in_range, code = "E0689")]
+#[diag(hir_analysis_missing_parentheses_in_range, code = "E0689")]
 pub struct MissingParentheseInRange {
     #[primary_span]
-    #[label(hir_analysis::missing_parentheses_in_range)]
+    #[label(hir_analysis_missing_parentheses_in_range)]
     pub span: Span,
     pub ty_str: String,
     pub method_name: String,
-
     #[subdiagnostic]
     pub add_missing_parentheses: Option<AddMissingParenthesesInRange>,
 }
 
 #[derive(Subdiagnostic)]
 #[multipart_suggestion_verbose(
-    hir_analysis::add_missing_parentheses_in_range,
+    hir_analysis_add_missing_parentheses_in_range,
     applicability = "maybe-incorrect"
 )]
 pub struct AddMissingParenthesesInRange {

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -18,19 +18,19 @@ use crate::infer::error_reporting::{
 pub mod note_and_explain;
 
 #[derive(Diagnostic)]
-#[diag(infer::opaque_hidden_type)]
+#[diag(infer_opaque_hidden_type)]
 pub struct OpaqueHiddenTypeDiag {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[note(infer::opaque_type)]
+    #[note(opaque_type)]
     pub opaque_type: Span,
-    #[note(infer::hidden_type)]
+    #[note(hidden_type)]
     pub hidden_type: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::type_annotations_needed, code = "E0282")]
+#[diag(infer_type_annotations_needed, code = "E0282")]
 pub struct AnnotationRequired<'a> {
     #[primary_span]
     pub span: Span,
@@ -48,7 +48,7 @@ pub struct AnnotationRequired<'a> {
 
 // Copy of `AnnotationRequired` for E0283
 #[derive(Diagnostic)]
-#[diag(infer::type_annotations_needed, code = "E0283")]
+#[diag(infer_type_annotations_needed, code = "E0283")]
 pub struct AmbigousImpl<'a> {
     #[primary_span]
     pub span: Span,
@@ -66,7 +66,7 @@ pub struct AmbigousImpl<'a> {
 
 // Copy of `AnnotationRequired` for E0284
 #[derive(Diagnostic)]
-#[diag(infer::type_annotations_needed, code = "E0284")]
+#[diag(infer_type_annotations_needed, code = "E0284")]
 pub struct AmbigousReturn<'a> {
     #[primary_span]
     pub span: Span,
@@ -83,7 +83,7 @@ pub struct AmbigousReturn<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::need_type_info_in_generator, code = "E0698")]
+#[diag(infer_need_type_info_in_generator, code = "E0698")]
 pub struct NeedTypeInfoInGenerator<'a> {
     #[primary_span]
     pub span: Span,
@@ -94,7 +94,7 @@ pub struct NeedTypeInfoInGenerator<'a> {
 
 // Used when a better one isn't available
 #[derive(Subdiagnostic)]
-#[label(infer::label_bad)]
+#[label(infer_label_bad)]
 pub struct InferenceBadError<'a> {
     #[primary_span]
     pub span: Span,
@@ -110,7 +110,7 @@ pub struct InferenceBadError<'a> {
 #[derive(Subdiagnostic)]
 pub enum SourceKindSubdiag<'a> {
     #[suggestion_verbose(
-        infer::source_kind_subdiag_let,
+        infer_source_kind_subdiag_let,
         code = ": {type_name}",
         applicability = "has-placeholders"
     )]
@@ -125,7 +125,7 @@ pub enum SourceKindSubdiag<'a> {
         prefix: &'a str,
         arg_name: String,
     },
-    #[label(infer::source_kind_subdiag_generic_label)]
+    #[label(infer_source_kind_subdiag_generic_label)]
     GenericLabel {
         #[primary_span]
         span: Span,
@@ -136,7 +136,7 @@ pub enum SourceKindSubdiag<'a> {
         parent_name: String,
     },
     #[suggestion_verbose(
-        infer::source_kind_subdiag_generic_suggestion,
+        infer_source_kind_subdiag_generic_suggestion,
         code = "::<{args}>",
         applicability = "has-placeholders"
     )]
@@ -151,7 +151,7 @@ pub enum SourceKindSubdiag<'a> {
 #[derive(Subdiagnostic)]
 pub enum SourceKindMultiSuggestion<'a> {
     #[multipart_suggestion_verbose(
-        infer::source_kind_fully_qualified,
+        infer_source_kind_fully_qualified,
         applicability = "has-placeholders"
     )]
     FullyQualified {
@@ -164,7 +164,7 @@ pub enum SourceKindMultiSuggestion<'a> {
         successor_pos: &'a str,
     },
     #[multipart_suggestion_verbose(
-        infer::source_kind_closure_return,
+        infer_source_kind_closure_return,
         applicability = "has-placeholders"
     )]
     ClosureReturn {
@@ -260,7 +260,7 @@ impl AddToDiagnostic for RegionOriginNote<'_> {
                 requirement,
                 expected_found: Some((expected, found)),
             } => {
-                label_or_note(span, fluent::infer::subtype);
+                label_or_note(span, fluent::infer_subtype);
                 diag.set_arg("requirement", requirement);
 
                 diag.note_expected_found(&"", expected, &"", found);
@@ -269,7 +269,7 @@ impl AddToDiagnostic for RegionOriginNote<'_> {
                 // FIXME: this really should be handled at some earlier stage. Our
                 // handling of region checking when type errors are present is
                 // *terrible*.
-                label_or_note(span, fluent::infer::subtype_2);
+                label_or_note(span, fluent::infer_subtype_2);
                 diag.set_arg("requirement", requirement);
             }
         };
@@ -300,9 +300,9 @@ impl AddToDiagnostic for LifetimeMismatchLabels {
     {
         match self {
             LifetimeMismatchLabels::InRet { param_span, ret_span, span, label_var1 } => {
-                diag.span_label(param_span, fluent::infer::declared_different);
-                diag.span_label(ret_span, fluent::infer::nothing);
-                diag.span_label(span, fluent::infer::data_returned);
+                diag.span_label(param_span, fluent::infer_declared_different);
+                diag.span_label(ret_span, fluent::infer_nothing);
+                diag.span_label(span, fluent::infer_data_returned);
                 diag.set_arg("label_var1_exists", label_var1.is_some());
                 diag.set_arg("label_var1", label_var1.map(|x| x.to_string()).unwrap_or_default());
             }
@@ -315,13 +315,13 @@ impl AddToDiagnostic for LifetimeMismatchLabels {
                 sub: label_var2,
             } => {
                 if hir_equal {
-                    diag.span_label(ty_sup, fluent::infer::declared_multiple);
-                    diag.span_label(ty_sub, fluent::infer::nothing);
-                    diag.span_label(span, fluent::infer::data_lifetime_flow);
+                    diag.span_label(ty_sup, fluent::infer_declared_multiple);
+                    diag.span_label(ty_sub, fluent::infer_nothing);
+                    diag.span_label(span, fluent::infer_data_lifetime_flow);
                 } else {
-                    diag.span_label(ty_sup, fluent::infer::types_declared_different);
-                    diag.span_label(ty_sub, fluent::infer::nothing);
-                    diag.span_label(span, fluent::infer::data_flows);
+                    diag.span_label(ty_sup, fluent::infer_types_declared_different);
+                    diag.span_label(ty_sub, fluent::infer_nothing);
+                    diag.span_label(span, fluent::infer_data_flows);
                     diag.set_arg("label_var1_exists", label_var1.is_some());
                     diag.set_arg(
                         "label_var1",
@@ -419,7 +419,7 @@ impl AddToDiagnostic for AddLifetimeParamsSuggestion<'_> {
             }
 
             diag.multipart_suggestion(
-                fluent::infer::lifetime_param_suggestion,
+                fluent::infer_lifetime_param_suggestion,
                 suggestions,
                 Applicability::MaybeIncorrect,
             );
@@ -427,13 +427,13 @@ impl AddToDiagnostic for AddLifetimeParamsSuggestion<'_> {
             true
         };
         if mk_suggestion() && self.add_note {
-            diag.note(fluent::infer::lifetime_param_suggestion_elided);
+            diag.note(fluent::infer_lifetime_param_suggestion_elided);
         }
     }
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::lifetime_mismatch, code = "E0623")]
+#[diag(infer_lifetime_mismatch, code = "E0623")]
 pub struct LifetimeMismatch<'a> {
     #[primary_span]
     pub span: Span,
@@ -454,32 +454,32 @@ impl AddToDiagnostic for IntroducesStaticBecauseUnmetLifetimeReq {
         F: Fn(&mut Diagnostic, SubdiagnosticMessage) -> SubdiagnosticMessage,
     {
         self.unmet_requirements
-            .push_span_label(self.binding_span, fluent::infer::msl_introduces_static);
-        diag.span_note(self.unmet_requirements, fluent::infer::msl_unmet_req);
+            .push_span_label(self.binding_span, fluent::infer_msl_introduces_static);
+        diag.span_note(self.unmet_requirements, fluent::infer_msl_unmet_req);
     }
 }
 
 // FIXME(#100717): replace with a `Option<Span>` when subdiagnostic supports that
 #[derive(Subdiagnostic)]
 pub enum DoesNotOutliveStaticFromImpl {
-    #[note(infer::does_not_outlive_static_from_impl)]
+    #[note(infer_does_not_outlive_static_from_impl)]
     Spanned {
         #[primary_span]
         span: Span,
     },
-    #[note(infer::does_not_outlive_static_from_impl)]
+    #[note(infer_does_not_outlive_static_from_impl)]
     Unspanned,
 }
 
 #[derive(Subdiagnostic)]
 pub enum ImplicitStaticLifetimeSubdiag {
-    #[note(infer::implicit_static_lifetime_note)]
+    #[note(infer_implicit_static_lifetime_note)]
     Note {
         #[primary_span]
         span: Span,
     },
     #[suggestion_verbose(
-        infer::implicit_static_lifetime_suggestion,
+        infer_implicit_static_lifetime_suggestion,
         code = " + '_",
         applicability = "maybe-incorrect"
     )]
@@ -490,7 +490,7 @@ pub enum ImplicitStaticLifetimeSubdiag {
 }
 
 #[derive(Diagnostic)]
-#[diag(infer::mismatched_static_lifetime)]
+#[diag(infer_mismatched_static_lifetime)]
 pub struct MismatchedStaticLifetime<'a> {
     #[primary_span]
     pub cause_span: Span,

--- a/compiler/rustc_infer/src/errors/note_and_explain.rs
+++ b/compiler/rustc_infer/src/errors/note_and_explain.rs
@@ -166,9 +166,9 @@ impl AddToDiagnostic for RegionExplanation<'_> {
         F: Fn(&mut Diagnostic, SubdiagnosticMessage) -> SubdiagnosticMessage,
     {
         if let Some(span) = self.desc.span {
-            diag.span_note(span, fluent::infer::region_explanation);
+            diag.span_note(span, fluent::infer_region_explanation);
         } else {
-            diag.note(fluent::infer::region_explanation);
+            diag.note(fluent::infer_region_explanation);
         }
         self.desc.add_to(diag);
         diag.set_arg("pref_kind", self.prefix);

--- a/compiler/rustc_infer/src/infer/error_reporting/note.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note.rs
@@ -19,26 +19,27 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 expected_found: self.values_str(trace.values),
             }
             .add_to_diagnostic(err),
-            infer::Reborrow(span) => RegionOriginNote::Plain { span, msg: fluent::infer::reborrow }
-                .add_to_diagnostic(err),
+            infer::Reborrow(span) => {
+                RegionOriginNote::Plain { span, msg: fluent::infer_reborrow }.add_to_diagnostic(err)
+            }
             infer::ReborrowUpvar(span, ref upvar_id) => {
                 let var_name = self.tcx.hir().name(upvar_id.var_path.hir_id);
                 RegionOriginNote::WithName {
                     span,
-                    msg: fluent::infer::reborrow,
+                    msg: fluent::infer_reborrow,
                     name: &var_name.to_string(),
                     continues: false,
                 }
                 .add_to_diagnostic(err);
             }
             infer::RelateObjectBound(span) => {
-                RegionOriginNote::Plain { span, msg: fluent::infer::relate_object_bound }
+                RegionOriginNote::Plain { span, msg: fluent::infer_relate_object_bound }
                     .add_to_diagnostic(err);
             }
             infer::DataBorrowed(ty, span) => {
                 RegionOriginNote::WithName {
                     span,
-                    msg: fluent::infer::data_borrowed,
+                    msg: fluent::infer_data_borrowed,
                     name: &self.ty_to_string(ty),
                     continues: false,
                 }
@@ -47,7 +48,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             infer::ReferenceOutlivesReferent(ty, span) => {
                 RegionOriginNote::WithName {
                     span,
-                    msg: fluent::infer::reference_outlives_referent,
+                    msg: fluent::infer_reference_outlives_referent,
                     name: &self.ty_to_string(ty),
                     continues: false,
                 }
@@ -56,22 +57,22 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             infer::RelateParamBound(span, ty, opt_span) => {
                 RegionOriginNote::WithName {
                     span,
-                    msg: fluent::infer::relate_param_bound,
+                    msg: fluent::infer_relate_param_bound,
                     name: &self.ty_to_string(ty),
                     continues: opt_span.is_some(),
                 }
                 .add_to_diagnostic(err);
                 if let Some(span) = opt_span {
-                    RegionOriginNote::Plain { span, msg: fluent::infer::relate_param_bound_2 }
+                    RegionOriginNote::Plain { span, msg: fluent::infer_relate_param_bound_2 }
                         .add_to_diagnostic(err);
                 }
             }
             infer::RelateRegionParamBound(span) => {
-                RegionOriginNote::Plain { span, msg: fluent::infer::relate_region_param_bound }
+                RegionOriginNote::Plain { span, msg: fluent::infer_relate_region_param_bound }
                     .add_to_diagnostic(err);
             }
             infer::CompareImplItemObligation { span, .. } => {
-                RegionOriginNote::Plain { span, msg: fluent::infer::compare_impl_item_obligation }
+                RegionOriginNote::Plain { span, msg: fluent::infer_compare_impl_item_obligation }
                     .add_to_diagnostic(err);
             }
             infer::CheckAssociatedTypeBounds { ref parent, .. } => {
@@ -80,7 +81,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             infer::AscribeUserTypeProvePredicate(span) => {
                 RegionOriginNote::Plain {
                     span,
-                    msg: fluent::infer::ascribe_user_type_prove_predicate,
+                    msg: fluent::infer_ascribe_user_type_prove_predicate,
                 }
                 .add_to_diagnostic(err);
             }

--- a/compiler/rustc_interface/src/errors.rs
+++ b/compiler/rustc_interface/src/errors.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::Path;
 
 #[derive(Diagnostic)]
-#[diag(interface::ferris_identifier)]
+#[diag(interface_ferris_identifier)]
 pub struct FerrisIdentifier {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -14,7 +14,7 @@ pub struct FerrisIdentifier {
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::emoji_identifier)]
+#[diag(interface_emoji_identifier)]
 pub struct EmojiIdentifier {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -22,67 +22,67 @@ pub struct EmojiIdentifier {
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::mixed_bin_crate)]
+#[diag(interface_mixed_bin_crate)]
 pub struct MixedBinCrate;
 
 #[derive(Diagnostic)]
-#[diag(interface::mixed_proc_macro_crate)]
+#[diag(interface_mixed_proc_macro_crate)]
 pub struct MixedProcMacroCrate;
 
 #[derive(Diagnostic)]
-#[diag(interface::proc_macro_doc_without_arg)]
+#[diag(interface_proc_macro_doc_without_arg)]
 pub struct ProcMacroDocWithoutArg;
 
 #[derive(Diagnostic)]
-#[diag(interface::error_writing_dependencies)]
+#[diag(interface_error_writing_dependencies)]
 pub struct ErrorWritingDependencies<'a> {
     pub path: &'a Path,
     pub error: io::Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::input_file_would_be_overwritten)]
+#[diag(interface_input_file_would_be_overwritten)]
 pub struct InputFileWouldBeOverWritten<'a> {
     pub path: &'a Path,
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::generated_file_conflicts_with_directory)]
+#[diag(interface_generated_file_conflicts_with_directory)]
 pub struct GeneratedFileConflictsWithDirectory<'a> {
     pub input_path: &'a Path,
     pub dir_path: &'a Path,
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::temps_dir_error)]
+#[diag(interface_temps_dir_error)]
 pub struct TempsDirError;
 
 #[derive(Diagnostic)]
-#[diag(interface::out_dir_error)]
+#[diag(interface_out_dir_error)]
 pub struct OutDirError;
 
 #[derive(Diagnostic)]
-#[diag(interface::cant_emit_mir)]
+#[diag(interface_cant_emit_mir)]
 pub struct CantEmitMIR {
     pub error: io::Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::rustc_error_fatal)]
+#[diag(interface_rustc_error_fatal)]
 pub struct RustcErrorFatal {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::rustc_error_unexpected_annotation)]
+#[diag(interface_rustc_error_unexpected_annotation)]
 pub struct RustcErrorUnexpectedAnnotation {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(interface::failed_writing_file)]
+#[diag(interface_failed_writing_file)]
 pub struct FailedWritingFile<'a> {
     pub path: &'a Path,
     pub error: io::Error,

--- a/compiler/rustc_lint/src/array_into_iter.rs
+++ b/compiler/rustc_lint/src/array_into_iter.rs
@@ -121,25 +121,25 @@ impl<'tcx> LateLintPass<'tcx> for ArrayIntoIter {
             cx.struct_span_lint(
                 ARRAY_INTO_ITER,
                 call.ident.span,
-                fluent::lint::array_into_iter,
+                fluent::lint_array_into_iter,
                 |diag| {
                     diag.set_arg("target", target);
                     diag.span_suggestion(
                         call.ident.span,
-                        fluent::lint::use_iter_suggestion,
+                        fluent::use_iter_suggestion,
                         "iter",
                         Applicability::MachineApplicable,
                     );
                     if self.for_expr_span == expr.span {
                         diag.span_suggestion(
                             receiver_arg.span.shrink_to_hi().to(expr.span.shrink_to_hi()),
-                            fluent::lint::remove_into_iter_suggestion,
+                            fluent::remove_into_iter_suggestion,
                             "",
                             Applicability::MaybeIncorrect,
                         );
                     } else if receiver_ty.is_array() {
                         diag.multipart_suggestion(
-                            fluent::lint::use_explicit_into_iter_suggestion,
+                            fluent::use_explicit_into_iter_suggestion,
                             vec![
                                 (expr.span.shrink_to_lo(), "IntoIterator::into_iter(".into()),
                                 (

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -106,11 +106,11 @@ impl EarlyLintPass for WhileTrue {
             cx.struct_span_lint(
                             WHILE_TRUE,
                             condition_span,
-                fluent::lint::builtin_while_true,
+                fluent::lint_builtin_while_true,
                             |lint| {
                     lint.span_suggestion_short(
                         condition_span,
-                        fluent::lint::suggestion,
+                        fluent::suggestion,
                         format!(
                             "{}loop",
                             label.map_or_else(String::new, |label| format!(
@@ -160,7 +160,7 @@ impl BoxPointers {
                     cx.struct_span_lint(
                         BOX_POINTERS,
                         span,
-                        fluent::lint::builtin_box_pointers,
+                        fluent::lint_builtin_box_pointers,
                         |lint| lint.set_arg("ty", ty),
                     );
                 }
@@ -264,13 +264,13 @@ impl<'tcx> LateLintPass<'tcx> for NonShorthandFieldPatterns {
                         cx.struct_span_lint(
                             NON_SHORTHAND_FIELD_PATTERNS,
                             fieldpat.span,
-                            fluent::lint::builtin_non_shorthand_field_patterns,
+                            fluent::lint_builtin_non_shorthand_field_patterns,
                             |lint| {
                                 let suggested_ident =
                                     format!("{}{}", binding_annot.prefix_str(), ident);
                                 lint.set_arg("ident", ident.clone()).span_suggestion(
                                     fieldpat.span,
-                                    fluent::lint::suggestion,
+                                    fluent::suggestion,
                                     suggested_ident,
                                     Applicability::MachineApplicable,
                                 )
@@ -335,7 +335,7 @@ impl UnsafeCode {
         msg: DiagnosticMessage,
     ) {
         self.report_unsafe(cx, span, msg, |lint| {
-            lint.note(fluent::lint::builtin_overridden_symbol_name)
+            lint.note(fluent::lint_builtin_overridden_symbol_name)
         })
     }
 
@@ -346,7 +346,7 @@ impl UnsafeCode {
         msg: DiagnosticMessage,
     ) {
         self.report_unsafe(cx, span, msg, |lint| {
-            lint.note(fluent::lint::builtin_overridden_symbol_section)
+            lint.note(fluent::lint_builtin_overridden_symbol_section)
         })
     }
 }
@@ -354,12 +354,9 @@ impl UnsafeCode {
 impl EarlyLintPass for UnsafeCode {
     fn check_attribute(&mut self, cx: &EarlyContext<'_>, attr: &ast::Attribute) {
         if attr.has_name(sym::allow_internal_unsafe) {
-            self.report_unsafe(
-                cx,
-                attr.span,
-                fluent::lint::builtin_allow_internal_unsafe,
-                |lint| lint,
-            );
+            self.report_unsafe(cx, attr.span, fluent::lint_builtin_allow_internal_unsafe, |lint| {
+                lint
+            });
         }
     }
 
@@ -367,7 +364,7 @@ impl EarlyLintPass for UnsafeCode {
         if let ast::ExprKind::Block(ref blk, _) = e.kind {
             // Don't warn about generated blocks; that'll just pollute the output.
             if blk.rules == ast::BlockCheckMode::Unsafe(ast::UserProvided) {
-                self.report_unsafe(cx, blk.span, fluent::lint::builtin_unsafe_block, |lint| lint);
+                self.report_unsafe(cx, blk.span, fluent::lint_builtin_unsafe_block, |lint| lint);
             }
         }
     }
@@ -375,11 +372,11 @@ impl EarlyLintPass for UnsafeCode {
     fn check_item(&mut self, cx: &EarlyContext<'_>, it: &ast::Item) {
         match it.kind {
             ast::ItemKind::Trait(box ast::Trait { unsafety: ast::Unsafe::Yes(_), .. }) => {
-                self.report_unsafe(cx, it.span, fluent::lint::builtin_unsafe_trait, |lint| lint)
+                self.report_unsafe(cx, it.span, fluent::lint_builtin_unsafe_trait, |lint| lint)
             }
 
             ast::ItemKind::Impl(box ast::Impl { unsafety: ast::Unsafe::Yes(_), .. }) => {
-                self.report_unsafe(cx, it.span, fluent::lint::builtin_unsafe_impl, |lint| lint)
+                self.report_unsafe(cx, it.span, fluent::lint_builtin_unsafe_impl, |lint| lint)
             }
 
             ast::ItemKind::Fn(..) => {
@@ -387,7 +384,7 @@ impl EarlyLintPass for UnsafeCode {
                     self.report_overridden_symbol_name(
                         cx,
                         attr.span,
-                        fluent::lint::builtin_no_mangle_fn,
+                        fluent::lint_builtin_no_mangle_fn,
                     );
                 }
 
@@ -395,7 +392,7 @@ impl EarlyLintPass for UnsafeCode {
                     self.report_overridden_symbol_name(
                         cx,
                         attr.span,
-                        fluent::lint::builtin_export_name_fn,
+                        fluent::lint_builtin_export_name_fn,
                     );
                 }
 
@@ -403,7 +400,7 @@ impl EarlyLintPass for UnsafeCode {
                     self.report_overridden_symbol_section(
                         cx,
                         attr.span,
-                        fluent::lint::builtin_link_section_fn,
+                        fluent::lint_builtin_link_section_fn,
                     );
                 }
             }
@@ -413,7 +410,7 @@ impl EarlyLintPass for UnsafeCode {
                     self.report_overridden_symbol_name(
                         cx,
                         attr.span,
-                        fluent::lint::builtin_no_mangle_static,
+                        fluent::lint_builtin_no_mangle_static,
                     );
                 }
 
@@ -421,7 +418,7 @@ impl EarlyLintPass for UnsafeCode {
                     self.report_overridden_symbol_name(
                         cx,
                         attr.span,
-                        fluent::lint::builtin_export_name_static,
+                        fluent::lint_builtin_export_name_static,
                     );
                 }
 
@@ -429,7 +426,7 @@ impl EarlyLintPass for UnsafeCode {
                     self.report_overridden_symbol_section(
                         cx,
                         attr.span,
-                        fluent::lint::builtin_link_section_static,
+                        fluent::lint_builtin_link_section_static,
                     );
                 }
             }
@@ -444,14 +441,14 @@ impl EarlyLintPass for UnsafeCode {
                 self.report_overridden_symbol_name(
                     cx,
                     attr.span,
-                    fluent::lint::builtin_no_mangle_method,
+                    fluent::lint_builtin_no_mangle_method,
                 );
             }
             if let Some(attr) = cx.sess().find_by_name(&it.attrs, sym::export_name) {
                 self.report_overridden_symbol_name(
                     cx,
                     attr.span,
-                    fluent::lint::builtin_export_name_method,
+                    fluent::lint_builtin_export_name_method,
                 );
             }
         }
@@ -469,9 +466,9 @@ impl EarlyLintPass for UnsafeCode {
         {
             let msg = match ctxt {
                 FnCtxt::Foreign => return,
-                FnCtxt::Free => fluent::lint::builtin_decl_unsafe_fn,
-                FnCtxt::Assoc(_) if body.is_none() => fluent::lint::builtin_decl_unsafe_method,
-                FnCtxt::Assoc(_) => fluent::lint::builtin_impl_unsafe_method,
+                FnCtxt::Free => fluent::lint_builtin_decl_unsafe_fn,
+                FnCtxt::Assoc(_) if body.is_none() => fluent::lint_builtin_decl_unsafe_method,
+                FnCtxt::Assoc(_) => fluent::lint_builtin_impl_unsafe_method,
             };
             self.report_unsafe(cx, span, msg, |lint| lint);
         }
@@ -577,7 +574,7 @@ impl MissingDoc {
             cx.struct_span_lint(
                 MISSING_DOCS,
                 cx.tcx.def_span(def_id),
-                fluent::lint::builtin_missing_doc,
+                fluent::lint_builtin_missing_doc,
                 |lint| lint.set_arg("article", article).set_arg("desc", desc),
             );
         }
@@ -769,7 +766,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingCopyImplementations {
             cx.struct_span_lint(
                 MISSING_COPY_IMPLEMENTATIONS,
                 item.span,
-                fluent::lint::builtin_missing_copy_impl,
+                fluent::lint_builtin_missing_copy_impl,
                 |lint| lint,
             )
         }
@@ -848,7 +845,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDebugImplementations {
             cx.struct_span_lint(
                 MISSING_DEBUG_IMPLEMENTATIONS,
                 item.span,
-                fluent::lint::builtin_missing_debug_impl,
+                fluent::lint_builtin_missing_debug_impl,
                 |lint| lint.set_arg("debug", cx.tcx.def_path_str(debug)),
             );
         }
@@ -928,11 +925,11 @@ impl EarlyLintPass for AnonymousParameters {
                         cx.struct_span_lint(
                             ANONYMOUS_PARAMETERS,
                             arg.pat.span,
-                            fluent::lint::builtin_anonymous_params,
+                            fluent::lint_builtin_anonymous_params,
                             |lint| {
                                 lint.span_suggestion(
                                     arg.pat.span,
-                                    fluent::lint::suggestion,
+                                    fluent::suggestion,
                                     format!("_: {}", ty_snip),
                                     appl,
                                 )
@@ -976,7 +973,7 @@ impl EarlyLintPass for DeprecatedAttr {
                     cx.struct_span_lint(
                         DEPRECATED,
                         attr.span,
-                        fluent::lint::builtin_deprecated_attr_link,
+                        fluent::lint_builtin_deprecated_attr_link,
                         |lint| {
                             lint.set_arg("name", name)
                                 .set_arg("reason", reason)
@@ -984,7 +981,7 @@ impl EarlyLintPass for DeprecatedAttr {
                                 .span_suggestion_short(
                                     attr.span,
                                     suggestion.map(|s| s.into()).unwrap_or(
-                                        fluent::lint::builtin_deprecated_attr_default_suggestion,
+                                        fluent::lint_builtin_deprecated_attr_default_suggestion,
                                     ),
                                     "",
                                     Applicability::MachineApplicable,
@@ -999,12 +996,12 @@ impl EarlyLintPass for DeprecatedAttr {
             cx.struct_span_lint(
                 DEPRECATED,
                 attr.span,
-                fluent::lint::builtin_deprecated_attr_used,
+                fluent::lint_builtin_deprecated_attr_used,
                 |lint| {
                     lint.set_arg("name", pprust::path_to_string(&attr.get_normal_item().path))
                         .span_suggestion_short(
                             attr.span,
-                            fluent::lint::builtin_deprecated_attr_default_suggestion,
+                            fluent::lint_builtin_deprecated_attr_default_suggestion,
                             "",
                             Applicability::MachineApplicable,
                         )
@@ -1039,14 +1036,14 @@ fn warn_if_doc(cx: &EarlyContext<'_>, node_span: Span, node_kind: &str, attrs: &
             cx.struct_span_lint(
                 UNUSED_DOC_COMMENTS,
                 span,
-                fluent::lint::builtin_unused_doc_comment,
+                fluent::lint_builtin_unused_doc_comment,
                 |lint| {
-                    lint.set_arg("kind", node_kind).span_label(node_span, fluent::lint::label).help(
+                    lint.set_arg("kind", node_kind).span_label(node_span, fluent::label).help(
                         match attr.kind {
                             AttrKind::DocComment(CommentKind::Line, _) | AttrKind::Normal(..) => {
-                                fluent::lint::plain_help
+                                fluent::plain_help
                             }
-                            AttrKind::DocComment(CommentKind::Block, _) => fluent::lint::block_help,
+                            AttrKind::DocComment(CommentKind::Block, _) => fluent::block_help,
                         },
                     )
                 },
@@ -1167,11 +1164,11 @@ impl<'tcx> LateLintPass<'tcx> for InvalidNoMangleItems {
                         cx.struct_span_lint(
                             NO_MANGLE_GENERIC_ITEMS,
                             span,
-                            fluent::lint::builtin_no_mangle_generic,
+                            fluent::lint_builtin_no_mangle_generic,
                             |lint| {
                                 lint.span_suggestion_short(
                                     no_mangle_attr.span,
-                                    fluent::lint::suggestion,
+                                    fluent::suggestion,
                                     "",
                                     // Use of `#[no_mangle]` suggests FFI intent; correct
                                     // fix may be to monomorphize source by hand
@@ -1197,7 +1194,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidNoMangleItems {
                     cx.struct_span_lint(
                         NO_MANGLE_CONST_ITEMS,
                         it.span,
-                        fluent::lint::builtin_const_no_mangle,
+                        fluent::lint_builtin_const_no_mangle,
                         |lint| {
                             // account for "pub const" (#45562)
                             let start = cx
@@ -1211,7 +1208,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidNoMangleItems {
                             let const_span = it.span.with_hi(BytePos(it.span.lo().0 + start + 5));
                             lint.span_suggestion(
                                 const_span,
-                                fluent::lint::suggestion,
+                                fluent::suggestion,
                                 "pub static",
                                 Applicability::MachineApplicable,
                             )
@@ -1279,7 +1276,7 @@ impl<'tcx> LateLintPass<'tcx> for MutableTransmutes {
                 cx.struct_span_lint(
                     MUTABLE_TRANSMUTES,
                     expr.span,
-                    fluent::lint::builtin_mutable_transmutes,
+                    fluent::lint_builtin_mutable_transmutes,
                     |lint| lint,
                 );
             }
@@ -1332,7 +1329,7 @@ impl<'tcx> LateLintPass<'tcx> for UnstableFeatures {
                     cx.struct_span_lint(
                         UNSTABLE_FEATURES,
                         item.span(),
-                        fluent::lint::builtin_unstable_features,
+                        fluent::lint_builtin_unstable_features,
                         |lint| lint,
                     );
                 }
@@ -1396,18 +1393,13 @@ impl UnreachablePub {
             cx.struct_span_lint(
                 UNREACHABLE_PUB,
                 def_span,
-                fluent::lint::builtin_unreachable_pub,
+                fluent::lint_builtin_unreachable_pub,
                 |lint| {
                     lint.set_arg("what", what);
 
-                    lint.span_suggestion(
-                        vis_span,
-                        fluent::lint::suggestion,
-                        "pub(crate)",
-                        applicability,
-                    );
+                    lint.span_suggestion(vis_span, fluent::suggestion, "pub(crate)", applicability);
                     if exportable {
-                        lint.help(fluent::lint::help);
+                        lint.help(fluent::help);
                     }
                     lint
                 },
@@ -1498,7 +1490,7 @@ impl TypeAliasBounds {
         impl Visitor<'_> for WalkAssocTypes<'_> {
             fn visit_qpath(&mut self, qpath: &hir::QPath<'_>, id: hir::HirId, span: Span) {
                 if TypeAliasBounds::is_type_variable_assoc(qpath) {
-                    self.err.span_help(span, fluent::lint::builtin_type_alias_bounds_help);
+                    self.err.span_help(span, fluent::lint_builtin_type_alias_bounds_help);
                 }
                 intravisit::walk_qpath(self, qpath, id)
             }
@@ -1541,11 +1533,11 @@ impl<'tcx> LateLintPass<'tcx> for TypeAliasBounds {
 
         let mut suggested_changing_assoc_types = false;
         if !where_spans.is_empty() {
-            cx.lint(TYPE_ALIAS_BOUNDS, fluent::lint::builtin_type_alias_where_clause, |lint| {
+            cx.lint(TYPE_ALIAS_BOUNDS, fluent::lint_builtin_type_alias_where_clause, |lint| {
                 lint.set_span(where_spans);
                 lint.span_suggestion(
                     type_alias_generics.where_clause_span,
-                    fluent::lint::suggestion,
+                    fluent::suggestion,
                     "",
                     Applicability::MachineApplicable,
                 );
@@ -1558,10 +1550,10 @@ impl<'tcx> LateLintPass<'tcx> for TypeAliasBounds {
         }
 
         if !inline_spans.is_empty() {
-            cx.lint(TYPE_ALIAS_BOUNDS, fluent::lint::builtin_type_alias_generic_bounds, |lint| {
+            cx.lint(TYPE_ALIAS_BOUNDS, fluent::lint_builtin_type_alias_generic_bounds, |lint| {
                 lint.set_span(inline_spans);
                 lint.multipart_suggestion(
-                    fluent::lint::suggestion,
+                    fluent::suggestion,
                     inline_sugg,
                     Applicability::MachineApplicable,
                 );
@@ -1670,7 +1662,7 @@ impl<'tcx> LateLintPass<'tcx> for TrivialConstraints {
                     cx.struct_span_lint(
                         TRIVIAL_BOUNDS,
                         span,
-                        fluent::lint::builtin_trivial_bounds,
+                        fluent::lint_builtin_trivial_bounds,
                         |lint| {
                             lint.set_arg("predicate_kind_name", predicate_kind_name)
                                 .set_arg("predicate", predicate)
@@ -1775,8 +1767,8 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
         };
 
         if let Some((start, end, join)) = endpoints {
-            let msg = fluent::lint::builtin_ellipsis_inclusive_range_patterns;
-            let suggestion = fluent::lint::suggestion;
+            let msg = fluent::lint_builtin_ellipsis_inclusive_range_patterns;
+            let suggestion = fluent::suggestion;
             if parenthesise {
                 self.node_id = Some(pat.id);
                 let end = expr_to_string(&end);
@@ -1899,7 +1891,7 @@ impl<'tcx> LateLintPass<'tcx> for UnnameableTestItems {
             cx.struct_span_lint(
                 UNNAMEABLE_TEST_ITEMS,
                 attr.span,
-                fluent::lint::builtin_unnameable_test_items,
+                fluent::lint_builtin_unnameable_test_items,
                 |lint| lint,
             );
         }
@@ -2020,11 +2012,11 @@ impl KeywordIdents {
         cx.struct_span_lint(
             KEYWORD_IDENTS,
             ident.span,
-            fluent::lint::builtin_keyword_idents,
+            fluent::lint_builtin_keyword_idents,
             |lint| {
                 lint.set_arg("kw", ident.clone()).set_arg("next", next_edition).span_suggestion(
                     ident.span,
-                    fluent::lint::suggestion,
+                    fluent::suggestion,
                     format!("r#{}", ident),
                     Applicability::MachineApplicable,
                 )
@@ -2283,10 +2275,10 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitOutlivesRequirements {
                 cx.struct_span_lint(
                     EXPLICIT_OUTLIVES_REQUIREMENTS,
                     lint_spans.clone(),
-                    fluent::lint::builtin_explicit_outlives,
+                    fluent::lint_builtin_explicit_outlives,
                     |lint| {
                         lint.set_arg("count", bound_count).multipart_suggestion(
-                            fluent::lint::suggestion,
+                            fluent::suggestion,
                             lint_spans
                                 .into_iter()
                                 .map(|span| (span, String::new()))
@@ -2344,17 +2336,17 @@ impl EarlyLintPass for IncompleteFeatures {
                 cx.struct_span_lint(
                     INCOMPLETE_FEATURES,
                     span,
-                    fluent::lint::builtin_incomplete_features,
+                    fluent::lint_builtin_incomplete_features,
                     |lint| {
                         lint.set_arg("name", name);
                         if let Some(n) =
                             rustc_feature::find_feature_issue(name, GateIssue::Language)
                         {
                             lint.set_arg("n", n);
-                            lint.note(fluent::lint::note);
+                            lint.note(fluent::note);
                         }
                         if HAS_MIN_FEATURES.contains(&name) {
-                            lint.help(fluent::lint::help);
+                            lint.help(fluent::help);
                         }
                         lint
                     },
@@ -3015,9 +3007,9 @@ impl<'tcx> LateLintPass<'tcx> for ClashingExternDeclarations {
                     // Finally, emit the diagnostic.
 
                     let msg = if orig.get_name() == this_fi.ident.name {
-                        fluent::lint::builtin_clashing_extern_same_name
+                        fluent::lint_builtin_clashing_extern_same_name
                     } else {
-                        fluent::lint::builtin_clashing_extern_diff_name
+                        fluent::lint_builtin_clashing_extern_diff_name
                     };
                     tcx.struct_span_lint_hir(
                         CLASHING_EXTERN_DECLARATIONS,
@@ -3032,14 +3024,8 @@ impl<'tcx> LateLintPass<'tcx> for ClashingExternDeclarations {
 
                             lint.set_arg("this_fi", this_fi.ident.name)
                                 .set_arg("orig", orig.get_name())
-                                .span_label(
-                                    get_relevant_span(orig_fi),
-                                    fluent::lint::previous_decl_label,
-                                )
-                                .span_label(
-                                    get_relevant_span(this_fi),
-                                    fluent::lint::mismatch_label,
-                                )
+                                .span_label(get_relevant_span(orig_fi), fluent::previous_decl_label)
+                                .span_label(get_relevant_span(this_fi), fluent::mismatch_label)
                                 // FIXME(davidtwco): translatable expected/found
                                 .note_expected_found(&"", expected_str, &"", found_str)
                         },
@@ -3125,8 +3111,8 @@ impl<'tcx> LateLintPass<'tcx> for DerefNullPtr {
                 cx.struct_span_lint(
                     DEREF_NULLPTR,
                     expr.span,
-                    fluent::lint::builtin_deref_nullptr,
-                    |lint| lint.span_label(expr.span, fluent::lint::label),
+                    fluent::lint_builtin_deref_nullptr,
+                    |lint| lint.span_label(expr.span, fluent::label),
                 );
             }
         }
@@ -3238,7 +3224,7 @@ impl<'tcx> LateLintPass<'tcx> for NamedAsmLabels {
                     cx.lookup_with_diagnostics(
                             NAMED_ASM_LABELS,
                             Some(target_spans),
-                            fluent::lint::builtin_asm_labels,
+                            fluent::lint_builtin_asm_labels,
                             |lint| lint,
                             BuiltinLintDiagnostics::NamedAsmLabel(
                                 "only local labels of the form `<number>:` should be used in inline asm"
@@ -3341,8 +3327,8 @@ impl EarlyLintPass for UnexpectedCfgs {
                     cx.lookup(
                         UNEXPECTED_CFGS,
                         None::<MultiSpan>,
-                        fluent::lint::builtin_unexpected_cli_config_name,
-                        |diag| diag.help(fluent::lint::help).set_arg("name", name),
+                        fluent::lint_builtin_unexpected_cli_config_name,
+                        |diag| diag.help(fluent::help).set_arg("name", name),
                     );
                 }
             }
@@ -3352,9 +3338,9 @@ impl EarlyLintPass for UnexpectedCfgs {
                         cx.lookup(
                             UNEXPECTED_CFGS,
                             None::<MultiSpan>,
-                            fluent::lint::builtin_unexpected_cli_config_value,
+                            fluent::lint_builtin_unexpected_cli_config_value,
                             |diag| {
-                                diag.help(fluent::lint::help)
+                                diag.help(fluent::help)
                                     .set_arg("name", name)
                                     .set_arg("value", value)
                             },

--- a/compiler/rustc_lint/src/enum_intrinsics_non_enums.rs
+++ b/compiler/rustc_lint/src/enum_intrinsics_non_enums.rs
@@ -53,8 +53,8 @@ fn enforce_mem_discriminant(
         cx.struct_span_lint(
             ENUM_INTRINSICS_NON_ENUMS,
             expr_span,
-            fluent::lint::enum_intrinsics_mem_discriminant,
-            |lint| lint.set_arg("ty_param", ty_param).span_note(args_span, fluent::lint::note),
+            fluent::lint_enum_intrinsics_mem_discriminant,
+            |lint| lint.set_arg("ty_param", ty_param).span_note(args_span, fluent::note),
         );
     }
 }
@@ -65,8 +65,8 @@ fn enforce_mem_variant_count(cx: &LateContext<'_>, func_expr: &hir::Expr<'_>, sp
         cx.struct_span_lint(
             ENUM_INTRINSICS_NON_ENUMS,
             span,
-            fluent::lint::enum_intrinsics_mem_variant,
-            |lint| lint.set_arg("ty_param", ty_param).note(fluent::lint::note),
+            fluent::lint_enum_intrinsics_mem_variant,
+            |lint| lint.set_arg("ty_param", ty_param).note(fluent::note),
         );
     }
 }

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_session::lint::Level;
 use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
-#[diag(lint::overruled_attribute, code = "E0453")]
+#[diag(lint_overruled_attribute, code = "E0453")]
 pub struct OverruledAttribute {
     #[primary_span]
     pub span: Span,
@@ -32,24 +32,24 @@ impl AddToDiagnostic for OverruledAttributeSub {
     {
         match self {
             OverruledAttributeSub::DefaultSource { id } => {
-                diag.note(fluent::lint::default_source);
+                diag.note(fluent::lint_default_source);
                 diag.set_arg("id", id);
             }
             OverruledAttributeSub::NodeSource { span, reason } => {
-                diag.span_label(span, fluent::lint::node_source);
+                diag.span_label(span, fluent::lint_node_source);
                 if let Some(rationale) = reason {
                     diag.note(rationale.as_str());
                 }
             }
             OverruledAttributeSub::CommandLineSource => {
-                diag.note(fluent::lint::command_line_source);
+                diag.note(fluent::lint_command_line_source);
             }
         }
     }
 }
 
 #[derive(Diagnostic)]
-#[diag(lint::malformed_attribute, code = "E0452")]
+#[diag(lint_malformed_attribute, code = "E0452")]
 pub struct MalformedAttribute {
     #[primary_span]
     pub span: Span,
@@ -59,16 +59,16 @@ pub struct MalformedAttribute {
 
 #[derive(Subdiagnostic)]
 pub enum MalformedAttributeSub {
-    #[label(lint::bad_attribute_argument)]
+    #[label(lint_bad_attribute_argument)]
     BadAttributeArgument(#[primary_span] Span),
-    #[label(lint::reason_must_be_string_literal)]
+    #[label(lint_reason_must_be_string_literal)]
     ReasonMustBeStringLiteral(#[primary_span] Span),
-    #[label(lint::reason_must_come_last)]
+    #[label(lint_reason_must_come_last)]
     ReasonMustComeLast(#[primary_span] Span),
 }
 
 #[derive(Diagnostic)]
-#[diag(lint::unknown_tool_in_scoped_lint, code = "E0710")]
+#[diag(lint_unknown_tool_in_scoped_lint, code = "E0710")]
 pub struct UnknownToolInScopedLint {
     #[primary_span]
     pub span: Option<Span>,
@@ -79,7 +79,7 @@ pub struct UnknownToolInScopedLint {
 }
 
 #[derive(Diagnostic)]
-#[diag(lint::builtin_ellipsis_inclusive_range_patterns, code = "E0783")]
+#[diag(lint_builtin_ellipsis_inclusive_range_patterns, code = "E0783")]
 pub struct BuiltinEllpisisInclusiveRangePatterns {
     #[primary_span]
     pub span: Span,
@@ -89,14 +89,14 @@ pub struct BuiltinEllpisisInclusiveRangePatterns {
 }
 
 #[derive(Subdiagnostic)]
-#[note(lint::requested_level)]
+#[note(lint_requested_level)]
 pub struct RequestedLevel {
     pub level: Level,
     pub lint_name: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(lint::unsupported_group, code = "E0602")]
+#[diag(lint_unsupported_group, code = "E0602")]
 pub struct UnsupportedGroup {
     pub lint_group: String,
 }
@@ -112,10 +112,10 @@ impl IntoDiagnostic<'_> for CheckNameUnknown {
         self,
         handler: &Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = handler.struct_err(fluent::lint::check_name_unknown);
+        let mut diag = handler.struct_err(fluent::lint_check_name_unknown);
         diag.code(rustc_errors::error_code!(E0602));
         if let Some(suggestion) = self.suggestion {
-            diag.help(fluent::lint::help);
+            diag.help(fluent::help);
             diag.set_arg("suggestion", suggestion);
         }
         diag.set_arg("lint_name", self.lint_name);
@@ -125,7 +125,7 @@ impl IntoDiagnostic<'_> for CheckNameUnknown {
 }
 
 #[derive(Diagnostic)]
-#[diag(lint::check_name_unknown_tool, code = "E0602")]
+#[diag(lint_check_name_unknown_tool, code = "E0602")]
 pub struct CheckNameUnknownTool {
     pub tool_name: Symbol,
     #[subdiagnostic]
@@ -133,7 +133,7 @@ pub struct CheckNameUnknownTool {
 }
 
 #[derive(Diagnostic)]
-#[diag(lint::check_name_warning)]
+#[diag(lint_check_name_warning)]
 pub struct CheckNameWarning {
     pub msg: String,
     #[subdiagnostic]
@@ -141,7 +141,7 @@ pub struct CheckNameWarning {
 }
 
 #[derive(Diagnostic)]
-#[diag(lint::check_name_deprecated)]
+#[diag(lint_check_name_deprecated)]
 pub struct CheckNameDeprecated {
     pub lint_name: String,
     pub new_name: String,

--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -45,14 +45,14 @@ fn emit_unfulfilled_expectation_lint(
         builtin::UNFULFILLED_LINT_EXPECTATIONS,
         hir_id,
         expectation.emission_span,
-        fluent::lint::expectation,
+        fluent::lint_expectation,
         |lint| {
             if let Some(rationale) = expectation.reason {
                 lint.note(rationale.as_str());
             }
 
             if expectation.is_unfulfilled_lint_expectations {
-                lint.note(fluent::lint::note);
+                lint.note(fluent::note);
             }
 
             lint

--- a/compiler/rustc_lint/src/hidden_unicode_codepoints.rs
+++ b/compiler/rustc_lint/src/hidden_unicode_codepoints.rs
@@ -63,12 +63,12 @@ impl HiddenUnicodeCodepoints {
         cx.struct_span_lint(
             TEXT_DIRECTION_CODEPOINT_IN_LITERAL,
             span,
-            fluent::lint::hidden_unicode_codepoints,
+            fluent::lint_hidden_unicode_codepoints,
             |lint| {
                 lint.set_arg("label", label);
                 lint.set_arg("count", spans.len());
-                lint.span_label(span, fluent::lint::label);
-                lint.note(fluent::lint::note);
+                lint.span_label(span, fluent::label);
+                lint.note(fluent::note);
                 if point_at_inner_spans {
                     for (c, span) in &spans {
                         lint.span_label(*span, format!("{:?}", c));
@@ -76,13 +76,13 @@ impl HiddenUnicodeCodepoints {
                 }
                 if point_at_inner_spans && !spans.is_empty() {
                     lint.multipart_suggestion_with_style(
-                        fluent::lint::suggestion_remove,
+                        fluent::suggestion_remove,
                         spans.iter().map(|(_, span)| (*span, "".to_string())).collect(),
                         Applicability::MachineApplicable,
                         SuggestionStyle::HideCodeAlways,
                     );
                     lint.multipart_suggestion(
-                        fluent::lint::suggestion_escape,
+                        fluent::suggestion_escape,
                         spans
                             .into_iter()
                             .map(|(c, span)| {
@@ -104,8 +104,8 @@ impl HiddenUnicodeCodepoints {
                             .collect::<Vec<String>>()
                             .join(", "),
                     );
-                    lint.note(fluent::lint::suggestion_remove);
-                    lint.note(fluent::lint::no_suggestion_note_escape);
+                    lint.note(fluent::suggestion_remove);
+                    lint.note(fluent::no_suggestion_note_escape);
                 }
                 lint
             },

--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -37,11 +37,11 @@ impl LateLintPass<'_> for DefaultHashTypes {
         cx.struct_span_lint(
             DEFAULT_HASH_TYPES,
             path.span,
-            fluent::lint::default_hash_types,
+            fluent::lint_default_hash_types,
             |lint| {
                 lint.set_arg("preferred", replace)
                     .set_arg("used", cx.tcx.item_name(def_id))
-                    .note(fluent::lint::note)
+                    .note(fluent::note)
             },
         );
     }
@@ -86,8 +86,8 @@ impl LateLintPass<'_> for QueryStability {
                 cx.struct_span_lint(
                     POTENTIAL_QUERY_INSTABILITY,
                     span,
-                    fluent::lint::query_instability,
-                    |lint| lint.set_arg("query", cx.tcx.item_name(def_id)).note(fluent::lint::note),
+                    fluent::lint_query_instability,
+                    |lint| lint.set_arg("query", cx.tcx.item_name(def_id)).note(fluent::note),
                 )
             }
         }
@@ -126,11 +126,11 @@ impl<'tcx> LateLintPass<'tcx> for TyTyKind {
             let span = path.span.with_hi(
                 segment.args.map_or(segment.ident.span, |a| a.span_ext).hi()
             );
-            cx.struct_span_lint(USAGE_OF_TY_TYKIND, path.span, fluent::lint::tykind_kind, |lint| {
+            cx.struct_span_lint(USAGE_OF_TY_TYKIND, path.span, fluent::lint_tykind_kind, |lint| {
                 lint
                     .span_suggestion(
                         span,
-                        fluent::lint::suggestion,
+                        fluent::suggestion,
                         "ty",
                         Applicability::MaybeIncorrect, // ty maybe needs an import
                     )
@@ -193,10 +193,10 @@ impl<'tcx> LateLintPass<'tcx> for TyTyKind {
                             cx.struct_span_lint(
                                 USAGE_OF_TY_TYKIND,
                                 path.span,
-                                fluent::lint::tykind_kind,
+                                fluent::lint_tykind_kind,
                                 |lint| lint.span_suggestion(
                                     span,
-                                    fluent::lint::suggestion,
+                                    fluent::suggestion,
                                     "ty",
                                     Applicability::MaybeIncorrect, // ty maybe needs an import
                                 )
@@ -205,18 +205,18 @@ impl<'tcx> LateLintPass<'tcx> for TyTyKind {
                         None => cx.struct_span_lint(
                             USAGE_OF_TY_TYKIND,
                             path.span,
-                            fluent::lint::tykind,
-                            |lint| lint.help(fluent::lint::help)
+                            fluent::lint_tykind,
+                            |lint| lint.help(fluent::help)
                         )
                     }
                 } else if !ty.span.from_expansion() && let Some(t) = is_ty_or_ty_ctxt(cx, &path) {
                     if path.segments.len() > 1 {
-                        cx.struct_span_lint(USAGE_OF_QUALIFIED_TY, path.span, fluent::lint::ty_qualified, |lint| {
+                        cx.struct_span_lint(USAGE_OF_QUALIFIED_TY, path.span, fluent::lint_ty_qualified, |lint| {
                             lint
                                 .set_arg("ty", t.clone())
                                 .span_suggestion(
                                     path.span,
-                                    fluent::lint::suggestion,
+                                    fluent::suggestion,
                                     t,
                                     // The import probably needs to be changed
                                     Applicability::MaybeIncorrect,
@@ -310,8 +310,8 @@ impl EarlyLintPass for LintPassImpl {
                         cx.struct_span_lint(
                             LINT_PASS_IMPL_WITHOUT_MACRO,
                             lint_pass.path.span,
-                            fluent::lint::lintpass_by_hand,
-                            |lint| lint.help(fluent::lint::help),
+                            fluent::lint_lintpass_by_hand,
+                            |lint| lint.help(fluent::help),
                         )
                     }
                 }
@@ -351,8 +351,8 @@ impl<'tcx> LateLintPass<'tcx> for ExistingDocKeyword {
                         cx.struct_span_lint(
                             EXISTING_DOC_KEYWORD,
                             attr.span,
-                            fluent::lint::non_existant_doc_keyword,
-                            |lint| lint.set_arg("keyword", v).help(fluent::lint::help),
+                            fluent::lint_non_existant_doc_keyword,
+                            |lint| lint.set_arg("keyword", v).help(fluent::help),
                         );
                     }
                 }
@@ -414,7 +414,7 @@ impl LateLintPass<'_> for Diagnostics {
             cx.struct_span_lint(
                 DIAGNOSTIC_OUTSIDE_OF_IMPL,
                 span,
-                fluent::lint::diag_out_of_impl,
+                fluent::lint_diag_out_of_impl,
                 |lint| lint,
             )
         }
@@ -435,7 +435,7 @@ impl LateLintPass<'_> for Diagnostics {
             cx.struct_span_lint(
                 UNTRANSLATABLE_DIAGNOSTIC,
                 span,
-                fluent::lint::untranslatable_diag,
+                fluent::lint_untranslatable_diag,
                 |lint| lint,
             )
         }

--- a/compiler/rustc_lint/src/methods.rs
+++ b/compiler/rustc_lint/src/methods.rs
@@ -93,12 +93,12 @@ fn lint_cstring_as_ptr(
                     cx.struct_span_lint(
                         TEMPORARY_CSTRING_AS_PTR,
                         as_ptr_span,
-                        fluent::lint::cstring_ptr,
+                        fluent::lint_cstring_ptr,
                         |diag| {
-                            diag.span_label(as_ptr_span, fluent::lint::as_ptr_label)
-                                .span_label(unwrap.span, fluent::lint::unwrap_label)
-                                .note(fluent::lint::note)
-                                .help(fluent::lint::help)
+                            diag.span_label(as_ptr_span, fluent::as_ptr_label)
+                                .span_label(unwrap.span, fluent::unwrap_label)
+                                .note(fluent::note)
+                                .help(fluent::help)
                         },
                     );
                 }

--- a/compiler/rustc_lint/src/non_ascii_idents.rs
+++ b/compiler/rustc_lint/src/non_ascii_idents.rs
@@ -183,7 +183,7 @@ impl EarlyLintPass for NonAsciiIdents {
             cx.struct_span_lint(
                 NON_ASCII_IDENTS,
                 sp,
-                fluent::lint::identifier_non_ascii_char,
+                fluent::lint_identifier_non_ascii_char,
                 |lint| lint,
             );
             if check_uncommon_codepoints
@@ -192,7 +192,7 @@ impl EarlyLintPass for NonAsciiIdents {
                 cx.struct_span_lint(
                     UNCOMMON_CODEPOINTS,
                     sp,
-                    fluent::lint::identifier_uncommon_codepoints,
+                    fluent::lint_identifier_uncommon_codepoints,
                     |lint| lint,
                 )
             }
@@ -225,11 +225,11 @@ impl EarlyLintPass for NonAsciiIdents {
                             cx.struct_span_lint(
                                 CONFUSABLE_IDENTS,
                                 sp,
-                                fluent::lint::confusable_identifier_pair,
+                                fluent::lint_confusable_identifier_pair,
                                 |lint| {
                                     lint.set_arg("existing_sym", *existing_symbol)
                                         .set_arg("sym", symbol)
-                                        .span_label(*existing_span, fluent::lint::label)
+                                        .span_label(*existing_span, fluent::label)
                                 },
                             );
                         }
@@ -334,7 +334,7 @@ impl EarlyLintPass for NonAsciiIdents {
                     cx.struct_span_lint(
                         MIXED_SCRIPT_CONFUSABLES,
                         sp,
-                        fluent::lint::mixed_script_confusables,
+                        fluent::lint_mixed_script_confusables,
                         |lint| {
                             let mut includes = String::new();
                             for (idx, ch) in ch_list.into_iter().enumerate() {
@@ -346,8 +346,8 @@ impl EarlyLintPass for NonAsciiIdents {
                             }
                             lint.set_arg("set", script_set.to_string())
                                 .set_arg("includes", includes)
-                                .note(fluent::lint::includes_note)
-                                .note(fluent::lint::note)
+                                .note(fluent::includes_note)
+                                .note(fluent::note)
                         },
                     );
                 }

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -139,7 +139,7 @@ impl NonCamelCaseTypes {
             cx.struct_span_lint(
                 NON_CAMEL_CASE_TYPES,
                 ident.span,
-                fluent::lint::non_camel_case_type,
+                fluent::lint_non_camel_case_type,
                 |lint| {
                     let cc = to_camel_case(name);
                     // We cannot provide meaningful suggestions
@@ -147,12 +147,12 @@ impl NonCamelCaseTypes {
                     if *name != cc {
                         lint.span_suggestion(
                             ident.span,
-                            fluent::lint::suggestion,
+                            fluent::suggestion,
                             to_camel_case(name),
                             Applicability::MaybeIncorrect,
                         );
                     } else {
-                        lint.span_label(ident.span, fluent::lint::label);
+                        lint.span_label(ident.span, fluent::label);
                     }
 
                     lint.set_arg("sort", sort);
@@ -284,7 +284,7 @@ impl NonSnakeCase {
         let name = ident.name.as_str();
 
         if !is_snake_case(name) {
-            cx.struct_span_lint(NON_SNAKE_CASE, ident.span, fluent::lint::non_snake_case, |lint| {
+            cx.struct_span_lint(NON_SNAKE_CASE, ident.span, fluent::lint_non_snake_case, |lint| {
                 let sc = NonSnakeCase::to_snake_case(name);
                 // We cannot provide meaningful suggestions
                 // if the characters are in the category of "Uppercase Letter".
@@ -298,13 +298,13 @@ impl NonSnakeCase {
                             // Instead, recommend renaming the identifier entirely or, if permitted,
                             // escaping it to create a raw identifier.
                             if sc_ident.name.can_be_raw() {
-                                (fluent::lint::rename_or_convert_suggestion, sc_ident.to_string())
+                                (fluent::rename_or_convert_suggestion, sc_ident.to_string())
                             } else {
-                                lint.note(fluent::lint::cannot_convert_note);
-                                (fluent::lint::rename_suggestion, String::new())
+                                lint.note(fluent::cannot_convert_note);
+                                (fluent::rename_suggestion, String::new())
                             }
                         } else {
-                            (fluent::lint::convert_suggestion, sc.clone())
+                            (fluent::convert_suggestion, sc.clone())
                         };
 
                         lint.span_suggestion(
@@ -314,10 +314,10 @@ impl NonSnakeCase {
                             Applicability::MaybeIncorrect,
                         );
                     } else {
-                        lint.help(fluent::lint::help);
+                        lint.help(fluent::help);
                     }
                 } else {
-                    lint.span_label(ident.span, fluent::lint::label);
+                    lint.span_label(ident.span, fluent::label);
                 }
 
                 lint.set_arg("sort", sort);
@@ -484,7 +484,7 @@ impl NonUpperCaseGlobals {
             cx.struct_span_lint(
                 NON_UPPER_CASE_GLOBALS,
                 ident.span,
-                fluent::lint::non_upper_case_global,
+                fluent::lint_non_upper_case_global,
                 |lint| {
                     let uc = NonSnakeCase::to_snake_case(&name).to_uppercase();
                     // We cannot provide meaningful suggestions
@@ -492,12 +492,12 @@ impl NonUpperCaseGlobals {
                     if *name != uc {
                         lint.span_suggestion(
                             ident.span,
-                            fluent::lint::suggestion,
+                            fluent::suggestion,
                             uc,
                             Applicability::MaybeIncorrect,
                         );
                     } else {
-                        lint.span_label(ident.span, fluent::lint::label);
+                        lint.span_label(ident.span, fluent::label);
                     }
 
                     lint.set_arg("sort", sort);

--- a/compiler/rustc_lint/src/noop_method_call.rs
+++ b/compiler/rustc_lint/src/noop_method_call.rs
@@ -85,11 +85,11 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
         }
         let expr_span = expr.span;
         let span = expr_span.with_lo(receiver.span.hi());
-        cx.struct_span_lint(NOOP_METHOD_CALL, span, fluent::lint::noop_method_call, |lint| {
+        cx.struct_span_lint(NOOP_METHOD_CALL, span, fluent::lint_noop_method_call, |lint| {
             lint.set_arg("method", call.ident.name)
                 .set_arg("receiver_ty", receiver_ty)
-                .span_label(span, fluent::lint::label)
-                .note(fluent::lint::note)
+                .span_label(span, fluent::label)
+                .note(fluent::note)
         });
     }
 }

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -141,11 +141,11 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint::opaque_hidden_inferred_bound)]
+#[diag(lint_opaque_hidden_inferred_bound)]
 struct OpaqueHiddenInferredBoundLint<'tcx> {
     ty: Ty<'tcx>,
     proj_ty: Ty<'tcx>,
-    #[label(lint::specifically)]
+    #[label(specifically)]
     assoc_pred_span: Span,
     #[subdiagnostic]
     add_bound: Option<AddBound<'tcx>>,
@@ -153,7 +153,7 @@ struct OpaqueHiddenInferredBoundLint<'tcx> {
 
 #[derive(Subdiagnostic)]
 #[suggestion_verbose(
-    lint::opaque_hidden_inferred_bound_sugg,
+    lint_opaque_hidden_inferred_bound_sugg,
     applicability = "machine-applicable",
     code = " + {trait_ref}"
 )]

--- a/compiler/rustc_lint/src/pass_by_value.rs
+++ b/compiler/rustc_lint/src/pass_by_value.rs
@@ -32,11 +32,11 @@ impl<'tcx> LateLintPass<'tcx> for PassByValue {
                     cx.struct_span_lint(
                         PASS_BY_VALUE,
                         ty.span,
-                        fluent::lint::pass_by_value,
+                        fluent::lint_pass_by_value,
                         |lint| {
                             lint.set_arg("ty", t.clone()).span_suggestion(
                                 ty.span,
-                                fluent::lint::suggestion,
+                                fluent::suggestion,
                                 t,
                                 // Changing type of function argument
                                 Applicability::MaybeIncorrect,

--- a/compiler/rustc_lint/src/redundant_semicolon.rs
+++ b/compiler/rustc_lint/src/redundant_semicolon.rs
@@ -51,11 +51,11 @@ fn maybe_lint_redundant_semis(cx: &EarlyContext<'_>, seq: &mut Option<(Span, boo
         cx.struct_span_lint(
             REDUNDANT_SEMICOLONS,
             span,
-            fluent::lint::redundant_semicolons,
+            fluent::lint_redundant_semicolons,
             |lint| {
                 lint.set_arg("multiple", multiple).span_suggestion(
                     span,
-                    fluent::lint::suggestion,
+                    fluent::suggestion,
                     "",
                     Applicability::MaybeIncorrect,
                 )

--- a/compiler/rustc_lint/src/traits.rs
+++ b/compiler/rustc_lint/src/traits.rs
@@ -106,7 +106,7 @@ impl<'tcx> LateLintPass<'tcx> for DropTraitConstraints {
                 cx.struct_span_lint(
                     DROP_BOUNDS,
                     span,
-                    fluent::lint::drop_trait_constraints,
+                    fluent::lint_drop_trait_constraints,
                     |lint| {
                         lint.set_arg("predicate", predicate)
                             .set_arg("needs_drop", cx.tcx.def_path_str(needs_drop))
@@ -125,7 +125,7 @@ impl<'tcx> LateLintPass<'tcx> for DropTraitConstraints {
             if cx.tcx.lang_items().drop_trait() == def_id
                 && let Some(needs_drop) = cx.tcx.get_diagnostic_item(sym::needs_drop)
             {
-                cx.struct_span_lint(DYN_DROP, bound.span, fluent::lint::drop_glue, |lint| {
+                cx.struct_span_lint(DYN_DROP, bound.span, fluent::lint_drop_glue, |lint| {
                     lint.set_arg("needs_drop", cx.tcx.def_path_str(needs_drop))
                 });
             }

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -151,7 +151,7 @@ fn lint_overflowing_range_endpoint<'tcx>(
     cx.struct_span_lint(
         OVERFLOWING_LITERALS,
         struct_expr.span,
-        fluent::lint::range_endpoint_out_of_range,
+        fluent::lint_range_endpoint_out_of_range,
         |lint| {
             use ast::{LitIntType, LitKind};
 
@@ -168,7 +168,7 @@ fn lint_overflowing_range_endpoint<'tcx>(
             let suggestion = format!("{}..={}{}", start, lit_val - 1, suffix);
             lint.span_suggestion(
                 struct_expr.span,
-                fluent::lint::suggestion,
+                fluent::suggestion,
                 suggestion,
                 Applicability::MachineApplicable,
             );
@@ -233,7 +233,7 @@ fn report_bin_hex_error(
     cx.struct_span_lint(
         OVERFLOWING_LITERALS,
         expr.span,
-        fluent::lint::overflowing_bin_hex,
+        fluent::lint_overflowing_bin_hex,
         |lint| {
             let (t, actually) = match ty {
                 attr::IntType::SignedInt(t) => {
@@ -253,10 +253,10 @@ fn report_bin_hex_error(
             if negative {
                 // If the value is negative,
                 // emits a note about the value itself, apart from the literal.
-                lint.note(fluent::lint::negative_note);
-                lint.note(fluent::lint::negative_becomes_note);
+                lint.note(fluent::negative_note);
+                lint.note(fluent::negative_becomes_note);
             } else {
-                lint.note(fluent::lint::positive_note);
+                lint.note(fluent::positive_note);
             }
             if let Some(sugg_ty) =
                 get_type_suggestion(cx.typeck_results().node_type(expr.hir_id), val, negative)
@@ -266,12 +266,12 @@ fn report_bin_hex_error(
                     let (sans_suffix, _) = repr_str.split_at(pos);
                     lint.span_suggestion(
                         expr.span,
-                        fluent::lint::suggestion,
+                        fluent::suggestion,
                         format!("{}{}", sans_suffix, sugg_ty),
                         Applicability::MachineApplicable,
                     );
                 } else {
-                    lint.help(fluent::lint::help);
+                    lint.help(fluent::help);
                 }
             }
             lint.set_arg("ty", t)
@@ -364,7 +364,7 @@ fn lint_int_literal<'tcx>(
             return;
         }
 
-        cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, fluent::lint::overflowing_int, |lint| {
+        cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, fluent::lint_overflowing_int, |lint| {
             lint.set_arg("ty", t.name_str())
                 .set_arg(
                     "lit",
@@ -375,13 +375,13 @@ fn lint_int_literal<'tcx>(
                 )
                 .set_arg("min", min)
                 .set_arg("max", max)
-                .note(fluent::lint::note);
+                .note(fluent::note);
 
             if let Some(sugg_ty) =
                 get_type_suggestion(cx.typeck_results().node_type(e.hir_id), v, negative)
             {
                 lint.set_arg("suggestion_ty", sugg_ty);
-                lint.help(fluent::lint::help);
+                lint.help(fluent::help);
             }
 
             lint
@@ -412,11 +412,11 @@ fn lint_uint_literal<'tcx>(
                         cx.struct_span_lint(
                             OVERFLOWING_LITERALS,
                             par_e.span,
-                            fluent::lint::only_cast_u8_to_char,
+                            fluent::lint_only_cast_u8_to_char,
                             |lint| {
                                 lint.span_suggestion(
                                     par_e.span,
-                                    fluent::lint::suggestion,
+                                    fluent::suggestion,
                                     format!("'\\u{{{:X}}}'", lit_val),
                                     Applicability::MachineApplicable,
                                 )
@@ -443,7 +443,7 @@ fn lint_uint_literal<'tcx>(
             );
             return;
         }
-        cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, fluent::lint::overflowing_uint, |lint| {
+        cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, fluent::lint_overflowing_uint, |lint| {
             lint.set_arg("ty", t.name_str())
                 .set_arg(
                     "lit",
@@ -454,7 +454,7 @@ fn lint_uint_literal<'tcx>(
                 )
                 .set_arg("min", min)
                 .set_arg("max", max)
-                .note(fluent::lint::note)
+                .note(fluent::note)
         });
     }
 }
@@ -487,7 +487,7 @@ fn lint_literal<'tcx>(
                 cx.struct_span_lint(
                     OVERFLOWING_LITERALS,
                     e.span,
-                    fluent::lint::overflowing_literal,
+                    fluent::lint_overflowing_literal,
                     |lint| {
                         lint.set_arg("ty", t.name_str())
                             .set_arg(
@@ -497,7 +497,7 @@ fn lint_literal<'tcx>(
                                     .span_to_snippet(lit.span)
                                     .expect("must get snippet from literal"),
                             )
-                            .note(fluent::lint::note)
+                            .note(fluent::note)
                     },
                 );
             }
@@ -520,7 +520,7 @@ impl<'tcx> LateLintPass<'tcx> for TypeLimits {
                     cx.struct_span_lint(
                         UNUSED_COMPARISONS,
                         e.span,
-                        fluent::lint::unused_comparisons,
+                        fluent::lint_unused_comparisons,
                         |lint| lint,
                     );
                 }
@@ -842,8 +842,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             self.emit_ffi_unsafe_type_lint(
                 ty,
                 sp,
-                fluent::lint::improper_ctypes_array_reason,
-                Some(fluent::lint::improper_ctypes_array_help),
+                fluent::lint_improper_ctypes_array_reason,
+                Some(fluent::lint_improper_ctypes_array_help),
             );
             true
         } else {
@@ -886,7 +886,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             } else {
                 // All fields are ZSTs; this means that the type should behave
                 // like (), which is FFI-unsafe
-                FfiUnsafe { ty, reason: fluent::lint::improper_ctypes_struct_zst, help: None }
+                FfiUnsafe { ty, reason: fluent::lint_improper_ctypes_struct_zst, help: None }
             }
         } else {
             // We can't completely trust repr(C) markings; make sure the fields are
@@ -900,7 +900,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                     FfiPhantom(..) if def.is_enum() => {
                         return FfiUnsafe {
                             ty,
-                            reason: fluent::lint::improper_ctypes_enum_phantomdata,
+                            reason: fluent::lint_improper_ctypes_enum_phantomdata,
                             help: None,
                         };
                     }
@@ -936,7 +936,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                     } else {
                         return FfiUnsafe {
                             ty,
-                            reason: fluent::lint::improper_ctypes_box,
+                            reason: fluent::lint_improper_ctypes_box,
                             help: None,
                         };
                     }
@@ -950,14 +950,14 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                             return FfiUnsafe {
                                 ty,
                                 reason: if def.is_struct() {
-                                    fluent::lint::improper_ctypes_struct_layout_reason
+                                    fluent::lint_improper_ctypes_struct_layout_reason
                                 } else {
-                                    fluent::lint::improper_ctypes_union_layout_reason
+                                    fluent::lint_improper_ctypes_union_layout_reason
                                 },
                                 help: if def.is_struct() {
-                                    Some(fluent::lint::improper_ctypes_struct_layout_help)
+                                    Some(fluent::lint_improper_ctypes_struct_layout_help)
                                 } else {
-                                    Some(fluent::lint::improper_ctypes_union_layout_help)
+                                    Some(fluent::lint_improper_ctypes_union_layout_help)
                                 },
                             };
                         }
@@ -968,9 +968,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                             return FfiUnsafe {
                                 ty,
                                 reason: if def.is_struct() {
-                                    fluent::lint::improper_ctypes_struct_non_exhaustive
+                                    fluent::lint_improper_ctypes_struct_non_exhaustive
                                 } else {
-                                    fluent::lint::improper_ctypes_union_non_exhaustive
+                                    fluent::lint_improper_ctypes_union_non_exhaustive
                                 },
                                 help: None,
                             };
@@ -980,14 +980,14 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                             return FfiUnsafe {
                                 ty,
                                 reason: if def.is_struct() {
-                                    fluent::lint::improper_ctypes_struct_fieldless_reason
+                                    fluent::lint_improper_ctypes_struct_fieldless_reason
                                 } else {
-                                    fluent::lint::improper_ctypes_union_fieldless_reason
+                                    fluent::lint_improper_ctypes_union_fieldless_reason
                                 },
                                 help: if def.is_struct() {
-                                    Some(fluent::lint::improper_ctypes_struct_fieldless_help)
+                                    Some(fluent::lint_improper_ctypes_struct_fieldless_help)
                                 } else {
-                                    Some(fluent::lint::improper_ctypes_union_fieldless_help)
+                                    Some(fluent::lint_improper_ctypes_union_fieldless_help)
                                 },
                             };
                         }
@@ -1008,8 +1008,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                             if repr_nullable_ptr(self.cx, ty, self.mode).is_none() {
                                 return FfiUnsafe {
                                     ty,
-                                    reason: fluent::lint::improper_ctypes_enum_repr_reason,
-                                    help: Some(fluent::lint::improper_ctypes_enum_repr_help),
+                                    reason: fluent::lint_improper_ctypes_enum_repr_reason,
+                                    help: Some(fluent::lint_improper_ctypes_enum_repr_help),
                                 };
                             }
                         }
@@ -1017,7 +1017,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         if def.is_variant_list_non_exhaustive() && !def.did().is_local() {
                             return FfiUnsafe {
                                 ty,
-                                reason: fluent::lint::improper_ctypes_non_exhaustive,
+                                reason: fluent::lint_improper_ctypes_non_exhaustive,
                                 help: None,
                             };
                         }
@@ -1028,7 +1028,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                             if is_non_exhaustive && !variant.def_id.is_local() {
                                 return FfiUnsafe {
                                     ty,
-                                    reason: fluent::lint::improper_ctypes_non_exhaustive_variant,
+                                    reason: fluent::lint_improper_ctypes_non_exhaustive_variant,
                                     help: None,
                                 };
                             }
@@ -1046,12 +1046,12 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
             ty::Char => FfiUnsafe {
                 ty,
-                reason: fluent::lint::improper_ctypes_char_reason,
-                help: Some(fluent::lint::improper_ctypes_char_help),
+                reason: fluent::lint_improper_ctypes_char_reason,
+                help: Some(fluent::lint_improper_ctypes_char_help),
             },
 
             ty::Int(ty::IntTy::I128) | ty::Uint(ty::UintTy::U128) => {
-                FfiUnsafe { ty, reason: fluent::lint::improper_ctypes_128bit, help: None }
+                FfiUnsafe { ty, reason: fluent::lint_improper_ctypes_128bit, help: None }
             }
 
             // Primitive types with a stable representation.
@@ -1059,24 +1059,24 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
             ty::Slice(_) => FfiUnsafe {
                 ty,
-                reason: fluent::lint::improper_ctypes_slice_reason,
-                help: Some(fluent::lint::improper_ctypes_slice_help),
+                reason: fluent::lint_improper_ctypes_slice_reason,
+                help: Some(fluent::lint_improper_ctypes_slice_help),
             },
 
             ty::Dynamic(..) => {
-                FfiUnsafe { ty, reason: fluent::lint::improper_ctypes_dyn, help: None }
+                FfiUnsafe { ty, reason: fluent::lint_improper_ctypes_dyn, help: None }
             }
 
             ty::Str => FfiUnsafe {
                 ty,
-                reason: fluent::lint::improper_ctypes_str_reason,
-                help: Some(fluent::lint::improper_ctypes_str_help),
+                reason: fluent::lint_improper_ctypes_str_reason,
+                help: Some(fluent::lint_improper_ctypes_str_help),
             },
 
             ty::Tuple(..) => FfiUnsafe {
                 ty,
-                reason: fluent::lint::improper_ctypes_tuple_reason,
-                help: Some(fluent::lint::improper_ctypes_tuple_help),
+                reason: fluent::lint_improper_ctypes_tuple_reason,
+                help: Some(fluent::lint_improper_ctypes_tuple_help),
             },
 
             ty::RawPtr(ty::TypeAndMut { ty, .. }) | ty::Ref(_, ty, _)
@@ -1107,8 +1107,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 if self.is_internal_abi(sig.abi()) {
                     return FfiUnsafe {
                         ty,
-                        reason: fluent::lint::improper_ctypes_fnptr_reason,
-                        help: Some(fluent::lint::improper_ctypes_fnptr_help),
+                        reason: fluent::lint_improper_ctypes_fnptr_reason,
+                        help: Some(fluent::lint_improper_ctypes_fnptr_help),
                     };
                 }
 
@@ -1139,7 +1139,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             // While opaque types are checked for earlier, if a projection in a struct field
             // normalizes to an opaque type, then it will reach this branch.
             ty::Opaque(..) => {
-                FfiUnsafe { ty, reason: fluent::lint::improper_ctypes_opaque, help: None }
+                FfiUnsafe { ty, reason: fluent::lint_improper_ctypes_opaque, help: None }
             }
 
             // `extern "C" fn` functions can have type parameters, which may or may not be FFI-safe,
@@ -1173,21 +1173,21 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             CItemKind::Definition => IMPROPER_CTYPES_DEFINITIONS,
         };
 
-        self.cx.struct_span_lint(lint, sp, fluent::lint::improper_ctypes, |lint| {
+        self.cx.struct_span_lint(lint, sp, fluent::lint_improper_ctypes, |lint| {
             let item_description = match self.mode {
                 CItemKind::Declaration => "block",
                 CItemKind::Definition => "fn",
             };
             lint.set_arg("ty", ty);
             lint.set_arg("desc", item_description);
-            lint.span_label(sp, fluent::lint::label);
+            lint.span_label(sp, fluent::label);
             if let Some(help) = help {
                 lint.help(help);
             }
             lint.note(note);
             if let ty::Adt(def, _) = ty.kind() {
                 if let Some(sp) = self.cx.tcx.hir().span_if_local(def.did()) {
-                    lint.span_note(sp, fluent::lint::note);
+                    lint.span_note(sp, fluent::note);
                 }
             }
             lint
@@ -1224,7 +1224,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         }
 
         if let Some(ty) = ty.visit_with(&mut ProhibitOpaqueTypes { cx: self.cx }).break_value() {
-            self.emit_ffi_unsafe_type_lint(ty, sp, fluent::lint::improper_ctypes_opaque, None);
+            self.emit_ffi_unsafe_type_lint(ty, sp, fluent::lint_improper_ctypes_opaque, None);
             true
         } else {
             false
@@ -1269,7 +1269,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 self.emit_ffi_unsafe_type_lint(
                     ty,
                     sp,
-                    fluent::lint::improper_ctypes_only_phantomdata,
+                    fluent::lint_improper_ctypes_only_phantomdata,
                     None,
                 );
             }
@@ -1403,7 +1403,7 @@ impl<'tcx> LateLintPass<'tcx> for VariantSizeDifferences {
                 cx.struct_span_lint(
                     VARIANT_SIZE_DIFFERENCES,
                     enum_definition.variants[largest_index].span,
-                    fluent::lint::variant_size_differences,
+                    fluent::lint_variant_size_differences,
                     |lint| lint.set_arg("largest", largest),
                 );
             }
@@ -1513,15 +1513,15 @@ impl InvalidAtomicOrdering {
     fn check_atomic_load_store(cx: &LateContext<'_>, expr: &Expr<'_>) {
         if let Some((method, args)) = Self::inherent_atomic_method_call(cx, expr, &[sym::load, sym::store])
             && let Some((ordering_arg, invalid_ordering, msg)) = match method {
-                sym::load => Some((&args[0], sym::Release, fluent::lint::atomic_ordering_load)),
-                sym::store => Some((&args[1], sym::Acquire, fluent::lint::atomic_ordering_store)),
+                sym::load => Some((&args[0], sym::Release, fluent::lint_atomic_ordering_load)),
+                sym::store => Some((&args[1], sym::Acquire, fluent::lint_atomic_ordering_store)),
                 _ => None,
             }
             && let Some(ordering) = Self::match_ordering(cx, ordering_arg)
             && (ordering == invalid_ordering || ordering == sym::AcqRel)
         {
             cx.struct_span_lint(INVALID_ATOMIC_ORDERING, ordering_arg.span, msg, |lint| {
-                lint.help(fluent::lint::help)
+                lint.help(fluent::help)
             });
         }
     }
@@ -1533,9 +1533,9 @@ impl InvalidAtomicOrdering {
             && matches!(cx.tcx.get_diagnostic_name(def_id), Some(sym::fence | sym::compiler_fence))
             && Self::match_ordering(cx, &args[0]) == Some(sym::Relaxed)
         {
-            cx.struct_span_lint(INVALID_ATOMIC_ORDERING, args[0].span, fluent::lint::atomic_ordering_fence, |lint| {
+            cx.struct_span_lint(INVALID_ATOMIC_ORDERING, args[0].span, fluent::lint_atomic_ordering_fence, |lint| {
                 lint
-                    .help(fluent::lint::help)
+                    .help(fluent::help)
             });
         }
     }
@@ -1554,7 +1554,7 @@ impl InvalidAtomicOrdering {
 
         if matches!(fail_ordering, sym::Release | sym::AcqRel) {
             #[derive(LintDiagnostic)]
-            #[diag(lint::atomic_ordering_invalid)]
+            #[diag(lint_atomic_ordering_invalid)]
             #[help]
             struct InvalidAtomicOrderingDiag {
                 method: Symbol,

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -155,12 +155,12 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
         };
 
         if let Some(must_use_op) = must_use_op {
-            cx.struct_span_lint(UNUSED_MUST_USE, expr.span, fluent::lint::unused_op, |lint| {
+            cx.struct_span_lint(UNUSED_MUST_USE, expr.span, fluent::lint_unused_op, |lint| {
                 lint.set_arg("op", must_use_op)
-                    .span_label(expr.span, fluent::lint::label)
+                    .span_label(expr.span, fluent::label)
                     .span_suggestion_verbose(
                         expr.span.shrink_to_lo(),
-                        fluent::lint::suggestion,
+                        fluent::suggestion,
                         "let _ = ",
                         Applicability::MachineApplicable,
                     )
@@ -169,7 +169,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
         }
 
         if !(type_permits_lack_of_use || fn_warned || op_warned) {
-            cx.struct_span_lint(UNUSED_RESULTS, s.span, fluent::lint::unused_result, |lint| {
+            cx.struct_span_lint(UNUSED_RESULTS, s.span, fluent::lint_unused_result, |lint| {
                 lint.set_arg("ty", ty)
             });
         }
@@ -272,14 +272,14 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                     cx.struct_span_lint(
                         UNUSED_MUST_USE,
                         span,
-                        fluent::lint::unused_closure,
+                        fluent::lint_unused_closure,
                         |lint| {
                             // FIXME(davidtwco): this isn't properly translatable because of the
                             // pre/post strings
                             lint.set_arg("count", plural_len)
                                 .set_arg("pre", descr_pre)
                                 .set_arg("post", descr_post)
-                                .note(fluent::lint::note)
+                                .note(fluent::note)
                         },
                     );
                     true
@@ -288,14 +288,14 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                     cx.struct_span_lint(
                         UNUSED_MUST_USE,
                         span,
-                        fluent::lint::unused_generator,
+                        fluent::lint_unused_generator,
                         |lint| {
                             // FIXME(davidtwco): this isn't properly translatable because of the
                             // pre/post strings
                             lint.set_arg("count", plural_len)
                                 .set_arg("pre", descr_pre)
                                 .set_arg("post", descr_post)
-                                .note(fluent::lint::note)
+                                .note(fluent::note)
                         },
                     );
                     true
@@ -317,7 +317,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
             descr_post_path: &str,
         ) -> bool {
             if let Some(attr) = cx.tcx.get_attr(def_id, sym::must_use) {
-                cx.struct_span_lint(UNUSED_MUST_USE, span, fluent::lint::unused_def, |lint| {
+                cx.struct_span_lint(UNUSED_MUST_USE, span, fluent::lint_unused_def, |lint| {
                     // FIXME(davidtwco): this isn't properly translatable because of the pre/post
                     // strings
                     lint.set_arg("pre", descr_pre_path);
@@ -369,17 +369,17 @@ impl<'tcx> LateLintPass<'tcx> for PathStatements {
                     cx.struct_span_lint(
                         PATH_STATEMENTS,
                         s.span,
-                        fluent::lint::path_statement_drop,
+                        fluent::lint_path_statement_drop,
                         |lint| {
                             if let Ok(snippet) = cx.sess().source_map().span_to_snippet(expr.span) {
                                 lint.span_suggestion(
                                     s.span,
-                                    fluent::lint::suggestion,
+                                    fluent::suggestion,
                                     format!("drop({});", snippet),
                                     Applicability::MachineApplicable,
                                 );
                             } else {
-                                lint.span_help(s.span, fluent::lint::suggestion);
+                                lint.span_help(s.span, fluent::suggestion);
                             }
                             lint
                         },
@@ -388,7 +388,7 @@ impl<'tcx> LateLintPass<'tcx> for PathStatements {
                     cx.struct_span_lint(
                         PATH_STATEMENTS,
                         s.span,
-                        fluent::lint::path_statement_no_effect,
+                        fluent::lint_path_statement_no_effect,
                         |lint| lint,
                     );
                 }
@@ -561,7 +561,7 @@ trait UnusedDelimLint {
         } else {
             MultiSpan::from(value_span)
         };
-        cx.struct_span_lint(self.lint(), primary_span, fluent::lint::unused_delim, |lint| {
+        cx.struct_span_lint(self.lint(), primary_span, fluent::lint_unused_delim, |lint| {
             lint.set_arg("delim", Self::DELIM_STR);
             lint.set_arg("item", msg);
             if let Some((lo, hi)) = spans {
@@ -570,7 +570,7 @@ trait UnusedDelimLint {
                     (hi, if keep_space.1 { " ".into() } else { "".into() }),
                 ];
                 lint.multipart_suggestion(
-                    fluent::lint::suggestion,
+                    fluent::suggestion,
                     replacement,
                     Applicability::MachineApplicable,
                 );
@@ -1146,7 +1146,7 @@ impl UnusedImportBraces {
             cx.struct_span_lint(
                 UNUSED_IMPORT_BRACES,
                 item.span,
-                fluent::lint::unused_import_braces,
+                fluent::lint_unused_import_braces,
                 |lint| lint.set_arg("node", node_name),
             );
         }
@@ -1201,9 +1201,9 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAllocation {
                     UNUSED_ALLOCATION,
                     e.span,
                     match m {
-                        adjustment::AutoBorrowMutability::Not => fluent::lint::unused_allocation,
+                        adjustment::AutoBorrowMutability::Not => fluent::lint_unused_allocation,
                         adjustment::AutoBorrowMutability::Mut { .. } => {
-                            fluent::lint::unused_allocation_mut
+                            fluent::lint_unused_allocation_mut
                         }
                     },
                     |lint| lint,

--- a/compiler/rustc_macros/src/diagnostics/diagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic.rs
@@ -40,7 +40,7 @@ impl<'a> DiagnosticDerive<'a> {
                     span_err(builder.span, "diagnostic slug not specified")
                         .help(&format!(
                             "specify the slug as the first argument to the `#[diag(...)]` \
-                            attribute, such as `#[diag(hir_analysis::example_error)]`",
+                            attribute, such as `#[diag(hir_analysis_example_error)]`",
                         ))
                         .emit();
                     return DiagnosticDeriveError::ErrorHandled.to_compile_error();
@@ -121,7 +121,7 @@ impl<'a> LintDiagnosticDerive<'a> {
                     span_err(builder.span, "diagnostic slug not specified")
                         .help(&format!(
                             "specify the slug as the first argument to the attribute, such as \
-                            `#[diag(compiletest::example)]`",
+                            `#[diag(compiletest_example)]`",
                         ))
                         .emit();
                     return DiagnosticDeriveError::ErrorHandled.to_compile_error();

--- a/compiler/rustc_macros/src/diagnostics/mod.rs
+++ b/compiler/rustc_macros/src/diagnostics/mod.rs
@@ -23,14 +23,14 @@ use synstructure::Structure;
 /// # extern crate rust_middle;
 /// # use rustc_middle::ty::Ty;
 /// #[derive(Diagnostic)]
-/// #[diag(borrowck::move_out_of_borrow, code = "E0505")]
+/// #[diag(borrowck_move_out_of_borrow, code = "E0505")]
 /// pub struct MoveOutOfBorrowError<'tcx> {
 ///     pub name: Ident,
 ///     pub ty: Ty<'tcx>,
 ///     #[primary_span]
 ///     #[label]
 ///     pub span: Span,
-///     #[label(borrowck::first_borrow_label)]
+///     #[label(first_borrow_label)]
 ///     pub first_borrow_span: Span,
 ///     #[suggestion(code = "{name}.clone()")]
 ///     pub clone_sugg: Option<(Span, Applicability)>
@@ -67,14 +67,14 @@ pub fn session_diagnostic_derive(s: Structure<'_>) -> TokenStream {
 ///
 /// ```ignore (rust)
 /// #[derive(LintDiagnostic)]
-/// #[diag(lint::atomic_ordering_invalid_fail_success)]
+/// #[diag(lint_atomic_ordering_invalid_fail_success)]
 /// pub struct AtomicOrderingInvalidLint {
 ///     method: Symbol,
 ///     success_ordering: Symbol,
 ///     fail_ordering: Symbol,
-///     #[label(lint::fail_label)]
+///     #[label(fail_label)]
 ///     fail_order_arg_span: Span,
-///     #[label(lint::success_label)]
+///     #[label(success_label)]
 ///     #[suggestion(
 ///         code = "std::sync::atomic::Ordering::{success_suggestion}",
 ///         applicability = "maybe-incorrect"
@@ -115,12 +115,12 @@ pub fn lint_diagnostic_derive(s: Structure<'_>) -> TokenStream {
 /// ```ignore (rust)
 /// #[derive(Subdiagnostic)]
 /// pub enum ExpectedIdentifierLabel<'tcx> {
-///     #[label(parser::expected_identifier)]
+///     #[label(expected_identifier)]
 ///     WithoutFound {
 ///         #[primary_span]
 ///         span: Span,
 ///     }
-///     #[label(parser::expected_identifier_found)]
+///     #[label(expected_identifier_found)]
 ///     WithFound {
 ///         #[primary_span]
 ///         span: Span,

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -12,41 +12,41 @@ use rustc_target::spec::{PanicStrategy, TargetTriple};
 use crate::locator::CrateFlavor;
 
 #[derive(Diagnostic)]
-#[diag(metadata::rlib_required)]
+#[diag(metadata_rlib_required)]
 pub struct RlibRequired {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::lib_required)]
+#[diag(metadata_lib_required)]
 pub struct LibRequired<'a> {
     pub crate_name: Symbol,
     pub kind: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::crate_dep_multiple)]
+#[diag(metadata_crate_dep_multiple)]
 #[help]
 pub struct CrateDepMultiple {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::two_panic_runtimes)]
+#[diag(metadata_two_panic_runtimes)]
 pub struct TwoPanicRuntimes {
     pub prev_name: Symbol,
     pub cur_name: Symbol,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::bad_panic_strategy)]
+#[diag(metadata_bad_panic_strategy)]
 pub struct BadPanicStrategy {
     pub runtime: Symbol,
     pub strategy: PanicStrategy,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::required_panic_strategy)]
+#[diag(metadata_required_panic_strategy)]
 pub struct RequiredPanicStrategy {
     pub crate_name: Symbol,
     pub found_strategy: PanicStrategy,
@@ -54,7 +54,7 @@ pub struct RequiredPanicStrategy {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::incompatible_panic_in_drop_strategy)]
+#[diag(metadata_incompatible_panic_in_drop_strategy)]
 pub struct IncompatiblePanicInDropStrategy {
     pub crate_name: Symbol,
     pub found_strategy: PanicStrategy,
@@ -62,56 +62,56 @@ pub struct IncompatiblePanicInDropStrategy {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_names_in_link)]
+#[diag(metadata_multiple_names_in_link)]
 pub struct MultipleNamesInLink {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_kinds_in_link)]
+#[diag(metadata_multiple_kinds_in_link)]
 pub struct MultipleKindsInLink {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_name_form)]
+#[diag(metadata_link_name_form)]
 pub struct LinkNameForm {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_kind_form)]
+#[diag(metadata_link_kind_form)]
 pub struct LinkKindForm {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_modifiers_form)]
+#[diag(metadata_link_modifiers_form)]
 pub struct LinkModifiersForm {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_cfg_form)]
+#[diag(metadata_link_cfg_form)]
 pub struct LinkCfgForm {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::wasm_import_form)]
+#[diag(metadata_wasm_import_form)]
 pub struct WasmImportForm {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::empty_link_name, code = "E0454")]
+#[diag(metadata_empty_link_name, code = "E0454")]
 pub struct EmptyLinkName {
     #[primary_span]
     #[label]
@@ -119,21 +119,21 @@ pub struct EmptyLinkName {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_framework_apple, code = "E0455")]
+#[diag(metadata_link_framework_apple, code = "E0455")]
 pub struct LinkFrameworkApple {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::framework_only_windows, code = "E0455")]
+#[diag(metadata_framework_only_windows, code = "E0455")]
 pub struct FrameworkOnlyWindows {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::unknown_link_kind, code = "E0458")]
+#[diag(metadata_unknown_link_kind, code = "E0458")]
 pub struct UnknownLinkKind<'a> {
     #[primary_span]
     #[label]
@@ -142,49 +142,49 @@ pub struct UnknownLinkKind<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_link_modifiers)]
+#[diag(metadata_multiple_link_modifiers)]
 pub struct MultipleLinkModifiers {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_cfgs)]
+#[diag(metadata_multiple_cfgs)]
 pub struct MultipleCfgs {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_cfg_single_predicate)]
+#[diag(metadata_link_cfg_single_predicate)]
 pub struct LinkCfgSinglePredicate {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_wasm_import)]
+#[diag(metadata_multiple_wasm_import)]
 pub struct MultipleWasmImport {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::unexpected_link_arg)]
+#[diag(metadata_unexpected_link_arg)]
 pub struct UnexpectedLinkArg {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::invalid_link_modifier)]
+#[diag(metadata_invalid_link_modifier)]
 pub struct InvalidLinkModifier {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_modifiers)]
+#[diag(metadata_multiple_modifiers)]
 pub struct MultipleModifiers<'a> {
     #[primary_span]
     pub span: Span,
@@ -192,28 +192,28 @@ pub struct MultipleModifiers<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::bundle_needs_static)]
+#[diag(metadata_bundle_needs_static)]
 pub struct BundleNeedsStatic {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::whole_archive_needs_static)]
+#[diag(metadata_whole_archive_needs_static)]
 pub struct WholeArchiveNeedsStatic {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::as_needed_compatibility)]
+#[diag(metadata_as_needed_compatibility)]
 pub struct AsNeededCompatibility {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::unknown_link_modifier)]
+#[diag(metadata_unknown_link_modifier)]
 pub struct UnknownLinkModifier<'a> {
     #[primary_span]
     pub span: Span,
@@ -221,14 +221,14 @@ pub struct UnknownLinkModifier<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::incompatible_wasm_link)]
+#[diag(metadata_incompatible_wasm_link)]
 pub struct IncompatibleWasmLink {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_requires_name, code = "E0459")]
+#[diag(metadata_link_requires_name, code = "E0459")]
 pub struct LinkRequiresName {
     #[primary_span]
     #[label]
@@ -236,126 +236,126 @@ pub struct LinkRequiresName {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::raw_dylib_no_nul)]
+#[diag(metadata_raw_dylib_no_nul)]
 pub struct RawDylibNoNul {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::link_ordinal_raw_dylib)]
+#[diag(metadata_link_ordinal_raw_dylib)]
 pub struct LinkOrdinalRawDylib {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::lib_framework_apple)]
+#[diag(metadata_lib_framework_apple)]
 pub struct LibFrameworkApple;
 
 #[derive(Diagnostic)]
-#[diag(metadata::empty_renaming_target)]
+#[diag(metadata_empty_renaming_target)]
 pub struct EmptyRenamingTarget<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::renaming_no_link)]
+#[diag(metadata_renaming_no_link)]
 pub struct RenamingNoLink<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_renamings)]
+#[diag(metadata_multiple_renamings)]
 pub struct MultipleRenamings<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::no_link_mod_override)]
+#[diag(metadata_no_link_mod_override)]
 pub struct NoLinkModOverride {
     #[primary_span]
     pub span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::unsupported_abi_i686)]
+#[diag(metadata_unsupported_abi_i686)]
 pub struct UnsupportedAbiI686 {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::unsupported_abi)]
+#[diag(metadata_unsupported_abi)]
 pub struct UnsupportedAbi {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::fail_create_file_encoder)]
+#[diag(metadata_fail_create_file_encoder)]
 pub struct FailCreateFileEncoder {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::fail_seek_file)]
+#[diag(metadata_fail_seek_file)]
 pub struct FailSeekFile {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::fail_write_file)]
+#[diag(metadata_fail_write_file)]
 pub struct FailWriteFile {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::crate_not_panic_runtime)]
+#[diag(metadata_crate_not_panic_runtime)]
 pub struct CrateNotPanicRuntime {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::no_panic_strategy)]
+#[diag(metadata_no_panic_strategy)]
 pub struct NoPanicStrategy {
     pub crate_name: Symbol,
     pub strategy: PanicStrategy,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::profiler_builtins_needs_core)]
+#[diag(metadata_profiler_builtins_needs_core)]
 pub struct ProfilerBuiltinsNeedsCore;
 
 #[derive(Diagnostic)]
-#[diag(metadata::not_profiler_runtime)]
+#[diag(metadata_not_profiler_runtime)]
 pub struct NotProfilerRuntime {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::no_multiple_global_alloc)]
+#[diag(metadata_no_multiple_global_alloc)]
 pub struct NoMultipleGlobalAlloc {
     #[primary_span]
     #[label]
     pub span2: Span,
-    #[label(metadata::prev_global_alloc)]
+    #[label(metadata_prev_global_alloc)]
     pub span1: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::conflicting_global_alloc)]
+#[diag(metadata_conflicting_global_alloc)]
 pub struct ConflictingGlobalAlloc {
     pub crate_name: Symbol,
     pub other_crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::global_alloc_required)]
+#[diag(metadata_global_alloc_required)]
 pub struct GlobalAllocRequired;
 
 #[derive(Diagnostic)]
-#[diag(metadata::no_transitive_needs_dep)]
+#[diag(metadata_no_transitive_needs_dep)]
 pub struct NoTransitiveNeedsDep<'a> {
     pub crate_name: Symbol,
     pub needs_crate_name: &'a str,
@@ -363,14 +363,14 @@ pub struct NoTransitiveNeedsDep<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::failed_write_error)]
+#[diag(metadata_failed_write_error)]
 pub struct FailedWriteError {
     pub filename: PathBuf,
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::missing_native_library)]
+#[diag(metadata_missing_native_library)]
 pub struct MissingNativeLibrary<'a> {
     libname: &'a str,
     #[subdiagnostic]
@@ -404,32 +404,32 @@ impl<'a> MissingNativeLibrary<'a> {
 }
 
 #[derive(Subdiagnostic)]
-#[help(metadata::only_provide_library_name)]
+#[help(metadata_only_provide_library_name)]
 pub struct SuggestLibraryName<'a> {
     suggested_name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::failed_create_tempdir)]
+#[diag(metadata_failed_create_tempdir)]
 pub struct FailedCreateTempdir {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::failed_create_file)]
+#[diag(metadata_failed_create_file)]
 pub struct FailedCreateFile<'a> {
     pub filename: &'a Path,
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::failed_create_encoded_metadata)]
+#[diag(metadata_failed_create_encoded_metadata)]
 pub struct FailedCreateEncodedMetadata {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::non_ascii_name)]
+#[diag(metadata_non_ascii_name)]
 pub struct NonAsciiName {
     #[primary_span]
     pub span: Span,
@@ -437,7 +437,7 @@ pub struct NonAsciiName {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::extern_location_not_exist)]
+#[diag(metadata_extern_location_not_exist)]
 pub struct ExternLocationNotExist<'a> {
     #[primary_span]
     pub span: Span,
@@ -446,7 +446,7 @@ pub struct ExternLocationNotExist<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::extern_location_not_file)]
+#[diag(metadata_extern_location_not_file)]
 pub struct ExternLocationNotFile<'a> {
     #[primary_span]
     pub span: Span,
@@ -466,7 +466,7 @@ impl IntoDiagnostic<'_> for MultipleCandidates {
         self,
         handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = handler.struct_err(rustc_errors::fluent::metadata::multiple_candidates);
+        let mut diag = handler.struct_err(rustc_errors::fluent::metadata_multiple_candidates);
         diag.set_arg("crate_name", self.crate_name);
         diag.set_arg("flavor", self.flavor);
         diag.code(error_code!(E0465));
@@ -479,7 +479,7 @@ impl IntoDiagnostic<'_> for MultipleCandidates {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_matching_crates, code = "E0464")]
+#[diag(metadata_multiple_matching_crates, code = "E0464")]
 #[note]
 pub struct MultipleMatchingCrates {
     #[primary_span]
@@ -489,7 +489,7 @@ pub struct MultipleMatchingCrates {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::symbol_conflicts_current, code = "E0519")]
+#[diag(metadata_symbol_conflicts_current, code = "E0519")]
 pub struct SymbolConflictsCurrent {
     #[primary_span]
     pub span: Span,
@@ -497,7 +497,7 @@ pub struct SymbolConflictsCurrent {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::symbol_conflicts_others, code = "E0523")]
+#[diag(metadata_symbol_conflicts_others, code = "E0523")]
 pub struct SymbolConflictsOthers {
     #[primary_span]
     pub span: Span,
@@ -505,7 +505,7 @@ pub struct SymbolConflictsOthers {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::stable_crate_id_collision)]
+#[diag(metadata_stable_crate_id_collision)]
 pub struct StableCrateIdCollision {
     #[primary_span]
     pub span: Span,
@@ -514,7 +514,7 @@ pub struct StableCrateIdCollision {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::dl_error)]
+#[diag(metadata_dl_error)]
 pub struct DlError {
     #[primary_span]
     pub span: Span,
@@ -522,9 +522,9 @@ pub struct DlError {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::newer_crate_version, code = "E0460")]
+#[diag(metadata_newer_crate_version, code = "E0460")]
 #[note]
-#[note(metadata::found_crate_versions)]
+#[note(metadata_found_crate_versions)]
 pub struct NewerCrateVersion {
     #[primary_span]
     pub span: Span,
@@ -534,8 +534,8 @@ pub struct NewerCrateVersion {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::no_crate_with_triple, code = "E0461")]
-#[note(metadata::found_crate_versions)]
+#[diag(metadata_no_crate_with_triple, code = "E0461")]
+#[note(metadata_found_crate_versions)]
 pub struct NoCrateWithTriple<'a> {
     #[primary_span]
     pub span: Span,
@@ -546,8 +546,8 @@ pub struct NoCrateWithTriple<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::found_staticlib, code = "E0462")]
-#[note(metadata::found_crate_versions)]
+#[diag(metadata_found_staticlib, code = "E0462")]
+#[note(metadata_found_crate_versions)]
 #[help]
 pub struct FoundStaticlib {
     #[primary_span]
@@ -558,8 +558,8 @@ pub struct FoundStaticlib {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::incompatible_rustc, code = "E0514")]
-#[note(metadata::found_crate_versions)]
+#[diag(metadata_incompatible_rustc, code = "E0514")]
+#[note(metadata_found_crate_versions)]
 #[help]
 pub struct IncompatibleRustc {
     #[primary_span]
@@ -582,7 +582,7 @@ impl IntoDiagnostic<'_> for InvalidMetadataFiles {
         self,
         handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = handler.struct_err(rustc_errors::fluent::metadata::invalid_meta_files);
+        let mut diag = handler.struct_err(rustc_errors::fluent::metadata_invalid_meta_files);
         diag.set_arg("crate_name", self.crate_name);
         diag.set_arg("add_info", self.add_info);
         diag.code(error_code!(E0786));
@@ -610,7 +610,7 @@ impl IntoDiagnostic<'_> for CannotFindCrate {
         self,
         handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = handler.struct_err(rustc_errors::fluent::metadata::cannot_find_crate);
+        let mut diag = handler.struct_err(rustc_errors::fluent::metadata_cannot_find_crate);
         diag.set_arg("crate_name", self.crate_name);
         diag.set_arg("current_crate", self.current_crate);
         diag.set_arg("add_info", self.add_info);
@@ -621,38 +621,38 @@ impl IntoDiagnostic<'_> for CannotFindCrate {
             && self.locator_triple != TargetTriple::from_triple(config::host_triple())
         {
             if self.missing_core {
-                diag.note(rustc_errors::fluent::metadata::target_not_installed);
+                diag.note(rustc_errors::fluent::metadata_target_not_installed);
             } else {
-                diag.note(rustc_errors::fluent::metadata::target_no_std_support);
+                diag.note(rustc_errors::fluent::metadata_target_no_std_support);
             }
             // NOTE: this suggests using rustup, even though the user may not have it installed.
             // That's because they could choose to install it; or this may give them a hint which
             // target they need to install from their distro.
             if self.missing_core {
-                diag.help(rustc_errors::fluent::metadata::consider_downloading_target);
+                diag.help(rustc_errors::fluent::metadata_consider_downloading_target);
             }
             // Suggest using #![no_std]. #[no_core] is unstable and not really supported anyway.
             // NOTE: this is a dummy span if `extern crate std` was injected by the compiler.
             // If it's not a dummy, that means someone added `extern crate std` explicitly and
             // `#![no_std]` won't help.
             if !self.missing_core && self.span.is_dummy() {
-                diag.note(rustc_errors::fluent::metadata::std_required);
+                diag.note(rustc_errors::fluent::metadata_std_required);
             }
             if self.is_nightly_build {
-                diag.help(rustc_errors::fluent::metadata::consider_building_std);
+                diag.help(rustc_errors::fluent::metadata_consider_building_std);
             }
         } else if self.crate_name == self.profiler_runtime {
-            diag.note(rustc_errors::fluent::metadata::compiler_missing_profiler);
+            diag.note(rustc_errors::fluent::metadata_compiler_missing_profiler);
         } else if self.crate_name.as_str().starts_with("rustc_") {
-            diag.help(rustc_errors::fluent::metadata::install_missing_components);
+            diag.help(rustc_errors::fluent::metadata_install_missing_components);
         }
-        diag.span_label(self.span, rustc_errors::fluent::metadata::cant_find_crate);
+        diag.span_label(self.span, rustc_errors::fluent::metadata_cant_find_crate);
         diag
     }
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::no_dylib_plugin, code = "E0457")]
+#[diag(metadata_no_dylib_plugin, code = "E0457")]
 pub struct NoDylibPlugin {
     #[primary_span]
     pub span: Span,
@@ -660,7 +660,7 @@ pub struct NoDylibPlugin {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::crate_location_unknown_type)]
+#[diag(metadata_crate_location_unknown_type)]
 pub struct CrateLocationUnknownType<'a> {
     #[primary_span]
     pub span: Span,
@@ -668,7 +668,7 @@ pub struct CrateLocationUnknownType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::lib_filename_form)]
+#[diag(metadata_lib_filename_form)]
 pub struct LibFilenameForm<'a> {
     #[primary_span]
     pub span: Span,
@@ -677,28 +677,28 @@ pub struct LibFilenameForm<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::multiple_import_name_type)]
+#[diag(metadata_multiple_import_name_type)]
 pub struct MultipleImportNameType {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::import_name_type_form)]
+#[diag(metadata_import_name_type_form)]
 pub struct ImportNameTypeForm {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::import_name_type_x86)]
+#[diag(metadata_import_name_type_x86)]
 pub struct ImportNameTypeX86 {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::unknown_import_name_type)]
+#[diag(metadata_unknown_import_name_type)]
 pub struct UnknownImportNameType<'a> {
     #[primary_span]
     pub span: Span,
@@ -706,7 +706,7 @@ pub struct UnknownImportNameType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata::import_name_type_raw)]
+#[diag(metadata_import_name_type_raw)]
 pub struct ImportNameTypeRaw {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -4,7 +4,7 @@ use rustc_span::Span;
 use crate::ty::Ty;
 
 #[derive(Diagnostic)]
-#[diag(middle::drop_check_overflow, code = "E0320")]
+#[diag(middle_drop_check_overflow, code = "E0320")]
 #[note]
 pub struct DropCheckOverflow<'tcx> {
     #[primary_span]
@@ -14,7 +14,7 @@ pub struct DropCheckOverflow<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(middle::opaque_hidden_type_mismatch)]
+#[diag(middle_opaque_hidden_type_mismatch)]
 pub struct OpaqueHiddenTypeMismatch<'tcx> {
     pub self_ty: Ty<'tcx>,
     pub other_ty: Ty<'tcx>,
@@ -27,12 +27,12 @@ pub struct OpaqueHiddenTypeMismatch<'tcx> {
 
 #[derive(Subdiagnostic)]
 pub enum TypeMismatchReason {
-    #[label(middle::conflict_types)]
+    #[label(middle_conflict_types)]
     ConflictType {
         #[primary_span]
         span: Span,
     },
-    #[note(middle::previous_use_here)]
+    #[note(middle_previous_use_here)]
     PreviousUse {
         #[primary_span]
         span: Span,
@@ -40,7 +40,7 @@ pub enum TypeMismatchReason {
 }
 
 #[derive(Diagnostic)]
-#[diag(middle::limit_invalid)]
+#[diag(middle_limit_invalid)]
 pub struct LimitInvalid<'a> {
     #[primary_span]
     pub span: Span,
@@ -50,7 +50,7 @@ pub struct LimitInvalid<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(middle::const_eval_non_int)]
+#[diag(middle_const_eval_non_int)]
 pub struct ConstEvalNonIntError {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -513,7 +513,7 @@ impl<'tcx> TypeVisitor<'tcx> for IsSuggestableVisitor<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(borrowck::const_not_used_in_type_alias)]
+#[diag(borrowck_const_not_used_in_type_alias)]
 pub(super) struct ConstNotUsedTraitAlias {
     pub ct: String,
     #[primary_span]

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -196,16 +196,16 @@ impl<'a> IntoDiagnostic<'a, !> for LayoutError<'a> {
         match self {
             LayoutError::Unknown(ty) => {
                 diag.set_arg("ty", ty);
-                diag.set_primary_message(rustc_errors::fluent::middle::unknown_layout);
+                diag.set_primary_message(rustc_errors::fluent::middle_unknown_layout);
             }
             LayoutError::SizeOverflow(ty) => {
                 diag.set_arg("ty", ty);
-                diag.set_primary_message(rustc_errors::fluent::middle::values_too_big);
+                diag.set_primary_message(rustc_errors::fluent::middle_values_too_big);
             }
             LayoutError::NormalizationFailure(ty, e) => {
                 diag.set_arg("ty", ty);
                 diag.set_arg("failure_ty", e.get_type_for_failure());
-                diag.set_primary_message(rustc_errors::fluent::middle::cannot_be_normalized);
+                diag.set_primary_message(rustc_errors::fluent::middle_cannot_be_normalized);
             }
         }
         diag

--- a/compiler/rustc_mir_dataflow/src/errors.rs
+++ b/compiler/rustc_mir_dataflow/src/errors.rs
@@ -2,21 +2,21 @@ use rustc_macros::Diagnostic;
 use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::path_must_end_in_filename)]
+#[diag(mir_dataflow_path_must_end_in_filename)]
 pub(crate) struct PathMustEndInFilename {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::unknown_formatter)]
+#[diag(mir_dataflow_unknown_formatter)]
 pub(crate) struct UnknownFormatter {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::duplicate_values_for)]
+#[diag(mir_dataflow_duplicate_values_for)]
 pub(crate) struct DuplicateValuesFor {
     #[primary_span]
     pub span: Span,
@@ -24,7 +24,7 @@ pub(crate) struct DuplicateValuesFor {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::requires_an_argument)]
+#[diag(mir_dataflow_requires_an_argument)]
 pub(crate) struct RequiresAnArgument {
     #[primary_span]
     pub span: Span,
@@ -32,39 +32,39 @@ pub(crate) struct RequiresAnArgument {
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::stop_after_dataflow_ended_compilation)]
+#[diag(mir_dataflow_stop_after_dataflow_ended_compilation)]
 pub(crate) struct StopAfterDataFlowEndedCompilation;
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::peek_must_be_place_or_ref_place)]
+#[diag(mir_dataflow_peek_must_be_place_or_ref_place)]
 pub(crate) struct PeekMustBePlaceOrRefPlace {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::peek_must_be_not_temporary)]
+#[diag(mir_dataflow_peek_must_be_not_temporary)]
 pub(crate) struct PeekMustBeNotTemporary {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::peek_bit_not_set)]
+#[diag(mir_dataflow_peek_bit_not_set)]
 pub(crate) struct PeekBitNotSet {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::peek_argument_not_a_local)]
+#[diag(mir_dataflow_peek_argument_not_a_local)]
 pub(crate) struct PeekArgumentNotALocal {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(mir_dataflow::peek_argument_untracked)]
+#[diag(mir_dataflow_peek_argument_untracked)]
 pub(crate) struct PeekArgumentUntracked {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -6,7 +6,7 @@ use rustc_macros::{Diagnostic, LintDiagnostic};
 use rustc_span::Span;
 
 #[derive(Diagnostic)]
-#[diag(monomorphize::recursion_limit)]
+#[diag(monomorphize_recursion_limit)]
 pub struct RecursionLimit {
     #[primary_span]
     pub span: Span,
@@ -14,26 +14,26 @@ pub struct RecursionLimit {
     #[note]
     pub def_span: Span,
     pub def_path_str: String,
-    #[note(monomorphize::written_to_path)]
+    #[note(monomorphize_written_to_path)]
     pub was_written: Option<()>,
     pub path: PathBuf,
 }
 
 #[derive(Diagnostic)]
-#[diag(monomorphize::type_length_limit)]
-#[help(monomorphize::consider_type_length_limit)]
+#[diag(monomorphize_type_length_limit)]
+#[help(monomorphize_consider_type_length_limit)]
 pub struct TypeLengthLimit {
     #[primary_span]
     pub span: Span,
     pub shrunk: String,
-    #[note(monomorphize::written_to_path)]
+    #[note(monomorphize_written_to_path)]
     pub was_written: Option<()>,
     pub path: PathBuf,
     pub type_length: usize,
 }
 
 #[derive(Diagnostic)]
-#[diag(monomorphize::requires_lang_item)]
+#[diag(monomorphize_requires_lang_item)]
 pub struct RequiresLangItem {
     pub lang_item: String,
 }
@@ -49,8 +49,7 @@ impl IntoDiagnostic<'_> for UnusedGenericParams {
         self,
         handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag =
-            handler.struct_err(rustc_errors::fluent::monomorphize::unused_generic_params);
+        let mut diag = handler.struct_err(rustc_errors::fluent::monomorphize_unused_generic_params);
         diag.set_span(self.span);
         for (span, name) in self.param_spans.into_iter().zip(self.param_names) {
             // FIXME: I can figure out how to do a label with a fluent string with a fixed message,
@@ -63,7 +62,7 @@ impl IntoDiagnostic<'_> for UnusedGenericParams {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(monomorphize::large_assignments)]
+#[diag(monomorphize_large_assignments)]
 #[note]
 pub struct LargeAssignmentsLint {
     #[label]
@@ -73,11 +72,11 @@ pub struct LargeAssignmentsLint {
 }
 
 #[derive(Diagnostic)]
-#[diag(monomorphize::unknown_partition_strategy)]
+#[diag(monomorphize_unknown_partition_strategy)]
 pub struct UnknownPartitionStrategy;
 
 #[derive(Diagnostic)]
-#[diag(monomorphize::symbol_already_defined)]
+#[diag(monomorphize_symbol_already_defined)]
 pub struct SymbolAlreadyDefined {
     #[primary_span]
     pub span: Option<Span>,

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -9,7 +9,7 @@ use rustc_span::{Span, Symbol};
 use crate::parser::TokenDescription;
 
 #[derive(Diagnostic)]
-#[diag(parser::maybe_report_ambiguous_plus)]
+#[diag(parser_maybe_report_ambiguous_plus)]
 pub(crate) struct AmbiguousPlus {
     pub sum_ty: String,
     #[primary_span]
@@ -18,7 +18,7 @@ pub(crate) struct AmbiguousPlus {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::maybe_recover_from_bad_type_plus, code = "E0178")]
+#[diag(parser_maybe_recover_from_bad_type_plus, code = "E0178")]
 pub(crate) struct BadTypePlus {
     pub ty: String,
     #[primary_span]
@@ -30,7 +30,7 @@ pub(crate) struct BadTypePlus {
 #[derive(Subdiagnostic)]
 pub(crate) enum BadTypePlusSub {
     #[suggestion(
-        parser::add_paren,
+        parser_add_paren,
         code = "{sum_with_parens}",
         applicability = "machine-applicable"
     )]
@@ -39,12 +39,12 @@ pub(crate) enum BadTypePlusSub {
         #[primary_span]
         span: Span,
     },
-    #[label(parser::forgot_paren)]
+    #[label(parser_forgot_paren)]
     ForgotParen {
         #[primary_span]
         span: Span,
     },
-    #[label(parser::expect_path)]
+    #[label(parser_expect_path)]
     ExpectPath {
         #[primary_span]
         span: Span,
@@ -52,7 +52,7 @@ pub(crate) enum BadTypePlusSub {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::maybe_recover_from_bad_qpath_stage_2)]
+#[diag(parser_maybe_recover_from_bad_qpath_stage_2)]
 pub(crate) struct BadQPathStage2 {
     #[primary_span]
     #[suggestion(code = "", applicability = "maybe-incorrect")]
@@ -61,7 +61,7 @@ pub(crate) struct BadQPathStage2 {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::incorrect_semicolon)]
+#[diag(parser_incorrect_semicolon)]
 pub(crate) struct IncorrectSemicolon<'a> {
     #[primary_span]
     #[suggestion_short(code = "", applicability = "machine-applicable")]
@@ -72,26 +72,26 @@ pub(crate) struct IncorrectSemicolon<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::incorrect_use_of_await)]
+#[diag(parser_incorrect_use_of_await)]
 pub(crate) struct IncorrectUseOfAwait {
     #[primary_span]
-    #[suggestion(parser::parentheses_suggestion, code = "", applicability = "machine-applicable")]
+    #[suggestion(parentheses_suggestion, code = "", applicability = "machine-applicable")]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::incorrect_use_of_await)]
+#[diag(parser_incorrect_use_of_await)]
 pub(crate) struct IncorrectAwait {
     #[primary_span]
     pub span: Span,
-    #[suggestion(parser::postfix_suggestion, code = "{expr}.await{question_mark}")]
+    #[suggestion(postfix_suggestion, code = "{expr}.await{question_mark}")]
     pub sugg_span: (Span, Applicability),
     pub expr: String,
     pub question_mark: &'static str,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::in_in_typo)]
+#[diag(parser_in_in_typo)]
 pub(crate) struct InInTypo {
     #[primary_span]
     pub span: Span,
@@ -100,7 +100,7 @@ pub(crate) struct InInTypo {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_variable_declaration)]
+#[diag(parser_invalid_variable_declaration)]
 pub(crate) struct InvalidVariableDeclaration {
     #[primary_span]
     pub span: Span,
@@ -110,26 +110,22 @@ pub(crate) struct InvalidVariableDeclaration {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidVariableDeclarationSub {
-    #[suggestion(
-        parser::switch_mut_let_order,
-        applicability = "maybe-incorrect",
-        code = "let mut"
-    )]
+    #[suggestion(parser_switch_mut_let_order, applicability = "maybe-incorrect", code = "let mut")]
     SwitchMutLetOrder(#[primary_span] Span),
     #[suggestion(
-        parser::missing_let_before_mut,
+        parser_missing_let_before_mut,
         applicability = "machine-applicable",
         code = "let mut"
     )]
     MissingLet(#[primary_span] Span),
-    #[suggestion(parser::use_let_not_auto, applicability = "machine-applicable", code = "let")]
+    #[suggestion(parser_use_let_not_auto, applicability = "machine-applicable", code = "let")]
     UseLetNotAuto(#[primary_span] Span),
-    #[suggestion(parser::use_let_not_var, applicability = "machine-applicable", code = "let")]
+    #[suggestion(parser_use_let_not_var, applicability = "machine-applicable", code = "let")]
     UseLetNotVar(#[primary_span] Span),
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_comparison_operator)]
+#[diag(parser_invalid_comparison_operator)]
 pub(crate) struct InvalidComparisonOperator {
     #[primary_span]
     pub span: Span,
@@ -140,23 +136,19 @@ pub(crate) struct InvalidComparisonOperator {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidComparisonOperatorSub {
-    #[suggestion_short(
-        parser::use_instead,
-        applicability = "machine-applicable",
-        code = "{correct}"
-    )]
+    #[suggestion_short(use_instead, applicability = "machine-applicable", code = "{correct}")]
     Correctable {
         #[primary_span]
         span: Span,
         invalid: String,
         correct: String,
     },
-    #[label(parser::spaceship_operator_invalid)]
+    #[label(spaceship_operator_invalid)]
     Spaceship(#[primary_span] Span),
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_logical_operator)]
+#[diag(parser_invalid_logical_operator)]
 #[note]
 pub(crate) struct InvalidLogicalOperator {
     #[primary_span]
@@ -169,13 +161,13 @@ pub(crate) struct InvalidLogicalOperator {
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidLogicalOperatorSub {
     #[suggestion_short(
-        parser::use_amp_amp_for_conjunction,
+        use_amp_amp_for_conjunction,
         applicability = "machine-applicable",
         code = "&&"
     )]
     Conjunction(#[primary_span] Span),
     #[suggestion_short(
-        parser::use_pipe_pipe_for_disjunction,
+        use_pipe_pipe_for_disjunction,
         applicability = "machine-applicable",
         code = "||"
     )]
@@ -183,7 +175,7 @@ pub(crate) enum InvalidLogicalOperatorSub {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::tilde_is_not_unary_operator)]
+#[diag(parser_tilde_is_not_unary_operator)]
 pub(crate) struct TildeAsUnaryOperator(
     #[primary_span]
     #[suggestion_short(applicability = "machine-applicable", code = "!")]
@@ -191,7 +183,7 @@ pub(crate) struct TildeAsUnaryOperator(
 );
 
 #[derive(Diagnostic)]
-#[diag(parser::unexpected_token_after_not)]
+#[diag(parser_unexpected_token_after_not)]
 pub(crate) struct NotAsNegationOperator {
     #[primary_span]
     pub negated: Span,
@@ -203,21 +195,21 @@ pub(crate) struct NotAsNegationOperator {
 #[derive(Subdiagnostic)]
 pub enum NotAsNegationOperatorSub {
     #[suggestion_short(
-        parser::unexpected_token_after_not_default,
+        parser_unexpected_token_after_not_default,
         applicability = "machine-applicable",
         code = "!"
     )]
     SuggestNotDefault(#[primary_span] Span),
 
     #[suggestion_short(
-        parser::unexpected_token_after_not_bitwise,
+        parser_unexpected_token_after_not_bitwise,
         applicability = "machine-applicable",
         code = "!"
     )]
     SuggestNotBitwise(#[primary_span] Span),
 
     #[suggestion_short(
-        parser::unexpected_token_after_not_logical,
+        parser_unexpected_token_after_not_logical,
         applicability = "machine-applicable",
         code = "!"
     )]
@@ -225,7 +217,7 @@ pub enum NotAsNegationOperatorSub {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::malformed_loop_label)]
+#[diag(parser_malformed_loop_label)]
 pub(crate) struct MalformedLoopLabel {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "{correct_label}")]
@@ -234,7 +226,7 @@ pub(crate) struct MalformedLoopLabel {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::lifetime_in_borrow_expression)]
+#[diag(parser_lifetime_in_borrow_expression)]
 pub(crate) struct LifetimeInBorrowExpression {
     #[primary_span]
     pub span: Span,
@@ -244,27 +236,27 @@ pub(crate) struct LifetimeInBorrowExpression {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::field_expression_with_generic)]
+#[diag(parser_field_expression_with_generic)]
 pub(crate) struct FieldExpressionWithGeneric(#[primary_span] pub Span);
 
 #[derive(Diagnostic)]
-#[diag(parser::macro_invocation_with_qualified_path)]
+#[diag(parser_macro_invocation_with_qualified_path)]
 pub(crate) struct MacroInvocationWithQualifiedPath(#[primary_span] pub Span);
 
 #[derive(Diagnostic)]
-#[diag(parser::unexpected_token_after_label)]
+#[diag(parser_unexpected_token_after_label)]
 pub(crate) struct UnexpectedTokenAfterLabel {
     #[primary_span]
-    #[label(parser::unexpected_token_after_label)]
+    #[label(parser_unexpected_token_after_label)]
     pub span: Span,
-    #[suggestion_verbose(parser::suggestion_remove_label, code = "")]
+    #[suggestion_verbose(suggestion_remove_label, code = "")]
     pub remove_label: Option<Span>,
     #[subdiagnostic]
     pub enclose_in_block: Option<UnexpectedTokenAfterLabelSugg>,
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion_enclose_in_block, applicability = "machine-applicable")]
+#[multipart_suggestion(suggestion_enclose_in_block, applicability = "machine-applicable")]
 pub(crate) struct UnexpectedTokenAfterLabelSugg {
     #[suggestion_part(code = "{{ ")]
     pub left: Span,
@@ -273,7 +265,7 @@ pub(crate) struct UnexpectedTokenAfterLabelSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::require_colon_after_labeled_expression)]
+#[diag(parser_require_colon_after_labeled_expression)]
 #[note]
 pub(crate) struct RequireColonAfterLabeledExpression {
     #[primary_span]
@@ -285,7 +277,7 @@ pub(crate) struct RequireColonAfterLabeledExpression {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::do_catch_syntax_removed)]
+#[diag(parser_do_catch_syntax_removed)]
 #[note]
 pub(crate) struct DoCatchSyntaxRemoved {
     #[primary_span]
@@ -294,7 +286,7 @@ pub(crate) struct DoCatchSyntaxRemoved {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::float_literal_requires_integer_part)]
+#[diag(parser_float_literal_requires_integer_part)]
 pub(crate) struct FloatLiteralRequiresIntegerPart {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "{correct}")]
@@ -303,7 +295,7 @@ pub(crate) struct FloatLiteralRequiresIntegerPart {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_int_literal_width)]
+#[diag(parser_invalid_int_literal_width)]
 #[help]
 pub(crate) struct InvalidIntLiteralWidth {
     #[primary_span]
@@ -312,7 +304,7 @@ pub(crate) struct InvalidIntLiteralWidth {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_num_literal_base_prefix)]
+#[diag(parser_invalid_num_literal_base_prefix)]
 #[note]
 pub(crate) struct InvalidNumLiteralBasePrefix {
     #[primary_span]
@@ -322,7 +314,7 @@ pub(crate) struct InvalidNumLiteralBasePrefix {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_num_literal_suffix)]
+#[diag(parser_invalid_num_literal_suffix)]
 #[help]
 pub(crate) struct InvalidNumLiteralSuffix {
     #[primary_span]
@@ -332,7 +324,7 @@ pub(crate) struct InvalidNumLiteralSuffix {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_float_literal_width)]
+#[diag(parser_invalid_float_literal_width)]
 #[help]
 pub(crate) struct InvalidFloatLiteralWidth {
     #[primary_span]
@@ -341,7 +333,7 @@ pub(crate) struct InvalidFloatLiteralWidth {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_float_literal_suffix)]
+#[diag(parser_invalid_float_literal_suffix)]
 #[help]
 pub(crate) struct InvalidFloatLiteralSuffix {
     #[primary_span]
@@ -351,14 +343,14 @@ pub(crate) struct InvalidFloatLiteralSuffix {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::int_literal_too_large)]
+#[diag(parser_int_literal_too_large)]
 pub(crate) struct IntLiteralTooLarge {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::missing_semicolon_before_array)]
+#[diag(parser_missing_semicolon_before_array)]
 pub(crate) struct MissingSemicolonBeforeArray {
     #[primary_span]
     pub open_delim: Span,
@@ -367,7 +359,7 @@ pub(crate) struct MissingSemicolonBeforeArray {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_block_macro_segment)]
+#[diag(parser_invalid_block_macro_segment)]
 pub(crate) struct InvalidBlockMacroSegment {
     #[primary_span]
     pub span: Span,
@@ -376,7 +368,7 @@ pub(crate) struct InvalidBlockMacroSegment {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::if_expression_missing_then_block)]
+#[diag(parser_if_expression_missing_then_block)]
 pub(crate) struct IfExpressionMissingThenBlock {
     #[primary_span]
     pub if_span: Span,
@@ -386,31 +378,31 @@ pub(crate) struct IfExpressionMissingThenBlock {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum IfExpressionMissingThenBlockSub {
-    #[help(parser::condition_possibly_unfinished)]
+    #[help(condition_possibly_unfinished)]
     UnfinishedCondition(#[primary_span] Span),
-    #[help(parser::add_then_block)]
+    #[help(add_then_block)]
     AddThenBlock(#[primary_span] Span),
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::if_expression_missing_condition)]
+#[diag(parser_if_expression_missing_condition)]
 pub(crate) struct IfExpressionMissingCondition {
     #[primary_span]
-    #[label(parser::condition_label)]
+    #[label(condition_label)]
     pub if_span: Span,
-    #[label(parser::block_label)]
+    #[label(block_label)]
     pub block_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::expected_expression_found_let)]
+#[diag(parser_expected_expression_found_let)]
 pub(crate) struct ExpectedExpressionFoundLet {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::expected_else_block)]
+#[diag(parser_expected_else_block)]
 pub(crate) struct ExpectedElseBlock {
     #[primary_span]
     pub first_tok_span: Span,
@@ -422,15 +414,15 @@ pub(crate) struct ExpectedElseBlock {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::outer_attribute_not_allowed_on_if_else)]
+#[diag(parser_outer_attribute_not_allowed_on_if_else)]
 pub(crate) struct OuterAttributeNotAllowedOnIfElse {
     #[primary_span]
     pub last: Span,
 
-    #[label(parser::branch_label)]
+    #[label(branch_label)]
     pub branch_span: Span,
 
-    #[label(parser::ctx_label)]
+    #[label(ctx_label)]
     pub ctx_span: Span,
     pub ctx: String,
 
@@ -439,7 +431,7 @@ pub(crate) struct OuterAttributeNotAllowedOnIfElse {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::missing_in_in_for_loop)]
+#[diag(parser_missing_in_in_for_loop)]
 pub(crate) struct MissingInInForLoop {
     #[primary_span]
     pub span: Span,
@@ -450,14 +442,14 @@ pub(crate) struct MissingInInForLoop {
 #[derive(Subdiagnostic)]
 pub(crate) enum MissingInInForLoopSub {
     // Has been misleading, at least in the past (closed Issue #48492), thus maybe-incorrect
-    #[suggestion_short(parser::use_in_not_of, applicability = "maybe-incorrect", code = "in")]
+    #[suggestion_short(use_in_not_of, applicability = "maybe-incorrect", code = "in")]
     InNotOf(#[primary_span] Span),
-    #[suggestion_short(parser::add_in, applicability = "maybe-incorrect", code = " in ")]
+    #[suggestion_short(add_in, applicability = "maybe-incorrect", code = " in ")]
     AddIn(#[primary_span] Span),
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::missing_comma_after_match_arm)]
+#[diag(parser_missing_comma_after_match_arm)]
 pub(crate) struct MissingCommaAfterMatchArm {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = ",")]
@@ -465,7 +457,7 @@ pub(crate) struct MissingCommaAfterMatchArm {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::catch_after_try)]
+#[diag(parser_catch_after_try)]
 #[help]
 pub(crate) struct CatchAfterTry {
     #[primary_span]
@@ -473,7 +465,7 @@ pub(crate) struct CatchAfterTry {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::comma_after_base_struct)]
+#[diag(parser_comma_after_base_struct)]
 #[note]
 pub(crate) struct CommaAfterBaseStruct {
     #[primary_span]
@@ -483,7 +475,7 @@ pub(crate) struct CommaAfterBaseStruct {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::eq_field_init)]
+#[diag(parser_eq_field_init)]
 pub(crate) struct EqFieldInit {
     #[primary_span]
     pub span: Span,
@@ -492,16 +484,16 @@ pub(crate) struct EqFieldInit {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::dotdotdot)]
+#[diag(parser_dotdotdot)]
 pub(crate) struct DotDotDot {
     #[primary_span]
-    #[suggestion(parser::suggest_exclusive_range, applicability = "maybe-incorrect", code = "..")]
-    #[suggestion(parser::suggest_inclusive_range, applicability = "maybe-incorrect", code = "..=")]
+    #[suggestion(suggest_exclusive_range, applicability = "maybe-incorrect", code = "..")]
+    #[suggestion(suggest_inclusive_range, applicability = "maybe-incorrect", code = "..=")]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::left_arrow_operator)]
+#[diag(parser_left_arrow_operator)]
 pub(crate) struct LeftArrowOperator {
     #[primary_span]
     #[suggestion(applicability = "maybe-incorrect", code = "< -")]
@@ -509,7 +501,7 @@ pub(crate) struct LeftArrowOperator {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::remove_let)]
+#[diag(parser_remove_let)]
 pub(crate) struct RemoveLet {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "")]
@@ -517,7 +509,7 @@ pub(crate) struct RemoveLet {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::use_eq_instead)]
+#[diag(parser_use_eq_instead)]
 pub(crate) struct UseEqInstead {
     #[primary_span]
     #[suggestion_short(applicability = "machine-applicable", code = "=")]
@@ -525,7 +517,7 @@ pub(crate) struct UseEqInstead {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::use_empty_block_not_semi)]
+#[diag(parser_use_empty_block_not_semi)]
 pub(crate) struct UseEmptyBlockNotSemi {
     #[primary_span]
     #[suggestion_hidden(applicability = "machine-applicable", code = "{{}}")]
@@ -533,33 +525,33 @@ pub(crate) struct UseEmptyBlockNotSemi {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::comparison_interpreted_as_generic)]
+#[diag(parser_comparison_interpreted_as_generic)]
 pub(crate) struct ComparisonInterpretedAsGeneric {
     #[primary_span]
-    #[label(parser::label_comparison)]
+    #[label(label_comparison)]
     pub comparison: Span,
     pub r#type: Path,
-    #[label(parser::label_args)]
+    #[label(label_args)]
     pub args: Span,
     #[subdiagnostic]
     pub suggestion: ComparisonOrShiftInterpretedAsGenericSugg,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::shift_interpreted_as_generic)]
+#[diag(parser_shift_interpreted_as_generic)]
 pub(crate) struct ShiftInterpretedAsGeneric {
     #[primary_span]
-    #[label(parser::label_comparison)]
+    #[label(label_comparison)]
     pub shift: Span,
     pub r#type: Path,
-    #[label(parser::label_args)]
+    #[label(label_args)]
     pub args: Span,
     #[subdiagnostic]
     pub suggestion: ComparisonOrShiftInterpretedAsGenericSugg,
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+#[multipart_suggestion(suggestion, applicability = "machine-applicable")]
 pub(crate) struct ComparisonOrShiftInterpretedAsGenericSugg {
     #[suggestion_part(code = "(")]
     pub left: Span,
@@ -568,7 +560,7 @@ pub(crate) struct ComparisonOrShiftInterpretedAsGenericSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::found_expr_would_be_stmt)]
+#[diag(parser_found_expr_would_be_stmt)]
 pub(crate) struct FoundExprWouldBeStmt {
     #[primary_span]
     #[label]
@@ -579,23 +571,19 @@ pub(crate) struct FoundExprWouldBeStmt {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::leading_plus_not_supported)]
+#[diag(parser_leading_plus_not_supported)]
 pub(crate) struct LeadingPlusNotSupported {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[suggestion_verbose(
-        parser::suggestion_remove_plus,
-        code = "",
-        applicability = "machine-applicable"
-    )]
+    #[suggestion_verbose(suggestion_remove_plus, code = "", applicability = "machine-applicable")]
     pub remove_plus: Option<Span>,
     #[subdiagnostic]
     pub add_parentheses: Option<ExprParenthesesNeeded>,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::parentheses_with_struct_fields)]
+#[diag(parser_parentheses_with_struct_fields)]
 pub(crate) struct ParenthesesWithStructFields {
     #[primary_span]
     pub span: Span,
@@ -607,7 +595,7 @@ pub(crate) struct ParenthesesWithStructFields {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion_braces_for_struct, applicability = "maybe-incorrect")]
+#[multipart_suggestion(suggestion_braces_for_struct, applicability = "maybe-incorrect")]
 pub(crate) struct BracesForStructLiteral {
     #[suggestion_part(code = " {{ ")]
     pub first: Span,
@@ -616,14 +604,14 @@ pub(crate) struct BracesForStructLiteral {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion_no_fields_for_fn, applicability = "maybe-incorrect")]
+#[multipart_suggestion(suggestion_no_fields_for_fn, applicability = "maybe-incorrect")]
 pub(crate) struct NoFieldsForFnCall {
     #[suggestion_part(code = "")]
     pub fields: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::labeled_loop_in_break)]
+#[diag(parser_labeled_loop_in_break)]
 pub(crate) struct LabeledLoopInBreak {
     #[primary_span]
     pub span: Span,
@@ -633,7 +621,7 @@ pub(crate) struct LabeledLoopInBreak {
 
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
-    parser::sugg_wrap_expression_in_parentheses,
+    parser_sugg_wrap_expression_in_parentheses,
     applicability = "machine-applicable"
 )]
 pub(crate) struct WrapExpressionInParentheses {
@@ -644,7 +632,7 @@ pub(crate) struct WrapExpressionInParentheses {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::array_brackets_instead_of_braces)]
+#[diag(parser_array_brackets_instead_of_braces)]
 pub(crate) struct ArrayBracketsInsteadOfSpaces {
     #[primary_span]
     pub span: Span,
@@ -653,7 +641,7 @@ pub(crate) struct ArrayBracketsInsteadOfSpaces {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "maybe-incorrect")]
+#[multipart_suggestion(suggestion, applicability = "maybe-incorrect")]
 pub(crate) struct ArrayBracketsInsteadOfSpacesSugg {
     #[suggestion_part(code = "[")]
     pub left: Span,
@@ -662,12 +650,12 @@ pub(crate) struct ArrayBracketsInsteadOfSpacesSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::match_arm_body_without_braces)]
+#[diag(parser_match_arm_body_without_braces)]
 pub(crate) struct MatchArmBodyWithoutBraces {
     #[primary_span]
-    #[label(parser::label_statements)]
+    #[label(label_statements)]
     pub statements: Span,
-    #[label(parser::label_arrow)]
+    #[label(label_arrow)]
     pub arrow: Span,
     pub num_statements: usize,
     #[subdiagnostic]
@@ -676,7 +664,7 @@ pub(crate) struct MatchArmBodyWithoutBraces {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum MatchArmBodyWithoutBracesSugg {
-    #[multipart_suggestion(parser::suggestion_add_braces, applicability = "machine-applicable")]
+    #[multipart_suggestion(suggestion_add_braces, applicability = "machine-applicable")]
     AddBraces {
         #[suggestion_part(code = "{{ ")]
         left: Span,
@@ -684,7 +672,7 @@ pub(crate) enum MatchArmBodyWithoutBracesSugg {
         right: Span,
     },
     #[suggestion(
-        parser::suggestion_use_comma_not_semicolon,
+        suggestion_use_comma_not_semicolon,
         code = ",",
         applicability = "machine-applicable"
     )]
@@ -695,7 +683,7 @@ pub(crate) enum MatchArmBodyWithoutBracesSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::struct_literal_not_allowed_here)]
+#[diag(parser_struct_literal_not_allowed_here)]
 pub(crate) struct StructLiteralNotAllowedHere {
     #[primary_span]
     pub span: Span,
@@ -704,7 +692,7 @@ pub(crate) struct StructLiteralNotAllowedHere {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+#[multipart_suggestion(suggestion, applicability = "machine-applicable")]
 pub(crate) struct StructLiteralNotAllowedHereSugg {
     #[suggestion_part(code = "(")]
     pub left: Span,
@@ -713,38 +701,38 @@ pub(crate) struct StructLiteralNotAllowedHereSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_interpolated_expression)]
+#[diag(parser_invalid_interpolated_expression)]
 pub(crate) struct InvalidInterpolatedExpression {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::hexadecimal_float_literal_not_supported)]
+#[diag(parser_hexadecimal_float_literal_not_supported)]
 pub(crate) struct HexadecimalFloatLiteralNotSupported {
     #[primary_span]
-    #[label(parser::not_supported)]
+    #[label(parser_not_supported)]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::octal_float_literal_not_supported)]
+#[diag(parser_octal_float_literal_not_supported)]
 pub(crate) struct OctalFloatLiteralNotSupported {
     #[primary_span]
-    #[label(parser::not_supported)]
+    #[label(parser_not_supported)]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::binary_float_literal_not_supported)]
+#[diag(parser_binary_float_literal_not_supported)]
 pub(crate) struct BinaryFloatLiteralNotSupported {
     #[primary_span]
-    #[label(parser::not_supported)]
+    #[label(parser_not_supported)]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_literal_suffix)]
+#[diag(parser_invalid_literal_suffix)]
 pub(crate) struct InvalidLiteralSuffix {
     #[primary_span]
     #[label]
@@ -755,20 +743,20 @@ pub(crate) struct InvalidLiteralSuffix {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_literal_suffix_on_tuple_index)]
+#[diag(parser_invalid_literal_suffix_on_tuple_index)]
 pub(crate) struct InvalidLiteralSuffixOnTupleIndex {
     #[primary_span]
     #[label]
     pub span: Span,
     pub suffix: Symbol,
-    #[help(parser::tuple_exception_line_1)]
-    #[help(parser::tuple_exception_line_2)]
-    #[help(parser::tuple_exception_line_3)]
+    #[help(tuple_exception_line_1)]
+    #[help(tuple_exception_line_2)]
+    #[help(tuple_exception_line_3)]
     pub exception: Option<()>,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::non_string_abi_literal)]
+#[diag(parser_non_string_abi_literal)]
 pub(crate) struct NonStringAbiLiteral {
     #[primary_span]
     #[suggestion(code = "\"C\"", applicability = "maybe-incorrect")]
@@ -776,21 +764,21 @@ pub(crate) struct NonStringAbiLiteral {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::mismatched_closing_delimiter)]
+#[diag(parser_mismatched_closing_delimiter)]
 pub(crate) struct MismatchedClosingDelimiter {
     #[primary_span]
     pub spans: Vec<Span>,
     pub delimiter: String,
-    #[label(parser::label_unmatched)]
+    #[label(label_unmatched)]
     pub unmatched: Span,
-    #[label(parser::label_opening_candidate)]
+    #[label(label_opening_candidate)]
     pub opening_candidate: Option<Span>,
-    #[label(parser::label_unclosed)]
+    #[label(label_unclosed)]
     pub unclosed: Option<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::incorrect_visibility_restriction, code = "E0704")]
+#[diag(parser_incorrect_visibility_restriction, code = "E0704")]
 #[help]
 pub(crate) struct IncorrectVisibilityRestriction {
     #[primary_span]
@@ -800,21 +788,21 @@ pub(crate) struct IncorrectVisibilityRestriction {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::assignment_else_not_allowed)]
+#[diag(parser_assignment_else_not_allowed)]
 pub(crate) struct AssignmentElseNotAllowed {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::expected_statement_after_outer_attr)]
+#[diag(parser_expected_statement_after_outer_attr)]
 pub(crate) struct ExpectedStatementAfterOuterAttr {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::doc_comment_does_not_document_anything, code = "E0585")]
+#[diag(parser_doc_comment_does_not_document_anything, code = "E0585")]
 #[help]
 pub(crate) struct DocCommentDoesNotDocumentAnything {
     #[primary_span]
@@ -824,7 +812,7 @@ pub(crate) struct DocCommentDoesNotDocumentAnything {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::const_let_mutually_exclusive)]
+#[diag(parser_const_let_mutually_exclusive)]
 pub(crate) struct ConstLetMutuallyExclusive {
     #[primary_span]
     #[suggestion(code = "const", applicability = "maybe-incorrect")]
@@ -832,7 +820,7 @@ pub(crate) struct ConstLetMutuallyExclusive {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_expression_in_let_else)]
+#[diag(parser_invalid_expression_in_let_else)]
 pub(crate) struct InvalidExpressionInLetElse {
     #[primary_span]
     pub span: Span,
@@ -842,7 +830,7 @@ pub(crate) struct InvalidExpressionInLetElse {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_curly_in_let_else)]
+#[diag(parser_invalid_curly_in_let_else)]
 pub(crate) struct InvalidCurlyInLetElse {
     #[primary_span]
     pub span: Span,
@@ -851,7 +839,7 @@ pub(crate) struct InvalidCurlyInLetElse {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::compound_assignment_expression_in_let)]
+#[diag(parser_compound_assignment_expression_in_let)]
 #[help]
 pub(crate) struct CompoundAssignmentExpressionInLet {
     #[primary_span]
@@ -860,7 +848,7 @@ pub(crate) struct CompoundAssignmentExpressionInLet {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::suffixed_literal_in_attribute)]
+#[diag(parser_suffixed_literal_in_attribute)]
 #[help]
 pub(crate) struct SuffixedLiteralInAttribute {
     #[primary_span]
@@ -868,7 +856,7 @@ pub(crate) struct SuffixedLiteralInAttribute {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::invalid_meta_item)]
+#[diag(parser_invalid_meta_item)]
 pub(crate) struct InvalidMetaItem {
     #[primary_span]
     pub span: Span,
@@ -877,7 +865,7 @@ pub(crate) struct InvalidMetaItem {
 
 #[derive(Subdiagnostic)]
 #[suggestion_verbose(
-    parser::sugg_escape_to_use_as_identifier,
+    parser_sugg_escape_to_use_as_identifier,
     applicability = "maybe-incorrect",
     code = "r#"
 )]
@@ -888,7 +876,7 @@ pub(crate) struct SuggEscapeToUseAsIdentifier {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::sugg_remove_comma, applicability = "machine-applicable", code = "")]
+#[suggestion(parser_sugg_remove_comma, applicability = "machine-applicable", code = "")]
 pub(crate) struct SuggRemoveComma {
     #[primary_span]
     pub span: Span,
@@ -896,15 +884,15 @@ pub(crate) struct SuggRemoveComma {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum ExpectedIdentifierFound {
-    #[label(parser::expected_identifier_found_reserved_identifier)]
+    #[label(parser_expected_identifier_found_reserved_identifier)]
     ReservedIdentifier(#[primary_span] Span),
-    #[label(parser::expected_identifier_found_keyword)]
+    #[label(parser_expected_identifier_found_keyword)]
     Keyword(#[primary_span] Span),
-    #[label(parser::expected_identifier_found_reserved_keyword)]
+    #[label(parser_expected_identifier_found_reserved_keyword)]
     ReservedKeyword(#[primary_span] Span),
-    #[label(parser::expected_identifier_found_doc_comment)]
+    #[label(parser_expected_identifier_found_doc_comment)]
     DocComment(#[primary_span] Span),
-    #[label(parser::expected_identifier)]
+    #[label(parser_expected_identifier)]
     Other(#[primary_span] Span),
 }
 
@@ -938,18 +926,16 @@ impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedIdentifier {
 
         let mut diag = handler.struct_diagnostic(match token_descr {
             Some(TokenDescription::ReservedIdentifier) => {
-                fluent::parser::expected_identifier_found_reserved_identifier_str
+                fluent::parser_expected_identifier_found_reserved_identifier_str
             }
-            Some(TokenDescription::Keyword) => {
-                fluent::parser::expected_identifier_found_keyword_str
-            }
+            Some(TokenDescription::Keyword) => fluent::parser_expected_identifier_found_keyword_str,
             Some(TokenDescription::ReservedKeyword) => {
-                fluent::parser::expected_identifier_found_reserved_keyword_str
+                fluent::parser_expected_identifier_found_reserved_keyword_str
             }
             Some(TokenDescription::DocComment) => {
-                fluent::parser::expected_identifier_found_doc_comment_str
+                fluent::parser_expected_identifier_found_doc_comment_str
             }
-            None => fluent::parser::expected_identifier_found_str,
+            None => fluent::parser_expected_identifier_found_str,
         });
         diag.set_span(self.span);
         diag.set_arg("token", self.token);
@@ -985,22 +971,22 @@ impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedSemi {
 
         let mut diag = handler.struct_diagnostic(match token_descr {
             Some(TokenDescription::ReservedIdentifier) => {
-                fluent::parser::expected_semi_found_reserved_identifier_str
+                fluent::parser_expected_semi_found_reserved_identifier_str
             }
-            Some(TokenDescription::Keyword) => fluent::parser::expected_semi_found_keyword_str,
+            Some(TokenDescription::Keyword) => fluent::parser_expected_semi_found_keyword_str,
             Some(TokenDescription::ReservedKeyword) => {
-                fluent::parser::expected_semi_found_reserved_keyword_str
+                fluent::parser_expected_semi_found_reserved_keyword_str
             }
             Some(TokenDescription::DocComment) => {
-                fluent::parser::expected_semi_found_doc_comment_str
+                fluent::parser_expected_semi_found_doc_comment_str
             }
-            None => fluent::parser::expected_semi_found_str,
+            None => fluent::parser_expected_semi_found_str,
         });
         diag.set_span(self.span);
         diag.set_arg("token", self.token);
 
         if let Some(unexpected_token_label) = self.unexpected_token_label {
-            diag.span_label(unexpected_token_label, fluent::parser::label_unexpected_token);
+            diag.span_label(unexpected_token_label, fluent::parser_label_unexpected_token);
         }
 
         self.sugg.add_to_diagnostic(&mut diag);
@@ -1012,17 +998,17 @@ impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedSemi {
 #[derive(Subdiagnostic)]
 pub(crate) enum ExpectedSemiSugg {
     #[suggestion(
-        parser::sugg_change_this_to_semi,
+        parser_sugg_change_this_to_semi,
         code = ";",
         applicability = "machine-applicable"
     )]
     ChangeToSemi(#[primary_span] Span),
-    #[suggestion_short(parser::sugg_add_semi, code = ";", applicability = "machine-applicable")]
+    #[suggestion_short(parser_sugg_add_semi, code = ";", applicability = "machine-applicable")]
     AddSemi(#[primary_span] Span),
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::struct_literal_body_without_path)]
+#[diag(parser_struct_literal_body_without_path)]
 pub(crate) struct StructLiteralBodyWithoutPath {
     #[primary_span]
     pub span: Span,
@@ -1031,7 +1017,7 @@ pub(crate) struct StructLiteralBodyWithoutPath {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "has-placeholders")]
+#[multipart_suggestion(suggestion, applicability = "has-placeholders")]
 pub(crate) struct StructLiteralBodyWithoutPathSugg {
     #[suggestion_part(code = "{{ SomeStruct ")]
     pub before: Span,
@@ -1040,7 +1026,7 @@ pub(crate) struct StructLiteralBodyWithoutPathSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::unmatched_angle_brackets)]
+#[diag(parser_unmatched_angle_brackets)]
 pub(crate) struct UnmatchedAngleBrackets {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -1049,7 +1035,7 @@ pub(crate) struct UnmatchedAngleBrackets {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::generic_parameters_without_angle_brackets)]
+#[diag(parser_generic_parameters_without_angle_brackets)]
 pub(crate) struct GenericParamsWithoutAngleBrackets {
     #[primary_span]
     pub span: Span,
@@ -1058,7 +1044,7 @@ pub(crate) struct GenericParamsWithoutAngleBrackets {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+#[multipart_suggestion(suggestion, applicability = "machine-applicable")]
 pub(crate) struct GenericParamsWithoutAngleBracketsSugg {
     #[suggestion_part(code = "<")]
     pub left: Span,
@@ -1067,18 +1053,18 @@ pub(crate) struct GenericParamsWithoutAngleBracketsSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::comparison_operators_cannot_be_chained)]
+#[diag(parser_comparison_operators_cannot_be_chained)]
 pub(crate) struct ComparisonOperatorsCannotBeChained {
     #[primary_span]
     pub span: Vec<Span>,
     #[suggestion_verbose(
-        parser::sugg_turbofish_syntax,
+        parser_sugg_turbofish_syntax,
         code = "::",
         applicability = "maybe-incorrect"
     )]
     pub suggest_turbofish: Option<Span>,
-    #[help(parser::sugg_turbofish_syntax)]
-    #[help(parser::sugg_parentheses_for_function_args)]
+    #[help(parser_sugg_turbofish_syntax)]
+    #[help(sugg_parentheses_for_function_args)]
     pub help_turbofish: Option<()>,
     #[subdiagnostic]
     pub chaining_sugg: Option<ComparisonOperatorsCannotBeChainedSugg>,
@@ -1087,7 +1073,7 @@ pub(crate) struct ComparisonOperatorsCannotBeChained {
 #[derive(Subdiagnostic)]
 pub(crate) enum ComparisonOperatorsCannotBeChainedSugg {
     #[suggestion_verbose(
-        parser::sugg_split_comparison,
+        sugg_split_comparison,
         code = " && {middle_term}",
         applicability = "maybe-incorrect"
     )]
@@ -1096,7 +1082,7 @@ pub(crate) enum ComparisonOperatorsCannotBeChainedSugg {
         span: Span,
         middle_term: String,
     },
-    #[multipart_suggestion(parser::sugg_parenthesize, applicability = "maybe-incorrect")]
+    #[multipart_suggestion(sugg_parenthesize, applicability = "maybe-incorrect")]
     Parenthesize {
         #[suggestion_part(code = "(")]
         left: Span,
@@ -1106,7 +1092,7 @@ pub(crate) enum ComparisonOperatorsCannotBeChainedSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::question_mark_in_type)]
+#[diag(parser_question_mark_in_type)]
 pub(crate) struct QuestionMarkInType {
     #[primary_span]
     #[label]
@@ -1116,7 +1102,7 @@ pub(crate) struct QuestionMarkInType {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+#[multipart_suggestion(suggestion, applicability = "machine-applicable")]
 pub(crate) struct QuestionMarkInTypeSugg {
     #[suggestion_part(code = "Option<")]
     pub left: Span,
@@ -1125,7 +1111,7 @@ pub(crate) struct QuestionMarkInTypeSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::unexpected_parentheses_in_for_head)]
+#[diag(parser_unexpected_parentheses_in_for_head)]
 pub(crate) struct ParenthesesInForHead {
     #[primary_span]
     pub span: Vec<Span>,
@@ -1134,7 +1120,7 @@ pub(crate) struct ParenthesesInForHead {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+#[multipart_suggestion(suggestion, applicability = "machine-applicable")]
 pub(crate) struct ParenthesesInForHeadSugg {
     #[suggestion_part(code = "")]
     pub left: Span,
@@ -1143,7 +1129,7 @@ pub(crate) struct ParenthesesInForHeadSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::doc_comment_on_param_type)]
+#[diag(parser_doc_comment_on_param_type)]
 pub(crate) struct DocCommentOnParamType {
     #[primary_span]
     #[label]
@@ -1151,7 +1137,7 @@ pub(crate) struct DocCommentOnParamType {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::attribute_on_param_type)]
+#[diag(parser_attribute_on_param_type)]
 pub(crate) struct AttributeOnParamType {
     #[primary_span]
     #[label]
@@ -1159,7 +1145,7 @@ pub(crate) struct AttributeOnParamType {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::pattern_method_param_without_body, code = "E0642")]
+#[diag(parser_pattern_method_param_without_body, code = "E0642")]
 pub(crate) struct PatternMethodParamWithoutBody {
     #[primary_span]
     #[suggestion(code = "_", applicability = "machine-applicable")]
@@ -1167,7 +1153,7 @@ pub(crate) struct PatternMethodParamWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::self_param_not_first)]
+#[diag(parser_self_param_not_first)]
 pub(crate) struct SelfParamNotFirst {
     #[primary_span]
     #[label]
@@ -1175,7 +1161,7 @@ pub(crate) struct SelfParamNotFirst {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::const_generic_without_braces)]
+#[diag(parser_const_generic_without_braces)]
 pub(crate) struct ConstGenericWithoutBraces {
     #[primary_span]
     pub span: Span,
@@ -1184,7 +1170,7 @@ pub(crate) struct ConstGenericWithoutBraces {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+#[multipart_suggestion(suggestion, applicability = "machine-applicable")]
 pub(crate) struct ConstGenericWithoutBracesSugg {
     #[suggestion_part(code = "{{ ")]
     pub left: Span,
@@ -1193,7 +1179,7 @@ pub(crate) struct ConstGenericWithoutBracesSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::unexpected_const_param_declaration)]
+#[diag(parser_unexpected_const_param_declaration)]
 pub(crate) struct UnexpectedConstParamDeclaration {
     #[primary_span]
     #[label]
@@ -1204,7 +1190,7 @@ pub(crate) struct UnexpectedConstParamDeclaration {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum UnexpectedConstParamDeclarationSugg {
-    #[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+    #[multipart_suggestion(suggestion, applicability = "machine-applicable")]
     AddParam {
         #[suggestion_part(code = "<{snippet}>")]
         impl_generics: Span,
@@ -1213,7 +1199,7 @@ pub(crate) enum UnexpectedConstParamDeclarationSugg {
         snippet: String,
         ident: String,
     },
-    #[multipart_suggestion(parser::suggestion, applicability = "machine-applicable")]
+    #[multipart_suggestion(suggestion, applicability = "machine-applicable")]
     AppendParam {
         #[suggestion_part(code = ", {snippet}")]
         impl_generics_end: Span,
@@ -1225,7 +1211,7 @@ pub(crate) enum UnexpectedConstParamDeclarationSugg {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::unexpected_const_in_generic_param)]
+#[diag(parser_unexpected_const_in_generic_param)]
 pub(crate) struct UnexpectedConstInGenericParam {
     #[primary_span]
     pub span: Span,
@@ -1234,7 +1220,7 @@ pub(crate) struct UnexpectedConstInGenericParam {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::async_move_order_incorrect)]
+#[diag(parser_async_move_order_incorrect)]
 pub(crate) struct AsyncMoveOrderIncorrect {
     #[primary_span]
     #[suggestion_verbose(code = "async move", applicability = "maybe-incorrect")]
@@ -1242,7 +1228,7 @@ pub(crate) struct AsyncMoveOrderIncorrect {
 }
 
 #[derive(Diagnostic)]
-#[diag(parser::double_colon_in_bound)]
+#[diag(parser_double_colon_in_bound)]
 pub(crate) struct DoubleColonInBound {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -55,7 +55,7 @@ impl<'a> Parser<'a> {
                     let span = self.token.span;
                     let mut err = self.sess.span_diagnostic.struct_span_err_with_code(
                         span,
-                        fluent::parser::inner_doc_comment_not_permitted,
+                        fluent::parser_inner_doc_comment_not_permitted,
                         error_code!(E0753),
                     );
                     if let Some(replacement_span) = self.annotate_following_item_if_applicable(
@@ -66,10 +66,10 @@ impl<'a> Parser<'a> {
                             token::CommentKind::Block => OuterAttributeType::DocBlockComment,
                         },
                     ) {
-                        err.note(fluent::parser::note);
+                        err.note(fluent::note);
                         err.span_suggestion_verbose(
                             replacement_span,
-                            fluent::parser::suggestion,
+                            fluent::suggestion,
                             "",
                             rustc_errors::Applicability::MachineApplicable,
                         );
@@ -173,10 +173,10 @@ impl<'a> Parser<'a> {
             Ok(Some(item)) => {
                 // FIXME(#100717)
                 err.set_arg("item", item.kind.descr());
-                err.span_label(item.span, fluent::parser::label_does_not_annotate_this);
+                err.span_label(item.span, fluent::label_does_not_annotate_this);
                 err.span_suggestion_verbose(
                     replacement_span,
-                    fluent::parser::sugg_change_inner_to_outer,
+                    fluent::sugg_change_inner_to_outer,
                     match attr_type {
                         OuterAttributeType::Attribute => "",
                         OuterAttributeType::DocBlockComment => "*",
@@ -200,27 +200,27 @@ impl<'a> Parser<'a> {
                 Some(InnerAttrForbiddenReason::AfterOuterDocComment { prev_doc_comment_span }) => {
                     let mut diag = self.struct_span_err(
                         attr_sp,
-                        fluent::parser::inner_attr_not_permitted_after_outer_doc_comment,
+                        fluent::parser_inner_attr_not_permitted_after_outer_doc_comment,
                     );
-                    diag.span_label(attr_sp, fluent::parser::label_attr)
-                        .span_label(prev_doc_comment_span, fluent::parser::label_prev_doc_comment);
+                    diag.span_label(attr_sp, fluent::label_attr)
+                        .span_label(prev_doc_comment_span, fluent::label_prev_doc_comment);
                     diag
                 }
                 Some(InnerAttrForbiddenReason::AfterOuterAttribute { prev_outer_attr_sp }) => {
                     let mut diag = self.struct_span_err(
                         attr_sp,
-                        fluent::parser::inner_attr_not_permitted_after_outer_attr,
+                        fluent::parser_inner_attr_not_permitted_after_outer_attr,
                     );
-                    diag.span_label(attr_sp, fluent::parser::label_attr)
-                        .span_label(prev_outer_attr_sp, fluent::parser::label_prev_attr);
+                    diag.span_label(attr_sp, fluent::label_attr)
+                        .span_label(prev_outer_attr_sp, fluent::label_prev_attr);
                     diag
                 }
                 Some(InnerAttrForbiddenReason::InCodeBlock) | None => {
-                    self.struct_span_err(attr_sp, fluent::parser::inner_attr_not_permitted)
+                    self.struct_span_err(attr_sp, fluent::parser_inner_attr_not_permitted)
                 }
             };
 
-            diag.note(fluent::parser::inner_attr_explanation);
+            diag.note(fluent::parser_inner_attr_explanation);
             if self
                 .annotate_following_item_if_applicable(
                     &mut diag,
@@ -229,7 +229,7 @@ impl<'a> Parser<'a> {
                 )
                 .is_some()
             {
-                diag.note(fluent::parser::outer_attr_explanation);
+                diag.note(fluent::parser_outer_attr_explanation);
             };
             diag.emit();
         }

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -926,7 +926,7 @@ impl<'a> Parser<'a> {
                     if self.eat(&token::Gt) {
                         e.span_suggestion_verbose(
                             binop.span.shrink_to_lo(),
-                            fluent::parser::sugg_turbofish_syntax,
+                            fluent::parser_sugg_turbofish_syntax,
                             "::",
                             Applicability::MaybeIncorrect,
                         )

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -822,8 +822,8 @@ impl CheckAttrVisitor<'_> {
             if let Some((prev_inline, prev_span)) = *specified_inline {
                 if do_inline != prev_inline {
                     let mut spans = MultiSpan::from_spans(vec![prev_span, meta.span()]);
-                    spans.push_span_label(prev_span, fluent::passes::doc_inline_conflict_first);
-                    spans.push_span_label(meta.span(), fluent::passes::doc_inline_conflict_second);
+                    spans.push_span_label(prev_span, fluent::passes_doc_inline_conflict_first);
+                    spans.push_span_label(meta.span(), fluent::passes_doc_inline_conflict_second);
                     self.tcx.sess.emit_err(errors::DocKeywordConflict { spans });
                     return false;
                 }
@@ -873,7 +873,7 @@ impl CheckAttrVisitor<'_> {
                 INVALID_DOC_ATTRIBUTES,
                 hir_id,
                 meta.span(),
-                fluent::passes::attr_crate_level,
+                fluent::passes_attr_crate_level,
                 |err| {
                     if attr.style == AttrStyle::Outer
                         && self.tcx.hir().get_parent_item(hir_id) == CRATE_OWNER_ID
@@ -882,15 +882,15 @@ impl CheckAttrVisitor<'_> {
                             src.insert(1, '!');
                             err.span_suggestion_verbose(
                                 attr.span,
-                                fluent::passes::suggestion,
+                                fluent::suggestion,
                                 src,
                                 Applicability::MaybeIncorrect,
                             );
                         } else {
-                            err.span_help(attr.span, fluent::passes::help);
+                            err.span_help(attr.span, fluent::help);
                         }
                     }
-                    err.note(fluent::passes::note);
+                    err.note(fluent::note);
                     err
                 },
             );

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -13,37 +13,37 @@ use rustc_span::{Span, Symbol, DUMMY_SP};
 use crate::lang_items::Duplicate;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::outer_crate_level_attr)]
+#[diag(passes_outer_crate_level_attr)]
 pub struct OuterCrateLevelAttr;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::inner_crate_level_attr)]
+#[diag(passes_inner_crate_level_attr)]
 pub struct InnerCrateLevelAttr;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::ignored_attr_with_macro)]
+#[diag(passes_ignored_attr_with_macro)]
 pub struct IgnoredAttrWithMacro<'a> {
     pub sym: &'a str,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::ignored_attr)]
+#[diag(passes_ignored_attr)]
 pub struct IgnoredAttr<'a> {
     pub sym: &'a str,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::inline_ignored_function_prototype)]
+#[diag(passes_inline_ignored_function_prototype)]
 pub struct IgnoredInlineAttrFnProto;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::inline_ignored_constants)]
+#[diag(passes_inline_ignored_constants)]
 #[warning]
 #[note]
 pub struct IgnoredInlineAttrConstants;
 
 #[derive(Diagnostic)]
-#[diag(passes::inline_not_fn_or_closure, code = "E0518")]
+#[diag(passes_inline_not_fn_or_closure, code = "E0518")]
 pub struct InlineNotFnOrClosure {
     #[primary_span]
     pub attr_span: Span,
@@ -52,19 +52,19 @@ pub struct InlineNotFnOrClosure {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::no_coverage_ignored_function_prototype)]
+#[diag(passes_no_coverage_ignored_function_prototype)]
 pub struct IgnoredNoCoverageFnProto;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::no_coverage_propagate)]
+#[diag(passes_no_coverage_propagate)]
 pub struct IgnoredNoCoveragePropagate;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::no_coverage_fn_defn)]
+#[diag(passes_no_coverage_fn_defn)]
 pub struct IgnoredNoCoverageFnDefn;
 
 #[derive(Diagnostic)]
-#[diag(passes::no_coverage_not_coverable, code = "E0788")]
+#[diag(passes_no_coverage_not_coverable, code = "E0788")]
 pub struct IgnoredNoCoverageNotCoverable {
     #[primary_span]
     pub attr_span: Span,
@@ -73,7 +73,7 @@ pub struct IgnoredNoCoverageNotCoverable {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::should_be_applied_to_fn)]
+#[diag(passes_should_be_applied_to_fn)]
 pub struct AttrShouldBeAppliedToFn {
     #[primary_span]
     pub attr_span: Span,
@@ -82,14 +82,14 @@ pub struct AttrShouldBeAppliedToFn {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::naked_tracked_caller, code = "E0736")]
+#[diag(passes_naked_tracked_caller, code = "E0736")]
 pub struct NakedTrackedCaller {
     #[primary_span]
     pub attr_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::should_be_applied_to_fn, code = "E0739")]
+#[diag(passes_should_be_applied_to_fn, code = "E0739")]
 pub struct TrackedCallerWrongLocation {
     #[primary_span]
     pub attr_span: Span,
@@ -98,7 +98,7 @@ pub struct TrackedCallerWrongLocation {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::should_be_applied_to_struct_enum, code = "E0701")]
+#[diag(passes_should_be_applied_to_struct_enum, code = "E0701")]
 pub struct NonExhaustiveWrongLocation {
     #[primary_span]
     pub attr_span: Span,
@@ -107,7 +107,7 @@ pub struct NonExhaustiveWrongLocation {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::should_be_applied_to_trait)]
+#[diag(passes_should_be_applied_to_trait)]
 pub struct AttrShouldBeAppliedToTrait {
     #[primary_span]
     pub attr_span: Span,
@@ -116,11 +116,11 @@ pub struct AttrShouldBeAppliedToTrait {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::target_feature_on_statement)]
+#[diag(passes_target_feature_on_statement)]
 pub struct TargetFeatureOnStatement;
 
 #[derive(Diagnostic)]
-#[diag(passes::should_be_applied_to_static)]
+#[diag(passes_should_be_applied_to_static)]
 pub struct AttrShouldBeAppliedToStatic {
     #[primary_span]
     pub attr_span: Span,
@@ -129,7 +129,7 @@ pub struct AttrShouldBeAppliedToStatic {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_expect_str)]
+#[diag(passes_doc_expect_str)]
 pub struct DocExpectStr<'a> {
     #[primary_span]
     pub attr_span: Span,
@@ -137,7 +137,7 @@ pub struct DocExpectStr<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_alias_empty)]
+#[diag(passes_doc_alias_empty)]
 pub struct DocAliasEmpty<'a> {
     #[primary_span]
     pub span: Span,
@@ -145,7 +145,7 @@ pub struct DocAliasEmpty<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_alias_bad_char)]
+#[diag(passes_doc_alias_bad_char)]
 pub struct DocAliasBadChar<'a> {
     #[primary_span]
     pub span: Span,
@@ -154,7 +154,7 @@ pub struct DocAliasBadChar<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_alias_start_end)]
+#[diag(passes_doc_alias_start_end)]
 pub struct DocAliasStartEnd<'a> {
     #[primary_span]
     pub span: Span,
@@ -162,7 +162,7 @@ pub struct DocAliasStartEnd<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_alias_bad_location)]
+#[diag(passes_doc_alias_bad_location)]
 pub struct DocAliasBadLocation<'a> {
     #[primary_span]
     pub span: Span,
@@ -171,7 +171,7 @@ pub struct DocAliasBadLocation<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_alias_not_an_alias)]
+#[diag(passes_doc_alias_not_an_alias)]
 pub struct DocAliasNotAnAlias<'a> {
     #[primary_span]
     pub span: Span,
@@ -179,42 +179,42 @@ pub struct DocAliasNotAnAlias<'a> {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_alias_duplicated)]
+#[diag(passes_doc_alias_duplicated)]
 pub struct DocAliasDuplicated {
     #[label]
     pub first_defn: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_alias_not_string_literal)]
+#[diag(passes_doc_alias_not_string_literal)]
 pub struct DocAliasNotStringLiteral {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_alias_malformed)]
+#[diag(passes_doc_alias_malformed)]
 pub struct DocAliasMalformed {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_keyword_empty_mod)]
+#[diag(passes_doc_keyword_empty_mod)]
 pub struct DocKeywordEmptyMod {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_keyword_not_mod)]
+#[diag(passes_doc_keyword_not_mod)]
 pub struct DocKeywordNotMod {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_keyword_invalid_ident)]
+#[diag(passes_doc_keyword_invalid_ident)]
 pub struct DocKeywordInvalidIdent {
     #[primary_span]
     pub span: Span,
@@ -222,21 +222,21 @@ pub struct DocKeywordInvalidIdent {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_fake_variadic_not_valid)]
+#[diag(passes_doc_fake_variadic_not_valid)]
 pub struct DocFakeVariadicNotValid {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_keyword_only_impl)]
+#[diag(passes_doc_keyword_only_impl)]
 pub struct DocKeywordOnlyImpl {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_inline_conflict)]
+#[diag(passes_doc_inline_conflict)]
 #[help]
 pub struct DocKeywordConflict {
     #[primary_span]
@@ -244,17 +244,17 @@ pub struct DocKeywordConflict {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_inline_only_use)]
+#[diag(passes_doc_inline_only_use)]
 #[note]
 pub struct DocInlineOnlyUse {
     #[label]
     pub attr_span: Span,
-    #[label(passes::not_a_use_item_label)]
+    #[label(not_a_use_item_label)]
     pub item_span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::doc_attr_not_crate_level)]
+#[diag(passes_doc_attr_not_crate_level)]
 pub struct DocAttrNotCrateLevel<'a> {
     #[primary_span]
     pub span: Span,
@@ -262,33 +262,33 @@ pub struct DocAttrNotCrateLevel<'a> {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_test_unknown)]
+#[diag(passes_doc_test_unknown)]
 pub struct DocTestUnknown {
     pub path: String,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_test_takes_list)]
+#[diag(passes_doc_test_takes_list)]
 pub struct DocTestTakesList;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_cfg_hide_takes_list)]
+#[diag(passes_doc_cfg_hide_takes_list)]
 pub struct DocCfgHideTakesList;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_primitive)]
+#[diag(passes_doc_primitive)]
 pub struct DocPrimitive;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_test_unknown_any)]
+#[diag(passes_doc_test_unknown_any)]
 pub struct DocTestUnknownAny {
     pub path: String,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_test_unknown_spotlight)]
+#[diag(passes_doc_test_unknown_spotlight)]
 #[note]
-#[note(passes::no_op_note)]
+#[note(no_op_note)]
 pub struct DocTestUnknownSpotlight {
     pub path: String,
     #[suggestion_short(applicability = "machine-applicable", code = "notable_trait")]
@@ -296,7 +296,7 @@ pub struct DocTestUnknownSpotlight {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_test_unknown_include)]
+#[diag(passes_doc_test_unknown_include)]
 pub struct DocTestUnknownInclude {
     pub path: String,
     pub value: String,
@@ -306,11 +306,11 @@ pub struct DocTestUnknownInclude {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::doc_invalid)]
+#[diag(passes_doc_invalid)]
 pub struct DocInvalid;
 
 #[derive(Diagnostic)]
-#[diag(passes::pass_by_value)]
+#[diag(passes_pass_by_value)]
 pub struct PassByValue {
     #[primary_span]
     pub attr_span: Span,
@@ -319,7 +319,7 @@ pub struct PassByValue {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::allow_incoherent_impl)]
+#[diag(passes_allow_incoherent_impl)]
 pub struct AllowIncoherentImpl {
     #[primary_span]
     pub attr_span: Span,
@@ -328,7 +328,7 @@ pub struct AllowIncoherentImpl {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::has_incoherent_inherent_impl)]
+#[diag(passes_has_incoherent_inherent_impl)]
 pub struct HasIncoherentInherentImpl {
     #[primary_span]
     pub attr_span: Span,
@@ -337,21 +337,21 @@ pub struct HasIncoherentInherentImpl {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::must_use_async)]
+#[diag(passes_must_use_async)]
 pub struct MustUseAsync {
     #[label]
     pub span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::must_use_no_effect)]
+#[diag(passes_must_use_no_effect)]
 pub struct MustUseNoEffect {
     pub article: &'static str,
     pub target: rustc_hir::Target,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::must_not_suspend)]
+#[diag(passes_must_not_suspend)]
 pub struct MustNotSuspend {
     #[primary_span]
     pub attr_span: Span,
@@ -360,7 +360,7 @@ pub struct MustNotSuspend {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::cold)]
+#[diag(passes_cold)]
 #[warning]
 pub struct Cold {
     #[label]
@@ -368,7 +368,7 @@ pub struct Cold {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::link)]
+#[diag(passes_link)]
 #[warning]
 pub struct Link {
     #[label]
@@ -376,7 +376,7 @@ pub struct Link {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::link_name)]
+#[diag(passes_link_name)]
 #[warning]
 pub struct LinkName<'a> {
     #[help]
@@ -387,7 +387,7 @@ pub struct LinkName<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::no_link)]
+#[diag(passes_no_link)]
 pub struct NoLink {
     #[primary_span]
     pub attr_span: Span,
@@ -396,7 +396,7 @@ pub struct NoLink {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::export_name)]
+#[diag(passes_export_name)]
 pub struct ExportName {
     #[primary_span]
     pub attr_span: Span,
@@ -405,7 +405,7 @@ pub struct ExportName {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_layout_scalar_valid_range_not_struct)]
+#[diag(passes_rustc_layout_scalar_valid_range_not_struct)]
 pub struct RustcLayoutScalarValidRangeNotStruct {
     #[primary_span]
     pub attr_span: Span,
@@ -414,14 +414,14 @@ pub struct RustcLayoutScalarValidRangeNotStruct {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_layout_scalar_valid_range_arg)]
+#[diag(passes_rustc_layout_scalar_valid_range_arg)]
 pub struct RustcLayoutScalarValidRangeArg {
     #[primary_span]
     pub attr_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_legacy_const_generics_only)]
+#[diag(passes_rustc_legacy_const_generics_only)]
 pub struct RustcLegacyConstGenericsOnly {
     #[primary_span]
     pub attr_span: Span,
@@ -430,7 +430,7 @@ pub struct RustcLegacyConstGenericsOnly {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_legacy_const_generics_index)]
+#[diag(passes_rustc_legacy_const_generics_index)]
 pub struct RustcLegacyConstGenericsIndex {
     #[primary_span]
     pub attr_span: Span,
@@ -439,7 +439,7 @@ pub struct RustcLegacyConstGenericsIndex {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_legacy_const_generics_index_exceed)]
+#[diag(passes_rustc_legacy_const_generics_index_exceed)]
 pub struct RustcLegacyConstGenericsIndexExceed {
     #[primary_span]
     #[label]
@@ -448,21 +448,21 @@ pub struct RustcLegacyConstGenericsIndexExceed {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_legacy_const_generics_index_negative)]
+#[diag(passes_rustc_legacy_const_generics_index_negative)]
 pub struct RustcLegacyConstGenericsIndexNegative {
     #[primary_span]
     pub invalid_args: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_dirty_clean)]
+#[diag(passes_rustc_dirty_clean)]
 pub struct RustcDirtyClean {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::link_section)]
+#[diag(passes_link_section)]
 #[warning]
 pub struct LinkSection {
     #[label]
@@ -470,7 +470,7 @@ pub struct LinkSection {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::no_mangle_foreign)]
+#[diag(passes_no_mangle_foreign)]
 #[warning]
 #[note]
 pub struct NoMangleForeign {
@@ -482,7 +482,7 @@ pub struct NoMangleForeign {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::no_mangle)]
+#[diag(passes_no_mangle)]
 #[warning]
 pub struct NoMangle {
     #[label]
@@ -490,32 +490,32 @@ pub struct NoMangle {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::repr_ident, code = "E0565")]
+#[diag(passes_repr_ident, code = "E0565")]
 pub struct ReprIdent {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::repr_conflicting, code = "E0566")]
+#[diag(passes_repr_conflicting, code = "E0566")]
 pub struct ReprConflicting;
 
 #[derive(Diagnostic)]
-#[diag(passes::used_static)]
+#[diag(passes_used_static)]
 pub struct UsedStatic {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::used_compiler_linker)]
+#[diag(passes_used_compiler_linker)]
 pub struct UsedCompilerLinker {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::allow_internal_unstable)]
+#[diag(passes_allow_internal_unstable)]
 pub struct AllowInternalUnstable {
     #[primary_span]
     pub attr_span: Span,
@@ -524,24 +524,24 @@ pub struct AllowInternalUnstable {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::debug_visualizer_placement)]
+#[diag(passes_debug_visualizer_placement)]
 pub struct DebugVisualizerPlacement {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::debug_visualizer_invalid)]
-#[note(passes::note_1)]
-#[note(passes::note_2)]
-#[note(passes::note_3)]
+#[diag(passes_debug_visualizer_invalid)]
+#[note(note_1)]
+#[note(note_2)]
+#[note(note_3)]
 pub struct DebugVisualizerInvalid {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::debug_visualizer_unreadable)]
+#[diag(passes_debug_visualizer_unreadable)]
 pub struct DebugVisualizerUnreadable<'a> {
     #[primary_span]
     pub span: Span,
@@ -550,7 +550,7 @@ pub struct DebugVisualizerUnreadable<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_allow_const_fn_unstable)]
+#[diag(passes_rustc_allow_const_fn_unstable)]
 pub struct RustcAllowConstFnUnstable {
     #[primary_span]
     pub attr_span: Span,
@@ -559,7 +559,7 @@ pub struct RustcAllowConstFnUnstable {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_std_internal_symbol)]
+#[diag(passes_rustc_std_internal_symbol)]
 pub struct RustcStdInternalSymbol {
     #[primary_span]
     pub attr_span: Span,
@@ -568,56 +568,56 @@ pub struct RustcStdInternalSymbol {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::const_trait)]
+#[diag(passes_const_trait)]
 pub struct ConstTrait {
     #[primary_span]
     pub attr_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::link_ordinal)]
+#[diag(passes_link_ordinal)]
 pub struct LinkOrdinal {
     #[primary_span]
     pub attr_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::stability_promotable)]
+#[diag(passes_stability_promotable)]
 pub struct StabilityPromotable {
     #[primary_span]
     pub attr_span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::deprecated)]
+#[diag(passes_deprecated)]
 pub struct Deprecated;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::macro_use)]
+#[diag(passes_macro_use)]
 pub struct MacroUse {
     pub name: Symbol,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::macro_export)]
+#[diag(passes_macro_export)]
 pub struct MacroExport;
 
 #[derive(LintDiagnostic)]
-#[diag(passes::plugin_registrar)]
+#[diag(passes_plugin_registrar)]
 pub struct PluginRegistrar;
 
 #[derive(Subdiagnostic)]
 pub enum UnusedNote {
-    #[note(passes::unused_empty_lints_note)]
+    #[note(passes_unused_empty_lints_note)]
     EmptyList { name: Symbol },
-    #[note(passes::unused_no_lints_note)]
+    #[note(passes_unused_no_lints_note)]
     NoLints { name: Symbol },
-    #[note(passes::unused_default_method_body_const_note)]
+    #[note(passes_unused_default_method_body_const_note)]
     DefaultMethodBodyConst,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::unused)]
+#[diag(passes_unused)]
 pub struct Unused {
     #[suggestion(code = "", applicability = "machine-applicable")]
     pub attr_span: Span,
@@ -626,7 +626,7 @@ pub struct Unused {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::non_exported_macro_invalid_attrs, code = "E0518")]
+#[diag(passes_non_exported_macro_invalid_attrs, code = "E0518")]
 pub struct NonExportedMacroInvalidAttrs {
     #[primary_span]
     #[label]
@@ -634,7 +634,7 @@ pub struct NonExportedMacroInvalidAttrs {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::unused_duplicate)]
+#[diag(passes_unused_duplicate)]
 pub struct UnusedDuplicate {
     #[suggestion(code = "", applicability = "machine-applicable")]
     pub this: Span,
@@ -645,7 +645,7 @@ pub struct UnusedDuplicate {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unused_multiple)]
+#[diag(passes_unused_multiple)]
 pub struct UnusedMultiple {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -656,7 +656,7 @@ pub struct UnusedMultiple {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_lint_opt_ty)]
+#[diag(passes_rustc_lint_opt_ty)]
 pub struct RustcLintOptTy {
     #[primary_span]
     pub attr_span: Span,
@@ -665,7 +665,7 @@ pub struct RustcLintOptTy {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::rustc_lint_opt_deny_field_access)]
+#[diag(passes_rustc_lint_opt_deny_field_access)]
 pub struct RustcLintOptDenyFieldAccess {
     #[primary_span]
     pub attr_span: Span,
@@ -674,7 +674,7 @@ pub struct RustcLintOptDenyFieldAccess {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::collapse_debuginfo)]
+#[diag(passes_collapse_debuginfo)]
 pub struct CollapseDebuginfo {
     #[primary_span]
     pub attr_span: Span,
@@ -683,14 +683,14 @@ pub struct CollapseDebuginfo {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::deprecated_annotation_has_no_effect)]
+#[diag(passes_deprecated_annotation_has_no_effect)]
 pub struct DeprecatedAnnotationHasNoEffect {
     #[suggestion(applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unknown_external_lang_item, code = "E0264")]
+#[diag(passes_unknown_external_lang_item, code = "E0264")]
 pub struct UnknownExternLangItem {
     #[primary_span]
     pub span: Span,
@@ -698,19 +698,19 @@ pub struct UnknownExternLangItem {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::missing_panic_handler)]
+#[diag(passes_missing_panic_handler)]
 pub struct MissingPanicHandler;
 
 #[derive(Diagnostic)]
-#[diag(passes::alloc_func_required)]
+#[diag(passes_alloc_func_required)]
 pub struct AllocFuncRequired;
 
 #[derive(Diagnostic)]
-#[diag(passes::missing_alloc_error_handler)]
+#[diag(passes_missing_alloc_error_handler)]
 pub struct MissingAllocErrorHandler;
 
 #[derive(Diagnostic)]
-#[diag(passes::missing_lang_item)]
+#[diag(passes_missing_lang_item)]
 #[note]
 #[help]
 pub struct MissingLangItem {
@@ -718,7 +718,7 @@ pub struct MissingLangItem {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::lang_item_on_incorrect_target, code = "E0718")]
+#[diag(passes_lang_item_on_incorrect_target, code = "E0718")]
 pub struct LangItemOnIncorrectTarget {
     #[primary_span]
     #[label]
@@ -729,7 +729,7 @@ pub struct LangItemOnIncorrectTarget {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unknown_lang_item, code = "E0522")]
+#[diag(passes_unknown_lang_item, code = "E0522")]
 pub struct UnknownLangItem {
     #[primary_span]
     #[label]
@@ -748,8 +748,7 @@ impl IntoDiagnostic<'_> for InvalidAttrAtCrateLevel {
         self,
         handler: &'_ rustc_errors::Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag =
-            handler.struct_err(rustc_errors::fluent::passes::invalid_attr_at_crate_level);
+        let mut diag = handler.struct_err(rustc_errors::fluent::passes_invalid_attr_at_crate_level);
         diag.set_span(self.span);
         diag.set_arg("name", self.name);
         // Only emit an error with a suggestion if we can create a string out
@@ -758,7 +757,7 @@ impl IntoDiagnostic<'_> for InvalidAttrAtCrateLevel {
             let replacement = src.replace("#!", "#");
             diag.span_suggestion_verbose(
                 self.span,
-                rustc_errors::fluent::passes::suggestion,
+                rustc_errors::fluent::suggestion,
                 replacement,
                 rustc_errors::Applicability::MachineApplicable,
             );
@@ -768,7 +767,7 @@ impl IntoDiagnostic<'_> for InvalidAttrAtCrateLevel {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::duplicate_diagnostic_item)]
+#[diag(passes_duplicate_diagnostic_item)]
 pub struct DuplicateDiagnosticItem {
     #[primary_span]
     pub span: Span,
@@ -776,9 +775,9 @@ pub struct DuplicateDiagnosticItem {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::duplicate_diagnostic_item_in_crate)]
+#[diag(passes_duplicate_diagnostic_item_in_crate)]
 pub struct DuplicateDiagnosticItemInCrate {
-    #[note(passes::diagnostic_item_first_defined)]
+    #[note(passes_diagnostic_item_first_defined)]
     pub span: Option<Span>,
     pub orig_crate_name: Symbol,
     #[note]
@@ -788,7 +787,7 @@ pub struct DuplicateDiagnosticItemInCrate {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::abi)]
+#[diag(passes_abi)]
 pub struct Abi {
     #[primary_span]
     pub span: Span,
@@ -796,7 +795,7 @@ pub struct Abi {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::align)]
+#[diag(passes_align)]
 pub struct Align {
     #[primary_span]
     pub span: Span,
@@ -804,7 +803,7 @@ pub struct Align {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::size)]
+#[diag(passes_size)]
 pub struct Size {
     #[primary_span]
     pub span: Span,
@@ -812,7 +811,7 @@ pub struct Size {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::homogeneous_aggregate)]
+#[diag(passes_homogeneous_aggregate)]
 pub struct HomogeneousAggregate {
     #[primary_span]
     pub span: Span,
@@ -820,7 +819,7 @@ pub struct HomogeneousAggregate {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::layout_of)]
+#[diag(passes_layout_of)]
 pub struct LayoutOf {
     #[primary_span]
     pub span: Span,
@@ -829,7 +828,7 @@ pub struct LayoutOf {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unrecognized_field)]
+#[diag(passes_unrecognized_field)]
 pub struct UnrecognizedField {
     #[primary_span]
     pub span: Span,
@@ -837,7 +836,7 @@ pub struct UnrecognizedField {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::feature_stable_twice, code = "E0711")]
+#[diag(passes_feature_stable_twice, code = "E0711")]
 pub struct FeatureStableTwice {
     #[primary_span]
     pub span: Span,
@@ -847,7 +846,7 @@ pub struct FeatureStableTwice {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::feature_previously_declared, code = "E0711")]
+#[diag(passes_feature_previously_declared, code = "E0711")]
 pub struct FeaturePreviouslyDeclared<'a, 'b> {
     #[primary_span]
     pub span: Span,
@@ -857,7 +856,7 @@ pub struct FeaturePreviouslyDeclared<'a, 'b> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::expr_not_allowed_in_context, code = "E0744")]
+#[diag(passes_expr_not_allowed_in_context, code = "E0744")]
 pub struct ExprNotAllowedInContext<'a> {
     #[primary_span]
     pub span: Span,
@@ -883,17 +882,17 @@ impl<'a> IntoDiagnostic<'_> for BreakNonLoop<'a> {
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
         let mut diag = handler.struct_span_err_with_code(
             self.span,
-            rustc_errors::fluent::passes::break_non_loop,
+            rustc_errors::fluent::passes_break_non_loop,
             error_code!(E0571),
         );
         diag.set_arg("kind", self.kind);
-        diag.span_label(self.span, rustc_errors::fluent::passes::label);
+        diag.span_label(self.span, rustc_errors::fluent::label);
         if let Some(head) = self.head {
-            diag.span_label(head, rustc_errors::fluent::passes::label2);
+            diag.span_label(head, rustc_errors::fluent::label2);
         }
         diag.span_suggestion(
             self.span,
-            rustc_errors::fluent::passes::suggestion,
+            rustc_errors::fluent::suggestion,
             self.suggestion,
             Applicability::MaybeIncorrect,
         );
@@ -911,7 +910,7 @@ impl<'a> IntoDiagnostic<'_> for BreakNonLoop<'a> {
                 _ => {
                     diag.span_suggestion(
                         self.break_expr_span,
-                        rustc_errors::fluent::passes::break_expr_suggestion,
+                        rustc_errors::fluent::break_expr_suggestion,
                         label.ident,
                         Applicability::MaybeIncorrect,
                     );
@@ -923,39 +922,39 @@ impl<'a> IntoDiagnostic<'_> for BreakNonLoop<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::continue_labeled_block, code = "E0696")]
+#[diag(passes_continue_labeled_block, code = "E0696")]
 pub struct ContinueLabeledBlock {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(passes::block_label)]
+    #[label(block_label)]
     pub block_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::break_inside_closure, code = "E0267")]
+#[diag(passes_break_inside_closure, code = "E0267")]
 pub struct BreakInsideClosure<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(passes::closure_label)]
+    #[label(closure_label)]
     pub closure_span: Span,
     pub name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::break_inside_async_block, code = "E0267")]
+#[diag(passes_break_inside_async_block, code = "E0267")]
 pub struct BreakInsideAsyncBlock<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(passes::async_block_label)]
+    #[label(async_block_label)]
     pub closure_span: Span,
     pub name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::outside_loop, code = "E0268")]
+#[diag(passes_outside_loop, code = "E0268")]
 pub struct OutsideLoop<'a> {
     #[primary_span]
     #[label]
@@ -964,7 +963,7 @@ pub struct OutsideLoop<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unlabeled_in_labeled_block, code = "E0695")]
+#[diag(passes_unlabeled_in_labeled_block, code = "E0695")]
 pub struct UnlabeledInLabeledBlock<'a> {
     #[primary_span]
     #[label]
@@ -973,7 +972,7 @@ pub struct UnlabeledInLabeledBlock<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unlabeled_cf_in_while_condition, code = "E0590")]
+#[diag(passes_unlabeled_cf_in_while_condition, code = "E0590")]
 pub struct UnlabeledCfInWhileCondition<'a> {
     #[primary_span]
     #[label]
@@ -982,25 +981,25 @@ pub struct UnlabeledCfInWhileCondition<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::cannot_inline_naked_function)]
+#[diag(passes_cannot_inline_naked_function)]
 pub struct CannotInlineNakedFunction {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::undefined_naked_function_abi)]
+#[diag(passes_undefined_naked_function_abi)]
 pub struct UndefinedNakedFunctionAbi;
 
 #[derive(Diagnostic)]
-#[diag(passes::no_patterns)]
+#[diag(passes_no_patterns)]
 pub struct NoPatterns {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::params_not_allowed)]
+#[diag(passes_params_not_allowed)]
 #[help]
 pub struct ParamsNotAllowed {
     #[primary_span]
@@ -1020,28 +1019,28 @@ impl IntoDiagnostic<'_> for NakedFunctionsAsmBlock {
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
         let mut diag = handler.struct_span_err_with_code(
             self.span,
-            rustc_errors::fluent::passes::naked_functions_asm_block,
+            rustc_errors::fluent::passes_naked_functions_asm_block,
             error_code!(E0787),
         );
         for span in self.multiple_asms.iter() {
-            diag.span_label(*span, rustc_errors::fluent::passes::label_multiple_asm);
+            diag.span_label(*span, rustc_errors::fluent::label_multiple_asm);
         }
         for span in self.non_asms.iter() {
-            diag.span_label(*span, rustc_errors::fluent::passes::label_non_asm);
+            diag.span_label(*span, rustc_errors::fluent::label_non_asm);
         }
         diag
     }
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::naked_functions_operands, code = "E0787")]
+#[diag(passes_naked_functions_operands, code = "E0787")]
 pub struct NakedFunctionsOperands {
     #[primary_span]
     pub unsupported_operands: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::naked_functions_asm_options, code = "E0787")]
+#[diag(passes_naked_functions_asm_options, code = "E0787")]
 pub struct NakedFunctionsAsmOptions {
     #[primary_span]
     pub span: Span,
@@ -1049,7 +1048,7 @@ pub struct NakedFunctionsAsmOptions {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::naked_functions_must_use_noreturn, code = "E0787")]
+#[diag(passes_naked_functions_must_use_noreturn, code = "E0787")]
 pub struct NakedFunctionsMustUseNoreturn {
     #[primary_span]
     pub span: Span,
@@ -1058,7 +1057,7 @@ pub struct NakedFunctionsMustUseNoreturn {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::attr_only_on_main)]
+#[diag(passes_attr_only_on_main)]
 pub struct AttrOnlyOnMain {
     #[primary_span]
     pub span: Span,
@@ -1066,7 +1065,7 @@ pub struct AttrOnlyOnMain {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::attr_only_on_root_main)]
+#[diag(passes_attr_only_on_root_main)]
 pub struct AttrOnlyOnRootMain {
     #[primary_span]
     pub span: Span,
@@ -1074,7 +1073,7 @@ pub struct AttrOnlyOnRootMain {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::attr_only_in_functions)]
+#[diag(passes_attr_only_in_functions)]
 pub struct AttrOnlyInFunctions {
     #[primary_span]
     pub span: Span,
@@ -1082,43 +1081,43 @@ pub struct AttrOnlyInFunctions {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::multiple_rustc_main, code = "E0137")]
+#[diag(passes_multiple_rustc_main, code = "E0137")]
 pub struct MultipleRustcMain {
     #[primary_span]
     pub span: Span,
-    #[label(passes::first)]
+    #[label(first)]
     pub first: Span,
-    #[label(passes::additional)]
+    #[label(additional)]
     pub additional: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::multiple_start_functions, code = "E0138")]
+#[diag(passes_multiple_start_functions, code = "E0138")]
 pub struct MultipleStartFunctions {
     #[primary_span]
     pub span: Span,
     #[label]
     pub labeled: Span,
-    #[label(passes::previous)]
+    #[label(previous)]
     pub previous: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::extern_main)]
+#[diag(passes_extern_main)]
 pub struct ExternMain {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unix_sigpipe_values)]
+#[diag(passes_unix_sigpipe_values)]
 pub struct UnixSigpipeValues {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::no_main_function, code = "E0601")]
+#[diag(passes_no_main_function, code = "E0601")]
 pub struct NoMainFunction {
     #[primary_span]
     pub span: Span,
@@ -1143,7 +1142,7 @@ impl<'a> IntoDiagnostic<'a> for NoMainErr {
     ) -> rustc_errors::DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut diag = handler.struct_span_err_with_code(
             DUMMY_SP,
-            rustc_errors::fluent::passes::no_main_function,
+            rustc_errors::fluent::passes_no_main_function,
             error_code!(E0601),
         );
         diag.set_arg("crate_name", self.crate_name);
@@ -1151,16 +1150,16 @@ impl<'a> IntoDiagnostic<'a> for NoMainErr {
         diag.set_arg("has_filename", self.has_filename);
         let note = if !self.non_main_fns.is_empty() {
             for &span in &self.non_main_fns {
-                diag.span_note(span, rustc_errors::fluent::passes::here_is_main);
+                diag.span_note(span, rustc_errors::fluent::here_is_main);
             }
-            diag.note(rustc_errors::fluent::passes::one_or_more_possible_main);
-            diag.help(rustc_errors::fluent::passes::consider_moving_main);
+            diag.note(rustc_errors::fluent::one_or_more_possible_main);
+            diag.help(rustc_errors::fluent::consider_moving_main);
             // There were some functions named `main` though. Try to give the user a hint.
-            rustc_errors::fluent::passes::main_must_be_defined_at_crate
+            rustc_errors::fluent::main_must_be_defined_at_crate
         } else if self.has_filename {
-            rustc_errors::fluent::passes::consider_adding_main_to_file
+            rustc_errors::fluent::consider_adding_main_to_file
         } else {
-            rustc_errors::fluent::passes::consider_adding_main_at_crate
+            rustc_errors::fluent::consider_adding_main_at_crate
         };
         if self.file_empty {
             diag.note(note);
@@ -1171,11 +1170,11 @@ impl<'a> IntoDiagnostic<'a> for NoMainErr {
 
         if let Some(main_def) = self.main_def_opt && main_def.opt_fn_def_id().is_none(){
             // There is something at `crate::main`, but it is not a function definition.
-            diag.span_label(main_def.span, rustc_errors::fluent::passes::non_function_main);
+            diag.span_label(main_def.span, rustc_errors::fluent::non_function_main);
         }
 
         if self.add_teach_note {
-            diag.note(rustc_errors::fluent::passes::teach_note);
+            diag.note(rustc_errors::fluent::teach_note);
         }
         diag
     }
@@ -1203,11 +1202,11 @@ impl IntoDiagnostic<'_> for DuplicateLangItem {
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
         let mut diag = handler.struct_err_with_code(
             match self.duplicate {
-                Duplicate::Plain => rustc_errors::fluent::passes::duplicate_lang_item,
+                Duplicate::Plain => rustc_errors::fluent::passes_duplicate_lang_item,
 
-                Duplicate::Crate => rustc_errors::fluent::passes::duplicate_lang_item_crate,
+                Duplicate::Crate => rustc_errors::fluent::passes_duplicate_lang_item_crate,
                 Duplicate::CrateDepends => {
-                    rustc_errors::fluent::passes::duplicate_lang_item_crate_depends
+                    rustc_errors::fluent::passes_duplicate_lang_item_crate_depends
                 }
             },
             error_code!(E0152),
@@ -1223,24 +1222,24 @@ impl IntoDiagnostic<'_> for DuplicateLangItem {
             diag.set_span(span);
         }
         if let Some(span) = self.first_defined_span {
-            diag.span_note(span, rustc_errors::fluent::passes::first_defined_span);
+            diag.span_note(span, rustc_errors::fluent::first_defined_span);
         } else {
             if self.orig_dependency_of.is_empty() {
-                diag.note(rustc_errors::fluent::passes::first_defined_crate);
+                diag.note(rustc_errors::fluent::first_defined_crate);
             } else {
-                diag.note(rustc_errors::fluent::passes::first_defined_crate_depends);
+                diag.note(rustc_errors::fluent::first_defined_crate_depends);
             }
 
             if self.orig_is_local {
-                diag.note(rustc_errors::fluent::passes::first_definition_local);
+                diag.note(rustc_errors::fluent::first_definition_local);
             } else {
-                diag.note(rustc_errors::fluent::passes::first_definition_path);
+                diag.note(rustc_errors::fluent::first_definition_path);
             }
 
             if self.is_local {
-                diag.note(rustc_errors::fluent::passes::second_definition_local);
+                diag.note(rustc_errors::fluent::second_definition_local);
             } else {
-                diag.note(rustc_errors::fluent::passes::second_definition_path);
+                diag.note(rustc_errors::fluent::second_definition_path);
             }
         }
         diag
@@ -1248,7 +1247,7 @@ impl IntoDiagnostic<'_> for DuplicateLangItem {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::incorrect_target, code = "E0718")]
+#[diag(passes_incorrect_target, code = "E0718")]
 pub struct IncorrectTarget<'a> {
     #[primary_span]
     pub span: Span,
@@ -1262,21 +1261,21 @@ pub struct IncorrectTarget<'a> {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::useless_assignment)]
+#[diag(passes_useless_assignment)]
 pub struct UselessAssignment<'a> {
     pub is_field_assign: bool,
     pub ty: Ty<'a>,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(passes::only_has_effect_on)]
+#[diag(passes_only_has_effect_on)]
 pub struct OnlyHasEffectOn {
     pub attr_name: Symbol,
     pub target_name: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::object_lifetime_err)]
+#[diag(passes_object_lifetime_err)]
 pub struct ObjectLifetimeErr {
     #[primary_span]
     pub span: Span,
@@ -1284,7 +1283,7 @@ pub struct ObjectLifetimeErr {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unrecognized_repr_hint, code = "E0552")]
+#[diag(passes_unrecognized_repr_hint, code = "E0552")]
 #[help]
 pub struct UnrecognizedReprHint {
     #[primary_span]
@@ -1293,35 +1292,35 @@ pub struct UnrecognizedReprHint {
 
 #[derive(Diagnostic)]
 pub enum AttrApplication {
-    #[diag(passes::attr_application_enum, code = "E0517")]
+    #[diag(passes_attr_application_enum, code = "E0517")]
     Enum {
         #[primary_span]
         hint_span: Span,
         #[label]
         span: Span,
     },
-    #[diag(passes::attr_application_struct, code = "E0517")]
+    #[diag(passes_attr_application_struct, code = "E0517")]
     Struct {
         #[primary_span]
         hint_span: Span,
         #[label]
         span: Span,
     },
-    #[diag(passes::attr_application_struct_union, code = "E0517")]
+    #[diag(passes_attr_application_struct_union, code = "E0517")]
     StructUnion {
         #[primary_span]
         hint_span: Span,
         #[label]
         span: Span,
     },
-    #[diag(passes::attr_application_struct_enum_union, code = "E0517")]
+    #[diag(passes_attr_application_struct_enum_union, code = "E0517")]
     StructEnumUnion {
         #[primary_span]
         hint_span: Span,
         #[label]
         span: Span,
     },
-    #[diag(passes::attr_application_struct_enum_function_union, code = "E0517")]
+    #[diag(passes_attr_application_struct_enum_function_union, code = "E0517")]
     StructEnumFunctionUnion {
         #[primary_span]
         hint_span: Span,
@@ -1331,7 +1330,7 @@ pub enum AttrApplication {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::transparent_incompatible, code = "E0692")]
+#[diag(passes_transparent_incompatible, code = "E0692")]
 pub struct TransparentIncompatible {
     #[primary_span]
     pub hint_spans: Vec<Span>,
@@ -1339,54 +1338,54 @@ pub struct TransparentIncompatible {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::deprecated_attribute, code = "E0549")]
+#[diag(passes_deprecated_attribute, code = "E0549")]
 pub struct DeprecatedAttribute {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::useless_stability)]
+#[diag(passes_useless_stability)]
 pub struct UselessStability {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(passes::item)]
+    #[label(item)]
     pub item_sp: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::invalid_stability)]
+#[diag(passes_invalid_stability)]
 pub struct InvalidStability {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(passes::item)]
+    #[label(item)]
     pub item_sp: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::cannot_stabilize_deprecated)]
+#[diag(passes_cannot_stabilize_deprecated)]
 pub struct CannotStabilizeDeprecated {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(passes::item)]
+    #[label(item)]
     pub item_sp: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::invalid_deprecation_version)]
+#[diag(passes_invalid_deprecation_version)]
 pub struct InvalidDeprecationVersion {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(passes::item)]
+    #[label(item)]
     pub item_sp: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::missing_stability_attr)]
+#[diag(passes_missing_stability_attr)]
 pub struct MissingStabilityAttr<'a> {
     #[primary_span]
     pub span: Span,
@@ -1394,7 +1393,7 @@ pub struct MissingStabilityAttr<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::missing_const_stab_attr)]
+#[diag(passes_missing_const_stab_attr)]
 pub struct MissingConstStabAttr<'a> {
     #[primary_span]
     pub span: Span,
@@ -1402,7 +1401,7 @@ pub struct MissingConstStabAttr<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::trait_impl_const_stable)]
+#[diag(passes_trait_impl_const_stable)]
 #[note]
 pub struct TraitImplConstStable {
     #[primary_span]
@@ -1410,7 +1409,7 @@ pub struct TraitImplConstStable {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::feature_only_on_nightly, code = "E0554")]
+#[diag(passes_feature_only_on_nightly, code = "E0554")]
 pub struct FeatureOnlyOnNightly {
     #[primary_span]
     pub span: Span,
@@ -1418,7 +1417,7 @@ pub struct FeatureOnlyOnNightly {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::unknown_feature, code = "E0635")]
+#[diag(passes_unknown_feature, code = "E0635")]
 pub struct UnknownFeature {
     #[primary_span]
     pub span: Span,
@@ -1426,7 +1425,7 @@ pub struct UnknownFeature {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::implied_feature_not_exist)]
+#[diag(passes_implied_feature_not_exist)]
 pub struct ImpliedFeatureNotExist {
     #[primary_span]
     pub span: Span,
@@ -1435,14 +1434,14 @@ pub struct ImpliedFeatureNotExist {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes::duplicate_feature_err, code = "E0636")]
+#[diag(passes_duplicate_feature_err, code = "E0636")]
 pub struct DuplicateFeatureErr {
     #[primary_span]
     pub span: Span,
     pub feature: Symbol,
 }
 #[derive(Diagnostic)]
-#[diag(passes::missing_const_err)]
+#[diag(passes_missing_const_err)]
 pub struct MissingConstErr {
     #[primary_span]
     #[help]

--- a/compiler/rustc_plugin_impl/src/errors.rs
+++ b/compiler/rustc_plugin_impl/src/errors.rs
@@ -4,7 +4,7 @@ use rustc_macros::Diagnostic;
 use rustc_span::Span;
 
 #[derive(Diagnostic)]
-#[diag(plugin_impl::load_plugin_error)]
+#[diag(plugin_impl_load_plugin_error)]
 pub struct LoadPluginError {
     #[primary_span]
     pub span: Span,
@@ -12,7 +12,7 @@ pub struct LoadPluginError {
 }
 
 #[derive(Diagnostic)]
-#[diag(plugin_impl::malformed_plugin_attribute, code = "E0498")]
+#[diag(plugin_impl_malformed_plugin_attribute, code = "E0498")]
 pub struct MalformedPluginAttribute {
     #[primary_span]
     #[label]

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -3,7 +3,7 @@ use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
-#[diag(privacy::field_is_private, code = "E0451")]
+#[diag(privacy_field_is_private, code = "E0451")]
 pub struct FieldIsPrivate {
     #[primary_span]
     pub span: Span,
@@ -16,13 +16,13 @@ pub struct FieldIsPrivate {
 
 #[derive(Subdiagnostic)]
 pub enum FieldIsPrivateLabel {
-    #[label(privacy::field_is_private_is_update_syntax_label)]
+    #[label(privacy_field_is_private_is_update_syntax_label)]
     IsUpdateSyntax {
         #[primary_span]
         span: Span,
         field_name: Symbol,
     },
-    #[label(privacy::field_is_private_label)]
+    #[label(privacy_field_is_private_label)]
     Other {
         #[primary_span]
         span: Span,
@@ -30,7 +30,7 @@ pub enum FieldIsPrivateLabel {
 }
 
 #[derive(Diagnostic)]
-#[diag(privacy::item_is_private)]
+#[diag(privacy_item_is_private)]
 pub struct ItemIsPrivate<'a> {
     #[primary_span]
     #[label]
@@ -40,7 +40,7 @@ pub struct ItemIsPrivate<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(privacy::unnamed_item_is_private)]
+#[diag(privacy_unnamed_item_is_private)]
 pub struct UnnamedItemIsPrivate {
     #[primary_span]
     pub span: Span,
@@ -49,7 +49,7 @@ pub struct UnnamedItemIsPrivate {
 
 // Duplicate of `InPublicInterface` but with a different error code, shares the same slug.
 #[derive(Diagnostic)]
-#[diag(privacy::in_public_interface, code = "E0445")]
+#[diag(privacy_in_public_interface, code = "E0445")]
 pub struct InPublicInterfaceTraits<'a> {
     #[primary_span]
     #[label]
@@ -57,13 +57,13 @@ pub struct InPublicInterfaceTraits<'a> {
     pub vis_descr: &'static str,
     pub kind: &'a str,
     pub descr: DiagnosticArgFromDisplay<'a>,
-    #[label(privacy::visibility_label)]
+    #[label(visibility_label)]
     pub vis_span: Span,
 }
 
 // Duplicate of `InPublicInterfaceTraits` but with a different error code, shares the same slug.
 #[derive(Diagnostic)]
-#[diag(privacy::in_public_interface, code = "E0446")]
+#[diag(privacy_in_public_interface, code = "E0446")]
 pub struct InPublicInterface<'a> {
     #[primary_span]
     #[label]
@@ -71,12 +71,12 @@ pub struct InPublicInterface<'a> {
     pub vis_descr: &'static str,
     pub kind: &'a str,
     pub descr: DiagnosticArgFromDisplay<'a>,
-    #[label(privacy::visibility_label)]
+    #[label(visibility_label)]
     pub vis_span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(privacy::report_effective_visibility)]
+#[diag(privacy_report_effective_visibility)]
 pub struct ReportEffectiveVisibility {
     #[primary_span]
     pub span: Span,
@@ -84,7 +84,7 @@ pub struct ReportEffectiveVisibility {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(privacy::from_private_dep_in_public_interface)]
+#[diag(privacy_from_private_dep_in_public_interface)]
 pub struct FromPrivateDependencyInPublicInterface<'a> {
     pub kind: &'a str,
     pub descr: DiagnosticArgFromDisplay<'a>,
@@ -92,7 +92,7 @@ pub struct FromPrivateDependencyInPublicInterface<'a> {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(privacy::private_in_public_lint)]
+#[diag(privacy_private_in_public_lint)]
 pub struct PrivateInPublicLint<'a> {
     pub vis_descr: &'static str,
     pub kind: &'a str,

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -3,7 +3,7 @@ use rustc_session::Limit;
 use rustc_span::{Span, Symbol};
 
 #[derive(Subdiagnostic)]
-#[note(query_system::cycle_stack_middle)]
+#[note(query_system_cycle_stack_middle)]
 pub struct CycleStack {
     #[primary_span]
     pub span: Span,
@@ -19,24 +19,24 @@ pub enum HandleCycleError {
 
 #[derive(Subdiagnostic)]
 pub enum StackCount {
-    #[note(query_system::cycle_stack_single)]
+    #[note(query_system_cycle_stack_single)]
     Single,
-    #[note(query_system::cycle_stack_multiple)]
+    #[note(query_system_cycle_stack_multiple)]
     Multiple,
 }
 
 #[derive(Subdiagnostic)]
 pub enum Alias {
-    #[note(query_system::cycle_recursive_ty_alias)]
-    #[help(query_system::cycle_recursive_ty_alias_help1)]
-    #[help(query_system::cycle_recursive_ty_alias_help2)]
+    #[note(query_system_cycle_recursive_ty_alias)]
+    #[help(query_system_cycle_recursive_ty_alias_help1)]
+    #[help(query_system_cycle_recursive_ty_alias_help2)]
     Ty,
-    #[note(query_system::cycle_recursive_trait_alias)]
+    #[note(query_system_cycle_recursive_trait_alias)]
     Trait,
 }
 
 #[derive(Subdiagnostic)]
-#[note(query_system::cycle_usage)]
+#[note(query_system_cycle_usage)]
 pub struct CycleUsage {
     #[primary_span]
     pub span: Span,
@@ -44,7 +44,7 @@ pub struct CycleUsage {
 }
 
 #[derive(Diagnostic)]
-#[diag(query_system::cycle, code = "E0391")]
+#[diag(query_system_cycle, code = "E0391")]
 pub struct Cycle {
     #[primary_span]
     pub span: Span,
@@ -60,14 +60,14 @@ pub struct Cycle {
 }
 
 #[derive(Diagnostic)]
-#[diag(query_system::reentrant)]
+#[diag(query_system_reentrant)]
 pub struct Reentrant;
 
 #[derive(Diagnostic)]
-#[diag(query_system::increment_compilation)]
+#[diag(query_system_increment_compilation)]
 #[help]
-#[note(query_system::increment_compilation_note1)]
-#[note(query_system::increment_compilation_note2)]
+#[note(query_system_increment_compilation_note1)]
+#[note(query_system_increment_compilation_note2)]
 pub struct IncrementCompilation {
     pub run_cmd: String,
     pub dep_node: String,
@@ -75,7 +75,7 @@ pub struct IncrementCompilation {
 
 #[derive(Diagnostic)]
 #[help]
-#[diag(query_system::query_overflow)]
+#[diag(query_system_query_overflow)]
 pub struct QueryOverflow {
     #[primary_span]
     pub span: Option<Span>,
@@ -86,7 +86,7 @@ pub struct QueryOverflow {
 }
 
 #[derive(Subdiagnostic)]
-#[note(query_system::layout_of_depth)]
+#[note(query_system_layout_of_depth)]
 pub struct LayoutOfDepth {
     pub desc: String,
     pub depth: usize,

--- a/compiler/rustc_save_analysis/src/errors.rs
+++ b/compiler/rustc_save_analysis/src/errors.rs
@@ -3,7 +3,7 @@ use rustc_macros::Diagnostic;
 use std::path::Path;
 
 #[derive(Diagnostic)]
-#[diag(save_analysis::could_not_open)]
+#[diag(save_analysis_could_not_open)]
 pub(crate) struct CouldNotOpen<'a> {
     pub file_name: &'a Path,
     pub err: std::io::Error,

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_span::{Span, Symbol};
 use rustc_target::spec::{SplitDebuginfo, StackProtector, TargetTriple};
 
 #[derive(Diagnostic)]
-#[diag(session::incorrect_cgu_reuse_type)]
+#[diag(session_incorrect_cgu_reuse_type)]
 pub struct IncorrectCguReuseType<'a> {
     #[primary_span]
     pub span: Span,
@@ -18,14 +18,14 @@ pub struct IncorrectCguReuseType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(session::cgu_not_recorded)]
+#[diag(session_cgu_not_recorded)]
 pub struct CguNotRecorded<'a> {
     pub cgu_user_name: &'a str,
     pub cgu_name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::feature_gate_error, code = "E0658")]
+#[diag(session_feature_gate_error, code = "E0658")]
 pub struct FeatureGateError<'a> {
     #[primary_span]
     pub span: MultiSpan,
@@ -33,99 +33,99 @@ pub struct FeatureGateError<'a> {
 }
 
 #[derive(Subdiagnostic)]
-#[note(session::feature_diagnostic_for_issue)]
+#[note(session_feature_diagnostic_for_issue)]
 pub struct FeatureDiagnosticForIssue {
     pub n: NonZeroU32,
 }
 
 #[derive(Subdiagnostic)]
-#[help(session::feature_diagnostic_help)]
+#[help(session_feature_diagnostic_help)]
 pub struct FeatureDiagnosticHelp {
     pub feature: Symbol,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::not_circumvent_feature)]
+#[diag(session_not_circumvent_feature)]
 pub struct NotCircumventFeature;
 
 #[derive(Diagnostic)]
-#[diag(session::linker_plugin_lto_windows_not_supported)]
+#[diag(session_linker_plugin_lto_windows_not_supported)]
 pub struct LinkerPluginToWindowsNotSupported;
 
 #[derive(Diagnostic)]
-#[diag(session::profile_use_file_does_not_exist)]
+#[diag(session_profile_use_file_does_not_exist)]
 pub struct ProfileUseFileDoesNotExist<'a> {
     pub path: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::profile_sample_use_file_does_not_exist)]
+#[diag(session_profile_sample_use_file_does_not_exist)]
 pub struct ProfileSampleUseFileDoesNotExist<'a> {
     pub path: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::target_requires_unwind_tables)]
+#[diag(session_target_requires_unwind_tables)]
 pub struct TargetRequiresUnwindTables;
 
 #[derive(Diagnostic)]
-#[diag(session::sanitizer_not_supported)]
+#[diag(session_sanitizer_not_supported)]
 pub struct SanitizerNotSupported {
     pub us: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::sanitizers_not_supported)]
+#[diag(session_sanitizers_not_supported)]
 pub struct SanitizersNotSupported {
     pub us: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::cannot_mix_and_match_sanitizers)]
+#[diag(session_cannot_mix_and_match_sanitizers)]
 pub struct CannotMixAndMatchSanitizers {
     pub first: String,
     pub second: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::cannot_enable_crt_static_linux)]
+#[diag(session_cannot_enable_crt_static_linux)]
 pub struct CannotEnableCrtStaticLinux;
 
 #[derive(Diagnostic)]
-#[diag(session::sanitizer_cfi_enabled)]
+#[diag(session_sanitizer_cfi_enabled)]
 pub struct SanitizerCfiEnabled;
 
 #[derive(Diagnostic)]
-#[diag(session::unstable_virtual_function_elimination)]
+#[diag(session_unstable_virtual_function_elimination)]
 pub struct UnstableVirtualFunctionElimination;
 
 #[derive(Diagnostic)]
-#[diag(session::unsupported_dwarf_version)]
+#[diag(session_unsupported_dwarf_version)]
 pub struct UnsupportedDwarfVersion {
     pub dwarf_version: u32,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::target_stack_protector_not_supported)]
+#[diag(session_target_stack_protector_not_supported)]
 pub struct StackProtectorNotSupportedForTarget<'a> {
     pub stack_protector: StackProtector,
     pub target_triple: &'a TargetTriple,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::split_debuginfo_unstable_platform)]
+#[diag(session_split_debuginfo_unstable_platform)]
 pub struct SplitDebugInfoUnstablePlatform {
     pub debuginfo: SplitDebuginfo,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::file_is_not_writeable)]
+#[diag(session_file_is_not_writeable)]
 pub struct FileIsNotWriteable<'a> {
     pub file: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::crate_name_does_not_match)]
+#[diag(session_crate_name_does_not_match)]
 pub struct CrateNameDoesNotMatch<'a> {
     #[primary_span]
     pub span: Span,
@@ -134,20 +134,20 @@ pub struct CrateNameDoesNotMatch<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(session::crate_name_invalid)]
+#[diag(session_crate_name_invalid)]
 pub struct CrateNameInvalid<'a> {
     pub s: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::crate_name_empty)]
+#[diag(session_crate_name_empty)]
 pub struct CrateNameEmpty {
     #[primary_span]
     pub span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag(session::invalid_character_in_create_name)]
+#[diag(session_invalid_character_in_create_name)]
 pub struct InvalidCharacterInCrateName<'a> {
     #[primary_span]
     pub span: Option<Span>,
@@ -156,7 +156,7 @@ pub struct InvalidCharacterInCrateName<'a> {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(session::expr_parentheses_needed, applicability = "machine-applicable")]
+#[multipart_suggestion(session_expr_parentheses_needed, applicability = "machine-applicable")]
 pub struct ExprParenthesesNeeded {
     #[suggestion_part(code = "(")]
     pub left: Span,
@@ -171,7 +171,7 @@ impl ExprParenthesesNeeded {
 }
 
 #[derive(Diagnostic)]
-#[diag(session::skipping_const_checks)]
+#[diag(session_skipping_const_checks)]
 pub struct SkippingConstChecks {
     #[subdiagnostic(eager)]
     pub unleashed_features: Vec<UnleashedFeatureHelp>,
@@ -179,13 +179,13 @@ pub struct SkippingConstChecks {
 
 #[derive(Subdiagnostic)]
 pub enum UnleashedFeatureHelp {
-    #[help(session::unleashed_feature_help_named)]
+    #[help(session_unleashed_feature_help_named)]
     Named {
         #[primary_span]
         span: Span,
         gate: Symbol,
     },
-    #[help(session::unleashed_feature_help_unnamed)]
+    #[help(session_unleashed_feature_help_unnamed)]
     Unnamed {
         #[primary_span]
         span: Span,

--- a/compiler/rustc_symbol_mangling/src/errors.rs
+++ b/compiler/rustc_symbol_mangling/src/errors.rs
@@ -5,7 +5,7 @@ use rustc_macros::Diagnostic;
 use rustc_span::Span;
 
 #[derive(Diagnostic)]
-#[diag(symbol_mangling::test_output)]
+#[diag(symbol_mangling_test_output)]
 pub struct TestOutput {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -5,7 +5,7 @@ use rustc_session::Limit;
 use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
-#[diag(trait_selection::dump_vtable_entries)]
+#[diag(trait_selection_dump_vtable_entries)]
 pub struct DumpVTableEntries<'a> {
     #[primary_span]
     pub span: Span,
@@ -14,7 +14,7 @@ pub struct DumpVTableEntries<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection::unable_to_construct_constant_value)]
+#[diag(trait_selection_unable_to_construct_constant_value)]
 pub struct UnableToConstructConstantValue<'a> {
     #[primary_span]
     pub span: Span,
@@ -23,7 +23,7 @@ pub struct UnableToConstructConstantValue<'a> {
 
 #[derive(Diagnostic)]
 #[help]
-#[diag(trait_selection::auto_deref_reached_recursion_limit, code = "E0055")]
+#[diag(trait_selection_auto_deref_reached_recursion_limit, code = "E0055")]
 pub struct AutoDerefReachedRecursionLimit<'a> {
     #[primary_span]
     #[label]
@@ -34,7 +34,7 @@ pub struct AutoDerefReachedRecursionLimit<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection::empty_on_clause_in_rustc_on_unimplemented, code = "E0232")]
+#[diag(trait_selection_empty_on_clause_in_rustc_on_unimplemented, code = "E0232")]
 pub struct EmptyOnClauseInOnUnimplemented {
     #[primary_span]
     #[label]
@@ -42,7 +42,7 @@ pub struct EmptyOnClauseInOnUnimplemented {
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection::invalid_on_clause_in_rustc_on_unimplemented, code = "E0232")]
+#[diag(trait_selection_invalid_on_clause_in_rustc_on_unimplemented, code = "E0232")]
 pub struct InvalidOnClauseInOnUnimplemented {
     #[primary_span]
     #[label]
@@ -50,7 +50,7 @@ pub struct InvalidOnClauseInOnUnimplemented {
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection::no_value_in_rustc_on_unimplemented, code = "E0232")]
+#[diag(trait_selection_no_value_in_rustc_on_unimplemented, code = "E0232")]
 #[note]
 pub struct NoValueInOnUnimplemented {
     #[primary_span]
@@ -71,7 +71,7 @@ impl IntoDiagnostic<'_> for NegativePositiveConflict<'_> {
         self,
         handler: &Handler,
     ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = handler.struct_err(fluent::trait_selection::negative_positive_conflict);
+        let mut diag = handler.struct_err(fluent::trait_selection_negative_positive_conflict);
         diag.set_arg("trait_desc", self.trait_desc);
         diag.set_arg(
             "self_desc",
@@ -81,19 +81,19 @@ impl IntoDiagnostic<'_> for NegativePositiveConflict<'_> {
         diag.code(rustc_errors::error_code!(E0751));
         match self.negative_impl_span {
             Ok(span) => {
-                diag.span_label(span, fluent::trait_selection::negative_implementation_here);
+                diag.span_label(span, fluent::negative_implementation_here);
             }
             Err(cname) => {
-                diag.note(fluent::trait_selection::negative_implementation_in_crate);
+                diag.note(fluent::negative_implementation_in_crate);
                 diag.set_arg("negative_impl_cname", cname.to_string());
             }
         }
         match self.positive_impl_span {
             Ok(span) => {
-                diag.span_label(span, fluent::trait_selection::positive_implementation_here);
+                diag.span_label(span, fluent::positive_implementation_here);
             }
             Err(cname) => {
-                diag.note(fluent::trait_selection::positive_implementation_in_crate);
+                diag.note(fluent::positive_implementation_in_crate);
                 diag.set_arg("positive_impl_cname", cname.to_string());
             }
         }

--- a/compiler/rustc_ty_utils/src/errors.rs
+++ b/compiler/rustc_ty_utils/src/errors.rs
@@ -5,18 +5,18 @@ use rustc_middle::ty::Ty;
 use rustc_span::Span;
 
 #[derive(Diagnostic)]
-#[diag(ty_utils::needs_drop_overflow)]
+#[diag(ty_utils_needs_drop_overflow)]
 pub struct NeedsDropOverflow<'tcx> {
     pub query_ty: Ty<'tcx>,
 }
 
 #[derive(Diagnostic)]
-#[diag(ty_utils::generic_constant_too_complex)]
+#[diag(ty_utils_generic_constant_too_complex)]
 #[help]
 pub struct GenericConstantTooComplex {
     #[primary_span]
     pub span: Span,
-    #[note(ty_utils::maybe_supported)]
+    #[note(maybe_supported)]
     pub maybe_supported: Option<()>,
     #[subdiagnostic]
     pub sub: GenericConstantTooComplexSub,
@@ -24,46 +24,46 @@ pub struct GenericConstantTooComplex {
 
 #[derive(Subdiagnostic)]
 pub enum GenericConstantTooComplexSub {
-    #[label(ty_utils::borrow_not_supported)]
+    #[label(ty_utils_borrow_not_supported)]
     BorrowNotSupported(#[primary_span] Span),
-    #[label(ty_utils::address_and_deref_not_supported)]
+    #[label(ty_utils_address_and_deref_not_supported)]
     AddressAndDerefNotSupported(#[primary_span] Span),
-    #[label(ty_utils::array_not_supported)]
+    #[label(ty_utils_array_not_supported)]
     ArrayNotSupported(#[primary_span] Span),
-    #[label(ty_utils::block_not_supported)]
+    #[label(ty_utils_block_not_supported)]
     BlockNotSupported(#[primary_span] Span),
-    #[label(ty_utils::never_to_any_not_supported)]
+    #[label(ty_utils_never_to_any_not_supported)]
     NeverToAnyNotSupported(#[primary_span] Span),
-    #[label(ty_utils::tuple_not_supported)]
+    #[label(ty_utils_tuple_not_supported)]
     TupleNotSupported(#[primary_span] Span),
-    #[label(ty_utils::index_not_supported)]
+    #[label(ty_utils_index_not_supported)]
     IndexNotSupported(#[primary_span] Span),
-    #[label(ty_utils::field_not_supported)]
+    #[label(ty_utils_field_not_supported)]
     FieldNotSupported(#[primary_span] Span),
-    #[label(ty_utils::const_block_not_supported)]
+    #[label(ty_utils_const_block_not_supported)]
     ConstBlockNotSupported(#[primary_span] Span),
-    #[label(ty_utils::adt_not_supported)]
+    #[label(ty_utils_adt_not_supported)]
     AdtNotSupported(#[primary_span] Span),
-    #[label(ty_utils::pointer_not_supported)]
+    #[label(ty_utils_pointer_not_supported)]
     PointerNotSupported(#[primary_span] Span),
-    #[label(ty_utils::yield_not_supported)]
+    #[label(ty_utils_yield_not_supported)]
     YieldNotSupported(#[primary_span] Span),
-    #[label(ty_utils::loop_not_supported)]
+    #[label(ty_utils_loop_not_supported)]
     LoopNotSupported(#[primary_span] Span),
-    #[label(ty_utils::box_not_supported)]
+    #[label(ty_utils_box_not_supported)]
     BoxNotSupported(#[primary_span] Span),
-    #[label(ty_utils::binary_not_supported)]
+    #[label(ty_utils_binary_not_supported)]
     BinaryNotSupported(#[primary_span] Span),
-    #[label(ty_utils::logical_op_not_supported)]
+    #[label(ty_utils_logical_op_not_supported)]
     LogicalOpNotSupported(#[primary_span] Span),
-    #[label(ty_utils::assign_not_supported)]
+    #[label(ty_utils_assign_not_supported)]
     AssignNotSupported(#[primary_span] Span),
-    #[label(ty_utils::closure_and_return_not_supported)]
+    #[label(ty_utils_closure_and_return_not_supported)]
     ClosureAndReturnNotSupported(#[primary_span] Span),
-    #[label(ty_utils::control_flow_not_supported)]
+    #[label(ty_utils_control_flow_not_supported)]
     ControlFlowNotSupported(#[primary_span] Span),
-    #[label(ty_utils::inline_asm_not_supported)]
+    #[label(ty_utils_inline_asm_not_supported)]
     InlineAsmNotSupported(#[primary_span] Span),
-    #[label(ty_utils::operation_not_supported)]
+    #[label(ty_utils_operation_not_supported)]
     OperationNotSupported(#[primary_span] Span),
 }

--- a/src/test/ui-fulldeps/fluent-messages/test.rs
+++ b/src/test/ui-fulldeps/fluent-messages/test.rs
@@ -49,6 +49,7 @@ mod duplicate {
     use super::fluent_messages;
 
     fluent_messages! {
+//~^ ERROR the name `a_b_key` is defined multiple times
         a => "./duplicate-a.ftl",
         a_b => "./duplicate-a-b.ftl",
 //~^ ERROR overrides existing message: `a_b_key`
@@ -80,7 +81,7 @@ mod valid {
         valid => "./valid.ftl",
     }
 
-    use self::fluent_generated::{DEFAULT_LOCALE_RESOURCES, valid::key};
+    use self::fluent_generated::{DEFAULT_LOCALE_RESOURCES, valid_key};
 }
 
 mod missing_crate_name {
@@ -93,5 +94,5 @@ mod missing_crate_name {
 //~| ERROR name `with-hyphens` does not start with the crate name
     }
 
-    use self::fluent_generated::{DEFAULT_LOCALE_RESOURCES, test_crate::{foo, with_hyphens}};
+    use self::fluent_generated::{DEFAULT_LOCALE_RESOURCES, test_crate_foo, with_hyphens};
 }

--- a/src/test/ui-fulldeps/fluent-messages/test.stderr
+++ b/src/test/ui-fulldeps/fluent-messages/test.stderr
@@ -30,19 +30,31 @@ error: expected a message field for "missing_message"
   |
 
 error: overrides existing message: `a_b_key`
-  --> $DIR/test.rs:53:16
+  --> $DIR/test.rs:54:16
    |
 LL |         a_b => "./duplicate-a-b.ftl",
    |                ^^^^^^^^^^^^^^^^^^^^^
    |
 help: previously defined in this resource
-  --> $DIR/test.rs:52:14
+  --> $DIR/test.rs:53:14
    |
 LL |         a => "./duplicate-a.ftl",
    |              ^^^^^^^^^^^^^^^^^^^
 
+error[E0428]: the name `a_b_key` is defined multiple times
+  --> $DIR/test.rs:51:5
+   |
+LL |     fluent_messages! {
+   |     ^^^^^^^^^^^^^^^^
+   |     |
+   |     `a_b_key` redefined here
+   |     previous definition of the value `a_b_key` here
+   |
+   = note: os-specific message
+   = note: os-specific message
+
 error: name `slug_with_hyphens_this-slug-has-hyphens` contains a '-' character
-  --> $DIR/test.rs:62:30
+  --> $DIR/test.rs:63:30
    |
 LL |         slug_with_hyphens => "./slug-with-hyphens.ftl",
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +62,7 @@ LL |         slug_with_hyphens => "./slug-with-hyphens.ftl",
    = help: replace any '-'s with '_'s
 
 error: attribute `label-has-hyphens` contains a '-' character
-  --> $DIR/test.rs:71:31
+  --> $DIR/test.rs:72:31
    |
 LL |         label_with_hyphens => "./label-with-hyphens.ftl",
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +70,7 @@ LL |         label_with_hyphens => "./label-with-hyphens.ftl",
    = help: replace any '-'s with '_'s
 
 error: name `with-hyphens` contains a '-' character
-  --> $DIR/test.rs:90:23
+  --> $DIR/test.rs:91:23
    |
 LL |         test_crate => "./missing-crate-name.ftl",
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +78,7 @@ LL |         test_crate => "./missing-crate-name.ftl",
    = help: replace any '-'s with '_'s
 
 error: name `with-hyphens` does not start with the crate name
-  --> $DIR/test.rs:90:23
+  --> $DIR/test.rs:91:23
    |
 LL |         test_crate => "./missing-crate-name.ftl",
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,12 +86,13 @@ LL |         test_crate => "./missing-crate-name.ftl",
    = help: prepend `test_crate_` to the slug name: `test_crate_with_hyphens`
 
 error: name `test-crate_foo` contains a '-' character
-  --> $DIR/test.rs:90:23
+  --> $DIR/test.rs:91:23
    |
 LL |         test_crate => "./missing-crate-name.ftl",
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: replace any '-'s with '_'s
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 
+For more information about this error, try `rustc --explain E0428`.

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.rs
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.rs
@@ -19,14 +19,14 @@ use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::Span;
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct DeriveDiagnostic {
     #[primary_span]
     span: Span,
 }
 
 #[derive(Subdiagnostic)]
-#[note(compiletest::example)]
+#[note(compiletest_example)]
 struct Note {
     #[primary_span]
     span: Span,
@@ -45,7 +45,7 @@ pub struct TranslatableInIntoDiagnostic;
 
 impl<'a> IntoDiagnostic<'a, ErrorGuaranteed> for TranslatableInIntoDiagnostic {
     fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
-        handler.struct_err(fluent::compiletest::example)
+        handler.struct_err(fluent::compiletest_example)
     }
 }
 
@@ -68,12 +68,12 @@ impl AddToDiagnostic for TranslatableInAddToDiagnostic {
     where
         F: Fn(&mut Diagnostic, SubdiagnosticMessage) -> SubdiagnosticMessage,
     {
-        diag.note(fluent::compiletest::note);
+        diag.note(fluent::note);
     }
 }
 
 pub fn make_diagnostics<'a>(handler: &'a Handler) {
-    let _diag = handler.struct_err(fluent::compiletest::example);
+    let _diag = handler.struct_err(fluent::compiletest_example);
     //~^ ERROR diagnostics should only be created in `IntoDiagnostic`/`AddToDiagnostic` impls
 
     let _diag = handler.struct_err("untranslatable diagnostic");

--- a/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
+++ b/src/test/ui-fulldeps/internal-lints/diagnostics.stderr
@@ -19,7 +19,7 @@ LL |         diag.note("untranslatable diagnostic");
 error: diagnostics should only be created in `IntoDiagnostic`/`AddToDiagnostic` impls
   --> $DIR/diagnostics.rs:76:25
    |
-LL |     let _diag = handler.struct_err(fluent::compiletest::example);
+LL |     let _diag = handler.struct_err(fluent::compiletest_example);
    |                         ^^^^^^^^^^
    |
 note: the lint level is defined here

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -28,15 +28,15 @@ use rustc_errors::{Applicability, MultiSpan};
 extern crate rustc_session;
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct Hello {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct HelloWarn {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 //~^ ERROR unsupported type attribute for diagnostic derive enum
 enum DiagnosticOnEnum {
     Foo,
@@ -46,13 +46,13 @@ enum DiagnosticOnEnum {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 #[diag = "E0123"]
 //~^ ERROR `#[diag = ...]` is not a valid attribute
 struct WrongStructAttrStyle {}
 
 #[derive(Diagnostic)]
-#[nonsense(compiletest::example, code = "E0123")]
+#[nonsense(compiletest_example, code = "E0123")]
 //~^ ERROR `#[nonsense(...)]` is not a valid attribute
 //~^^ ERROR diagnostic slug not specified
 //~^^^ ERROR cannot find attribute `nonsense` in this scope
@@ -90,12 +90,12 @@ struct InvalidNestedStructAttr2 {}
 struct InvalidNestedStructAttr3 {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123", slug = "foo")]
+#[diag(compiletest_example, code = "E0123", slug = "foo")]
 //~^ ERROR `#[diag(slug = ...)]` is not a valid attribute
 struct InvalidNestedStructAttr4 {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct WrongPlaceField {
     #[suggestion = "bar"]
     //~^ ERROR `#[suggestion = ...]` is not a valid attribute
@@ -103,20 +103,20 @@ struct WrongPlaceField {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
-#[diag(compiletest::example, code = "E0456")]
+#[diag(compiletest_example, code = "E0123")]
+#[diag(compiletest_example, code = "E0456")]
 //~^ ERROR specified multiple times
 //~^^ ERROR specified multiple times
 struct DiagSpecifiedTwice {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0456", code = "E0457")]
+#[diag(compiletest_example, code = "E0456", code = "E0457")]
 //~^ ERROR specified multiple times
 struct CodeSpecifiedTwice {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, compiletest::example, code = "E0456")]
-//~^ ERROR `#[diag(compiletest::example)]` is not a valid attribute
+#[diag(compiletest_example, compiletest_example, code = "E0456")]
+//~^ ERROR `#[diag(compiletest_example)]` is not a valid attribute
 struct SlugSpecifiedTwice {}
 
 #[derive(Diagnostic)]
@@ -128,11 +128,11 @@ struct KindNotProvided {} //~ ERROR diagnostic slug not specified
 struct SlugNotProvided {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct CodeNotProvided {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct MessageWrongType {
     #[primary_span]
     //~^ ERROR `#[primary_span]` attribute can only be applied to fields of type `Span` or `MultiSpan`
@@ -140,7 +140,7 @@ struct MessageWrongType {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct InvalidPathFieldAttr {
     #[nonsense]
     //~^ ERROR `#[nonsense]` is not a valid attribute
@@ -149,34 +149,34 @@ struct InvalidPathFieldAttr {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithField {
     name: String,
-    #[label(compiletest::label)]
+    #[label(label)]
     span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithMessageAppliedToField {
-    #[label(compiletest::label)]
+    #[label(label)]
     //~^ ERROR the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
     name: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithNonexistentField {
-    #[suggestion(compiletest::suggestion, code = "{name}")]
+    #[suggestion(suggestion, code = "{name}")]
     //~^ ERROR `name` doesn't refer to a field on this type
     suggestion: (Span, Applicability),
 }
 
 #[derive(Diagnostic)]
 //~^ ERROR invalid format string: expected `'}'`
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorMissingClosingBrace {
-    #[suggestion(compiletest::suggestion, code = "{name")]
+    #[suggestion(suggestion, code = "{name")]
     suggestion: (Span, Applicability),
     name: String,
     val: usize,
@@ -184,49 +184,49 @@ struct ErrorMissingClosingBrace {
 
 #[derive(Diagnostic)]
 //~^ ERROR invalid format string: unmatched `}`
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorMissingOpeningBrace {
-    #[suggestion(compiletest::suggestion, code = "name}")]
+    #[suggestion(suggestion, code = "name}")]
     suggestion: (Span, Applicability),
     name: String,
     val: usize,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct LabelOnSpan {
-    #[label(compiletest::label)]
+    #[label(label)]
     sp: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct LabelOnNonSpan {
-    #[label(compiletest::label)]
+    #[label(label)]
     //~^ ERROR the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
     id: u32,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct Suggest {
-    #[suggestion(compiletest::suggestion, code = "This is the suggested code")]
-    #[suggestion_short(compiletest::suggestion, code = "This is the suggested code")]
-    #[suggestion_hidden(compiletest::suggestion, code = "This is the suggested code")]
-    #[suggestion_verbose(compiletest::suggestion, code = "This is the suggested code")]
+    #[suggestion(suggestion, code = "This is the suggested code")]
+    #[suggestion_short(suggestion, code = "This is the suggested code")]
+    #[suggestion_hidden(suggestion, code = "This is the suggested code")]
+    #[suggestion_verbose(suggestion, code = "This is the suggested code")]
     suggestion: (Span, Applicability),
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithoutCode {
-    #[suggestion(compiletest::suggestion)]
+    #[suggestion(suggestion)]
     //~^ ERROR suggestion without `code = "..."`
     suggestion: (Span, Applicability),
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithBadKey {
     #[suggestion(nonsense = "bar")]
     //~^ ERROR `#[suggestion(nonsense = ...)]` is not a valid attribute
@@ -235,7 +235,7 @@ struct SuggestWithBadKey {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithShorthandMsg {
     #[suggestion(msg = "bar")]
     //~^ ERROR `#[suggestion(msg = ...)]` is not a valid attribute
@@ -244,52 +244,52 @@ struct SuggestWithShorthandMsg {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithoutMsg {
     #[suggestion(code = "bar")]
     suggestion: (Span, Applicability),
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithTypesSwapped {
-    #[suggestion(compiletest::suggestion, code = "This is suggested code")]
+    #[suggestion(suggestion, code = "This is suggested code")]
     suggestion: (Applicability, Span),
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithWrongTypeApplicabilityOnly {
-    #[suggestion(compiletest::suggestion, code = "This is suggested code")]
+    #[suggestion(suggestion, code = "This is suggested code")]
     //~^ ERROR wrong field type for suggestion
     suggestion: Applicability,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithSpanOnly {
-    #[suggestion(compiletest::suggestion, code = "This is suggested code")]
+    #[suggestion(suggestion, code = "This is suggested code")]
     suggestion: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithDuplicateSpanAndApplicability {
-    #[suggestion(compiletest::suggestion, code = "This is suggested code")]
+    #[suggestion(suggestion, code = "This is suggested code")]
     suggestion: (Span, Span, Applicability),
     //~^ ERROR specified multiple times
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct SuggestWithDuplicateApplicabilityAndSpan {
-    #[suggestion(compiletest::suggestion, code = "This is suggested code")]
+    #[suggestion(suggestion, code = "This is suggested code")]
     suggestion: (Applicability, Applicability, Span),
     //~^ ERROR specified multiple times
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct WrongKindOfAnnotation {
     #[label = "bar"]
     //~^ ERROR `#[label = ...]` is not a valid attribute
@@ -297,38 +297,38 @@ struct WrongKindOfAnnotation {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct OptionsInErrors {
-    #[label(compiletest::label)]
+    #[label(label)]
     label: Option<Span>,
-    #[suggestion(compiletest::suggestion, code = "...")]
+    #[suggestion(suggestion, code = "...")]
     opt_sugg: Option<(Span, Applicability)>,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0456")]
+#[diag(compiletest_example, code = "E0456")]
 struct MoveOutOfBorrowError<'tcx> {
     name: Ident,
     ty: Ty<'tcx>,
     #[primary_span]
-    #[label(compiletest::label)]
+    #[label(label)]
     span: Span,
-    #[label(compiletest::label)]
+    #[label(label)]
     other_span: Span,
-    #[suggestion(compiletest::suggestion, code = "{name}.clone()")]
+    #[suggestion(suggestion, code = "{name}.clone()")]
     opt_sugg: Option<(Span, Applicability)>,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithLifetime<'a> {
-    #[label(compiletest::label)]
+    #[label(label)]
     span: Span,
     name: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithDefaultLabelAttr<'a> {
     #[label]
     span: Span,
@@ -337,7 +337,7 @@ struct ErrorWithDefaultLabelAttr<'a> {
 
 #[derive(Diagnostic)]
 //~^ ERROR the trait bound `Hello: IntoDiagnosticArg` is not satisfied
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ArgFieldWithoutSkip {
     #[primary_span]
     span: Span,
@@ -345,7 +345,7 @@ struct ArgFieldWithoutSkip {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ArgFieldWithSkip {
     #[primary_span]
     span: Span,
@@ -356,132 +356,132 @@ struct ArgFieldWithSkip {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithSpannedNote {
     #[note]
     span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithSpannedNoteCustom {
-    #[note(compiletest::note)]
+    #[note(note)]
     span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 #[note]
 struct ErrorWithNote {
     val: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
-#[note(compiletest::note)]
+#[diag(compiletest_example, code = "E0123")]
+#[note(note)]
 struct ErrorWithNoteCustom {
     val: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithSpannedHelp {
     #[help]
     span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithSpannedHelpCustom {
-    #[help(compiletest::help)]
+    #[help(help)]
     span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 #[help]
 struct ErrorWithHelp {
     val: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
-#[help(compiletest::help)]
+#[diag(compiletest_example, code = "E0123")]
+#[help(help)]
 struct ErrorWithHelpCustom {
     val: String,
 }
 
 #[derive(Diagnostic)]
 #[help]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithHelpWrongOrder {
     val: String,
 }
 
 #[derive(Diagnostic)]
-#[help(compiletest::help)]
-#[diag(compiletest::example, code = "E0123")]
+#[help(help)]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithHelpCustomWrongOrder {
     val: String,
 }
 
 #[derive(Diagnostic)]
 #[note]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithNoteWrongOrder {
     val: String,
 }
 
 #[derive(Diagnostic)]
-#[note(compiletest::note)]
-#[diag(compiletest::example, code = "E0123")]
+#[note(note)]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithNoteCustomWrongOrder {
     val: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ApplicabilityInBoth {
-    #[suggestion(compiletest::suggestion, code = "...", applicability = "maybe-incorrect")]
+    #[suggestion(suggestion, code = "...", applicability = "maybe-incorrect")]
     //~^ ERROR specified multiple times
     suggestion: (Span, Applicability),
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct InvalidApplicability {
-    #[suggestion(compiletest::suggestion, code = "...", applicability = "batman")]
+    #[suggestion(suggestion, code = "...", applicability = "batman")]
     //~^ ERROR invalid applicability
     suggestion: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ValidApplicability {
-    #[suggestion(compiletest::suggestion, code = "...", applicability = "maybe-incorrect")]
+    #[suggestion(suggestion, code = "...", applicability = "maybe-incorrect")]
     suggestion: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct NoApplicability {
-    #[suggestion(compiletest::suggestion, code = "...")]
+    #[suggestion(suggestion, code = "...")]
     suggestion: Span,
 }
 
 #[derive(Subdiagnostic)]
-#[note(parser::add_paren)]
+#[note(parser_add_paren)]
 struct Note;
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct Subdiagnostic {
     #[subdiagnostic]
     note: Note,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct VecField {
     #[primary_span]
     #[label]
@@ -489,58 +489,58 @@ struct VecField {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct UnitField {
     #[primary_span]
     spans: Span,
     #[help]
     foo: (),
-    #[help(compiletest::help)]
+    #[help(help)]
     bar: (),
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct OptUnitField {
     #[primary_span]
     spans: Span,
     #[help]
     foo: Option<()>,
-    #[help(compiletest::help)]
+    #[help(help)]
     bar: Option<()>,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct LabelWithTrailingPath {
-    #[label(compiletest::label, foo)]
+    #[label(label, foo)]
     //~^ ERROR `#[label(foo)]` is not a valid attribute
     span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct LabelWithTrailingNameValue {
-    #[label(compiletest::label, foo = "...")]
+    #[label(label, foo = "...")]
     //~^ ERROR `#[label(foo = ...)]` is not a valid attribute
     span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct LabelWithTrailingList {
-    #[label(compiletest::label, foo("..."))]
+    #[label(label, foo("..."))]
     //~^ ERROR `#[label(foo(...))]` is not a valid attribute
     span: Span,
 }
 
 #[derive(LintDiagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct LintsGood {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct PrimarySpanOnLint {
     #[primary_span]
     //~^ ERROR `#[primary_span]` is not a valid attribute
@@ -548,42 +548,42 @@ struct PrimarySpanOnLint {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct ErrorWithMultiSpan {
     #[primary_span]
     span: MultiSpan,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 #[warning]
 struct ErrorWithWarn {
     val: String,
 }
 
 #[derive(Diagnostic)]
-#[error(compiletest::example, code = "E0123")]
+#[error(compiletest_example, code = "E0123")]
 //~^ ERROR `#[error(...)]` is not a valid attribute
 //~| ERROR diagnostic slug not specified
 //~| ERROR cannot find attribute `error` in this scope
 struct ErrorAttribute {}
 
 #[derive(Diagnostic)]
-#[warn_(compiletest::example, code = "E0123")]
+#[warn_(compiletest_example, code = "E0123")]
 //~^ ERROR `#[warn_(...)]` is not a valid attribute
 //~| ERROR diagnostic slug not specified
 //~| ERROR cannot find attribute `warn_` in this scope
 struct WarnAttribute {}
 
 #[derive(Diagnostic)]
-#[lint(compiletest::example, code = "E0123")]
+#[lint(compiletest_example, code = "E0123")]
 //~^ ERROR `#[lint(...)]` is not a valid attribute
 //~| ERROR diagnostic slug not specified
 //~| ERROR cannot find attribute `lint` in this scope
 struct LintAttributeOnSessionDiag {}
 
 #[derive(LintDiagnostic)]
-#[lint(compiletest::example, code = "E0123")]
+#[lint(compiletest_example, code = "E0123")]
 //~^ ERROR `#[lint(...)]` is not a valid attribute
 //~| ERROR `#[lint(...)]` is not a valid attribute
 //~| ERROR diagnostic slug not specified
@@ -591,55 +591,55 @@ struct LintAttributeOnSessionDiag {}
 struct LintAttributeOnLintDiag {}
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct DuplicatedSuggestionCode {
-    #[suggestion(compiletest::suggestion, code = "...", code = ",,,")]
+    #[suggestion(suggestion, code = "...", code = ",,,")]
     //~^ ERROR specified multiple times
     suggestion: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct InvalidTypeInSuggestionTuple {
-    #[suggestion(compiletest::suggestion, code = "...")]
+    #[suggestion(suggestion, code = "...")]
     suggestion: (Span, usize),
     //~^ ERROR wrong types for suggestion
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct MissingApplicabilityInSuggestionTuple {
-    #[suggestion(compiletest::suggestion, code = "...")]
+    #[suggestion(suggestion, code = "...")]
     suggestion: (Span,),
     //~^ ERROR wrong types for suggestion
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct MissingCodeInSuggestion {
-    #[suggestion(compiletest::suggestion)]
+    #[suggestion(suggestion)]
     //~^ ERROR suggestion without `code = "..."`
     suggestion: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
-#[multipart_suggestion(compiletest::suggestion)]
+#[diag(compiletest_example, code = "E0123")]
+#[multipart_suggestion(suggestion)]
 //~^ ERROR `#[multipart_suggestion(...)]` is not a valid attribute
 //~| ERROR cannot find attribute `multipart_suggestion` in this scope
 #[multipart_suggestion()]
 //~^ ERROR `#[multipart_suggestion(...)]` is not a valid attribute
 //~| ERROR cannot find attribute `multipart_suggestion` in this scope
 struct MultipartSuggestion {
-    #[multipart_suggestion(compiletest::suggestion)]
+    #[multipart_suggestion(suggestion)]
     //~^ ERROR `#[multipart_suggestion(...)]` is not a valid attribute
     //~| ERROR cannot find attribute `multipart_suggestion` in this scope
     suggestion: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
-#[suggestion(compiletest::suggestion, code = "...")]
+#[diag(compiletest_example, code = "E0123")]
+#[suggestion(suggestion, code = "...")]
 //~^ ERROR `#[suggestion(...)]` is not a valid attribute
 struct SuggestionOnStruct {
     #[primary_span]
@@ -647,7 +647,7 @@ struct SuggestionOnStruct {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 #[label]
 //~^ ERROR `#[label]` is not a valid attribute
 struct LabelOnStruct {
@@ -657,30 +657,30 @@ struct LabelOnStruct {
 
 #[derive(Diagnostic)]
 enum ExampleEnum {
-    #[diag(compiletest::example)]
+    #[diag(compiletest_example)]
     Foo {
         #[primary_span]
         sp: Span,
         #[note]
         note_sp: Span,
     },
-    #[diag(compiletest::example)]
+    #[diag(compiletest_example)]
     Bar {
         #[primary_span]
         sp: Span,
     },
-    #[diag(compiletest::example)]
+    #[diag(compiletest_example)]
     Baz,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct RawIdentDiagnosticArg {
     pub r#type: String,
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct SubdiagnosticBad {
     #[subdiagnostic(bad)]
 //~^ ERROR `#[subdiagnostic(bad)]` is not a valid attribute
@@ -688,7 +688,7 @@ struct SubdiagnosticBad {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct SubdiagnosticBadStr {
     #[subdiagnostic = "bad"]
 //~^ ERROR `#[subdiagnostic = ...]` is not a valid attribute
@@ -696,7 +696,7 @@ struct SubdiagnosticBadStr {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct SubdiagnosticBadTwice {
     #[subdiagnostic(bad, bad)]
 //~^ ERROR `#[subdiagnostic(...)]` is not a valid attribute
@@ -704,7 +704,7 @@ struct SubdiagnosticBadTwice {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct SubdiagnosticBadLitStr {
     #[subdiagnostic("bad")]
 //~^ ERROR `#[subdiagnostic("...")]` is not a valid attribute
@@ -712,7 +712,7 @@ struct SubdiagnosticBadLitStr {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct SubdiagnosticEagerLint {
     #[subdiagnostic(eager)]
 //~^ ERROR `#[subdiagnostic(...)]` is not a valid attribute
@@ -720,7 +720,7 @@ struct SubdiagnosticEagerLint {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct SubdiagnosticEagerCorrect {
     #[subdiagnostic(eager)]
     note: Note,
@@ -732,7 +732,7 @@ struct SubdiagnosticEagerCorrect {
 
 #[derive(Subdiagnostic)]
 #[suggestion_short(
-    parser::use_instead,
+    use_instead,
     applicability = "machine-applicable",
     code = "{correct}"
 )]
@@ -744,7 +744,7 @@ pub(crate) struct SubdiagnosticWithSuggestion {
 }
 
 #[derive(Diagnostic)]
-#[diag(compiletest::example)]
+#[diag(compiletest_example)]
 struct SubdiagnosticEagerSuggestion {
     #[subdiagnostic(eager)]
     sub: SubdiagnosticWithSuggestion,
@@ -752,7 +752,7 @@ struct SubdiagnosticEagerSuggestion {
 
 /// with a doc comment on the type..
 #[derive(Diagnostic)]
-#[diag(compiletest::example, code = "E0123")]
+#[diag(compiletest_example, code = "E0123")]
 struct WithDocComment {
     /// ..and the field
     #[primary_span]

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -1,8 +1,8 @@
 error: unsupported type attribute for diagnostic derive enum
   --> $DIR/diagnostic-derive.rs:39:1
    |
-LL | #[diag(compiletest::example, code = "E0123")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[diag(compiletest_example, code = "E0123")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:42:5
@@ -10,7 +10,7 @@ error: diagnostic slug not specified
 LL |     Foo,
    |     ^^^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:44:5
@@ -18,7 +18,7 @@ error: diagnostic slug not specified
 LL |     Bar,
    |     ^^^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[diag = ...]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:50:1
@@ -29,20 +29,20 @@ LL | #[diag = "E0123"]
 error: `#[nonsense(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:55:1
    |
-LL | #[nonsense(compiletest::example, code = "E0123")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[nonsense(compiletest_example, code = "E0123")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:55:1
    |
-LL | / #[nonsense(compiletest::example, code = "E0123")]
+LL | / #[nonsense(compiletest_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
 LL | | struct InvalidStructAttr {}
    | |___________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[diag("...")]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:62:8
@@ -61,7 +61,7 @@ LL | |
 LL | | struct InvalidLitNestedAttr {}
    | |______________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[diag(nonsense(...))]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:73:8
@@ -80,7 +80,7 @@ LL | |
 LL | | struct InvalidNestedStructAttr1 {}
    | |__________________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[diag(nonsense = ...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:79:8
@@ -108,7 +108,7 @@ LL | |
 LL | | struct InvalidNestedStructAttr2 {}
    | |__________________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[diag(nonsense = ...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:86:8
@@ -134,13 +134,13 @@ LL | |
 LL | | struct InvalidNestedStructAttr3 {}
    | |__________________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[diag(slug = ...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:93:46
+  --> $DIR/diagnostic-derive.rs:93:45
    |
-LL | #[diag(compiletest::example, code = "E0123", slug = "foo")]
-   |                                              ^^^^^^^^^^^^
+LL | #[diag(compiletest_example, code = "E0123", slug = "foo")]
+   |                                             ^^^^^^^^^^^^
    |
    = help: only `code` is a valid nested attributes following the slug
 
@@ -153,44 +153,44 @@ LL |     #[suggestion = "bar"]
 error: specified multiple times
   --> $DIR/diagnostic-derive.rs:107:8
    |
-LL | #[diag(compiletest::example, code = "E0456")]
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | #[diag(compiletest_example, code = "E0456")]
+   |        ^^^^^^^^^^^^^^^^^^^
    |
 note: previously specified here
   --> $DIR/diagnostic-derive.rs:106:8
    |
-LL | #[diag(compiletest::example, code = "E0123")]
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | #[diag(compiletest_example, code = "E0123")]
+   |        ^^^^^^^^^^^^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:107:37
+  --> $DIR/diagnostic-derive.rs:107:36
    |
-LL | #[diag(compiletest::example, code = "E0456")]
-   |                                     ^^^^^^^
+LL | #[diag(compiletest_example, code = "E0456")]
+   |                                    ^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:106:37
+  --> $DIR/diagnostic-derive.rs:106:36
    |
-LL | #[diag(compiletest::example, code = "E0123")]
-   |                                     ^^^^^^^
+LL | #[diag(compiletest_example, code = "E0123")]
+   |                                    ^^^^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:113:53
+  --> $DIR/diagnostic-derive.rs:113:52
    |
-LL | #[diag(compiletest::example, code = "E0456", code = "E0457")]
-   |                                                     ^^^^^^^
+LL | #[diag(compiletest_example, code = "E0456", code = "E0457")]
+   |                                                    ^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:113:37
+  --> $DIR/diagnostic-derive.rs:113:36
    |
-LL | #[diag(compiletest::example, code = "E0456", code = "E0457")]
-   |                                     ^^^^^^^
+LL | #[diag(compiletest_example, code = "E0456", code = "E0457")]
+   |                                    ^^^^^^^
 
-error: `#[diag(compiletest::example)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:118:30
+error: `#[diag(compiletest_example)]` is not a valid attribute
+  --> $DIR/diagnostic-derive.rs:118:29
    |
-LL | #[diag(compiletest::example, compiletest::example, code = "E0456")]
-   |                              ^^^^^^^^^^^^^^^^^^^^
+LL | #[diag(compiletest_example, compiletest_example, code = "E0456")]
+   |                             ^^^^^^^^^^^^^^^^^^^
    |
    = help: diagnostic slug must be the first argument
 
@@ -200,7 +200,7 @@ error: diagnostic slug not specified
 LL | struct KindNotProvided {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:126:1
@@ -210,7 +210,7 @@ LL | |
 LL | | struct SlugNotProvided {}
    | |_________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: the `#[primary_span]` attribute can only be applied to fields of type `Span` or `MultiSpan`
   --> $DIR/diagnostic-derive.rs:137:5
@@ -227,14 +227,14 @@ LL |     #[nonsense]
 error: the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
   --> $DIR/diagnostic-derive.rs:162:5
    |
-LL |     #[label(compiletest::label)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[label(label)]
+   |     ^^^^^^^^^^^^^^^
 
 error: `name` doesn't refer to a field on this type
-  --> $DIR/diagnostic-derive.rs:170:50
+  --> $DIR/diagnostic-derive.rs:170:37
    |
-LL |     #[suggestion(compiletest::suggestion, code = "{name}")]
-   |                                                  ^^^^^^^^
+LL |     #[suggestion(suggestion, code = "{name}")]
+   |                                     ^^^^^^^^
 
 error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/diagnostic-derive.rs:175:10
@@ -257,14 +257,14 @@ LL | #[derive(Diagnostic)]
 error: the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
   --> $DIR/diagnostic-derive.rs:205:5
    |
-LL |     #[label(compiletest::label)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[label(label)]
+   |     ^^^^^^^^^^^^^^^
 
 error: suggestion without `code = "..."`
   --> $DIR/diagnostic-derive.rs:223:5
    |
-LL |     #[suggestion(compiletest::suggestion)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[suggestion(suggestion)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[suggestion(nonsense = ...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:231:18
@@ -297,7 +297,7 @@ LL |     #[suggestion(msg = "bar")]
 error: wrong field type for suggestion
   --> $DIR/diagnostic-derive.rs:263:5
    |
-LL | /     #[suggestion(compiletest::suggestion, code = "This is suggested code")]
+LL | /     #[suggestion(suggestion, code = "This is suggested code")]
 LL | |
 LL | |     suggestion: Applicability,
    | |_____________________________^
@@ -335,10 +335,10 @@ LL |     #[label = "bar"]
    |     ^^^^^^^^^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:445:57
+  --> $DIR/diagnostic-derive.rs:445:44
    |
-LL |     #[suggestion(compiletest::suggestion, code = "...", applicability = "maybe-incorrect")]
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[suggestion(suggestion, code = "...", applicability = "maybe-incorrect")]
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: previously specified here
   --> $DIR/diagnostic-derive.rs:447:24
@@ -347,30 +347,30 @@ LL |     suggestion: (Span, Applicability),
    |                        ^^^^^^^^^^^^^
 
 error: invalid applicability
-  --> $DIR/diagnostic-derive.rs:453:57
+  --> $DIR/diagnostic-derive.rs:453:44
    |
-LL |     #[suggestion(compiletest::suggestion, code = "...", applicability = "batman")]
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[suggestion(suggestion, code = "...", applicability = "batman")]
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[label(foo)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:516:33
+  --> $DIR/diagnostic-derive.rs:516:20
    |
-LL |     #[label(compiletest::label, foo)]
-   |                                 ^^^
+LL |     #[label(label, foo)]
+   |                    ^^^
    |
    = help: a diagnostic slug must be the first argument to the attribute
 
 error: `#[label(foo = ...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:524:33
+  --> $DIR/diagnostic-derive.rs:524:20
    |
-LL |     #[label(compiletest::label, foo = "...")]
-   |                                 ^^^^^^^^^^^
+LL |     #[label(label, foo = "...")]
+   |                    ^^^^^^^^^^^
 
 error: `#[label(foo(...))]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:532:33
+  --> $DIR/diagnostic-derive.rs:532:20
    |
-LL |     #[label(compiletest::label, foo("..."))]
-   |                                 ^^^^^^^^^^
+LL |     #[label(label, foo("..."))]
+   |                    ^^^^^^^^^^
 
 error: `#[primary_span]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:545:5
@@ -383,73 +383,73 @@ LL |     #[primary_span]
 error: `#[error(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:565:1
    |
-LL | #[error(compiletest::example, code = "E0123")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[error(compiletest_example, code = "E0123")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:565:1
    |
-LL | / #[error(compiletest::example, code = "E0123")]
+LL | / #[error(compiletest_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
 LL | | struct ErrorAttribute {}
    | |________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[warn_(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:572:1
    |
-LL | #[warn_(compiletest::example, code = "E0123")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[warn_(compiletest_example, code = "E0123")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:572:1
    |
-LL | / #[warn_(compiletest::example, code = "E0123")]
+LL | / #[warn_(compiletest_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
 LL | | struct WarnAttribute {}
    | |_______________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:579:1
    |
-LL | #[lint(compiletest::example, code = "E0123")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[lint(compiletest_example, code = "E0123")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:579:1
    |
-LL | / #[lint(compiletest::example, code = "E0123")]
+LL | / #[lint(compiletest_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
 LL | | struct LintAttributeOnSessionDiag {}
    | |____________________________________^
    |
-   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis::example_error)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:586:1
    |
-LL | #[lint(compiletest::example, code = "E0123")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[lint(compiletest_example, code = "E0123")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[lint(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:586:1
    |
-LL | #[lint(compiletest::example, code = "E0123")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[lint(compiletest_example, code = "E0123")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:586:1
    |
-LL | / #[lint(compiletest::example, code = "E0123")]
+LL | / #[lint(compiletest_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
@@ -457,19 +457,19 @@ LL | |
 LL | | struct LintAttributeOnLintDiag {}
    | |_________________________________^
    |
-   = help: specify the slug as the first argument to the attribute, such as `#[diag(compiletest::example)]`
+   = help: specify the slug as the first argument to the attribute, such as `#[diag(compiletest_example)]`
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:596:57
+  --> $DIR/diagnostic-derive.rs:596:44
    |
-LL |     #[suggestion(compiletest::suggestion, code = "...", code = ",,,")]
-   |                                                         ^^^^^^^^^^^^
+LL |     #[suggestion(suggestion, code = "...", code = ",,,")]
+   |                                            ^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:596:43
+  --> $DIR/diagnostic-derive.rs:596:30
    |
-LL |     #[suggestion(compiletest::suggestion, code = "...", code = ",,,")]
-   |                                           ^^^^^^^^^^^^
+LL |     #[suggestion(suggestion, code = "...", code = ",,,")]
+   |                              ^^^^^^^^^^^^
 
 error: wrong types for suggestion
   --> $DIR/diagnostic-derive.rs:605:24
@@ -490,14 +490,14 @@ LL |     suggestion: (Span,),
 error: suggestion without `code = "..."`
   --> $DIR/diagnostic-derive.rs:620:5
    |
-LL |     #[suggestion(compiletest::suggestion)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[suggestion(suggestion)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:627:1
    |
-LL | #[multipart_suggestion(compiletest::suggestion)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[multipart_suggestion(suggestion)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider creating a `Subdiagnostic` instead
 
@@ -512,16 +512,16 @@ LL | #[multipart_suggestion()]
 error: `#[multipart_suggestion(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:634:5
    |
-LL |     #[multipart_suggestion(compiletest::suggestion)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[multipart_suggestion(suggestion)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[suggestion(...)]` is not a valid attribute
   --> $DIR/diagnostic-derive.rs:642:1
    |
-LL | #[suggestion(compiletest::suggestion, code = "...")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[suggestion(suggestion, code = "...")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
@@ -576,7 +576,7 @@ LL |     #[subdiagnostic(eager)]
 error: cannot find attribute `nonsense` in this scope
   --> $DIR/diagnostic-derive.rs:55:3
    |
-LL | #[nonsense(compiletest::example, code = "E0123")]
+LL | #[nonsense(compiletest_example, code = "E0123")]
    |   ^^^^^^^^
 
 error: cannot find attribute `nonsense` in this scope
@@ -588,31 +588,31 @@ LL |     #[nonsense]
 error: cannot find attribute `error` in this scope
   --> $DIR/diagnostic-derive.rs:565:3
    |
-LL | #[error(compiletest::example, code = "E0123")]
+LL | #[error(compiletest_example, code = "E0123")]
    |   ^^^^^
 
 error: cannot find attribute `warn_` in this scope
   --> $DIR/diagnostic-derive.rs:572:3
    |
-LL | #[warn_(compiletest::example, code = "E0123")]
+LL | #[warn_(compiletest_example, code = "E0123")]
    |   ^^^^^ help: a built-in attribute with a similar name exists: `warn`
 
 error: cannot find attribute `lint` in this scope
   --> $DIR/diagnostic-derive.rs:579:3
    |
-LL | #[lint(compiletest::example, code = "E0123")]
+LL | #[lint(compiletest_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `lint` in this scope
   --> $DIR/diagnostic-derive.rs:586:3
    |
-LL | #[lint(compiletest::example, code = "E0123")]
+LL | #[lint(compiletest_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `multipart_suggestion` in this scope
   --> $DIR/diagnostic-derive.rs:627:3
    |
-LL | #[multipart_suggestion(compiletest::suggestion)]
+LL | #[multipart_suggestion(suggestion)]
    |   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot find attribute `multipart_suggestion` in this scope
@@ -624,7 +624,7 @@ LL | #[multipart_suggestion()]
 error: cannot find attribute `multipart_suggestion` in this scope
   --> $DIR/diagnostic-derive.rs:634:7
    |
-LL |     #[multipart_suggestion(compiletest::suggestion)]
+LL |     #[multipart_suggestion(suggestion)]
    |       ^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find value `nonsense` in module `rustc_errors::fluent`

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -20,7 +20,7 @@ use rustc_span::Span;
 use rustc_macros::Subdiagnostic;
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct A {
     #[primary_span]
     span: Span,
@@ -29,13 +29,13 @@ struct A {
 
 #[derive(Subdiagnostic)]
 enum B {
-    #[label(parser::add_paren)]
+    #[label(parser_add_paren)]
     A {
         #[primary_span]
         span: Span,
         var: String,
     },
-    #[label(parser::add_paren)]
+    #[label(parser_add_paren)]
     B {
         #[primary_span]
         span: Span,
@@ -44,7 +44,7 @@ enum B {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 //~^ ERROR label without `#[primary_span]` field
 struct C {
     var: String,
@@ -138,7 +138,7 @@ struct M {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren, code = "...")]
+#[label(parser_add_paren, code = "...")]
 //~^ ERROR `#[label(code = ...)]` is not a valid attribute
 struct N {
     #[primary_span]
@@ -147,7 +147,7 @@ struct N {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren, applicability = "machine-applicable")]
+#[label(parser_add_paren, applicability = "machine-applicable")]
 //~^ ERROR `#[label(applicability = ...)]` is not a valid attribute
 struct O {
     #[primary_span]
@@ -160,7 +160,7 @@ struct O {
 //~^ ERROR cannot find attribute `foo` in this scope
 //~^^ ERROR unsupported type attribute for subdiagnostic enum
 enum P {
-    #[label(parser::add_paren)]
+    #[label(parser_add_paren)]
     A {
         #[primary_span]
         span: Span,
@@ -230,7 +230,7 @@ enum U {
 
 #[derive(Subdiagnostic)]
 enum V {
-    #[label(parser::add_paren)]
+    #[label(parser_add_paren)]
     A {
         #[primary_span]
         span: Span,
@@ -244,7 +244,7 @@ enum V {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 //~^ ERROR label without `#[primary_span]` field
 struct W {
     #[primary_span]
@@ -253,7 +253,7 @@ struct W {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct X {
     #[primary_span]
     span: Span,
@@ -263,7 +263,7 @@ struct X {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct Y {
     #[primary_span]
     span: Span,
@@ -274,7 +274,7 @@ struct Y {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct Z {
     #[primary_span]
     span: Span,
@@ -285,7 +285,7 @@ struct Z {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct AA {
     #[primary_span]
     span: Span,
@@ -296,7 +296,7 @@ struct AA {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct AB {
     #[primary_span]
     span: Span,
@@ -312,23 +312,23 @@ union AC {
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
+#[label(parser_add_paren)]
 struct AD {
     #[primary_span]
     span: Span,
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren, parser::add_paren)]
-//~^ ERROR `#[label(parser::add_paren)]` is not a valid attribute
+#[label(parser_add_paren, parser_add_paren)]
+//~^ ERROR `#[label(parser_add_paren)]` is not a valid attribute
 struct AE {
     #[primary_span]
     span: Span,
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct AF {
     #[primary_span]
     //~^ NOTE previously specified here
@@ -346,7 +346,7 @@ struct AG {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code = "...")]
+#[suggestion(parser_add_paren, code = "...")]
 struct AH {
     #[primary_span]
     span: Span,
@@ -357,7 +357,7 @@ struct AH {
 
 #[derive(Subdiagnostic)]
 enum AI {
-    #[suggestion(parser::add_paren, code = "...")]
+    #[suggestion(parser_add_paren, code = "...")]
     A {
         #[primary_span]
         span: Span,
@@ -365,7 +365,7 @@ enum AI {
         applicability: Applicability,
         var: String,
     },
-    #[suggestion(parser::add_paren, code = "...")]
+    #[suggestion(parser_add_paren, code = "...")]
     B {
         #[primary_span]
         span: Span,
@@ -376,7 +376,7 @@ enum AI {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code = "...", code = "...")]
+#[suggestion(parser_add_paren, code = "...", code = "...")]
 //~^ ERROR specified multiple times
 //~^^ NOTE previously specified here
 struct AJ {
@@ -387,7 +387,7 @@ struct AJ {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code = "...")]
+#[suggestion(parser_add_paren, code = "...")]
 struct AK {
     #[primary_span]
     span: Span,
@@ -400,7 +400,7 @@ struct AK {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code = "...")]
+#[suggestion(parser_add_paren, code = "...")]
 struct AL {
     #[primary_span]
     span: Span,
@@ -410,14 +410,14 @@ struct AL {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code = "...")]
+#[suggestion(parser_add_paren, code = "...")]
 struct AM {
     #[primary_span]
     span: Span,
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren)]
+#[suggestion(parser_add_paren)]
 //~^ ERROR suggestion without `code = "..."`
 struct AN {
     #[primary_span]
@@ -427,7 +427,7 @@ struct AN {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code ="...", applicability = "foo")]
+#[suggestion(parser_add_paren, code ="...", applicability = "foo")]
 //~^ ERROR invalid applicability
 struct AO {
     #[primary_span]
@@ -435,24 +435,24 @@ struct AO {
 }
 
 #[derive(Subdiagnostic)]
-#[help(parser::add_paren)]
+#[help(parser_add_paren)]
 struct AP {
     var: String
 }
 
 #[derive(Subdiagnostic)]
-#[note(parser::add_paren)]
+#[note(parser_add_paren)]
 struct AQ;
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code = "...")]
+#[suggestion(parser_add_paren, code = "...")]
 //~^ ERROR suggestion without `#[primary_span]` field
 struct AR {
     var: String,
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code ="...", applicability = "machine-applicable")]
+#[suggestion(parser_add_paren, code ="...", applicability = "machine-applicable")]
 struct AS {
     #[primary_span]
     span: Span,
@@ -462,7 +462,7 @@ struct AS {
 #[label]
 //~^ ERROR unsupported type attribute for subdiagnostic enum
 enum AT {
-    #[label(parser::add_paren)]
+    #[label(parser_add_paren)]
     A {
         #[primary_span]
         span: Span,
@@ -471,7 +471,7 @@ enum AT {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
+#[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
 struct AU {
     #[primary_span]
     span: Span,
@@ -479,7 +479,7 @@ struct AU {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
+#[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
 //~^ ERROR `var` doesn't refer to a field on this type
 struct AV {
     #[primary_span]
@@ -488,7 +488,7 @@ struct AV {
 
 #[derive(Subdiagnostic)]
 enum AW {
-    #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
+    #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
     A {
         #[primary_span]
         span: Span,
@@ -498,7 +498,7 @@ enum AW {
 
 #[derive(Subdiagnostic)]
 enum AX {
-    #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
+    #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
 //~^ ERROR `var` doesn't refer to a field on this type
     A {
         #[primary_span]
@@ -507,18 +507,18 @@ enum AX {
 }
 
 #[derive(Subdiagnostic)]
-#[warning(parser::add_paren)]
+#[warning(parser_add_paren)]
 struct AY {}
 
 #[derive(Subdiagnostic)]
-#[warning(parser::add_paren)]
+#[warning(parser_add_paren)]
 struct AZ {
     #[primary_span]
     span: Span,
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser::add_paren, code = "...")]
+#[suggestion(parser_add_paren, code = "...")]
 //~^ ERROR suggestion without `#[primary_span]` field
 struct BA {
     #[suggestion_part]
@@ -533,7 +533,7 @@ struct BA {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren, code = "...", applicability = "machine-applicable")]
+#[multipart_suggestion(parser_add_paren, code = "...", applicability = "machine-applicable")]
 //~^ ERROR multipart suggestion without any `#[suggestion_part(...)]` fields
 //~| ERROR `#[multipart_suggestion(code = ...)]` is not a valid attribute
 struct BBa {
@@ -541,7 +541,7 @@ struct BBa {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren, applicability = "machine-applicable")]
+#[multipart_suggestion(parser_add_paren, applicability = "machine-applicable")]
 struct BBb {
     #[suggestion_part]
     //~^ ERROR `#[suggestion_part(...)]` attribute without `code = "..."`
@@ -549,7 +549,7 @@ struct BBb {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren, applicability = "machine-applicable")]
+#[multipart_suggestion(parser_add_paren, applicability = "machine-applicable")]
 struct BBc {
     #[suggestion_part()]
     //~^ ERROR `#[suggestion_part(...)]` attribute without `code = "..."`
@@ -557,7 +557,7 @@ struct BBc {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren)]
+#[multipart_suggestion(parser_add_paren)]
 //~^ ERROR multipart suggestion without any `#[suggestion_part(...)]` fields
 struct BC {
     #[primary_span]
@@ -566,7 +566,7 @@ struct BC {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren)]
+#[multipart_suggestion(parser_add_paren)]
 struct BD {
     #[suggestion_part]
     //~^ ERROR `#[suggestion_part(...)]` attribute without `code = "..."`
@@ -586,7 +586,7 @@ struct BD {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren, applicability = "machine-applicable")]
+#[multipart_suggestion(parser_add_paren, applicability = "machine-applicable")]
 struct BE {
     #[suggestion_part(code = "...", code = ",,,")]
     //~^ ERROR specified multiple times
@@ -595,7 +595,7 @@ struct BE {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren, applicability = "machine-applicable")]
+#[multipart_suggestion(parser_add_paren, applicability = "machine-applicable")]
 struct BF {
     #[suggestion_part(code = "(")]
     first: Span,
@@ -604,7 +604,7 @@ struct BF {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren)]
+#[multipart_suggestion(parser_add_paren)]
 struct BG {
     #[applicability]
     appl: Applicability,
@@ -615,7 +615,7 @@ struct BG {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren, applicability = "machine-applicable")]
+#[multipart_suggestion(parser_add_paren, applicability = "machine-applicable")]
 struct BH {
     #[applicability]
     //~^ ERROR `#[applicability]` has no effect
@@ -627,14 +627,14 @@ struct BH {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(parser::add_paren, applicability = "machine-applicable")]
+#[multipart_suggestion(parser_add_paren, applicability = "machine-applicable")]
 struct BI {
     #[suggestion_part(code = "")]
     spans: Vec<Span>,
 }
 
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct BJ {
     #[primary_span]
     span: Span,
@@ -643,7 +643,7 @@ struct BJ {
 
 /// with a doc comment on the type..
 #[derive(Subdiagnostic)]
-#[label(parser::add_paren)]
+#[label(parser_add_paren)]
 struct BK {
     /// ..and the field
     #[primary_span]
@@ -654,7 +654,7 @@ struct BK {
 #[derive(Subdiagnostic)]
 enum BL {
     /// ..and the variant..
-    #[label(parser::add_paren)]
+    #[label(parser_add_paren)]
     Foo {
         /// ..and the field
         #[primary_span]

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -1,7 +1,7 @@
 error: label without `#[primary_span]` field
   --> $DIR/subdiagnostic-derive.rs:47:1
    |
-LL | / #[label(parser::add_paren)]
+LL | / #[label(parser_add_paren)]
 LL | |
 LL | | struct C {
 LL | |     var: String,
@@ -81,16 +81,16 @@ LL | #[label()]
    | ^^^^^^^^^^
 
 error: `#[label(code = ...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:141:28
+  --> $DIR/subdiagnostic-derive.rs:141:27
    |
-LL | #[label(parser::add_paren, code = "...")]
-   |                            ^^^^^^^^^^^^
+LL | #[label(parser_add_paren, code = "...")]
+   |                           ^^^^^^^^^^^^
 
 error: `#[label(applicability = ...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:150:28
+  --> $DIR/subdiagnostic-derive.rs:150:27
    |
-LL | #[label(parser::add_paren, applicability = "machine-applicable")]
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[label(parser_add_paren, applicability = "machine-applicable")]
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsupported type attribute for subdiagnostic enum
   --> $DIR/subdiagnostic-derive.rs:159:1
@@ -143,7 +143,7 @@ LL |     #[primary_span]
 error: label without `#[primary_span]` field
   --> $DIR/subdiagnostic-derive.rs:247:1
    |
-LL | / #[label(parser::add_paren)]
+LL | / #[label(parser_add_paren)]
 LL | |
 LL | | struct W {
 LL | |     #[primary_span]
@@ -190,11 +190,11 @@ LL | |     b: u64
 LL | | }
    | |_^
 
-error: `#[label(parser::add_paren)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:323:28
+error: `#[label(parser_add_paren)]` is not a valid attribute
+  --> $DIR/subdiagnostic-derive.rs:323:27
    |
-LL | #[label(parser::add_paren, parser::add_paren)]
-   |                            ^^^^^^^^^^^^^^^^^
+LL | #[label(parser_add_paren, parser_add_paren)]
+   |                           ^^^^^^^^^^^^^^^^
    |
    = help: a diagnostic slug must be the first argument to the attribute
 
@@ -217,16 +217,16 @@ LL | struct AG {
    |        ^^
 
 error: specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:379:47
+  --> $DIR/subdiagnostic-derive.rs:379:46
    |
-LL | #[suggestion(parser::add_paren, code = "...", code = "...")]
-   |                                               ^^^^^^^^^^^^
+LL | #[suggestion(parser_add_paren, code = "...", code = "...")]
+   |                                              ^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:379:33
+  --> $DIR/subdiagnostic-derive.rs:379:32
    |
-LL | #[suggestion(parser::add_paren, code = "...", code = "...")]
-   |                                 ^^^^^^^^^^^^
+LL | #[suggestion(parser_add_paren, code = "...", code = "...")]
+   |                                ^^^^^^^^^^^^
 
 error: specified multiple times
   --> $DIR/subdiagnostic-derive.rs:397:5
@@ -249,19 +249,19 @@ LL |     #[applicability]
 error: suggestion without `code = "..."`
   --> $DIR/subdiagnostic-derive.rs:420:1
    |
-LL | #[suggestion(parser::add_paren)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[suggestion(parser_add_paren)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid applicability
-  --> $DIR/subdiagnostic-derive.rs:430:46
+  --> $DIR/subdiagnostic-derive.rs:430:45
    |
-LL | #[suggestion(parser::add_paren, code ="...", applicability = "foo")]
-   |                                              ^^^^^^^^^^^^^^^^^^^^^
+LL | #[suggestion(parser_add_paren, code ="...", applicability = "foo")]
+   |                                             ^^^^^^^^^^^^^^^^^^^^^
 
 error: suggestion without `#[primary_span]` field
   --> $DIR/subdiagnostic-derive.rs:448:1
    |
-LL | / #[suggestion(parser::add_paren, code = "...")]
+LL | / #[suggestion(parser_add_paren, code = "...")]
 LL | |
 LL | | struct AR {
 LL | |     var: String,
@@ -275,16 +275,16 @@ LL | #[label]
    | ^^^^^^^^
 
 error: `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:482:39
+  --> $DIR/subdiagnostic-derive.rs:482:38
    |
-LL | #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
-   |                                       ^^^^^^^
+LL | #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
+   |                                      ^^^^^^^
 
 error: `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:501:43
+  --> $DIR/subdiagnostic-derive.rs:501:42
    |
-LL |     #[suggestion(parser::add_paren, code ="{var}", applicability = "machine-applicable")]
-   |                                           ^^^^^^^
+LL |     #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
+   |                                          ^^^^^^^
 
 error: `#[suggestion_part]` is not a valid attribute
   --> $DIR/subdiagnostic-derive.rs:524:5
@@ -305,7 +305,7 @@ LL |     #[suggestion_part(code = "...")]
 error: suggestion without `#[primary_span]` field
   --> $DIR/subdiagnostic-derive.rs:521:1
    |
-LL | / #[suggestion(parser::add_paren, code = "...")]
+LL | / #[suggestion(parser_add_paren, code = "...")]
 LL | |
 LL | | struct BA {
 LL | |     #[suggestion_part]
@@ -315,17 +315,17 @@ LL | | }
    | |_^
 
 error: `#[multipart_suggestion(code = ...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:536:43
+  --> $DIR/subdiagnostic-derive.rs:536:42
    |
-LL | #[multipart_suggestion(parser::add_paren, code = "...", applicability = "machine-applicable")]
-   |                                           ^^^^^^^^^^^^
+LL | #[multipart_suggestion(parser_add_paren, code = "...", applicability = "machine-applicable")]
+   |                                          ^^^^^^^^^^^^
    |
    = help: only `applicability` is a valid nested attributes
 
 error: multipart suggestion without any `#[suggestion_part(...)]` fields
   --> $DIR/subdiagnostic-derive.rs:536:1
    |
-LL | / #[multipart_suggestion(parser::add_paren, code = "...", applicability = "machine-applicable")]
+LL | / #[multipart_suggestion(parser_add_paren, code = "...", applicability = "machine-applicable")]
 LL | |
 LL | |
 LL | | struct BBa {
@@ -356,7 +356,7 @@ LL |     #[primary_span]
 error: multipart suggestion without any `#[suggestion_part(...)]` fields
   --> $DIR/subdiagnostic-derive.rs:560:1
    |
-LL | / #[multipart_suggestion(parser::add_paren)]
+LL | / #[multipart_suggestion(parser_add_paren)]
 LL | |
 LL | | struct BC {
 LL | |     #[primary_span]


### PR DESCRIPTION
This makes it easier to grep for the slugs in the code.

See https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Localization.20infra.20interferes.20with.20grepping.20for.20error for more discussion about it.

This was mostly done with a few regexes and a bunch of manual work. This also exposes a pretty annoying inconsistency for the extra labels. Some of the extra labels are defined as additional properties in the fluent message (which makes them not prefixed with the crate name) and some of them are new fluent messages themselves (which makes them prefixed with the crate name). I don't know whether we want to clean this up at some point but it's useful to know.

r? @davidtwco 