### PR TITLE
Resolve lang items in AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4064,6 +4064,7 @@ dependencies = [
  "rustc_feature",
  "rustc_hir",
  "rustc_index",
+ "rustc_macros",
  "rustc_metadata",
  "rustc_middle",
  "rustc_query_system",

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2882,7 +2882,7 @@ impl ItemKind {
         }
     }
 
-    pub fn descr(&self) -> &str {
+    pub fn descr(&self) -> &'static str {
         match self {
             ItemKind::ExternCrate(..) => "extern crate",
             ItemKind::Use(..) => "`use` import",
@@ -2950,6 +2950,15 @@ impl AssocItemKind {
             | Self::Fn(box Fn { defaultness, .. })
             | Self::Type(box TyAlias { defaultness, .. }) => defaultness,
             Self::MacCall(..) => Defaultness::Final,
+        }
+    }
+
+    pub fn generics(&self) -> Option<&Generics> {
+        match self {
+            Self::Const(..) => None,
+            Self::Fn(f) => Some(&f.generics),
+            Self::Type(t) => Some(&t.generics),
+            Self::MacCall(_) => None,
         }
     }
 }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -272,8 +272,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ExprKind::Paren(ref ex) => {
                     let mut ex = self.lower_expr_mut(ex);
                     // Include parens in span, but only if it is a super-span.
+                    // Use the inner ctxt to maintain desugaring marker for `(a..b)`
                     if e.span.contains(ex.span) {
-                        ex.span = self.lower_span(e.span);
+                        ex.span = self.lower_span(e.span.with_ctxt(ex.span.ctxt()));
                     }
                     // Merge attributes into the inner expression.
                     if !e.attrs.is_empty() {

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -781,22 +781,34 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         if let hir::ItemKind::OpaqueTy(hir::OpaqueTy {
             bounds:
                 [
-                    hir::GenericBound::LangItemTrait(
-                        hir::LangItem::Future,
-                        _,
-                        _,
-                        hir::GenericArgs {
-                            bindings:
-                                [
-                                    hir::TypeBinding {
-                                        ident: Ident { name: sym::Output, .. },
-                                        kind:
-                                            hir::TypeBindingKind::Equality { term: hir::Term::Ty(ty) },
-                                        ..
-                                    },
-                                ],
+                    hir::GenericBound::Trait(
+                        hir::PolyTraitRef {
+                            trait_ref: hir::TraitRef {
+                                path: hir::Path {
+                                    segments: [
+                                        ..,
+                                        hir::PathSegment {
+                                            args: Some(hir::GenericArgs {
+                                                args: [],
+                                                bindings: [hir::TypeBinding {
+                                                    ident: Ident { name: sym::Output, .. },
+                                                    kind: hir::TypeBindingKind::Equality {
+                                                        term: hir::Term::Ty(ty)
+                                                    },
+                                                    ..
+                                                }],
+                                                ..
+                                           }),
+                                            ..
+                                        }
+                                    ],
+                                    ..
+                                },
+                                ..
+                            },
                             ..
                         },
+                        _,
                     ),
                 ],
             ..

--- a/compiler/rustc_error_messages/locales/en-US/passes.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/passes.ftl
@@ -361,9 +361,6 @@ passes_deprecated_annotation_has_no_effect =
     this `#[deprecated]` annotation has no effect
     .suggestion = remove the unnecessary deprecation attribute
 
-passes_unknown_external_lang_item =
-    unknown external lang item: `{$lang_item}`
-
 passes_missing_panic_handler =
     `#[panic_handler]` function required, but not found
 
@@ -371,14 +368,6 @@ passes_missing_lang_item =
     language item required, but not found: `{$name}`
     .note = this can occur when a binary crate with `#![no_std]` is compiled for a target where `{$name}` is defined in the standard library
     .help = you may be able to compile for a target that doesn't need `{$name}`, specify a target with `--target` or in `.cargo/config`
-
-passes_lang_item_on_incorrect_target =
-    `{$name}` language item must be applied to a {$expected_target}
-    .label = attribute should be applied to a {$expected_target}, not a {$actual_target}
-
-passes_unknown_lang_item =
-    definition of an unknown language item: `{$name}`
-    .label = definition of unknown language item `{$name}`
 
 passes_invalid_attr_at_crate_level =
     `{$name}` attribute cannot be used at crate level
@@ -558,19 +547,6 @@ passes_duplicate_lang_item_crate_depends =
     .second_definition_local = second definition in the local crate (`{$crate_name}`)
     .first_definition_path = first definition in `{$orig_crate_name}` loaded from {$orig_path}
     .second_definition_path = second definition in `{$crate_name}` loaded from {$path}
-
-passes_incorrect_target =
-    `{$name}` language item must be applied to a {$kind} with {$at_least ->
-        [true] at least {$num}
-        *[false] {$num}
-    } generic {$num ->
-        [one] argument
-        *[other] arguments
-    }
-    .label = this {$kind} has {$actual_num} generic {$actual_num ->
-        [one] argument
-        *[other] arguments
-    }
 
 passes_useless_assignment =
     useless assignment of {$is_field_assign ->

--- a/compiler/rustc_error_messages/locales/en-US/resolve.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/resolve.ftl
@@ -1,0 +1,23 @@
+resolve_lang_item_on_incorrect_target =
+    `{$name}` language item must be applied to a {$expected_target}
+    .label = attribute should be applied to a {$expected_target}, not a {$actual_target}
+
+resolve_unknown_external_lang_item =
+    unknown external lang item: `{$lang_item}`
+
+resolve_unknown_lang_item =
+    definition of an unknown language item: `{$name}`
+    .label = definition of unknown language item `{$name}`
+
+resolve_incorrect_target =
+    `{$name}` language item must be applied to a {$kind} with {$at_least ->
+        [true] at least {$num}
+        *[false] {$num}
+    } generic {$num ->
+        [one] argument
+        *[other] arguments
+    }
+    .label = this {$kind} has {$actual_num} generic {$actual_num ->
+        [one] argument
+        *[other] arguments
+    }

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -61,6 +61,7 @@ fluent_messages! {
     plugin_impl => "../locales/en-US/plugin_impl.ftl",
     privacy => "../locales/en-US/privacy.ftl",
     query_system => "../locales/en-US/query_system.ftl",
+    resolve => "../locales/en-US/resolve.ftl",
     save_analysis => "../locales/en-US/save_analysis.ftl",
     session => "../locales/en-US/session.ftl",
     symbol_mangling => "../locales/en-US/symbol_mangling.ftl",

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2,7 +2,6 @@ use crate::def::{CtorKind, DefKind, Res};
 use crate::def_id::DefId;
 pub(crate) use crate::hir_id::{HirId, ItemLocalId, OwnerId};
 use crate::intravisit::FnKind;
-use crate::LangItem;
 
 use rustc_ast as ast;
 use rustc_ast::util::parser::ExprPrecedence;
@@ -427,8 +426,6 @@ pub enum TraitBoundModifier {
 #[derive(Clone, Debug, HashStable_Generic)]
 pub enum GenericBound<'hir> {
     Trait(PolyTraitRef<'hir>, TraitBoundModifier),
-    // FIXME(davidtwco): Introduce `PolyTraitRef::LangItem`
-    LangItemTrait(LangItem, Span, HirId, &'hir GenericArgs<'hir>),
     Outlives(&'hir Lifetime),
 }
 
@@ -443,7 +440,6 @@ impl GenericBound<'_> {
     pub fn span(&self) -> Span {
         match self {
             GenericBound::Trait(t, ..) => t.span,
-            GenericBound::LangItemTrait(_, span, ..) => *span,
             GenericBound::Outlives(l) => l.span,
         }
     }

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -704,7 +704,6 @@ pub fn walk_qpath<'v, V: Visitor<'v>>(visitor: &mut V, qpath: &'v QPath<'v>, id:
             visitor.visit_ty(qself);
             visitor.visit_path_segment(segment);
         }
-        QPath::LangItem(..) => {}
     }
 }
 

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -809,10 +809,6 @@ pub fn walk_param_bound<'v, V: Visitor<'v>>(visitor: &mut V, bound: &'v GenericB
         GenericBound::Trait(ref typ, _modifier) => {
             visitor.visit_poly_trait_ref(typ);
         }
-        GenericBound::LangItemTrait(_, _span, hir_id, args) => {
-            visitor.visit_id(hir_id);
-            visitor.visit_generic_args(args);
-        }
         GenericBound::Outlives(ref lifetime) => visitor.visit_lifetime(lifetime),
     }
 }

--- a/compiler/rustc_hir/src/target.rs
+++ b/compiler/rustc_hir/src/target.rs
@@ -99,28 +99,28 @@ impl Target {
         }
     }
 
-    // FIXME: For now, should only be used with def_kinds from ItemIds
-    pub fn from_def_kind(def_kind: DefKind) -> Target {
-        match def_kind {
-            DefKind::ExternCrate => Target::ExternCrate,
-            DefKind::Use => Target::Use,
-            DefKind::Static(..) => Target::Static,
-            DefKind::Const => Target::Const,
-            DefKind::Fn => Target::Fn,
-            DefKind::Macro(..) => Target::MacroDef,
-            DefKind::Mod => Target::Mod,
-            DefKind::ForeignMod => Target::ForeignMod,
-            DefKind::GlobalAsm => Target::GlobalAsm,
-            DefKind::TyAlias => Target::TyAlias,
-            DefKind::OpaqueTy => Target::OpaqueTy,
-            DefKind::ImplTraitPlaceholder => Target::ImplTraitPlaceholder,
-            DefKind::Enum => Target::Enum,
-            DefKind::Struct => Target::Struct,
-            DefKind::Union => Target::Union,
-            DefKind::Trait => Target::Trait,
-            DefKind::TraitAlias => Target::TraitAlias,
-            DefKind::Impl => Target::Impl,
-            _ => panic!("impossible case reached"),
+    pub fn to_def_kind(self) -> DefKind {
+        match self {
+            Target::ExternCrate => DefKind::ExternCrate,
+            Target::Use => DefKind::Use,
+            Target::Static => DefKind::Static(ast::Mutability::Not),
+            Target::Const => DefKind::Const,
+            Target::Fn => DefKind::Fn,
+            Target::Mod => DefKind::Mod,
+            Target::ForeignMod => DefKind::ForeignMod,
+            Target::GlobalAsm => DefKind::GlobalAsm,
+            Target::TyAlias => DefKind::TyAlias,
+            Target::OpaqueTy => DefKind::OpaqueTy,
+            Target::ImplTraitPlaceholder => DefKind::ImplTraitPlaceholder,
+            Target::Enum => DefKind::Enum,
+            Target::Struct => DefKind::Struct,
+            Target::Union => DefKind::Union,
+            Target::Trait => DefKind::Trait,
+            Target::TraitAlias => DefKind::TraitAlias,
+            Target::Impl => DefKind::Impl,
+            Target::Method(_) => DefKind::AssocFn,
+            Target::Variant => DefKind::Variant,
+            _ => panic!("unsupported Target::to_def_kind: {self:?}"),
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -2676,21 +2676,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     .map(|(ty, _, _)| ty)
                     .unwrap_or_else(|_| tcx.ty_error())
             }
-            hir::TyKind::Path(hir::QPath::LangItem(lang_item, span, _)) => {
-                let def_id = tcx.require_lang_item(lang_item, Some(span));
-                let (substs, _) = self.create_substs_for_ast_path(
-                    span,
-                    def_id,
-                    &[],
-                    &hir::PathSegment::invalid(),
-                    &GenericArgs::none(),
-                    true,
-                    None,
-                    None,
-                );
-                EarlyBinder(self.normalize_ty(span, tcx.at(span).type_of(def_id)))
-                    .subst(tcx, substs)
-            }
             hir::TyKind::Array(ref ty, ref length) => {
                 let length = match length {
                     &hir::ArrayLen::Infer(_, span) => self.ct_infer(tcx.types.usize, None, span),

--- a/compiler/rustc_hir_analysis/src/collect/lifetimes.rs
+++ b/compiler/rustc_hir_analysis/src/collect/lifetimes.rs
@@ -1074,32 +1074,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
         })
     }
 
-    fn visit_param_bound(&mut self, bound: &'tcx hir::GenericBound<'tcx>) {
-        match bound {
-            hir::GenericBound::LangItemTrait(_, _, hir_id, _) => {
-                // FIXME(jackh726): This is pretty weird. `LangItemTrait` doesn't go
-                // through the regular poly trait ref code, so we don't get another
-                // chance to introduce a binder. For now, I'm keeping the existing logic
-                // of "if there isn't a Binder scope above us, add one", but I
-                // imagine there's a better way to go about this.
-                let (binders, scope_type) = self.poly_trait_ref_binder_info();
-
-                self.record_late_bound_vars(*hir_id, binders);
-                let scope = Scope::Binder {
-                    hir_id: *hir_id,
-                    lifetimes: FxIndexMap::default(),
-                    s: self.scope,
-                    scope_type,
-                    where_bound_origin: None,
-                };
-                self.with(scope, |this| {
-                    intravisit::walk_param_bound(this, bound);
-                });
-            }
-            _ => intravisit::walk_param_bound(self, bound),
-        }
-    }
-
     fn visit_poly_trait_ref(&mut self, trait_ref: &'tcx hir::PolyTraitRef<'tcx>) {
         debug!("visit_poly_trait_ref(trait_ref={:?})", trait_ref);
 

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2102,11 +2102,6 @@ impl<'a> State<'a> {
                     }
                     self.print_poly_trait_ref(tref);
                 }
-                GenericBound::LangItemTrait(lang_item, span, ..) => {
-                    self.word("#[lang = \"");
-                    self.print_ident(Ident::new(lang_item.name(), *span));
-                    self.word("\"]");
-                }
                 GenericBound::Outlives(lt) => {
                     self.print_lifetime(lt);
                 }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1652,11 +1652,6 @@ impl<'a> State<'a> {
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(item_segment.args(), colons_before_params)
             }
-            hir::QPath::LangItem(lang_item, span, _) => {
-                self.word("#[lang = \"");
-                self.print_ident(Ident::new(lang_item.name(), span));
-                self.word("\"]");
-            }
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -80,12 +80,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Expectation<'tcx>,
     ) -> Ty<'tcx> {
         let original_callee_ty = match &callee_expr.kind {
-            hir::ExprKind::Path(hir::QPath::Resolved(..) | hir::QPath::TypeRelative(..)) => self
-                .check_expr_with_expectation_and_args(
-                    callee_expr,
-                    Expectation::NoExpectation,
-                    arg_exprs,
-                ),
+            hir::ExprKind::Path(..) => self.check_expr_with_expectation_and_args(
+                callee_expr,
+                Expectation::NoExpectation,
+                arg_exprs,
+            ),
             _ => self.check_expr(callee_expr),
         };
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1658,9 +1658,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 (result.map_or(Res::Err, |(kind, def_id)| Res::Def(kind, def_id)), ty)
             }
-            QPath::LangItem(lang_item, span, id) => {
-                self.resolve_lang_item_path(lang_item, span, hir_id, id)
-            }
         }
     }
 
@@ -2009,7 +2006,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     return true;
                 }
             }
-            _ => {}
         }
 
         false

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(min_specialization)]
 #![feature(control_flow_enum)]
 #![feature(drain_filter)]
