### PR TITLE
Fix unwanted merge of inline doc comments for impl blocks

### DIFF
--- a/src/test/rustdoc/auxiliary/reexport-doc-aux.rs
+++ b/src/test/rustdoc/auxiliary/reexport-doc-aux.rs
@@ -1,0 +1,5 @@
+pub struct Foo;
+
+impl Foo {
+    pub fn foo() {}
+}

--- a/src/test/rustdoc/reexport-doc.rs
+++ b/src/test/rustdoc/reexport-doc.rs
@@ -1,0 +1,8 @@
+// aux-build:reexport-doc-aux.rs
+
+extern crate reexport_doc_aux as dep;
+
+// @has 'reexport_doc/struct.Foo.html'
+// @count - '//p' 'These are the docs for Foo.' 1
+/// These are the docs for Foo.
+pub use dep::Foo;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/102909.

We need this merge mechanism for inlined items but it's completely unwanted for impl blocks (at least the doc comments are, not the other attributes) since we want to keep what `cfg()` is put on the `pub use` or other attributes.

r? @notriddle 