### PR TITLE
Add From<&(T, U, ...)> for (&T, &U, ...) impls

### DIFF
--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -101,6 +101,34 @@ macro_rules! tuple_impls {
                 }
             }
         }
+
+        maybe_tuple_doc! {
+            $($T)+ @
+            #[stable(feature = "transpose_tuple_ref", since = "CURRENT_RUSTC_VERSION")]
+            impl<'a, $($T),+> From<&'a ($($T,)+)> for ($(&'a $T,)+)
+            where
+                last_type!($($T,)+): ?Sized
+            {
+                #[inline]
+                fn from(val: &'a ($($T,)+)) -> ($(&'a $T,)+) {
+                    ($( ${ignore(T)} &val.${index()}, )+)
+                }
+            }
+        }
+
+        maybe_tuple_doc! {
+            $($T)+ @
+            #[stable(feature = "transpose_tuple_ref", since = "CURRENT_RUSTC_VERSION")]
+            impl<'a, $($T),+> From<&'a mut ($($T,)+)> for ($(&'a mut $T,)+)
+            where
+                last_type!($($T,)+): ?Sized
+            {
+                #[inline]
+                fn from(val: &'a mut ($($T,)+)) -> ($(&'a mut $T,)+) {
+                    ($( ${ignore(T)} &mut val.${index()}, )+)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
So, this is one of those weird impls that *feels* like `AsRef` but actually isn't, and so has to be implemented via `From`. The closest prior art at the moment is that `Option` exposes its `as_ref` and `as_mut` methods as `From` impls as well.

My current use case for this was to be able to ensure that a type is "kind like a reference" by nature of having a `From<&T>` impl. This fails for things like the `Iter` and `IterMut` adapters of `BTreeMap` and `HashMap`, who return `(&K, &V)` instead of references to anything.

Definitely willing to go through ACP first or some other forum, but I figured I'd try my luck with submitting this PR and see where it goes, since the code is relatively straightforward.