### PR TITLE
Add `multivalue` target feature to WASM target

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -267,6 +267,7 @@ const WASM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     // tidy-alphabetical-start
     ("atomics", Some(sym::wasm_target_feature)),
     ("bulk-memory", Some(sym::wasm_target_feature)),
+    ("multivalue", Some(sym::wasm_target_feature)),
     ("mutable-globals", Some(sym::wasm_target_feature)),
     ("nontrapping-fptoint", Some(sym::wasm_target_feature)),
     ("reference-types", Some(sym::wasm_target_feature)),


### PR DESCRIPTION
This PR is similar to #99643 and #97808. It addresses #96472 for the `multivalue` target feature.

The problem I am trying to fix is to remove the following warning when compiling with `-C target-feature=+multivalue` for `--target=wasm32-unknown-unknown`.

```
warning: unknown feature specified for `-Ctarget-feature`: `multivalue`
  |
  = note: it is still passed through to the codegen backend
  = note: consider filing a feature request
```