### PR TITLE
Use Min ModFlagBehavior for control-flow protection if available

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -79,6 +79,7 @@ pub enum LLVMModFlagBehavior {
     Append = 5,
     AppendUnique = 6,
     Max = 7,
+    Min = 8,
 }
 
 // Consts for the LLVM CallConv type, pre-cast to usize.

--- a/src/test/assembly/x86_64-naked-fn-no-cet-prolog.rs
+++ b/src/test/assembly/x86_64-naked-fn-no-cet-prolog.rs
@@ -1,4 +1,5 @@
 // compile-flags: -C no-prepopulate-passes -Zcf-protection=full
+// min-llvm-version: 15.0
 // assembly-output: emit-asm
 // needs-asm-support
 // only-x86_64

--- a/src/test/codegen/cf-protection.rs
+++ b/src/test/codegen/cf-protection.rs
@@ -1,6 +1,7 @@
 // Test that the correct module flags are emitted with different control-flow protection flags.
 
 // revisions: undefined none branch return full
+// min-llvm-version: 15.0
 // needs-llvm-components: x86
 // [undefined] compile-flags:
 // [none] compile-flags: -Z cf-protection=none


### PR DESCRIPTION
Followup to https://reviews.llvm.org/D130065

See also: https://reviews.llvm.org/D123493 and https://reviews.llvm.org/D129911

r? @ghost
cc: @rcvalle 