### PR TITLE
rustdoc: remove CSS workaround for Firefox 29

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -857,9 +857,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	   causes rounded corners and no border on iOS Safari. */
 	-webkit-appearance: none;
 	/* Override Normalize.css: we have margins and do
-	 not want to overflow - the `moz` attribute is necessary
-	 until Firefox 29, too early to drop at this point */
-	-moz-box-sizing: border-box !important;
+	 not want to overflow */
 	box-sizing: border-box !important;
 	outline: none;
 	border: 1px solid var(--border-color);


### PR DESCRIPTION
CSS variables, which rustdoc now relies on, are only supported in Firefox 31 and later: https://www.mozilla.org/en-US/firefox/31.0/releasenotes/

This means it’s fine to also rely on unprefixed box-sizing, which is supported in Firefox 29 and later: https://www.mozilla.org/en-US/firefox/29.0/releasenotes/