### PR TITLE
Removed verbose printing from the `PrettyPrinter` when printing constants

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics/type_name.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/type_name.rs
@@ -4,7 +4,7 @@ use rustc_hir::definitions::DisambiguatedDefPathData;
 use rustc_middle::mir::interpret::{Allocation, ConstAllocation};
 use rustc_middle::ty::{
     self,
-    print::{PrettyPrinter, Print, Printer},
+    print::{with_no_verbose_constants, PrettyPrinter, Print, Printer},
     subst::{GenericArg, GenericArgKind},
     Ty, TyCtxt,
 };
@@ -190,7 +190,9 @@ impl Write for AbsolutePathPrinter<'_> {
 
 /// Directly returns an `Allocation` containing an absolute path representation of the given type.
 pub(crate) fn alloc_type_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> ConstAllocation<'tcx> {
-    let path = AbsolutePathPrinter { tcx, path: String::new() }.print_type(ty).unwrap().path;
+    let path = with_no_verbose_constants!(
+        AbsolutePathPrinter { tcx, path: String::new() }.print_type(ty).unwrap().path
+    );
     let alloc = Allocation::from_bytes_byte_aligned_immutable(path.into_bytes());
     tcx.intern_const_alloc(alloc)
 }

--- a/src/test/ui/type/issue-94187-verbose-type-name.rs
+++ b/src/test/ui/type/issue-94187-verbose-type-name.rs
@@ -1,0 +1,13 @@
+// Check to insure that the output of `std::any::type_name` does not change based on -Zverbose
+// when printing constants
+// run-pass
+// edition: 2018
+// revisions: normal verbose
+// [verbose]compile-flags:-Zverbose
+
+struct Wrapper<const VALUE: usize>;
+
+fn main() {
+    assert_eq!(std::any::type_name::<[u32; 0]>(), "[u32; 0]");
+    assert_eq!(std::any::type_name::<Wrapper<0>>(), "issue_94187_verbose_type_name::Wrapper<0>");
+}


### PR DESCRIPTION
Partially solves #94187 by completing the first step described in [this comment](https://github.com/rust-lang/rust/issues/94187#issuecomment-1282339909).