### PR TITLE
Implement `saturating_shl` and `saturating_shr` on ints

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -989,6 +989,63 @@ macro_rules! int_impl {
             intrinsics::saturating_sub(0, self)
         }
 
+        /// Panic-free bitwise shift-left; yields `0` where the shift exceeds the bitwidth of the type.
+        ///
+        /// Note that this is *not* the same as a rotate-left; the RHS of a saturating shift-left is restricted to
+        /// the range of the type, rather than the bits shifted out of the LHS being returned to the other end.
+        /// The primitive integer types all implement a [`rotate_left`](Self::rotate_left) function,
+        /// which may be what you want instead.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(saturating_bit_shifts)]
+        #[doc = concat!("assert_eq!(0b0000_0001_u8.saturating_shl(u8::BITS - 1), 0b1000_0000_u8);")]
+        #[doc = concat!("assert_eq!(0b0000_0001_u8.saturating_shl(u8::BITS), 0b0000_0000_u8);")]
+        /// ```
+        #[unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[rustc_const_unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn saturating_shl(self, rhs: u32) -> Self {
+            if rhs >= <$SelfT>::BITS {
+                0
+            } else {
+                self << rhs
+            }
+        }
+
+        /// Panic-free bitwise shift-right; yields `0` where the shift exceeds the bitwidth of the type.
+        ///
+        /// Note that this is *not* the same as a rotate-right; the RHS of a saturating shift-right is restricted
+        /// to the range of the type, rather than the bits shifted out of the LHS being returned to the other
+        /// end. The primitive integer types all implement a [`rotate_right`](Self::rotate_right) function,
+        /// which may be what you want instead.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(saturating_bit_shifts)]
+        #[doc = concat!("assert_eq!(0b1000_0000_u8.saturating_shr(u8::BITS), 0b0000_0000_u8);")]
+        /// ```
+        #[unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[rustc_const_unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn saturating_shr(self, rhs: u32) -> Self {
+            if rhs >= <$SelfT>::BITS {
+                0
+            } else {
+                self >> rhs
+            }
+        }
+
         /// Saturating absolute value. Computes `self.abs()`, returning `MAX` if `self ==
         /// MIN` instead of overflowing.
         ///

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1002,9 +1002,12 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(saturating_bit_shifts)]
+        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".saturating_shl(0), 42);")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".saturating_shl(1), 0);")]
         #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), 0);")]
         #[doc = concat!("assert_eq!(1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 2), 1_", stringify!($SelfT), " << ", stringify!($SelfT), "::BITS - 2);")]
         #[doc = concat!("assert_eq!(1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 1), ", stringify!($SelfT), "::MAX);")]
+        #[doc = concat!("assert_eq!(-42_", stringify!($SelfT), ".saturating_shl(0), -42);")]
         #[doc = concat!("assert_eq!(-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 2), -1_", stringify!($SelfT), " << ", stringify!($SelfT), "::BITS - 2);")]
         #[doc = concat!("assert_eq!(-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 1), ", stringify!($SelfT), "::MIN);")]
         #[doc = concat!("assert_eq!(-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), ", stringify!($SelfT), "::MIN, \"-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), ", stringify!($SelfT), "::MIN\");")]
@@ -1018,11 +1021,11 @@ macro_rules! int_impl {
             if rhs == 0 {
                 self
             } else {
-                // leading zeros ignoring first bit (which indicates negative values)
+                // leading zeros/ones but ignoring first bit (which indicates negative values)
                 let leading_zeros = (self << 1).leading_zeros();
                 let leading_ones = (self << 1).leading_ones();
 
-                // would overflow => MIN / MAX depending on whether the value is negative or not
+                // would overflow? => MIN / MAX depending on whether the value is negative or not
                 if self > 0 && leading_zeros <  rhs {
                     Self::MAX
                 } else if self < 0 && leading_ones < rhs {

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1002,11 +1002,12 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(saturating_bit_shifts)]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), 0);")]
         #[doc = concat!("assert_eq!(1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 2), 1_", stringify!($SelfT), " << ", stringify!($SelfT), "::BITS - 2);")]
         #[doc = concat!("assert_eq!(1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 1), ", stringify!($SelfT), "::MAX);")]
         #[doc = concat!("assert_eq!(-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 2), -1_", stringify!($SelfT), " << ", stringify!($SelfT), "::BITS - 2);")]
         #[doc = concat!("assert_eq!(-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 1), ", stringify!($SelfT), "::MIN);")]
-        #[doc = concat!("assert_eq!(-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), ", stringify!($SelfT), "::MIN);")]
+        #[doc = concat!("assert_eq!(-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), ", stringify!($SelfT), "::MIN, \"-1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), ", stringify!($SelfT), "::MIN\");")]
         /// ```
         #[unstable(feature = "saturating_bit_shifts", issue = "103440")]
         #[rustc_const_unstable(feature = "saturating_bit_shifts", issue = "103440")]
