### PR TITLE
wf: discard nested obligations with placeholders

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -177,9 +177,12 @@ pub fn predicate_obligations<'tcx>(
 /// `for<'a> where { T: 'a } fn(&'a T)`, at which point the `T: 'a` bound is
 /// trivially implied from the `param_env`.
 ///
-/// This means that we WF bounds aren't always sufficiently checked for now. 
+/// This means that we WF bounds aren't always sufficiently checked for now.
 fn emit_obligations_for<'tcx, T: TypeVisitable<'tcx>>(value: T) -> bool {
-    !value.has_escaping_bound_vars()
+    // We also don't emit obligations for placeholders. This will be incorrect
+    // if we ever decide to also replace `ty::Param` with placeholders during
+    // canonicalization or whatever. Hopefully we will have implications by then.
+    !value.has_escaping_bound_vars() && !value.has_placeholders()
 }
 
 struct WfPredicates<'tcx> {

--- a/src/test/ui/wf/higher-ranked/ignored-trait-bound.rs
+++ b/src/test/ui/wf/higher-ranked/ignored-trait-bound.rs
@@ -1,0 +1,19 @@
+// check-pass
+struct NeedsCopy<T: Copy>(T);
+
+// Skips WF because of an escaping bound region.
+struct HasWfHigherRanked
+where
+    (for<'a> fn(NeedsCopy<&'a mut u32>)):,
+{}
+
+// Skips WF because of a placeholder region.
+struct HasWfPlaceholder
+where
+    for<'a> NeedsCopy<&'a mut u32>:,
+{}
+
+fn main() {
+    let _: HasWfHigherRanked;
+    let _: HasWfPlaceholder;
+}

--- a/src/test/ui/wf/higher-ranked/on-impl-not-implied.rs
+++ b/src/test/ui/wf/higher-ranked/on-impl-not-implied.rs
@@ -1,0 +1,17 @@
+// Checks that manual WF bounds are not use for implied bounds.
+//
+// With the current implementation for WF check, this can easily cause
+// unsoundness, as wf does not emit any obligations containing
+// placeholders or bound variables.
+struct MyStruct<T, U>(T, U);
+
+trait Foo<'a, 'b> {}
+
+// IF THIS TEST STOPS EMITTING ERRORS, PLEASE NOTIFY T-TYPES TO CHECK WHETHER THE CHANGE IS SOUND.
+impl<'a, 'b> Foo<'a, 'b> for () //~ ERROR cannot infer an appropriate lifetime
+where
+    &'a &'b ():,
+    //~^ ERROR in type `&'a &'b ()`, reference has a longer lifetime than the data it references
+{}
+
+fn main() {}

--- a/src/test/ui/wf/higher-ranked/on-impl-not-implied.stderr
+++ b/src/test/ui/wf/higher-ranked/on-impl-not-implied.stderr
@@ -1,0 +1,45 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting requirements
+  --> $DIR/on-impl-not-implied.rs:11:14
+   |
+LL | impl<'a, 'b> Foo<'a, 'b> for ()
+   |              ^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
+  --> $DIR/on-impl-not-implied.rs:11:10
+   |
+LL | impl<'a, 'b> Foo<'a, 'b> for ()
+   |          ^^
+note: ...but the lifetime must also be valid for the lifetime `'a` as defined here...
+  --> $DIR/on-impl-not-implied.rs:11:6
+   |
+LL | impl<'a, 'b> Foo<'a, 'b> for ()
+   |      ^^
+note: ...so that the types are compatible
+  --> $DIR/on-impl-not-implied.rs:11:14
+   |
+LL | impl<'a, 'b> Foo<'a, 'b> for ()
+   |              ^^^^^^^^^^^
+   = note: expected `Foo<'a, 'b>`
+              found `Foo<'_, '_>`
+
+error[E0491]: in type `&'a &'b ()`, reference has a longer lifetime than the data it references
+  --> $DIR/on-impl-not-implied.rs:13:5
+   |
+LL |     &'a &'b ():,
+   |     ^^^^^^^^^^
+   |
+note: the pointer is valid for the lifetime `'a` as defined here
+  --> $DIR/on-impl-not-implied.rs:11:6
+   |
+LL | impl<'a, 'b> Foo<'a, 'b> for ()
+   |      ^^
+note: but the referenced data is only valid for the lifetime `'b` as defined here
+  --> $DIR/on-impl-not-implied.rs:11:10
+   |
+LL | impl<'a, 'b> Foo<'a, 'b> for ()
+   |          ^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0491, E0495.
+For more information about an error, try `rustc --explain E0491`.

--- a/src/test/ui/wf/higher-ranked/on-impl.rs
+++ b/src/test/ui/wf/higher-ranked/on-impl.rs
@@ -1,0 +1,21 @@
+// check-pass
+trait Foo<A> {}
+impl<'a, T: Foo<A>, A> Foo<A> for &'a mut T
+where
+    // Needed to use `(A,)` because `A:` by itself doesn't emit a WF bound
+    // as of writing this comment.
+    //
+    // This happens in `fn explicit_predicates_of`.
+    (A,):,
+{}
+
+fn tragic<T, F: for<'a> Foo<&'a T>>(_: F) {}
+fn oh_no<T, F: for<'a> Foo<&'a T>>(mut f: F) {
+    // This results in a `for<'a> WF(&'a T)` bound where `'a` is replaced
+    // with a placeholder before we compute the wf requirements.
+    //
+    // This bound would otherwise result in a `T: 'static` bound.
+    tragic::<T, _>(&mut f);
+}
+
+fn main() {}


### PR DESCRIPTION
WF check currently treats `WF(for<'a> fn(MyType<'a>))` differently from `for<'a> WF(MyType<'a>)`. The first one uses a bound variable when computing the WF requirements for `MyType`, while the second one starts by instantiating the bound variable with a placeholder. This means that currently, we emit WF requirements in the second case while discarding them for the first.

However, checking WF for the second one is also broken by binders not having any implications. See `src/test/ui/wf/higher-ranked/on-impl.rs` which currently fails. ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=46d4f2f24f152fc0361a9afc42efff1e)) This happens because `for<'a> &'a T` should mean `for<'a> where { T: 'a } &'a T` instead of `&'a T`. When adding implied bounds to `predicates_of`, this kind of issue happens pretty much all the time we have a higher ranked trait bound. We should therefore also skip nested obligations in wf if they have placeholders.

As long as we do not consider explicit WF bounds for implied-bounds, this should not cause any additional unsoundness. It may allow for more instances of [an undesirable pattern](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=8991a3bfef466a8dd7b3ae9f03858074) but doing so is difficult. For impls, most of the time the placeholders when using the impl were free regions when checking the impl, at which point we did consider to nested obligations. It is possible using higher ranked bounds, see `src/test/ui/wf/higher-ranked/ignored-trait-bound.rs` where `HasWfPlaceholder` currently results in an error but is allowed with this PR.

I don't expect this change to meaningfully impact the prevalence of this pattern. In our test suite there is a single existing test for which we now skip a nested obligation while there are far more tests where we discard obligations due to escaping bound vars. https://github.com/rust-lang/rust/blob/d49e7e7fa13479c11a3733824c78e280e391288b/src/test/ui/higher-rank-trait-bounds/issue-95230.rs#L3-L7

This unblocks future work on implied bounds and feels like an acceptable band-aid until we can correctly deal with implications.

r? types