+#![feature(is_some_and)]
 #![allow(rustc::potential_query_instability)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -860,7 +860,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Type-check the path.
         let (pat_ty, pat_res) =
-            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.hir_id);
+            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.hir_id, None);
         if let Some(err) =
             self.demand_suptype_with_origin(&self.pattern_cause(ti, pat.span), expected, pat_ty)
         {
@@ -1030,7 +1030,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Type-check the path.
         let (pat_ty, res) =
-            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.hir_id);
+            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.hir_id, None);
         if !pat_ty.is_fn() {
             report_unexpected_res(res);
             return tcx.ty_error();

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -3213,14 +3213,6 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             {
                                 true
                             }
-                            (
-                                hir::GenericBound::LangItemTrait(langl, _, _, argsl),
-                                hir::GenericBound::LangItemTrait(langr, _, _, argsr),
-                            ) if langl == langr => {
-                                // FIXME: consider the bounds!
-                                debug!("{:?} {:?}", argsl, argsr);
-                                true
-                            }
                             _ => false,
                         }
                     }) =>

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -1067,7 +1067,6 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
 
                 Box::new(segment.into_iter())
             }
-            hir::QPath::LangItem(_, _, _) => Box::new(iter::empty()),
         }
     }
 }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1479,7 +1479,7 @@ impl TypeAliasBounds {
                     _ => false,
                 }
             }
