### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -514,8 +514,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
 
                 for ty in [first_ty, second_ty] {
-                    for pred in self.tcx.bound_explicit_item_bounds(rpit_def_id).transpose_iter() {
-                        let pred = pred.map_bound(|(pred, _)| *pred).subst(self.tcx, substs);
+                    for (pred, _) in self
+                        .tcx
+                        .bound_explicit_item_bounds(rpit_def_id)
+                        .subst_iter_copied(self.tcx, substs)
+                    {
                         let pred = match pred.kind().skip_binder() {
                             ty::PredicateKind::Trait(mut trait_pred) => {
                                 assert_eq!(trait_pred.trait_ref.self_ty(), opaque_ty);

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -338,8 +338,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
             let bounds = self.tcx.bound_explicit_item_bounds(*def_id);
 
-            for predicate in bounds.transpose_iter().map(|e| e.map_bound(|(p, _)| *p)) {
-                let predicate = predicate.subst(self.tcx, substs);
+            for (predicate, _) in bounds.subst_iter_copied(self.tcx, substs) {
                 let output = predicate
                     .kind()
                     .map_bound(|kind| match kind {

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -543,10 +543,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
         let item_bounds = tcx.bound_explicit_item_bounds(def_id.to_def_id());
 
-        for predicate in item_bounds.transpose_iter().map(|e| e.map_bound(|(p, _)| *p)) {
-            debug!(?predicate);
-            let predicate = predicate.subst(tcx, substs);
-
+        for (predicate, _) in item_bounds.subst_iter_copied(tcx, substs) {
             let predicate = predicate.fold_with(&mut BottomUpFolder {
                 tcx,
                 ty_op: |ty| match *ty.kind() {

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -960,7 +960,7 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
                                         sp,
                                         "did you mean",
                                         suggestion,
-                                        Applicability::MachineApplicable,
+                                        Applicability::MaybeIncorrect,
                                     );
                                 }
                                 lint

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -91,14 +91,12 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
             // For example, in `impl Trait<Assoc = impl Send>`, for all of the bounds on `Assoc`,
             // e.g. `type Assoc: OtherTrait`, replace `<impl Trait as Trait>::Assoc: OtherTrait`
             // with `impl Send: OtherTrait`.
-            for assoc_pred_and_span in
-                cx.tcx.bound_explicit_item_bounds(proj.projection_ty.item_def_id).transpose_iter()
+            for (assoc_pred, assoc_pred_span) in cx
+                .tcx
+                .bound_explicit_item_bounds(proj.projection_ty.item_def_id)
+                .subst_iter_copied(cx.tcx, &proj.projection_ty.substs)
             {
-                let assoc_pred_span = assoc_pred_and_span.0.1;
-                let assoc_pred = assoc_pred_and_span
-                    .map_bound(|(pred, _)| *pred)
-                    .subst(cx.tcx, &proj.projection_ty.substs)
-                    .fold_with(proj_replacer);
+                let assoc_pred = assoc_pred.fold_with(proj_replacer);
                 let Ok(assoc_pred) = traits::fully_normalize(infcx, traits::ObligationCause::dummy(), cx.param_env, assoc_pred) else {
                     continue;
                 };

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -795,8 +795,7 @@ pub trait PrettyPrinter<'tcx>:
         let mut fn_traits = FxIndexMap::default();
         let mut is_sized = false;
 
-        for predicate in bounds.transpose_iter().map(|e| e.map_bound(|(p, _)| *p)) {
-            let predicate = predicate.subst(tcx, substs);
+        for (predicate, _) in bounds.subst_iter_copied(tcx, substs) {
             let bound_predicate = predicate.kind();
 
             match bound_predicate.skip_binder() {

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -6,6 +6,7 @@ use crate::ty::sty::{ClosureSubsts, GeneratorSubsts, InlineConstSubsts};
 use crate::ty::visit::{TypeVisitable, TypeVisitor};
 use crate::ty::{self, Lift, List, ParamConst, Ty, TyCtxt};
 
+use rustc_data_structures::captures::Captures;
 use rustc_data_structures::intern::{Interned, WithStableHash};
 use rustc_hir::def_id::DefId;
 use rustc_macros::HashStable;
@@ -547,6 +548,28 @@ impl<T> EarlyBinder<Option<T>> {
 impl<T, U> EarlyBinder<(T, U)> {
     pub fn transpose_tuple2(self) -> (EarlyBinder<T>, EarlyBinder<U>) {
         (EarlyBinder(self.0.0), EarlyBinder(self.0.1))
+    }
+}
+
+impl<'tcx, 's, T: IntoIterator<Item = I>, I: TypeFoldable<'tcx>> EarlyBinder<T> {
+    pub fn subst_iter(
+        self,
+        tcx: TyCtxt<'tcx>,
+        substs: &'s [GenericArg<'tcx>],
+    ) -> impl Iterator<Item = I> + Captures<'s> + Captures<'tcx> {
+        self.0.into_iter().map(move |t| EarlyBinder(t).subst(tcx, substs))
+    }
+}
+
+impl<'tcx, 's, 'a, T: IntoIterator<Item = &'a I>, I: Copy + TypeFoldable<'tcx> + 'a>
+    EarlyBinder<T>
+{
+    pub fn subst_iter_copied(
+        self,
+        tcx: TyCtxt<'tcx>,
+        substs: &'s [GenericArg<'tcx>],
+    ) -> impl Iterator<Item = I> + Captures<'s> + Captures<'tcx> + Captures<'a> {
+        self.0.into_iter().map(move |t| EarlyBinder(*t).subst(tcx, substs))
     }
 }
 

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -113,11 +113,26 @@ pub(crate) fn emit_unescape_error(
                 } else {
                     ("", "if you meant to write a `str` literal, use double quotes")
                 };
-
+                let mut escaped = String::with_capacity(lit.len());
+                let mut chrs = lit.chars().peekable();
+                while let Some(first) = chrs.next() {
+                    match (first, chrs.peek()) {
+                        ('\\', Some('"')) => {
+                            escaped.push('\\');
+                            escaped.push('"');
+                            chrs.next();
+                        }
+                        ('"', _) => {
+                            escaped.push('\\');
+                            escaped.push('"')
+                        }
+                        (c, _) => escaped.push(c),
+                    };
+                }
                 handler.span_suggestion(
                     span_with_quotes,
                     msg,
-                    format!("{}\"{}\"", prefix, lit),
+                    format!("{prefix}\"{escaped}\""),
                     Applicability::MachineApplicable,
                 );
             }

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1851,7 +1851,7 @@ impl String {
     }
 
     /// Consumes and leaks the `String`, returning a mutable reference to the contents,
-    /// `&'a mut str`.
+    /// `&'static mut str`.
     ///
     /// This is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -352,16 +352,12 @@ cfg_if::cfg_if! {
         extern "C" {}
     } else if #[cfg(target_os = "macos")] {
         #[link(name = "System")]
-        // res_init and friends require -lresolv on macOS/iOS.
-        // See #41582 and https://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html
-        #[link(name = "resolv")]
         extern "C" {}
     } else if #[cfg(any(target_os = "ios", target_os = "watchos"))] {
         #[link(name = "System")]
         #[link(name = "objc")]
         #[link(name = "Security", kind = "framework")]
         #[link(name = "Foundation", kind = "framework")]
-        #[link(name = "resolv")]
         extern "C" {}
     } else if #[cfg(target_os = "fuchsia")] {
         #[link(name = "zircon")]

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -132,8 +132,11 @@ impl Thread {
 
     #[cfg(target_os = "linux")]
     pub fn set_name(name: &CStr) {
+        const TASK_COMM_LEN: usize = 16;
+
         unsafe {
             // Available since glibc 2.12, musl 1.1.16, and uClibc 1.0.20.
+            let name = truncate_cstr(name, TASK_COMM_LEN);
             libc::pthread_setname_np(libc::pthread_self(), name.as_ptr());
         }
     }
@@ -148,6 +151,7 @@ impl Thread {
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
     pub fn set_name(name: &CStr) {
         unsafe {
+            let name = truncate_cstr(name, libc::MAXTHREADNAMESIZE);
             libc::pthread_setname_np(name.as_ptr());
         }
     }
@@ -273,6 +277,20 @@ impl Drop for Thread {
     fn drop(&mut self) {
         let ret = unsafe { libc::pthread_detach(self.id) };
         debug_assert_eq!(ret, 0);
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios", target_os = "watchos"))]
+fn truncate_cstr(cstr: &CStr, max_with_nul: usize) -> crate::borrow::Cow<'_, CStr> {
+    use crate::{borrow::Cow, ffi::CString};
+
+    if cstr.to_bytes_with_nul().len() > max_with_nul {
+        let bytes = cstr.to_bytes()[..max_with_nul - 1].to_vec();
+        // SAFETY: the non-nul bytes came straight from a CStr.
+        // (CString will add the terminating nul.)
+        Cow::Owned(unsafe { CString::from_vec_unchecked(bytes) })
+    } else {
+        Cow::Borrowed(cstr)
     }
 }
 
@@ -901,4 +919,29 @@ fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
 #[cfg(target_os = "netbsd")]
 fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
     2048 // just a guess
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios", target_os = "watchos"))]
+fn test_named_thread_truncation() {
+    use crate::thread::{self, Builder};
+
+    let long_name = crate::iter::once("test_named_thread_truncation")
+        .chain(crate::iter::repeat(" yada").take(100))
+        .collect::<String>();
+
+    let result = Builder::new().name(long_name.clone()).spawn(move || {
+        // Rust remembers the full thread name itself.
+        assert_eq!(thread::current().name(), Some(long_name.as_str()));
+
+        // But the kernel is limited -- make sure we successfully set a truncation.
+        let mut buf = vec![0u8; long_name.len() + 1];
+        unsafe {
+            libc::pthread_getname_np(libc::pthread_self(), buf.as_mut_ptr().cast(), buf.len());
+        }
+        let cstr = CStr::from_bytes_until_nul(&buf).unwrap();
+        assert!(cstr.to_bytes().len() > 0);
+        assert!(long_name.as_bytes().starts_with(cstr.to_bytes()));
+    });
+    result.unwrap().join().unwrap();
 }

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -37,6 +37,31 @@ fn test_named_thread() {
         .unwrap();
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios", target_os = "watchos"))]
+#[test]
+fn test_named_thread_truncation() {
+    use crate::ffi::CStr;
+
+    let long_name = crate::iter::once("test_named_thread_truncation")
+        .chain(crate::iter::repeat(" yada").take(100))
+        .collect::<String>();
+
+    let result = Builder::new().name(long_name.clone()).spawn(move || {
+        // Rust remembers the full thread name itself.
+        assert_eq!(thread::current().name(), Some(long_name.as_str()));
+
+        // But the system is limited -- make sure we successfully set a truncation.
+        let mut buf = vec![0u8; long_name.len() + 1];
+        unsafe {
+            libc::pthread_getname_np(libc::pthread_self(), buf.as_mut_ptr().cast(), buf.len());
+        }
+        let cstr = CStr::from_bytes_until_nul(&buf).unwrap();
+        assert!(cstr.to_bytes().len() > 0);
+        assert!(long_name.as_bytes().starts_with(cstr.to_bytes()));
+    });
+    result.unwrap().join().unwrap();
+}
+
 #[test]
 #[should_panic]
 fn test_invalid_named_thread() {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -920,7 +920,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	flex-flow: row wrap;
 }
 
-.search-results .result-name, .search-results div.desc, .search-results .result-description {
+.search-results .result-name, .search-results div.desc {
 	width: 50%;
 }
 .search-results .result-name {
@@ -1899,10 +1899,10 @@ in storage.js
 		border-bottom: 1px solid #aaa9;
 		padding: 5px 0px;
 	}
-	.search-results .result-name, .search-results div.desc, .search-results .result-description {
+	.search-results .result-name, .search-results div.desc {
 		width: 100%;
 	}
-	.search-results div.desc, .search-results .result-description, .item-right {
+	.search-results div.desc, .item-right {
 		padding-left: 2em;
 	}
 

--- a/src/test/rustdoc-gui/headings.goml
+++ b/src/test/rustdoc-gui/headings.goml
@@ -150,109 +150,85 @@ assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
 assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "20px"})
 assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
 
-// Checking colors now.
+// Needed to check colors
 show-text: true
-local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 goto: "file://" + |DOC_PATH| + "/test_docs/struct.HeavilyDocumentedStruct.html"
-assert-css: (
-    ".top-doc .docblock h2",
-    {"color": "rgb(0, 0, 0)", "border-bottom": "1px solid rgb(221, 221, 221)"},
+
+define-function: (
+    "check-colors",
+    (theme, heading_color, small_heading_color, heading_border_color),
+    [
+        ("local-storage", {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}),
+        ("reload"),
+        ("assert-css", (
+            ".top-doc .docblock h2",
+            {"color": |heading_color|, "border-bottom": "1px solid " + |heading_border_color|},
+        )),
+        ("assert-css", (
+            ".top-doc .docblock h3",
+            {"color": |heading_color|, "border-bottom": "1px solid " + |heading_border_color|},
+        )),
+        ("assert-css", (
+            ".top-doc .docblock h4",
+            {"color": |heading_color|, "border-bottom": "1px solid " + |heading_border_color|},
+        )),
+        ("assert-css", (
+            ".top-doc .docblock h5",
+            {"color": |small_heading_color|, "border-bottom-width": "0px"},
+        )),
+        ("assert-css", (
+            "#implementations-list .docblock h4",
+            {"color": |heading_color|, "border-bottom-width": "0px"},
+        )),
+        ("assert-css", (
+            "#implementations-list .docblock h5",
+            {"color": |small_heading_color|, "border-bottom-width": "0px"},
+        )),
+        ("assert-css", (
+            "#implementations-list .docblock h6",
+            {"color": |small_heading_color|, "border-bottom-width": "0px"},
+        )),
+    ],
 )
-assert-css: (
-    ".top-doc .docblock h3",
-    {"color": "rgb(0, 0, 0)", "border-bottom": "1px solid rgb(221, 221, 221)"},
+call-function: (
+    "check-colors",
+    {
+        "theme": "ayu",
+        "heading_color": "rgb(255, 255, 255)",
+        "small_heading_color": "rgb(197, 197, 197)",
+        "heading_border_color": "rgb(92, 103, 115)",
+    },
 )
-assert-css: (
-    ".top-doc .docblock h4",
-    {"color": "rgb(0, 0, 0)", "border-bottom": "1px solid rgb(221, 221, 221)"},
+call-function: (
+    "check-colors",
+    {
+        "theme": "dark",
+        "heading_color": "rgb(221, 221, 221)",
+        "small_heading_color": "rgb(221, 221, 221)",
+        "heading_border_color": "rgb(210, 210, 210)",
+    },
 )
-assert-css: (
-    ".top-doc .docblock h5",
-    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h4",
-    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h5",
-    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h6",
-    {"color": "rgb(0, 0, 0)", "border-bottom-width": "0px"},
+call-function: (
+    "check-colors",
+    {
+        "theme": "light",
+        "heading_color": "rgb(0, 0, 0)",
+        "small_heading_color": "rgb(0, 0, 0)",
+        "heading_border_color": "rgb(221, 221, 221)",
+    },
 )
 
-local-storage: {"rustdoc-theme": "dark"}
-reload:
-assert-css: (
-    ".top-doc .docblock h2",
-    {"color": "rgb(221, 221, 221)", "border-bottom": "1px solid rgb(210, 210, 210)"},
-)
-assert-css: (
-    ".top-doc .docblock h3",
-    {"color": "rgb(221, 221, 221)", "border-bottom": "1px solid rgb(210, 210, 210)"},
-)
-assert-css: (
-    ".top-doc .docblock h4",
-    {"color": "rgb(221, 221, 221)", "border-bottom": "1px solid rgb(210, 210, 210)"},
-)
-assert-css: (
-    ".top-doc .docblock h5",
-    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h4",
-    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h5",
-    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h6",
-    {"color": "rgb(221, 221, 221)", "border-bottom-width": "0px"},
+define-function: (
+    "check-since-color",
+    (theme),
+    [
+        ("local-storage", {"rustdoc-theme": |theme|}),
+        ("reload"),
+        ("assert-css", (".since", {"color": "rgb(128, 128, 128)"}, ALL)),
+    ],
 )
 
-local-storage: {"rustdoc-theme": "ayu"}
-reload:
-assert-css: (
-    ".top-doc .docblock h2",
-    {"color": "rgb(255, 255, 255)", "border-bottom": "1px solid rgb(92, 103, 115)"},
-)
-assert-css: (
-    ".top-doc .docblock h2",
-    {"color": "rgb(255, 255, 255)", "border-bottom": "1px solid rgb(92, 103, 115)"},
-)
-assert-css: (
-    ".top-doc .docblock h4",
-    {"color": "rgb(255, 255, 255)", "border-bottom": "1px solid rgb(92, 103, 115)"},
-)
-assert-css: (
-    ".top-doc .docblock h5",
-    {"color": "rgb(197, 197, 197)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h4",
-    {"color": "rgb(255, 255, 255)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h5",
-    {"color": "rgb(197, 197, 197)", "border-bottom-width": "0px"},
-)
-assert-css: (
-    "#implementations-list .docblock h6",
-    {"color": "rgb(197, 197, 197)", "border-bottom-width": "0px"},
-)
-
-local-storage: {"rustdoc-theme": "light"}
 goto: "file://" + |DOC_PATH| + "/staged_api/struct.Foo.html"
-assert-css: (".since", {"color": "rgb(128, 128, 128)"}, ALL)
-
-local-storage: {"rustdoc-theme": "dark"}
-reload:
-assert-css: (".since", {"color": "rgb(128, 128, 128)"}, ALL)
-
-local-storage: {"rustdoc-theme": "ayu"}
-reload:
-assert-css: (".since", {"color": "rgb(128, 128, 128)"}, ALL)
+call-function: ("check-since-color", ("ayu"))
+call-function: ("check-since-color", ("dark"))
+call-function: ("check-since-color", ("light"))

--- a/src/test/ui/inference/char-as-str-single.fixed
+++ b/src/test/ui/inference/char-as-str-single.fixed
@@ -8,4 +8,5 @@
 fn main() {
     let _: char = 'a'; //~ ERROR mismatched types
     let _: char = '人'; //~ ERROR mismatched types
+    let _: char = '\''; //~ ERROR mismatched types
 }

--- a/src/test/ui/inference/char-as-str-single.rs
+++ b/src/test/ui/inference/char-as-str-single.rs
@@ -8,4 +8,5 @@
 fn main() {
     let _: char = "a"; //~ ERROR mismatched types
     let _: char = "人"; //~ ERROR mismatched types
+    let _: char = "'"; //~ ERROR mismatched types
 }

--- a/src/test/ui/inference/char-as-str-single.stderr
+++ b/src/test/ui/inference/char-as-str-single.stderr
@@ -24,6 +24,19 @@ help: if you meant to write a `char` literal, use single quotes
 LL |     let _: char = '人';
    |                   ~~~~
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/char-as-str-single.rs:11:19
+   |
+LL |     let _: char = "'";
+   |            ----   ^^^ expected `char`, found `&str`
+   |            |
+   |            expected due to this
+   |
+help: if you meant to write a `char` literal, use single quotes
+   |
+LL |     let _: char = '\'';
+   |                   ~~~~
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/inference/str-as-char.fixed
+++ b/src/test/ui/inference/str-as-char.fixed
@@ -4,5 +4,7 @@
 // run-rustfix
 
 fn main() {
-    let _: &str = "a"; //~ ERROR mismatched types
+    let _: &str = "a";   //~ ERROR mismatched types
+    let _: &str = "\"\"\""; //~ ERROR character literal may only contain one codepoint
+    let _: &str = "\"\"\""; //~ ERROR character literal may only contain one codepoint
 }

--- a/src/test/ui/inference/str-as-char.rs
+++ b/src/test/ui/inference/str-as-char.rs
@@ -4,5 +4,7 @@
 // run-rustfix
 
 fn main() {
-    let _: &str = 'a'; //~ ERROR mismatched types
+    let _: &str = 'a';   //~ ERROR mismatched types
+    let _: &str = '"""'; //~ ERROR character literal may only contain one codepoint
+    let _: &str = '\"\"\"'; //~ ERROR character literal may only contain one codepoint
 }

--- a/src/test/ui/inference/str-as-char.stderr
+++ b/src/test/ui/inference/str-as-char.stderr
@@ -1,3 +1,25 @@
+error: character literal may only contain one codepoint
+  --> $DIR/str-as-char.rs:8:19
+   |
+LL |     let _: &str = '"""';
+   |                   ^^^^^
+   |
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _: &str = "\"\"\"";
+   |                   ~~~~~~~~
+
+error: character literal may only contain one codepoint
+  --> $DIR/str-as-char.rs:9:19
+   |
+LL |     let _: &str = '\"\"\"';
+   |                   ^^^^^^^^
+   |
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _: &str = "\"\"\"";
+   |                   ~~~~~~~~
+
 error[E0308]: mismatched types
   --> $DIR/str-as-char.rs:7:19
    |
@@ -11,6 +33,6 @@ help: if you meant to write a `str` literal, use double quotes
 LL |     let _: &str = "a";
    |                   ~~~
 
-error: aborting due to previous error
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #102766 (Don't link to `libresolv` in libstd on Darwin)
 - #103123 (Introduce `subst_iter` and `subst_iter_copied` on `EarlyBinder` )
 - #103354 (Escape string literals when fixing overlong char literal)
 - #103379 (Truncate thread names on Linux and Apple targets)
 - #103388 (rustdoc: remove unused CSS class `.result-description`)
 - #103399 (Change `unknown_lint` applicability to `MaybeIncorrect`)
 - #103401 (Use functions for headings rustdoc GUI test)
 - #103412 (Fix typo in docs of `String::leak`.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=102766,103123,103354,103379,103388,103399,103401,103412)
<!-- homu-ignore:end -->