### PR TITLE
Add regression test for reexports in search results

### DIFF
--- a/src/test/rustdoc-js/reexport.js
+++ b/src/test/rustdoc-js/reexport.js
@@ -1,0 +1,17 @@
+// exact-check
+
+const QUERY = ['Subscriber', 'AnotherOne'];
+
+const EXPECTED = [
+    {
+        'others': [
+            { 'path': 'reexport::fmt', 'name': 'Subscriber' },
+            { 'path': 'reexport', 'name': 'FmtSubscriber' },
+        ],
+    },
+    {
+        'others': [
+            { 'path': 'reexport', 'name': 'AnotherOne' },
+        ],
+    },
+];

--- a/src/test/rustdoc-js/reexport.rs
+++ b/src/test/rustdoc-js/reexport.rs
@@ -1,0 +1,11 @@
+// This test enforces that the (renamed) reexports are present in the search results.
+
+pub mod fmt {
+    pub struct Subscriber;
+}
+mod foo {
+    pub struct AnotherOne;
+}
+
+pub use foo::AnotherOne;
+pub use fmt::Subscriber as FmtSubscriber;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/86337.

r? @notriddle 