### PR TITLE
Fix variable debuginfo being optimized away at `mir-opt-level=2 `

### DIFF
--- a/compiler/rustc_mir_transform/src/const_debuginfo.rs
+++ b/compiler/rustc_mir_transform/src/const_debuginfo.rs
@@ -16,7 +16,7 @@ pub struct ConstDebugInfo;
 
 impl<'tcx> MirPass<'tcx> for ConstDebugInfo {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.opts.unstable_opts.unsound_mir_opts && sess.mir_opt_level() > 0
+        sess.mir_opt_level() > 0
     }
 
     fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/src/test/codegen/debuginfo-constant-locals.rs
+++ b/src/test/codegen/debuginfo-constant-locals.rs
@@ -1,0 +1,28 @@
+// compile-flags: -g -O
+
+// Check that simple constant values are preserved in debuginfo across both MIR opts and LLVM opts
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn check_it() {
+    let a = 1;
+    let b = 42;
+
+    foo(a + b);
+}
+
+#[inline(never)]
+fn foo(x: i32) {
+    std::process::exit(x);
+}
+
+// CHECK-LABEL: @check_it
+// CHECK: call void @llvm.dbg.value(metadata i32 1, metadata ![[a_metadata:[0-9]+]], metadata !DIExpression())
+// CHECK: call void @llvm.dbg.value(metadata i32 42, metadata ![[b_metadata:[0-9]+]], metadata !DIExpression())
+
+// CHECK: ![[a_metadata]] = !DILocalVariable(name: "a"
+// CHECK-SAME: line: 9
+
+// CHECK: ![[b_metadata]] = !DILocalVariable(name: "b"
+// CHECK-SAME: line: 10

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
@@ -2,26 +2,17 @@
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/optimizes_into_variable.rs:+0:11: +0:11
-    let _1: i32;                         // in scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
     scope 1 {
-        debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        let _2: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
+        debug x => const 4_i32;          // in scope 1 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
         scope 2 {
-            debug y => _2;               // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
-            let _3: u32;                 // in scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+            debug y => const 3_i32;      // in scope 2 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
             scope 3 {
-                debug z => _3;           // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
+                debug z => const 42_u32; // in scope 3 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
             }
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+1:9: +1:10
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+2:9: +2:10
-        StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:+3:9: +3:10
-        StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:+4:1: +4:2
         return;                          // scope 0 at $DIR/optimizes_into_variable.rs:+4:2: +4:2
     }
 }

--- a/src/test/mir-opt/dead-store-elimination/constant-local-debuginfo.rs
+++ b/src/test/mir-opt/dead-store-elimination/constant-local-debuginfo.rs
@@ -1,0 +1,14 @@
+// compile-flags: -Zmir-opt-level=2
+// mir-opt-level is fixed at 2 because that's the max level that can be set on stable
+// EMIT_MIR constant_local_debuginfo.main.DeadStoreElimination.diff
+fn main() {
+    let a = 1;
+    let b = 4;
+
+    foo(a + b);
+}
+
+#[inline(never)]
+fn foo(x: i32) {
+    std::process::exit(x);
+}

