### PR TITLE
Fix non-associativity of `Instant` math on `aarch64-apple-darwin` targets

### DIFF
--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -150,7 +150,7 @@ impl From<libc::timespec> for Timespec {
 }
 
 #[cfg(any(
-    all(target_os = "macos", not(target_arch = "aarch64")),
+    all(target_os = "macos", any(not(target_arch = "aarch64"), miri)),
     target_os = "ios",
     target_os = "watchos"
 ))]
@@ -270,7 +270,7 @@ mod inner {
 }
 
 #[cfg(not(any(
-    all(target_os = "macos", not(target_arch = "aarch64")),
+    all(target_os = "macos", any(not(target_arch = "aarch64"), miri)),
     target_os = "ios",
     target_os = "watchos"
 )))]

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -290,9 +290,9 @@ mod inner {
     impl Instant {
         pub fn now() -> Instant {
             #[cfg(target_os = "macos")]
-            const clock_id: clock_t = libc::CLOCK_UPTIME_RAW;
+            const clock_id: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
             #[cfg(not(target_os = "macos"))]
-            const clock_id: clock_t = libc::CLOCK_MONOTONIC;
+            const clock_id: libc::clockid_t = libc::CLOCK_MONOTONIC;
             Instant { t: Timespec::now(clock_id) }
         }
 
@@ -324,13 +324,8 @@ mod inner {
         }
     }
 
-    #[cfg(not(any(target_os = "dragonfly", target_os = "espidf", target_os = "horizon")))]
-    pub type clock_t = libc::c_int;
-    #[cfg(any(target_os = "dragonfly", target_os = "espidf", target_os = "horizon"))]
-    pub type clock_t = libc::c_ulong;
-
     impl Timespec {
-        pub fn now(clock: clock_t) -> Timespec {
+        pub fn now(clock: libc::clockid_t) -> Timespec {
             // Try to use 64-bit time in preparation for Y2038.
             #[cfg(all(target_os = "linux", target_env = "gnu", target_pointer_width = "32"))]
             {

--- a/library/std/src/time/tests.rs
+++ b/library/std/src/time/tests.rs
@@ -88,6 +88,14 @@ fn instant_math_is_associative() {
     // Changing the order of instant math shouldn't change the results,
     // especially when the expression reduces to X + identity.
     assert_eq!((now + offset) - now, (now - now) + offset);
+
+    // On any platform, `Instant` should have the same resolution as `Duration` (e.g. 1 nanosecond)
+    // or better. Otherwise, math will be non-associative (see #91417).
+    let now = Instant::now();
+    let provided_offset = Duration::from_nanos(1);
+    let later = now + provided_offset;
+    let measured_offset = later - now;
+    assert_eq!(measured_offset, provided_offset);
 }
 
 #[test]


### PR DESCRIPTION
This is a duplicate of #94100 (since the original author is unresponsive), which resolves #91417.

On `aarch64-apple-darwin` targets, the internal resolution of `Instant` is lower than that of `Duration`, so math between them becomes non-associative with small-enough durations.

This PR makes this target use the standard Unix implementation (where `Instant` has 1ns resolution), but with `CLOCK_UPTIME_RAW` so it still returns the same values as `mach_absolute_time`[^1].

(Edit: I need someone to confirm that this still works, I do not have access to an M1 device.)

[^1]: https://www.manpagez.com/man/3/clock_gettime/