### PR TITLE
Remove `rustc_driver::set_sigpipe_handler()`

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -427,18 +427,6 @@ fn run_compiler(
     })
 }
 
-#[cfg(unix)]
-pub fn set_sigpipe_handler() {
-    unsafe {
-        // Set the SIGPIPE signal handler, so that an EPIPE
-        // will cause rustc to terminate, as expected.
-        assert_ne!(libc::signal(libc::SIGPIPE, libc::SIG_DFL), libc::SIG_ERR);
-    }
-}
-
-#[cfg(windows)]
-pub fn set_sigpipe_handler() {}
-
 // Extract output directory and file from matches.
 fn make_output(matches: &getopts::Matches) -> (Option<PathBuf>, Option<PathBuf>) {
     let odir = matches.opt_str("out-dir").map(|o| PathBuf::from(&o));


### PR DESCRIPTION
Its usage was removed in https://github.com/rust-lang/rust/pull/102587 and https://github.com/rust-lang/rust/pull/103495, so we do not need to keep it around any longer. According to [preliminary input](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Find.20.60rustc_driver.60.20dependent.20projects.3F/near/304490764), we do not need to worry about any deprecation cycle for this explicitly unstable API, and can just straight up remove it.

PR that added `set_sigpipe_handler`: https://github.com/rust-lang/rust/pull/49606

Tracking issue for `unix_sigpipe`: #97889

Migration instructions for any remaining clients
---

Change from

```rust
#![feature(rustc_private)]

extern crate rustc_driver;

fn main() {
    rustc_driver::set_sigpipe_handler();
    // ...
```

to

```rust
#![feature(unix_sigpipe)]

#[unix_sigpipe = "sig_dfl"]
fn main() {
    // ...
```

@rustbot labels +T-compiler