### PR TITLE
[do not merge] Ban `std::env::{set_var, remove_var}` in unsafe

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -331,6 +331,9 @@ language_item_table! {
     Range,                   sym::Range,               range_struct,               Target::Struct,         GenericRequirement::None;
     RangeToInclusive,        sym::RangeToInclusive,    range_to_inclusive_struct,  Target::Struct,         GenericRequirement::None;
     RangeTo,                 sym::RangeTo,             range_to_struct,            Target::Struct,         GenericRequirement::None;
+
+    EnvSetVar,               sym::env_set_var,         env_set_var,                Target::Fn,             GenericRequirement::Exact(2);
+    EnvRemoveVar,            sym::env_remove_var,      env_remove_var,             Target::Fn,             GenericRequirement::Exact(1);
 }
 
 pub enum GenericRequirement {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -673,6 +673,8 @@ symbols! {
         end,
         env,
         env_macro,
+        env_remove_var,
+        env_set_var,
         eprint_macro,
         eprintln_macro,
         eq,

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -343,7 +343,7 @@ impl Error for VarError {
 /// env::set_var(key, "VALUE");
 /// assert_eq!(env::var(key), Ok("VALUE".to_string()));
 /// ```
-#[cfg_attr(not(bootstrap), lang = "env_set_var")]
+#[cfg_attr(all(not(bootstrap), not(test)), lang = "env_set_var")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
     _set_var(key.as_ref(), value.as_ref())
@@ -386,7 +386,7 @@ fn _set_var(key: &OsStr, value: &OsStr) {
 /// env::remove_var(key);
 /// assert!(env::var(key).is_err());
 /// ```
-#[cfg_attr(not(bootstrap), lang = "env_remove_var")]
+#[cfg_attr(all(not(bootstrap), not(test)), lang = "env_remove_var")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn remove_var<K: AsRef<OsStr>>(key: K) {
     _remove_var(key.as_ref())

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -343,6 +343,7 @@ impl Error for VarError {
 /// env::set_var(key, "VALUE");
 /// assert_eq!(env::var(key), Ok("VALUE".to_string()));
 /// ```
+#[cfg_attr(not(bootstrap), lang = "env_set_var")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
     _set_var(key.as_ref(), value.as_ref())
@@ -385,6 +386,7 @@ fn _set_var(key: &OsStr, value: &OsStr) {
 /// env::remove_var(key);
 /// assert!(env::var(key).is_err());
 /// ```
+#[cfg_attr(not(bootstrap), lang = "env_remove_var")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn remove_var<K: AsRef<OsStr>>(key: K) {
     _remove_var(key.as_ref())

--- a/src/test/ui/mut-env-in-unsafe.rs
+++ b/src/test/ui/mut-env-in-unsafe.rs
@@ -1,0 +1,11 @@
+use std::env::{remove_var, set_var};
+
+fn main() {
+    set_var("FOO", "bar");
+    remove_var("FOO");
+
+    unsafe {
+        set_var("FOO", "bar"); //~ ERROR mutation of environment inside unsafe context
+        remove_var("FOO"); //~ ERROR mutation of environment inside unsafe context
+    }
+}

--- a/src/test/ui/mut-env-in-unsafe.stderr
+++ b/src/test/ui/mut-env-in-unsafe.stderr
@@ -1,0 +1,14 @@
+error: mutation of environment inside unsafe context
+  --> $DIR/mut-env-in-unsafe.rs:8:9
+   |
+LL |         set_var("FOO", "bar");
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
+error: mutation of environment inside unsafe context
+  --> $DIR/mut-env-in-unsafe.rs:9:9
+   |
+LL |         remove_var("FOO");
+   |         ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
-const ROOT_ENTRY_LIMIT: usize = 948;
+const ROOT_ENTRY_LIMIT: usize = 949;
 const ISSUES_ENTRY_LIMIT: usize = 2117;
 
 fn check_entries(path: &Path, bad: &mut bool) {


### PR DESCRIPTION
This PR prohibits any use of `std::env::ser_var` and `std::env::remove_var` in an unsafe context. It is an experiment to see how many times this actually occurs in real-world code. As such, it should not be merged.

cc #90308

@rustbot label -A-testsuite