### PR TITLE
rustdoc: Use `unix_sigpipe` instead of `rustc_driver::set_sigpipe_handler`

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -154,7 +154,6 @@ pub fn main() {
         }
     }
 
-    rustc_driver::set_sigpipe_handler();
     rustc_driver::install_ice_hook();
 
     // When using CI artifacts (with `download_stage1 = true`), tracing is unconditionally built

--- a/src/tools/rustdoc/main.rs
+++ b/src/tools/rustdoc/main.rs
@@ -1,3 +1,6 @@
+#![feature(unix_sigpipe)]
+
+#[unix_sigpipe = "sig_dfl"]
 fn main() {
     rustdoc::main()
 }


### PR DESCRIPTION
Do what was already done for `rustc` in #102587, namely start using `unix_sigpipe` instead of `rustc_driver::set_sigpipe_handler`.

After this has been merged, we can completely remove `rustc_driver::set_sigpipe_handler`.

PR that added `set_sigpipe_handler`: https://github.com/rust-lang/rust/pull/49606

Tracking issue for `unix_sigpipe`: #97889

Verification of this change
---------------------------

1. Remove `#[unix_sigpipe = "sig_dfl"]`
1. Run `./x.py build`
1. Run `./build/aarch64-apple-darwin/stage1/bin/rustdoc --help | false`
1. Observe ICE
1. Add back `#[unix_sigpipe = "sig_dfl"]`
1. Run `./x.py build`
1. Run `./build/aarch64-apple-darwin/stage1/bin/rustdoc --help | false`
1. Observe ICE fixed

@rustbot labels +T-rustdoc