### PR TITLE
rustdoc: don't mark Box<T> as Iterator, Read, etc

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1276,6 +1276,15 @@ fn notable_traits_decl(decl: &clean::FnDecl, cx: &Context<'_>) -> String {
 
     if let Some((did, ty)) = decl.output.as_return().and_then(|t| Some((t.def_id(cx.cache())?, t)))
     {
+        // Box has pass-through impls for Read, Write, Iterator, and Future when the
+        // boxed type implements one of those. We don't want to treat every Box return
+        // as being notably an Iterator (etc), though, so we exempt it. Pin has the same
+        // issue, with a pass-through impl for Future.
+        if Some(did) == cx.tcx().lang_items().owned_box()
+            || Some(did) == cx.tcx().lang_items().pin_type()
+        {
+            return "".to_string();
+        }
         if let Some(impls) = cx.cache().impls.get(&did) {
             for i in impls {
                 let impl_ = i.inner_impl();

--- a/src/test/rustdoc/doc-notable_trait_box_is_not_an_iterator.rs
+++ b/src/test/rustdoc/doc-notable_trait_box_is_not_an_iterator.rs
@@ -1,0 +1,38 @@
+#![feature(doc_notable_trait)]
+#![feature(lang_items)]
+#![feature(no_core)]
+#![no_core]
+#[lang = "owned_box"]
+pub struct Box<T>;
+
+impl<T> Box<T> {
+    pub fn new(x: T) -> Box<T> {
+        Box
+    }
+}
+
+#[doc(notable_trait)]
+pub trait FakeIterator {}
+
+impl<I: FakeIterator> FakeIterator for Box<I> {}
+
+#[lang = "pin"]
+pub struct Pin<T>;
+
+impl<T> Pin<T> {
+    pub fn new(x: T) -> Pin<T> {
+        Pin
+    }
+}
+
+impl<I: FakeIterator> FakeIterator for Pin<I> {}
+
+// @!has doc_notable_trait_box_is_not_an_iterator/fn.foo.html '//*' 'Notable'
+pub fn foo<T>(x: T) -> Box<T> {
+    Box::new(x)
+}
+
+// @!has doc_notable_trait_box_is_not_an_iterator/fn.bar.html '//*' 'Notable'
+pub fn bar<T>(x: T) -> Pin<T> {
+    Pin::new(x)
+}


### PR DESCRIPTION
Because Box<T> has pass-through implementations, rustdoc was giving it the "Notable Traits" treatment for Iterator, Read, Write, and Future, even when the type of T was unspecified.

Pin had the same problem, but just for Future.

Fixes #100320