### PR TITLE
chore: add inline attribute to most iterator method implementations

### DIFF
--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -61,6 +61,7 @@ where
         self.iter.count() / N
     }
 
+    #[inline]
     fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
     where
         Self: Sized,
@@ -95,6 +96,7 @@ where
         self.try_rfold((), |(), x| ControlFlow::Break(x)).break_value()
     }
 
+    #[inline]
     fn try_rfold<B, F, R>(&mut self, init: B, mut f: F) -> R
     where
         Self: Sized,
@@ -128,6 +130,7 @@ where
     I: DoubleEndedIterator + ExactSizeIterator,
 {
     /// Updates `self.remainder` such that `self.iter.len` is divisible by `N`.
+    #[inline]
     fn next_back_remainder(&mut self) {
         // Make sure to not override `self.remainder` with an empty array
         // when `next_back` is called after `ArrayChunks` exhaustion.

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -64,6 +64,7 @@ where
         a_count + b_count
     }
 
+    #[inline]
     fn try_fold<Acc, F, R>(&mut self, mut acc: Acc, mut f: F) -> R
     where
         Self: Sized,
@@ -81,6 +82,7 @@ where
         try { acc }
     }
 
+    #[inline]
     fn fold<Acc, F>(self, mut acc: Acc, mut f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -234,6 +236,7 @@ where
             .or_else(|| self.a.as_mut()?.rfind(predicate))
     }
 
+    #[inline]
     fn try_rfold<Acc, F, R>(&mut self, mut acc: Acc, mut f: F) -> R
     where
         Self: Sized,
@@ -251,6 +254,7 @@ where
         try { acc }
     }
 
