### PR TITLE
Show note where the macro failed to match

### DIFF
--- a/src/test/ui/array-slice-vec/vec-macro-with-comma-only.stderr
+++ b/src/test/ui/array-slice-vec/vec-macro-with-comma-only.stderr
@@ -3,6 +3,8 @@ error: no rules expected the token `,`
    |
 LL |     vec![,];
    |          ^ no rules expected this token in macro call
+   |
+   = note: while trying to match end of macro
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -53,6 +53,12 @@ LL |     macro_rules! gimme_a_const {
 ...
 LL |   let _fail = Example::<gimme_a_const!()>;
    |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$rusty:ident`
+  --> $DIR/macro-fail.rs:28:8
+   |
+LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+   |        ^^^^^^^^^^^^^
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/macro-fail.rs:14:33

--- a/src/test/ui/editions/edition-keywords-2015-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2015-2015-parsing.stderr
@@ -3,12 +3,24 @@ error: no rules expected the token `r#async`
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `async`
+  --> $DIR/auxiliary/edition-kw-macro-2015.rs:17:6
+   |
+LL |     (async) => (1)
+   |      ^^^^^
 
 error: no rules expected the token `async`
   --> $DIR/edition-keywords-2015-2015-parsing.rs:17:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `r#async`
+  --> $DIR/auxiliary/edition-kw-macro-2015.rs:22:6
+   |
+LL |     (r#async) => (1)
+   |      ^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/editions/edition-keywords-2015-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2015-2018-parsing.stderr
@@ -3,12 +3,24 @@ error: no rules expected the token `r#async`
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `async`
+  --> $DIR/auxiliary/edition-kw-macro-2018.rs:17:6
+   |
+LL |     (async) => (1)
+   |      ^^^^^
 
 error: no rules expected the token `async`
   --> $DIR/edition-keywords-2015-2018-parsing.rs:17:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `r#async`
+  --> $DIR/auxiliary/edition-kw-macro-2018.rs:22:6
+   |
+LL |     (r#async) => (1)
+   |      ^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -25,12 +25,24 @@ error: no rules expected the token `r#async`
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `async`
+  --> $DIR/auxiliary/edition-kw-macro-2015.rs:17:6
+   |
+LL |     (async) => (1)
+   |      ^^^^^
 
 error: no rules expected the token `async`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:21:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `r#async`
+  --> $DIR/auxiliary/edition-kw-macro-2015.rs:22:6
+   |
+LL |     (r#async) => (1)
+   |      ^^^^^^^
 
 error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
   --> $DIR/auxiliary/edition-kw-macro-2015.rs:27:23

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -25,12 +25,24 @@ error: no rules expected the token `r#async`
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `async`
+  --> $DIR/auxiliary/edition-kw-macro-2018.rs:17:6
+   |
+LL |     (async) => (1)
+   |      ^^^^^
 
 error: no rules expected the token `async`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:21:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `r#async`
+  --> $DIR/auxiliary/edition-kw-macro-2018.rs:22:6
+   |
+LL |     (r#async) => (1)
+   |      ^^^^^^^
 
 error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
   --> $DIR/auxiliary/edition-kw-macro-2018.rs:27:23

--- a/src/test/ui/empty/empty-comment.stderr
+++ b/src/test/ui/empty/empty-comment.stderr
@@ -6,6 +6,12 @@ LL | macro_rules! one_arg_macro {
 ...
 LL |     one_arg_macro!(/**/);
    |     ^^^^^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$fmt:expr`
+  --> $DIR/empty-comment.rs:6:6
+   |
+LL |     ($fmt:expr) => (print!(concat!($fmt, "\n")));
+   |      ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/fail-simple.stderr
+++ b/src/test/ui/fail-simple.stderr
@@ -3,6 +3,8 @@ error: no rules expected the token `@`
    |
 LL |     panic!(@);
    |            ^ no rules expected this token in macro call
+   |
+   = note: while trying to match end of macro
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7970a.stderr
+++ b/src/test/ui/issues/issue-7970a.stderr
@@ -6,6 +6,12 @@ LL | macro_rules! one_arg_macro {
 ...
 LL |     one_arg_macro!();
    |     ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$fmt:expr`
+  --> $DIR/issue-7970a.rs:2:6
+   |
+LL |     ($fmt:expr) => (print!(concat!($fmt, "\n")));
+   |      ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/assert-trailing-junk.with-generic-asset.stderr
+++ b/src/test/ui/macros/assert-trailing-junk.with-generic-asset.stderr
@@ -17,6 +17,8 @@ LL |     assert!(true, "whatever" blah);
    |                             -^^^^ no rules expected this token in macro call
    |                             |
    |                             help: missing comma here
+   |
+   = note: while trying to match sequence start
 
 error: unexpected string literal
   --> $DIR/assert-trailing-junk.rs:18:18
@@ -33,6 +35,8 @@ LL |     assert!(true "whatever" blah);
    |                            -^^^^ no rules expected this token in macro call
    |                            |
    |                            help: missing comma here
+   |
+   = note: while trying to match sequence start
 
 error: macro requires an expression as an argument
   --> $DIR/assert-trailing-junk.rs:22:5

--- a/src/test/ui/macros/assert-trailing-junk.without-generic-asset.stderr
+++ b/src/test/ui/macros/assert-trailing-junk.without-generic-asset.stderr
@@ -17,6 +17,8 @@ LL |     assert!(true, "whatever" blah);
    |                             -^^^^ no rules expected this token in macro call
    |                             |
    |                             help: missing comma here
+   |
+   = note: while trying to match sequence start
 
 error: unexpected string literal
   --> $DIR/assert-trailing-junk.rs:18:18
@@ -33,6 +35,8 @@ LL |     assert!(true "whatever" blah);
    |                            -^^^^ no rules expected this token in macro call
    |                            |
    |                            help: missing comma here
+   |
+   = note: while trying to match sequence start
 
 error: macro requires an expression as an argument
   --> $DIR/assert-trailing-junk.rs:22:5

--- a/src/test/ui/macros/macro-at-most-once-rep-2015.stderr
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015.stderr
@@ -12,6 +12,8 @@ LL | macro_rules! foo {
 ...
 LL |     foo!(a?);
    |           ^ no rules expected this token in macro call
+   |
+   = note: while trying to match sequence end
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:26:11
@@ -21,6 +23,8 @@ LL | macro_rules! foo {
 ...
 LL |     foo!(a?a);
    |           ^ no rules expected this token in macro call
+   |
+   = note: while trying to match sequence end
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:27:11
@@ -30,6 +34,8 @@ LL | macro_rules! foo {
 ...
 LL |     foo!(a?a?a);
    |           ^ no rules expected this token in macro call
+   |
+   = note: while trying to match sequence end
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2015.rs:29:5
@@ -39,6 +45,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!();
    |     ^^^^^^^^^^ missing tokens in macro arguments
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2015.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2015.rs:30:15
@@ -48,6 +60,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!(a);
    |               ^ missing tokens in macro arguments
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2015.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:31:15
@@ -57,6 +75,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!(a?);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2015.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:32:15
@@ -66,6 +90,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!(a?a);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2015.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2015.rs:36:5
@@ -75,6 +105,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!();
    |     ^^^^^^^^^^ missing tokens in macro arguments
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2015.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2015.rs:37:15
@@ -84,6 +120,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!(a);
    |               ^ missing tokens in macro arguments
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2015.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:38:15
@@ -93,6 +135,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!(a?);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2015.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:39:15
@@ -102,6 +150,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!(a?a);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2015.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/macros/macro-at-most-once-rep-2018.stderr
+++ b/src/test/ui/macros/macro-at-most-once-rep-2018.stderr
@@ -12,6 +12,8 @@ LL | macro_rules! foo {
 ...
 LL |     foo!(a?);
    |           ^ no rules expected this token in macro call
+   |
+   = note: while trying to match sequence end
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:26:11
@@ -21,6 +23,8 @@ LL | macro_rules! foo {
 ...
 LL |     foo!(a?a);
    |           ^ no rules expected this token in macro call
+   |
+   = note: while trying to match sequence end
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:27:11
@@ -30,6 +34,8 @@ LL | macro_rules! foo {
 ...
 LL |     foo!(a?a?a);
    |           ^ no rules expected this token in macro call
+   |
+   = note: while trying to match sequence end
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2018.rs:29:5
@@ -39,6 +45,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!();
    |     ^^^^^^^^^^ missing tokens in macro arguments
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2018.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2018.rs:30:15
@@ -48,6 +60,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!(a);
    |               ^ missing tokens in macro arguments
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2018.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:31:15
@@ -57,6 +75,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!(a?);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2018.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:32:15
@@ -66,6 +90,12 @@ LL | macro_rules! barplus {
 ...
 LL |     barplus!(a?a);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `+`
+  --> $DIR/macro-at-most-once-rep-2018.rs:15:11
+   |
+LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
+   |           ^
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2018.rs:36:5
@@ -75,6 +105,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!();
    |     ^^^^^^^^^^ missing tokens in macro arguments
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2018.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2018.rs:37:15
@@ -84,6 +120,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!(a);
    |               ^ missing tokens in macro arguments
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2018.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:38:15
@@ -93,6 +135,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!(a?);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2018.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: no rules expected the token `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:39:15
@@ -102,6 +150,12 @@ LL | macro_rules! barstar {
 ...
 LL |     barstar!(a?a);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `*`
+  --> $DIR/macro-at-most-once-rep-2018.rs:19:11
+   |
+LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
+   |           ^
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/macros/macro-non-lifetime.stderr
+++ b/src/test/ui/macros/macro-non-lifetime.stderr
@@ -6,6 +6,12 @@ LL | macro_rules! m { ($x:lifetime) => { } }
 ...
 LL |     m!(a);
    |        ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$x:lifetime`
+  --> $DIR/macro-non-lifetime.rs:3:19
+   |
+LL | macro_rules! m { ($x:lifetime) => { } }
+   |                   ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/missing-comma.stderr
+++ b/src/test/ui/macros/missing-comma.stderr
@@ -14,6 +14,12 @@ LL |     foo!(a b);
    |           -^ no rules expected this token in macro call
    |           |
    |           help: missing comma here
+   |
+note: while trying to match meta-variable `$a:ident`
+  --> $DIR/missing-comma.rs:2:6
+   |
+LL |     ($a:ident) => ();
+   |      ^^^^^^^^
 
 error: no rules expected the token `e`
   --> $DIR/missing-comma.rs:23:21
@@ -25,6 +31,12 @@ LL |     foo!(a, b, c, d e);
    |                    -^ no rules expected this token in macro call
    |                    |
    |                    help: missing comma here
+   |
+note: while trying to match meta-variable `$d:ident`
+  --> $DIR/missing-comma.rs:5:36
+   |
+LL |     ($a:ident, $b:ident, $c:ident, $d:ident) => ();
+   |                                    ^^^^^^^^
 
 error: no rules expected the token `d`
   --> $DIR/missing-comma.rs:25:18
@@ -36,6 +48,12 @@ LL |     foo!(a, b, c d, e);
    |                 -^ no rules expected this token in macro call
    |                 |
    |                 help: missing comma here
+   |
+note: while trying to match meta-variable `$c:ident`
+  --> $DIR/missing-comma.rs:4:26
+   |
+LL |     ($a:ident, $b:ident, $c:ident) => ();
+   |                          ^^^^^^^^
 
 error: no rules expected the token `d`
   --> $DIR/missing-comma.rs:27:18
@@ -45,6 +63,12 @@ LL | macro_rules! foo {
 ...
 LL |     foo!(a, b, c d e);
    |                  ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$c:ident`
+  --> $DIR/missing-comma.rs:4:26
+   |
+LL |     ($a:ident, $b:ident, $c:ident) => ();
+   |                          ^^^^^^^^
 
 error: unexpected end of macro invocation
   --> $DIR/missing-comma.rs:29:23
@@ -54,6 +78,12 @@ LL | macro_rules! bar {
 ...
 LL |     bar!(Level::Error, );
    |                       ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$arg:tt`
+  --> $DIR/missing-comma.rs:10:19
+   |
+LL |     ($lvl:expr, $($arg:tt)+) => {}
+   |                   ^^^^^^^
 
 error: no rules expected the token `,`
   --> $DIR/missing-comma.rs:32:38
@@ -63,6 +93,12 @@ LL | macro_rules! check {
 ...
 LL |     check!(<str as Debug>::fmt, "fmt",);
    |                                      ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$expected:expr`
+  --> $DIR/missing-comma.rs:14:14
+   |
+LL |     ($ty:ty, $expected:expr) => {};
+   |              ^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/macros/nonterminal-matching.stderr
+++ b/src/test/ui/macros/nonterminal-matching.stderr
@@ -10,6 +10,14 @@ LL |     n!(a $nt_item b);
 LL | complex_nonterminal!(enum E {});
    | ------------------------------- in this macro invocation
    |
+note: while trying to match `enum E {}`
+  --> $DIR/nonterminal-matching.rs:15:15
+   |
+LL |     macro n(a $nt_item b) {
+   |               ^^^^^^^^
+...
+LL | complex_nonterminal!(enum E {});
+   | ------------------------------- in this macro invocation
    = note: this error originates in the macro `complex_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/macros/trace_faulty_macros.stderr
+++ b/src/test/ui/macros/trace_faulty_macros.stderr
@@ -10,6 +10,7 @@ LL |         my_faulty_macro!(bcd);
 LL |     my_faulty_macro!();
    |     ------------------ in this macro invocation
    |
+   = note: while trying to match end of macro
    = note: this error originates in the macro `my_faulty_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: trace_macro

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
@@ -6,6 +6,12 @@ LL | macro_rules! accept_pat {
 ...
 LL | accept_pat!(p | q);
    |               ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$p:pat`
+  --> $DIR/or-patterns-syntactic-fail-2018.rs:9:6
+   |
+LL |     ($p:pat) => {};
+   |      ^^^^^^
 
 error: no rules expected the token `|`
   --> $DIR/or-patterns-syntactic-fail-2018.rs:13:13
@@ -15,6 +21,12 @@ LL | macro_rules! accept_pat {
 ...
 LL | accept_pat!(|p| q);
    |             ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$p:pat`
+  --> $DIR/or-patterns-syntactic-fail-2018.rs:9:6
+   |
+LL |     ($p:pat) => {};
+   |      ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/macro/macro-doc-comments-1.stderr
+++ b/src/test/ui/parser/macro/macro-doc-comments-1.stderr
@@ -9,6 +9,12 @@ LL |     //! Inner
    |     |
    |     no rules expected this token in macro call
    |     inner doc comments expand to `#![doc = "..."]`, which is what this macro attempted to match
+   |
+note: while trying to match `[`
+  --> $DIR/macro-doc-comments-1.rs:2:7
+   |
+LL |     (#[$outer:meta]) => ()
+   |       ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/macro/macro-doc-comments-2.stderr
+++ b/src/test/ui/parser/macro/macro-doc-comments-2.stderr
@@ -9,6 +9,12 @@ LL |     /// Outer
    |     |
    |     no rules expected this token in macro call
    |     outer doc comments expand to `#[doc = "..."]`, which is what this macro attempted to match
+   |
+note: while trying to match `!`
+  --> $DIR/macro-doc-comments-2.rs:2:7
+   |
+LL |     (#![$inner:meta]) => ()
+   |       ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/feature-gate.stderr
@@ -72,6 +72,12 @@ LL |     macro_rules! use_expr {
 ...
 LL |     use_expr!(let 0 = 1);
    |               ^^^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$e:expr`
+  --> $DIR/feature-gate.rs:61:10
+   |
+LL |         ($e:expr) => {
+   |          ^^^^^^^
 
 error[E0658]: `if let` guards are experimental
   --> $DIR/feature-gate.rs:7:12

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
@@ -18,6 +18,12 @@ LL |     macro_rules! use_expr {
 ...
 LL |     use_expr!(let 0 = 1);
    |               ^^^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$e:expr`
+  --> $DIR/feature-gate.rs:50:10
+   |
+LL |         ($e:expr) => {
+   |          ^^^^^^^
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:14:16

--- a/src/test/ui/underscore-ident-matcher.stderr
+++ b/src/test/ui/underscore-ident-matcher.stderr
@@ -6,6 +6,12 @@ LL | macro_rules! identity {
 ...
 LL |     let identity!(_) = 10;
    |                   ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$i:ident`
+  --> $DIR/underscore-ident-matcher.rs:2:6
+   |
+LL |     ($i: ident) => (
+   |      ^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When feeding the wrong tokens, it used to fail with a very generic error that wasn't very helpful. This change tries to help by noting where specifically the matching went wrong.

```rust
macro_rules! uwu {
    (a a a b) => {};
}
uwu! { a a a c }
```

```diff
error: no rules expected the token `c`
 --> macros.rs:5:14
  |
1 | macro_rules! uwu {
  | ---------------- when calling this macro
...
4 | uwu! { a a a c }
  |              ^ no rules expected this token in macro call
  |
+note: while trying to match `b`
+ --> macros.rs:2:12
+  |
+2 |     (a a a b) => {};
+  |            ^
```