### PR TITLE
rustdoc: add support for incoherent impls on structs and traits

### DIFF
--- a/src/test/rustdoc/auxiliary/incoherent-impl-types.rs
+++ b/src/test/rustdoc/auxiliary/incoherent-impl-types.rs
@@ -1,0 +1,7 @@
+#![feature(rustc_attrs)]
+
+#[rustc_has_incoherent_inherent_impls]
+pub trait FooTrait {}
+
+#[rustc_has_incoherent_inherent_impls]
+pub struct FooStruct;

--- a/src/test/rustdoc/rustc-incoherent-impls.rs
+++ b/src/test/rustdoc/rustc-incoherent-impls.rs
@@ -1,0 +1,28 @@
+// aux-build:incoherent-impl-types.rs
+// build-aux-docs
+
+#![crate_name = "foo"]
+#![feature(rustc_attrs)]
+
+extern crate incoherent_impl_types;
+
+// The only way this actually shows up is if the type gets inlined.
+#[doc(inline)]
+pub use incoherent_impl_types::FooTrait;
+
+// @has foo/trait.FooTrait.html
+// @count - '//section[@id="method.do_something"]' 1
+impl dyn FooTrait {
+    #[rustc_allow_incoherent_impl]
+    pub fn do_something() {}
+}
+
+#[doc(inline)]
+pub use incoherent_impl_types::FooStruct;
+
+// @has foo/struct.FooStruct.html
+// @count - '//section[@id="method.do_something"]' 1
+impl FooStruct {
+    #[rustc_allow_incoherent_impl]
+    pub fn do_something() {}
+}


### PR DESCRIPTION
Fixes #103170