### PR TITLE
Reduce span of let else irrefutable_let_patterns warning

### DIFF
--- a/src/test/ui/let-else/let-else-irrefutable.rs
+++ b/src/test/ui/let-else/let-else-irrefutable.rs
@@ -1,7 +1,11 @@
 // check-pass
 
-
-
 fn main() {
     let x = 1 else { return }; //~ WARN irrefutable `let...else` pattern
+
+    // Multiline else blocks should not get printed
+    let x = 1 else { //~ WARN irrefutable `let...else` pattern
+        eprintln!("problem case encountered");
+        return
+    };
 }

--- a/src/test/ui/let-else/let-else-irrefutable.stderr
+++ b/src/test/ui/let-else/let-else-irrefutable.stderr
@@ -1,12 +1,21 @@
 warning: irrefutable `let...else` pattern
-  --> $DIR/let-else-irrefutable.rs:6:5
+  --> $DIR/let-else-irrefutable.rs:4:5
    |
 LL |     let x = 1 else { return };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^
    |
    = note: this pattern will always match, so the `else` clause is useless
    = help: consider removing the `else` clause
    = note: `#[warn(irrefutable_let_patterns)]` on by default
 
-warning: 1 warning emitted
+warning: irrefutable `let...else` pattern
+  --> $DIR/let-else-irrefutable.rs:7:5
+   |
+LL |     let x = 1 else {
+   |     ^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: 2 warnings emitted
 


### PR DESCRIPTION
Huge spans aren't good for IDE users as they underline constructs that are possibly multiline.

Similar PR to #90761 which did the same for the `unused_macros` lint.