### PR TITLE
Remove `commit_if_ok` probe from NLL type relation

### DIFF
--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -592,7 +592,7 @@ where
             (&ty::Infer(ty::TyVar(vid)), _) => self.relate_ty_var((vid, b)),
 
             (&ty::Opaque(a_def_id, _), &ty::Opaque(b_def_id, _)) if a_def_id == b_def_id => {
-                infcx.commit_if_ok(|_| infcx.super_combine_tys(self, a, b)).or_else(|err| {
+                infcx.super_combine_tys(self, a, b).or_else(|err| {
                     self.tcx().sess.delay_span_bug(
                         self.delegate.span(),
                         "failure to relate an opaque to itself should result in an error later on",

--- a/src/test/ui/impl-trait/issue-103599.rs
+++ b/src/test/ui/impl-trait/issue-103599.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+trait T {}
+
+fn wrap(x: impl T) -> impl T {
+    //~^ WARN function cannot return without recursing
+    wrap(wrap(x))
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issue-103599.stderr
+++ b/src/test/ui/impl-trait/issue-103599.stderr
@@ -1,0 +1,14 @@
+warning: function cannot return without recursing
+  --> $DIR/issue-103599.rs:5:1
+   |
+LL | fn wrap(x: impl T) -> impl T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
+LL |
+LL |     wrap(wrap(x))
+   |          ------- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
It was not really necessary to add the `commit_if_ok` in #100092 -- I added it to protect us against weird inference error messages due to recursive RPIT calls, but we are always on the error path when this happens anyways, and I can't come up with an example that makes this manifest.

Fixes #103599

r? @oli-obk since you reviewed #100092, feel free to re-roll.

:b: :loudspeaker:  beta-nominating this since it's on beta (which forks in ~a week~ two days :fearful:) -- worst case we could revert the original PR on beta and land this on nightly, to give it some extra soak time...