### PR TITLE
[dont merge] Revert "Inline a few functions."

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -721,7 +721,6 @@ impl Token {
 }
 
 impl PartialEq<TokenKind> for Token {
-    #[inline]
     fn eq(&self, rhs: &TokenKind) -> bool {
         self.kind == *rhs
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1706,7 +1706,6 @@ impl Ident {
     /// macro (e.g., `macro` or `macro_rules!` items) and stay different if they came from different
     /// non-transparent macros.
     /// Technically, this operation strips all transparent marks from ident's syntactic context.
-    #[inline]
     pub fn normalize_to_macro_rules(self) -> Ident {
         Ident::new(self.name, self.span.normalize_to_macro_rules())
     }
@@ -1722,7 +1721,6 @@ impl Ident {
 }
 
 impl PartialEq for Ident {
-    #[inline]
     fn eq(&self, rhs: &Self) -> bool {
         self.name == rhs.name && self.span.eq_ctxt(rhs.span)
     }


### PR DESCRIPTION
Reverts rust-lang/rust#102387

Now that we have LTO for `rustc`, I want to try if it can make some of the recent "adhoc" `#[inline]` sprinkling redundant.

This PR had a very nice win and no regressions, so let's see what happens if we revert it with LTO being turned on.