+    #[inline]
     fn rfold<Acc, F>(self, mut acc: Acc, mut f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -36,14 +36,17 @@ where
 {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         self.it.next().cloned()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
 
+    #[inline]
     fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -53,6 +56,7 @@ where
         self.it.try_fold(init, clone_try_fold(f))
     }
 
+    #[inline]
     fn fold<Acc, F>(self, init: Acc, f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -60,6 +64,7 @@ where
         self.it.map(T::clone).fold(init, f)
     }
 
+    #[inline]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
         Self: TrustedRandomAccessNoCoerce,
@@ -76,10 +81,12 @@ where
     I: DoubleEndedIterator<Item = &'a T>,
     T: Clone,
 {
+    #[inline]
     fn next_back(&mut self) -> Option<T> {
         self.it.next_back().cloned()
     }
 
+    #[inline]
     fn try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -89,6 +96,7 @@ where
         self.it.try_rfold(init, clone_try_fold(f))
     }
 
+    #[inline]
     fn rfold<Acc, F>(self, init: Acc, f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -103,10 +111,12 @@ where
     I: ExactSizeIterator<Item = &'a T>,
     T: Clone,
 {
+    #[inline]
     fn len(&self) -> usize {
         self.it.len()
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.it.is_empty()
     }

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -43,10 +43,12 @@ where
 {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         self.it.next().copied()
     }
 
+    #[inline]
     fn next_chunk<const N: usize>(
         &mut self,
     ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>>
@@ -56,10 +58,12 @@ where
         <I as SpecNextChunk<'_, N, T>>::spec_next_chunk(&mut self.it)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
 
+    #[inline]
     fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -69,6 +73,7 @@ where
         self.it.try_fold(init, copy_try_fold(f))
     }
 
+    #[inline]
     fn fold<Acc, F>(self, init: Acc, f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -76,14 +81,17 @@ where
         self.it.fold(init, copy_fold(f))
     }
 
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<T> {
         self.it.nth(n).copied()
     }
 
+    #[inline]
     fn last(self) -> Option<T> {
         self.it.last().copied()
     }
 
+    #[inline]
     fn count(self) -> usize {
         self.it.count()
     }
@@ -93,6 +101,7 @@ where
         self.it.advance_by(n)
     }
 
+    #[inline]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
         Self: TrustedRandomAccessNoCoerce,
@@ -109,10 +118,12 @@ where
     I: DoubleEndedIterator<Item = &'a T>,
     T: Copy,
 {
+    #[inline]
     fn next_back(&mut self) -> Option<T> {
         self.it.next_back().copied()
     }
 
+    #[inline]
     fn try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -122,6 +133,7 @@ where
         self.it.try_rfold(init, copy_try_fold(f))
     }
 
+    #[inline]
     fn rfold<Acc, F>(self, init: Acc, f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -141,10 +153,12 @@ where
     I: ExactSizeIterator<Item = &'a T>,
     T: Copy,
 {
+    #[inline]
     fn len(&self) -> usize {
         self.it.len()
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.it.is_empty()
     }
@@ -191,6 +205,7 @@ where
     I: Iterator<Item = &'a T>,
     T: Copy,
 {
+    #[inline]
     default fn spec_next_chunk(&mut self) -> Result<[T; N], array::IntoIter<T, N>> {
         array::iter_next_chunk(&mut self.map(|e| *e))
     }

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -172,6 +172,7 @@ where
     {
         // Can safely add and subtract the count, as `ExactSizeIterator` promises
         // that the number of elements fits into a `usize`.
+        #[inline]
         fn enumerate<T, Acc, R>(
             mut count: usize,
             mut fold: impl FnMut(Acc, (usize, T)) -> R,
@@ -193,6 +194,7 @@ where
     {
         // Can safely add and subtract the count, as `ExactSizeIterator` promises
         // that the number of elements fits into a `usize`.
+        #[inline]
         fn enumerate<T, Acc>(
             mut count: usize,
             mut fold: impl FnMut(Acc, (usize, T)) -> Acc,
@@ -220,10 +222,12 @@ impl<I> ExactSizeIterator for Enumerate<I>
 where
     I: ExactSizeIterator,
 {
+    #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -24,6 +24,7 @@ impl<I: Clone, U, F: Clone> Clone for FlatMap<I, U, F>
 where
     U: Clone + IntoIterator<IntoIter: Clone>,
 {
+    #[inline]
     fn clone(&self) -> Self {
         FlatMap { inner: self.inner.clone() }
     }
@@ -194,6 +195,7 @@ where
     I: Clone + Iterator<Item: IntoIterator<IntoIter = U, Item = U::Item>>,
     U: Clone + Iterator,
 {
+    #[inline]
     fn clone(&self) -> Self {
         Flatten { inner: self.inner.clone() }
     }

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -166,6 +166,7 @@ impl<I> ExactSizeIterator for Fuse<I>
 where
     I: ExactSizeIterator,
 {
+    #[inline]
     fn len(&self) -> usize {
         match self.iter {
             Some(ref iter) => iter.len(),
@@ -173,6 +174,7 @@ where
         }
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         match self.iter {
             Some(ref iter) => iter.is_empty(),

--- a/library/core/src/iter/adapters/inspect.rs
+++ b/library/core/src/iter/adapters/inspect.rs
@@ -136,10 +136,12 @@ impl<I: ExactSizeIterator, F> ExactSizeIterator for Inspect<I, F>
 where
     F: FnMut(&I::Item),
 {
+    #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -43,6 +43,7 @@ where
         }
     }
 
+    #[inline]
     fn fold<B, F>(self, init: B, f: F) -> B
     where
         Self: Sized,
@@ -52,6 +53,7 @@ where
         intersperse_fold(self.iter, init, f, move || separator.clone(), self.needs_sep)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         intersperse_size_hint(&self.iter, self.needs_sep)
     }
@@ -94,6 +96,7 @@ where
     I::Item: crate::clone::Clone,
     G: Clone,
 {
+    #[inline]
     fn clone(&self) -> Self {
         IntersperseWith {
             separator: self.separator.clone(),
@@ -132,6 +135,7 @@ where
         }
     }
 
+    #[inline]
     fn fold<B, F>(self, init: B, f: F) -> B
     where
         Self: Sized,
@@ -140,6 +144,7 @@ where
         intersperse_fold(self.iter, init, f, self.separator, self.needs_sep)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         intersperse_size_hint(&self.iter, self.needs_sep)
     }

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -108,6 +108,7 @@ where
         self.iter.size_hint()
     }
 
+    #[inline]
     fn try_fold<Acc, G, R>(&mut self, init: Acc, g: G) -> R
     where
         Self: Sized,
@@ -117,6 +118,7 @@ where
         self.iter.try_fold(init, map_try_fold(&mut self.f, g))
     }
 
+    #[inline]
     fn fold<Acc, G>(self, init: Acc, g: G) -> Acc
     where
         G: FnMut(Acc, Self::Item) -> Acc,
@@ -145,6 +147,7 @@ where
         self.iter.next_back().map(&mut self.f)
     }
 
+    #[inline]
     fn try_rfold<Acc, G, R>(&mut self, init: Acc, g: G) -> R
     where
         Self: Sized,
@@ -154,6 +157,7 @@ where
         self.iter.try_rfold(init, map_try_fold(&mut self.f, g))
     }
 
+    #[inline]
     fn rfold<Acc, G>(self, init: Acc, g: G) -> Acc
     where
         G: FnMut(Acc, Self::Item) -> Acc,
@@ -167,10 +171,12 @@ impl<B, I: ExactSizeIterator, F> ExactSizeIterator for Map<I, F>
 where
     F: FnMut(I::Item) -> B,
 {
+    #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -174,10 +174,12 @@ where
 {
     type Item = <I::Item as Try>::Output;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.try_for_each(ControlFlow::Break).break_value()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.residual.is_some() {
             (0, Some(0))
@@ -187,6 +189,7 @@ where
         }
     }
 
+    #[inline]
     fn try_fold<B, F, T>(&mut self, init: B, mut f: F) -> T
     where
         F: FnMut(B, Self::Item) -> T,

--- a/library/core/src/iter/adapters/rev.rs
+++ b/library/core/src/iter/adapters/rev.rs
@@ -47,6 +47,7 @@ where
         self.iter.nth_back(n)
     }
 
+    #[inline]
     fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -56,6 +57,7 @@ where
         self.iter.try_rfold(init, f)
     }
 
+    #[inline]
     fn fold<Acc, F>(self, init: Acc, f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -92,6 +94,7 @@ where
         self.iter.nth(n)
     }
 
+    #[inline]
     fn try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -101,6 +104,7 @@ where
         self.iter.try_fold(init, f)
     }
 
+    #[inline]
     fn rfold<Acc, F>(self, init: Acc, f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -108,6 +112,7 @@ where
         self.iter.fold(init, f)
     }
 
+    #[inline]
     fn rfind<P>(&mut self, predicate: P) -> Option<Self::Item>
     where
         P: FnMut(&Self::Item) -> bool,
@@ -121,10 +126,12 @@ impl<I> ExactSizeIterator for Rev<I>
 where
     I: ExactSizeIterator + DoubleEndedIterator,
 {
+    #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }

--- a/library/core/src/iter/adapters/scan.rs
+++ b/library/core/src/iter/adapters/scan.rs
@@ -58,6 +58,7 @@ where
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
+        #[inline]
         fn scan<'a, T, St, B, Acc, R: Try<Output = Acc>>(
             state: &'a mut St,
             f: &'a mut impl FnMut(&mut St, T) -> Option<B>,

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -167,6 +167,7 @@ impl<I> DoubleEndedIterator for Skip<I>
 where
     I: DoubleEndedIterator + ExactSizeIterator,
 {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.len() > 0 { self.iter.next_back() } else { None }
     }
@@ -185,12 +186,14 @@ where
         }
     }
 
+    #[inline]
     fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
     where
         Self: Sized,
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
+        #[inline]
         fn check<T, Acc, R: Try<Output = Acc>>(
             mut n: usize,
             mut fold: impl FnMut(Acc, T) -> R,

--- a/library/core/src/iter/adapters/skip_while.rs
+++ b/library/core/src/iter/adapters/skip_while.rs
@@ -40,6 +40,7 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
+        #[inline]
         fn check<'a, T>(
             flag: &'a mut bool,
             pred: &'a mut impl FnMut(&T) -> bool,

--- a/library/core/src/iter/adapters/step_by.rs
+++ b/library/core/src/iter/adapters/step_by.rs
@@ -108,6 +108,7 @@ where
         }
     }
 
+    #[inline]
     fn try_fold<Acc, F, R>(&mut self, mut acc: Acc, mut f: F) -> R
     where
         F: FnMut(Acc, Self::Item) -> R,
@@ -128,6 +129,7 @@ where
         from_fn(nth(&mut self.iter, self.step)).try_fold(acc, f)
     }
 
+    #[inline]
     fn fold<Acc, F>(mut self, mut acc: Acc, mut f: F) -> Acc
     where
         F: FnMut(Acc, Self::Item) -> Acc,
@@ -154,6 +156,7 @@ where
 {
     // The zero-based index starting from the end of the iterator of the
     // last element. Used in the `DoubleEndedIterator` implementation.
+    #[inline]
     fn next_back_index(&self) -> usize {
         let rem = self.iter.len() % (self.step + 1);
         if self.first_take {
@@ -184,6 +187,7 @@ where
         self.iter.nth_back(n)
     }
 
+    #[inline]
     fn try_rfold<Acc, F, R>(&mut self, init: Acc, mut f: F) -> R
     where
         F: FnMut(Acc, Self::Item) -> R,

--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -79,6 +79,7 @@ where
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
+        #[inline]
         fn check<'a, T, Acc, R: Try<Output = Acc>>(
             n: &'a mut usize,
             mut fold: impl FnMut(Acc, T) -> R + 'a,

--- a/library/core/src/iter/adapters/take_while.rs
+++ b/library/core/src/iter/adapters/take_while.rs
@@ -70,6 +70,7 @@ where
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
+        #[inline]
         fn check<'a, T, Acc, R: Try<Output = Acc>>(
             flag: &'a mut bool,
             p: &'a mut impl FnMut(&T) -> bool,

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -22,6 +22,7 @@ impl<A: Iterator, B: Iterator> Zip<A, B> {
     pub(in crate::iter) fn new(a: A, b: B) -> Zip<A, B> {
         ZipImpl::new(a, b)
     }
+    #[inline]
     fn super_nth(&mut self, mut n: usize) -> Option<(A::Item, B::Item)> {
         while let Some(x) = Iterator::next(self) {
             if n == 0 {
@@ -222,6 +223,7 @@ where
         (lower, upper)
     }
 
+    #[inline]
     default unsafe fn get_unchecked(&mut self, _idx: usize) -> <Self as Iterator>::Item
     where
         Self: TrustedRandomAccessNoCoerce,
@@ -535,6 +537,7 @@ pub unsafe trait TrustedRandomAccess: TrustedRandomAccessNoCoerce {}
 #[rustc_specialization_trait]
 pub unsafe trait TrustedRandomAccessNoCoerce: Sized {
     // Convenience method.
+    #[inline]
     fn size(&self) -> usize
     where
         Self: Iterator,
@@ -570,6 +573,7 @@ unsafe trait SpecTrustedRandomAccess: Iterator {
 }
 
 unsafe impl<I: Iterator> SpecTrustedRandomAccess for I {
+    #[inline]
     default unsafe fn try_get_unchecked(&mut self, _: usize) -> Self::Item {
         panic!("Should only be called on TrustedRandomAccess iterators");
     }

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -84,6 +84,7 @@ pub trait Step: Clone + PartialOrd + Sized {
     ///   * Corollary: `Step::forward(a, 0) == a`
     /// * `Step::forward(a, n) >= a`
     /// * `Step::backward(Step::forward(a, n), n) == a`
+    #[inline]
     fn forward(start: Self, count: usize) -> Self {
         Step::forward_checked(start, count).expect("overflow in `Step::forward`")
     }
@@ -108,6 +109,7 @@ pub trait Step: Clone + PartialOrd + Sized {
     /// For any `a` and `n`, where no overflow occurs:
     ///
     /// * `Step::forward_unchecked(a, n)` is equivalent to `Step::forward(a, n)`
+    #[inline]
     unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
         Step::forward(start, count)
     }
@@ -153,6 +155,7 @@ pub trait Step: Clone + PartialOrd + Sized {
     ///   * Corollary: `Step::backward(a, 0) == a`
     /// * `Step::backward(a, n) <= a`
     /// * `Step::forward(Step::backward(a, n), n) == a`
+    #[inline]
     fn backward(start: Self, count: usize) -> Self {
         Step::backward_checked(start, count).expect("overflow in `Step::backward`")
     }
@@ -177,6 +180,7 @@ pub trait Step: Clone + PartialOrd + Sized {
     /// For any `a` and `n`, where no overflow occurs:
     ///
     /// * `Step::backward_unchecked(a, n)` is equivalent to `Step::backward(a, n)`
+    #[inline]
     unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
         Step::backward(start, count)
     }

--- a/library/core/src/iter/sources/empty.rs
+++ b/library/core/src/iter/sources/empty.rs
@@ -16,6 +16,7 @@ use crate::marker;
 ///
 /// assert_eq!(None, nope.next());
 /// ```
+#[inline]
 #[stable(feature = "iter_empty", since = "1.2.0")]
 #[rustc_const_stable(feature = "const_iter_empty", since = "1.32.0")]
 pub const fn empty<T>() -> Empty<T> {
@@ -45,10 +46,12 @@ impl<T> fmt::Debug for Empty<T> {
 impl<T> Iterator for Empty<T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         None
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(0))
     }
@@ -56,6 +59,7 @@ impl<T> Iterator for Empty<T> {
 
 #[stable(feature = "iter_empty", since = "1.2.0")]
 impl<T> DoubleEndedIterator for Empty<T> {
+    #[inline]
     fn next_back(&mut self) -> Option<T> {
         None
     }
@@ -63,6 +67,7 @@ impl<T> DoubleEndedIterator for Empty<T> {
 
 #[stable(feature = "iter_empty", since = "1.2.0")]
 impl<T> ExactSizeIterator for Empty<T> {
+    #[inline]
     fn len(&self) -> usize {
         0
     }
@@ -78,6 +83,7 @@ impl<T> FusedIterator for Empty<T> {}
 // which isn't necessary.
 #[stable(feature = "iter_empty", since = "1.2.0")]
 impl<T> Clone for Empty<T> {
+    #[inline]
     fn clone(&self) -> Empty<T> {
         Empty(marker::PhantomData)
     }
@@ -88,6 +94,7 @@ impl<T> Clone for Empty<T> {
 #[stable(feature = "iter_empty", since = "1.2.0")]
 #[rustc_const_unstable(feature = "const_default_impls", issue = "87864")]
 impl<T> const Default for Empty<T> {
+    #[inline]
     fn default() -> Empty<T> {
         Empty(marker::PhantomData)
     }

--- a/library/core/src/iter/sources/from_generator.rs
+++ b/library/core/src/iter/sources/from_generator.rs
@@ -34,6 +34,7 @@ struct FromGenerator<G>(G);
 impl<G: Generator<Return = ()> + Unpin> Iterator for FromGenerator<G> {
     type Item = G::Yield;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match Pin::new(&mut self.0).resume(()) {
             GeneratorState::Yielded(n) => Some(n),

--- a/library/core/src/iter/sources/once.rs
+++ b/library/core/src/iter/sources/once.rs
@@ -51,6 +51,7 @@ use crate::iter::{FusedIterator, TrustedLen};
 ///     println!("{f:?}");
 /// }
 /// ```
+#[inline]
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub fn once<T>(value: T) -> Once<T> {
     Once { inner: Some(value).into_iter() }
@@ -69,10 +70,12 @@ pub struct Once<T> {
 impl<T> Iterator for Once<T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         self.inner.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
@@ -80,6 +83,7 @@ impl<T> Iterator for Once<T> {
 
 #[stable(feature = "iter_once", since = "1.2.0")]
 impl<T> DoubleEndedIterator for Once<T> {
+    #[inline]
     fn next_back(&mut self) -> Option<T> {
         self.inner.next_back()
     }
@@ -87,6 +91,7 @@ impl<T> DoubleEndedIterator for Once<T> {
 
 #[stable(feature = "iter_once", since = "1.2.0")]
 impl<T> ExactSizeIterator for Once<T> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }

--- a/library/core/src/iter/sources/once_with.rs
+++ b/library/core/src/iter/sources/once_with.rs
@@ -90,6 +90,7 @@ impl<A, F: FnOnce() -> A> Iterator for OnceWith<F> {
 
 #[stable(feature = "iter_once_with", since = "1.43.0")]
 impl<A, F: FnOnce() -> A> DoubleEndedIterator for OnceWith<F> {
+    #[inline]
     fn next_back(&mut self) -> Option<A> {
         self.next()
     }
@@ -97,6 +98,7 @@ impl<A, F: FnOnce() -> A> DoubleEndedIterator for OnceWith<F> {
 
 #[stable(feature = "iter_once_with", since = "1.43.0")]
 impl<A, F: FnOnce() -> A> ExactSizeIterator for OnceWith<F> {
+    #[inline]
     fn len(&self) -> usize {
         self.gen.iter().len()
     }

--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -92,10 +92,12 @@ impl<A: Clone> Iterator for Repeat<A> {
         Some(self.element.clone())
     }
 
+    #[inline]
     fn last(self) -> Option<A> {
         loop {}
     }
 
+    #[inline]
     fn count(self) -> usize {
         loop {}
     }

--- a/library/core/src/iter/sources/successors.rs
+++ b/library/core/src/iter/sources/successors.rs
@@ -11,6 +11,7 @@ use crate::{fmt, iter::FusedIterator};
 /// let powers_of_10 = successors(Some(1_u16), |n| n.checked_mul(10));
 /// assert_eq!(powers_of_10.collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);
 /// ```
+#[inline]
 #[stable(feature = "iter_successors", since = "1.34.0")]
 pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
 where

--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -38,6 +38,7 @@ macro_rules! integer_sum_product {
     (@impls $zero:expr, $one:expr, #[$attr:meta], $($a:ty)*) => ($(
         #[$attr]
         impl Sum for $a {
+            #[inline]
             fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
                 iter.fold(
                     $zero,
@@ -49,6 +50,7 @@ macro_rules! integer_sum_product {
 
         #[$attr]
         impl Product for $a {
+            #[inline]
             fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
                 iter.fold(
                     $one,
@@ -60,6 +62,7 @@ macro_rules! integer_sum_product {
 
         #[$attr]
         impl<'a> Sum<&'a $a> for $a {
+            #[inline]
             fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
                 iter.fold(
                     $zero,
@@ -71,6 +74,7 @@ macro_rules! integer_sum_product {
 
         #[$attr]
         impl<'a> Product<&'a $a> for $a {
+            #[inline]
             fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
                 iter.fold(
                     $one,
@@ -94,6 +98,7 @@ macro_rules! float_sum_product {
     ($($a:ident)*) => ($(
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl Sum for $a {
+            #[inline]
             fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
                 iter.fold(
                     0.0,
@@ -105,6 +110,7 @@ macro_rules! float_sum_product {
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl Product for $a {
+            #[inline]
             fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
                 iter.fold(
                     1.0,
@@ -116,6 +122,7 @@ macro_rules! float_sum_product {
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl<'a> Sum<&'a $a> for $a {
+            #[inline]
             fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
                 iter.fold(
                     0.0,
@@ -127,6 +134,7 @@ macro_rules! float_sum_product {
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl<'a> Product<&'a $a> for $a {
+            #[inline]
             fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
                 iter.fold(
                     1.0,
@@ -163,6 +171,7 @@ where
     /// ).sum();
     /// assert_eq!(res, Ok(3));
     /// ```
+    #[inline]
     fn sum<I>(iter: I) -> Result<T, E>
     where
         I: Iterator<Item = Result<U, E>>,
@@ -179,6 +188,7 @@ where
     /// Takes each element in the [`Iterator`]: if it is an [`Err`], no further
     /// elements are taken, and the [`Err`] is returned. Should no [`Err`]
     /// occur, the product of all elements is returned.
+    #[inline]
     fn product<I>(iter: I) -> Result<T, E>
     where
         I: Iterator<Item = Result<U, E>>,
@@ -206,6 +216,7 @@ where
     /// let total: Option<usize> = words.iter().map(|w| w.find('a')).sum();
     /// assert_eq!(total, Some(5));
     /// ```
+    #[inline]
     fn sum<I>(iter: I) -> Option<T>
     where
         I: Iterator<Item = Option<U>>,
@@ -222,6 +233,7 @@ where
     /// Takes each element in the [`Iterator`]: if it is a [`None`], no further
     /// elements are taken, and the [`None`] is returned. Should no [`None`]
     /// occur, the product of all elements is returned.
+    #[inline]
     fn product<I>(iter: I) -> Option<T>
     where
         I: Iterator<Item = Option<U>>,

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -368,6 +368,7 @@ pub trait Extend<A> {
     fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T);
 
     /// Extends a collection with exactly one element.
+    #[inline]
     #[unstable(feature = "extend_one", issue = "72631")]
     fn extend_one(&mut self, item: A) {
         self.extend(Some(item));
@@ -376,6 +377,7 @@ pub trait Extend<A> {
     /// Reserves capacity in a collection for the given number of additional elements.
     ///
     /// The default implementation does nothing.
+    #[inline]
     #[unstable(feature = "extend_one", issue = "72631")]
     fn extend_reserve(&mut self, additional: usize) {
         let _ = additional;
@@ -384,9 +386,11 @@ pub trait Extend<A> {
 
 #[stable(feature = "extend_for_unit", since = "1.28.0")]
 impl Extend<()> for () {
+    #[inline]
     fn extend<T: IntoIterator<Item = ()>>(&mut self, iter: T) {
         iter.into_iter().for_each(drop)
     }
+    #[inline]
     fn extend_one(&mut self, _item: ()) {}
 }
 
@@ -416,10 +420,12 @@ where
     /// assert_eq!(b, [2, 5, 8]);
     /// assert_eq!(c, [3, 6, 9]);
     /// ```
+    #[inline]
     fn extend<T: IntoIterator<Item = (A, B)>>(&mut self, into_iter: T) {
         let (a, b) = self;
         let iter = into_iter.into_iter();
 
+        #[inline]
         fn extend<'a, A, B>(
             a: &'a mut impl Extend<A>,
             b: &'a mut impl Extend<B>,
@@ -439,11 +445,13 @@ where
         iter.fold((), extend(a, b));
     }
 
+    #[inline]
     fn extend_one(&mut self, item: (A, B)) {
         self.0.extend_one(item.0);
         self.1.extend_one(item.1);
     }
 
+    #[inline]
     fn extend_reserve(&mut self, additional: usize) {
         self.0.extend_reserve(additional);
         self.1.extend_reserve(additional);

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -362,12 +362,15 @@ pub trait DoubleEndedIterator: Iterator {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for &'a mut I {
+    #[inline]
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
+    #[inline]
     fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
         (**self).advance_back_by(n)
     }
+    #[inline]
     fn nth_back(&mut self, n: usize) -> Option<I::Item> {
         (**self).nth_back(n)
     }

--- a/library/core/src/iter/traits/exact_size.rs
+++ b/library/core/src/iter/traits/exact_size.rs
@@ -142,9 +142,11 @@ pub trait ExactSizeIterator: Iterator {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for &mut I {
+    #[inline]
     fn len(&self) -> usize {
         (**self).len()
     }
+    #[inline]
     fn is_empty(&self) -> bool {
         (**self).is_empty()
     }

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2132,6 +2132,7 @@ pub trait Iterator {
     /// assert!("Iterator".chars().is_partitioned(char::is_uppercase));
     /// assert!(!"IntoIterator".chars().is_partitioned(char::is_uppercase));
     /// ```
+    #[inline]
     #[unstable(feature = "iter_is_partitioned", reason = "new API", issue = "62544")]
     fn is_partitioned<P>(mut self, mut predicate: P) -> bool
     where
@@ -3186,6 +3187,7 @@ pub trait Iterator {
     /// assert_eq!(y, [2, 5]);
     /// assert_eq!(z, [3, 6]);
     /// ```
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn unzip<A, B, FromA, FromB>(self) -> (FromA, FromB)
     where
@@ -3218,6 +3220,7 @@ pub trait Iterator {
     /// assert_eq!(v_copied, vec![1, 2, 3]);
     /// assert_eq!(v_map, vec![1, 2, 3]);
     /// ```
+    #[inline]
     #[stable(feature = "iter_copied", since = "1.36.0")]
     fn copied<'a, T: 'a>(self) -> Copied<Self>
     where
@@ -3265,6 +3268,7 @@ pub trait Iterator {
     /// let faster: Vec<_> = a.iter().filter(|s| s.len() == 1).cloned().collect();
     /// assert_eq!(&[vec![23]], &faster[..]);
     /// ```
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn cloned<'a, T: 'a>(self) -> Cloned<Self>
     where
@@ -3298,8 +3302,8 @@ pub trait Iterator {
     /// assert_eq!(it.next(), Some(&3));
     /// assert_eq!(it.next(), Some(&1));
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn cycle(self) -> Cycle<Self>
     where
         Self: Sized + Clone,
@@ -3342,6 +3346,7 @@ pub trait Iterator {
     /// }
     /// ```
     #[track_caller]
+    #[inline]
     #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
     fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
     where
@@ -3372,6 +3377,7 @@ pub trait Iterator {
     ///
     /// assert_eq!(sum, 6);
     /// ```
+    #[inline]
     #[stable(feature = "iter_arith", since = "1.11.0")]
     fn sum<S>(self) -> S
     where
@@ -3401,6 +3407,7 @@ pub trait Iterator {
     /// assert_eq!(factorial(1), 1);
     /// assert_eq!(factorial(5), 120);
     /// ```
+    #[inline]
     #[stable(feature = "iter_arith", since = "1.11.0")]
     fn product<P>(self) -> P
     where
@@ -3422,6 +3429,7 @@ pub trait Iterator {
     /// assert_eq!([1].iter().cmp([1, 2].iter()), Ordering::Less);
     /// assert_eq!([1, 2].iter().cmp([1].iter()), Ordering::Greater);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn cmp<I>(self, other: I) -> Ordering
     where
@@ -3451,6 +3459,7 @@ pub trait Iterator {
     /// assert_eq!(xs.iter().cmp_by(&ys, |&x, &y| (x * x).cmp(&y)), Ordering::Equal);
     /// assert_eq!(xs.iter().cmp_by(&ys, |&x, &y| (2 * x).cmp(&y)), Ordering::Greater);
     /// ```
+    #[inline]
     #[unstable(feature = "iter_order_by", issue = "64295")]
     fn cmp_by<I, F>(self, other: I, cmp: F) -> Ordering
     where
@@ -3489,6 +3498,7 @@ pub trait Iterator {
     ///
     /// assert_eq!([f64::NAN].iter().partial_cmp([1.].iter()), None);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn partial_cmp<I>(self, other: I) -> Option<Ordering>
     where
@@ -3527,6 +3537,7 @@ pub trait Iterator {
     ///     Some(Ordering::Greater)
     /// );
     /// ```
+    #[inline]
     #[unstable(feature = "iter_order_by", issue = "64295")]
     fn partial_cmp_by<I, F>(self, other: I, partial_cmp: F) -> Option<Ordering>
     where
@@ -3560,6 +3571,7 @@ pub trait Iterator {
     /// assert_eq!([1].iter().eq([1].iter()), true);
     /// assert_eq!([1].iter().eq([1, 2].iter()), false);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn eq<I>(self, other: I) -> bool
     where
@@ -3585,6 +3597,7 @@ pub trait Iterator {
     ///
     /// assert!(xs.iter().eq_by(&ys, |&x, &y| x * x == y));
     /// ```
+    #[inline]
     #[unstable(feature = "iter_order_by", issue = "64295")]
     fn eq_by<I, F>(self, other: I, eq: F) -> bool
     where
@@ -3617,6 +3630,7 @@ pub trait Iterator {
     /// assert_eq!([1].iter().ne([1].iter()), false);
     /// assert_eq!([1].iter().ne([1, 2].iter()), true);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn ne<I>(self, other: I) -> bool
     where
@@ -3638,6 +3652,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().lt([1].iter()), false);
     /// assert_eq!([1, 2].iter().lt([1, 2].iter()), false);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn lt<I>(self, other: I) -> bool
     where
@@ -3659,6 +3674,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().le([1].iter()), false);
     /// assert_eq!([1, 2].iter().le([1, 2].iter()), true);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn le<I>(self, other: I) -> bool
     where
@@ -3680,6 +3696,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().gt([1].iter()), true);
     /// assert_eq!([1, 2].iter().gt([1, 2].iter()), false);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn gt<I>(self, other: I) -> bool
     where
@@ -3701,6 +3718,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().ge([1].iter()), true);
     /// assert_eq!([1, 2].iter().ge([1, 2].iter()), true);
     /// ```
+    #[inline]
     #[stable(feature = "iter_order", since = "1.5.0")]
     fn ge<I>(self, other: I) -> bool
     where
@@ -3760,6 +3778,7 @@ pub trait Iterator {
     /// ```
     ///
     /// [`is_sorted`]: Iterator::is_sorted
+    #[inline]
     #[unstable(feature = "is_sorted", reason = "new API", issue = "53485")]
     fn is_sorted_by<F>(mut self, compare: F) -> bool
     where
@@ -3877,12 +3896,15 @@ impl<I: Iterator + ?Sized> Iterator for &mut I {
     fn next(&mut self) -> Option<I::Item> {
         (**self).next()
     }
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (**self).size_hint()
     }
+    #[inline]
     fn advance_by(&mut self, n: usize) -> Result<(), usize> {
         (**self).advance_by(n)
     }
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
     }


### PR DESCRIPTION
I have no idea if this is necessary or not for the standard library but it was inconsistently used so
I put it everywhere.

There are still the `Display` impls that don't have it, I don't think they are perf-sensitive though.