### PR TITLE
Add Iterator::map_into

### DIFF
--- a/library/core/src/iter/adapters/convert.rs
+++ b/library/core/src/iter/adapters/convert.rs
@@ -1,0 +1,144 @@
+use crate::iter::adapters::{
+    zip::try_get_unchecked, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
+};
+use crate::iter::{FusedIterator, TrustedLen};
+use crate::marker::PhantomData;
+use crate::ops::Try;
+
+/// An iterator that converts the elements of an underlying iterator.
+///
+/// This `struct` is created by the [`map_into`] method on [`Iterator`]. See its
+/// documentation for more.
+///
+/// [`map_into`]: Iterator::map_into
+/// [`Iterator`]: trait.Iterator.html
+#[unstable(feature = "converting_iterators", issue = "none")]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+#[derive(Clone, Debug)]
+pub struct MapInto<I, T> {
+    it: I,
+    into: PhantomData<T>,
+}
+
+impl<I, T> MapInto<I, T> {
+    pub(in crate::iter) fn new(it: I) -> MapInto<I, T> {
+        MapInto { it, into: PhantomData }
+    }
+}
+
+fn try_fold_into<T: Into<U>, U, Acc, R>(mut f: impl FnMut(Acc, U) -> R) -> impl FnMut(Acc, T) -> R {
+    move |acc, elt| f(acc, elt.into())
+}
+
+#[unstable(feature = "converting_iterators", issue = "none")]
+impl<I, T> Iterator for MapInto<I, T>
+where
+    I: Iterator,
+    I::Item: Into<T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.it.next().map(Into::into)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.it.size_hint()
+    }
+
+    fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        self.it.try_fold(init, try_fold_into(f))
+    }
+
+    fn fold<Acc, F>(self, init: Acc, f: F) -> Acc
+    where
+        F: FnMut(Acc, Self::Item) -> Acc,
+    {
+        self.it.map(Into::into).fold(init, f)
+    }
+
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
+    where
+        Self: TrustedRandomAccessNoCoerce,
+    {
+        // SAFETY: the caller must uphold the contract for
+        // `Iterator::__iterator_get_unchecked`.
+        unsafe { try_get_unchecked(&mut self.it, idx).into() }
+    }
+}
+
+#[unstable(feature = "converting_iterators", issue = "none")]
+impl<I, T> DoubleEndedIterator for MapInto<I, T>
+where
+    I: DoubleEndedIterator,
+    I::Item: Into<T>,
+{
+    fn next_back(&mut self) -> Option<T> {
+        self.it.next_back().map(Into::into)
+    }
+
+    fn try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        self.it.try_rfold(init, try_fold_into(f))
+    }
+
+    fn rfold<Acc, F>(self, init: Acc, f: F) -> Acc
+    where
+        F: FnMut(Acc, Self::Item) -> Acc,
+    {
+        self.it.map(Into::into).rfold(init, f)
+    }
+}
+
+#[unstable(feature = "converting_iterators", issue = "none")]
+impl<I, T> ExactSizeIterator for MapInto<I, T>
+where
+    I: ExactSizeIterator,
+    I::Item: Into<T>,
+{
+    fn len(&self) -> usize {
+        self.it.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.it.is_empty()
+    }
+}
+
+#[unstable(feature = "converting_iterators", issue = "none")]
+impl<I, T> FusedIterator for MapInto<I, T>
+where
+    I: FusedIterator,
+    I::Item: Into<T>,
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I, T> TrustedRandomAccess for MapInto<I, T> where I: TrustedRandomAccess {}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I, T> TrustedRandomAccessNoCoerce for MapInto<I, T>
+where
+    I: TrustedRandomAccessNoCoerce,
+{
+    const MAY_HAVE_SIDE_EFFECT: bool = true;
+}
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<I, T> TrustedLen for MapInto<I, T>
+where
+    I: TrustedLen,
+    I::Item: Into<T>,
+{
+}

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -5,6 +5,7 @@ mod array_chunks;
 mod by_ref_sized;
 mod chain;
 mod cloned;
+mod convert;
 mod copied;
 mod cycle;
 mod enumerate;
@@ -65,6 +66,9 @@ pub use self::zip::TrustedRandomAccessNoCoerce;
 
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::zip::zip;
+
+#[unstable(feature = "converting_iterators", issue = "none")]
+pub use self::convert::MapInto;
 
 /// This trait provides transitive access to source-stage in an iterator-adapter pipeline
 /// under the conditions that

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -431,6 +431,8 @@ pub use self::adapters::Cloned;
 pub use self::adapters::Copied;
 #[stable(feature = "iterator_flatten", since = "1.29.0")]
 pub use self::adapters::Flatten;
+#[unstable(feature = "converting_iterators", issue = "none")]
+pub use self::adapters::MapInto;
 #[stable(feature = "iter_map_while", since = "1.57.0")]
 pub use self::adapters::MapWhile;
 #[unstable(feature = "inplace_iteration", issue = "none")]

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -9,7 +9,7 @@ use super::super::{ArrayChunks, Chain, Cloned, Copied, Cycle, Enumerate, Filter,
 use super::super::{FlatMap, Flatten};
 use super::super::{FromIterator, Intersperse, IntersperseWith, Product, Sum, Zip};
 use super::super::{
-    Inspect, Map, MapWhile, Peekable, Rev, Scan, Skip, SkipWhile, StepBy, Take, TakeWhile,
+    Inspect, Map, MapInto, MapWhile, Peekable, Rev, Scan, Skip, SkipWhile, StepBy, Take, TakeWhile,
 };
 
 fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
@@ -3272,6 +3272,30 @@ pub trait Iterator {
         T: Clone,
     {
         Cloned::new(self)
+    }
+
+    /// Creates an iterator which converts its elements [`into`] something else.
+    ///
+    /// [`into`]: Into::into
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let bools = [true, false];
+    ///
+    /// let conv: Vec<u32> = a.iter().map_into().collect();
+    ///
+    /// assert_eq!(conv, vec![1, 0]);
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn map_into<T>(self) -> MapInto<Self, T>
+    where
+        Self: Sized,
+        Self::Item: Into<T>,
+    {
+        MapInto::new(self)
     }
 
     /// Repeats an iterator endlessly.


### PR DESCRIPTION
Justification: until [TAIT](https://github.com/rust-lang/rust/issues/63063) is stabilized, there is currently no easy way to use `.map(Into::into)` in iterators without rewriting all of that logic by hand. Additionally, even after that logic is written, there is already precedent for "helper adapters" that could be written using `map`, like `cloned` and `copied`.

This is also one of the conversions offered by the `itertools` crate.