### PR TITLE
Point only to the identifiers in the typo suggestions of shadowed names instead of the entire struct

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -691,7 +691,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         let is_expected = &|res| source.is_expected(res);
         let ident_span = path.last().map_or(span, |ident| ident.ident.span);
         let typo_sugg = self.lookup_typo_candidate(path, source.namespace(), is_expected);
-        if let TypoCandidate::Shadowed(res, Some(sugg_span)) = typo_sugg {
+        let is_local = &|res: Res| res.opt_def_id().map_or(false, |id| id.is_local());
+        if let TypoCandidate::Shadowed(res, Some(sugg_span)) = typo_sugg && is_local(res) {
             err.span_label(
                 sugg_span,
                 format!("you might have meant to refer to this {}", res.descr()),

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -2,7 +2,7 @@ error[E0574]: expected struct, variant or union type, found type parameter `T`
   --> $DIR/lexical-scopes.rs:3:13
    |
 LL | struct T { i: i32 }
-   | ------------------- you might have meant to refer to this struct
+   |        - you might have meant to refer to this struct
 LL | fn f<T>() {
    |      - found this type parameter
 LL |     let t = T { i: 0 };

--- a/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
+++ b/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
@@ -1,16 +1,14 @@
 error[E0574]: expected struct, variant or union type, found type parameter `Baz`
   --> $DIR/point-at-type-parameter-shadowing-another-type.rs:16:13
    |
-LL | / struct Baz {
-LL | |     num: usize,
-LL | | }
-   | |_- you might have meant to refer to this struct
-LL |
-LL |   impl<Baz> Foo<Baz> for Bar {
-   |        --- found this type parameter
+LL | struct Baz {
+   |        --- you might have meant to refer to this struct
 ...
-LL |               Baz { num } => num,
-   |               ^^^ not a struct, variant or union type
+LL | impl<Baz> Foo<Baz> for Bar {
+   |      --- found this type parameter
+...
+LL |             Baz { num } => num,
+   |             ^^^ not a struct, variant or union type
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -1,6 +1,9 @@
 error[E0404]: expected trait, found type parameter `Add`
   --> $DIR/issue-35987.rs:5:21
    |
+LL | use std::ops::Add;
+   |               --- you might have meant to refer to this trait
+LL |
 LL | impl<T: Clone, Add> Add for Foo<T> {
    |                ---  ^^^ not a trait
    |                |


### PR DESCRIPTION
Fixes #103358.

As discussed in the issue, the `Span` of the candidate `Ident` for a typo replacement is stored alongside its `Symbol` in `TypoSuggestion`. Then, the span of the identifier is what the "you might have meant to refer to" note is pointed at, rather than the entire struct definition.

Comments in #103111 and the issue both suggest that it is desirable to:
1. include names defined in the same crate as the typo,
2. ignore names defined elsewhere such as in `std`, _and_
3. include names introduced indirectly via `use`.

Since a name from another crate but introduced via `use` has non-local `def_id`, to achieve this, a suggestion is displayed if either the `def_id` of the suggested name is local, or the `span` of the suggested name is in the same file as the typo itself.

Some UI tests have also been modified to reflect this change.

r? @cjgillot 