--- a/src/test/mir-opt/dead-store-elimination/constant_local_debuginfo.main.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/constant_local_debuginfo.main.DeadStoreElimination.diff
@@ -1,0 +1,52 @@
+- // MIR for `main` before DeadStoreElimination
++ // MIR for `main` after DeadStoreElimination
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/constant-local-debuginfo.rs:+0:11: +0:11
+      let _1: i32;                         // in scope 0 at $DIR/constant-local-debuginfo.rs:+1:9: +1:10
+      let _3: ();                          // in scope 0 at $DIR/constant-local-debuginfo.rs:+4:5: +4:15
+      let mut _4: i32;                     // in scope 0 at $DIR/constant-local-debuginfo.rs:+4:9: +4:14
+      let mut _5: i32;                     // in scope 0 at $DIR/constant-local-debuginfo.rs:+4:9: +4:10
+      let mut _6: i32;                     // in scope 0 at $DIR/constant-local-debuginfo.rs:+4:13: +4:14
+      scope 1 {
+          debug a => _1;                   // in scope 1 at $DIR/constant-local-debuginfo.rs:+1:9: +1:10
+          let _2: i32;                     // in scope 1 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
+          scope 2 {
+              debug b => _2;               // in scope 2 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/constant-local-debuginfo.rs:+1:9: +1:10
+-         _1 = const 1_i32;                // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
++         nop;                             // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
+          StorageLive(_2);                 // scope 1 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
+-         _2 = const 4_i32;                // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
++         nop;                             // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
+          StorageLive(_3);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:5: +4:15
+          StorageLive(_4);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:14
+          StorageLive(_5);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:10
+-         _5 = const 1_i32;                // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:10
++         nop;                             // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:10
+          StorageLive(_6);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:13: +4:14
+-         _6 = const 4_i32;                // scope 2 at $DIR/constant-local-debuginfo.rs:+4:13: +4:14
++         nop;                             // scope 2 at $DIR/constant-local-debuginfo.rs:+4:13: +4:14
+          _4 = const 5_i32;                // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:14
+          StorageDead(_6);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:13: +4:14
+          StorageDead(_5);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:13: +4:14
+          _3 = foo(move _4) -> bb1;        // scope 2 at $DIR/constant-local-debuginfo.rs:+4:5: +4:15
+                                           // mir::Constant
+                                           // + span: $DIR/constant-local-debuginfo.rs:8:5: 8:8
+                                           // + literal: Const { ty: fn(i32) {foo}, val: Value(<ZST>) }
+      }
+  
+      bb1: {
+          StorageDead(_4);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:14: +4:15
+          StorageDead(_3);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:15: +4:16
+          nop;                             // scope 0 at $DIR/constant-local-debuginfo.rs:+0:11: +5:2
+          StorageDead(_2);                 // scope 1 at $DIR/constant-local-debuginfo.rs:+5:1: +5:2
+          StorageDead(_1);                 // scope 0 at $DIR/constant-local-debuginfo.rs:+5:1: +5:2
+          return;                          // scope 0 at $DIR/constant-local-debuginfo.rs:+5:2: +5:2
+      }
+  }
+  

--- a/src/test/mir-opt/dead-store-elimination/constant_local_debuginfo.main.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/constant_local_debuginfo.main.DeadStoreElimination.diff
@@ -18,11 +18,9 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/constant-local-debuginfo.rs:+1:9: +1:10
--         _1 = const 1_i32;                // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
-+         nop;                             // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
+          _1 = const 1_i32;                // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
           StorageLive(_2);                 // scope 1 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
--         _2 = const 4_i32;                // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
-+         nop;                             // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
+          _2 = const 4_i32;                // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
           StorageLive(_3);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:5: +4:15
           StorageLive(_4);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:14
           StorageLive(_5);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:10

--- a/src/test/mir-opt/dead-store-elimination/constant_local_debuginfo.main.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/constant_local_debuginfo.main.DeadStoreElimination.diff
@@ -9,18 +9,20 @@
       let mut _5: i32;                     // in scope 0 at $DIR/constant-local-debuginfo.rs:+4:9: +4:10
       let mut _6: i32;                     // in scope 0 at $DIR/constant-local-debuginfo.rs:+4:13: +4:14
       scope 1 {
-          debug a => _1;                   // in scope 1 at $DIR/constant-local-debuginfo.rs:+1:9: +1:10
+          debug a => const 1_i32;          // in scope 1 at $DIR/constant-local-debuginfo.rs:+1:9: +1:10
           let _2: i32;                     // in scope 1 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
           scope 2 {
-              debug b => _2;               // in scope 2 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
+              debug b => const 4_i32;      // in scope 2 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
           }
       }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/constant-local-debuginfo.rs:+1:9: +1:10
