### PR TITLE
Remap early bound lifetimes in return-position `impl Trait` in traits too

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_method.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_method.rs
@@ -597,7 +597,7 @@ pub fn collect_trait_impl_trait_tys<'tcx>(
                 let num_trait_substs = trait_to_impl_substs.len();
                 let num_impl_substs = tcx.generics_of(impl_m.container_id(tcx)).params.len();
                 let ty = tcx.fold_regions(ty, |region, _| {
-                    let ty::ReFree(_) = region.kind() else { return region; };
+                    let (ty::ReFree(_) | ty::ReEarlyBound(_)) = region.kind() else { return region; };
                     let Some(ty::ReEarlyBound(e)) = map.get(&region.into()).map(|r| r.expect_region().kind())
                     else {
                         tcx

--- a/src/test/ui/impl-trait/in-trait/early.rs
+++ b/src/test/ui/impl-trait/in-trait/early.rs
@@ -1,0 +1,23 @@
+// check-pass
+// edition:2021
+
+#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+pub trait Foo {
+    async fn bar<'a: 'a>(&'a mut self);
+}
+
+impl Foo for () {
+    async fn bar<'a: 'a>(&'a mut self) {}
+}
+
+pub trait Foo2 {
+    fn bar<'a: 'a>(&'a mut self) -> impl Sized + 'a;
+}
+
+impl Foo2 for () {
+    fn bar<'a: 'a>(&'a mut self) -> impl Sized + 'a {}
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes part of #103457

r? @cjgillot, though feel free to reassign, just thought you'd have sufficient context to review.