### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -346,7 +346,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_parenthesized_parameter_data(
         &mut self,
         data: &ParenthesizedArgs,
-        itctx: ImplTraitContext,
+        itctx: &ImplTraitContext,
     ) -> (GenericArgsCtor<'hir>, bool) {
         // Switch to `PassThrough` mode for anonymous lifetimes; this
         // means that we permit things like `&Ref<T>`, where `Ref` has

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -363,7 +363,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             // fn f(_: impl Fn() -> impl Debug) -> impl Fn() -> impl Debug
             // //      disallowed --^^^^^^^^^^        allowed --^^^^^^^^^^
             // ```
-            FnRetTy::Ty(ty) if matches!(itctx, ImplTraitContext::ReturnPositionOpaqueTy { .. }) => {
+            FnRetTy::Ty(ty)
+                if matches!(itctx, ImplTraitContext::ReturnPositionOpaqueTy { .. })
+                    && self.tcx.features().impl_trait_in_fn_trait_return =>
+            {
                 self.lower_ty(&ty, itctx)
             }
             FnRetTy::Ty(ty) => {

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -191,7 +191,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     self.lower_angle_bracketed_parameter_data(data, param_mode, itctx)
                 }
                 GenericArgs::Parenthesized(ref data) => match parenthesized_generic_args {
-                    ParenthesizedGenericArgs::Ok => self.lower_parenthesized_parameter_data(data),
+                    ParenthesizedGenericArgs::Ok => {
+                        self.lower_parenthesized_parameter_data(data, itctx)
+                    }
                     ParenthesizedGenericArgs::Err => {
                         // Suggest replacing parentheses with angle brackets `Trait(params...)` to `Trait<params...>`
                         let sub = if !data.inputs.is_empty() {
@@ -344,6 +346,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_parenthesized_parameter_data(
         &mut self,
         data: &ParenthesizedArgs,
+        itctx: ImplTraitContext,
     ) -> (GenericArgsCtor<'hir>, bool) {
         // Switch to `PassThrough` mode for anonymous lifetimes; this
         // means that we permit things like `&Ref<T>`, where `Ref` has
@@ -355,6 +358,14 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             self.lower_ty_direct(ty, &ImplTraitContext::Disallowed(ImplTraitPosition::FnTraitParam))
         }));
         let output_ty = match output {
+            // Only allow `impl Trait` in return position. i.e.:
+            // ```rust
+            // fn f(_: impl Fn() -> impl Debug) -> impl Fn() -> impl Debug
+            // //      disallowed --^^^^^^^^^^        allowed --^^^^^^^^^^
+            // ```
+            FnRetTy::Ty(ty) if matches!(itctx, ImplTraitContext::ReturnPositionOpaqueTy { .. }) => {
+                self.lower_ty(&ty, itctx)
+            }
             FnRetTy::Ty(ty) => {
                 self.lower_ty(&ty, &ImplTraitContext::Disallowed(ImplTraitPosition::FnTraitReturn))
             }

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -414,6 +414,8 @@ declare_features! (
     (active, half_open_range_patterns_in_slices, "CURRENT_RUSTC_VERSION", Some(67264), None),
     /// Allows `if let` guard in match arms.
     (active, if_let_guard, "1.47.0", Some(51114), None),
+    /// Allows `impl Trait` as output type in `Fn` traits in return position of functions.
+    (active, impl_trait_in_fn_trait_return, "1.64.0", Some(99697), None),
     /// Allows using imported `main` function
     (active, imported_main, "1.53.0", Some(28937), None),
     /// Allows associated types in inherent impls.

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -691,7 +691,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         let is_expected = &|res| source.is_expected(res);
         let ident_span = path.last().map_or(span, |ident| ident.ident.span);
         let typo_sugg = self.lookup_typo_candidate(path, source.namespace(), is_expected);
-        if let TypoCandidate::Shadowed(res, Some(sugg_span)) = typo_sugg {
+        let is_local = &|res: Res| res.opt_def_id().map_or(false, |id| id.is_local());
+        if let TypoCandidate::Shadowed(res, Some(sugg_span)) = typo_sugg && is_local(res) {
             err.span_label(
                 sugg_span,
                 format!("you might have meant to refer to this {}", res.descr()),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -813,6 +813,7 @@ symbols! {
         impl_lint_pass,
         impl_macros,
         impl_trait_in_bindings,
+        impl_trait_in_fn_trait_return,
         implied_by,
         import,
         import_name_type,

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -228,9 +228,9 @@ fn on_test_event(
     out: &mut dyn OutputFormatter,
 ) -> io::Result<()> {
     match (*event).clone() {
-        TestEvent::TeFiltered(ref filtered_tests, shuffle_seed) => {
-            st.total = filtered_tests.len();
-            out.write_run_start(filtered_tests.len(), shuffle_seed)?;
+        TestEvent::TeFiltered(filtered_tests, shuffle_seed) => {
+            st.total = filtered_tests;
+            out.write_run_start(filtered_tests, shuffle_seed)?;
         }
         TestEvent::TeFilteredOut(filtered_out) => {
             st.filtered_out = filtered_out;

--- a/library/test/src/event.rs
+++ b/library/test/src/event.rs
@@ -28,7 +28,7 @@ impl CompletedTest {
 
 #[derive(Debug, Clone)]
 pub enum TestEvent {
-    TeFiltered(Vec<TestDesc>, Option<u64>),
+    TeFiltered(usize, Option<u64>),
     TeWait(TestDesc),
     TeResult(CompletedTest),
     TeTimeout(TestDesc),

--- a/src/doc/rustdoc/book.toml
+++ b/src/doc/rustdoc/book.toml
@@ -6,5 +6,9 @@ title = "The rustdoc book"
 git-repository-url = "https://github.com/rust-lang/rust/tree/master/src/doc/rustdoc"
 
 [output.html.redirect]
+"/what-to-include.html" = "write-documentation/what-to-include.html"
 "/the-doc-attribute.html" = "write-documentation/the-doc-attribute.html"
+"/linking-to-items-by-name.html" = "write-documentation/linking-to-items-by-name.html"
 "/documentation-tests.html" = "write-documentation/documentation-tests.html"
+"/website-features.html" = "advanced-features.html#custom-search-engines"
+"/passes.html" = "deprecated-features.html#passes"

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -878,7 +878,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 
 .search-results {
 	display: none;
-	padding-bottom: 2em;
 }
 
 .search-results.active {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1893,7 +1893,7 @@ fn disambiguator_error(
     diag_info.link_range = disambiguator_range;
     report_diagnostic(cx.tcx, BROKEN_INTRA_DOC_LINKS, msg, &diag_info, |diag, _sp| {
         let msg = format!(
-            "see {}/rustdoc/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators",
+            "see {}/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators",
             crate::DOC_RUST_LANG_ORG_CHANNEL
         );
         diag.note(&msg);

--- a/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
+++ b/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
@@ -4,7 +4,7 @@ error: unknown disambiguator `foo`
 LL | //! Linking to [foo@banana] and [`bar@banana!()`].
    |                 ^^^
    |
-   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 note: the lint level is defined here
   --> $DIR/unknown-disambiguator.rs:2:9
    |
@@ -18,7 +18,7 @@ error: unknown disambiguator `bar`
 LL | //! Linking to [foo@banana] and [`bar@banana!()`].
    |                                   ^^^
    |
-   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 error: unknown disambiguator `foo`
   --> $DIR/unknown-disambiguator.rs:10:34
@@ -26,7 +26,7 @@ error: unknown disambiguator `foo`
 LL | //! And with weird backticks: [``foo@hello``] [foo`@`hello].
    |                                  ^^^
    |
-   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 error: unknown disambiguator `foo`
   --> $DIR/unknown-disambiguator.rs:10:48
@@ -34,7 +34,7 @@ error: unknown disambiguator `foo`
 LL | //! And with weird backticks: [``foo@hello``] [foo`@`hello].
    |                                                ^^^
    |
-   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 error: unknown disambiguator ``
   --> $DIR/unknown-disambiguator.rs:7:31
@@ -42,7 +42,7 @@ error: unknown disambiguator ``
 LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
    |                               ^
    |
-   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 error: unknown disambiguator ``
   --> $DIR/unknown-disambiguator.rs:7:57
@@ -50,7 +50,7 @@ error: unknown disambiguator ``
 LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
    |                                                         ^
    |
-   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.rs
+++ b/src/test/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.rs
@@ -1,0 +1,6 @@
+fn f() -> impl Fn() -> impl Sized { || () }
+//~^ ERROR `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+fn g() -> &'static dyn Fn() -> impl Sized { &|| () }
+//~^ ERROR `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
+++ b/src/test/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
@@ -1,0 +1,15 @@
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+  --> $DIR/feature-gate-impl_trait_in_fn_trait_return.rs:1:24
+   |
+LL | fn f() -> impl Fn() -> impl Sized { || () }
+   |                        ^^^^^^^^^^
+
+error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
+  --> $DIR/feature-gate-impl_trait_in_fn_trait_return.rs:3:32
+   |
+LL | fn g() -> &'static dyn Fn() -> impl Sized { &|| () }
+   |                                ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.rs
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.rs
@@ -1,7 +1,8 @@
+#![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
 fn a() -> impl Fn(&u8) -> impl Debug {
-    |x| x //~ ERROR lifetime may not live long enough
+    |x| x //~ ERROR hidden type for `impl Debug` captures lifetime that does not appear in bounds
 }
 
 fn main() {}

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.rs
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.rs
@@ -1,0 +1,7 @@
+use std::fmt::Debug;
+
+fn a() -> impl Fn(&u8) -> impl Debug {
+    |x| x //~ ERROR lifetime may not live long enough
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.stderr
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.stderr
@@ -1,11 +1,11 @@
-error: lifetime may not live long enough
-  --> $DIR/impl-fn-hrtb-bounds-2.rs:4:9
+error[E0700]: hidden type for `impl Debug` captures lifetime that does not appear in bounds
+  --> $DIR/impl-fn-hrtb-bounds-2.rs:5:9
    |
 LL |     |x| x
-   |      -- ^ returning this value requires that `'1` must outlive `'2`
-   |      ||
-   |      |return type of closure is &'2 u8
-   |      has type `&'1 u8`
+   |     --- ^
+   |     |
+   |     hidden type `&u8` captures the anonymous lifetime #1 defined here
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0700`.

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.stderr
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds-2.stderr
@@ -1,0 +1,11 @@
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds-2.rs:4:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is &'2 u8
+   |      has type `&'1 u8`
+
+error: aborting due to previous error
+

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds.rs
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds.rs
@@ -10,4 +10,14 @@ fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
     |x| x
 }
 
+fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
+    //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+    |x| x
+}
+
+fn d() -> impl Fn() -> (impl Debug + '_) {
+    //~^ ERROR missing lifetime specifier
+    || ()
+}
+
 fn main() {}

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds.rs
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds.rs
@@ -1,0 +1,13 @@
+use std::fmt::Debug;
+
+fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
+    //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+    |x| x
+}
+
+fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
+    //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+    |x| x
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds.rs
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds.rs
@@ -1,3 +1,4 @@
+#![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
 fn a() -> impl Fn(&u8) -> (impl Debug + '_) {

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -22,5 +22,35 @@ note: lifetime declared here
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                    ^^
 
-error: aborting due to 2 previous errors
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/impl-fn-hrtb-bounds.rs:13:52
+   |
+LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
+   |                                                    ^^
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-hrtb-bounds.rs:13:20
+   |
+LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
+   |                    ^^
 
+error[E0106]: missing lifetime specifier
+  --> $DIR/impl-fn-hrtb-bounds.rs:18:38
+   |
+LL | fn d() -> impl Fn() -> (impl Debug + '_) {
+   |                                      ^^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL | fn d() -> impl for<'a> Fn() -> (impl Debug + 'a) {
+   |                +++++++                       ~~
+help: consider using the `'static` lifetime
+   |
+LL | fn d() -> impl Fn() -> (impl Debug + 'static) {
+   |                                      ~~~~~~~
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -1,55 +1,50 @@
-error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:3:41
-   |
-LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
-   |                                         ^^
-   |
-note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:3:19
-   |
-LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
-   |                   ^
-
-error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:8:52
-   |
-LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
-   |                                                    ^^
-   |
-note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:8:20
-   |
-LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
-   |                    ^^
-
-error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:13:52
-   |
-LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
-   |                                                    ^^
-   |
-note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:13:20
-   |
-LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
-   |                    ^^
-
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-fn-hrtb-bounds.rs:18:38
+  --> $DIR/impl-fn-hrtb-bounds.rs:19:38
    |
 LL | fn d() -> impl Fn() -> (impl Debug + '_) {
    |                                      ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider making the bound lifetime-generic with a new `'a` lifetime
-   |
-LL | fn d() -> impl for<'a> Fn() -> (impl Debug + 'a) {
-   |                +++++++                       ~~
 help: consider using the `'static` lifetime
    |
 LL | fn d() -> impl Fn() -> (impl Debug + 'static) {
    |                                      ~~~~~~~
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/impl-fn-hrtb-bounds.rs:4:41
+   |
+LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
+   |                                         ^^
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-hrtb-bounds.rs:4:19
+   |
+LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
+   |                   ^
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/impl-fn-hrtb-bounds.rs:9:52
+   |
+LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
+   |                                                    ^^
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-hrtb-bounds.rs:9:20
+   |
+LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
+   |                    ^^
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/impl-fn-hrtb-bounds.rs:14:52
+   |
+LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
+   |                                                    ^^
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-hrtb-bounds.rs:14:20
+   |
+LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
+   |                    ^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/src/test/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -1,0 +1,26 @@
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/impl-fn-hrtb-bounds.rs:3:41
+   |
+LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
+   |                                         ^^
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-hrtb-bounds.rs:3:19
+   |
+LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
+   |                   ^
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/impl-fn-hrtb-bounds.rs:8:52
+   |
+LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
+   |                                                    ^^
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-hrtb-bounds.rs:8:20
+   |
+LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
+   |                    ^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.rs
+++ b/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.rs
@@ -1,3 +1,4 @@
+#![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
 fn a() -> impl Fn(&u8) -> impl Debug + '_ {

--- a/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.rs
+++ b/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.rs
@@ -1,0 +1,14 @@
+use std::fmt::Debug;
+
+fn a() -> impl Fn(&u8) -> impl Debug + '_ {
+    //~^ ERROR ambiguous `+` in a type
+    //~^^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+    |x| x
+}
+
+fn b() -> impl Fn() -> impl Debug + Send {
+    //~^ ERROR ambiguous `+` in a type
+    || ()
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -1,0 +1,26 @@
+error: ambiguous `+` in a type
+  --> $DIR/impl-fn-parsing-ambiguities.rs:3:27
+   |
+LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
+   |                           ^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + '_)`
+
+error: ambiguous `+` in a type
+  --> $DIR/impl-fn-parsing-ambiguities.rs:9:24
+   |
+LL | fn b() -> impl Fn() -> impl Debug + Send {
+   |                        ^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + Send)`
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/impl-fn-parsing-ambiguities.rs:3:40
+   |
+LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
+   |                                        ^^
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-parsing-ambiguities.rs:3:19
+   |
+LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
+   |                   ^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/src/test/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -1,23 +1,23 @@
 error: ambiguous `+` in a type
-  --> $DIR/impl-fn-parsing-ambiguities.rs:3:27
+  --> $DIR/impl-fn-parsing-ambiguities.rs:4:27
    |
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                           ^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + '_)`
 
 error: ambiguous `+` in a type
-  --> $DIR/impl-fn-parsing-ambiguities.rs:9:24
+  --> $DIR/impl-fn-parsing-ambiguities.rs:10:24
    |
 LL | fn b() -> impl Fn() -> impl Debug + Send {
    |                        ^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + Send)`
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-parsing-ambiguities.rs:3:40
+  --> $DIR/impl-fn-parsing-ambiguities.rs:4:40
    |
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                                        ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-parsing-ambiguities.rs:3:19
+  --> $DIR/impl-fn-parsing-ambiguities.rs:4:19
    |
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                   ^

--- a/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.rs
+++ b/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.rs
@@ -1,7 +1,8 @@
-// check-pass
+#![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
 fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
+    //~^ ERROR hidden type for `impl Debug` captures lifetime that does not appear in bounds
     |x| x
 }
 

--- a/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.rs
+++ b/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.rs
@@ -2,8 +2,10 @@
 use std::fmt::Debug;
 
 fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
-    //~^ ERROR hidden type for `impl Debug` captures lifetime that does not appear in bounds
+    //~^ ERROR cannot resolve opaque type
+
     |x| x
+    //~^ ERROR concrete type differs from previous defining opaque type use
 }
 
 fn _b<'a>() -> impl Fn(&'a u8) -> (impl Debug + 'a) {

--- a/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.rs
+++ b/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.rs
@@ -1,0 +1,12 @@
+// check-pass
+use std::fmt::Debug;
+
+fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
+    |x| x
+}
+
+fn _b<'a>() -> impl Fn(&'a u8) -> (impl Debug + 'a) {
+    a()
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.stderr
+++ b/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.stderr
@@ -1,0 +1,15 @@
+error[E0700]: hidden type for `impl Debug` captures lifetime that does not appear in bounds
+  --> $DIR/impl-fn-predefined-lifetimes.rs:4:35
+   |
+LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
+   |                                   ^^^^^^^^^^^^^^^
+   |
+note: hidden type `&'<empty> u8` captures lifetime smaller than the function body
+  --> $DIR/impl-fn-predefined-lifetimes.rs:4:35
+   |
+LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
+   |                                   ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0700`.

--- a/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.stderr
+++ b/src/test/ui/impl-trait/impl-fn-predefined-lifetimes.stderr
@@ -1,15 +1,24 @@
-error[E0700]: hidden type for `impl Debug` captures lifetime that does not appear in bounds
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/impl-fn-predefined-lifetimes.rs:7:9
+   |
+LL |     |x| x
+   |         ^ expected `impl Debug + '_`, got `&u8`
+   |
+note: previous use here
+  --> $DIR/impl-fn-predefined-lifetimes.rs:7:5
+   |
+LL |     |x| x
+   |     ^^^^^
+
+error[E0720]: cannot resolve opaque type
   --> $DIR/impl-fn-predefined-lifetimes.rs:4:35
    |
 LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
-   |                                   ^^^^^^^^^^^^^^^
-   |
-note: hidden type `&'<empty> u8` captures lifetime smaller than the function body
-  --> $DIR/impl-fn-predefined-lifetimes.rs:4:35
-   |
-LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
-   |                                   ^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^ recursive opaque type
+...
+LL |     |x| x
+   |     ----- returning here with type `[closure@$DIR/impl-fn-predefined-lifetimes.rs:7:5: 7:8]`
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0700`.
+For more information about this error, try `rustc --explain E0720`.

--- a/src/test/ui/impl-trait/impl_fn_associativity.rs
+++ b/src/test/ui/impl-trait/impl_fn_associativity.rs
@@ -1,0 +1,16 @@
+// run-pass
+use std::fmt::Debug;
+
+fn f_debug() -> impl Fn() -> impl Debug {
+    || ()
+}
+
+fn ff_debug() -> impl Fn() -> impl Fn() -> impl Debug {
+    || f_debug()
+}
+
+fn main() {
+    // Check that `ff_debug` is `() -> (() -> Debug)` and not `(() -> ()) -> Debug`
+    let debug = ff_debug()()();
+    assert_eq!(format!("{:?}", debug), "()");
+}

--- a/src/test/ui/impl-trait/impl_fn_associativity.rs
+++ b/src/test/ui/impl-trait/impl_fn_associativity.rs
@@ -9,8 +9,17 @@ fn ff_debug() -> impl Fn() -> impl Fn() -> impl Debug {
     || f_debug()
 }
 
+fn multi() -> impl Fn() -> (impl Debug + Send) {
+    || ()
+}
+
 fn main() {
     // Check that `ff_debug` is `() -> (() -> Debug)` and not `(() -> ()) -> Debug`
     let debug = ff_debug()()();
     assert_eq!(format!("{:?}", debug), "()");
+
+    let x = multi()();
+    assert_eq!(format!("{:?}", x), "()");
+    fn assert_send(_: &impl Send) {}
+    assert_send(&x);
 }

--- a/src/test/ui/impl-trait/impl_fn_associativity.rs
+++ b/src/test/ui/impl-trait/impl_fn_associativity.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
 fn f_debug() -> impl Fn() -> impl Debug {

--- a/src/test/ui/impl-trait/nested_impl_trait.rs
+++ b/src/test/ui/impl-trait/nested_impl_trait.rs
@@ -25,8 +25,7 @@ fn allowed_in_assoc_type() -> impl Iterator<Item=impl Fn()> {
 }
 
 fn allowed_in_ret_type() -> impl Fn() -> impl Into<u32> {
-//~^ `impl Trait` only allowed in function and inherent method return types
-    || 5
+    || 5u8
 }
 
 fn main() {}

--- a/src/test/ui/impl-trait/nested_impl_trait.rs
+++ b/src/test/ui/impl-trait/nested_impl_trait.rs
@@ -1,3 +1,4 @@
+#![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
 fn fine(x: impl Into<u32>) -> impl Into<u32> { x }

--- a/src/test/ui/impl-trait/nested_impl_trait.stderr
+++ b/src/test/ui/impl-trait/nested_impl_trait.stderr
@@ -1,5 +1,5 @@
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/nested_impl_trait.rs:5:56
+  --> $DIR/nested_impl_trait.rs:6:56
    |
 LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                              ----------^^^^^^^^^^-
@@ -8,7 +8,7 @@ LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                              outer `impl Trait`
 
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/nested_impl_trait.rs:9:42
+  --> $DIR/nested_impl_trait.rs:10:42
    |
 LL | fn bad_in_fn_syntax(x: fn() -> impl Into<impl Debug>) {}
    |                                ----------^^^^^^^^^^-
@@ -17,7 +17,7 @@ LL | fn bad_in_fn_syntax(x: fn() -> impl Into<impl Debug>) {}
    |                                outer `impl Trait`
 
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/nested_impl_trait.rs:13:37
+  --> $DIR/nested_impl_trait.rs:14:37
    |
 LL | fn bad_in_arg_position(_: impl Into<impl Debug>) { }
    |                           ----------^^^^^^^^^^-
@@ -26,7 +26,7 @@ LL | fn bad_in_arg_position(_: impl Into<impl Debug>) { }
    |                           outer `impl Trait`
 
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/nested_impl_trait.rs:18:44
+  --> $DIR/nested_impl_trait.rs:19:44
    |
 LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  ----------^^^^^^^^^^-
@@ -35,13 +35,13 @@ LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  outer `impl Trait`
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
-  --> $DIR/nested_impl_trait.rs:9:32
+  --> $DIR/nested_impl_trait.rs:10:32
    |
 LL | fn bad_in_fn_syntax(x: fn() -> impl Into<impl Debug>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfied
-  --> $DIR/nested_impl_trait.rs:5:46
+  --> $DIR/nested_impl_trait.rs:6:46
    |
 LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                              ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
@@ -50,7 +50,7 @@ LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
 error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfied
-  --> $DIR/nested_impl_trait.rs:18:34
+  --> $DIR/nested_impl_trait.rs:19:34
    |
 LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`

--- a/src/test/ui/impl-trait/nested_impl_trait.stderr
+++ b/src/test/ui/impl-trait/nested_impl_trait.stderr
@@ -40,12 +40,6 @@ error[E0562]: `impl Trait` only allowed in function and inherent method return t
 LL | fn bad_in_fn_syntax(x: fn() -> impl Into<impl Debug>) {}
    |                                ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/nested_impl_trait.rs:27:42
-   |
-LL | fn allowed_in_ret_type() -> impl Fn() -> impl Into<u32> {
-   |                                          ^^^^^^^^^^^^^^
-
 error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfied
   --> $DIR/nested_impl_trait.rs:5:46
    |
@@ -64,7 +58,7 @@ LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    = help: the trait `Into<U>` is implemented for `T`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0277, E0562, E0666.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/impl-trait/where-allowed.rs
+++ b/src/test/ui/impl-trait/where-allowed.rs
@@ -1,5 +1,6 @@
 //! A simple test for testing many permutations of allowedness of
 //! impl Trait
+#![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
 // Allowed

--- a/src/test/ui/impl-trait/where-allowed.rs
+++ b/src/test/ui/impl-trait/where-allowed.rs
@@ -39,9 +39,8 @@ fn in_dyn_Fn_return_in_parameters(_: &dyn Fn() -> impl Debug) { panic!() }
 fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!() }
 //~^ ERROR `impl Trait` only allowed in function and inherent method return types
 
-// Disallowed
+// Allowed
 fn in_dyn_Fn_return_in_return() -> &'static dyn Fn() -> impl Debug { panic!() }
-//~^ ERROR `impl Trait` only allowed in function and inherent method return types
 
 // Disallowed
 fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
@@ -57,9 +56,8 @@ fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
 //~^ ERROR `impl Trait` only allowed in function and inherent method return types
 //~| ERROR nested `impl Trait` is not allowed
 
-// Disallowed
+// Allowed
 fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { panic!() }
-//~^ ERROR `impl Trait` only allowed in function and inherent method return types
 
 // Disallowed
 fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }

--- a/src/test/ui/impl-trait/where-allowed.stderr
+++ b/src/test/ui/impl-trait/where-allowed.stderr
@@ -1,5 +1,5 @@
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:46:51
+  --> $DIR/where-allowed.rs:47:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           --------^^^^^^^^^^-
@@ -8,7 +8,7 @@ LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           outer `impl Trait`
 
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:55:57
+  --> $DIR/where-allowed.rs:56:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                 --------^^^^^^^^^^-
@@ -17,7 +17,7 @@ LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic
    |                                                 outer `impl Trait`
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:117:16
+  --> $DIR/where-allowed.rs:118:16
    |
 LL |     type Out = impl Debug;
    |                ^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     type Out = impl Debug;
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:152:23
+  --> $DIR/where-allowed.rs:153:23
    |
 LL | type InTypeAlias<R> = impl Debug;
    |                       ^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | type InTypeAlias<R> = impl Debug;
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:155:39
+  --> $DIR/where-allowed.rs:156:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
@@ -44,109 +44,109 @@ LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer param
-  --> $DIR/where-allowed.rs:15:40
+  --> $DIR/where-allowed.rs:16:40
    |
 LL | fn in_fn_parameter_in_parameters(_: fn(impl Debug)) { panic!() }
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
-  --> $DIR/where-allowed.rs:19:42
+  --> $DIR/where-allowed.rs:20:42
    |
 LL | fn in_fn_return_in_parameters(_: fn() -> impl Debug) { panic!() }
    |                                          ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer param
-  --> $DIR/where-allowed.rs:23:38
+  --> $DIR/where-allowed.rs:24:38
    |
 LL | fn in_fn_parameter_in_return() -> fn(impl Debug) { panic!() }
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
-  --> $DIR/where-allowed.rs:27:40
+  --> $DIR/where-allowed.rs:28:40
    |
 LL | fn in_fn_return_in_return() -> fn() -> impl Debug { panic!() }
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:31:49
+  --> $DIR/where-allowed.rs:32:49
    |
 LL | fn in_dyn_Fn_parameter_in_parameters(_: &dyn Fn(impl Debug)) { panic!() }
    |                                                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:35:51
+  --> $DIR/where-allowed.rs:36:51
    |
 LL | fn in_dyn_Fn_return_in_parameters(_: &dyn Fn() -> impl Debug) { panic!() }
    |                                                   ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:39:55
+  --> $DIR/where-allowed.rs:40:55
    |
 LL | fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!() }
    |                                                       ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:46:51
+  --> $DIR/where-allowed.rs:47:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                                   ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:51:53
+  --> $DIR/where-allowed.rs:52:53
    |
 LL | fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() }
    |                                                     ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:55:57
+  --> $DIR/where-allowed.rs:56:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:63:38
+  --> $DIR/where-allowed.rs:64:38
    |
 LL | fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:67:40
+  --> $DIR/where-allowed.rs:68:40
    |
 LL | fn in_Fn_return_in_generics<F: Fn() -> impl Debug> (_: F) { panic!() }
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:80:32
+  --> $DIR/where-allowed.rs:81:32
    |
 LL | struct InBraceStructField { x: impl Debug }
    |                                ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in path
-  --> $DIR/where-allowed.rs:84:41
+  --> $DIR/where-allowed.rs:85:41
    |
 LL | struct InAdtInBraceStructField { x: Vec<impl Debug> }
    |                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:88:27
+  --> $DIR/where-allowed.rs:89:27
    |
 LL | struct InTupleStructField(impl Debug);
    |                           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:93:25
+  --> $DIR/where-allowed.rs:94:25
    |
 LL |     InBraceVariant { x: impl Debug },
    |                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:95:20
+  --> $DIR/where-allowed.rs:96:20
    |
 LL |     InTupleVariant(impl Debug),
    |                    ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
-  --> $DIR/where-allowed.rs:106:23
+  --> $DIR/where-allowed.rs:107:23
    |
 LL |     fn in_return() -> impl Debug;
    |                       ^^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     fn in_return() -> impl Debug;
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return
-  --> $DIR/where-allowed.rs:123:34
+  --> $DIR/where-allowed.rs:124:34
    |
 LL |     fn in_trait_impl_return() -> impl Debug { () }
    |                                  ^^^^^^^^^^
@@ -164,127 +164,127 @@ LL |     fn in_trait_impl_return() -> impl Debug { () }
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` param
-  --> $DIR/where-allowed.rs:136:33
+  --> $DIR/where-allowed.rs:137:33
    |
 LL |     fn in_foreign_parameters(_: impl Debug);
    |                                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` return
-  --> $DIR/where-allowed.rs:139:31
+  --> $DIR/where-allowed.rs:140:31
    |
 LL |     fn in_foreign_return() -> impl Debug;
    |                               ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
-  --> $DIR/where-allowed.rs:155:39
+  --> $DIR/where-allowed.rs:156:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait
-  --> $DIR/where-allowed.rs:160:16
+  --> $DIR/where-allowed.rs:161:16
    |
 LL | impl PartialEq<impl Debug> for () {
    |                ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:165:24
+  --> $DIR/where-allowed.rs:166:24
    |
 LL | impl PartialEq<()> for impl Debug {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:170:6
+  --> $DIR/where-allowed.rs:171:6
    |
 LL | impl impl Debug {
    |      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:176:24
+  --> $DIR/where-allowed.rs:177:24
    |
 LL | impl InInherentImplAdt<impl Debug> {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:182:11
+  --> $DIR/where-allowed.rs:183:11
    |
 LL |     where impl Debug: Debug
    |           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:189:15
+  --> $DIR/where-allowed.rs:190:15
    |
 LL |     where Vec<impl Debug>: Debug
    |               ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
-  --> $DIR/where-allowed.rs:196:24
+  --> $DIR/where-allowed.rs:197:24
    |
 LL |     where T: PartialEq<impl Debug>
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:203:17
+  --> $DIR/where-allowed.rs:204:17
    |
 LL |     where T: Fn(impl Debug)
    |                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:210:22
+  --> $DIR/where-allowed.rs:211:22
    |
 LL |     where T: Fn() -> impl Debug
    |                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:216:40
+  --> $DIR/where-allowed.rs:217:40
    |
 LL | struct InStructGenericParamDefault<T = impl Debug>(T);
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:220:36
+  --> $DIR/where-allowed.rs:221:36
    |
 LL | enum InEnumGenericParamDefault<T = impl Debug> { Variant(T) }
    |                                    ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:224:38
+  --> $DIR/where-allowed.rs:225:38
    |
 LL | trait InTraitGenericParamDefault<T = impl Debug> {}
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:228:41
+  --> $DIR/where-allowed.rs:229:41
    |
 LL | type InTypeAliasGenericParamDefault<T = impl Debug> = T;
    |                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:232:11
+  --> $DIR/where-allowed.rs:233:11
    |
 LL | impl <T = impl Debug> T {}
    |           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:239:40
+  --> $DIR/where-allowed.rs:240:40
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
-  --> $DIR/where-allowed.rs:245:29
+  --> $DIR/where-allowed.rs:246:29
    |
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in closure return
-  --> $DIR/where-allowed.rs:247:46
+  --> $DIR/where-allowed.rs:248:46
    |
 LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };
    |                                              ^^^^^^^^^
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:232:7
+  --> $DIR/where-allowed.rs:233:7
    |
 LL | impl <T = impl Debug> T {}
    |       ^^^^^^^^^^^^^^
@@ -294,7 +294,7 @@ LL | impl <T = impl Debug> T {}
    = note: `#[deny(invalid_type_param_default)]` on by default
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:239:36
+  --> $DIR/where-allowed.rs:240:36
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                    ^^^^^^^^^^^^^^
@@ -303,7 +303,7 @@ LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
 error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/where-allowed.rs:232:23
+  --> $DIR/where-allowed.rs:233:23
    |
 LL | impl <T = impl Debug> T {}
    |                       ^ impl requires a nominal type

--- a/src/test/ui/impl-trait/where-allowed.stderr
+++ b/src/test/ui/impl-trait/where-allowed.stderr
@@ -1,5 +1,5 @@
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:47:51
+  --> $DIR/where-allowed.rs:46:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           --------^^^^^^^^^^-
@@ -8,7 +8,7 @@ LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           outer `impl Trait`
 
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:56:57
+  --> $DIR/where-allowed.rs:55:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                 --------^^^^^^^^^^-
@@ -17,7 +17,7 @@ LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic
    |                                                 outer `impl Trait`
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:119:16
+  --> $DIR/where-allowed.rs:117:16
    |
 LL |     type Out = impl Debug;
    |                ^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     type Out = impl Debug;
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:154:23
+  --> $DIR/where-allowed.rs:152:23
    |
 LL | type InTypeAlias<R> = impl Debug;
    |                       ^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | type InTypeAlias<R> = impl Debug;
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:157:39
+  --> $DIR/where-allowed.rs:155:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
@@ -85,80 +85,68 @@ error[E0562]: `impl Trait` only allowed in function and inherent method return t
 LL | fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!() }
    |                                                       ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:43:57
-   |
-LL | fn in_dyn_Fn_return_in_return() -> &'static dyn Fn() -> impl Debug { panic!() }
-   |                                                         ^^^^^^^^^^
-
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:47:51
+  --> $DIR/where-allowed.rs:46:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                                   ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:52:53
+  --> $DIR/where-allowed.rs:51:53
    |
 LL | fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() }
    |                                                     ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:56:57
+  --> $DIR/where-allowed.rs:55:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                         ^^^^^^^^^^
 
-error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:61:59
-   |
-LL | fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { panic!() }
-   |                                                           ^^^^^^^^^^
-
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:65:38
+  --> $DIR/where-allowed.rs:63:38
    |
 LL | fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:69:40
+  --> $DIR/where-allowed.rs:67:40
    |
 LL | fn in_Fn_return_in_generics<F: Fn() -> impl Debug> (_: F) { panic!() }
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:82:32
+  --> $DIR/where-allowed.rs:80:32
    |
 LL | struct InBraceStructField { x: impl Debug }
    |                                ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in path
-  --> $DIR/where-allowed.rs:86:41
+  --> $DIR/where-allowed.rs:84:41
    |
 LL | struct InAdtInBraceStructField { x: Vec<impl Debug> }
    |                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:90:27
+  --> $DIR/where-allowed.rs:88:27
    |
 LL | struct InTupleStructField(impl Debug);
    |                           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:95:25
+  --> $DIR/where-allowed.rs:93:25
    |
 LL |     InBraceVariant { x: impl Debug },
    |                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:97:20
+  --> $DIR/where-allowed.rs:95:20
    |
 LL |     InTupleVariant(impl Debug),
    |                    ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return
-  --> $DIR/where-allowed.rs:108:23
+  --> $DIR/where-allowed.rs:106:23
    |
 LL |     fn in_return() -> impl Debug;
    |                       ^^^^^^^^^^
@@ -167,7 +155,7 @@ LL |     fn in_return() -> impl Debug;
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `impl` method return
-  --> $DIR/where-allowed.rs:125:34
+  --> $DIR/where-allowed.rs:123:34
    |
 LL |     fn in_trait_impl_return() -> impl Debug { () }
    |                                  ^^^^^^^^^^
@@ -176,127 +164,127 @@ LL |     fn in_trait_impl_return() -> impl Debug { () }
    = help: add `#![feature(return_position_impl_trait_in_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` param
-  --> $DIR/where-allowed.rs:138:33
+  --> $DIR/where-allowed.rs:136:33
    |
 LL |     fn in_foreign_parameters(_: impl Debug);
    |                                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `extern fn` return
-  --> $DIR/where-allowed.rs:141:31
+  --> $DIR/where-allowed.rs:139:31
    |
 LL |     fn in_foreign_return() -> impl Debug;
    |                               ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `fn` pointer return
-  --> $DIR/where-allowed.rs:157:39
+  --> $DIR/where-allowed.rs:155:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait
-  --> $DIR/where-allowed.rs:162:16
+  --> $DIR/where-allowed.rs:160:16
    |
 LL | impl PartialEq<impl Debug> for () {
    |                ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:167:24
+  --> $DIR/where-allowed.rs:165:24
    |
 LL | impl PartialEq<()> for impl Debug {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:172:6
+  --> $DIR/where-allowed.rs:170:6
    |
 LL | impl impl Debug {
    |      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:178:24
+  --> $DIR/where-allowed.rs:176:24
    |
 LL | impl InInherentImplAdt<impl Debug> {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:184:11
+  --> $DIR/where-allowed.rs:182:11
    |
 LL |     where impl Debug: Debug
    |           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:191:15
+  --> $DIR/where-allowed.rs:189:15
    |
 LL |     where Vec<impl Debug>: Debug
    |               ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in bound
-  --> $DIR/where-allowed.rs:198:24
+  --> $DIR/where-allowed.rs:196:24
    |
 LL |     where T: PartialEq<impl Debug>
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait param
-  --> $DIR/where-allowed.rs:205:17
+  --> $DIR/where-allowed.rs:203:17
    |
 LL |     where T: Fn(impl Debug)
    |                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in `Fn` trait return
-  --> $DIR/where-allowed.rs:212:22
+  --> $DIR/where-allowed.rs:210:22
    |
 LL |     where T: Fn() -> impl Debug
    |                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:218:40
+  --> $DIR/where-allowed.rs:216:40
    |
 LL | struct InStructGenericParamDefault<T = impl Debug>(T);
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:222:36
+  --> $DIR/where-allowed.rs:220:36
    |
 LL | enum InEnumGenericParamDefault<T = impl Debug> { Variant(T) }
    |                                    ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:226:38
+  --> $DIR/where-allowed.rs:224:38
    |
 LL | trait InTraitGenericParamDefault<T = impl Debug> {}
    |                                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:230:41
+  --> $DIR/where-allowed.rs:228:41
    |
 LL | type InTypeAliasGenericParamDefault<T = impl Debug> = T;
    |                                         ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:234:11
+  --> $DIR/where-allowed.rs:232:11
    |
 LL | impl <T = impl Debug> T {}
    |           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in type
-  --> $DIR/where-allowed.rs:241:40
+  --> $DIR/where-allowed.rs:239:40
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in variable binding
-  --> $DIR/where-allowed.rs:247:29
+  --> $DIR/where-allowed.rs:245:29
    |
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
 
 error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in closure return
-  --> $DIR/where-allowed.rs:249:46
+  --> $DIR/where-allowed.rs:247:46
    |
 LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };
    |                                              ^^^^^^^^^
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:234:7
+  --> $DIR/where-allowed.rs:232:7
    |
 LL | impl <T = impl Debug> T {}
    |       ^^^^^^^^^^^^^^
@@ -306,7 +294,7 @@ LL | impl <T = impl Debug> T {}
    = note: `#[deny(invalid_type_param_default)]` on by default
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:241:36
+  --> $DIR/where-allowed.rs:239:36
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                    ^^^^^^^^^^^^^^
@@ -315,14 +303,14 @@ LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
 error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/where-allowed.rs:234:23
+  --> $DIR/where-allowed.rs:232:23
    |
 LL | impl <T = impl Debug> T {}
    |                       ^ impl requires a nominal type
    |
    = note: either implement a trait on it or create a newtype to wrap it instead
 
-error: aborting due to 49 previous errors
+error: aborting due to 47 previous errors
 
 Some errors have detailed explanations: E0118, E0562, E0658, E0666.
 For more information about an error, try `rustc --explain E0118`.

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -2,7 +2,7 @@ error[E0574]: expected struct, variant or union type, found type parameter `T`
   --> $DIR/lexical-scopes.rs:3:13
    |
 LL | struct T { i: i32 }
-   | ------------------- you might have meant to refer to this struct
+   |        - you might have meant to refer to this struct
 LL | fn f<T>() {
    |      - found this type parameter
 LL |     let t = T { i: 0 };

--- a/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
+++ b/src/test/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
@@ -1,16 +1,14 @@
 error[E0574]: expected struct, variant or union type, found type parameter `Baz`
   --> $DIR/point-at-type-parameter-shadowing-another-type.rs:16:13
    |
-LL | / struct Baz {
-LL | |     num: usize,
-LL | | }
-   | |_- you might have meant to refer to this struct
-LL |
-LL |   impl<Baz> Foo<Baz> for Bar {
-   |        --- found this type parameter
+LL | struct Baz {
+   |        --- you might have meant to refer to this struct
 ...
-LL |               Baz { num } => num,
-   |               ^^^ not a struct, variant or union type
+LL | impl<Baz> Foo<Baz> for Bar {
+   |      --- found this type parameter
+...
+LL |             Baz { num } => num,
+   |             ^^^ not a struct, variant or union type
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -1,6 +1,9 @@
 error[E0404]: expected trait, found type parameter `Add`
   --> $DIR/issue-35987.rs:5:21
    |
+LL | use std::ops::Add;
+   |               --- you might have meant to refer to this trait
+LL |
 LL | impl<T: Clone, Add> Add for Foo<T> {
    |                ---  ^^^ not a trait
    |                |


### PR DESCRIPTION
Successful merges:

 - #93582 (Allow `impl Fn() -> impl Trait` in return position)
 - #103560 (Point only to the identifiers in the typo suggestions of shadowed names instead of the entire struct)
 - #103588 (rustdoc: add missing URL redirect)
 - #103689 (Do fewer passes and generally be more efficient when filtering tests)
 - #103740 (rustdoc: remove unnecessary CSS `.search-results { padding-bottom }`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93582,103560,103588,103689,103740)
<!-- homu-ignore:end -->