### PR TITLE
All verbosity checks in `PrettyPrinter` now go through `PrettyPrinter::should_print_verbose`

### DIFF
--- a/src/test/ui/type/issue-94187-verbose-type-name.rs
+++ b/src/test/ui/type/issue-94187-verbose-type-name.rs
@@ -1,13 +1,19 @@
-// Check to insure that the output of `std::any::type_name` does not change based on -Zverbose
-// when printing constants
+// Check to insure that the output of `std::any::type_name` does not change based on `-Zverbose`
 // run-pass
 // edition: 2018
 // revisions: normal verbose
 // [verbose]compile-flags:-Zverbose
 
-struct Wrapper<const VALUE: usize>;
+use std::any::type_name;
 
 fn main() {
-    assert_eq!(std::any::type_name::<[u32; 0]>(), "[u32; 0]");
-    assert_eq!(std::any::type_name::<Wrapper<0>>(), "issue_94187_verbose_type_name::Wrapper<0>");
+    assert_eq!(type_name::<[u32; 0]>(), "[u32; 0]");
+
+    struct Wrapper<const VALUE: usize>;
+    assert_eq!(type_name::<Wrapper<0>>(), "issue_94187_verbose_type_name::main::Wrapper<0>");
+
+    assert_eq!(
+        type_name::<dyn Fn(u32) -> u32>(),
+        "dyn core::ops::function::Fn<(u32,)>+Output = u32"
+    );
 }


### PR DESCRIPTION
Follow-up to #103428. That pr only partially fixed #94187. In some cases (like closures) `std::any::type_name` was still producing a different output when `-Zverbose` was enabled.

This pr fixes those cases and adds a new function `PrettyPrinter::should_print_verbose`. This function should always be used over `self.tcx().sess.verbose()` inside a `impl PrettyPrinter`.

Maybe closes #94187 now.

r? @compiler-errors 