-          _1 = const 1_i32;                // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
+-         _1 = const 1_i32;                // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
++         nop;                             // scope 0 at $DIR/constant-local-debuginfo.rs:+1:13: +1:14
           StorageLive(_2);                 // scope 1 at $DIR/constant-local-debuginfo.rs:+2:9: +2:10
-          _2 = const 4_i32;                // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
+-         _2 = const 4_i32;                // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
++         nop;                             // scope 1 at $DIR/constant-local-debuginfo.rs:+2:13: +2:14
           StorageLive(_3);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:5: +4:15
           StorageLive(_4);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:14
           StorageLive(_5);                 // scope 2 at $DIR/constant-local-debuginfo.rs:+4:9: +4:10

--- a/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
+++ b/src/test/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.diff
@@ -37,25 +37,18 @@
   
       bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/cycle.rs:+4:13: +4:17
--         _6 = _3;                         // scope 0 at $DIR/cycle.rs:+4:20: +4:21
-+         nop;                             // scope 0 at $DIR/cycle.rs:+4:20: +4:21
+          _6 = _3;                         // scope 0 at $DIR/cycle.rs:+4:20: +4:21
           StorageLive(_7);                 // scope 1 at $DIR/cycle.rs:+5:13: +5:14
--         _7 = _2;                         // scope 1 at $DIR/cycle.rs:+5:13: +5:14
--         _3 = move _7;                    // scope 1 at $DIR/cycle.rs:+5:9: +5:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+5:13: +5:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+5:9: +5:14
+          _7 = _2;                         // scope 1 at $DIR/cycle.rs:+5:13: +5:14
+          _3 = move _7;                    // scope 1 at $DIR/cycle.rs:+5:9: +5:14
           StorageDead(_7);                 // scope 1 at $DIR/cycle.rs:+5:13: +5:14
           StorageLive(_8);                 // scope 1 at $DIR/cycle.rs:+6:13: +6:14
--         _8 = _1;                         // scope 1 at $DIR/cycle.rs:+6:13: +6:14
--         _2 = move _8;                    // scope 1 at $DIR/cycle.rs:+6:9: +6:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+6:13: +6:14
-+         nop;                             // scope 1 at $DIR/cycle.rs:+6:9: +6:14
+          _8 = _1;                         // scope 1 at $DIR/cycle.rs:+6:13: +6:14
+          _2 = move _8;                    // scope 1 at $DIR/cycle.rs:+6:9: +6:14
           StorageDead(_8);                 // scope 1 at $DIR/cycle.rs:+6:13: +6:14
           StorageLive(_9);                 // scope 1 at $DIR/cycle.rs:+7:13: +7:17
