### PR TITLE
Fix test for issue 80706

### DIFF
--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-80706.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-80706.rs
@@ -1,11 +1,7 @@
 // build-pass
 // edition:2018
 
-type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output=T>>>;
-
-fn main() {
-    f();
-}
+type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output = T>>>;
 
 async fn f() {
     run("dependency").await;
@@ -55,9 +51,7 @@ impl<'dep> User<'dep> {
         S: Storage,
         for<'a> SaveUser<'a>: StorageRequest<S>,
     {
-        SaveUser { name: "Joe" }
-            .execute()
-            .await;
+        SaveUser { name: "Joe" }.execute().await;
     }
 }
 
@@ -68,4 +62,8 @@ where
     for<'a> SaveUser<'a>: StorageRequestReturnType,
 {
     User { dep }.save().await;
+}
+
+fn main() {
+    f();
 }


### PR DESCRIPTION
Fixes #80706

Actually afaict the test is already good (i.e. the `check-pass` had already long been changed to `build-pass` to catch the ICE during codegen (flagged out by tmandry)). So this PR just cleans the test up. Correct me if I am wrong. cc @compiler-errors since you last edited this file.

r? @lcnr