### PR TITLE
rustdoc: remove unnecessary CSS `.search-results { clear: both }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -880,8 +880,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 
 .search-results.active {
 	display: block;
-	/* prevent overhanging tabs from moving the first result */
-	clear: both;
 }
 
 .search-results .desc > span {


### PR DESCRIPTION
Since the tabs use flexbox instead of float as of 44d9b8d07014d976c88f541dbe0af37e64e37bdd, clearing does nothing.