### PR TITLE
Fix late-bound lifetime closure ICEs in HIR typeck and MIR borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -2314,7 +2314,7 @@ impl<'tcx> ClosureRegionRequirementsExt<'tcx> for ClosureRegionRequirements<'tcx
             tcx,
             closure_substs,
             self.num_external_vids,
-            tcx.typeck_root_def_id(closure_def_id),
+            closure_def_id.expect_local(),
         );
         debug!("apply_requirements: closure_mapping={:?}", closure_mapping);
 

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -869,6 +869,10 @@ fn for_each_late_bound_region_in_item<'tcx>(
     mir_def_id: LocalDefId,
     mut f: impl FnMut(ty::Region<'tcx>),
 ) {
+    if !tcx.def_kind(mir_def_id).is_fn_like() {
+        return;
+    }
+
     for bound_var in tcx.late_bound_vars(tcx.hir().local_def_id_to_hir_id(mir_def_id)) {
         let ty::BoundVariableKind::Region(bound_region) = bound_var else { continue; };
         let liberated_region = tcx

--- a/compiler/rustc_hir_analysis/src/collect/lifetimes.rs
+++ b/compiler/rustc_hir_analysis/src/collect/lifetimes.rs
@@ -1377,11 +1377,12 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             } else if let Some(body_id) = outermost_body {
                 let fn_id = self.tcx.hir().body_owner(body_id);
                 match self.tcx.hir().get(fn_id) {
-                    Node::Item(&hir::Item { kind: hir::ItemKind::Fn(..), .. })
-                    | Node::TraitItem(&hir::TraitItem {
+                    Node::Item(hir::Item { kind: hir::ItemKind::Fn(..), .. })
+                    | Node::TraitItem(hir::TraitItem {
                         kind: hir::TraitItemKind::Fn(..), ..
                     })
-                    | Node::ImplItem(&hir::ImplItem { kind: hir::ImplItemKind::Fn(..), .. }) => {
+                    | Node::ImplItem(hir::ImplItem { kind: hir::ImplItemKind::Fn(..), .. })
+                    | Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(..), .. }) => {
                         let scope = self.tcx.hir().local_def_id(fn_id);
                         def = Region::Free(scope.to_def_id(), def.id().unwrap());
                     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2895,7 +2895,9 @@ impl<'tcx> TyCtxt<'tcx> {
         self.mk_bound_variable_kinds(
             self.late_bound_vars_map(id.owner)
                 .and_then(|map| map.get(&id.local_id).cloned())
-                .unwrap_or_default()
+                .unwrap_or_else(|| {
+                    bug!("No bound vars found for {:?} ({:?})", self.hir().node_to_string(id), id)
+                })
                 .iter(),
         )
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2895,9 +2895,7 @@ impl<'tcx> TyCtxt<'tcx> {
         self.mk_bound_variable_kinds(
             self.late_bound_vars_map(id.owner)
                 .and_then(|map| map.get(&id.local_id).cloned())
-                .unwrap_or_else(|| {
-                    bug!("No bound vars found for {:?} ({:?})", self.hir().node_to_string(id), id)
-                })
+                .unwrap_or_default()
                 .iter(),
         )
     }

--- a/src/test/ui/closures/binder/late-bound-in-body.rs
+++ b/src/test/ui/closures/binder/late-bound-in-body.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(closure_lifetime_binder)]
+
+fn main() {
+    let _ = for<'a> || -> () {
+        let _: &'a bool = &true;
+    };
+}

--- a/src/test/ui/closures/binder/nested-closures-regions.rs
+++ b/src/test/ui/closures/binder/nested-closures-regions.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(closure_lifetime_binder)]
+#![feature(rustc_attrs)]
+
+#[rustc_regions]
+fn main() {
+    for<'a> || -> () { for<'c> |_: &'a ()| -> () {}; };
+}

--- a/src/test/ui/closures/binder/nested-closures-regions.stderr
+++ b/src/test/ui/closures/binder/nested-closures-regions.stderr
@@ -1,0 +1,38 @@
+note: external requirements
+  --> $DIR/nested-closures-regions.rs:8:24
+   |
+LL |     for<'a> || -> () { for<'c> |_: &'a ()| -> () {}; };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: main::{closure#0}::{closure#0} with closure substs [
+               i8,
+               extern "rust-call" fn((&(),)),
+               (),
+           ]
+   = note: late-bound region is '_#4r
+   = note: late-bound region is '_#2r
+   = note: number of external vids: 3
+   = note: where '_#1r: '_#2r
+   = note: where '_#2r: '_#1r
+
+note: no external requirements
+  --> $DIR/nested-closures-regions.rs:8:5
+   |
+LL |     for<'a> || -> () { for<'c> |_: &'a ()| -> () {}; };
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: main::{closure#0} with closure substs [
+               i8,
+               extern "rust-call" fn(()),
+               (),
+           ]
+   = note: late-bound region is '_#2r
+
+note: no external requirements
+  --> $DIR/nested-closures-regions.rs:7:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
+   |
+   = note: defining type: main
+

--- a/src/test/ui/closures/binder/nested-closures.rs
+++ b/src/test/ui/closures/binder/nested-closures.rs
@@ -1,0 +1,7 @@
+// check-pass
+
+#![feature(closure_lifetime_binder)]
+
+fn main() {
+    for<'a> || -> () { for<'c> |_: &'a ()| -> () {}; };
+}


### PR DESCRIPTION
During HIR typeck, we need to teach astconv to treat late-bound regions within a closure body as free, fixing escaping bound vars ICEs in both of the issues below. 

However, this then gets us to MIR borrowck, which itself needs to be taught how to instantiate free region vids for late-bound regions that come from items that _aren't_ the typeck root (for now, just closures).

Fixes #103771
Fixes #103736