### PR TITLE
Delay span bug when we can't map lifetimes back in `collect_trait_impl_trait_tys`

### DIFF
--- a/src/test/ui/impl-trait/in-trait/signature-mismatch.rs
+++ b/src/test/ui/impl-trait/in-trait/signature-mismatch.rs
@@ -1,0 +1,21 @@
+// edition:2021
+
+#![feature(return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+use std::future::Future;
+
+pub trait AsyncTrait {
+    fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
+}
+
+pub struct Struct;
+
+impl AsyncTrait for Struct {
+    fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
+        //~^ ERROR `impl` item signature doesn't match `trait` item signature
+        async move { buff.to_vec() }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/in-trait/signature-mismatch.stderr
+++ b/src/test/ui/impl-trait/in-trait/signature-mismatch.stderr
@@ -1,0 +1,16 @@
+error: `impl` item signature doesn't match `trait` item signature
+  --> $DIR/signature-mismatch.rs:15:5
+   |
+LL |     fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
+   |     ----------------------------------------------------------------- expected `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + 'static`
+...
+LL |     fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + '2`
+   |
+   = note: expected `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + 'static`
+              found `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + '2`
+   = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
+   = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When a lifetime is late-bound in a trait signature, but early-bound in an impl signature, we already emit an error -- however, we also ICE in `collect_trait_impl_trait_tys`, so just delay a bug here.

Fixes #103407