### PR TITLE
do not count non-codegen statement as estimzed cgu element

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -48,12 +48,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     .codegen_set_discr(&mut bx, variant_index);
                 bx
             }
-            mir::StatementKind::Deinit(..) => {
-                // For now, don't codegen this to anything. In the future it may be worth
-                // experimenting with what kind of information we can emit to LLVM without hurting
-                // perf here
-                bx
-            }
             mir::StatementKind::StorageLive(local) => {
                 if let LocalRef::Place(cg_place) = self.locals[local] {
                     cg_place.storage_live(&mut bx);
@@ -95,6 +89,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let dst = dst_val.immediate();
                 let src = src_val.immediate();
                 bx.memcpy(dst, align, src, align, bytes, crate::MemFlags::empty());
+                bx
+            }
+            mir::StatementKind::Deinit(..) => {
+                // For now, don't codegen this to anything. In the future it may be worth
+                // experimenting with what kind of information we can emit to LLVM without hurting
+                // perf here
                 bx
             }
             mir::StatementKind::FakeRead(..)

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -372,7 +372,7 @@ fn instance_def_size_estimate<'tcx>(
                                     | StatementKind::Nop
                             )
                         })
-                        .count()
+                        .count() + 1
                 })
                 .sum()
         }

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -372,7 +372,8 @@ fn instance_def_size_estimate<'tcx>(
                                     | StatementKind::Nop
                             )
                         })
-                        .count() + 1
+                        .count()
+                        + 1
                 })
                 .sum()
         }

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -1,6 +1,7 @@
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
+use rustc_middle::mir::StatementKind;
 use rustc_middle::ty::{self, Binder, Predicate, PredicateKind, ToPredicate, Ty, TyCtxt};
 use rustc_trait_selection::traits;
 
@@ -355,7 +356,25 @@ fn instance_def_size_estimate<'tcx>(
     match instance_def {
         InstanceDef::Item(..) | InstanceDef::DropGlue(..) => {
             let mir = tcx.instance_mir(instance_def);
-            mir.basic_blocks.iter().map(|bb| bb.statements.len() + 1).sum()
+            mir.basic_blocks
+                .iter()
+                .map(|bb| {
+                    bb.statements
+                        .iter()
+                        .filter(|s| {
+                            // do not count non-codegen statement
+                            !matches!(
+                                s.kind,
+                                StatementKind::Deinit(..)
+                                    | StatementKind::FakeRead(..)
+                                    | StatementKind::Retag { .. }
+                                    | StatementKind::AscribeUserType(..)
+                                    | StatementKind::Nop
+                            )
+                        })
+                        .count()
+                })
+                .sum()
         }
         // Estimate the size of other compiler-generated shims to be 1.
         _ => 1,


### PR DESCRIPTION
Found that some [statements](https://github.com/rust-lang/rust/blob/4596f4f8b565bdd02d3b99d1ab12ff09146a93de/compiler/rustc_codegen_ssa/src/mir/statement.rs#L100-L103) doesn't codegen nowadays, so they shouldn't be count as a element in cgu size estimation.

cc https://github.com/rust-lang/rust/issues/69382

r?@bjorn3 may I have a perf-run? 