@@ -1022,10 +1023,10 @@ macro_rules! int_impl {
                 let leading_ones = (self << 1).leading_ones();
 
                 // would overflow => MIN / MAX depending on whether the value is negative or not
-                if self >= 0 && leading_zeros <  rhs {
-                    <$SelfT>::MAX
+                if self > 0 && leading_zeros <  rhs {
+                    Self::MAX
                 } else if self < 0 && leading_ones < rhs {
-                    <$SelfT>::MIN
+                    Self::MIN
                 } else {
                     // normal shift left
                     self << rhs
@@ -1046,7 +1047,7 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(saturating_bit_shifts)]
-        #[doc = concat!("assert_eq!(0b1000_0000_u8.saturating_shr(u8::BITS), 0b0000_0000_u8);")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.saturating_shr(", stringify!($SelfT), "::BITS - 1), 0);")]
         /// ```
         #[unstable(feature = "saturating_bit_shifts", issue = "103440")]
         #[rustc_const_unstable(feature = "saturating_bit_shifts", issue = "103440")]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1164,6 +1164,63 @@ macro_rules! uint_impl {
             }
         }
 
+        /// Panic-free bitwise shift-left; yields `0` where the shift exceeds the bitwidth of the type.
+        ///
+        /// Note that this is *not* the same as a rotate-left; the RHS of a saturating shift-left is restricted to
+        /// the range of the type, rather than the bits shifted out of the LHS being returned to the other end.
+        /// The primitive integer types all implement a [`rotate_left`](Self::rotate_left) function,
+        /// which may be what you want instead.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(saturating_bit_shifts)]
+        #[doc = concat!("assert_eq!(0b0000_0001_u8.saturating_shl(u8::BITS - 1), 0b1000_0000_u8);")]
+        #[doc = concat!("assert_eq!(0b0000_0001_u8.saturating_shl(u8::BITS), 0b0000_0000_u8);")]
+        /// ```
+        #[unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[rustc_const_unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn saturating_shl(self, rhs: u32) -> Self {
+            if rhs >= <$SelfT>::BITS {
+                0
+            } else {
+                self << rhs
+            }
+        }
+
+        /// Panic-free bitwise shift-right; yields `0` where the shift exceeds the bitwidth of the type.
+        ///
+        /// Note that this is *not* the same as a rotate-right; the RHS of a saturating shift-right is restricted
+        /// to the range of the type, rather than the bits shifted out of the LHS being returned to the other
+        /// end. The primitive integer types all implement a [`rotate_right`](Self::rotate_right) function,
+        /// which may be what you want instead.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(saturating_bit_shifts)]
+        #[doc = concat!("assert_eq!(0b1000_0000_u8.saturating_shr(u8::BITS), 0b0000_0000_u8);")]
+        /// ```
+        #[unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[rustc_const_unstable(feature = "saturating_bit_shifts", issue = "103440")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn saturating_shr(self, rhs: u32) -> Self {
+            if rhs >= <$SelfT>::BITS {
+                0
+            } else {
+                self >> rhs
+            }
+        }
+
         /// Wrapping (modular) addition. Computes `self + rhs`,
         /// wrapping around at the boundary of the type.
         ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1164,7 +1164,7 @@ macro_rules! uint_impl {
             }
         }
 
-        /// Panic-free bitwise shift-left; yields `0` where the shift exceeds the bitwidth of the type.
+        /// Panic-free bitwise shift-left; saturates `MAX` instead of wrapping around.
         ///
         /// Note that this is *not* the same as a rotate-left; the RHS of a saturating shift-left is restricted to
         /// the range of the type, rather than the bits shifted out of the LHS being returned to the other end.
@@ -1177,8 +1177,8 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(saturating_bit_shifts)]
-        #[doc = concat!("assert_eq!(0b0000_0001_u8.saturating_shl(u8::BITS - 1), 0b1000_0000_u8);")]
-        #[doc = concat!("assert_eq!(0b0000_0001_u8.saturating_shl(u8::BITS), 0b0000_0000_u8);")]
+        #[doc = concat!("assert_eq!(1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS - 1), 1_", stringify!($SelfT), " << ", stringify!($SelfT), "::BITS - 1);")]
+        #[doc = concat!("assert_eq!(1_", stringify!($SelfT), ".saturating_shl(", stringify!($SelfT), "::BITS), ", stringify!($SelfT), "::MAX);")]
         /// ```
         #[unstable(feature = "saturating_bit_shifts", issue = "103440")]
         #[rustc_const_unstable(feature = "saturating_bit_shifts", issue = "103440")]
@@ -1186,8 +1186,8 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         pub const fn saturating_shl(self, rhs: u32) -> Self {
-            if rhs >= <$SelfT>::BITS {
-                0
+            if rhs > self.leading_zeros() {
+                <$SelfT>::MAX
             } else {
                 self << rhs
             }


### PR DESCRIPTION
Tracking issue #103440

Implementation based on proposed design by @avitex: https://github.com/avitex/rfcs/blob/master/text/0000-saturating-bit-shifts.md