### PR TITLE
Remove bounds check when array is indexed by enum

### DIFF
--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -101,12 +101,10 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
             | StatementKind::Retag { .. }
             | StatementKind::AscribeUserType(..)
             | StatementKind::Coverage(..)
+            | StatementKind::Intrinsic(..)
             | StatementKind::Nop => {
                 // safe (at least as emitted during MIR construction)
             }
-
-            // Move to above list once mir construction uses it.
-            StatementKind::Intrinsic(..) => unreachable!(),
         }
         self.super_statement(statement, location);
     }

--- a/src/test/codegen/enum-bounds-check-derived-idx.rs
+++ b/src/test/codegen/enum-bounds-check-derived-idx.rs
@@ -12,15 +12,13 @@ pub enum Bar {
 // CHECK-LABEL: @lookup_inc
 #[no_mangle]
 pub fn lookup_inc(buf: &[u8; 5], f: Bar) -> u8 {
-    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
-    // CHECK: panic_bounds_check
+    // CHECK-NOT: panic_bounds_check
     buf[f as usize + 1]
 }
 
 // CHECK-LABEL: @lookup_dec
 #[no_mangle]
 pub fn lookup_dec(buf: &[u8; 5], f: Bar) -> u8 {
-    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
-    // CHECK: panic_bounds_check
+    // CHECK-NOT: panic_bounds_check
     buf[f as usize - 1]
 }

--- a/src/test/codegen/enum-bounds-check-issue-13926.rs
+++ b/src/test/codegen/enum-bounds-check-issue-13926.rs
@@ -13,7 +13,6 @@ pub enum Exception {
 // CHECK-LABEL: @access
 #[no_mangle]
 pub fn access(array: &[usize; 12], exc: Exception) -> usize {
-    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
-    // CHECK: panic_bounds_check
+    // CHECK-NOT: panic_bounds_check
     array[(exc as u8 - 4) as usize]
 }

--- a/src/test/codegen/enum-bounds-check.rs
+++ b/src/test/codegen/enum-bounds-check.rs
@@ -21,7 +21,6 @@ pub enum Bar {
 // CHECK-LABEL: @lookup_unmodified
 #[no_mangle]
 pub fn lookup_unmodified(buf: &[u8; 5], f: Bar) -> u8 {
-    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
-    // CHECK: panic_bounds_check
+    // CHECK-NOT: panic_bounds_check
     buf[f as usize]
 }

--- a/src/test/mir-opt/building/enum_cast.bar.built.after.mir
+++ b/src/test/mir-opt/building/enum_cast.bar.built.after.mir
@@ -5,11 +5,17 @@ fn bar(_1: Bar) -> usize {
     let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:+0:21: +0:26
     let _2: Bar;                         // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
     let mut _3: isize;                   // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
+    let mut _4: bool;                    // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+    let mut _5: bool;                    // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
         _2 = move _1;                    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
         _3 = discriminant(_2);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _4 = Ge(const 1_isize, _3);      // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        assume(_4);                      // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _5 = Le(const 0_isize, _3);      // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        assume(_5);                      // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
         _0 = move _3 as usize (IntToInt); // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
         StorageDead(_2);                 // scope 0 at $DIR/enum_cast.rs:+1:16: +1:17
         return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2

--- a/src/test/mir-opt/building/enum_cast.boo.built.after.mir
+++ b/src/test/mir-opt/building/enum_cast.boo.built.after.mir
@@ -5,11 +5,17 @@ fn boo(_1: Boo) -> usize {
     let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:+0:21: +0:26
     let _2: Boo;                         // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
     let mut _3: u8;                      // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
+    let mut _4: bool;                    // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+    let mut _5: bool;                    // in scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
         _2 = move _1;                    // scope 0 at $DIR/enum_cast.rs:+1:5: +1:8
         _3 = discriminant(_2);           // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _4 = Ge(const 1_u8, _3);         // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        assume(_4);                      // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        _5 = Le(const 0_u8, _3);         // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
+        assume(_5);                      // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
         _0 = move _3 as usize (IntToInt); // scope 0 at $DIR/enum_cast.rs:+1:5: +1:17
         StorageDead(_2);                 // scope 0 at $DIR/enum_cast.rs:+1:16: +1:17
         return;                          // scope 0 at $DIR/enum_cast.rs:+2:2: +2:2

--- a/src/test/mir-opt/building/enum_cast.droppy.built.after.mir
+++ b/src/test/mir-opt/building/enum_cast.droppy.built.after.mir
@@ -6,7 +6,9 @@ fn droppy() -> () {
     let _2: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:+2:13: +2:14
     let _4: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:+5:17: +5:18
     let mut _5: isize;                   // in scope 0 at $DIR/enum_cast.rs:+5:17: +5:18
-    let _6: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
+    let mut _6: bool;                    // in scope 0 at $DIR/enum_cast.rs:+5:17: +5:27
+    let mut _7: bool;                    // in scope 0 at $DIR/enum_cast.rs:+5:17: +5:27
+    let _8: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
     scope 1 {
         debug x => _2;                   // in scope 1 at $DIR/enum_cast.rs:+2:13: +2:14
         scope 2 {
@@ -17,7 +19,7 @@ fn droppy() -> () {
         }
     }
     scope 4 {
-        debug z => _6;                   // in scope 4 at $DIR/enum_cast.rs:+7:9: +7:10
+        debug z => _8;                   // in scope 4 at $DIR/enum_cast.rs:+7:9: +7:10
     }
 
     bb0: {
@@ -29,6 +31,10 @@ fn droppy() -> () {
         StorageLive(_4);                 // scope 3 at $DIR/enum_cast.rs:+5:17: +5:18
         _4 = move _2;                    // scope 3 at $DIR/enum_cast.rs:+5:17: +5:18
         _5 = discriminant(_4);           // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
+        _6 = Ge(const 2_isize, _5);      // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
+        assume(_6);                      // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
+        _7 = Le(const 0_isize, _5);      // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
+        assume(_7);                      // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
         _3 = move _5 as usize (IntToInt); // scope 3 at $DIR/enum_cast.rs:+5:17: +5:27
         drop(_4) -> [return: bb1, unwind: bb4]; // scope 3 at $DIR/enum_cast.rs:+5:26: +5:27
     }
@@ -44,15 +50,15 @@ fn droppy() -> () {
     bb2: {
         StorageDead(_2);                 // scope 0 at $DIR/enum_cast.rs:+6:5: +6:6
         StorageDead(_1);                 // scope 0 at $DIR/enum_cast.rs:+6:5: +6:6
-        StorageLive(_6);                 // scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
-        _6 = Droppy::B;                  // scope 0 at $DIR/enum_cast.rs:+7:13: +7:22
-        FakeRead(ForLet(None), _6);      // scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
+        StorageLive(_8);                 // scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
+        _8 = Droppy::B;                  // scope 0 at $DIR/enum_cast.rs:+7:13: +7:22
+        FakeRead(ForLet(None), _8);      // scope 0 at $DIR/enum_cast.rs:+7:9: +7:10
         _0 = const ();                   // scope 0 at $DIR/enum_cast.rs:+0:13: +8:2
-        drop(_6) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/enum_cast.rs:+8:1: +8:2
+        drop(_8) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/enum_cast.rs:+8:1: +8:2
     }
 
     bb3: {
-        StorageDead(_6);                 // scope 0 at $DIR/enum_cast.rs:+8:1: +8:2
+        StorageDead(_8);                 // scope 0 at $DIR/enum_cast.rs:+8:1: +8:2
         return;                          // scope 0 at $DIR/enum_cast.rs:+8:2: +8:2
     }
 

--- a/src/test/ui/type-alias-enum-variants/self-in-enum-definition.stderr
+++ b/src/test/ui/type-alias-enum-variants/self-in-enum-definition.stderr
@@ -14,6 +14,46 @@ note: ...which requires const-evaluating + checking `Alpha::V3::{constant#0}`...
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires caching mir of `Alpha::V3::{constant#0}` for CTFE...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires elaborating drops for `Alpha::V3::{constant#0}`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires borrow-checking `Alpha::V3::{constant#0}`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires processing MIR for `Alpha::V3::{constant#0}`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const checking `Alpha::V3::{constant#0}`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires preparing `Alpha::V3::{constant#0}` for borrow checking...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires unsafety-checking `Alpha::V3::{constant#0}`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires building MIR for `Alpha::V3::{constant#0}`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires computing layout of `Alpha`...
    = note: ...which again requires simplifying constant for the type system `Alpha::V3::{constant#0}`, completing the cycle
 note: cycle used when collecting item types in top-level module


### PR DESCRIPTION
As the title says, this reverts the behavior introduced with 1.64.

Fixes #102303

r? @oli-obk 