### PR TITLE
Simplify some pointer method implementations

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -154,6 +154,7 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(ptr_alignment_type)]
 #![feature(ptr_metadata)]
+#![feature(set_ptr_value)]
 #![feature(slice_ptr_get)]
 #![feature(slice_split_at_unchecked)]
 #![feature(str_internals)]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -79,19 +79,14 @@ impl<T: ?Sized> *const T {
     /// }
     /// ```
     #[unstable(feature = "set_ptr_value", issue = "75091")]
+    #[rustc_const_unstable(feature = "set_ptr_value", issue = "75091")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline]
-    pub fn with_metadata_of<U>(self, mut val: *const U) -> *const U
+    pub const fn with_metadata_of<U>(self, meta: *const U) -> *const U
     where
         U: ?Sized,
     {
-        let target = &mut val as *mut *const U as *mut *const u8;
-        // SAFETY: In case of a thin pointer, this operations is identical
-        // to a simple assignment. In case of a fat pointer, with the current
-        // fat pointer layout implementation, the first field of such a
-        // pointer is always the data pointer, which is likewise assigned.
-        unsafe { *target = self as *const u8 };
-        val
+        from_raw_parts::<U>(self as *const (), metadata(meta))
     }
 
     /// Changes constness without changing the type.

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -473,8 +473,7 @@ impl<T: ?Sized> *const T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
-        let this = unsafe { self.cast::<u8>().offset(count).cast::<()>() };
-        from_raw_parts::<T>(this, metadata(self))
+        unsafe { self.cast::<u8>().offset(count).with_metadata_of(self) }
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -554,7 +553,7 @@ impl<T: ?Sized> *const T {
     #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_offset(self, count: isize) -> Self {
-        from_raw_parts::<T>(self.cast::<u8>().wrapping_offset(count).cast::<()>(), metadata(self))
+        self.cast::<u8>().wrapping_offset(count).with_metadata_of(self)
     }
 
     /// Masks out bits of the pointer according to a mask.
@@ -567,8 +566,7 @@ impl<T: ?Sized> *const T {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline(always)]
     pub fn mask(self, mask: usize) -> *const T {
-        let this = intrinsics::ptr_mask(self.cast::<()>(), mask);
-        from_raw_parts::<T>(this, metadata(self))
+        intrinsics::ptr_mask(self.cast::<()>(), mask).with_metadata_of(self)
     }
 
     /// Calculates the distance between two pointers. The returned value is in
@@ -906,8 +904,7 @@ impl<T: ?Sized> *const T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
-        let this = unsafe { self.cast::<u8>().add(count).cast::<()>() };
-        from_raw_parts::<T>(this, metadata(self))
+        unsafe { self.cast::<u8>().add(count).with_metadata_of(self) }
     }
 
     /// Calculates the offset from a pointer (convenience for
