### PR TITLE
Fix typo in docs of `String::leak`.

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1851,7 +1851,7 @@ impl String {
     }
 
     /// Consumes and leaks the `String`, returning a mutable reference to the contents,
-    /// `&'a mut str`.
+    /// `&'static mut str`.
     ///
     /// This is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory


### PR DESCRIPTION
I introduced a typo in #103280, this PR fixes it.

See https://github.com/rust-lang/rust/pull/103280#discussion_r1002538265