### PR TITLE
Update note about unstable split-debuginfo flag.

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -531,8 +531,10 @@ platforms. Possible values are:
   debug information. On other Unix platforms this means that `*.dwo` files will
   contain debug information.
 
-Note that `packed` and `unpacked` are gated behind `-Z unstable-options` on
-non-macOS platforms at this time.
+Note that all three options are supported on Linux and Apple platforms,
+`packed` is supported on Windows-MSVC, and all other platforms support `off`.
+Attempting to use an unsupported option requires using the nightly channel
+with the `-Z unstable-options` flag.
 
 ## strip
 


### PR DESCRIPTION
split-debuginfo was effectively stabilized in #98051. The note about it requiring `-Z unstable-options` is no longer accurate.

The rules for when it is gated and when it is supported are somewhat complex. I considered removing the note entirely, or making it more generic, but opted to instead try to summarize the current state.