### PR TITLE
Fixed consistency of Apple simulator target's ABI 

### DIFF
--- a/compiler/rustc_target/src/spec/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/apple/tests.rs
@@ -1,0 +1,15 @@
+use crate::spec::{aarch64_apple_ios_sim, aarch64_apple_watchos_sim, x86_64_apple_ios};
+
+#[test]
+fn simulator_targets_set_abi() {
+    let all_sim_targets = [
+        x86_64_apple_ios::target(),
+        aarch64_apple_ios_sim::target(),
+        aarch64_apple_watchos_sim::target(),
+        // TODO: x86_64-apple-tvos and x86_64-apple-watchos-sim
+    ];
+
+    for target in all_sim_targets {
+        assert_eq!(target.abi, "sim")
+    }
+}

--- a/compiler/rustc_target/src/spec/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/apple/tests.rs
@@ -1,12 +1,16 @@
-use crate::spec::{aarch64_apple_ios_sim, aarch64_apple_watchos_sim, x86_64_apple_ios};
+use crate::spec::{
+    aarch64_apple_ios_sim, aarch64_apple_watchos_sim, x86_64_apple_ios, x86_64_apple_tvos,
+};
 
 #[test]
 fn simulator_targets_set_abi() {
     let all_sim_targets = [
         x86_64_apple_ios::target(),
+        x86_64_apple_tvos::target(),
         aarch64_apple_ios_sim::target(),
+        // Note: There is currently no ARM64 tvOS simulator target
         aarch64_apple_watchos_sim::target(),
-        // TODO: x86_64-apple-tvos and x86_64-apple-watchos-sim
+        // TODO: x86_64-apple-watchos-sim
     ];
 
     for target in all_sim_targets {

--- a/compiler/rustc_target/src/spec/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/apple/tests.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
     aarch64_apple_ios_sim, aarch64_apple_watchos_sim, x86_64_apple_ios, x86_64_apple_tvos,
+    x86_64_apple_watchos_sim,
 };
 
 #[test]
@@ -7,10 +8,10 @@ fn simulator_targets_set_abi() {
     let all_sim_targets = [
         x86_64_apple_ios::target(),
         x86_64_apple_tvos::target(),
+        x86_64_apple_watchos_sim::target(),
         aarch64_apple_ios_sim::target(),
         // Note: There is currently no ARM64 tvOS simulator target
         aarch64_apple_watchos_sim::target(),
-        // TODO: x86_64-apple-watchos-sim
     ];
 
     for target in all_sim_targets {

--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -15,6 +15,7 @@ pub enum Arch {
     Arm64,
     Arm64_32,
     I386,
+    #[allow(dead_code)] // Some targets don't use this enum...
     X86_64,
     X86_64_sim,
     X86_64_macabi,

--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -1,6 +1,10 @@
 use crate::spec::{cvs, TargetOptions};
 use std::borrow::Cow;
 
+#[cfg(test)]
+#[path = "apple/tests.rs"]
+mod tests;
+
 use Arch::*;
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
@@ -12,6 +16,7 @@ pub enum Arch {
     Arm64_32,
     I386,
     X86_64,
+    X86_64_sim,
     X86_64_macabi,
     Arm64_macabi,
     Arm64_sim,
@@ -25,7 +30,7 @@ fn target_arch_name(arch: Arch) -> &'static str {
         Arm64 | Arm64_macabi | Arm64_sim => "arm64",
         Arm64_32 => "arm64_32",
         I386 => "i386",
-        X86_64 | X86_64_macabi => "x86_64",
+        X86_64 | X86_64_sim | X86_64_macabi => "x86_64",
     }
 }
 
@@ -33,7 +38,9 @@ fn target_abi(arch: Arch) -> &'static str {
     match arch {
         Armv7 | Armv7k | Armv7s | Arm64 | Arm64_32 | I386 | X86_64 => "",
         X86_64_macabi | Arm64_macabi => "macabi",
-        Arm64_sim => "sim",
+        // x86_64-apple-ios is a simulator target, even though it isn't
+        // declared that way in the target like the other ones...
+        Arm64_sim | X86_64_sim => "sim",
     }
 }
 
@@ -45,7 +52,7 @@ fn target_cpu(arch: Arch) -> &'static str {
         Arm64 => "apple-a7",
         Arm64_32 => "apple-s4",
         I386 => "yonah",
-        X86_64 => "core2",
+        X86_64 | X86_64_sim => "core2",
         X86_64_macabi => "core2",
         Arm64_macabi => "apple-a12",
         Arm64_sim => "apple-a12",
@@ -54,7 +61,7 @@ fn target_cpu(arch: Arch) -> &'static str {
 
 fn link_env_remove(arch: Arch) -> Cow<'static, [Cow<'static, str>]> {
     match arch {
-        Armv7 | Armv7k | Armv7s | Arm64 | Arm64_32 | I386 | X86_64 | Arm64_sim => {
+        Armv7 | Armv7k | Armv7s | Arm64 | Arm64_32 | I386 | X86_64 | X86_64_sim | Arm64_sim => {
             cvs!["MACOSX_DEPLOYMENT_TARGET"]
         }
         X86_64_macabi | Arm64_macabi => cvs!["IPHONEOS_DEPLOYMENT_TARGET"],
@@ -62,11 +69,12 @@ fn link_env_remove(arch: Arch) -> Cow<'static, [Cow<'static, str>]> {
 }
 
 pub fn opts(os: &'static str, arch: Arch) -> TargetOptions {
+    let abi = target_abi(arch);
     TargetOptions {
-        abi: target_abi(arch).into(),
+        abi: abi.into(),
         cpu: target_cpu(arch).into(),
         link_env_remove: link_env_remove(arch),
         has_thread_local: false,
-        ..super::apple_base::opts(os, target_arch_name(arch), target_abi(arch))
+        ..super::apple_base::opts(os, target_arch_name(arch), abi)
     }
 }

--- a/compiler/rustc_target/src/spec/x86_64_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_ios.rs
@@ -2,7 +2,7 @@ use super::apple_sdk_base::{opts, Arch};
 use crate::spec::{StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
-    let base = opts("ios", Arch::X86_64);
+    let base = opts("ios", Arch::X86_64_sim);
     let llvm_target = super::apple_base::ios_sim_llvm_target("x86_64");
 
     Target {

--- a/compiler/rustc_target/src/spec/x86_64_apple_tvos.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_tvos.rs
@@ -2,7 +2,7 @@ use super::apple_sdk_base::{opts, Arch};
 use crate::spec::{StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
-    let base = opts("tvos", Arch::X86_64);
+    let base = opts("tvos", Arch::X86_64_sim);
     Target {
         llvm_target: "x86_64-apple-tvos".into(),
         pointer_width: 64,

--- a/compiler/rustc_target/src/spec/x86_64_apple_watchos_sim.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_watchos_sim.rs
@@ -2,7 +2,7 @@ use super::apple_sdk_base::{opts, Arch};
 use crate::spec::{StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
-    let base = opts("watchos", Arch::X86_64);
+    let base = opts("watchos", Arch::X86_64_sim);
 
     let arch = "x86_64";
     let llvm_target = super::apple_base::watchos_sim_llvm_target(arch);


### PR DESCRIPTION
Currently there's a few Apple device simulator targets that are inconsistent since some set `target_abi = "sim"` (the correct thing to do) while a bunch of others don't set anything (`""`). Due to this its very hard to reliability check if some Rust code is running inside a simulator. This changes all of them to do the same thing and set `sim` as their `target_abi`. 

The new way to identity a simulator during compilation is as simple as `cfg(all(target_vendor="apple", target_abi = "sim"))` or even `cfg(target_abi = "sim")` being less pedantic about it.

The issues with the current form (and inspiration for this) are also summarized in @thomcc's [Tweet](https://twitter.com/at_tcsc/status/1576685244702691328).