### PR TITLE
Mention const and lifetime parameters in error E0207

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0207.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0207.md
@@ -1,4 +1,5 @@
-A type parameter that is specified for `impl` is not constrained.
+A type, const or lifetime parameter that is specified for `impl` is not
+constrained.
 
 Erroneous code example:
 
@@ -14,14 +15,17 @@ impl<T: Default> Foo {
 }
 ```
 
-Any type parameter of an `impl` must meet at least one of
-the following criteria:
+Any type or const parameter of an `impl` must meet at least one of the
+following criteria:
 
  - it appears in the _implementing type_ of the impl, e.g. `impl<T> Foo<T>`
  - for a trait impl, it appears in the _implemented trait_, e.g.
    `impl<T> SomeTrait<T> for Foo`
  - it is bound as an associated type, e.g. `impl<T, U> SomeTrait for T
    where T: AnotherTrait<AssocType=U>`
+
+Any unconstrained lifetime parameter of an `impl` is not supported if the
+lifetime parameter is used by an associated type.
 
 ### Error example 1
 
@@ -31,7 +35,6 @@ The previous code example has a definition which leads to a compiler error:
 The problem is that the parameter `T` does not appear in the implementing type
 (`Foo`) of the impl. In this case, we can fix the error by moving the type
 parameter from the `impl` to the method `get`:
-
 
 ```
 struct Foo;
@@ -127,6 +130,70 @@ impl<T: Default> Maker<Foo<T>> for FooMaker {
     }
 }
 ```
+
+### Error example 3
+
+Suppose we have a struct `Foo` and we would like to define some methods for it.
+The following code example has a definition which leads to a compiler error:
+
+```compile_fail,E0207
+struct Foo;
+
+impl<const T: i32> Foo {
+    // error: the const parameter `T` is not constrained by the impl trait, self
+    // type, or predicates [E0207]
+    fn get(&self) -> i32 {
+        i32::default()
+    }
+}
+```
+
+The problem is that the const parameter `T` does not appear in the implementing
+type (`Foo`) of the impl. In this case, we can fix the error by moving the type
+parameter from the `impl` to the method `get`:
+
+
+```
+struct Foo;
+
+// Move the const parameter from the impl to the method
+impl Foo {
+    fn get<const T: i32>(&self) -> i32 {
+        i32::default()
+    }
+}
+```
+
+### Error example 4
+
+Suppose we have a struct `Foo` and a struct `Bar` that uses lifetime `'a`. We
+would like to implement trait `Contains` for `Foo`. The trait `Contains` have
+the associated type `B`. The following code example has a definition which
+leads to a compiler error:
+
+```compile_fail,E0207
+struct Foo;
+struct Bar<'a>;
+
+trait Contains {
+    type B;
+
+    fn get(&self) -> i32;
+}
+
+impl<'a> Contains for Foo {
+    type B = Bar<'a>;
+
+    // error: the lifetime parameter `'a` is not constrained by the impl trait,
+    // self type, or predicates [E0207]
+    fn get(&self) -> i32 {
+        i32::default()
+    }
+}
+```
+
+Please note that unconstrained lifetime parameters are not supported if they are
+being used by an associated type.
 
 ### Additional information
 


### PR DESCRIPTION
Error Index for E0207 must mention const and lifetime parameters. In addition, add code examples for these situations.

Fixes #80862