--         _9 = _6;                         // scope 1 at $DIR/cycle.rs:+7:13: +7:17
--         _1 = move _9;                    // scope 1 at $DIR/cycle.rs:+7:9: +7:17
-+         nop;                             // scope 1 at $DIR/cycle.rs:+7:13: +7:17
-+         nop;                             // scope 1 at $DIR/cycle.rs:+7:9: +7:17
+          _9 = _6;                         // scope 1 at $DIR/cycle.rs:+7:13: +7:17
+          _1 = move _9;                    // scope 1 at $DIR/cycle.rs:+7:9: +7:17
           StorageDead(_9);                 // scope 1 at $DIR/cycle.rs:+7:16: +7:17
 -         _4 = const ();                   // scope 0 at $DIR/cycle.rs:+3:18: +8:6
 +         nop;                             // scope 0 at $DIR/cycle.rs:+3:18: +8:6

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -6,23 +6,22 @@ fn num_to_digit(_1: char) -> u32 {
     let mut _2: char;                    // in scope 0 at $DIR/issue-59352.rs:+2:8: +2:11
     let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/issue-59352.rs:+2:26: +2:41
     let mut _4: char;                    // in scope 0 at $DIR/issue-59352.rs:+2:26: +2:29
-    let mut _5: u32;                     // in scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
-    let mut _12: isize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _11: isize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 (inlined char::methods::<impl char>::is_digit) { // at $DIR/issue-59352.rs:14:8: 14:23
         debug self => _2;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        debug radix => _5;               // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        let mut _6: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        let _7: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        let mut _8: char;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        debug radix => const 8_u32;      // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let mut _5: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let _6: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let mut _7: char;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         scope 2 (inlined Option::<u32>::is_some) { // at $SRC_DIR/core/src/char/methods.rs:LL:COL
-            debug self => _6;            // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
-            let mut _9: isize;           // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+            debug self => _5;            // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+            let mut _8: isize;           // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
     scope 3 (inlined #[track_caller] Option::<u32>::unwrap) { // at $DIR/issue-59352.rs:14:26: 14:50
         debug self => _3;                // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _10: isize;              // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _11: !;                  // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _9: isize;               // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _10: !;                  // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         scope 4 {
             debug val => _0;             // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
         }
@@ -31,19 +30,18 @@ fn num_to_digit(_1: char) -> u32 {
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-59352.rs:+2:8: +2:11
         _2 = _1;                         // scope 0 at $DIR/issue-59352.rs:+2:8: +2:11
-        StorageLive(_5);                 // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageLive(_8);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _8 = _2;                         // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _7 = char::methods::<impl char>::to_digit(move _8, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _7 = _2;                         // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _6 = char::methods::<impl char>::to_digit(move _7, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_12);                // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
         StorageLive(_3);                 // scope 0 at $DIR/issue-59352.rs:+2:26: +2:41
         StorageLive(_4);                 // scope 0 at $DIR/issue-59352.rs:+2:26: +2:29
         _4 = _1;                         // scope 0 at $DIR/issue-59352.rs:+2:26: +2:29
@@ -55,12 +53,12 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb2: {
         StorageDead(_4);                 // scope 0 at $DIR/issue-59352.rs:+2:40: +2:41
-        _10 = discriminant(_3);          // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _10) -> [0_isize: bb6, 1_isize: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _9 = discriminant(_3);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _9) -> [0_isize: bb6, 1_isize: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb3: {
-        StorageDead(_12);                // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
         _0 = const 0_u32;                // scope 0 at $DIR/issue-59352.rs:+2:60: +2:61
         goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:+2:5: +2:63
     }
@@ -70,21 +68,20 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb5: {
-        _6 = &_7;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_8);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _9 = discriminant((*_6));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
-        StorageLive(_12);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _12 = move _9;                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _5 = &_6;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_5);                 // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        _8 = discriminant((*_5));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _11 = move _8;                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_2);                 // scope 0 at $DIR/issue-59352.rs:+2:22: +2:23
-        switchInt(move _12) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
+        switchInt(move _11) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/issue-59352.rs:+2:8: +2:23
     }
 
     bb6: {
-        StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        _11 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        _10 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL
                                          // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(<ZST>) }

--- a/src/test/mir-opt/lower_intrinsics_e2e.f_u64.PreCodegen.after.mir
+++ b/src/test/mir-opt/lower_intrinsics_e2e.f_u64.PreCodegen.after.mir
@@ -4,7 +4,7 @@ fn f_u64() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics_e2e.rs:+0:16: +0:16
     let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics_e2e.rs:+1:5: +1:21
     scope 1 (inlined f_dispatch::<u64>) { // at $DIR/lower_intrinsics_e2e.rs:15:5: 15:21
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics_e2e.rs:19:22: 19:23
+        debug t => const 0_u64;          // in scope 1 at $DIR/lower_intrinsics_e2e.rs:19:22: 19:23
         let _2: ();                      // in scope 1 at $DIR/lower_intrinsics_e2e.rs:23:9: 23:21
         let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics_e2e.rs:23:19: 23:20
         scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics_e2e.rs:20:8: 20:32


### PR DESCRIPTION
The `DeadStoreElmination` pass was removing the uses of these locals
because the are never used in the MIR body except for debuginfo. I've
updated the pass to consider locals referenced by debuginfo as always
alive unless a higher MIR opt level is requested by the user.

Fixes #103655 

r? @ghost