### PR TITLE
rustdoc: remove redundant CSS `a.test-arrow:hover`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1233,9 +1233,6 @@ a.test-arrow {
 .example-wrap:hover .test-arrow {
 	visibility: visible;
 }
-a.test-arrow:hover {
-	text-decoration: none;
-}
 
 .code-attribute {
 	font-weight: 300;


### PR DESCRIPTION
In 4b402dbe690dd00f567542ca9e41042826a168b5, when this rule was added, it was overriding a rule that made all links in docblock get an underline when hovered. This became redundant when, after reordering the rules, 7585632052298f9c84cc12ac5afcb23786ae1d3d changed the pro-underline rule to exclude the test-arrow link anyway.