### PR TITLE
Clarify preconditions of raw size/align methods

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -171,7 +171,9 @@ impl Layout {
     ///
     /// # Safety
     ///
-    /// This function is only safe to call if the following conditions hold:
+    /// This function is safe to call if the pointer is safe to reborrow as `&T`
+    /// (in which case you could also call [`Layout::for_value`]). Otherwise,
+    /// the following conditions must hold:
     ///
     /// - If `T` is `Sized`, this function is always safe to call.
     /// - If the unsized tail of `T` is:
@@ -187,8 +189,7 @@ impl Layout {
     ///       extern type's layout is not known. This is the same behavior as
     ///       [`Layout::for_value`] on a reference to an extern type tail.
     ///     - otherwise, it is conservatively allowed to call this function
-    ///       only when it would be safe to reborrow `t` as a shared reference
-    ///       and pass it to [`Layout::for_value`].
+    ///       only when it would be safe to reborrow `t` as a shared reference.
     ///
     /// [trait object]: ../../book/ch17-02-trait-objects.html
     /// [extern type]: ../../unstable-book/language-features/extern-types.html

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -186,7 +186,9 @@ impl Layout {
     ///       call, but may panic or otherwise return the wrong value, as the
     ///       extern type's layout is not known. This is the same behavior as
     ///       [`Layout::for_value`] on a reference to an extern type tail.
-    ///     - otherwise, it is conservatively not allowed to call this function.
+    ///     - otherwise, it is conservatively allowed to call this function
+    ///       only when it would be safe to reborrow `t` as a shared reference
+    ///       and pass it to [`Layout::for_value`].
     ///
     /// [trait object]: ../../book/ch17-02-trait-objects.html
     /// [extern type]: ../../unstable-book/language-features/extern-types.html

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -351,7 +351,9 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// # Safety
 ///
-/// This function is only safe to call if the following conditions hold:
+/// This function is safe to call if the pointer is safe to reborrow as `&T`
+/// (in which case you could also call [`size_of_val`]). Otherwise, the
+/// following conditions must hold:
 ///
 /// - If `T` is `Sized`, this function is always safe to call.
 /// - If the unsized tail of `T` is:
@@ -367,8 +369,7 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///       extern type's layout is not known. This is the same behavior as
 ///       [`size_of_val`] on a reference to a type with an extern type tail.
 ///     - otherwise, it is conservatively allowed to call this function
-///       only when it would be safe to reborrow `val` as a shared reference
-///       and pass it to [`size_of_val`].
+///       only when it would be safe to reborrow `val` as a shared reference.
 ///
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html
@@ -499,7 +500,9 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// # Safety
 ///
-/// This function is only safe to call if the following conditions hold:
+/// This function is safe to call if the pointer is safe to reborrow as `&T`
+/// (in which case you could also call [`align_of_val`]). Otherwise, the
+/// following conditions must hold:
 ///
 /// - If `T` is `Sized`, this function is always safe to call.
 /// - If the unsized tail of `T` is:
@@ -515,8 +518,7 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///       extern type's layout is not known. This is the same behavior as
 ///       [`align_of_val`] on a reference to a type with an extern type tail.
 ///     - otherwise, it is conservatively allowed to call this function
-///       only when it would be safe to reborrow `val` as a shared reference
-///       and pass it to [`align_of_val`].
+///       only when it would be safe to reborrow `val` as a shared reference.
 ///
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -366,7 +366,9 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///       call, but may panic or otherwise return the wrong value, as the
 ///       extern type's layout is not known. This is the same behavior as
 ///       [`size_of_val`] on a reference to a type with an extern type tail.
-///     - otherwise, it is conservatively not allowed to call this function.
+///     - otherwise, it is conservatively allowed to call this function
+///       only when it would be safe to reborrow `val` as a shared reference
+///       and pass it to [`size_of_val`].
 ///
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html
@@ -512,7 +514,9 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///       call, but may panic or otherwise return the wrong value, as the
 ///       extern type's layout is not known. This is the same behavior as
 ///       [`align_of_val`] on a reference to a type with an extern type tail.
-///     - otherwise, it is conservatively not allowed to call this function.
+///     - otherwise, it is conservatively allowed to call this function
+///       only when it would be safe to reborrow `val` as a shared reference
+///       and pass it to [`align_of_val`].
 ///
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html


### PR DESCRIPTION
The documentation of the preconditions of `mem::size_of_val_raw`, `mem::align_of_val_raw`, and `Layout::for_value_raw` was overly conservative. This PR resolves that problem.

Discussion: https://github.com/rust-lang/rust/issues/69835#issuecomment-1287316637