### PR TITLE
[rustc_ty_utils] Add the LLVM `noalias` parameter attribute to `drop_in_place` in certain cases.

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -441,7 +441,7 @@ mod mut_ptr;
 ///
 /// ```
 /// # struct Foo { x: i32 }
-/// fn drop_in_place(to_drop: *mut Foo) {
+/// unsafe fn drop_in_place(to_drop: *mut Foo) {
 ///     let mut value = &mut *to_drop;
 ///     // ... drop the fields of `value` ...
 /// }

--- a/src/test/codegen/drop-in-place-noalias.rs
+++ b/src/test/codegen/drop-in-place-noalias.rs
@@ -1,0 +1,34 @@
+// Tests that the compiler can mark `drop_in_place` as `noalias` when safe to do so.
+
+#![crate_type="lib"]
+
+use std::hint::black_box;
+
+// CHECK: define{{.*}}drop_in_place{{.*}}Foo{{.*}}({{.*}}noalias{{.*}})
+
+#[repr(C)]
+pub struct Foo {
+    a: i32,
+    b: i32,
+    c: i32,
+}
+
+impl Drop for Foo {
+    #[inline(never)]
+    fn drop(&mut self) {
+        black_box(self.a);
+    }
+}
+
+extern {
+    fn bar();
+    fn baz(foo: Foo);
+}
+
+pub fn haha() {
+    let foo = Foo { a: 1, b: 2, c: 3 };
+    unsafe {
+        bar();
+        baz(foo);
+    }
+}

--- a/src/test/codegen/drop-in-place-noalias.rs
+++ b/src/test/codegen/drop-in-place-noalias.rs
@@ -4,7 +4,7 @@
 
 use std::hint::black_box;
 
-// CHECK: define{{.*}}drop_in_place{{.*}}Foo{{.*}}({{.*}}noalias{{.*}})
+// CHECK: define{{.*}}core{{.*}}ptr{{.*}}drop_in_place{{.*}}Foo{{.*}}({{.*}}noalias {{.*}} align 4 dereferenceable(12){{.*}})
 
 #[repr(C)]
 pub struct Foo {

--- a/src/test/codegen/noalias-box-off.rs
+++ b/src/test/codegen/noalias-box-off.rs
@@ -3,6 +3,6 @@
 #![crate_type = "lib"]
 
 // CHECK-LABEL: @box_should_not_have_noalias_if_disabled(
-// CHECK-NOT: noalias
+// CHECK-NOT: noalias{{.*}}%
 #[no_mangle]
 pub fn box_should_not_have_noalias_if_disabled(_b: Box<u8>) {}


### PR DESCRIPTION
LLVM can make use of the `noalias` parameter attribute on the parameter to `drop_in_place` in areas like argument promotion. Because the Rust compiler fully controls the code for `drop_in_place`, it can soundly deduce parameter attributes on it. In the case of a value that has a programmer-defined Drop implementation, we know that the first thing `drop_in_place` will do is pass a pointer to the object to `Drop::drop`. `Drop::drop` takes `&mut`, so it must be guaranteed that there are no pointers to the object upon entering that function. Therefore, it should be safe to mark `noalias` there.

With this patch, we mark `noalias` only when the type is a value with a programmer-defined Drop implementation. This is possibly overly conservative, but I thought that proceeding cautiously was best in this instance.