### PR TITLE
diagnostics: do not suggest static candidates as traits to import

### DIFF
--- a/src/test/ui/suggestions/issue-102354.rs
+++ b/src/test/ui/suggestions/issue-102354.rs
@@ -1,0 +1,10 @@
+trait Trait {
+    fn func() {}
+}
+
+impl Trait for i32 {}
+
+fn main() {
+    let x: i32 = 123;
+    x.func(); //~ERROR no method
+}

--- a/src/test/ui/suggestions/issue-102354.stderr
+++ b/src/test/ui/suggestions/issue-102354.stderr
@@ -1,0 +1,24 @@
+error[E0599]: no method named `func` found for type `i32` in the current scope
+  --> $DIR/issue-102354.rs:9:7
+   |
+LL |     x.func();
+   |       ^^^^ this is an associated function, not a method
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: the candidate is defined in the trait `Trait`
+  --> $DIR/issue-102354.rs:2:5
+   |
+LL |     fn func() {}
+   |     ^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL |     i32::func();
+   |     ~~~~~~~~~
+help: disambiguate the associated function for the candidate
+   |
+LL |     <i32 as Trait>::func(x);
+   |     ~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
If it's a static candidate, then it's already implemented. Do not suggest it a second time for implementing.

Partial fix for #102354