### PR TITLE
rustdoc: remove redundant CSS selector `.notable-traits .notable`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1302,7 +1302,7 @@ h3.variant {
 	content: "\00a0\00a0\00a0";
 }
 
-.notable-traits .notable, .notable-traits .docblock {
+.notable-traits .docblock {
 	margin: 0;
 }
 

--- a/src/test/rustdoc-gui/notable-trait.goml
+++ b/src/test/rustdoc-gui/notable-trait.goml
@@ -24,7 +24,23 @@ assert-position: (
     "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",
     {"x": 951},
 )
-
+// The tooltip should be beside the `i`
+click: "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']"
+compare-elements-position-near: (
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits-tooltiptext force-tooltip']",
+    {"y": 2}
+)
+compare-elements-position-false: (
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits-tooltiptext force-tooltip']",
+    ("x")
+)
+// The docblock should be flush with the border.
+assert-css: (
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits-tooltiptext force-tooltip']/*[@class='docblock']",
+    {"margin-left": "0px"}
+)
 
 // Now only the `i` should be on the next line.
 size: (1055, 600)
@@ -80,6 +96,27 @@ assert-position: (
 assert-position: (
     "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",
     {"x": 289},
+)
+// The tooltip should be below `i`
+compare-elements-position-near-false: (
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits-tooltiptext force-tooltip']",
+    {"y": 2}
+)
+compare-elements-position-false: (
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits']",
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits-tooltiptext force-tooltip']",
+    ("x")
+)
+compare-elements-position-near: (
+    "//*[@id='method.create_an_iterator_from_read']/parent::*",
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits-tooltiptext force-tooltip']",
+    {"x": 5}
+)
+// The docblock should be flush with the border.
+assert-css: (
+    "//*[@id='method.create_an_iterator_from_read']//*[@class='notable-traits-tooltiptext force-tooltip']/*[@class='docblock']",
+    {"margin-left": "0px"}
 )
 
 // Checking on very small mobile. The `i` should be on its own line.


### PR DESCRIPTION
The margin was already being set to 0 only a few lines lower.