### PR TITLE
Change #[suggestion_*] attributes to use style="..."

### DIFF
--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -277,8 +277,9 @@ pub struct RegisterConflict<'a> {
 pub struct SubTupleBinding<'a> {
     #[primary_span]
     #[label]
-    #[suggestion_verbose(
+    #[suggestion(
         ast_lowering_sub_tuple_binding_suggestion,
+        style = "verbose",
         code = "..",
         applicability = "maybe-incorrect"
     )]

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -49,7 +49,7 @@ pub(crate) struct GenericDoesNotLiveLongEnough {
 #[derive(LintDiagnostic)]
 #[diag(borrowck_var_does_not_need_mut)]
 pub(crate) struct VarNeedNotMut {
-    #[suggestion_short(applicability = "machine-applicable", code = "")]
+    #[suggestion(style = "short", applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -120,7 +120,7 @@ pub struct TypeofReservedKeywordUsed<'tcx> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[suggestion_verbose(code = "{ty}")]
+    #[suggestion(style = "verbose", code = "{ty}")]
     pub opt_sugg: Option<(Span, Applicability)>,
 }
 
@@ -237,7 +237,11 @@ pub struct UnusedExternCrate {
 #[derive(LintDiagnostic)]
 #[diag(hir_analysis_extern_crate_not_idiomatic)]
 pub struct ExternCrateNotIdiomatic {
-    #[suggestion_short(applicability = "machine-applicable", code = "{suggestion_code}")]
+    #[suggestion(
+        style = "short",
+        applicability = "machine-applicable",
+        code = "{suggestion_code}"
+    )]
     pub span: Span,
     pub msg_code: String,
     pub suggestion_code: String,

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -113,8 +113,9 @@ pub struct MissingParentheseInRange {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion_verbose(
+#[multipart_suggestion(
     hir_analysis_add_missing_parentheses_in_range,
+    style = "verbose",
     applicability = "maybe-incorrect"
 )]
 pub struct AddMissingParenthesesInRange {

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -109,8 +109,9 @@ pub struct InferenceBadError<'a> {
 
 #[derive(Subdiagnostic)]
 pub enum SourceKindSubdiag<'a> {
-    #[suggestion_verbose(
+    #[suggestion(
         infer_source_kind_subdiag_let,
+        style = "verbose",
         code = ": {type_name}",
         applicability = "has-placeholders"
     )]
@@ -135,8 +136,9 @@ pub enum SourceKindSubdiag<'a> {
         parent_prefix: String,
         parent_name: String,
     },
-    #[suggestion_verbose(
+    #[suggestion(
         infer_source_kind_subdiag_generic_suggestion,
+        style = "verbose",
         code = "::<{args}>",
         applicability = "has-placeholders"
     )]
@@ -150,8 +152,9 @@ pub enum SourceKindSubdiag<'a> {
 
 #[derive(Subdiagnostic)]
 pub enum SourceKindMultiSuggestion<'a> {
-    #[multipart_suggestion_verbose(
+    #[multipart_suggestion(
         infer_source_kind_fully_qualified,
+        style = "verbose",
         applicability = "has-placeholders"
     )]
     FullyQualified {
@@ -163,8 +166,9 @@ pub enum SourceKindMultiSuggestion<'a> {
         adjustment: &'a str,
         successor_pos: &'a str,
     },
-    #[multipart_suggestion_verbose(
+    #[multipart_suggestion(
         infer_source_kind_closure_return,
+        style = "verbose",
         applicability = "has-placeholders"
     )]
     ClosureReturn {
@@ -478,8 +482,9 @@ pub enum ImplicitStaticLifetimeSubdiag {
         #[primary_span]
         span: Span,
     },
-    #[suggestion_verbose(
+    #[suggestion(
         infer_implicit_static_lifetime_suggestion,
+        style = "verbose",
         code = " + '_",
         applicability = "maybe-incorrect"
     )]

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -83,7 +83,7 @@ pub struct UnknownToolInScopedLint {
 pub struct BuiltinEllpisisInclusiveRangePatterns {
     #[primary_span]
     pub span: Span,
-    #[suggestion_short(code = "{replace}", applicability = "machine-applicable")]
+    #[suggestion(style = "short", code = "{replace}", applicability = "machine-applicable")]
     pub suggestion: Span,
     pub replace: String,
 }

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -150,8 +150,9 @@ struct OpaqueHiddenInferredBoundLint<'tcx> {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion_verbose(
+#[suggestion(
     lint_opaque_hidden_inferred_bound_sugg,
+    style = "verbose",
     applicability = "machine-applicable",
     code = " + {trait_ref}"
 )]

