### PR TITLE
rustdoc: remove unused CSS `.out-of-band { font-weight: normal }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -634,7 +634,6 @@ pre.example-line-numbers {
 .out-of-band {
 	flex-grow: 0;
 	font-size: 1.125rem;
-	font-weight: normal;
 }
 
 .docblock code, .docblock-short code,


### PR DESCRIPTION
This CSS was added in 083c3952e0d5473cd5c41a9eb7b4ffca18cc8e5f to normalize the appearance of out-of-band elements that were nested directly below headers.

Now, the only use of `out-of-band` is in the main page header, and it is nested below a wrapper, not the `<h1>` itself.