@@ -993,8 +990,7 @@ impl<T: ?Sized> *const T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.
-        let this = unsafe { self.cast::<u8>().sub(count).cast::<()>() };
-        from_raw_parts::<T>(this, metadata(self))
+        unsafe { self.cast::<u8>().sub(count).with_metadata_of(self) }
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1074,7 +1070,7 @@ impl<T: ?Sized> *const T {
     #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_add(self, count: usize) -> Self {
-        from_raw_parts::<T>(self.cast::<u8>().wrapping_add(count).cast::<()>(), metadata(self))
+        self.cast::<u8>().wrapping_add(count).with_metadata_of(self)
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1154,7 +1150,7 @@ impl<T: ?Sized> *const T {
     #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_sub(self, count: usize) -> Self {
-        from_raw_parts::<T>(self.cast::<u8>().wrapping_sub(count).cast::<()>(), metadata(self))
+        self.cast::<u8>().wrapping_sub(count).with_metadata_of(self)
     }
 
     /// Reads the value from `self` without moving it. This leaves the

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -78,23 +78,14 @@ impl<T: ?Sized> *mut T {
     /// }
     /// ```
     #[unstable(feature = "set_ptr_value", issue = "75091")]
+    #[rustc_const_unstable(feature = "set_ptr_value", issue = "75091")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline]
-    pub fn with_metadata_of<U>(self, val: *const U) -> *mut U
+    pub const fn with_metadata_of<U>(self, meta: *const U) -> *mut U
     where
         U: ?Sized,
     {
-        // Prepare in the type system that we will replace the pointer value with a mutable
-        // pointer, taking the mutable provenance from the `self` pointer.
-        let mut val = val as *mut U;
-        // Pointer to the pointer value within the value.
-        let target = &mut val as *mut *mut U as *mut *mut u8;
-        // SAFETY: In case of a thin pointer, this operations is identical
-        // to a simple assignment. In case of a fat pointer, with the current
-        // fat pointer layout implementation, the first field of such a
-        // pointer is always the data pointer, which is likewise assigned.
-        unsafe { *target = self as *mut u8 };
-        val
+        from_raw_parts_mut::<U>(self as *mut (), metadata(meta))
     }
 
     /// Changes constness without changing the type.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -487,8 +487,7 @@ impl<T: ?Sized> *mut T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
-        let this = unsafe { self.cast::<u8>().offset(count).cast::<()>() };
-        from_raw_parts_mut::<T>(this, metadata(self))
+        unsafe { self.cast::<u8>().offset(count).with_metadata_of(self) }
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -567,10 +566,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_offset(self, count: isize) -> Self {
-        from_raw_parts_mut::<T>(
-            self.cast::<u8>().wrapping_offset(count).cast::<()>(),
-            metadata(self),
-        )
+        self.cast::<u8>().wrapping_offset(count).with_metadata_of(self)
     }
 
     /// Masks out bits of the pointer according to a mask.
@@ -583,8 +579,7 @@ impl<T: ?Sized> *mut T {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline(always)]
     pub fn mask(self, mask: usize) -> *mut T {
-        let this = intrinsics::ptr_mask(self.cast::<()>(), mask) as *mut ();
-        from_raw_parts_mut::<T>(this, metadata(self))
+        intrinsics::ptr_mask(self.cast::<()>(), mask).cast_mut().with_metadata_of(self)
     }
 
     /// Returns `None` if the pointer is null, or else returns a unique reference to
@@ -1011,8 +1006,7 @@ impl<T: ?Sized> *mut T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
-        let this = unsafe { self.cast::<u8>().add(count).cast::<()>() };
-        from_raw_parts_mut::<T>(this, metadata(self))
+        unsafe { self.cast::<u8>().add(count).with_metadata_of(self) }
     }
 
     /// Calculates the offset from a pointer (convenience for
@@ -1098,8 +1092,7 @@ impl<T: ?Sized> *mut T {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.
-        let this = unsafe { self.cast::<u8>().sub(count).cast::<()>() };
-        from_raw_parts_mut::<T>(this, metadata(self))
+        unsafe { self.cast::<u8>().sub(count).with_metadata_of(self) }
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1179,7 +1172,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_add(self, count: usize) -> Self {
-        from_raw_parts_mut::<T>(self.cast::<u8>().wrapping_add(count).cast::<()>(), metadata(self))
+        self.cast::<u8>().wrapping_add(count).with_metadata_of(self)
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1259,7 +1252,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_sub(self, count: usize) -> Self {
-        from_raw_parts_mut::<T>(self.cast::<u8>().wrapping_sub(count).cast::<()>(), metadata(self))
+        self.cast::<u8>().wrapping_sub(count).with_metadata_of(self)
     }
 
     /// Reads the value from `self` without moving it. This leaves the


### PR DESCRIPTION
- Make `pointer::with_metadata_of` const (+simplify implementation) (cc #75091)
- Simplify implementation of various pointer methods

r? @scottmcm 

----

`from_raw_parts::<T>(this, metadata(self))` was annoying me for a while and I've finally figured out how it should _actually_ be done.