### PR TITLE
Parser: Recover from using colon as path separator in imports

### DIFF
--- a/src/test/ui/parser/use-colon-as-mod-sep.rs
+++ b/src/test/ui/parser/use-colon-as-mod-sep.rs
@@ -1,0 +1,11 @@
+// Recover from using a colon as a path separator.
+
+use std::process:Command;
+//~^ ERROR expected `::`, found `:`
+use std:fs::File;
+//~^ ERROR expected `::`, found `:`
+use std:collections:HashMap;
+//~^ ERROR expected `::`, found `:`
+//~| ERROR expected `::`, found `:`
+
+fn main() { }

--- a/src/test/ui/parser/use-colon-as-mod-sep.stderr
+++ b/src/test/ui/parser/use-colon-as-mod-sep.stderr
@@ -1,0 +1,28 @@
+error: expected `::`, found `:`
+  --> $DIR/use-colon-as-mod-sep.rs:3:17
+   |
+LL | use std::process:Command;
+   |                 ^ help: use double colon
+   |
+   = note: import paths are delimited using `::`
+
+error: expected `::`, found `:`
+  --> $DIR/use-colon-as-mod-sep.rs:5:8
+   |
+LL | use std:fs::File;
+   |        ^ help: use double colon
+
+error: expected `::`, found `:`
+  --> $DIR/use-colon-as-mod-sep.rs:7:8
+   |
+LL | use std:collections:HashMap;
+   |        ^ help: use double colon
+
+error: expected `::`, found `:`
+  --> $DIR/use-colon-as-mod-sep.rs:7:20
+   |
+LL | use std:collections:HashMap;
+   |                    ^ help: use double colon
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
I don't know if this is the right approach, any feedback is welcome. 

r? @compiler-errors

Fixes #103269