### PR TITLE
rustdoc: remove no-op CSS `.code-header { border-bottom: none }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -184,7 +184,6 @@ h4.code-header {
 }
 .code-header {
 	font-weight: 600;
-	border-bottom-style: none;
 	margin: 0;
 	padding: 0;
 }


### PR DESCRIPTION
The code headers are always h3 or h4, which don't have border-bottom by default anyway.