### PR TITLE
rustdoc: add margins to all impl-item toggles, not just methods

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1961,24 +1961,26 @@ in storage.js
 	}
 }
 
-.method-toggle > summary,
 .implementors-toggle > summary,
 .impl,
 #implementors-list > .docblock,
 .impl-items > section,
-.methods > section
+.impl-items > .rustdoc-toggle > summary,
+.methods > section,
+.methods > .rustdoc-toggle > summary
 {
 	margin-bottom: 0.75em;
 }
 
-.method-toggle[open]:not(:last-child),
+.impl-items > .rustdoc-toggle[open]:not(:last-child),
+.methods > .rustdoc-toggle[open]:not(:last-child),
 .implementors-toggle[open]:not(:last-child) {
 	margin-bottom: 2em;
 }
 
-#trait-implementations-list .method-toggle:not(:last-child),
-#synthetic-implementations-list .method-toggle:not(:last-child),
-#blanket-implementations-list .method-toggle:not(:last-child) {
+#trait-implementations-list .impl-items > .rustdoc-toggle:not(:last-child),
+#synthetic-implementations-list .impl-items > .rustdoc-toggle:not(:last-child),
+#blanket-implementations-list .impl-items > .rustdoc-toggle:not(:last-child) {
 	margin-bottom: 1em;
 }
 

--- a/src/test/rustdoc-gui/method-margins.goml
+++ b/src/test/rustdoc-gui/method-margins.goml
@@ -1,0 +1,17 @@
+goto: "file://" + |DOC_PATH| + "/test_docs/trait_members/struct.HasTrait.html#impl-TraitMembers-for-HasTrait"
+
+assert-count: ("#trait-implementations-list > .rustdoc-toggle", 1)
+
+compare-elements-css: (
+    // compare margin on type with margin on method
+    "#trait-implementations-list .impl-items > .rustdoc-toggle:nth-child(1) > summary",
+    "#trait-implementations-list .impl-items > .rustdoc-toggle:nth-child(2) > summary",
+    ["margin"]
+)
+
+compare-elements-css: (
+    // compare margin on type with margin on method
+    "#trait-implementations-list .impl-items > .rustdoc-toggle:nth-child(1)",
+    "#trait-implementations-list .impl-items > .rustdoc-toggle:nth-child(2)",
+    ["margin"]
+)

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -416,3 +416,20 @@ pub trait TraitWithoutGenerics {
 
     fn foo();
 }
+
+pub mod trait_members {
+    pub trait TraitMembers {
+        /// Some type
+        type Type;
+        /// Some function
+        fn function();
+        /// Some other function
+        fn function2();
+    }
+    pub struct HasTrait;
+    impl TraitMembers for HasTrait {
+        type Type = u8;
+        fn function() {}
+        fn function2() {}
+    }
+}


### PR DESCRIPTION
Fixes #103782

## Before

![image](https://user-images.githubusercontent.com/1593513/198943087-8cab8b25-2092-49d6-89b4-caa2989dedf0.png)

## After

![image](https://user-images.githubusercontent.com/1593513/198943111-bc08c2d6-f058-4362-b999-0caf09eb93bf.png)