--- a/compiler/rustc_macros/src/diagnostics/mod.rs
+++ b/compiler/rustc_macros/src/diagnostics/mod.rs
@@ -129,7 +129,7 @@ pub fn lint_diagnostic_derive(s: Structure<'_>) -> TokenStream {
 /// }
 ///
 /// #[derive(Subdiagnostic)]
-/// #[suggestion_verbose(parser::raw_identifier)]
+/// #[suggestion(style = "verbose",parser::raw_identifier)]
 /// pub struct RawIdentifierSuggestion<'tcx> {
 ///     #[primary_span]
 ///     span: Span,

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -64,7 +64,7 @@ pub(crate) struct BadQPathStage2 {
 #[diag(parser_incorrect_semicolon)]
 pub(crate) struct IncorrectSemicolon<'a> {
     #[primary_span]
-    #[suggestion_short(code = "", applicability = "machine-applicable")]
+    #[suggestion(style = "short", code = "", applicability = "machine-applicable")]
     pub span: Span,
     #[help]
     pub opt_help: Option<()>,
@@ -136,7 +136,12 @@ pub(crate) struct InvalidComparisonOperator {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidComparisonOperatorSub {
-    #[suggestion_short(use_instead, applicability = "machine-applicable", code = "{correct}")]
+    #[suggestion(
+        use_instead,
+        style = "short",
+        applicability = "machine-applicable",
+        code = "{correct}"
+    )]
     Correctable {
         #[primary_span]
         span: Span,
@@ -160,14 +165,16 @@ pub(crate) struct InvalidLogicalOperator {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidLogicalOperatorSub {
-    #[suggestion_short(
+    #[suggestion(
         use_amp_amp_for_conjunction,
+        style = "short",
         applicability = "machine-applicable",
         code = "&&"
     )]
     Conjunction(#[primary_span] Span),
-    #[suggestion_short(
+    #[suggestion(
         use_pipe_pipe_for_disjunction,
+        style = "short",
         applicability = "machine-applicable",
         code = "||"
     )]
@@ -178,7 +185,7 @@ pub(crate) enum InvalidLogicalOperatorSub {
 #[diag(parser_tilde_is_not_unary_operator)]
 pub(crate) struct TildeAsUnaryOperator(
     #[primary_span]
-    #[suggestion_short(applicability = "machine-applicable", code = "!")]
+    #[suggestion(style = "short", applicability = "machine-applicable", code = "!")]
     pub Span,
 );
 
@@ -194,22 +201,25 @@ pub(crate) struct NotAsNegationOperator {
 
 #[derive(Subdiagnostic)]
 pub enum NotAsNegationOperatorSub {
-    #[suggestion_short(
+    #[suggestion(
         parser_unexpected_token_after_not_default,
+        style = "short",
         applicability = "machine-applicable",
         code = "!"
     )]
     SuggestNotDefault(#[primary_span] Span),
 
-    #[suggestion_short(
+    #[suggestion(
         parser_unexpected_token_after_not_bitwise,
+        style = "short",
         applicability = "machine-applicable",
         code = "!"
     )]
     SuggestNotBitwise(#[primary_span] Span),
 
-    #[suggestion_short(
+    #[suggestion(
         parser_unexpected_token_after_not_logical,
+        style = "short",
         applicability = "machine-applicable",
         code = "!"
     )]
@@ -249,7 +259,7 @@ pub(crate) struct UnexpectedTokenAfterLabel {
     #[primary_span]
     #[label(parser_unexpected_token_after_label)]
     pub span: Span,
-    #[suggestion_verbose(suggestion_remove_label, code = "")]
+    #[suggestion(suggestion_remove_label, style = "verbose", code = "")]
     pub remove_label: Option<Span>,
     #[subdiagnostic]
     pub enclose_in_block: Option<UnexpectedTokenAfterLabelSugg>,
@@ -272,7 +282,7 @@ pub(crate) struct RequireColonAfterLabeledExpression {
     pub span: Span,
     #[label]
     pub label: Span,
-    #[suggestion_short(applicability = "machine-applicable", code = ": ")]
+    #[suggestion(style = "short", applicability = "machine-applicable", code = ": ")]
     pub label_end: Span,
 }
 
@@ -354,7 +364,7 @@ pub(crate) struct IntLiteralTooLarge {
 pub(crate) struct MissingSemicolonBeforeArray {
     #[primary_span]
     pub open_delim: Span,
-    #[suggestion_verbose(applicability = "maybe-incorrect", code = ";")]
+    #[suggestion(style = "verbose", applicability = "maybe-incorrect", code = ";")]
     pub semicolon: Span,
 }
 
@@ -442,9 +452,9 @@ pub(crate) struct MissingInInForLoop {
 #[derive(Subdiagnostic)]
 pub(crate) enum MissingInInForLoopSub {
     // Has been misleading, at least in the past (closed Issue #48492), thus maybe-incorrect
-    #[suggestion_short(use_in_not_of, applicability = "maybe-incorrect", code = "in")]
+    #[suggestion(use_in_not_of, style = "short", applicability = "maybe-incorrect", code = "in")]
     InNotOf(#[primary_span] Span),
-    #[suggestion_short(add_in, applicability = "maybe-incorrect", code = " in ")]
+    #[suggestion(add_in, style = "short", applicability = "maybe-incorrect", code = " in ")]
     AddIn(#[primary_span] Span),
 }
 
@@ -470,7 +480,7 @@ pub(crate) struct CatchAfterTry {
 pub(crate) struct CommaAfterBaseStruct {
     #[primary_span]
     pub span: Span,
-    #[suggestion_short(applicability = "machine-applicable", code = "")]
+    #[suggestion(style = "short", applicability = "machine-applicable", code = "")]
     pub comma: Span,
 }
 
@@ -512,7 +522,7 @@ pub(crate) struct RemoveLet {
 #[diag(parser_use_eq_instead)]
 pub(crate) struct UseEqInstead {
     #[primary_span]
-    #[suggestion_short(applicability = "machine-applicable", code = "=")]
+    #[suggestion(style = "short", applicability = "machine-applicable", code = "=")]
     pub span: Span,
 }
 
@@ -520,7 +530,7 @@ pub(crate) struct UseEqInstead {
 #[diag(parser_use_empty_block_not_semi)]
 pub(crate) struct UseEmptyBlockNotSemi {
     #[primary_span]
-    #[suggestion_hidden(applicability = "machine-applicable", code = "{{}}")]
+    #[suggestion(style = "hidden", applicability = "machine-applicable", code = "{{}}")]
     pub span: Span,
 }
 
@@ -576,7 +586,12 @@ pub(crate) struct LeadingPlusNotSupported {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[suggestion_verbose(suggestion_remove_plus, code = "", applicability = "machine-applicable")]
+    #[suggestion(
+        suggestion_remove_plus,
+        style = "verbose",
+        code = "",
+        applicability = "machine-applicable"
+    )]
     pub remove_plus: Option<Span>,
     #[subdiagnostic]
     pub add_parentheses: Option<ExprParenthesesNeeded>,
@@ -843,7 +858,7 @@ pub(crate) struct InvalidCurlyInLetElse {
 #[help]
 pub(crate) struct CompoundAssignmentExpressionInLet {
     #[primary_span]
-    #[suggestion_short(code = "=", applicability = "maybe-incorrect")]
+    #[suggestion(style = "short", code = "=", applicability = "maybe-incorrect")]
     pub span: Span,
 }
 
@@ -864,8 +879,9 @@ pub(crate) struct InvalidMetaItem {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion_verbose(
+#[suggestion(
     parser_sugg_escape_to_use_as_identifier,
+    style = "verbose",
     applicability = "maybe-incorrect",
     code = "r#"
 )]
@@ -1003,7 +1019,12 @@ pub(crate) enum ExpectedSemiSugg {
         applicability = "machine-applicable"
     )]
     ChangeToSemi(#[primary_span] Span),
-    #[suggestion_short(parser_sugg_add_semi, code = ";", applicability = "machine-applicable")]
+    #[suggestion(
+        parser_sugg_add_semi,
+        style = "short",
+        code = ";",
+        applicability = "machine-applicable"
+    )]
     AddSemi(#[primary_span] Span),
 }
 
@@ -1057,8 +1078,9 @@ pub(crate) struct GenericParamsWithoutAngleBracketsSugg {
 pub(crate) struct ComparisonOperatorsCannotBeChained {
     #[primary_span]
     pub span: Vec<Span>,
-    #[suggestion_verbose(
+    #[suggestion(
         parser_sugg_turbofish_syntax,
+        style = "verbose",
         code = "::",
         applicability = "maybe-incorrect"
     )]
@@ -1072,8 +1094,9 @@ pub(crate) struct ComparisonOperatorsCannotBeChained {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum ComparisonOperatorsCannotBeChainedSugg {
-    #[suggestion_verbose(
+    #[suggestion(
         sugg_split_comparison,
+        style = "verbose",
         code = " && {middle_term}",
         applicability = "maybe-incorrect"
     )]
@@ -1215,7 +1238,7 @@ pub(crate) enum UnexpectedConstParamDeclarationSugg {
 pub(crate) struct UnexpectedConstInGenericParam {
     #[primary_span]
     pub span: Span,
-    #[suggestion_verbose(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(style = "verbose", code = "", applicability = "maybe-incorrect")]
     pub to_remove: Option<Span>,
 }
 
@@ -1223,7 +1246,7 @@ pub(crate) struct UnexpectedConstInGenericParam {
 #[diag(parser_async_move_order_incorrect)]
 pub(crate) struct AsyncMoveOrderIncorrect {
     #[primary_span]
-    #[suggestion_verbose(code = "async move", applicability = "maybe-incorrect")]
+    #[suggestion(style = "verbose", code = "async move", applicability = "maybe-incorrect")]
     pub span: Span,
 }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -291,7 +291,7 @@ pub struct DocTestUnknownAny {
 #[note(no_op_note)]
 pub struct DocTestUnknownSpotlight {
     pub path: String,
-    #[suggestion_short(applicability = "machine-applicable", code = "notable_trait")]
+    #[suggestion(style = "short", applicability = "machine-applicable", code = "notable_trait")]
     pub span: Span,
 }
 

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -796,3 +796,10 @@ struct SuggestionsInvalidLiteral {
     //~^ ERROR `code = "..."`/`code(...)` must contain only string literals
     sub: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(compiletest_example)]
+struct SuggestionStyleGood {
+    #[suggestion(code = "", style = "hidden")]
+    sub: Span,
+}

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -40,9 +40,9 @@ struct HelloWarn {}
 //~^ ERROR unsupported type attribute for diagnostic derive enum
 enum DiagnosticOnEnum {
     Foo,
-//~^ ERROR diagnostic slug not specified
+    //~^ ERROR diagnostic slug not specified
     Bar,
-//~^ ERROR diagnostic slug not specified
+    //~^ ERROR diagnostic slug not specified
 }
 
 #[derive(Diagnostic)]
@@ -536,8 +536,7 @@ struct LabelWithTrailingList {
 
 #[derive(LintDiagnostic)]
 #[diag(compiletest_example)]
-struct LintsGood {
-}
+struct LintsGood {}
 
 #[derive(LintDiagnostic)]
 #[diag(compiletest_example)]
@@ -683,7 +682,7 @@ struct RawIdentDiagnosticArg {
 #[diag(compiletest_example)]
 struct SubdiagnosticBad {
     #[subdiagnostic(bad)]
-//~^ ERROR `#[subdiagnostic(bad)]` is not a valid attribute
+    //~^ ERROR `#[subdiagnostic(bad)]` is not a valid attribute
     note: Note,
 }
 
@@ -691,7 +690,7 @@ struct SubdiagnosticBad {
 #[diag(compiletest_example)]
 struct SubdiagnosticBadStr {
     #[subdiagnostic = "bad"]
-//~^ ERROR `#[subdiagnostic = ...]` is not a valid attribute
+    //~^ ERROR `#[subdiagnostic = ...]` is not a valid attribute
     note: Note,
 }
 
@@ -699,7 +698,7 @@ struct SubdiagnosticBadStr {
 #[diag(compiletest_example)]
 struct SubdiagnosticBadTwice {
     #[subdiagnostic(bad, bad)]
-//~^ ERROR `#[subdiagnostic(...)]` is not a valid attribute
+    //~^ ERROR `#[subdiagnostic(...)]` is not a valid attribute
     note: Note,
 }
 
@@ -707,7 +706,7 @@ struct SubdiagnosticBadTwice {
 #[diag(compiletest_example)]
 struct SubdiagnosticBadLitStr {
     #[subdiagnostic("bad")]
-//~^ ERROR `#[subdiagnostic("...")]` is not a valid attribute
+    //~^ ERROR `#[subdiagnostic("...")]` is not a valid attribute
     note: Note,
 }
 
@@ -715,7 +714,7 @@ struct SubdiagnosticBadLitStr {
 #[diag(compiletest_example)]
 struct SubdiagnosticEagerLint {
     #[subdiagnostic(eager)]
-//~^ ERROR `#[subdiagnostic(...)]` is not a valid attribute
+    //~^ ERROR `#[subdiagnostic(...)]` is not a valid attribute
     note: Note,
 }
 
@@ -731,11 +730,7 @@ struct SubdiagnosticEagerCorrect {
 // after the `span_suggestion` call - which breaks eager translation.
 
 #[derive(Subdiagnostic)]
-#[suggestion_short(
-    use_instead,
-    applicability = "machine-applicable",
-    code = "{correct}"
-)]
+#[suggestion_short(use_instead, applicability = "machine-applicable", code = "{correct}")]
 pub(crate) struct SubdiagnosticWithSuggestion {
     #[primary_span]
     span: Span,

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -211,9 +211,10 @@ struct LabelOnNonSpan {
 #[diag(compiletest_example, code = "E0123")]
 struct Suggest {
     #[suggestion(suggestion, code = "This is the suggested code")]
-    #[suggestion_short(suggestion, code = "This is the suggested code")]
-    #[suggestion_hidden(suggestion, code = "This is the suggested code")]
-    #[suggestion_verbose(suggestion, code = "This is the suggested code")]
+    #[suggestion(suggestion, code = "This is the suggested code", style = "normal")]
+    #[suggestion(suggestion, code = "This is the suggested code", style = "short")]
+    #[suggestion(suggestion, code = "This is the suggested code", style = "hidden")]
+    #[suggestion(suggestion, code = "This is the suggested code", style = "verbose")]
     suggestion: (Span, Applicability),
 }
 
@@ -730,7 +731,7 @@ struct SubdiagnosticEagerCorrect {
 // after the `span_suggestion` call - which breaks eager translation.
 
 #[derive(Subdiagnostic)]
-#[suggestion_short(use_instead, applicability = "machine-applicable", code = "{correct}")]
+#[suggestion(use_instead, applicability = "machine-applicable", code = "{correct}")]
 pub(crate) struct SubdiagnosticWithSuggestion {
     #[primary_span]
     span: Span,

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -272,7 +272,7 @@ error: `#[suggestion(nonsense = ...)]` is not a valid attribute
 LL |     #[suggestion(nonsense = "bar")]
    |                  ^^^^^^^^^^^^^^^^
    |
-   = help: only `code` and `applicability` are valid nested attributes
+   = help: only `style`, `code` and `applicability` are valid nested attributes
 
 error: suggestion without `code = "..."`
   --> $DIR/diagnostic-derive.rs:231:5
@@ -286,7 +286,7 @@ error: `#[suggestion(msg = ...)]` is not a valid attribute
 LL |     #[suggestion(msg = "bar")]
    |                  ^^^^^^^^^^^
    |
-   = help: only `code` and `applicability` are valid nested attributes
+   = help: only `style`, `code` and `applicability` are valid nested attributes
 
 error: suggestion without `code = "..."`
   --> $DIR/diagnostic-derive.rs:240:5

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -261,13 +261,13 @@ LL |     #[label(label)]
    |     ^^^^^^^^^^^^^^^
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:223:5
+  --> $DIR/diagnostic-derive.rs:224:5
    |
 LL |     #[suggestion(suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[suggestion(nonsense = ...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:231:18
+  --> $DIR/diagnostic-derive.rs:232:18
    |
 LL |     #[suggestion(nonsense = "bar")]
    |                  ^^^^^^^^^^^^^^^^
@@ -275,13 +275,13 @@ LL |     #[suggestion(nonsense = "bar")]
    = help: only `style`, `code` and `applicability` are valid nested attributes
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:231:5
+  --> $DIR/diagnostic-derive.rs:232:5
    |
 LL |     #[suggestion(nonsense = "bar")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[suggestion(msg = ...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:240:18
+  --> $DIR/diagnostic-derive.rs:241:18
    |
 LL |     #[suggestion(msg = "bar")]
    |                  ^^^^^^^^^^^
@@ -289,13 +289,13 @@ LL |     #[suggestion(msg = "bar")]
    = help: only `style`, `code` and `applicability` are valid nested attributes
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:240:5
+  --> $DIR/diagnostic-derive.rs:241:5
    |
 LL |     #[suggestion(msg = "bar")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: wrong field type for suggestion
-  --> $DIR/diagnostic-derive.rs:263:5
+  --> $DIR/diagnostic-derive.rs:264:5
    |
 LL | /     #[suggestion(suggestion, code = "This is suggested code")]
 LL | |
@@ -305,55 +305,55 @@ LL | |     suggestion: Applicability,
    = help: `#[suggestion(...)]` should be applied to fields of type `Span` or `(Span, Applicability)`
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:279:24
+  --> $DIR/diagnostic-derive.rs:280:24
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                        ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:279:18
+  --> $DIR/diagnostic-derive.rs:280:18
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                  ^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:287:33
+  --> $DIR/diagnostic-derive.rs:288:33
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                                 ^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:287:18
+  --> $DIR/diagnostic-derive.rs:288:18
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                  ^^^^^^^^^^^^^
 
 error: `#[label = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:294:5
+  --> $DIR/diagnostic-derive.rs:295:5
    |
 LL |     #[label = "bar"]
    |     ^^^^^^^^^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:445:44
+  --> $DIR/diagnostic-derive.rs:446:44
    |
 LL |     #[suggestion(suggestion, code = "...", applicability = "maybe-incorrect")]
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:447:24
+  --> $DIR/diagnostic-derive.rs:448:24
    |
 LL |     suggestion: (Span, Applicability),
    |                        ^^^^^^^^^^^^^
 
 error: invalid applicability
-  --> $DIR/diagnostic-derive.rs:453:44
+  --> $DIR/diagnostic-derive.rs:454:44
    |
 LL |     #[suggestion(suggestion, code = "...", applicability = "batman")]
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[label(foo)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:516:20
+  --> $DIR/diagnostic-derive.rs:517:20
    |
 LL |     #[label(label, foo)]
    |                    ^^^
@@ -361,19 +361,19 @@ LL |     #[label(label, foo)]
    = help: a diagnostic slug must be the first argument to the attribute
 
 error: `#[label(foo = ...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:524:20
+  --> $DIR/diagnostic-derive.rs:525:20
    |
 LL |     #[label(label, foo = "...")]
    |                    ^^^^^^^^^^^
 
 error: `#[label(foo(...))]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:532:20
+  --> $DIR/diagnostic-derive.rs:533:20
    |
 LL |     #[label(label, foo("..."))]
    |                    ^^^^^^^^^^
 
 error: `#[primary_span]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:544:5
+  --> $DIR/diagnostic-derive.rs:545:5
    |
 LL |     #[primary_span]
    |     ^^^^^^^^^^^^^^^
@@ -381,13 +381,13 @@ LL |     #[primary_span]
    = help: the `primary_span` field attribute is not valid for lint diagnostics
 
 error: `#[error(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:564:1
+  --> $DIR/diagnostic-derive.rs:565:1
    |
 LL | #[error(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:564:1
+  --> $DIR/diagnostic-derive.rs:565:1
    |
 LL | / #[error(compiletest_example, code = "E0123")]
 LL | |
@@ -399,13 +399,13 @@ LL | | struct ErrorAttribute {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[warn_(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:571:1
+  --> $DIR/diagnostic-derive.rs:572:1
    |
 LL | #[warn_(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:571:1
+  --> $DIR/diagnostic-derive.rs:572:1
    |
 LL | / #[warn_(compiletest_example, code = "E0123")]
 LL | |
@@ -417,13 +417,13 @@ LL | | struct WarnAttribute {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:578:1
+  --> $DIR/diagnostic-derive.rs:579:1
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:578:1
+  --> $DIR/diagnostic-derive.rs:579:1
    |
 LL | / #[lint(compiletest_example, code = "E0123")]
 LL | |
@@ -435,19 +435,19 @@ LL | | struct LintAttributeOnSessionDiag {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:585:1
+  --> $DIR/diagnostic-derive.rs:586:1
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:585:1
+  --> $DIR/diagnostic-derive.rs:586:1
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:585:1
+  --> $DIR/diagnostic-derive.rs:586:1
    |
 LL | / #[lint(compiletest_example, code = "E0123")]
 LL | |
@@ -460,19 +460,19 @@ LL | | struct LintAttributeOnLintDiag {}
    = help: specify the slug as the first argument to the attribute, such as `#[diag(compiletest_example)]`
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:595:44
+  --> $DIR/diagnostic-derive.rs:596:44
    |
 LL |     #[suggestion(suggestion, code = "...", code = ",,,")]
    |                                            ^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:595:30
+  --> $DIR/diagnostic-derive.rs:596:30
    |
 LL |     #[suggestion(suggestion, code = "...", code = ",,,")]
    |                              ^^^^^^^^^^^^
 
 error: wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:604:24
+  --> $DIR/diagnostic-derive.rs:605:24
    |
 LL |     suggestion: (Span, usize),
    |                        ^^^^^
@@ -480,7 +480,7 @@ LL |     suggestion: (Span, usize),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:612:17
+  --> $DIR/diagnostic-derive.rs:613:17
    |
 LL |     suggestion: (Span,),
    |                 ^^^^^^^
@@ -488,13 +488,13 @@ LL |     suggestion: (Span,),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:619:5
+  --> $DIR/diagnostic-derive.rs:620:5
    |
 LL |     #[suggestion(suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:626:1
+  --> $DIR/diagnostic-derive.rs:627:1
    |
 LL | #[multipart_suggestion(suggestion)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -502,7 +502,7 @@ LL | #[multipart_suggestion(suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:629:1
+  --> $DIR/diagnostic-derive.rs:630:1
    |
 LL | #[multipart_suggestion()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -510,7 +510,7 @@ LL | #[multipart_suggestion()]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:633:5
+  --> $DIR/diagnostic-derive.rs:634:5
    |
 LL |     #[multipart_suggestion(suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -518,7 +518,7 @@ LL |     #[multipart_suggestion(suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:641:1
+  --> $DIR/diagnostic-derive.rs:642:1
    |
 LL | #[suggestion(suggestion, code = "...")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -526,7 +526,7 @@ LL | #[suggestion(suggestion, code = "...")]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: `#[label]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:650:1
+  --> $DIR/diagnostic-derive.rs:651:1
    |
 LL | #[label]
    | ^^^^^^^^
@@ -534,7 +534,7 @@ LL | #[label]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: `#[subdiagnostic(bad)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:684:21
+  --> $DIR/diagnostic-derive.rs:685:21
    |
 LL |     #[subdiagnostic(bad)]
    |                     ^^^
@@ -542,7 +542,7 @@ LL |     #[subdiagnostic(bad)]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:692:5
+  --> $DIR/diagnostic-derive.rs:693:5
    |
 LL |     #[subdiagnostic = "bad"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -550,7 +550,7 @@ LL |     #[subdiagnostic = "bad"]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:700:5
+  --> $DIR/diagnostic-derive.rs:701:5
    |
 LL |     #[subdiagnostic(bad, bad)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -558,7 +558,7 @@ LL |     #[subdiagnostic(bad, bad)]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic("...")]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:708:21
+  --> $DIR/diagnostic-derive.rs:709:21
    |
 LL |     #[subdiagnostic("bad")]
    |                     ^^^^^
@@ -566,7 +566,7 @@ LL |     #[subdiagnostic("bad")]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:716:5
+  --> $DIR/diagnostic-derive.rs:717:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -574,19 +574,19 @@ LL |     #[subdiagnostic(eager)]
    = help: eager subdiagnostics are not supported on lints
 
 error: expected at least one string literal for `code(...)`
-  --> $DIR/diagnostic-derive.rs:774:18
+  --> $DIR/diagnostic-derive.rs:775:18
    |
 LL |     #[suggestion(code())]
    |                  ^^^^^^
 
 error: `code(...)` must contain only string literals
-  --> $DIR/diagnostic-derive.rs:782:23
+  --> $DIR/diagnostic-derive.rs:783:23
    |
 LL |     #[suggestion(code(foo))]
    |                       ^^^
 
 error: `code = "..."`/`code(...)` must contain only string literals
-  --> $DIR/diagnostic-derive.rs:790:18
+  --> $DIR/diagnostic-derive.rs:791:18
    |
 LL |     #[suggestion(code = 3)]
    |                  ^^^^^^^^
@@ -604,43 +604,43 @@ LL |     #[nonsense]
    |       ^^^^^^^^
 
 error: cannot find attribute `error` in this scope
-  --> $DIR/diagnostic-derive.rs:564:3
+  --> $DIR/diagnostic-derive.rs:565:3
    |
 LL | #[error(compiletest_example, code = "E0123")]
    |   ^^^^^
 
 error: cannot find attribute `warn_` in this scope
-  --> $DIR/diagnostic-derive.rs:571:3
+  --> $DIR/diagnostic-derive.rs:572:3
    |
 LL | #[warn_(compiletest_example, code = "E0123")]
    |   ^^^^^ help: a built-in attribute with a similar name exists: `warn`
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:578:3
+  --> $DIR/diagnostic-derive.rs:579:3
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:585:3
+  --> $DIR/diagnostic-derive.rs:586:3
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:626:3
+  --> $DIR/diagnostic-derive.rs:627:3
    |
 LL | #[multipart_suggestion(suggestion)]
    |   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:629:3
+  --> $DIR/diagnostic-derive.rs:630:3
    |
 LL | #[multipart_suggestion()]
    |   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:633:7
+  --> $DIR/diagnostic-derive.rs:634:7
    |
 LL |     #[multipart_suggestion(suggestion)]
    |       ^^^^^^^^^^^^^^^^^^^^
@@ -652,7 +652,7 @@ LL | #[diag(nonsense, code = "E0123")]
    |        ^^^^^^^^ not found in `rustc_errors::fluent`
 
 error[E0277]: the trait bound `Hello: IntoDiagnosticArg` is not satisfied
-  --> $DIR/diagnostic-derive.rs:338:10
+  --> $DIR/diagnostic-derive.rs:339:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `Hello`

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -373,7 +373,7 @@ LL |     #[label(label, foo("..."))]
    |                    ^^^^^^^^^^
 
 error: `#[primary_span]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:545:5
+  --> $DIR/diagnostic-derive.rs:544:5
    |
 LL |     #[primary_span]
    |     ^^^^^^^^^^^^^^^
@@ -381,13 +381,13 @@ LL |     #[primary_span]
    = help: the `primary_span` field attribute is not valid for lint diagnostics
 
 error: `#[error(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:565:1
+  --> $DIR/diagnostic-derive.rs:564:1
    |
 LL | #[error(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:565:1
+  --> $DIR/diagnostic-derive.rs:564:1
    |
 LL | / #[error(compiletest_example, code = "E0123")]
 LL | |
@@ -399,13 +399,13 @@ LL | | struct ErrorAttribute {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[warn_(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:572:1
+  --> $DIR/diagnostic-derive.rs:571:1
    |
 LL | #[warn_(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:572:1
+  --> $DIR/diagnostic-derive.rs:571:1
    |
 LL | / #[warn_(compiletest_example, code = "E0123")]
 LL | |
@@ -417,13 +417,13 @@ LL | | struct WarnAttribute {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:579:1
+  --> $DIR/diagnostic-derive.rs:578:1
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:579:1
+  --> $DIR/diagnostic-derive.rs:578:1
    |
 LL | / #[lint(compiletest_example, code = "E0123")]
 LL | |
@@ -435,19 +435,19 @@ LL | | struct LintAttributeOnSessionDiag {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:586:1
+  --> $DIR/diagnostic-derive.rs:585:1
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:586:1
+  --> $DIR/diagnostic-derive.rs:585:1
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:586:1
+  --> $DIR/diagnostic-derive.rs:585:1
    |
 LL | / #[lint(compiletest_example, code = "E0123")]
 LL | |
@@ -460,19 +460,19 @@ LL | | struct LintAttributeOnLintDiag {}
    = help: specify the slug as the first argument to the attribute, such as `#[diag(compiletest_example)]`
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:596:44
+  --> $DIR/diagnostic-derive.rs:595:44
    |
 LL |     #[suggestion(suggestion, code = "...", code = ",,,")]
    |                                            ^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:596:30
+  --> $DIR/diagnostic-derive.rs:595:30
    |
 LL |     #[suggestion(suggestion, code = "...", code = ",,,")]
    |                              ^^^^^^^^^^^^
 
 error: wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:605:24
+  --> $DIR/diagnostic-derive.rs:604:24
    |
 LL |     suggestion: (Span, usize),
    |                        ^^^^^
@@ -480,7 +480,7 @@ LL |     suggestion: (Span, usize),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:613:17
+  --> $DIR/diagnostic-derive.rs:612:17
    |
 LL |     suggestion: (Span,),
    |                 ^^^^^^^
@@ -488,13 +488,13 @@ LL |     suggestion: (Span,),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:620:5
+  --> $DIR/diagnostic-derive.rs:619:5
    |
 LL |     #[suggestion(suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:627:1
+  --> $DIR/diagnostic-derive.rs:626:1
    |
 LL | #[multipart_suggestion(suggestion)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -502,7 +502,7 @@ LL | #[multipart_suggestion(suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:630:1
+  --> $DIR/diagnostic-derive.rs:629:1
    |
 LL | #[multipart_suggestion()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -510,7 +510,7 @@ LL | #[multipart_suggestion()]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:634:5
+  --> $DIR/diagnostic-derive.rs:633:5
    |
 LL |     #[multipart_suggestion(suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -518,7 +518,7 @@ LL |     #[multipart_suggestion(suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:642:1
+  --> $DIR/diagnostic-derive.rs:641:1
    |
 LL | #[suggestion(suggestion, code = "...")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -526,7 +526,7 @@ LL | #[suggestion(suggestion, code = "...")]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: `#[label]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:651:1
+  --> $DIR/diagnostic-derive.rs:650:1
    |
 LL | #[label]
    | ^^^^^^^^
@@ -534,7 +534,7 @@ LL | #[label]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: `#[subdiagnostic(bad)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:685:21
+  --> $DIR/diagnostic-derive.rs:684:21
    |
 LL |     #[subdiagnostic(bad)]
    |                     ^^^
@@ -542,7 +542,7 @@ LL |     #[subdiagnostic(bad)]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:693:5
+  --> $DIR/diagnostic-derive.rs:692:5
    |
 LL |     #[subdiagnostic = "bad"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -550,7 +550,7 @@ LL |     #[subdiagnostic = "bad"]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:701:5
+  --> $DIR/diagnostic-derive.rs:700:5
    |
 LL |     #[subdiagnostic(bad, bad)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -558,7 +558,7 @@ LL |     #[subdiagnostic(bad, bad)]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic("...")]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:709:21
+  --> $DIR/diagnostic-derive.rs:708:21
    |
 LL |     #[subdiagnostic("bad")]
    |                     ^^^^^
@@ -566,7 +566,7 @@ LL |     #[subdiagnostic("bad")]
    = help: `eager` is the only supported nested attribute for `subdiagnostic`
 
 error: `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:717:5
+  --> $DIR/diagnostic-derive.rs:716:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -574,19 +574,19 @@ LL |     #[subdiagnostic(eager)]
    = help: eager subdiagnostics are not supported on lints
 
 error: expected at least one string literal for `code(...)`
-  --> $DIR/diagnostic-derive.rs:779:18
+  --> $DIR/diagnostic-derive.rs:774:18
    |
 LL |     #[suggestion(code())]
    |                  ^^^^^^
 
 error: `code(...)` must contain only string literals
-  --> $DIR/diagnostic-derive.rs:787:23
+  --> $DIR/diagnostic-derive.rs:782:23
    |
 LL |     #[suggestion(code(foo))]
    |                       ^^^
 
 error: `code = "..."`/`code(...)` must contain only string literals
-  --> $DIR/diagnostic-derive.rs:795:18
+  --> $DIR/diagnostic-derive.rs:790:18
    |
 LL |     #[suggestion(code = 3)]
    |                  ^^^^^^^^
@@ -604,43 +604,43 @@ LL |     #[nonsense]
    |       ^^^^^^^^
 
 error: cannot find attribute `error` in this scope
-  --> $DIR/diagnostic-derive.rs:565:3
+  --> $DIR/diagnostic-derive.rs:564:3
    |
 LL | #[error(compiletest_example, code = "E0123")]
    |   ^^^^^
 
 error: cannot find attribute `warn_` in this scope
-  --> $DIR/diagnostic-derive.rs:572:3
+  --> $DIR/diagnostic-derive.rs:571:3
    |
 LL | #[warn_(compiletest_example, code = "E0123")]
    |   ^^^^^ help: a built-in attribute with a similar name exists: `warn`
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:579:3
+  --> $DIR/diagnostic-derive.rs:578:3
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:586:3
+  --> $DIR/diagnostic-derive.rs:585:3
    |
 LL | #[lint(compiletest_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:627:3
+  --> $DIR/diagnostic-derive.rs:626:3
    |
 LL | #[multipart_suggestion(suggestion)]
    |   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:630:3
+  --> $DIR/diagnostic-derive.rs:629:3
    |
 LL | #[multipart_suggestion()]
    |   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:634:7
+  --> $DIR/diagnostic-derive.rs:633:7
    |
 LL |     #[multipart_suggestion(suggestion)]
    |       ^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -11,13 +11,13 @@
 #![crate_type = "lib"]
 
 extern crate rustc_errors;
+extern crate rustc_macros;
 extern crate rustc_session;
 extern crate rustc_span;
-extern crate rustc_macros;
 
 use rustc_errors::Applicability;
-use rustc_span::Span;
 use rustc_macros::Subdiagnostic;
+use rustc_span::Span;
 
 #[derive(Subdiagnostic)]
 #[label(parser_add_paren)]
@@ -40,7 +40,7 @@ enum B {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -165,7 +165,7 @@ enum P {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -177,7 +177,7 @@ enum Q {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -189,7 +189,7 @@ enum R {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -201,7 +201,7 @@ enum S {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -213,7 +213,7 @@ enum T {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -225,7 +225,7 @@ enum U {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -240,7 +240,7 @@ enum V {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -301,14 +301,14 @@ struct AB {
     #[primary_span]
     span: Span,
     #[skip_arg]
-    z: Z
+    z: Z,
 }
 
 #[derive(Subdiagnostic)]
 union AC {
-//~^ ERROR unexpected unsupported untagged union
+    //~^ ERROR unexpected unsupported untagged union
     span: u32,
-    b: u64
+    b: u64,
 }
 
 #[derive(Subdiagnostic)]
@@ -372,7 +372,7 @@ enum AI {
         #[applicability]
         applicability: Applicability,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -427,7 +427,7 @@ struct AN {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser_add_paren, code ="...", applicability = "foo")]
+#[suggestion(parser_add_paren, code = "...", applicability = "foo")]
 //~^ ERROR invalid applicability
 struct AO {
     #[primary_span]
@@ -437,7 +437,7 @@ struct AO {
 #[derive(Subdiagnostic)]
 #[help(parser_add_paren)]
 struct AP {
-    var: String
+    var: String,
 }
 
 #[derive(Subdiagnostic)]
@@ -452,7 +452,7 @@ struct AR {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser_add_paren, code ="...", applicability = "machine-applicable")]
+#[suggestion(parser_add_paren, code = "...", applicability = "machine-applicable")]
 struct AS {
     #[primary_span]
     span: Span,
@@ -467,11 +467,11 @@ enum AT {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
+#[suggestion(parser_add_paren, code = "{var}", applicability = "machine-applicable")]
 struct AU {
     #[primary_span]
     span: Span,
@@ -479,7 +479,7 @@ struct AU {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
+#[suggestion(parser_add_paren, code = "{var}", applicability = "machine-applicable")]
 //~^ ERROR `var` doesn't refer to a field on this type
 struct AV {
     #[primary_span]
@@ -488,22 +488,22 @@ struct AV {
 
 #[derive(Subdiagnostic)]
 enum AW {
-    #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
+    #[suggestion(parser_add_paren, code = "{var}", applicability = "machine-applicable")]
     A {
         #[primary_span]
         span: Span,
         var: String,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
 enum AX {
-    #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
-//~^ ERROR `var` doesn't refer to a field on this type
+    #[suggestion(parser_add_paren, code = "{var}", applicability = "machine-applicable")]
+    //~^ ERROR `var` doesn't refer to a field on this type
     A {
         #[primary_span]
         span: Span,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]
@@ -659,7 +659,7 @@ enum BL {
         /// ..and the field
         #[primary_span]
         span: Span,
-    }
+    },
 }
 
 #[derive(Subdiagnostic)]

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -736,6 +736,13 @@ struct SuggestionStyleVerbose {
 }
 
 #[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style = "tool-only")]
+struct SuggestionStyleToolOnly {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
 #[suggestion(parser_add_paren, code = "", style = "hidden", style = "normal")]
 //~^ ERROR specified multiple times
 //~| NOTE previously specified here

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -706,3 +706,81 @@ struct BQ {
     span: Span,
     r#type: String,
 }
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "")]
+struct SuggestionStyleDefault {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style = "short")]
+struct SuggestionStyleShort {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style = "hidden")]
+struct SuggestionStyleHidden {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style = "verbose")]
+struct SuggestionStyleVerbose {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style = "hidden", style = "normal")]
+//~^ ERROR specified multiple times
+//~| NOTE previously specified here
+struct SuggestionStyleTwice {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
+//~^ ERROR specified multiple times
+//~| NOTE previously specified here
+struct SuggestionStyleTwiceExplicit {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style = "foo")]
+//~^ ERROR invalid suggestion style
+struct SuggestionStyleInvalid1 {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style = 42)]
+//~^ ERROR `#[suggestion(style = ...)]` is not a valid attribute
+struct SuggestionStyleInvalid2 {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style)]
+//~^ ERROR `#[suggestion(style)]` is not a valid attribute
+struct SuggestionStyleInvalid3 {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(parser_add_paren, code = "", style("foo"))]
+//~^ ERROR `#[suggestion(style(...))]` is not a valid attribute
+struct SuggestionStyleInvalid4 {
+    #[primary_span]
+    sub: Span,
+}

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -752,10 +752,17 @@ struct SuggestionStyleTwice {
 }
 
 #[derive(Subdiagnostic)]
+#[suggestion_hidden(parser_add_paren, code = "")]
+//~^ ERROR #[suggestion_hidden(...)]` is not a valid attribute
+struct SuggestionStyleOldSyntax {
+    #[primary_span]
+    sub: Span,
+}
+
+#[derive(Subdiagnostic)]
 #[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
-//~^ ERROR specified multiple times
-//~| NOTE previously specified here
-struct SuggestionStyleTwiceExplicit {
+//~^ ERROR #[suggestion_hidden(...)]` is not a valid attribute
+struct SuggestionStyleOldAndNewSyntax {
     #[primary_span]
     sub: Span,
 }

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -186,7 +186,7 @@ error: unexpected unsupported untagged union
 LL | / union AC {
 LL | |
 LL | |     span: u32,
-LL | |     b: u64
+LL | |     b: u64,
 LL | | }
    | |_^
 
@@ -253,10 +253,10 @@ LL | #[suggestion(parser_add_paren)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid applicability
-  --> $DIR/subdiagnostic-derive.rs:430:45
+  --> $DIR/subdiagnostic-derive.rs:430:46
    |
-LL | #[suggestion(parser_add_paren, code ="...", applicability = "foo")]
-   |                                             ^^^^^^^^^^^^^^^^^^^^^
+LL | #[suggestion(parser_add_paren, code = "...", applicability = "foo")]
+   |                                              ^^^^^^^^^^^^^^^^^^^^^
 
 error: suggestion without `#[primary_span]` field
   --> $DIR/subdiagnostic-derive.rs:448:1
@@ -275,16 +275,16 @@ LL | #[label]
    | ^^^^^^^^
 
 error: `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:482:38
+  --> $DIR/subdiagnostic-derive.rs:482:39
    |
-LL | #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
-   |                                      ^^^^^^^
+LL | #[suggestion(parser_add_paren, code = "{var}", applicability = "machine-applicable")]
+   |                                       ^^^^^^^
 
 error: `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:501:42
+  --> $DIR/subdiagnostic-derive.rs:501:43
    |
-LL |     #[suggestion(parser_add_paren, code ="{var}", applicability = "machine-applicable")]
-   |                                          ^^^^^^^
+LL |     #[suggestion(parser_add_paren, code = "{var}", applicability = "machine-applicable")]
+   |                                           ^^^^^^^
 
 error: `#[suggestion_part]` is not a valid attribute
   --> $DIR/subdiagnostic-derive.rs:524:5

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -446,45 +446,45 @@ LL |     #[suggestion_part(code = 3)]
    |                       ^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:739:61
+  --> $DIR/subdiagnostic-derive.rs:746:61
    |
 LL | #[suggestion(parser_add_paren, code = "", style = "hidden", style = "normal")]
    |                                                             ^^^^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:739:43
+  --> $DIR/subdiagnostic-derive.rs:746:43
    |
 LL | #[suggestion(parser_add_paren, code = "", style = "hidden", style = "normal")]
    |                                           ^^^^^^^^^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:748:50
+  --> $DIR/subdiagnostic-derive.rs:755:50
    |
 LL | #[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
    |                                                  ^^^^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:748:3
+  --> $DIR/subdiagnostic-derive.rs:755:3
    |
 LL | #[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
    |   ^^^^^^^^^^^^^^^^^
 
 error: invalid suggestion style
-  --> $DIR/subdiagnostic-derive.rs:757:51
+  --> $DIR/subdiagnostic-derive.rs:764:51
    |
 LL | #[suggestion(parser_add_paren, code = "", style = "foo")]
    |                                                   ^^^^^
    |
-   = help: valid styles are `normal`, `short`, `hidden` and `verbose`
+   = help: valid styles are `normal`, `short`, `hidden`, `verbose` and `tool-only`
 
 error: `#[suggestion(style = ...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:765:43
+  --> $DIR/subdiagnostic-derive.rs:772:43
    |
 LL | #[suggestion(parser_add_paren, code = "", style = 42)]
    |                                           ^^^^^^^^^^
 
 error: `#[suggestion(style)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:773:43
+  --> $DIR/subdiagnostic-derive.rs:780:43
    |
 LL | #[suggestion(parser_add_paren, code = "", style)]
    |                                           ^^^^^
@@ -492,7 +492,7 @@ LL | #[suggestion(parser_add_paren, code = "", style)]
    = help: a diagnostic slug must be the first argument to the attribute
 
 error: `#[suggestion(style(...))]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:781:43
+  --> $DIR/subdiagnostic-derive.rs:788:43
    |
 LL | #[suggestion(parser_add_paren, code = "", style("foo"))]
    |                                           ^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -320,7 +320,7 @@ error: `#[multipart_suggestion(code = ...)]` is not a valid attribute
 LL | #[multipart_suggestion(parser_add_paren, code = "...", applicability = "machine-applicable")]
    |                                          ^^^^^^^^^^^^
    |
-   = help: only `applicability` is a valid nested attributes
+   = help: only `style` and `applicability` are valid nested attributes
 
 error: multipart suggestion without any `#[suggestion_part(...)]` fields
   --> $DIR/subdiagnostic-derive.rs:536:1
@@ -445,6 +445,58 @@ error: `code = "..."`/`code(...)` must contain only string literals
 LL |     #[suggestion_part(code = 3)]
    |                       ^^^^^^^^
 
+error: specified multiple times
+  --> $DIR/subdiagnostic-derive.rs:739:61
+   |
+LL | #[suggestion(parser_add_paren, code = "", style = "hidden", style = "normal")]
+   |                                                             ^^^^^^^^^^^^^^^^
+   |
+note: previously specified here
+  --> $DIR/subdiagnostic-derive.rs:739:43
+   |
+LL | #[suggestion(parser_add_paren, code = "", style = "hidden", style = "normal")]
+   |                                           ^^^^^^^^^^^^^^^^
+
+error: specified multiple times
+  --> $DIR/subdiagnostic-derive.rs:748:50
+   |
+LL | #[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
+   |                                                  ^^^^^^^^^^^^^^^^
+   |
+note: previously specified here
+  --> $DIR/subdiagnostic-derive.rs:748:3
+   |
+LL | #[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
+   |   ^^^^^^^^^^^^^^^^^
+
+error: invalid suggestion style
+  --> $DIR/subdiagnostic-derive.rs:757:51
+   |
+LL | #[suggestion(parser_add_paren, code = "", style = "foo")]
+   |                                                   ^^^^^
+   |
+   = help: valid styles are `normal`, `short`, `hidden` and `verbose`
+
+error: `#[suggestion(style = ...)]` is not a valid attribute
+  --> $DIR/subdiagnostic-derive.rs:765:43
+   |
+LL | #[suggestion(parser_add_paren, code = "", style = 42)]
+   |                                           ^^^^^^^^^^
+
+error: `#[suggestion(style)]` is not a valid attribute
+  --> $DIR/subdiagnostic-derive.rs:773:43
+   |
+LL | #[suggestion(parser_add_paren, code = "", style)]
+   |                                           ^^^^^
+   |
+   = help: a diagnostic slug must be the first argument to the attribute
+
+error: `#[suggestion(style(...))]` is not a valid attribute
+  --> $DIR/subdiagnostic-derive.rs:781:43
+   |
+LL | #[suggestion(parser_add_paren, code = "", style("foo"))]
+   |                                           ^^^^^^^^^^^^
+
 error: cannot find attribute `foo` in this scope
   --> $DIR/subdiagnostic-derive.rs:63:3
    |
@@ -505,6 +557,6 @@ error[E0425]: cannot find value `slug` in module `rustc_errors::fluent`
 LL | #[label(slug)]
    |         ^^^^ not found in `rustc_errors::fluent`
 
-error: aborting due to 72 previous errors
+error: aborting due to 78 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/src/test/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -457,20 +457,24 @@ note: previously specified here
 LL | #[suggestion(parser_add_paren, code = "", style = "hidden", style = "normal")]
    |                                           ^^^^^^^^^^^^^^^^
 
-error: specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:755:50
+error: `#[suggestion_hidden(...)]` is not a valid attribute
+  --> $DIR/subdiagnostic-derive.rs:755:1
+   |
+LL | #[suggestion_hidden(parser_add_paren, code = "")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Use `#[suggestion(..., style = "hidden")]` instead
+
+error: `#[suggestion_hidden(...)]` is not a valid attribute
+  --> $DIR/subdiagnostic-derive.rs:763:1
    |
 LL | #[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
-   |                                                  ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:755:3
-   |
-LL | #[suggestion_hidden(parser_add_paren, code = "", style = "normal")]
-   |   ^^^^^^^^^^^^^^^^^
+   = help: Use `#[suggestion(..., style = "hidden")]` instead
 
 error: invalid suggestion style
-  --> $DIR/subdiagnostic-derive.rs:764:51
+  --> $DIR/subdiagnostic-derive.rs:771:51
    |
 LL | #[suggestion(parser_add_paren, code = "", style = "foo")]
    |                                                   ^^^^^
@@ -478,13 +482,13 @@ LL | #[suggestion(parser_add_paren, code = "", style = "foo")]
    = help: valid styles are `normal`, `short`, `hidden`, `verbose` and `tool-only`
 
 error: `#[suggestion(style = ...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:772:43
+  --> $DIR/subdiagnostic-derive.rs:779:43
    |
 LL | #[suggestion(parser_add_paren, code = "", style = 42)]
    |                                           ^^^^^^^^^^
 
 error: `#[suggestion(style)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:780:43
+  --> $DIR/subdiagnostic-derive.rs:787:43
    |
 LL | #[suggestion(parser_add_paren, code = "", style)]
    |                                           ^^^^^
@@ -492,7 +496,7 @@ LL | #[suggestion(parser_add_paren, code = "", style)]
    = help: a diagnostic slug must be the first argument to the attribute
 
 error: `#[suggestion(style(...))]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:788:43
+  --> $DIR/subdiagnostic-derive.rs:795:43
    |
 LL | #[suggestion(parser_add_paren, code = "", style("foo"))]
    |                                           ^^^^^^^^^^^^
@@ -557,6 +561,6 @@ error[E0425]: cannot find value `slug` in module `rustc_errors::fluent`
 LL | #[label(slug)]
    |         ^^^^ not found in `rustc_errors::fluent`
 
-error: aborting due to 78 previous errors
+error: aborting due to 79 previous errors
 
 For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
As discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/336883-i18n/topic/.23100717.20tool_only_span_suggestion), this changes `#[(multipart_)suggestion_{short,verbose,hidden}(...)]` attributes to plain `#[(multipart_)suggestion(...)]` attributes with a `style = "{short,verbose,hidden}"` parameter.

It also adds a new style, `tool-only`, that corresponds to `tool_only_span_suggestion`/`tool_only_multipart_suggestion` and causes the suggestion to not be shown in human-readable output at all.

Best reviewed commit-by-commit, there's a bit of noise in there.

cc #100717 @compiler-errors 
r? @davidtwco 