### PR TITLE
rustdoc: Do not add external traits to the crate in `register_res`

### DIFF
--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -7,7 +7,6 @@ use crate::clean::{
     PathSegment, Primitive, PrimitiveType, Type, TypeBinding, Visibility,
 };
 use crate::core::DocContext;
-use crate::formats::item_type::ItemType;
 
 use rustc_ast as ast;
 use rustc_ast::tokenstream::TokenTree;
@@ -503,9 +502,6 @@ pub(crate) fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
         return did;
     }
     inline::record_extern_fqn(cx, did, kind);
-    if let ItemType::Trait = kind {
-        inline::record_extern_trait(cx, did);
-    }
     did
 }
 

--- a/src/test/rustdoc/intra-doc/auxiliary/issue-103463-aux.rs
+++ b/src/test/rustdoc/intra-doc/auxiliary/issue-103463-aux.rs
@@ -1,0 +1,4 @@
+pub trait Trait {
+    /// [`u8::clone`]
+    fn method();
+}

--- a/src/test/rustdoc/intra-doc/issue-103463.rs
+++ b/src/test/rustdoc/intra-doc/issue-103463.rs
@@ -1,0 +1,8 @@
+// The `Trait` is not pulled into the crate resulting in doc links in its methods being resolved.
+
+// aux-build:issue-103463-aux.rs
+
+extern crate issue_103463_aux;
+use issue_103463_aux::Trait;
+
+fn main() {}


### PR DESCRIPTION
It's not clear why it was done, and apparently it's no longer necessary now.
Such additions are unpredictable for early doc link resolution and would force us to collect all doc links from all external traits.

Fixes https://github.com/rust-lang/rust/issues/103463