### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
@@ -147,6 +147,6 @@ hir_analysis_const_impl_for_non_const_trait =
 hir_analysis_const_bound_for_non_const_trait =
     ~const can only be applied to `#[const_trait]` traits
 
-hir_analysis_self_in_impl_self = 
+hir_analysis_self_in_impl_self =
     `Self` is not valid in the self type of an impl block
     .note = replace `Self` with a different type

--- a/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
@@ -146,3 +146,5 @@ hir_analysis_const_impl_for_non_const_trait =
 
 hir_analysis_const_bound_for_non_const_trait =
     ~const can only be applied to `#[const_trait]` traits
+
+hir_analysis_self_in_impl_self = `Self` is not valid at this location

--- a/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/hir_analysis.ftl
@@ -147,4 +147,6 @@ hir_analysis_const_impl_for_non_const_trait =
 hir_analysis_const_bound_for_non_const_trait =
     ~const can only be applied to `#[const_trait]` traits
 
-hir_analysis_self_in_impl_self = `Self` is not valid at this location
+hir_analysis_self_in_impl_self = 
+    `Self` is not valid in the self type of an impl block
+    .note = replace `Self` with a different type

--- a/compiler/rustc_hir_analysis/src/check/compare_method.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_method.rs
@@ -597,7 +597,7 @@ pub fn collect_trait_impl_trait_tys<'tcx>(
                 let num_trait_substs = trait_to_impl_substs.len();
                 let num_impl_substs = tcx.generics_of(impl_m.container_id(tcx)).params.len();
                 let ty = tcx.fold_regions(ty, |region, _| {
-                    let ty::ReFree(_) = region.kind() else { return region; };
+                    let (ty::ReFree(_) | ty::ReEarlyBound(_)) = region.kind() else { return region; };
                     let Some(ty::ReEarlyBound(e)) = map.get(&region.into()).map(|r| r.expect_region().kind())
                     else {
                         tcx

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -319,36 +319,11 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                     }
                 }
                 ItemKind::TyAlias(self_ty, _) => icx.to_ty(self_ty),
-                ItemKind::Impl(
-                    hir::Impl { self_ty, .. }
-                ) => {
-                    struct MyVisitor(Vec<Span>);
-                    impl<'v> hir::intravisit::Visitor<'v> for MyVisitor {
-                        fn visit_ty(&mut self, t: &'v Ty<'v>) {
-                            if matches!(
-                                &t.kind,
-                                TyKind::Path(hir::QPath::Resolved(
-                                    _,
-                                    Path {
-                                        res: hir::def::Res::SelfTyAlias { .. },
-                                        ..
-                                    },
-                                ))
-                            ) {
-                                self.0.push(t.span);
-                                return;
-                            }
-                            hir::intravisit::walk_ty(self, t);
-                        }
-                    }
-
-                    let mut my_visitor = MyVisitor(vec![]);
-                    my_visitor.visit_ty(self_ty);
-
-                    match my_visitor.0 {
-                        spans if spans.len() > 0 => { 
+                ItemKind::Impl(hir::Impl { self_ty, .. }) => {
+                    match self_ty.find_self_aliases() {
+                        spans if spans.len() > 0 => {
                             tcx.sess.emit_err(crate::errors::SelfInImplSelf { span: spans.into(), note: (), });
-                            tcx.ty_error() 
+                            tcx.ty_error()
                         },
                         _ => icx.to_ty(*self_ty),
                     }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1,7 +1,7 @@
 //! Errors emitted by `rustc_hir_analysis`.
 
-use rustc_errors::IntoDiagnostic;
 use rustc_errors::{error_code, Applicability, DiagnosticBuilder, ErrorGuaranteed, Handler};
+use rustc_errors::{IntoDiagnostic, MultiSpan};
 use rustc_macros::{Diagnostic, LintDiagnostic};
 use rustc_middle::ty::Ty;
 use rustc_span::{symbol::Ident, Span, Symbol};
@@ -275,5 +275,7 @@ pub struct ConstBoundForNonConstTrait {
 #[diag(hir_analysis_self_in_impl_self)]
 pub struct SelfInImplSelf {
     #[primary_span]
-    pub span: Span,
+    pub span: MultiSpan,
+    #[note]
+    pub note: (),
 }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -270,3 +270,10 @@ pub struct ConstBoundForNonConstTrait {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_self_in_impl_self)]
+pub struct SelfInImplSelf {
+    #[primary_span]
+    pub span: Span,
+}

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -292,10 +292,6 @@ p:last-child {
 	margin: 0;
 }
 
-summary {
-	outline: none;
-}
-
 /* Fix some style changes due to normalize.css 8 */
 
 button {
@@ -1538,6 +1534,8 @@ details.rustdoc-toggle > summary.hideme {
 
 details.rustdoc-toggle > summary {
 	list-style: none;
+	/* focus outline is shown on `::before` instead of this */
+	outline: none;
 }
 details.rustdoc-toggle > summary::-webkit-details-marker,
 details.rustdoc-toggle > summary::marker {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -571,10 +571,18 @@ ul.block, .block li {
 	padding: 13px 8px;
 	border-top-left-radius: 5px;
 	border-bottom-left-radius: 5px;
+	border-color: var(--example-line-numbers-border-color);
 }
 
 .src-line-numbers span {
 	cursor: pointer;
+	color: var(--src-line-numbers-span-color);
+}
+.src-line-numbers .line-highlighted {
+	background-color: var(--src-line-number-highlighted-background-color);
+}
+.src-line-numbers :target {
+	background-color: transparent;
 }
 
 .search-loading {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -55,6 +55,9 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--code-highlight-question-mark-color: #ff9011;
 	--code-highlight-comment-color: #788797;
 	--code-highlight-doc-comment-color: #a1ac88;
+	--example-line-numbers-border-color: none;
+	--src-line-numbers-span-color: #5c6773;
+	--src-line-number-highlighted-background-color: rgba(255, 236, 164, 0.06);
 }
 
 .slider {
@@ -112,10 +115,8 @@ pre, .rustdoc.source .example-wrap {
 	color: #ff7733;
 }
 
-.src-line-numbers span { color: #5c6773; }
 .src-line-numbers .line-highlighted {
 	color: #708090;
-	background-color: rgba(255, 236, 164, 0.06);
 	padding-right: 4px;
 	border-right: 1px solid #ffb44c;
 }
@@ -168,13 +169,6 @@ details.rustdoc-toggle > summary::before {
 
 .result-name .primitive > i, .result-name .keyword > i {
 	color: #788797;
-}
-
-.src-line-numbers :target { background-color: transparent; }
-
-pre.example-line-numbers {
-	color: #5c67736e;
-	border: none;
 }
 
 a.test-arrow {

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -50,6 +50,9 @@
 	--code-highlight-question-mark-color: #ff9011;
 	--code-highlight-comment-color: #8d8d8b;
 	--code-highlight-doc-comment-color: #8ca375;
+	--example-line-numbers-border-color: #4a4949;
+	--src-line-numbers-span-color: #3b91e2;
+	--src-line-number-highlighted-background-color: #0a042f;
 }
 
 .slider {
@@ -67,11 +70,6 @@ input:focus + .slider {
 		drop-shadow(0 1px 0 #fff)
 		drop-shadow(-1px 0 0 #fff)
 		drop-shadow(0 -1px 0 #fff)
-}
-
-.src-line-numbers span { color: #3B91E2; }
-.src-line-numbers .line-highlighted {
-	background-color: #0a042f !important;
 }
 
 .content .item-info::before { color: #ccc; }
@@ -93,12 +91,6 @@ details.rustdoc-toggle > summary::before {
 }
 #crate-search-div:hover::after, #crate-search-div:focus-within::after {
 	filter: invert(69%) sepia(60%) saturate(6613%) hue-rotate(184deg) brightness(100%) contrast(91%);
-}
-
-.src-line-numbers :target { background-color: transparent; }
-
-pre.example-line-numbers {
-	border-color: #4a4949;
 }
 
 a.test-arrow {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -50,6 +50,9 @@
 	--code-highlight-question-mark-color: #ff9011;
 	--code-highlight-comment-color: #8e908c;
 	--code-highlight-doc-comment-color: #4d4d4c;
+	--example-line-numbers-border-color: #c7c7c7;
+	--src-line-numbers-span-color: #c67e2d;
+	--src-line-number-highlighted-background-color: #fdffd3;
 }
 
 .slider {
@@ -68,11 +71,6 @@ input:focus + .slider {
 	 */
 }
 
-.src-line-numbers span { color: #c67e2d; }
-.src-line-numbers .line-highlighted {
-	background-color: #FDFFD3 !important;
-}
-
 .content .item-info::before { color: #ccc; }
 
 body.source .example-wrap pre.rust a {
@@ -88,12 +86,6 @@ body.source .example-wrap pre.rust a {
 }
 #crate-search-div:hover::after, #crate-search-div:focus-within::after {
 	filter: invert(44%) sepia(18%) saturate(23%) hue-rotate(317deg) brightness(96%) contrast(93%);
-}
-
-.src-line-numbers :target { background-color: transparent; }
-
-pre.example-line-numbers {
-	border-color: #c7c7c7;
 }
 
 a.test-arrow {

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -1,5 +1,6 @@
 // Checks that the interactions with the source code pages are working as expected.
 goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
+show-text: true
 // Check that we can click on the line number.
 click: ".src-line-numbers > span:nth-child(4)" // This is the span for line 4.
 // Ensure that the page URL was updated.
@@ -12,6 +13,48 @@ assert-attribute: (".src-line-numbers > span:nth-child(4)", {"class": "line-high
 assert-attribute: (".src-line-numbers > span:nth-child(5)", {"class": "line-highlighted"})
 assert-attribute: (".src-line-numbers > span:nth-child(6)", {"class": "line-highlighted"})
 assert-attribute-false: (".src-line-numbers > span:nth-child(7)", {"class": "line-highlighted"})
+
+define-function: (
+    "check-colors",
+    (theme, color, background_color, highlight_color, highlight_background_color),
+    [
+        ("local-storage", {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}),
+        ("reload"),
+        ("assert-css", (
+            ".src-line-numbers > span:not(.line-highlighted)",
+            {"color": |color|, "background-color": |background_color|},
+            ALL,
+        )),
+        ("assert-css", (
+            ".src-line-numbers > span.line-highlighted",
+            {"color": |highlight_color|, "background-color": |highlight_background_color|},
+            ALL,
+        )),
+    ],
+)
+
+call-function: ("check-colors", {
+    "theme": "ayu",
+    "color": "rgb(92, 103, 115)",
+    "background_color": "rgba(0, 0, 0, 0)",
+    "highlight_color": "rgb(112, 128, 144)",
+    "highlight_background_color": "rgba(255, 236, 164, 0.06)",
+})
+call-function: ("check-colors", {
+    "theme": "dark",
+    "color": "rgb(59, 145, 226)",
+    "background_color": "rgba(0, 0, 0, 0)",
+    "highlight_color": "rgb(59, 145, 226)",
+    "highlight_background_color": "rgb(10, 4, 47)",
+})
+call-function: ("check-colors", {
+    "theme": "light",
+    "color": "rgb(198, 126, 45)",
+    "background_color": "rgba(0, 0, 0, 0)",
+    "highlight_color": "rgb(198, 126, 45)",
+    "highlight_background_color": "rgb(253, 255, 211)",
+})
+
 // This is to ensure that the content is correctly align with the line numbers.
 compare-elements-position: ("//*[@id='1']", ".rust > code > span", ("y"))
 
@@ -20,7 +63,6 @@ assert-css: (".src-line-numbers", {"text-align": "right"})
 
 // Now let's check that clicking on something else than the line number doesn't
 // do anything (and certainly not add a `#NaN` to the URL!).
-show-text: true
 goto: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 // We use this assert-position to know where we will click.
 assert-position: ("//*[@id='1']", {"x": 104, "y": 112})

--- a/src/test/ui/coercion/issue-36007.rs
+++ b/src/test/ui/coercion/issue-36007.rs
@@ -1,0 +1,20 @@
+// check-pass
+#![feature(coerce_unsized, unsize)]
+
+use std::marker::Unsize;
+use std::ops::CoerceUnsized;
+
+struct Foo<T: ?Sized>(Box<T>);
+
+impl<T> CoerceUnsized<Foo<dyn Baz>> for Foo<T> where T: Unsize<dyn Baz> {}
+
+struct Bar;
+
+trait Baz {}
+
+impl Baz for Bar {}
+
+fn main() {
+    let foo = Foo(Box::new(Bar));
+    let foobar: Foo<Bar> = foo;
+}

--- a/src/test/ui/impl-trait/in-trait/early.rs
+++ b/src/test/ui/impl-trait/in-trait/early.rs
@@ -1,0 +1,23 @@
+// check-pass
+// edition:2021
+
+#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
+#![allow(incomplete_features)]
+
+pub trait Foo {
+    async fn bar<'a: 'a>(&'a mut self);
+}
+
+impl Foo for () {
+    async fn bar<'a: 'a>(&'a mut self) {}
+}
+
+pub trait Foo2 {
+    fn bar<'a: 'a>(&'a mut self) -> impl Sized + 'a;
+}
+
+impl Foo2 for () {
+    fn bar<'a: 'a>(&'a mut self) -> impl Sized + 'a {}
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-23305.rs
+++ b/src/test/ui/resolve/issue-23305.rs
@@ -3,6 +3,6 @@ pub trait ToNbt<T> {
 }
 
 impl dyn ToNbt<Self> {}
-//~^ ERROR cycle detected
+//~^ ERROR `Self` is not valid at this location
 
 fn main() {}

--- a/src/test/ui/resolve/issue-23305.rs
+++ b/src/test/ui/resolve/issue-23305.rs
@@ -3,6 +3,6 @@ pub trait ToNbt<T> {
 }
 
 impl dyn ToNbt<Self> {}
-//~^ ERROR `Self` is not valid at this location
+//~^ ERROR `Self` is not valid in the self type of an impl block
 
 fn main() {}

--- a/src/test/ui/resolve/issue-23305.stderr
+++ b/src/test/ui/resolve/issue-23305.stderr
@@ -1,22 +1,8 @@
-error[E0391]: cycle detected when computing type of `<impl at $DIR/issue-23305.rs:5:1: 5:21>`
-  --> $DIR/issue-23305.rs:5:16
+error: `Self` is not valid at this location
+  --> $DIR/issue-23305.rs:5:6
    |
 LL | impl dyn ToNbt<Self> {}
-   |                ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/issue-23305.rs:5:1: 5:21>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-23305.rs:1:1
-   |
-LL | / pub trait ToNbt<T> {
-LL | |     fn new(val: T) -> Self;
-LL | | }
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   |      ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/resolve/issue-23305.stderr
+++ b/src/test/ui/resolve/issue-23305.stderr
@@ -1,8 +1,10 @@
-error: `Self` is not valid at this location
-  --> $DIR/issue-23305.rs:5:6
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/issue-23305.rs:5:16
    |
 LL | impl dyn ToNbt<Self> {}
-   |      ^^^^^^^^^^^^^^^
+   |                ^^^^
+   |
+   = note: replace `Self` with a different type
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/resolve-self-in-impl.rs
+++ b/src/test/ui/resolve/resolve-self-in-impl.rs
@@ -11,10 +11,10 @@ impl Tr for S where Self: Copy {} // OK
 impl Tr for S where S<Self>: Copy {} // OK
 impl Tr for S where Self::A: Copy {} // OK
 
-impl Tr for Self {} //~ ERROR cycle detected
-impl Tr for S<Self> {} //~ ERROR cycle detected
-impl Self {} //~ ERROR cycle detected
-impl S<Self> {} //~ ERROR cycle detected
+impl Tr for Self {} //~ ERROR `Self` is not valid at this location
+impl Tr for S<Self> {} //~ ERROR `Self` is not valid at this location
+impl Self {} //~ ERROR `Self` is not valid at this location
+impl S<Self> {} //~ ERROR `Self` is not valid at this location
 impl Tr<Self::A> for S {} //~ ERROR cycle detected
 
 fn main() {}

--- a/src/test/ui/resolve/resolve-self-in-impl.rs
+++ b/src/test/ui/resolve/resolve-self-in-impl.rs
@@ -11,10 +11,11 @@ impl Tr for S where Self: Copy {} // OK
 impl Tr for S where S<Self>: Copy {} // OK
 impl Tr for S where Self::A: Copy {} // OK
 
-impl Tr for Self {} //~ ERROR `Self` is not valid at this location
-impl Tr for S<Self> {} //~ ERROR `Self` is not valid at this location
-impl Self {} //~ ERROR `Self` is not valid at this location
-impl S<Self> {} //~ ERROR `Self` is not valid at this location
+impl Tr for Self {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl Tr for S<Self> {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl Self {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl S<Self> {} //~ ERROR `Self` is not valid in the self type of an impl block
+impl (Self, Self) {} //~ ERROR `Self` is not valid in the self type of an impl block
 impl Tr<Self::A> for S {} //~ ERROR cycle detected
 
 fn main() {}

--- a/src/test/ui/resolve/resolve-self-in-impl.stderr
+++ b/src/test/ui/resolve/resolve-self-in-impl.stderr
@@ -1,78 +1,26 @@
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:14:1: 14:17>`
+error: `Self` is not valid at this location
   --> $DIR/resolve-self-in-impl.rs:14:13
    |
 LL | impl Tr for Self {}
    |             ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:14:1: 14:17>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:15:1: 15:20>`
-  --> $DIR/resolve-self-in-impl.rs:15:15
+error: `Self` is not valid at this location
+  --> $DIR/resolve-self-in-impl.rs:15:13
    |
 LL | impl Tr for S<Self> {}
-   |               ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:15:1: 15:20>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   |             ^^^^^^^
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:16:1: 16:10>`
+error: `Self` is not valid at this location
   --> $DIR/resolve-self-in-impl.rs:16:6
    |
 LL | impl Self {}
    |      ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:16:1: 16:10>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:17:1: 17:13>`
-  --> $DIR/resolve-self-in-impl.rs:17:8
+error: `Self` is not valid at this location
+  --> $DIR/resolve-self-in-impl.rs:17:6
    |
 LL | impl S<Self> {}
-   |        ^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:17:1: 17:13>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   |      ^^^^^^^
 
 error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:23>`
   --> $DIR/resolve-self-in-impl.rs:18:1

--- a/src/test/ui/resolve/resolve-self-in-impl.stderr
+++ b/src/test/ui/resolve/resolve-self-in-impl.stderr
@@ -1,34 +1,50 @@
-error: `Self` is not valid at this location
+error: `Self` is not valid in the self type of an impl block
   --> $DIR/resolve-self-in-impl.rs:14:13
    |
 LL | impl Tr for Self {}
    |             ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error: `Self` is not valid at this location
-  --> $DIR/resolve-self-in-impl.rs:15:13
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/resolve-self-in-impl.rs:15:15
    |
 LL | impl Tr for S<Self> {}
-   |             ^^^^^^^
+   |               ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error: `Self` is not valid at this location
+error: `Self` is not valid in the self type of an impl block
   --> $DIR/resolve-self-in-impl.rs:16:6
    |
 LL | impl Self {}
    |      ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error: `Self` is not valid at this location
-  --> $DIR/resolve-self-in-impl.rs:17:6
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/resolve-self-in-impl.rs:17:8
    |
 LL | impl S<Self> {}
-   |      ^^^^^^^
+   |        ^^^^
+   |
+   = note: replace `Self` with a different type
 
-error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:23>`
-  --> $DIR/resolve-self-in-impl.rs:18:1
+error: `Self` is not valid in the self type of an impl block
+  --> $DIR/resolve-self-in-impl.rs:18:7
+   |
+LL | impl (Self, Self) {}
+   |       ^^^^  ^^^^
+   |
+   = note: replace `Self` with a different type
+
+error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>`
+  --> $DIR/resolve-self-in-impl.rs:19:1
    |
 LL | impl Tr<Self::A> for S {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: ...which immediately requires computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:23>` again
+   = note: ...which immediately requires computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>` again
 note: cycle used when collecting item types in top-level module
   --> $DIR/resolve-self-in-impl.rs:1:1
    |
@@ -41,6 +57,6 @@ LL | |
 LL | | fn main() {}
    | |____________^
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Successful merges:

 - #103585 (Migrate source line numbers CSS to CSS variables)
 - #103608 (Remap early bound lifetimes in return-position `impl Trait` in traits too)
 - #103609 (Emit a nicer error on `impl Self {`)
 - #103631 (Add test for issue 36007)
 - #103643 (rustdoc: stop hiding focus outlines on non-rustdoc-toggle details tags)
 - #103645 (Update cargo)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=103585,103608,103609,103631,103643,103645)
<!-- homu-ignore:end -->