-            hir::QPath::Resolved(..) | hir::QPath::LangItem(..) => false,
+            hir::QPath::Resolved(..) => false,
         }
     }
 

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -1078,7 +1078,7 @@ impl<'tcx> LateContext<'tcx> {
     pub fn qpath_res(&self, qpath: &hir::QPath<'_>, id: hir::HirId) -> Res {
         match *qpath {
             hir::QPath::Resolved(_, ref path) => path.res,
-            hir::QPath::TypeRelative(..) | hir::QPath::LangItem(..) => self
+            hir::QPath::TypeRelative(..) => self
                 .maybe_typeck_results()
                 .filter(|typeck_results| typeck_results.hir_owner == id.owner)
                 .or_else(|| {

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -15,6 +15,7 @@ use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_hir::definitions::{DefKey, DefPath, DefPathData, DefPathHash};
 use rustc_hir::diagnostic_items::DiagnosticItems;
+use rustc_hir::LangItem;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::metadata::ModChild;
 use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo};

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1908,10 +1908,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
     fn encode_lang_items(&mut self) -> LazyArray<(DefIndex, LangItem)> {
         empty_proc_macro!(self);
-        let lang_items = self.tcx.lang_items().iter();
-        self.lazy_array(lang_items.filter_map(|(lang_item, def_id)| {
-            def_id.as_local().map(|id| (id.local_def_index, lang_item))
-        }))
+        let lang_items = self.tcx.resolutions(()).lang_items.iter();
+        self.lazy_array(lang_items.map(|&(def_id, lang_item)| (def_id.local_def_index, lang_item)))
     }
 
     fn encode_lang_items_missing(&mut self) -> LazyArray<LangItem> {

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -480,7 +480,10 @@ pub fn in_external_macro(sess: &Session, span: Span) -> bool {
         ExpnKind::Inlined
         | ExpnKind::Root
         | ExpnKind::Desugaring(
-            DesugaringKind::ForLoop | DesugaringKind::WhileLoop | DesugaringKind::OpaqueTy,
+            DesugaringKind::ForLoop
+            | DesugaringKind::WhileLoop
+            | DesugaringKind::OpaqueTy
+            | DesugaringKind::RangeLiteral,
         ) => false,
         ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => true, // well, it's "external"
         ExpnKind::Macro(MacroKind::Bang, _) => {

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -407,7 +407,7 @@ pub enum ObligationCauseCode<'tcx> {
     /// If `X` is the concrete type of an opaque type `impl Y`, then `X` must implement `Y`
     OpaqueType,
 
-    AwaitableExpr(Option<hir::HirId>),
+    AwaitableExpr(hir::HirId),
 
     ForLoopIterator,
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -625,7 +625,7 @@ impl<'tcx> TypeckResults<'tcx> {
     pub fn qpath_res(&self, qpath: &hir::QPath<'_>, id: hir::HirId) -> Res {
         match *qpath {
             hir::QPath::Resolved(_, ref path) => path.res,
-            hir::QPath::TypeRelative(..) | hir::QPath::LangItem(..) => self
+            hir::QPath::TypeRelative(..) => self
                 .type_dependent_def(id)
                 .map_or(Res::Err, |(kind, def_id)| Res::Def(kind, def_id)),
         }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -39,7 +39,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, LifetimeRes, Res};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LocalDefIdMap};
 use rustc_hir::definitions::Definitions;
-use rustc_hir::Node;
+use rustc_hir::{LangItem, Node};
 use rustc_index::vec::IndexVec;
 use rustc_macros::HashStable;
 use rustc_query_system::ich::StableHashingContext;
@@ -178,6 +178,8 @@ pub struct ResolverGlobalCtxt {
     /// exist under `std`. For example, wrote `str::from_utf8` instead of `std::str::from_utf8`.
     pub confused_type_with_std_module: FxHashMap<Span, Span>,
     pub registered_tools: RegisteredTools,
+    pub lang_items: Vec<(LocalDefId, LangItem)>,
+    pub missing_lang_items: Vec<LangItem>,
 }
 
 /// Resolutions that should only be used for lowering.

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -5,7 +5,7 @@ use std::{
 
 use rustc_ast::Label;
 use rustc_errors::{error_code, Applicability, ErrorGuaranteed, IntoDiagnostic, MultiSpan};
-use rustc_hir::{self as hir, ExprKind, Target};
+use rustc_hir::{self as hir, ExprKind};
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::{MainDefinition, Ty};
 use rustc_span::{Span, Symbol, DUMMY_SP};
@@ -690,14 +690,6 @@ pub struct DeprecatedAnnotationHasNoEffect {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_unknown_external_lang_item, code = "E0264")]
-pub struct UnknownExternLangItem {
-    #[primary_span]
-    pub span: Span,
-    pub lang_item: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag(passes_missing_panic_handler)]
 pub struct MissingPanicHandler;
 
@@ -706,26 +698,6 @@ pub struct MissingPanicHandler;
 #[note]
 #[help]
 pub struct MissingLangItem {
-    pub name: Symbol,
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_lang_item_on_incorrect_target, code = "E0718")]
-pub struct LangItemOnIncorrectTarget {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-    pub name: Symbol,
-    pub expected_target: Target,
-    pub actual_target: Target,
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_unknown_lang_item, code = "E0522")]
-pub struct UnknownLangItem {
-    #[primary_span]
-    #[label]
-    pub span: Span,
     pub name: Symbol,
 }
 
@@ -1236,20 +1208,6 @@ impl IntoDiagnostic<'_> for DuplicateLangItem {
         }
         diag
     }
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_incorrect_target, code = "E0718")]
-pub struct IncorrectTarget<'a> {
-    #[primary_span]
-    pub span: Span,
-    #[label]
-    pub generics_span: Span,
-    pub name: &'a str, // cannot be symbol because it renders e.g. `r#fn` instead of `fn`
-    pub kind: &'static str,
-    pub num: usize,
-    pub actual_num: usize,
-    pub at_least: bool,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -409,7 +409,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     fn visit_param_bound(&mut self, b: &'v hir::GenericBound<'v>) {
         record_variants!(
             (self, b, b, Id::None, hir, GenericBound, GenericBound),
-            [Trait, LangItemTrait, Outlives]
+            [Trait, Outlives]
         );
         hir_visit::walk_param_bound(self, b)
     }

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -7,20 +7,14 @@
 //! * Traits that represent operators; e.g., `Add`, `Sub`, `Index`.
 //! * Functions called by the compiler itself.
 
-use crate::check_attr::target_from_impl_item;
-use crate::errors::{
-    DuplicateLangItem, IncorrectTarget, LangItemOnIncorrectTarget, UnknownLangItem,
-};
+use crate::errors::DuplicateLangItem;
 use crate::weak_lang_items;
 
-use rustc_hir as hir;
-use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items::{extract, GenericRequirement};
-use rustc_hir::{HirId, LangItem, LanguageItems, Target};
+use rustc_hir::{LangItem, LanguageItems};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::cstore::ExternCrate;
-use rustc_span::{symbol::kw::Empty, Span};
+use rustc_span::symbol::kw::Empty;
 
 use rustc_middle::ty::query::Providers;
 
@@ -30,215 +24,101 @@ pub(crate) enum Duplicate {
     CrateDepends,
 }
 
-struct LanguageItemCollector<'tcx> {
-    items: LanguageItems,
-    tcx: TyCtxt<'tcx>,
-}
-
-impl<'tcx> LanguageItemCollector<'tcx> {
-    fn new(tcx: TyCtxt<'tcx>) -> LanguageItemCollector<'tcx> {
-        LanguageItemCollector { tcx, items: LanguageItems::new() }
-    }
-
-    fn check_for_lang(&mut self, actual_target: Target, hir_id: HirId) {
-        let attrs = self.tcx.hir().attrs(hir_id);
-        if let Some((name, span)) = extract(&attrs) {
-            match LangItem::from_name(name) {
-                // Known lang item with attribute on correct target.
-                Some(lang_item) if actual_target == lang_item.target() => {
-                    self.collect_item_extended(lang_item, hir_id, span);
-                }
-                // Known lang item with attribute on incorrect target.
-                Some(lang_item) => {
-                    self.tcx.sess.emit_err(LangItemOnIncorrectTarget {
-                        span,
-                        name,
-                        expected_target: lang_item.target(),
-                        actual_target,
-                    });
-                }
-                // Unknown lang item.
-                _ => {
-                    self.tcx.sess.emit_err(UnknownLangItem { span, name });
+fn collect_item(
+    tcx: TyCtxt<'_>,
+    items: &mut LanguageItems,
+    lang_item: LangItem,
+    item_def_id: DefId,
+) {
+    // Check for duplicates.
+    if let Some(original_def_id) = items.get(lang_item) {
+        if original_def_id != item_def_id {
+            let local_span = item_def_id.as_local().map(|id| tcx.source_span(id));
+            let lang_item_name = lang_item.name();
+            let crate_name = tcx.crate_name(item_def_id.krate);
+            let mut dependency_of = Empty;
+            let is_local = item_def_id.is_local();
+            let path = if is_local {
+                String::new()
+            } else {
+                tcx.crate_extern_paths(item_def_id.krate)
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+                    .into()
+            };
+            let first_defined_span = original_def_id.as_local().map(|id| tcx.source_span(id));
+            let mut orig_crate_name = Empty;
+            let mut orig_dependency_of = Empty;
+            let orig_is_local = original_def_id.is_local();
+            let orig_path = if orig_is_local {
+                String::new()
+            } else {
+                tcx.crate_extern_paths(original_def_id.krate)
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+                    .into()
+            };
+            if first_defined_span.is_none() {
+                orig_crate_name = tcx.crate_name(original_def_id.krate);
+                if let Some(ExternCrate { dependency_of: inner_dependency_of, .. }) =
+                    tcx.extern_crate(original_def_id)
+                {
+                    orig_dependency_of = tcx.crate_name(*inner_dependency_of);
                 }
             }
-        }
-    }
 
-    fn collect_item(&mut self, lang_item: LangItem, item_def_id: DefId) {
-        // Check for duplicates.
-        if let Some(original_def_id) = self.items.get(lang_item) {
-            if original_def_id != item_def_id {
-                let local_span = self.tcx.hir().span_if_local(item_def_id);
-                let lang_item_name = lang_item.name();
-                let crate_name = self.tcx.crate_name(item_def_id.krate);
-                let mut dependency_of = Empty;
-                let is_local = item_def_id.is_local();
-                let path = if is_local {
-                    String::new()
-                } else {
-                    self.tcx
-                        .crate_extern_paths(item_def_id.krate)
-                        .iter()
-                        .map(|p| p.display().to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                        .into()
-                };
-                let first_defined_span = self.tcx.hir().span_if_local(original_def_id);
-                let mut orig_crate_name = Empty;
-                let mut orig_dependency_of = Empty;
-                let orig_is_local = original_def_id.is_local();
-                let orig_path = if orig_is_local {
-                    String::new()
-                } else {
-                    self.tcx
-                        .crate_extern_paths(original_def_id.krate)
-                        .iter()
-                        .map(|p| p.display().to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                        .into()
-                };
-                if first_defined_span.is_none() {
-                    orig_crate_name = self.tcx.crate_name(original_def_id.krate);
-                    if let Some(ExternCrate { dependency_of: inner_dependency_of, .. }) =
-                        self.tcx.extern_crate(original_def_id)
-                    {
-                        orig_dependency_of = self.tcx.crate_name(*inner_dependency_of);
+            let duplicate = if local_span.is_some() {
+                Duplicate::Plain
+            } else {
+                match tcx.extern_crate(item_def_id) {
+                    Some(ExternCrate { dependency_of: inner_dependency_of, .. }) => {
+                        dependency_of = tcx.crate_name(*inner_dependency_of);
+                        Duplicate::CrateDepends
                     }
+                    _ => Duplicate::Crate,
                 }
-
-                let duplicate = if local_span.is_some() {
-                    Duplicate::Plain
-                } else {
-                    match self.tcx.extern_crate(item_def_id) {
-                        Some(ExternCrate { dependency_of: inner_dependency_of, .. }) => {
-                            dependency_of = self.tcx.crate_name(*inner_dependency_of);
-                            Duplicate::CrateDepends
-                        }
-                        _ => Duplicate::Crate,
-                    }
-                };
-
-                self.tcx.sess.emit_err(DuplicateLangItem {
-                    local_span,
-                    lang_item_name,
-                    crate_name,
-                    dependency_of,
-                    is_local,
-                    path,
-                    first_defined_span,
-                    orig_crate_name,
-                    orig_dependency_of,
-                    orig_is_local,
-                    orig_path,
-                    duplicate,
-                });
-            }
-        }
-
-        // Matched.
-        self.items.set(lang_item, item_def_id);
-    }
-
-    // Like collect_item() above, but also checks whether the lang item is declared
-    // with the right number of generic arguments.
-    fn collect_item_extended(&mut self, lang_item: LangItem, hir_id: HirId, span: Span) {
-        let item_def_id = self.tcx.hir().local_def_id(hir_id).to_def_id();
-        let name = lang_item.name();
-
-        // Now check whether the lang_item has the expected number of generic
-        // arguments. Generally speaking, binary and indexing operations have
-        // one (for the RHS/index), unary operations have none, the closure
-        // traits have one for the argument list, generators have one for the
-        // resume argument, and ordering/equality relations have one for the RHS
-        // Some other types like Box and various functions like drop_in_place
-        // have minimum requirements.
-
-        if let hir::Node::Item(hir::Item { kind, span: item_span, .. }) = self.tcx.hir().get(hir_id)
-        {
-            let (actual_num, generics_span) = match kind.generics() {
-                Some(generics) => (generics.params.len(), generics.span),
-                None => (0, *item_span),
             };
 
-            let mut at_least = false;
-            let required = match lang_item.required_generics() {
-                GenericRequirement::Exact(num) if num != actual_num => Some(num),
-                GenericRequirement::Minimum(num) if actual_num < num => {
-                    at_least = true;
-                    Some(num)}
-                ,
-                // If the number matches, or there is no requirement, handle it normally
-                _ => None,
-            };
-
-            if let Some(num) = required {
-                // We are issuing E0718 "incorrect target" here, because while the
-                // item kind of the target is correct, the target is still wrong
-                // because of the wrong number of generic arguments.
-                self.tcx.sess.emit_err(IncorrectTarget {
-                    span,
-                    generics_span,
-                    name: name.as_str(),
-                    kind: kind.descr(),
-                    num,
-                    actual_num,
-                    at_least,
-                });
-
-                // return early to not collect the lang item
-                return;
-            }
+            tcx.sess.emit_err(DuplicateLangItem {
+                local_span,
+                lang_item_name,
+                crate_name,
+                dependency_of,
+                is_local,
+                path,
+                first_defined_span,
+                orig_crate_name,
+                orig_dependency_of,
+                orig_is_local,
+                orig_path,
+                duplicate,
+            });
         }
-
-        self.collect_item(lang_item, item_def_id);
     }
+
+    // Matched.
+    items.set(lang_item, item_def_id);
 }
 
 /// Traverses and collects all the lang items in all crates.
 fn get_lang_items(tcx: TyCtxt<'_>, (): ()) -> LanguageItems {
-    // Initialize the collector.
-    let mut collector = LanguageItemCollector::new(tcx);
+    let mut items = LanguageItems::new();
 
     // Collect lang items in other crates.
     for &cnum in tcx.crates(()).iter() {
         for &(def_id, lang_item) in tcx.defined_lang_items(cnum).iter() {
-            collector.collect_item(lang_item, def_id);
+            collect_item(tcx, &mut items, lang_item, def_id);
         }
     }
 
-    // Collect lang items in this crate.
-    let crate_items = tcx.hir_crate_items(());
-
-    for id in crate_items.items() {
-        collector.check_for_lang(Target::from_def_kind(tcx.def_kind(id.owner_id)), id.hir_id());
-
-        if matches!(tcx.def_kind(id.owner_id), DefKind::Enum) {
-            let item = tcx.hir().item(id);
-            if let hir::ItemKind::Enum(def, ..) = &item.kind {
-                for variant in def.variants {
-                    collector.check_for_lang(Target::Variant, variant.id);
-                }
-            }
-        }
+    // Collect lang items from this crate
+    for &(def_id, lang_item) in &tcx.resolutions(()).lang_items {
+        collect_item(tcx, &mut items, lang_item, def_id.to_def_id());
     }
-
-    // FIXME: avoid calling trait_item() when possible
-    for id in crate_items.trait_items() {
-        let item = tcx.hir().trait_item(id);
-        collector.check_for_lang(Target::from_trait_item(item), item.hir_id())
-    }
-
-    // FIXME: avoid calling impl_item() when possible
-    for id in crate_items.impl_items() {
-        let item = tcx.hir().impl_item(id);
-        collector.check_for_lang(target_from_impl_item(tcx, item), item.hir_id())
-    }
-
-    // Extract out the found lang items.
-    let LanguageItemCollector { mut items, .. } = collector;
 
     // Find all required but not-yet-defined lang items.
     weak_lang_items::check_crate(tcx, &mut items);

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -478,8 +478,7 @@ impl<'tcx> Visitor<'tcx> for IrMaps<'tcx> {
             | hir::ExprKind::Box(..)
             | hir::ExprKind::Type(..)
             | hir::ExprKind::Err
-            | hir::ExprKind::Path(hir::QPath::TypeRelative(..))
-            | hir::ExprKind::Path(hir::QPath::LangItem(..)) => {
+            | hir::ExprKind::Path(hir::QPath::TypeRelative(..)) => {
                 intravisit::walk_expr(self, expr);
             }
         }
@@ -1133,8 +1132,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             hir::ExprKind::Lit(..)
             | hir::ExprKind::ConstBlock(..)
             | hir::ExprKind::Err
-            | hir::ExprKind::Path(hir::QPath::TypeRelative(..))
-            | hir::ExprKind::Path(hir::QPath::LangItem(..)) => succ,
+            | hir::ExprKind::Path(hir::QPath::TypeRelative(..)) => succ,
 
             // Note that labels have been resolved, so we don't need to look
             // at the label ident

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1309,7 +1309,7 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
                 Res::Def(kind, def_id) => Some((kind, def_id)),
                 _ => None,
             },
-            hir::QPath::TypeRelative(..) | hir::QPath::LangItem(..) => self
+            hir::QPath::TypeRelative(..) => self
                 .maybe_typeck_results
                 .and_then(|typeck_results| typeck_results.type_dependent_def(id)),
         };
@@ -1326,9 +1326,7 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
                 let sess = self.tcx.sess;
                 let sm = sess.source_map();
                 let name = match qpath {
-                    hir::QPath::Resolved(..) | hir::QPath::LangItem(..) => {
-                        sm.span_to_snippet(qpath.span()).ok()
-                    }
+                    hir::QPath::Resolved(..) => sm.span_to_snippet(qpath.span()).ok(),
                     hir::QPath::TypeRelative(_, segment) => Some(segment.ident.to_string()),
                 };
                 let kind = kind.descr(def_id);

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -10,6 +10,7 @@ bitflags = "1.2.1"
 tracing = "0.1"
 rustc_ast = { path = "../rustc_ast" }
 rustc_arena = { path = "../rustc_arena" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_middle = { path = "../rustc_middle" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1,0 +1,45 @@
+use rustc_hir::Target;
+use rustc_macros::Diagnostic;
+use rustc_span::{Span, Symbol};
+
+#[derive(Diagnostic)]
+#[diag(resolve_lang_item_on_incorrect_target, code = "E0718")]
+pub struct LangItemOnIncorrectTarget {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub name: Symbol,
+    pub expected_target: Target,
+    pub actual_target: Target,
+}
+
+#[derive(Diagnostic)]
+#[diag(resolve_incorrect_target, code = "E0718")]
+pub struct IncorrectTarget<'a> {
+    #[primary_span]
+    pub span: Span,
+    #[label]
+    pub generics_span: Span,
+    pub name: &'a str,
+    pub kind: &'static str,
+    pub num: usize,
+    pub actual_num: usize,
+    pub at_least: bool,
+}
+
+#[derive(Diagnostic)]
+#[diag(resolve_unknown_external_lang_item, code = "E0264")]
+pub struct UnknownExternLangItem {
+    #[primary_span]
+    pub span: Span,
+    pub lang_item: Symbol,
+}
+
+#[derive(Diagnostic)]
+#[diag(resolve_unknown_lang_item, code = "E0522")]
+pub struct UnknownLangItem {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub name: Symbol,
+}

--- a/compiler/rustc_resolve/src/lang_items.rs
+++ b/compiler/rustc_resolve/src/lang_items.rs
@@ -1,0 +1,126 @@
+use crate::errors::{
+    IncorrectTarget, LangItemOnIncorrectTarget, UnknownExternLangItem, UnknownLangItem,
+};
+use crate::Resolver;
+
+use rustc_ast::visit;
+use rustc_ast::visit::{AssocCtxt, Visitor};
+use rustc_ast::*;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::lang_items::{extract, GenericRequirement};
+use rustc_hir::{LangItem, Target};
+
+impl<'a> Resolver<'a> {
+    pub(crate) fn resolve_lang_items(&mut self, krate: &Crate) {
+        let mut collector =
+            LanguageItemCollector { resolver: self, items: Vec::new(), missing: Vec::new() };
+        visit::walk_crate(&mut collector, krate);
+        let LanguageItemCollector { items, missing, .. } = collector;
+        self.lang_items = items;
+        self.missing_lang_items = missing;
+    }
+}
+struct LanguageItemCollector<'a, 'b> {
+    resolver: &'b Resolver<'a>,
+    items: Vec<(LocalDefId, LangItem)>,
+    missing: Vec<LangItem>,
+}
+
+impl<'ast> Visitor<'ast> for LanguageItemCollector<'_, '_> {
+    fn visit_item(&mut self, item: &'ast Item) {
+        self.check_for_lang(
+            Target::from_ast_item(item),
+            &item.attrs,
+            item.id,
+            item.kind.generics(),
+            item.kind.descr(),
+        );
+        visit::walk_item(self, item);
+    }
+
+    fn visit_assoc_item(&mut self, item: &'ast AssocItem, ctxt: AssocCtxt) {
+        let target = Target::from_ast_assoc_item(&item.kind, ctxt);
+        self.check_for_lang(target, &item.attrs, item.id, item.kind.generics(), target.name());
+        visit::walk_assoc_item(self, item, ctxt);
+    }
+
+    fn visit_variant(&mut self, variant: &'ast Variant) {
+        self.check_for_lang(Target::Variant, &variant.attrs, variant.id, None, "variant");
+        visit::walk_variant(self, variant);
+    }
+
+    fn visit_foreign_item(&mut self, item: &'ast ForeignItem) {
+        let Some((lang_item, _)) = extract(&item.attrs) else { return };
+        if let Some(item) = LangItem::from_name(lang_item) && item.is_weak() {
+            self.missing.push(item);
+        } else {
+            self.resolver.session.emit_err(UnknownExternLangItem { span: item.span, lang_item });
+        }
+        visit::walk_foreign_item(self, item);
+    }
+}
+
+impl LanguageItemCollector<'_, '_> {
+    fn check_for_lang(
+        &mut self,
+        actual_target: Target,
+        attrs: &[Attribute],
+        id: NodeId,
+        generics: Option<&Generics>,
+        descr: &'static str,
+    ) {
+        let Some((name, span)) = extract(attrs) else { return };
+        let Some(lang_item) = LangItem::from_name(name) else {
+            self.resolver.session.emit_err(UnknownLangItem { span, name });
+            return;
+        };
+        if actual_target != lang_item.target() {
+            self.resolver.session.emit_err(LangItemOnIncorrectTarget {
+                span,
+                name,
+                expected_target: lang_item.target(),
+                actual_target,
+            });
+            return;
+        }
+        // Now check whether the lang_item has the expected number of generic
+        // arguments. Generally speaking, binary and indexing operations have
+        // one (for the RHS/index), unary operations have none, the closure
+        // traits have one for the argument list, generators have one for the
+        // resume argument, and ordering/equality relations have one for the RHS
+        // Some other types like Box and various functions like drop_in_place
+        // have minimum requirements.
+        if let Some(generics) = generics {
+            let actual_num = generics.params.len();
+            let mut at_least = false;
+            let required = match lang_item.required_generics() {
+                GenericRequirement::Exact(num) if num != actual_num => Some(num),
+                GenericRequirement::Minimum(num) if actual_num < num => {
+                    at_least = true;
+                    Some(num)}
+                ,
+                // If the number matches, or there is no requirement, handle it normally
+                _ => None,
+            };
+
+            if let Some(num) = required {
+                // We are issuing E0718 "incorrect target" here, because while the
+                // item kind of the target is correct, the target is still wrong
+                // because of the wrong number of generic arguments.
+                self.resolver.session.emit_err(IncorrectTarget {
+                    span,
+                    generics_span: generics.span,
+                    name: lang_item.name().as_str(),
+                    kind: descr,
+                    num,
+                    actual_num,
+                    at_least,
+                });
+                return;
+            }
+        }
+
+        let item_def_id = self.resolver.local_def_id(id);
+        self.items.push((item_def_id, lang_item));
+    }
+}

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -746,7 +746,6 @@ impl<'tcx> DumpVisitor<'tcx> {
                 self.visit_ty(ty);
                 std::slice::from_ref(*segment)
             }
-            hir::QPath::LangItem(..) => return,
         };
         for seg in segments {
             if let Some(ref generic_args) = seg.args {

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -673,9 +673,6 @@ impl<'tcx> DumpVisitor<'tcx> {
                     self.lookup_def_id(trait_ref.trait_ref.hir_ref_id),
                     trait_ref.trait_ref.path.segments.last().unwrap().ident.span,
                 ),
-                hir::GenericBound::LangItemTrait(lang_item, span, _, _) => {
-                    (Some(self.tcx.require_lang_item(lang_item, Some(span))), span)
-                }
                 hir::GenericBound::Outlives(..) => continue,
             };
 

--- a/compiler/rustc_save_analysis/src/sig.rs
+++ b/compiler/rustc_save_analysis/src/sig.rs
@@ -286,9 +286,6 @@ impl<'hir> Sig for hir::Ty<'hir> {
                     refs: vec![SigElement { id, start, end }],
                 })
             }
-            hir::TyKind::Path(hir::QPath::LangItem(lang_item, _, _)) => {
-                Ok(text_sig(format!("#[lang = \"{}\"]", lang_item.name())))
-            }
             hir::TyKind::TraitObject(bounds, ..) => {
                 // FIXME recurse into bounds
                 let bounds: Vec<hir::GenericBound<'_>> = bounds

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1148,6 +1148,7 @@ pub enum DesugaringKind {
     Await,
     ForLoop,
     WhileLoop,
+    RangeLiteral,
 }
 
 impl DesugaringKind {
@@ -1163,6 +1164,7 @@ impl DesugaringKind {
             DesugaringKind::OpaqueTy => "`impl Trait`",
             DesugaringKind::ForLoop => "`for` loop",
             DesugaringKind::WhileLoop => "`while` loop",
+            DesugaringKind::RangeLiteral => "range literal",
         }
     }
 }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -588,6 +588,7 @@ impl Span {
         // FIXME: If this span comes from a `derive` macro but it points at code the user wrote,
         // the callsite span and the span will be pointing at different places. It also means that
         // we can safely provide suggestions on this span.
+            || self.is_desugaring(DesugaringKind::RangeLiteral)
             || (matches!(self.ctxt().outer_expn_data().kind, ExpnKind::Macro(MacroKind::Derive, _))
                 && self.parent_callsite().map(|p| (p.lo(), p.hi())) != Some((self.lo(), self.hi())))
     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -371,6 +371,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
     }
 }
 impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
+    #[instrument(level = "debug", skip(self))]
     fn report_fulfillment_errors(
         &self,
         errors: &[FulfillmentError<'tcx>],
@@ -422,6 +423,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         // We do this in 2 passes because we want to display errors in order, though
         // maybe it *is* better to sort errors by span or something.
         let mut is_suppressed = vec![false; errors.len()];
+        debug!(?error_map);
         for (_, error_set) in error_map.iter() {
             // We want to suppress "duplicate" errors with the same span.
             for error in error_set {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1244,9 +1244,10 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
     fn suggest_remove_await(&self, obligation: &PredicateObligation<'tcx>, err: &mut Diagnostic) {
         let span = obligation.cause.span;
 
-        if let ObligationCauseCode::AwaitableExpr(hir_id) = obligation.cause.code().peel_derives() {
+        if let ObligationCauseCode::AwaitableExpr(hir_id) = *obligation.cause.code().peel_derives()
+        {
             let hir = self.tcx.hir();
-            if let Some(node) = hir_id.and_then(|hir_id| hir.find(hir_id)) {
+            if let Some(node) = hir.find(hir_id) {
                 if let hir::Node::Expr(expr) = node {
                     // FIXME: use `obligation.predicate.kind()...trait_ref.self_ty()` to see if we have `()`
                     // and if not maybe suggest doing something else? If we kept the expression around we
@@ -2886,7 +2887,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     ..
                 })) = hir.find(call_hir_id)
                 {
-                    if Some(*span) != err.span.primary_span() {
+                    if Some(*span) != err.span.primary_span() && span.desugaring_kind().is_none() {
                         err.span_label(*span, "required by a bound introduced by this call");
                     }
                 }

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -518,7 +518,7 @@ pub fn panicking() -> bool {
 }
 
 /// Entry point of panics from the libcore crate (`panic_impl` lang item).
-#[cfg(not(test))]
+#[cfg(not(any(test, doctest)))]
 #[panic_handler]
 pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
     struct PanicPayload<'a> {
@@ -590,7 +590,7 @@ pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
 /// panic!() and assert!(). In particular, this is the only entry point that supports
 /// arbitrary payloads, not just format strings.
 #[unstable(feature = "libstd_sys_internals", reason = "used by the panic! macro", issue = "none")]
-#[cfg_attr(not(test), lang = "begin_panic")]
+#[cfg_attr(not(any(test, doctest)), lang = "begin_panic")]
 // lang item for CTFE panic support
 // never inline unless panic_immediate_abort to avoid code
 // bloat at the call sites as much as possible

--- a/library/std/src/personality.rs
+++ b/library/std/src/personality.rs
@@ -12,7 +12,7 @@
 
 mod dwarf;
 
-#[cfg(not(test))]
+#[cfg(not(any(test, doctest)))]
 cfg_if::cfg_if! {
     if #[cfg(target_os = "emscripten")] {
         mod emcc;

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2151,7 +2151,7 @@ pub fn id() -> u32 {
 /// of the `main` function, this trait is likely to be available only on
 /// standard library's runtime for convenience. Other runtimes are not required
 /// to provide similar functionality.
-#[cfg_attr(not(test), lang = "termination")]
+#[cfg_attr(not(any(test, doctest)), lang = "termination")]
 #[stable(feature = "termination_trait_lib", since = "1.61.0")]
 #[rustc_on_unimplemented(
     on(

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -154,7 +154,7 @@ fn lang_start_internal(
     ret_code
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, doctest)))]
 #[lang = "start"]
 fn lang_start<T: crate::process::Termination + 'static>(
     main: fn() -> T,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -124,23 +124,6 @@ fn clean_generic_bound<'tcx>(
 ) -> Option<GenericBound> {
     Some(match *bound {
         hir::GenericBound::Outlives(lt) => GenericBound::Outlives(clean_lifetime(lt, cx)),
-        hir::GenericBound::LangItemTrait(lang_item, span, _, generic_args) => {
-            let def_id = cx.tcx.require_lang_item(lang_item, Some(span));
-
-            let trait_ref = ty::TraitRef::identity(cx.tcx, def_id).skip_binder();
-
-            let generic_args = clean_generic_args(generic_args, cx);
-            let GenericArgs::AngleBracketed { bindings, .. } = generic_args
-            else {
-                bug!("clean: parenthesized `GenericBound::LangItemTrait`");
-            };
-
-            let trait_ = clean_trait_ref_with_bindings(cx, trait_ref, bindings);
-            GenericBound::TraitBound(
-                PolyTrait { trait_, generic_params: vec![] },
-                hir::TraitBoundModifier::None,
-            )
-        }
         hir::GenericBound::Trait(ref t, modifier) => {
             // `T: ~const Destruct` is hidden because `T: Destruct` is a no-op.
             if modifier == hir::TraitBoundModifier::MaybeConst

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1420,7 +1420,6 @@ fn clean_qpath<'tcx>(hir_ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> Type 
                 trait_,
             }))
         }
-        hir::QPath::LangItem(..) => bug!("clean: requiring documentation of lang item"),
     }
 }
 

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -156,7 +156,6 @@ pub(crate) fn qpath_to_string(p: &hir::QPath<'_>) -> String {
     let segments = match *p {
         hir::QPath::Resolved(_, path) => &path.segments,
         hir::QPath::TypeRelative(_, segment) => return segment.ident.to_string(),
-        hir::QPath::LangItem(lang_item, ..) => return lang_item.name().to_string(),
     };
 
     let mut s = String::new();
@@ -413,8 +412,6 @@ pub(crate) fn print_const_expr(tcx: TyCtxt<'_>, body: hir::BodyId) -> String {
             // FIXME: Claiming that those kinds of QPaths are simple is probably not true if the Ty
             //        contains const arguments. Is there a *concise* way to check for this?
             hir::ExprKind::Path(hir::QPath::TypeRelative(..)) => Simple,
-            // FIXME: Can they contain const arguments and thus leak private struct fields?
-            hir::ExprKind::Path(hir::QPath::LangItem(..)) => Simple,
             _ => Complex,
         }
     }

--- a/src/test/incremental/hashes/indexing_expressions.rs
+++ b/src/test/incremental/hashes/indexing_expressions.rs
@@ -128,9 +128,9 @@ fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
     &slice[3..=7]

--- a/src/test/ui/async-await/issue-98634.rs
+++ b/src/test/ui/async-await/issue-98634.rs
@@ -45,6 +45,5 @@ fn main() {
         StructAsync { callback }.await;
         //~^ ERROR expected `fn() -> impl Future<Output = ()> {callback}` to be a fn item that returns `Pin<Box<(dyn Future<Output = ()> + 'static)>>`, but it returns `impl Future<Output = ()>`
         //~| ERROR expected `fn() -> impl Future<Output = ()> {callback}` to be a fn item that returns `Pin<Box<(dyn Future<Output = ()> + 'static)>>`, but it returns `impl Future<Output = ()>`
-        //~| ERROR expected `fn() -> impl Future<Output = ()> {callback}` to be a fn item that returns `Pin<Box<(dyn Future<Output = ()> + 'static)>>`, but it returns `impl Future<Output = ()>`
     });
 }

--- a/src/test/ui/async-await/issue-98634.stderr
+++ b/src/test/ui/async-await/issue-98634.stderr
@@ -18,25 +18,6 @@ LL | pub struct StructAsync<F: Fn() -> Pin<Box<dyn Future<Output = ()>>>> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StructAsync`
 
 error[E0271]: expected `fn() -> impl Future<Output = ()> {callback}` to be a fn item that returns `Pin<Box<(dyn Future<Output = ()> + 'static)>>`, but it returns `impl Future<Output = ()>`
-  --> $DIR/issue-98634.rs:45:9
-   |
-LL |         StructAsync { callback }.await;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Pin`, found opaque type
-   |
-note: while checking the return type of the `async fn`
-  --> $DIR/issue-98634.rs:24:21
-   |
-LL | async fn callback() {}
-   |                     ^ checked the `Output` of this `async fn`, found opaque type
-   = note:   expected struct `Pin<Box<(dyn Future<Output = ()> + 'static)>>`
-           found opaque type `impl Future<Output = ()>`
-note: required by a bound in `StructAsync`
-  --> $DIR/issue-98634.rs:9:35
-   |
-LL | pub struct StructAsync<F: Fn() -> Pin<Box<dyn Future<Output = ()>>>> {
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StructAsync`
-
-error[E0271]: expected `fn() -> impl Future<Output = ()> {callback}` to be a fn item that returns `Pin<Box<(dyn Future<Output = ()> + 'static)>>`, but it returns `impl Future<Output = ()>`
   --> $DIR/issue-98634.rs:45:33
    |
 LL |         StructAsync { callback }.await;
@@ -55,6 +36,6 @@ note: required by a bound in `StructAsync`
 LL | pub struct StructAsync<F: Fn() -> Pin<Box<dyn Future<Output = ()>>>> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StructAsync`
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/duplicate_entry_error.stderr
+++ b/src/test/ui/duplicate_entry_error.stderr
@@ -1,8 +1,11 @@
 error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/duplicate_entry_error.rs:11:1
    |
-LL | fn panic_impl(info: &PanicInfo) -> ! {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / fn panic_impl(info: &PanicInfo) -> ! {
+LL | |
+LL | |     loop {}
+LL | | }
+   | |_^
    |
    = note: the lang item is first defined in crate `std` (which `duplicate_entry_error` depends on)
    = note: first definition in `std` loaded from SYSROOT/libstd-*.rlib

--- a/src/test/ui/error-codes/E0152.stderr
+++ b/src/test/ui/error-codes/E0152.stderr
@@ -2,7 +2,7 @@ error[E0152]: found duplicate lang item `owned_box`
   --> $DIR/E0152.rs:5:1
    |
 LL | struct Foo<T>(T);
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^
    |
    = note: the lang item is first defined in crate `alloc` (which `std` depends on)
    = note: first definition in `alloc` loaded from SYSROOT/liballoc-*.rlib

--- a/src/test/ui/error-codes/E0264.stderr
+++ b/src/test/ui/error-codes/E0264.stderr
@@ -2,7 +2,7 @@ error[E0264]: unknown external lang item: `cake`
   --> $DIR/E0264.rs:5:5
    |
 LL |     fn cake();
-   |     ^^^^^^^^^
+   |     ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-lang-items.stderr
+++ b/src/test/ui/feature-gates/feature-gate-lang-items.stderr
@@ -1,3 +1,9 @@
+error[E0522]: definition of an unknown language item: `foo`
+  --> $DIR/feature-gate-lang-items.rs:1:1
+   |
+LL | #[lang = "foo"]
+   | ^^^^^^^^^^^^^^^ definition of unknown language item `foo`
+
 error[E0658]: language items are subject to change
   --> $DIR/feature-gate-lang-items.rs:1:1
    |
@@ -5,12 +11,6 @@ LL | #[lang = "foo"]
    | ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
-
-error[E0522]: definition of an unknown language item: `foo`
-  --> $DIR/feature-gate-lang-items.rs:1:1
-   |
-LL | #[lang = "foo"]
-   | ^^^^^^^^^^^^^^^ definition of unknown language item `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/iterators/collect-into-array.stderr
+++ b/src/test/ui/iterators/collect-into-array.stderr
@@ -1,10 +1,10 @@
 error[E0277]: an array of type `[u32; 10]` cannot be built directly from an iterator
-  --> $DIR/collect-into-array.rs:3:31
+  --> $DIR/collect-into-array.rs:3:32
    |
 LL |     let whatever: [u32; 10] = (0..10).collect();
-   |                               ^^^^^^^ ------- required by a bound introduced by this call
-   |                               |
-   |                               try collecting into a `Vec<{integer}>`, then using `.try_into()`
+   |                                ^^^^^  ------- required by a bound introduced by this call
+   |                                |
+   |                                try collecting into a `Vec<{integer}>`, then using `.try_into()`
    |
    = help: the trait `FromIterator<{integer}>` is not implemented for `[u32; 10]`
 note: required by a bound in `collect`

--- a/src/test/ui/iterators/collect-into-slice.stderr
+++ b/src/test/ui/iterators/collect-into-slice.stderr
@@ -22,12 +22,12 @@ LL |     fn collect<B: FromIterator<Self::Item>>(self) -> B
    |                ^ required by this bound in `collect`
 
 error[E0277]: a slice of type `[i32]` cannot be built since `[i32]` has no definite size
-  --> $DIR/collect-into-slice.rs:8:30
+  --> $DIR/collect-into-slice.rs:8:31
    |
 LL |     let some_generated_vec = (0..10).collect();
-   |                              ^^^^^^^ ------- required by a bound introduced by this call
-   |                              |
-   |                              try explicitly collecting into a `Vec<{integer}>`
+   |                               ^^^^^  ------- required by a bound introduced by this call
+   |                               |
+   |                               try explicitly collecting into a `Vec<{integer}>`
    |
    = help: the trait `FromIterator<{integer}>` is not implemented for `[i32]`
 note: required by a bound in `collect`

--- a/src/test/ui/lang-items/issue-83471.stderr
+++ b/src/test/ui/lang-items/issue-83471.stderr
@@ -1,3 +1,12 @@
+error[E0718]: `fn` language item must be applied to a trait with 1 generic argument
+  --> $DIR/issue-83471.rs:11:1
+   |
+LL | #[lang = "fn"]
+   | ^^^^^^^^^^^^^^
+...
+LL | trait Fn {
+   |         - this trait has 0 generic arguments
+
 error[E0573]: expected type, found built-in attribute `export_name`
   --> $DIR/issue-83471.rs:15:13
    |
@@ -29,15 +38,6 @@ LL |     fn call(export_name);
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
    = note: `#[warn(anonymous_parameters)]` on by default
-
-error[E0718]: `fn` language item must be applied to a trait with 1 generic argument
-  --> $DIR/issue-83471.rs:11:1
-   |
-LL | #[lang = "fn"]
-   | ^^^^^^^^^^^^^^
-...
-LL | trait Fn {
-   |         - this trait has 0 generic arguments
 
 error[E0425]: cannot find function `a` in this scope
   --> $DIR/issue-83471.rs:21:5

--- a/src/test/ui/panic-handler/panic-handler-duplicate.stderr
+++ b/src/test/ui/panic-handler/panic-handler-duplicate.stderr
@@ -1,14 +1,18 @@
 error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/panic-handler-duplicate.rs:15:1
    |
-LL | fn panic2(info: &PanicInfo) -> ! {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / fn panic2(info: &PanicInfo) -> ! {
+LL | |     loop {}
+LL | | }
+   | |_^
    |
 note: the lang item is first defined here
   --> $DIR/panic-handler-duplicate.rs:10:1
    |
-LL | fn panic(info: &PanicInfo) -> ! {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / fn panic(info: &PanicInfo) -> ! {
+LL | |     loop {}
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/panic-handler/panic-handler-std.stderr
+++ b/src/test/ui/panic-handler/panic-handler-std.stderr
@@ -1,8 +1,10 @@
 error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/panic-handler-std.rs:8:1
    |
-LL | fn panic(info: PanicInfo) -> ! {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / fn panic(info: PanicInfo) -> ! {
+LL | |     loop {}
+LL | | }
+   | |_^
    |
    = note: the lang item is first defined in crate `std` (which `panic_handler_std` depends on)
    = note: first definition in `std` loaded from SYSROOT/libstd-*.rlib

--- a/src/test/ui/traits/issue-102989.stderr
+++ b/src/test/ui/traits/issue-102989.stderr
@@ -22,7 +22,7 @@ error[E0152]: found duplicate lang item `sized`
   --> $DIR/issue-102989.rs:5:1
    |
 LL | trait Sized { }
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^
    |
    = note: the lang item is first defined in crate `core` (which `std` depends on)
    = note: first definition in `core` loaded from SYSROOT/libcore-*.rlib

--- a/src/tools/clippy/clippy_lints/src/matches/try_err.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/try_err.rs
@@ -1,11 +1,11 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::is_type_diagnostic_item;
-use clippy_utils::{get_parent_expr, is_res_lang_ctor, match_def_path, path_res, paths};
+use clippy_utils::{get_parent_expr, is_path_lang_item, is_res_lang_ctor, match_def_path, path_res, paths};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::ResultErr;
-use rustc_hir::{Expr, ExprKind, LangItem, MatchSource, QPath};
+use rustc_hir::{Expr, ExprKind, LangItem, MatchSource};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, Ty};
 use rustc_span::{hygiene, sym};
@@ -24,8 +24,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, scrutine
     // };
     if_chain! {
         if let ExprKind::Call(match_fun, [try_arg, ..]) = scrutinee.kind;
-        if let ExprKind::Path(ref match_fun_path) = match_fun.kind;
-        if matches!(match_fun_path, QPath::LangItem(LangItem::TryTraitBranch, ..));
+        if is_path_lang_item(cx, match_fun, LangItem::TryTraitBranch);
         if let ExprKind::Call(err_fun, [err_arg, ..]) = try_arg.kind;
         if is_res_lang_ctor(cx, path_res(cx, err_fun), ResultErr);
         if let Some(return_ty) = find_return_type(cx, &expr.kind);

--- a/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
@@ -1,10 +1,10 @@
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
-use clippy_utils::get_parent_node;
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::sugg;
 use clippy_utils::ty::is_copy;
+use clippy_utils::{get_parent_node, is_path_lang_item};
 use rustc_errors::Applicability;
-use rustc_hir::{BindingAnnotation, ByRef, Expr, ExprKind, MatchSource, Node, PatKind, QPath};
+use rustc_hir::{BindingAnnotation, ByRef, Expr, ExprKind, LangItem, MatchSource, Node, PatKind};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, adjustment::Adjust};
 use rustc_span::symbol::{sym, Symbol};
@@ -93,10 +93,7 @@ pub(super) fn check(
                     return;
                 },
                 // ? is a Call, makes sure not to rec *x?, but rather (*x)?
-                ExprKind::Call(hir_callee, _) => matches!(
-                    hir_callee.kind,
-                    ExprKind::Path(QPath::LangItem(rustc_hir::LangItem::TryTraitBranch, _, _))
-                ),
+                ExprKind::Call(hir_callee, _) => is_path_lang_item(cx, hir_callee, LangItem::TryTraitBranch),
                 ExprKind::MethodCall(_, self_arg, ..) if expr.hir_id == self_arg.hir_id => true,
                 ExprKind::Match(_, _, MatchSource::TryDesugar | MatchSource::AwaitDesugar)
                 | ExprKind::Field(..)

--- a/src/tools/clippy/clippy_lints/src/misc.rs
+++ b/src/tools/clippy/clippy_lints/src/misc.rs
@@ -240,7 +240,7 @@ impl<'tcx> LateLintPass<'tcx> for MiscLints {
         }
         let sym;
         let binding = match expr.kind {
-            ExprKind::Path(ref qpath) if !matches!(qpath, hir::QPath::LangItem(..)) => {
+            ExprKind::Path(ref qpath) => {
                 let binding = last_path_segment(qpath).ident.as_str();
                 if binding.starts_with('_') &&
                     !binding.starts_with("__") &&

--- a/src/tools/clippy/clippy_lints/src/needless_question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_question_mark.rs
@@ -1,10 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::path_res;
 use clippy_utils::source::snippet;
+use clippy_utils::{is_path_lang_item, path_res};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::{AsyncGeneratorKind, Block, Body, Expr, ExprKind, GeneratorKind, LangItem, MatchSource, QPath};
+use rustc_hir::{AsyncGeneratorKind, Block, Body, Expr, ExprKind, GeneratorKind, LangItem, MatchSource};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::DefIdTree;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -124,8 +124,8 @@ fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
             return;
         };
         if let ExprKind::Match(inner_expr_with_q, _, MatchSource::TryDesugar) = &arg.kind;
-        if let ExprKind::Call(called, [inner_expr]) = &inner_expr_with_q.kind;
-        if let ExprKind::Path(QPath::LangItem(LangItem::TryTraitBranch, ..)) = &called.kind;
+        if let ExprKind::Call(called, [inner_expr]) = inner_expr_with_q.kind;
+        if is_path_lang_item(cx, called, LangItem::TryTraitBranch);
         if expr.span.ctxt() == inner_expr.span.ctxt();
         let expr_ty = cx.typeck_results().expr_ty(expr);
         let inner_ty = cx.typeck_results().expr_ty(inner_expr);

--- a/src/tools/clippy/clippy_lints/src/strings.rs
+++ b/src/tools/clippy/clippy_lints/src/strings.rs
@@ -1,12 +1,12 @@
 use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::source::{snippet, snippet_with_applicability};
 use clippy_utils::ty::is_type_diagnostic_item;
-use clippy_utils::{get_parent_expr, is_lint_allowed, match_function_call, method_calls, paths};
+use clippy_utils::{get_parent_expr, is_lint_allowed, is_qpath_lang_item, match_function_call, method_calls, paths};
 use clippy_utils::{peel_blocks, SpanlessEq};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{BinOpKind, BorrowKind, Expr, ExprKind, LangItem, QPath};
+use rustc_hir::{BinOpKind, BorrowKind, Expr, ExprKind, LangItem};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty;
@@ -266,7 +266,8 @@ impl<'tcx> LateLintPass<'tcx> for StringLitAsBytes {
             if method_names[0] == sym!(as_bytes);
 
             // Check for slicer
-            if let ExprKind::Struct(QPath::LangItem(LangItem::Range, ..), _, _) = right.kind;
+            if let ExprKind::Struct(ref qpath, _, _) = right.kind;
+            if is_qpath_lang_item(cx, qpath, LangItem::Range);
 
             then {
                 let mut applicability = Applicability::MachineApplicable;

--- a/src/tools/clippy/clippy_lints/src/types/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/types/mod.rs
@@ -534,7 +534,6 @@ impl Types {
                             }
                         }
                     },
-                    QPath::LangItem(..) => {},
                 }
             },
             TyKind::Rptr(lt, ref mut_ty) => {

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -266,11 +266,7 @@ impl<'a, 'tcx> PrintVisitor<'a, 'tcx> {
     }
 
     fn qpath(&self, qpath: &Binding<&QPath<'_>>) {
-        if let QPath::LangItem(lang_item, ..) = *qpath.value {
-            chain!(self, "matches!({qpath}, QPath::LangItem(LangItem::{lang_item:?}, _))");
-        } else {
-            chain!(self, "match_qpath({qpath}, &[{}])", path_to_string(qpath.value));
-        }
+        chain!(self, "match_qpath({qpath}, &[{}])", path_to_string(qpath.value));
     }
 
     fn lit(&self, lit: &Binding<&Lit>) {
@@ -748,7 +744,6 @@ fn path_to_string(path: &QPath<'_>) -> String {
                 },
                 other => write!(s, "/* unimplemented: {other:?}*/").unwrap(),
             },
-            QPath::LangItem(..) => panic!("path_to_string: called for lang item qpath"),
         }
     }
     let mut s = String::new();

--- a/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
+++ b/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
@@ -103,7 +103,6 @@ fn qpath_search_pat(path: &QPath<'_>) -> (Pat, Pat) {
             (start, end)
         },
         QPath::TypeRelative(_, name) => (Pat::Str(""), Pat::Sym(name.ident.name)),
-        QPath::LangItem(..) => (Pat::Str(""), Pat::Str("")),
     }
 }
 

--- a/src/tools/clippy/clippy_utils/src/eager_or_lazy.rs
+++ b/src/tools/clippy/clippy_utils/src/eager_or_lazy.rs
@@ -138,7 +138,6 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                         QPath::TypeRelative(_, name) => {
                             self.eagerness |= fn_eagerness(self.cx, id, name.ident.name, !args.is_empty());
                         },
-                        QPath::LangItem(..) => self.eagerness = Lazy,
                     },
                     _ => self.eagerness = Lazy,
                 },

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -391,7 +391,6 @@ impl HirEqInterExpr<'_, '_, '_> {
             (&QPath::TypeRelative(lty, lseg), &QPath::TypeRelative(rty, rseg)) => {
                 self.eq_ty(lty, rty) && self.eq_path_segment(lseg, rseg)
             },
-            (&QPath::LangItem(llang_item, ..), &QPath::LangItem(rlang_item, ..)) => llang_item == rlang_item,
             _ => false,
         }
     }
@@ -811,9 +810,6 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
             },
             QPath::TypeRelative(_, path) => {
                 self.hash_name(path.ident.name);
-            },
-            QPath::LangItem(lang_item, ..) => {
-                std::mem::discriminant(&lang_item).hash(&mut self.s);
             },
         }
         // self.maybe_typeck_results.unwrap().qpath_res(p, id).hash(&mut self.s);

--- a/src/tools/clippy/tests/ui/author/blocks.stdout
+++ b/src/tools/clippy/tests/ui/author/blocks.stdout
@@ -45,7 +45,7 @@ if let ExprKind::Closure(CaptureBy::Value, fn_decl, body_id, _, None) = expr.kin
     && expr1 = &cx.tcx.hir().body(body_id).value
     && let ExprKind::Call(func, args) = expr1.kind
     && let ExprKind::Path(ref qpath) = func.kind
-    && matches!(qpath, QPath::LangItem(LangItem::FromGenerator, _))
+    && match_qpath(qpath, &["from_generator"])
     && args.len() == 1
     && let ExprKind::Closure(CaptureBy::Value, fn_decl1, body_id1, _, Some(Movability::Static)) = args[0].kind
     && let FnRetTy::DefaultReturn(_) = fn_decl1.output

--- a/src/tools/clippy/tests/ui/author/loop.stdout
+++ b/src/tools/clippy/tests/ui/author/loop.stdout
@@ -2,7 +2,7 @@ if let Some(higher::ForLoop { pat: pat, arg: arg, body: body, .. }) = higher::Fo
     && let PatKind::Binding(BindingAnnotation::NONE, _, name, None) = pat.kind
     && name.as_str() == "y"
     && let ExprKind::Struct(qpath, fields, None) = arg.kind
-    && matches!(qpath, QPath::LangItem(LangItem::Range, _))
+    && match_qpath(qpath, &["Range"])
     && fields.len() == 2
     && fields[0].ident.as_str() == "start"
     && let ExprKind::Lit(ref lit) = fields[0].expr.kind
@@ -25,7 +25,7 @@ if let Some(higher::ForLoop { pat: pat, arg: arg, body: body, .. }) = higher::Fo
 if let Some(higher::ForLoop { pat: pat, arg: arg, body: body, .. }) = higher::ForLoop::hir(expr)
     && let PatKind::Wild = pat.kind
     && let ExprKind::Struct(qpath, fields, None) = arg.kind
-    && matches!(qpath, QPath::LangItem(LangItem::Range, _))
+    && match_qpath(qpath, &["Range"])
     && fields.len() == 2
     && fields[0].ident.as_str() == "start"
     && let ExprKind::Lit(ref lit) = fields[0].expr.kind
@@ -45,7 +45,7 @@ if let Some(higher::ForLoop { pat: pat, arg: arg, body: body, .. }) = higher::Fo
 if let Some(higher::ForLoop { pat: pat, arg: arg, body: body, .. }) = higher::ForLoop::hir(expr)
     && let PatKind::Wild = pat.kind
     && let ExprKind::Struct(qpath, fields, None) = arg.kind
-    && matches!(qpath, QPath::LangItem(LangItem::Range, _))
+    && match_qpath(qpath, &["Range"])
     && fields.len() == 2
     && fields[0].ident.as_str() == "start"
     && let ExprKind::Lit(ref lit) = fields[0].expr.kind


### PR DESCRIPTION
Based on #103603

Lang items can be resolved in the AST rather than the HIR. And then any HIR structures referencing `LangItem` can be replaced with their "normal" couterpart. Specifically `QPath::LangItem` and `GenericBound::LangItemTrait` are factored out.

Best reviewed commit-at-a-time.