### PR TITLE
rustdoc: remove no-op CSS `.source pre.rust { white-space: pre }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -538,7 +538,6 @@ ul.block, .block li {
 }
 
 .source .content pre.rust {
-	white-space: pre;
 	overflow: auto;
 	padding-left: 0;
 }


### PR DESCRIPTION
This rule, added in 49e6db7f3510a99ab3d3723b2430add985629c39, overrode a rule in normalize.css.

https://github.com/rust-lang/rust/blob/49e6db7f3510a99ab3d3723b2430add985629c39/src/librustdoc/html/static/normalize.css#L169-L175

When normalize.css was updated, this rule went away.

https://github.com/necolas/normalize.css/commit/a8edd0c5aa06b905e8e1550fd6a5c01e46375194