### PR TITLE
rustc_metadata: Encode even less doc comments

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -787,8 +787,7 @@ fn should_encode_attr(
     } else if attr.doc_str().is_some() {
         // We keep all public doc comments because they might be "imported" into downstream crates
         // if they use `#[doc(inline)]` to copy an item's documentation into their own.
-        *is_def_id_public
-            .get_or_insert_with(|| tcx.effective_visibilities(()).effective_vis(def_id).is_some())
+        *is_def_id_public.get_or_insert_with(|| tcx.effective_visibilities(()).is_exported(def_id))
     } else if attr.has_name(sym::doc) {
         // If this is a `doc` attribute, and it's marked `inline` (as in `#[doc(inline)]`), we can
         // remove it. It won't be inlinable in downstream crates.


### PR DESCRIPTION
The fact that `def_id` is in the `tcx.privacy_access_levels(())` table is not very meaningful, especially after https://github.com/rust-lang/rust/pull/102026, `is_exported` (or `is_reachable` in the worst case) is what you need.

Follow up to https://github.com/rust-lang/rust/pull/98450.
r? @GuillaumeGomez @lqd 