### PR TITLE
[Experiment] Don't merge vtables for improved debugging.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -241,7 +241,14 @@ impl<'ll> CodegenCx<'ll, '_> {
             };
             llvm::LLVMSetInitializer(gv, cv);
             set_global_alignment(self, gv, align);
-            llvm::SetUnnamedAddress(gv, llvm::UnnamedAddr::Global);
+
+            // Experiment: What's the impact of making vtables unmergable?
+            if kind == Some("vtable") {
+                llvm::SetUnnamedAddress(gv, llvm::UnnamedAddr::No);
+            } else {
+                llvm::SetUnnamedAddress(gv, llvm::UnnamedAddr::Global);
+            }
+
             gv
         }
     }


### PR DESCRIPTION
With this PR I'd like to test the performance and size impact of making vtables unique by removing the `unnamed_addr` attribute from them. Having unique vtables is good for debuginfo, because it allows to map from a `dyn` pointer to the self-type of the trait-object by looking at the vtable's debuginfo. If vtables are merged, we lose this ability because we might get the wrong self-type.

This PR disables vtable merging unconditionally, so we can see the impact on perf.rlo. An actual implementation would likely only disable it when full debuginfo is enabled.

r? @ghost