### PR TITLE
Emit proper error when casting to `dyn*`

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -866,7 +866,13 @@ impl<'a, 'tcx> CastCheck<'tcx> {
 
             (Int(_) | Float, Int(_) | Float) => Ok(CastKind::NumericCast),
 
-            (_, DynStar) | (DynStar, _) => bug!("should be handled by `try_coerce`"),
+            (_, DynStar) | (DynStar, _) => {
+                if fcx.tcx.features().dyn_star {
+                    bug!("should be handled by `try_coerce`")
+                } else {
+                    Err(CastError::IllegalCast)
+                }
+            }
         }
     }
 

--- a/src/test/ui/dyn-star/no-explicit-dyn-star-cast.rs
+++ b/src/test/ui/dyn-star/no-explicit-dyn-star-cast.rs
@@ -1,0 +1,13 @@
+use std::fmt::Debug;
+
+fn make_dyn_star() {
+    let i = 42usize;
+    let dyn_i: dyn* Debug = i as dyn* Debug;
+    //~^ ERROR casting `usize` as `dyn* Debug` is invalid
+    //~| ERROR dyn* trait objects are unstable
+    //~| ERROR dyn* trait objects are unstable
+}
+
+fn main() {
+    make_dyn_star();
+}

--- a/src/test/ui/dyn-star/no-explicit-dyn-star-cast.stderr
+++ b/src/test/ui/dyn-star/no-explicit-dyn-star-cast.stderr
@@ -1,0 +1,28 @@
+error[E0658]: dyn* trait objects are unstable
+  --> $DIR/no-explicit-dyn-star-cast.rs:5:16
+   |
+LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
+   |                ^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(dyn_star)]` to the crate attributes to enable
+
+error[E0658]: dyn* trait objects are unstable
+  --> $DIR/no-explicit-dyn-star-cast.rs:5:34
+   |
+LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
+   |                                  ^^^^^^^^^^
+   |
+   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
+   = help: add `#![feature(dyn_star)]` to the crate attributes to enable
+
+error[E0606]: casting `usize` as `dyn* Debug` is invalid
+  --> $DIR/no-explicit-dyn-star-cast.rs:5:29
+   |
+LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
+   |                             ^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0606, E0658.
+For more information about an error, try `rustc --explain E0606`.

--- a/src/test/ui/dyn-star/no-explicit-dyn-star.rs
+++ b/src/test/ui/dyn-star/no-explicit-dyn-star.rs
@@ -1,0 +1,8 @@
+// aux-build:dyn-star-foreign.rs
+
+extern crate dyn_star_foreign;
+
+fn main() {
+    dyn_star_foreign::require_dyn_star_display(1usize as _);
+    //~^ ERROR casting `usize` as `dyn* std::fmt::Display` is invalid
+}

--- a/src/test/ui/dyn-star/no-explicit-dyn-star.stderr
+++ b/src/test/ui/dyn-star/no-explicit-dyn-star.stderr
@@ -1,0 +1,9 @@
+error[E0606]: casting `usize` as `dyn* std::fmt::Display` is invalid
+  --> $DIR/no-explicit-dyn-star.rs:6:48
+   |
+LL |     dyn_star_foreign::require_dyn_star_display(1usize as _);
+   |                                                ^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0606`.


### PR DESCRIPTION
Fixes #103679