### PR TITLE
Emit a nicer error on `impl Self {`

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
@@ -147,6 +147,6 @@ hir_analysis_const_impl_for_non_const_trait =
 hir_analysis_const_bound_for_non_const_trait =
     ~const can only be applied to `#[const_trait]` traits
 
-hir_analysis_self_in_impl_self = 
+hir_analysis_self_in_impl_self =
     `Self` is not valid in the self type of an impl block
     .note = replace `Self` with a different type

--- a/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
@@ -146,3 +146,5 @@ hir_analysis_const_impl_for_non_const_trait =
 
 hir_analysis_const_bound_for_non_const_trait =
     ~const can only be applied to `#[const_trait]` traits
+
+hir_analysis_self_in_impl_self = `Self` is not valid at this location

--- a/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
@@ -147,4 +147,6 @@ hir_analysis_const_impl_for_non_const_trait =
 hir_analysis_const_bound_for_non_const_trait =
     ~const can only be applied to `#[const_trait]` traits
 
-hir_analysis_self_in_impl_self = `Self` is not valid at this location
+hir_analysis_self_in_impl_self = 
+    `Self` is not valid in the self type of an impl block
+    .note = replace `Self` with a different type

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -319,36 +319,11 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                     }
                 }
                 ItemKind::TyAlias(self_ty, _) => icx.to_ty(self_ty),
