### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -251,7 +251,8 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             .or_else(|| self.give_name_if_anonymous_region_appears_in_upvars(fr))
             .or_else(|| self.give_name_if_anonymous_region_appears_in_output(fr))
             .or_else(|| self.give_name_if_anonymous_region_appears_in_yield_ty(fr))
-            .or_else(|| self.give_name_if_anonymous_region_appears_in_impl_signature(fr));
+            .or_else(|| self.give_name_if_anonymous_region_appears_in_impl_signature(fr))
+            .or_else(|| self.give_name_if_anonymous_region_appears_in_arg_position_impl_trait(fr));
 
         if let Some(ref value) = value {
             self.region_names.try_borrow_mut().unwrap().insert(fr, value.clone());
@@ -869,13 +870,8 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             return None;
         }
 
-        let mut found = false;
-        tcx.fold_regions(tcx.type_of(region_parent), |r: ty::Region<'tcx>, _| {
-            if *r == ty::ReEarlyBound(region) {
-                found = true;
-            }
-            r
-        });
+        let found = tcx
+            .any_free_region_meets(&tcx.type_of(region_parent), |r| *r == ty::ReEarlyBound(region));
 
         Some(RegionName {
             name: self.synthesize_region_name(),
@@ -886,6 +882,94 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 // example of a `'_` in the impl's trait being referenceable.
                 if found { "self type" } else { "header" },
             ),
+        })
+    }
+
+    fn give_name_if_anonymous_region_appears_in_arg_position_impl_trait(
+        &self,
+        fr: RegionVid,
+    ) -> Option<RegionName> {
+        let ty::ReEarlyBound(region) = *self.to_error_region(fr)? else {
+            return None;
+        };
+        if region.has_name() {
+            return None;
+        };
+
+        let predicates = self
+            .infcx
+            .tcx
+            .predicates_of(self.body.source.def_id())
+            .instantiate_identity(self.infcx.tcx)
+            .predicates;
+
+        if let Some(upvar_index) = self
+            .regioncx
+            .universal_regions()
+            .defining_ty
+            .upvar_tys()
+            .position(|ty| self.any_param_predicate_mentions(&predicates, ty, region))
+        {
+            let (upvar_name, upvar_span) = self.regioncx.get_upvar_name_and_span_for_region(
+                self.infcx.tcx,
+                &self.upvars,
+                upvar_index,
+            );
+            let region_name = self.synthesize_region_name();
+
+            Some(RegionName {
+                name: region_name,
+                source: RegionNameSource::AnonRegionFromUpvar(upvar_span, upvar_name),
+            })
+        } else if let Some(arg_index) = self
+            .regioncx
+            .universal_regions()
+            .unnormalized_input_tys
+            .iter()
+            .position(|ty| self.any_param_predicate_mentions(&predicates, *ty, region))
+        {
+            let (arg_name, arg_span) = self.regioncx.get_argument_name_and_span_for_region(
+                self.body,
+                &self.local_names,
+                arg_index,
+            );
+            let region_name = self.synthesize_region_name();
+
+            Some(RegionName {
+                name: region_name,
+                source: RegionNameSource::AnonRegionFromArgument(
+                    RegionNameHighlight::CannotMatchHirTy(arg_span, arg_name?.to_string()),
+                ),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn any_param_predicate_mentions(
+        &self,
+        predicates: &[ty::Predicate<'tcx>],
+        ty: Ty<'tcx>,
+        region: ty::EarlyBoundRegion,
+    ) -> bool {
+        let tcx = self.infcx.tcx;
+        ty.walk().any(|arg| {
+            if let ty::GenericArgKind::Type(ty) = arg.unpack()
+                && let ty::Param(_) = ty.kind()
+            {
+                predicates.iter().any(|pred| {
+                    match pred.kind().skip_binder() {
+                        ty::PredicateKind::Trait(data) if data.self_ty() == ty => {}
+                        ty::PredicateKind::Projection(data) if data.projection_ty.self_ty() == ty => {}
+                        _ => return false,
+                    }
+                    tcx.any_free_region_meets(pred, |r| {
+                        *r == ty::ReEarlyBound(region)
+                    })
+                })
+            } else {
+                false
+            }
         })
     }
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0210.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0210.md
@@ -76,7 +76,5 @@ Let `Ti` be the first such type.
 For information on the design of the orphan rules,
 see [RFC 2451] and [RFC 1023].
 
-For information on the design of the orphan rules, see [RFC 1023].
-
 [RFC 2451]: https://rust-lang.github.io/rfcs/2451-re-rebalancing-coherence.html
 [RFC 1023]: https://github.com/rust-lang/rfcs/blob/master/text/1023-rebalancing-coherence.md

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -273,16 +273,23 @@ impl<'a> Parser<'a> {
         let cursor_snapshot_next_calls = cursor_snapshot.num_next_calls;
         let mut end_pos = self.token_cursor.num_next_calls;
 
+        let mut captured_trailing = false;
+
         // Capture a trailing token if requested by the callback 'f'
         match trailing {
             TrailingToken::None => {}
+            TrailingToken::Gt => {
+                assert_eq!(self.token.kind, token::Gt);
+            }
             TrailingToken::Semi => {
                 assert_eq!(self.token.kind, token::Semi);
                 end_pos += 1;
+                captured_trailing = true;
             }
             TrailingToken::MaybeComma => {
                 if self.token.kind == token::Comma {
                     end_pos += 1;
+                    captured_trailing = true;
                 }
             }
         }
@@ -292,11 +299,7 @@ impl<'a> Parser<'a> {
         // was not actually bumped past it. When the `LazyAttrTokenStream` gets converted
         // into an `AttrTokenStream`, we will create the proper token.
         if self.token_cursor.break_last_token {
-            assert_eq!(
-                trailing,
-                TrailingToken::None,
-                "Cannot set `break_last_token` and have trailing token"
-            );
+            assert!(!captured_trailing, "Cannot set break_last_token and have trailing token");
             end_pos += 1;
         }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3080,6 +3080,8 @@ impl<'a> Parser<'a> {
                 && this.token.kind == token::Semi
             {
                 TrailingToken::Semi
+            } else if this.token.kind == token::Gt {
+                TrailingToken::Gt
             } else {
                 // FIXME - pass this through from the place where we know
                 // we need a comma, rather than assuming that `#[attr] expr,`

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -79,6 +79,7 @@ pub enum ForceCollect {
 pub enum TrailingToken {
     None,
     Semi,
+    Gt,
     /// If the trailing token is a comma, then capture it
     /// Otherwise, ignore the trailing token
     MaybeComma,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -38,8 +38,8 @@ type Res = def::Res<ast::NodeId>;
 /// A field or associated item from self type suggested in case of resolution failure.
 enum AssocSuggestion {
     Field,
-    MethodWithSelf,
-    AssocFn,
+    MethodWithSelf { called: bool },
+    AssocFn { called: bool },
     AssocType,
     AssocConst,
 }
@@ -48,8 +48,14 @@ impl AssocSuggestion {
     fn action(&self) -> &'static str {
         match self {
             AssocSuggestion::Field => "use the available field",
-            AssocSuggestion::MethodWithSelf => "call the method with the fully-qualified path",
-            AssocSuggestion::AssocFn => "call the associated function",
+            AssocSuggestion::MethodWithSelf { called: true } => {
+                "call the method with the fully-qualified path"
+            }
+            AssocSuggestion::MethodWithSelf { called: false } => {
+                "refer to the method with the fully-qualified path"
+            }
+            AssocSuggestion::AssocFn { called: true } => "call the associated function",
+            AssocSuggestion::AssocFn { called: false } => "refer to the associated function",
             AssocSuggestion::AssocConst => "use the associated `const`",
             AssocSuggestion::AssocType => "use the associated type",
         }
@@ -498,7 +504,9 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         // Try Levenshtein algorithm.
         let typo_sugg = self.lookup_typo_candidate(path, source.namespace(), is_expected);
         if path.len() == 1 && self.self_type_is_available() {
-            if let Some(candidate) = self.lookup_assoc_candidate(ident, ns, is_expected) {
+            if let Some(candidate) =
+                self.lookup_assoc_candidate(ident, ns, is_expected, source.is_call())
+            {
                 let self_is_available = self.self_value_is_available(path[0].ident.span);
                 match candidate {
                     AssocSuggestion::Field => {
@@ -513,16 +521,21 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                             err.span_label(span, "a field by this name exists in `Self`");
                         }
                     }
-                    AssocSuggestion::MethodWithSelf if self_is_available => {
+                    AssocSuggestion::MethodWithSelf { called } if self_is_available => {
+                        let msg = if called {
+                            "you might have meant to call the method"
+                        } else {
+                            "you might have meant to refer to the method"
+                        };
                         err.span_suggestion(
                             span,
-                            "you might have meant to call the method",
+                            msg,
                             format!("self.{path_str}"),
                             Applicability::MachineApplicable,
                         );
                     }
-                    AssocSuggestion::MethodWithSelf
-                    | AssocSuggestion::AssocFn
+                    AssocSuggestion::MethodWithSelf { .. }
+                    | AssocSuggestion::AssocFn { .. }
                     | AssocSuggestion::AssocConst
                     | AssocSuggestion::AssocType => {
                         err.span_suggestion(
@@ -1494,6 +1507,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         ident: Ident,
         ns: Namespace,
         filter_fn: FilterFn,
+        called: bool,
     ) -> Option<AssocSuggestion>
     where
         FilterFn: Fn(Res) -> bool,
@@ -1535,9 +1549,9 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                     return Some(match &assoc_item.kind {
                         ast::AssocItemKind::Const(..) => AssocSuggestion::AssocConst,
                         ast::AssocItemKind::Fn(box ast::Fn { sig, .. }) if sig.decl.has_self() => {
-                            AssocSuggestion::MethodWithSelf
+                            AssocSuggestion::MethodWithSelf { called }
                         }
-                        ast::AssocItemKind::Fn(..) => AssocSuggestion::AssocFn,
+                        ast::AssocItemKind::Fn(..) => AssocSuggestion::AssocFn { called },
                         ast::AssocItemKind::Type(..) => AssocSuggestion::AssocType,
                         ast::AssocItemKind::MacCall(_) => continue,
                     });
@@ -1556,10 +1570,12 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                 let res = binding.res();
                 if filter_fn(res) {
                     if self.r.has_self.contains(&res.def_id()) {
-                        return Some(AssocSuggestion::MethodWithSelf);
+                        return Some(AssocSuggestion::MethodWithSelf { called });
                     } else {
                         match res {
-                            Res::Def(DefKind::AssocFn, _) => return Some(AssocSuggestion::AssocFn),
+                            Res::Def(DefKind::AssocFn, _) => {
+                                return Some(AssocSuggestion::AssocFn { called });
+                            }
                             Res::Def(DefKind::AssocConst, _) => {
                                 return Some(AssocSuggestion::AssocConst);
                             }

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -302,7 +302,7 @@ _Note:_ The order of these lint level arguments is taken into account, see [lint
 This flag will allow you to set unstable options of rustc. In order to set multiple options,
 the -Z flag can be used multiple times. For example: `rustc -Z verbose -Z time-passes`.
 Specifying options with -Z is only available on nightly. To view all available options
-run: `rustc -Z help`.
+run: `rustc -Z help`, or see [The Unstable Book](../unstable-book/index.html).
 
 <a id="option-cap-lints"></a>
 ## `--cap-lints`: set the most restrictive lint level

--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -18,3 +18,7 @@ nav.sub {
 	/* The search bar and related controls don't work without JS */
 	display: none;
 }
+
+.source .sidebar {
+	display: none;
+}

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -538,7 +538,6 @@ ul.block, .block li {
 }
 
 .source .content pre.rust {
-	white-space: pre;
 	overflow: auto;
 	padding-left: 0;
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1233,9 +1233,6 @@ a.test-arrow {
 .example-wrap:hover .test-arrow {
 	visibility: visible;
 }
-a.test-arrow:hover {
-	text-decoration: none;
-}
 
 .code-attribute {
 	font-weight: 300;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -402,10 +402,6 @@ img {
 	overflow-y: hidden;
 }
 
-.rustdoc.source .sidebar .sidebar-logo {
-	display: none;
-}
-
 .source .sidebar, #sidebar-toggle, #source-sidebar {
 	background-color: var(--sidebar-background-color);
 }

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -89,6 +89,7 @@
     </nav> {#- -#}
     {%- endif -%}
     <nav class="sidebar"> {#- -#}
+        {%- if page.css_class != "source" -%}
         <a class="sidebar-logo" href="{{page.root_path|safe}}{{krate_with_trailing_slash|safe}}index.html"> {#- -#}
             <div class="logo-container"> {#- -#}
                 {%- if !layout.logo.is_empty()  %}
@@ -98,6 +99,7 @@
                 {%- endif -%}
             </div> {#- -#}
         </a> {#- -#}
+        {%- endif -%}
         {{- sidebar|safe -}}
     </nav> {#- -#}
     <main> {#- -#}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -154,7 +154,6 @@ pub fn main() {
         }
     }
 
-    rustc_driver::set_sigpipe_handler();
     rustc_driver::install_ice_hook();
 
     // When using CI artifacts (with `download_stage1 = true`), tracing is unconditionally built

--- a/src/test/rustdoc-gui/highlight-colors.goml
+++ b/src/test/rustdoc-gui/highlight-colors.goml
@@ -2,56 +2,93 @@
 goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 show-text: true
 
-local-storage: {"rustdoc-theme": "ayu", "rustdoc-use-system-theme": "false"}
-reload:
+define-function: (
+    "check-colors",
+    (
+        theme,
+        kw,
+        kw2,
+        prelude_ty,
+        prelude_val,
+        lifetime,
+        number,
+        string,
+        bool_val,
+        self,
+        attribute,
+        macro,
+        question_mark,
+        comment,
+        doc_comment,
+    ),
+    [
+        ("local-storage", {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}),
+        ("reload"),
+        ("assert-css", ("pre.rust .kw", {"color": |kw|}, ALL)),
+        ("assert-css", ("pre.rust .kw-2", {"color": |kw2|}, ALL)),
+        ("assert-css", ("pre.rust .prelude-ty", {"color": |prelude_ty|}, ALL)),
+        ("assert-css", ("pre.rust .prelude-val", {"color": |prelude_val|}, ALL)),
+        ("assert-css", ("pre.rust .lifetime", {"color": |lifetime|}, ALL)),
+        ("assert-css", ("pre.rust .number", {"color": |number|}, ALL)),
+        ("assert-css", ("pre.rust .string", {"color": |string|}, ALL)),
+        ("assert-css", ("pre.rust .bool-val", {"color": |bool_val|}, ALL)),
+        ("assert-css", ("pre.rust .self", {"color": |self|}, ALL)),
+        ("assert-css", ("pre.rust .attribute", {"color": |attribute|}, ALL)),
+        ("assert-css", ("pre.rust .macro", {"color": |macro|}, ALL)),
+        ("assert-css", ("pre.rust .question-mark", {"color": |question_mark|}, ALL)),
+        ("assert-css", ("pre.rust .comment", {"color": |comment|}, ALL)),
+        ("assert-css", ("pre.rust .doccomment", {"color": |doc_comment|}, ALL)),
+    ],
+)
 
-assert-css: ("pre.rust .kw", {"color": "rgb(255, 119, 51)"}, ALL)
-assert-css: ("pre.rust .kw-2", {"color": "rgb(255, 119, 51)"}, ALL)
-assert-css: ("pre.rust .prelude-ty", {"color": "rgb(105, 242, 223)"}, ALL)
-assert-css: ("pre.rust .prelude-val", {"color": "rgb(255, 119, 51)"}, ALL)
-assert-css: ("pre.rust .lifetime", {"color": "rgb(255, 119, 51)"}, ALL)
-assert-css: ("pre.rust .number", {"color": "rgb(184, 204, 82)"}, ALL)
-assert-css: ("pre.rust .string", {"color": "rgb(184, 204, 82)"}, ALL)
-assert-css: ("pre.rust .bool-val", {"color": "rgb(255, 119, 51)"}, ALL)
-assert-css: ("pre.rust .self", {"color": "rgb(54, 163, 217)"}, ALL)
-assert-css: ("pre.rust .attribute", {"color": "rgb(230, 225, 207)"}, ALL)
-assert-css: ("pre.rust .macro", {"color": "rgb(163, 122, 204)"}, ALL)
-assert-css: ("pre.rust .question-mark", {"color": "rgb(255, 144, 17)"}, ALL)
-assert-css: ("pre.rust .comment", {"color": "rgb(120, 135, 151)"}, ALL)
-assert-css: ("pre.rust .doccomment", {"color": "rgb(161, 172, 136)"}, ALL)
-
-local-storage: {"rustdoc-theme": "dark"}
-reload:
-
-assert-css: ("pre.rust .kw", {"color": "rgb(171, 138, 193)"}, ALL)
-assert-css: ("pre.rust .kw-2", {"color": "rgb(118, 154, 203)"}, ALL)
-assert-css: ("pre.rust .prelude-ty", {"color": "rgb(118, 154, 203)"}, ALL)
-assert-css: ("pre.rust .prelude-val", {"color": "rgb(238, 104, 104)"}, ALL)
-assert-css: ("pre.rust .lifetime", {"color": "rgb(217, 127, 38)"}, ALL)
-assert-css: ("pre.rust .number", {"color": "rgb(131, 163, 0)"}, ALL)
-assert-css: ("pre.rust .string", {"color": "rgb(131, 163, 0)"}, ALL)
-assert-css: ("pre.rust .bool-val", {"color": "rgb(238, 104, 104)"}, ALL)
-assert-css: ("pre.rust .self", {"color": "rgb(238, 104, 104)"}, ALL)
-assert-css: ("pre.rust .attribute", {"color": "rgb(238, 104, 104)"}, ALL)
-assert-css: ("pre.rust .macro", {"color": "rgb(62, 153, 159)"}, ALL)
-assert-css: ("pre.rust .question-mark", {"color": "rgb(255, 144, 17)"}, ALL)
-assert-css: ("pre.rust .comment", {"color": "rgb(141, 141, 139)"}, ALL)
-assert-css: ("pre.rust .doccomment", {"color": "rgb(140, 163, 117)"}, ALL)
-
-local-storage: {"rustdoc-theme": "light"}
-reload:
-
-assert-css: ("pre.rust .kw", {"color": "rgb(137, 89, 168)"}, ALL)
-assert-css: ("pre.rust .kw-2", {"color": "rgb(66, 113, 174)"}, ALL)
-assert-css: ("pre.rust .prelude-ty", {"color": "rgb(66, 113, 174)"}, ALL)
-assert-css: ("pre.rust .prelude-val", {"color": "rgb(200, 40, 41)"}, ALL)
-assert-css: ("pre.rust .lifetime", {"color": "rgb(183, 101, 20)"}, ALL)
-assert-css: ("pre.rust .number", {"color": "rgb(113, 140, 0)"}, ALL)
-assert-css: ("pre.rust .string", {"color": "rgb(113, 140, 0)"}, ALL)
-assert-css: ("pre.rust .bool-val", {"color": "rgb(200, 40, 41)"}, ALL)
-assert-css: ("pre.rust .self", {"color": "rgb(200, 40, 41)"}, ALL)
-assert-css: ("pre.rust .attribute", {"color": "rgb(200, 40, 41)"}, ALL)
-assert-css: ("pre.rust .macro", {"color": "rgb(62, 153, 159)"}, ALL)
-assert-css: ("pre.rust .question-mark", {"color": "rgb(255, 144, 17)"}, ALL)
-assert-css: ("pre.rust .comment", {"color": "rgb(142, 144, 140)"}, ALL)
-assert-css: ("pre.rust .doccomment", {"color": "rgb(77, 77, 76)"}, ALL)
+call-function: ("check-colors", {
+    "theme": "ayu",
+    "kw": "rgb(255, 119, 51)",
+    "kw2": "rgb(255, 119, 51)",
+    "prelude_ty": "rgb(105, 242, 223)",
+    "prelude_val": "rgb(255, 119, 51)",
+    "lifetime": "rgb(255, 119, 51)",
+    "number": "rgb(184, 204, 82)",
+    "string": "rgb(184, 204, 82)",
+    "bool_val": "rgb(255, 119, 51)",
+    "self": "rgb(54, 163, 217)",
+    "attribute": "rgb(230, 225, 207)",
+    "macro": "rgb(163, 122, 204)",
+    "question_mark": "rgb(255, 144, 17)",
+    "comment": "rgb(120, 135, 151)",
+    "doc_comment": "rgb(161, 172, 136)",
+})
+call-function: ("check-colors", {
+    "theme": "dark",
+    "kw": "rgb(171, 138, 193)",
+    "kw2": "rgb(118, 154, 203)",
+    "prelude_ty": "rgb(118, 154, 203)",
+    "prelude_val": "rgb(238, 104, 104)",
+    "lifetime": "rgb(217, 127, 38)",
+    "number": "rgb(131, 163, 0)",
+    "string": "rgb(131, 163, 0)",
+    "bool_val": "rgb(238, 104, 104)",
+    "self": "rgb(238, 104, 104)",
+    "attribute": "rgb(238, 104, 104)",
+    "macro": "rgb(62, 153, 159)",
+    "question_mark": "rgb(255, 144, 17)",
+    "comment": "rgb(141, 141, 139)",
+    "doc_comment": "rgb(140, 163, 117)",
+})
+call-function: ("check-colors", {
+    "theme": "light",
+    "kw": "rgb(137, 89, 168)",
+    "kw2": "rgb(66, 113, 174)",
+    "prelude_ty": "rgb(66, 113, 174)",
+    "prelude_val": "rgb(200, 40, 41)",
+    "lifetime": "rgb(183, 101, 20)",
+    "number": "rgb(113, 140, 0)",
+    "string": "rgb(113, 140, 0)",
+    "bool_val": "rgb(200, 40, 41)",
+    "self": "rgb(200, 40, 41)",
+    "attribute": "rgb(200, 40, 41)",
+    "macro": "rgb(62, 153, 159)",
+    "question_mark": "rgb(255, 144, 17)",
+    "comment": "rgb(142, 144, 140)",
+    "doc_comment": "rgb(77, 77, 76)",
+})

--- a/src/test/rustdoc-gui/sidebar-source-code-display.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code-display.goml
@@ -3,7 +3,7 @@ javascript: false
 goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 // Since the javascript is disabled, there shouldn't be a toggle.
 assert-false: "#sidebar-toggle"
-wait-for-css: (".sidebar > *", {"visibility": "hidden"})
+wait-for-css: (".sidebar", {"display": "none"})
 
 // Let's retry with javascript enabled.
 javascript: true

--- a/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
+++ b/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
@@ -25,7 +25,7 @@ LL | |     (a, b)
 LL | | }
    | |_^
    |
-help: to declare that the `impl Trait` captures `'b`, you can add an explicit `'b` lifetime bound
+help: to declare that `impl Trait<'a>` captures `'b`, you can add an explicit `'b` lifetime bound
    |
 LL | async fn async_ret_impl_trait1<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a> + 'b {
    |                                                                                ++++

--- a/src/test/ui/borrowck/anonymous-region-in-apit.rs
+++ b/src/test/ui/borrowck/anonymous-region-in-apit.rs
@@ -1,0 +1,12 @@
+#![feature(anonymous_lifetime_in_impl_trait)]
+
+trait Foo<T> {
+    fn bar(self, baz: T);
+}
+
+fn qux(foo: impl Foo<&str>) {
+    |baz: &str| foo.bar(baz);
+    //~^ ERROR borrowed data escapes outside of closure
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/anonymous-region-in-apit.stderr
+++ b/src/test/ui/borrowck/anonymous-region-in-apit.stderr
@@ -1,0 +1,16 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> $DIR/anonymous-region-in-apit.rs:8:17
+   |
+LL | fn qux(foo: impl Foo<&str>) {
+   |        --- lifetime `'2` appears in the type of `foo`
+LL |     |baz: &str| foo.bar(baz);
+   |      ---  -     ^^^^^^^^^^^^
+   |      |    |     |
+   |      |    |     `baz` escapes the closure body here
+   |      |    |     argument requires that `'1` must outlive `'2`
+   |      |    let's call the lifetime of this reference `'1`
+   |      `baz` is a reference that is only valid in the closure body
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/impl-trait/hidden-lifetimes.stderr
+++ b/src/test/ui/impl-trait/hidden-lifetimes.stderr
@@ -6,7 +6,7 @@ LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
 LL |     x
    |     ^
    |
-help: to declare that the `impl Trait` captures `'b`, you can add an explicit `'b` lifetime bound
+help: to declare that `impl Swap` captures `'b`, you can add an explicit `'b` lifetime bound
    |
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a + 'b {
    |                                                                     ++++
@@ -19,7 +19,7 @@ LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl S
 LL |     x
    |     ^
    |
-help: to declare that the `impl Trait` captures `'b`, you can add an explicit `'b` lifetime bound
+help: to declare that `impl Swap` captures `'b`, you can add an explicit `'b` lifetime bound
    |
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a + 'b {
    |                                                                                     ++++

--- a/src/test/ui/impl-trait/in-trait/signature-mismatch.rs
+++ b/src/test/ui/impl-trait/in-trait/signature-mismatch.rs
@@ -1,0 +1,21 @@
+// edition:2021
+
+#![feature(return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+use std::future::Future;
+
+pub trait AsyncTrait {
+    fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
+}
+
+pub struct Struct;
+
+impl AsyncTrait for Struct {
+    fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
+        //~^ ERROR `impl` item signature doesn't match `trait` item signature
+        async move { buff.to_vec() }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/in-trait/signature-mismatch.stderr
+++ b/src/test/ui/impl-trait/in-trait/signature-mismatch.stderr
@@ -1,0 +1,16 @@
+error: `impl` item signature doesn't match `trait` item signature
+  --> $DIR/signature-mismatch.rs:15:5
+   |
+LL |     fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
+   |     ----------------------------------------------------------------- expected `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + 'static`
+...
+LL |     fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + '2`
+   |
+   = note: expected `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + 'static`
+              found `fn(&'1 Struct, &'2 [u8]) -> impl Future<Output = Vec<u8>> + '2`
+   = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
+   = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
+
+error: aborting due to previous error
+

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.stderr
@@ -7,7 +7,7 @@ LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> im
 LL |     if condition() { a } else { b }
    |                                 ^
    |
-help: to declare that the `impl Trait` captures `'b`, you can add an explicit `'b` lifetime bound
+help: to declare that `impl Trait<'d, 'e>` captures `'b`, you can add an explicit `'b` lifetime bound
    |
 LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e> + 'b
    |                                                                                             ++++

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.stderr
@@ -7,7 +7,7 @@ LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a,
 LL |     if condition() { a } else { b }
    |                                 ^
    |
-help: to declare that the `impl Trait` captures `'b`, you can add an explicit `'b` lifetime bound
+help: to declare that `impl Trait<'a, 'b>` captures `'b`, you can add an explicit `'b` lifetime bound
    |
 LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b> + 'b
    |                                                                                 ++++

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -6,7 +6,7 @@ LL | fn elided(x: &i32) -> impl Copy { x }
    |              |
    |              hidden type `&i32` captures the anonymous lifetime defined here
    |
-help: to declare that the `impl Trait` captures `'_`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Copy` captures `'_`, you can add an explicit `'_` lifetime bound
    |
 LL | fn elided(x: &i32) -> impl Copy + '_ { x }
    |                                 ++++
@@ -19,7 +19,7 @@ LL | fn explicit<'a>(x: &'a i32) -> impl Copy { x }
    |             |
    |             hidden type `&'a i32` captures the lifetime `'a` as defined here
    |
-help: to declare that the `impl Trait` captures `'a`, you can add an explicit `'a` lifetime bound
+help: to declare that `impl Copy` captures `'a`, you can add an explicit `'a` lifetime bound
    |
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy + 'a { x }
    |                                          ++++
@@ -32,7 +32,7 @@ LL | fn elided2(x: &i32) -> impl Copy + 'static { x }
    |               |
    |               let's call the lifetime of this reference `'1`
    |
-help: consider changing the `impl Trait`'s explicit `'static` bound to the lifetime of argument `x`
+help: consider changing `impl Copy`'s explicit `'static` bound to the lifetime of argument `x`
    |
 LL | fn elided2(x: &i32) -> impl Copy + '_ { x }
    |                                    ~~
@@ -47,7 +47,7 @@ error: lifetime may not live long enough
 LL | fn explicit2<'a>(x: &'a i32) -> impl Copy + 'static { x }
    |              -- lifetime `'a` defined here            ^ returning this value requires that `'a` must outlive `'static`
    |
-help: consider changing the `impl Trait`'s explicit `'static` bound to the lifetime of argument `x`
+help: consider changing `impl Copy`'s explicit `'static` bound to the lifetime of argument `x`
    |
 LL | fn explicit2<'a>(x: &'a i32) -> impl Copy + 'a { x }
    |                                             ~~
@@ -76,7 +76,7 @@ help: to declare that the trait object captures data from argument `x`, you can 
    |
 LL | fn elided5(x: &i32) -> (Box<dyn Debug + '_>, impl Debug) { (Box::new(x), x) }
    |                                       ++++
-help: to declare that the `impl Trait` captures data from argument `x`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Debug` captures data from argument `x`, you can add an explicit `'_` lifetime bound
    |
 LL | fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug + '_) { (Box::new(x), x) }
    |                                                    ++++
@@ -87,7 +87,7 @@ error: lifetime may not live long enough
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
    |               -- lifetime `'a` defined here                         ^ returning this value requires that `'a` must outlive `'static`
    |
-help: consider changing the `impl Trait`'s explicit `'static` bound to the lifetime of argument `x`
+help: consider changing `impl LifetimeTrait<'a>`'s explicit `'static` bound to the lifetime of argument `x`
    |
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'a { x }
    |                                                           ~~
@@ -104,7 +104,7 @@ LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32
 LL |     move |_| println!("{}", y)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: to declare that the `impl Trait` captures `'b`, you can add an explicit `'b` lifetime bound
+help: to declare that `impl Fn(&'a u32)` captures `'b`, you can add an explicit `'b` lifetime bound
    |
 LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32) + 'b {
    |                                                                              ++++

--- a/src/test/ui/impl-trait/region-escape-via-bound.stderr
+++ b/src/test/ui/impl-trait/region-escape-via-bound.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'x, 'y>(x: Cell<&'x u32>) -> impl Trait<'y>
 LL |     x
    |     ^
    |
-help: to declare that the `impl Trait` captures `'x`, you can add an explicit `'x` lifetime bound
+help: to declare that `impl Trait<'y>` captures `'x`, you can add an explicit `'x` lifetime bound
    |
 LL | fn foo<'x, 'y>(x: Cell<&'x u32>) -> impl Trait<'y> + 'x
    |                                                    ++++

--- a/src/test/ui/impl-trait/static-return-lifetime-infered.stderr
+++ b/src/test/ui/impl-trait/static-return-lifetime-infered.stderr
@@ -6,7 +6,7 @@ LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> {
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: to declare that the `impl Trait` captures `'_`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Iterator<Item = u32>` captures `'_`, you can add an explicit `'_` lifetime bound
    |
 LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> + '_ {
    |                                                           ++++
@@ -19,7 +19,7 @@ LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> {
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: to declare that the `impl Trait` captures `'_`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Iterator<Item = u32>` captures `'_`, you can add an explicit `'_` lifetime bound
    |
 LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> + '_ {
    |                                                           ++++
@@ -32,7 +32,7 @@ LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: to declare that the `impl Trait` captures `'a`, you can add an explicit `'a` lifetime bound
+help: to declare that `impl Iterator<Item = u32>` captures `'a`, you can add an explicit `'a` lifetime bound
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> + 'a {
    |                                                             ++++
@@ -45,7 +45,7 @@ LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: to declare that the `impl Trait` captures `'a`, you can add an explicit `'a` lifetime bound
+help: to declare that `impl Iterator<Item = u32>` captures `'a`, you can add an explicit `'a` lifetime bound
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> + 'a {
    |                                                             ++++

--- a/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
+++ b/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
@@ -6,7 +6,7 @@ LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> {
 LL |     x
    |     ^
    |
-help: to declare that the `impl Trait` captures `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:12 ~ impl_trait_captures[1afc]::foo::'_), '_))`, you can add an explicit `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:12 ~ impl_trait_captures[1afc]::foo::'_), '_))` lifetime bound
+help: to declare that `Opaque(DefId(0:13 ~ impl_trait_captures[1afc]::foo::{opaque#0}), [ReEarlyBound(0, 'a), T, ReEarlyBound(2, 'a)])` captures `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:12 ~ impl_trait_captures[1afc]::foo::'_), '_))`, you can add an explicit `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:12 ~ impl_trait_captures[1afc]::foo::'_), '_))` lifetime bound
    |
 LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> + ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:12 ~ impl_trait_captures[1afc]::foo::'_), '_)) {
    |                                      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/test/ui/parser/issue-103143.rs
+++ b/src/test/ui/parser/issue-103143.rs
@@ -1,0 +1,5 @@
+fn main() {
+    x::<#[a]y::<z>>
+    //~^ ERROR invalid const generic expression
+    //~| ERROR cannot find value `x` in this scope
+}

--- a/src/test/ui/parser/issue-103143.stderr
+++ b/src/test/ui/parser/issue-103143.stderr
@@ -1,0 +1,20 @@
+error: invalid const generic expression
+  --> $DIR/issue-103143.rs:2:13
+   |
+LL |     x::<#[a]y::<z>>
+   |             ^^^^^^
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     x::<#[a]{ y::<z> }>
+   |             +        +
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/issue-103143.rs:2:5
+   |
+LL |     x::<#[a]y::<z>>
+   |     ^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/resolve/issue-14254.stderr
+++ b/src/test/ui/resolve/issue-14254.stderr
@@ -26,7 +26,12 @@ error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:36:9
    |
 LL |         bah;
-   |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+   |         ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
 
 error[E0425]: cannot find value `b` in this scope
   --> $DIR/issue-14254.rs:38:9
@@ -56,7 +61,12 @@ error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:53:9
    |
 LL |         bah;
-   |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+   |         ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
 
 error[E0425]: cannot find value `b` in this scope
   --> $DIR/issue-14254.rs:55:9
@@ -68,31 +78,56 @@ error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:64:9
    |
 LL |         bah;
-   |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+   |         ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:73:9
    |
 LL |         bah;
-   |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+   |         ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:82:9
    |
 LL |         bah;
-   |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+   |         ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:91:9
    |
 LL |         bah;
-   |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+   |         ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:100:9
    |
 LL |         bah;
-   |         ^^^ help: you might have meant to call the associated function: `Self::bah`
+   |         ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:19:9

--- a/src/test/ui/resolve/resolve-assoc-suggestions.stderr
+++ b/src/test/ui/resolve/resolve-assoc-suggestions.stderr
@@ -50,7 +50,7 @@ error[E0425]: cannot find value `method` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:34:9
    |
 LL |         method;
-   |         ^^^^^^ help: you might have meant to call the method: `self.method`
+   |         ^^^^^^ help: you might have meant to refer to the method: `self.method`
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -40,7 +40,7 @@ LL |         bah;
 LL | fn ba() {}
    | ------- similarly named function `ba` defined here
    |
-help: you might have meant to call the associated function
+help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
    |         ~~~~~~~~~

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.stderr
@@ -6,7 +6,7 @@ LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }
    |                          |
    |                          hidden type `Pin<&Foo>` captures the anonymous lifetime defined here
    |
-help: to declare that the `impl Trait` captures `'_`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Clone` captures `'_`, you can add an explicit `'_` lifetime bound
    |
 LL |     async fn f(self: Pin<&Self>) -> impl Clone + '_ { self }
    |                                                ++++

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.stderr
@@ -6,7 +6,7 @@ LL |     fn f(self: Pin<&Self>) -> impl Clone { self }
    |                    |
    |                    hidden type `Pin<&Foo>` captures the anonymous lifetime defined here
    |
-help: to declare that the `impl Trait` captures `'_`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Clone` captures `'_`, you can add an explicit `'_` lifetime bound
    |
 LL |     fn f(self: Pin<&Self>) -> impl Clone + '_ { self }
    |                                          ++++

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -18,7 +18,7 @@ LL | |         *dest = g.get();
 LL | |     }
    | |_____^
    |
-help: to declare that the `impl Trait` captures `'_`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl FnOnce()` captures `'_`, you can add an explicit `'_` lifetime bound
    |
 LL | fn foo<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
    |                                                   ++++

--- a/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.stderr
+++ b/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.stderr
@@ -10,7 +10,7 @@ LL | |             remaining: self.0.iter(),
 LL | |         }
    | |_________^ returning this value requires that `'1` must outlive `'static`
    |
-help: to declare that the `impl Trait` captures data from argument `self`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Iterator<Item = Box<(dyn Foo + 'static)>>` captures data from argument `self`, you can add an explicit `'_` lifetime bound
    |
 LL |     fn iter(&self) -> impl Iterator<Item = Box<dyn Foo>> + '_ {
    |                                                          ++++
@@ -65,7 +65,7 @@ LL | |             remaining: self.0.iter(),
 LL | |         }
    | |_________^ returning this value requires that `'a` must outlive `'static`
    |
-help: to declare that the `impl Trait` captures data from argument `self`, you can add an explicit `'a` lifetime bound
+help: to declare that `impl Iterator<Item = Box<(dyn Foo + 'static)>>` captures data from argument `self`, you can add an explicit `'a` lifetime bound
    |
 LL |     fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> + 'a {
    |                                                                 ++++

--- a/src/tools/rustdoc/main.rs
+++ b/src/tools/rustdoc/main.rs
@@ -1,3 +1,6 @@
+#![feature(unix_sigpipe)]
+
+#[unix_sigpipe = "sig_dfl"]
 fn main() {
     rustdoc::main()
 }


### PR DESCRIPTION
Successful merges:

 - #103333 (Fix assertion failed for break_last_token and trailing token)
 - #103350 (Change terminology for assoc method suggestions when they are not called)
 - #103382 (Don't ICE when reporting borrowck errors involving regions from `anonymous_lifetime_in_impl_trait`)
 - #103409 (Delay span bug when we can't map lifetimes back in `collect_trait_impl_trait_tys`)
 - #103410 (-Z docs: Add link to unstable book)
 - #103416 (Name the `impl Trait` in region bound suggestions)
 - #103462 (rustdoc: remove no-op CSS `.source pre.rust { white-space: pre }`)
 - #103465 (E0210 explanation: remove redundant sentence)
 - #103486 (Use functions in highlight-colors rustdoc GUI test)
 - #103493 (rustdoc: remove unused `.sidebar-logo` DOM on source pages)
 - #103494 (rustdoc: remove redundant CSS `a.test-arrow:hover`)
 - #103495 (rustdoc: Use `unix_sigpipe` instead of `rustc_driver::set_sigpipe_handler`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=103333,103350,103382,103409,103410,103416,103462,103465,103486,103493,103494,103495)
<!-- homu-ignore:end -->