### PR TITLE
Don't allow `CoerceUnsized` into `dyn*` (except for trait upcasting)

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -779,7 +779,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         match (source.kind(), target.kind()) {
             // Trait+Kx+'a -> Trait+Ky+'b (upcasts).
-            (&ty::Dynamic(ref data_a, _, ty::Dyn), &ty::Dynamic(ref data_b, _, ty::Dyn)) => {
+            (&ty::Dynamic(ref data_a, _, dyn_a), &ty::Dynamic(ref data_b, _, dyn_b))
+                if dyn_a == dyn_b =>
+            {
                 // Upcast coercions permit several things:
                 //
                 // 1. Dropping auto traits, e.g., `Foo + Send` to `Foo`

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -779,7 +779,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         match (source.kind(), target.kind()) {
             // Trait+Kx+'a -> Trait+Ky+'b (upcasts).
-            (&ty::Dynamic(ref data_a, ..), &ty::Dynamic(ref data_b, ..)) => {
+            (&ty::Dynamic(ref data_a, _, ty::Dyn), &ty::Dynamic(ref data_b, _, ty::Dyn)) => {
                 // Upcast coercions permit several things:
                 //
                 // 1. Dropping auto traits, e.g., `Foo + Send` to `Foo`

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -840,7 +840,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             // `T` -> `Trait`
-            (_, &ty::Dynamic(..)) => {
+            (_, &ty::Dynamic(_, _, ty::Dyn)) => {
                 candidates.vec.push(BuiltinUnsizeCandidate);
             }
 

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -1145,7 +1145,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }));
             }
 
-            _ => bug!(),
+            _ => bug!("source: {source}, target: {target}"),
         };
 
         Ok(ImplSourceBuiltinData { nested })

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -919,7 +919,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let mut nested = vec![];
         match (source.kind(), target.kind()) {
             // Trait+Kx+'a -> Trait+Ky+'b (auto traits and lifetime subtyping).
-            (&ty::Dynamic(ref data_a, r_a, ty::Dyn), &ty::Dynamic(ref data_b, r_b, ty::Dyn)) => {
+            (&ty::Dynamic(ref data_a, r_a, dyn_a), &ty::Dynamic(ref data_b, r_b, dyn_b))
+                if dyn_a == dyn_b =>
+            {
                 // See `assemble_candidates_for_unsizing` for more info.
                 // We already checked the compatibility of auto traits within `assemble_candidates_for_unsizing`.
                 let iter = data_a
@@ -938,7 +940,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                             .map(ty::Binder::dummy),
                     );
                 let existential_predicates = tcx.mk_poly_existential_predicates(iter);
-                let source_trait = tcx.mk_dynamic(existential_predicates, r_b, ty::Dyn);
+                let source_trait = tcx.mk_dynamic(existential_predicates, r_b, dyn_a);
 
                 // Require that the traits involved in this upcast are **equal**;
                 // only the **lifetime bound** is changed.

--- a/src/test/ui/dyn-star/dont-unsize-coerce-dyn-star.rs
+++ b/src/test/ui/dyn-star/dont-unsize-coerce-dyn-star.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+trait AddOne {
+    fn add1(&mut self) -> usize;
+}
+
+impl AddOne for usize {
+    fn add1(&mut self) -> usize {
+        *self += 1;
+        *self
+    }
+}
+
+fn add_one(i: &mut (dyn* AddOne + '_)) -> usize {
+    i.add1()
+}
+
+fn main() {
+    let mut x = 42usize as dyn* AddOne;
+
+    println!("{}", add_one(&mut x));
+    println!("{}", add_one(&mut x));
+}

--- a/src/test/ui/dyn-star/unsize-into-ref-dyn-star.rs
+++ b/src/test/ui/dyn-star/unsize-into-ref-dyn-star.rs
@@ -1,0 +1,9 @@
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+use std::fmt::Debug;
+
+fn main() {
+    let i = 42 as &dyn* Debug;
+    //~^ ERROR non-primitive cast: `i32` as `&dyn* Debug`
+}

--- a/src/test/ui/dyn-star/unsize-into-ref-dyn-star.stderr
+++ b/src/test/ui/dyn-star/unsize-into-ref-dyn-star.stderr
@@ -1,0 +1,9 @@
+error[E0605]: non-primitive cast: `i32` as `&dyn* Debug`
+  --> $DIR/unsize-into-ref-dyn-star.rs:7:13
+   |
+LL |     let i = 42 as &dyn* Debug;
+   |             ^^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0605`.


### PR DESCRIPTION
This makes sure we don't accidentally allow coercions like `Box<T>` -> `Box<dyn* Trait>`, or in the case of this ICE, `&T` to `&dyn* Trait`. These coercions don't make sense, at least not via the `CoerceUnsized` trait.

Fixes #102172
Fixes #102429