### PR TITLE
Pinning tests for some `macro_rules!` errors discussed in the lang meeting

### DIFF
--- a/src/test/ui/macros/macro_rules-unmatchable-literals.rs
+++ b/src/test/ui/macros/macro_rules-unmatchable-literals.rs
@@ -1,0 +1,14 @@
+// Pinning tests for things that don't work to make sure we notice if that changes
+
+#![crate_type = "lib"]
+
+macro_rules! octal_with_bad_digit {
+    ( 0o1238 ) => {}; //~ ERROR invalid digit
+}
+
+macro_rules! binary_with_bad_digit {
+    ( 0b012 ) => {}; //~ ERROR invalid digit
+}
+
+// This can't happen for Hex and Decimal as things like `123A` and `0xFFG`
+// get treated as unknown *suffixes*, rather than digits.

--- a/src/test/ui/macros/macro_rules-unmatchable-literals.stderr
+++ b/src/test/ui/macros/macro_rules-unmatchable-literals.stderr
@@ -1,0 +1,14 @@
+error: invalid digit for a base 8 literal
+  --> $DIR/macro_rules-unmatchable-literals.rs:6:12
+   |
+LL |     ( 0o1238 ) => {};
+   |            ^
+
+error: invalid digit for a base 2 literal
+  --> $DIR/macro_rules-unmatchable-literals.rs:10:11
+   |
+LL |     ( 0b012 ) => {};
+   |           ^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
r? @nikomatsakis 

Mind just stamping these, since they were useful for the meeting discussion today?