### PR TITLE
rustdoc: stop hiding focus outlines on non-rustdoc-toggle details tags

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -292,10 +292,6 @@ p:last-child {
 	margin: 0;
 }
 
-summary {
-	outline: none;
-}
-
 /* Fix some style changes due to normalize.css 8 */
 
 button {
@@ -1538,6 +1534,8 @@ details.rustdoc-toggle > summary.hideme {
 
 details.rustdoc-toggle > summary {
 	list-style: none;
+	/* focus outline is shown on `::before` instead of this */
+	outline: none;
 }
 details.rustdoc-toggle > summary::-webkit-details-marker,
 details.rustdoc-toggle > summary::marker {


### PR DESCRIPTION
We really shouldn't be overriding this kind of stuff unless the browser default is really broken (like outlining the thing that isn't clickable). This directly reverts b8f4e74cbc938d3448507d422c98061c2b71c922.