### PR TITLE
Format `dyn Trait` better in `type_name` intrinsic

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -73,18 +73,10 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
     }
 
     fn print_dyn_existential(
-        mut self,
+        self,
         predicates: &'tcx ty::List<ty::Binder<'tcx, ty::ExistentialPredicate<'tcx>>>,
     ) -> Result<Self::DynExistential, Self::Error> {
-        let mut first = true;
-        for p in predicates {
-            if !first {
-                write!(self, "+")?;
-            }
-            first = false;
-            self = p.print(self)?;
-        }
-        Ok(self)
+        self.pretty_print_dyn_existential(predicates)
     }
 
     fn path_crate(mut self, cnum: CrateNum) -> Result<Self::Path, Self::Error> {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1137,7 +1137,7 @@ pub trait PrettyPrinter<'tcx>:
         //
         // To avoid causing instabilities in compiletest
         // output, sort the auto-traits alphabetically.
-        auto_traits.sort_by_cached_key(|did| self.tcx().def_path_str(*did));
+        auto_traits.sort_by_cached_key(|did| with_no_trimmed_paths!(self.tcx().def_path_str(*did)));
 
         for def_id in auto_traits {
             if !first {

--- a/library/core/tests/any.rs
+++ b/library/core/tests/any.rs
@@ -131,6 +131,24 @@ fn distinct_type_names() {
     assert_ne!(type_name_of_val(Velocity), type_name_of_val(Velocity(0.0, -9.8)),);
 }
 
+#[cfg(not(bootstrap))]
+#[test]
+fn dyn_type_name() {
+    trait Foo {
+        type Bar;
+    }
+
+    assert_eq!(
+        "dyn core::ops::function::Fn(i32, i32) -> i32",
+        std::any::type_name::<dyn Fn(i32, i32) -> i32>()
+    );
+    assert_eq!(
+        "dyn coretests::any::dyn_type_name::Foo<Bar = i32> \
+        + core::marker::Send + core::marker::Sync",
+        std::any::type_name::<dyn Foo<Bar = i32> + Send + Sync>()
+    );
+}
+
 // Test the `Provider` API.
 
 struct SomeConcreteType {

--- a/src/test/ui/type/issue-94187-verbose-type-name.rs
+++ b/src/test/ui/type/issue-94187-verbose-type-name.rs
@@ -12,8 +12,5 @@ fn main() {
     struct Wrapper<const VALUE: usize>;
     assert_eq!(type_name::<Wrapper<0>>(), "issue_94187_verbose_type_name::main::Wrapper<0>");
 
-    assert_eq!(
-        type_name::<dyn Fn(u32) -> u32>(),
-        "dyn core::ops::function::Fn<(u32,)>+Output = u32"
-    );
+    assert_eq!(type_name::<dyn Fn(u32) -> u32>(), "dyn core::ops::function::Fn(u32) -> u32");
 }


### PR DESCRIPTION
Noticed this in #103764 (though not related to that PR at all!)

```rust
trait Foo {
    type Bar;
}

fn main() {
    println!(
        "`dyn Fn(i32, i32) -> i32` => `{}`",
        std::any::type_name::<dyn Fn(i32, i32) -> i32>()
    );
    println!(
        "`dyn Foo<Bar = i32> + Send + Sync` => `{}`",
        std::any::type_name::<dyn Foo<Bar = i32> + Send + Sync>()
    );
}
```

```
`dyn Fn(i32, i32) -> i32` => `dyn core::ops::function::Fn<(i32, i32)>+Output = i32`
`dyn Foo<Bar = i32> + Send + Sync` => `dyn playground::Foo+Bar = i32+core::marker::Sync+core::marker::Send`
```

Just reuse `pretty_print_dyn_existential` which already makes an attempt to make its output stable.