-                ItemKind::Impl(
-                    hir::Impl { self_ty, .. }
-                ) => {
-                    struct MyVisitor(Vec<Span>);
-                    impl<'v> hir::intravisit::Visitor<'v> for MyVisitor {
-                        fn visit_ty(&mut self, t: &'v Ty<'v>) {
-                            if matches!(
-                                &t.kind,
-                                TyKind::Path(hir::QPath::Resolved(
-                                    _,
-                                    Path {
-                                        res: hir::def::Res::SelfTyAlias { .. },
-                                        ..
-                                    },
-                                ))
-                            ) {
-                                self.0.push(t.span);
-                                return;
-                            }
-                            hir::intravisit::walk_ty(self, t);
-                        }
-                    }
-
-                    let mut my_visitor = MyVisitor(vec![]);
-                    my_visitor.visit_ty(self_ty);
-
-                    match my_visitor.0 {
-                        spans if spans.len() > 0 => { 
+                ItemKind::Impl(hir::Impl { self_ty, .. }) => {
+                    match self_ty.find_self_aliases() {
+                        spans if spans.len() > 0 => {
                             tcx.sess.emit_err(crate::errors::SelfInImplSelf { span: spans.into(), note: (), });
-                            tcx.ty_error() 
+                            tcx.ty_error()
                         },
                         _ => icx.to_ty(*self_ty),
                     }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1,7 +1,7 @@
 //! Errors emitted by `rustc_hir_analysis`.
 
-use rustc_errors::IntoDiagnostic;
 use rustc_errors::{error_code, Applicability, DiagnosticBuilder, ErrorGuaranteed, Handler};
+use rustc_errors::{IntoDiagnostic, MultiSpan};
 use rustc_macros::{Diagnostic, LintDiagnostic};
 use rustc_middle::ty::Ty;
 use rustc_span::{symbol::Ident, Span, Symbol};
@@ -275,5 +275,7 @@ pub struct ConstBoundForNonConstTrait {
 #[diag(hir_analysis_self_in_impl_self)]
 pub struct SelfInImplSelf {
     #[primary_span]
-    pub span: Span,
+    pub span: MultiSpan,
+    #[note]
+    pub note: (),
 }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -270,3 +270,10 @@ pub struct ConstBoundForNonConstTrait {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_self_in_impl_self)]
+pub struct SelfInImplSelf {
+    #[primary_span]
+    pub span: Span,
+}

--- a/src/test/ui/resolve/issue-23305.rs
+++ b/src/test/ui/resolve/issue-23305.rs
@@ -3,6 +3,6 @@ pub trait ToNbt<T> {
 }
 
 impl dyn ToNbt<Self> {}
-//~^ ERROR cycle detected
+//~^ ERROR `Self` is not valid at this location
 
 fn main() {}

--- a/src/test/ui/resolve/issue-23305.rs
+++ b/src/test/ui/resolve/issue-23305.rs
@@ -3,6 +3,6 @@ pub trait ToNbt<T> {
 }
 
 impl dyn ToNbt<Self> {}
-//~^ ERROR `Self` is not valid at this location
+//~^ ERROR `Self` is not valid in the self type of an impl block
 
 fn main() {}

--- a/src/test/ui/resolve/issue-23305.stderr
+++ b/src/test/ui/resolve/issue-23305.stderr
@@ -1,22 +1,8 @@
-error[E0391]: cycle detected when computing type of `<impl at $DIR/issue-23305.rs:5:1: 5:21>`
-  --> $DIR/issue-23305.rs:5:16
+error: `Self` is not valid at this location
+  --> $DIR/issue-23305.rs:5:6
    |
 LL | impl dyn ToNbt<Self> {}
-   |                ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/issue-23305.rs:5:1: 5:21>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-23305.rs:1:1
-   |
-LL | / pub trait ToNbt<T> {
-LL | |     fn new(val: T) -> Self;
-LL | | }
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   |      ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/resolve/issue-23305.stderr
+++ b/src/test/ui/resolve/issue-23305.stderr
@@ -1,8 +1,10 @@
-error: `Self` is not valid at this location
-  --> $DIR/issue-23305.rs:5:6
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/issue-23305.rs:5:16
    |
 LL | impl dyn ToNbt<Self> {}
-   |      ^^^^^^^^^^^^^^^
+   |                ^^^^
+   |
+   = note: replace `Self` with a different type
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/resolve-self-in-impl.rs
+++ b/src/test/ui/resolve/resolve-self-in-impl.rs
@@ -11,10 +11,10 @@ impl Tr for S where Self: Copy {} // OK
 impl Tr for S where S<Self>: Copy {} // OK
 impl Tr for S where Self::A: Copy {} // OK
 
-impl Tr for Self {} //~ ERROR cycle detected
-impl Tr for S<Self> {} //~ ERROR cycle detected
-impl Self {} //~ ERROR cycle detected
-impl S<Self> {} //~ ERROR cycle detected
+impl Tr for Self {} //~ ERROR `Self` is not valid at this location
+impl Tr for S<Self> {} //~ ERROR `Self` is not valid at this location
+impl Self {} //~ ERROR `Self` is not valid at this location
+impl S<Self> {} //~ ERROR `Self` is not valid at this location
 impl Tr<Self::A> for S {} //~ ERROR cycle detected
 
 fn main() {}

--- a/src/test/ui/resolve/resolve-self-in-impl.rs
+++ b/src/test/ui/resolve/resolve-self-in-impl.rs
@@ -11,10 +11,11 @@ impl Tr for S where Self: Copy {} // OK
 impl Tr for S where S<Self>: Copy {} // OK
 impl Tr for S where Self::A: Copy {} // OK
 
-impl Tr for Self {} //~ ERROR `Self` is not valid at this location
-impl Tr for S<Self> {} //~ ERROR `Self` is not valid at this location
-impl Self {} //~ ERROR `Self` is not valid at this location
-impl S<Self> {} //~ ERROR `Self` is not valid at this location
+impl Tr for Self {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl Tr for S<Self> {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl Self {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl S<Self> {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl (Self, Self) {} //~ ERROR `Self` is not valid in the self type of an impl block
 impl Tr<Self::A> for S {} //~ ERROR cycle detected
 
 fn main() {}

--- a/src/test/ui/resolve/resolve-self-in-impl.stderr
+++ b/src/test/ui/resolve/resolve-self-in-impl.stderr
@@ -1,78 +1,26 @@
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:14:1: 14:17>`
+error: `Self` is not valid at this location
   --> $DIR/resolve-self-in-impl.rs:14:13
    |
 LL | impl Tr for Self {}
    |             ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:14:1: 14:17>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:15:1: 15:20>`
-  --> $DIR/resolve-self-in-impl.rs:15:15
+error: `Self` is not valid at this location
+  --> $DIR/resolve-self-in-impl.rs:15:13
    |
 LL | impl Tr for S<Self> {}
-   |               ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:15:1: 15:20>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   |             ^^^^^^^
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:16:1: 16:10>`
+error: `Self` is not valid at this location
   --> $DIR/resolve-self-in-impl.rs:16:6
    |
 LL | impl Self {}
    |      ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:16:1: 16:10>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:17:1: 17:13>`
-  --> $DIR/resolve-self-in-impl.rs:17:8
+error: `Self` is not valid at this location
+  --> $DIR/resolve-self-in-impl.rs:17:6
    |
 LL | impl S<Self> {}
-   |        ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:17:1: 17:13>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   |      ^^^^^^^
 
 error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:23>`
   --> $DIR/resolve-self-in-impl.rs:18:1

--- a/src/test/ui/resolve/resolve-self-in-impl.stderr
+++ b/src/test/ui/resolve/resolve-self-in-impl.stderr
@@ -1,34 +1,50 @@
-error: `Self` is not valid at this location
+error: `Self` is not valid in the self type of an impl block
   --> $DIR/resolve-self-in-impl.rs:14:13
    |
 LL | impl Tr for Self {}
    |             ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error: `Self` is not valid at this location
-  --> $DIR/resolve-self-in-impl.rs:15:13
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/resolve-self-in-impl.rs:15:15
    |
 LL | impl Tr for S<Self> {}
-   |             ^^^^^^^
+   |               ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error: `Self` is not valid at this location
+error: `Self` is not valid in the self type of an impl block
   --> $DIR/resolve-self-in-impl.rs:16:6
    |
 LL | impl Self {}
    |      ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error: `Self` is not valid at this location
-  --> $DIR/resolve-self-in-impl.rs:17:6
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/resolve-self-in-impl.rs:17:8
    |
 LL | impl S<Self> {}
-   |      ^^^^^^^
+   |        ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:23>`
-  --> $DIR/resolve-self-in-impl.rs:18:1
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/resolve-self-in-impl.rs:18:7
+   |
+LL | impl (Self, Self) {}
+   |       ^^^^  ^^^^
+   |
+   = note: replace `Self` with a different type
+
+error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>`
+  --> $DIR/resolve-self-in-impl.rs:19:1
    |
 LL | impl Tr<Self::A> for S {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: ...which immediately requires computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:23>` again
+   = note: ...which immediately requires computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>` again
 note: cycle used when collecting item types in top-level module
   --> $DIR/resolve-self-in-impl.rs:1:1
    |
@@ -41,6 +57,6 @@ LL | |
 LL | | fn main() {}
    | |____________^
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
currently it emits a "cycle detected error" but this PR makes it emit a more user friendly error specifically saying that `Self` is disallowed in that position. this is a pretty hacky fix so i dont expect this to be merged (I basically only made this PR because i wanted to see if CI passes)

r? @compiler-errors 