### PR TITLE
rustdoc: remove unnecessary CSS `.search-results { padding-bottom }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -878,7 +878,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 
 .search-results {
 	display: none;
-	padding-bottom: 2em;
 }
 
 .search-results.active {


### PR DESCRIPTION
There's nothing underneath it anyway. The conversation on #84462 never really spelled out why it was added.