### PR TITLE
Adjust stabilization version to 1.65.0 for wasi fds

### DIFF
--- a/library/std/src/os/wasi/io/mod.rs
+++ b/library/std/src/os/wasi/io/mod.rs
@@ -1,6 +1,6 @@
 //! WASI-specific extensions to general I/O primitives.
 
-#![stable(feature = "io_safety", since = "1.63.0")]
+#![stable(feature = "io_safety_wasi", since = "1.65.0")]
 
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "io_safety_wasi", since = "1.65.0")]
 pub use crate::os::fd::*;


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/103308#issuecomment-1292277645 for this ask.

Backport of that PR to beta (1.65.0) will include a similar patch.