### PR TITLE
Fix json flag in bootstrap doc

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -689,6 +689,7 @@ impl<'a> Builder<'a> {
                 doc::UnstableBookGen,
                 doc::TheBook,
                 doc::Standalone,
+                doc::JsonStd,
                 doc::Std,
                 doc::Rustc,
                 doc::Rustdoc,

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -689,7 +689,6 @@ impl<'a> Builder<'a> {
                 doc::UnstableBookGen,
                 doc::TheBook,
                 doc::Standalone,
-                doc::JsonStd,
                 doc::Std,
                 doc::Rustc,
                 doc::Rustdoc,

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -19,6 +19,7 @@ use crate::cache::{Interned, INTERNER};
 use crate::channel;
 use crate::compile;
 use crate::config::TargetSelection;
+use crate::doc::DocumentationFormat;
 use crate::tarball::{GeneratedTarball, OverlayKind, Tarball};
 use crate::tool::{self, Tool};
 use crate::util::{exe, is_dylib, output, t, timeit};
@@ -97,7 +98,11 @@ impl Step for JsonDocs {
     /// Builds the `rust-docs-json` installer component.
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
         let host = self.host;
-        builder.ensure(crate::doc::JsonStd { stage: builder.top_stage, target: host });
+        builder.ensure(crate::doc::Std {
+            stage: builder.top_stage,
+            target: host,
+            format: DocumentationFormat::JSON,
+        });
 
         let dest = "share/doc/rust/json";
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -506,6 +506,11 @@ impl Step for Std {
 
         doc_std(builder, self.format, stage, target, &out, &extra_args, &requested_crates);
 
+        // Don't open if the format is json
+        if let DocumentationFormat::JSON = self.format {
+            return;
+        }
+
         // Look for library/std, library/core etc in the `x.py doc` arguments and
         // open the corresponding rendered docs.
         for requested_crate in requested_crates {

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -524,8 +524,13 @@ impl Step for JsonStd {
     const DEFAULT: bool = false;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        let default = run.builder.config.docs && run.builder.config.cmd.json();
-        run.all_krates("test").path("library").default_condition(default)
+        if run.builder.config.cmd.json() {
+            let default = run.builder.config.docs && run.builder.config.cmd.json();
+            run.all_krates("test").path("library").default_condition(default)
+        } else {
+            // Without this JsonStd would take priority on Std and prevent it from running.
+            run.never()
+        }
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -434,6 +434,7 @@ impl Step for SharedAssets {
 pub struct Std {
     pub stage: u32,
     pub target: TargetSelection,
+    pub format: DocumentationFormat,
 }
 
 impl Step for Std {
@@ -446,7 +447,15 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(Std { stage: run.builder.top_stage, target: run.target });
+        run.builder.ensure(Std {
+            stage: run.builder.top_stage,
+            target: run.target,
+            format: if run.builder.config.cmd.json() {
+                DocumentationFormat::JSON
+            } else {
+                DocumentationFormat::HTML
+            },
+        });
     }
 
     /// Compile all standard library documentation.
@@ -462,13 +471,16 @@ impl Step for Std {
         builder.ensure(SharedAssets { target: self.target });
 
         let index_page = builder.src.join("src/doc/index.md").into_os_string();
-        let mut extra_args = vec![
-            OsStr::new("--markdown-css"),
-            OsStr::new("rust.css"),
-            OsStr::new("--markdown-no-toc"),
-            OsStr::new("--index-page"),
-            &index_page,
-        ];
+        let mut extra_args = match self.format {
+            DocumentationFormat::HTML => vec![
+                OsStr::new("--markdown-css"),
+                OsStr::new("rust.css"),
+                OsStr::new("--markdown-no-toc"),
+                OsStr::new("--index-page"),
+                &index_page,
+            ],
+            DocumentationFormat::JSON => vec![OsStr::new("--output-format"), OsStr::new("json")],
+        };
 
         if !builder.config.docs_minification {
             extra_args.push(OsStr::new("--disable-minification"));
@@ -492,15 +504,7 @@ impl Step for Std {
             })
             .collect::<Vec<_>>();
 
-        doc_std(
-            builder,
-            DocumentationFormat::HTML,
-            stage,
-            target,
-            &out,
-            &extra_args,
-            &requested_crates,
-        );
+        doc_std(builder, self.format, stage, target, &out, &extra_args, &requested_crates);
 
         // Look for library/std, library/core etc in the `x.py doc` arguments and
         // open the corresponding rendered docs.
@@ -510,43 +514,6 @@ impl Step for Std {
                 open(builder, &index);
             }
         }
-    }
-}
-
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub struct JsonStd {
-    pub stage: u32,
-    pub target: TargetSelection,
-}
-
-impl Step for JsonStd {
-    type Output = ();
-    const DEFAULT: bool = false;
-
-    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        if run.builder.config.cmd.json() {
-            let default = run.builder.config.docs && run.builder.config.cmd.json();
-            run.all_krates("test").path("library").default_condition(default)
-        } else {
-            // Without this JsonStd would take priority on Std and prevent it from running.
-            run.never()
-        }
-    }
-
-    fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(JsonStd { stage: run.builder.top_stage, target: run.target });
-    }
-
-    /// Build JSON documentation for the standard library crates.
-    ///
-    /// This is largely just a wrapper around `cargo doc`.
-    fn run(self, builder: &Builder<'_>) {
-        let stage = self.stage;
-        let target = self.target;
-        let out = builder.json_doc_out(target);
-        t!(fs::create_dir_all(&out));
-        let extra_args = [OsStr::new("--output-format"), OsStr::new("json")];
-        doc_std(builder, DocumentationFormat::JSON, stage, target, &out, &extra_args, &[])
     }
 }
 
@@ -562,7 +529,7 @@ impl Step for JsonStd {
 const STD_PUBLIC_CRATES: [&str; 5] = ["core", "alloc", "std", "proc_macro", "test"];
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-enum DocumentationFormat {
+pub enum DocumentationFormat {
     HTML,
     JSON,
 }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -465,7 +465,11 @@ impl Step for Std {
     fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
-        let out = builder.doc_out(target);
+        let out = match self.format {
+            DocumentationFormat::HTML => builder.doc_out(target),
+            DocumentationFormat::JSON => builder.json_doc_out(target),
+        };
+
         t!(fs::create_dir_all(&out));
 
         builder.ensure(SharedAssets { target: self.target });

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -529,7 +529,7 @@ impl Step for JsonStd {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(Std { stage: run.builder.top_stage, target: run.target });
+        run.builder.ensure(JsonStd { stage: run.builder.top_stage, target: run.target });
     }
 
     /// Build JSON documentation for the standard library crates.

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -16,6 +16,7 @@ use crate::cache::Interned;
 use crate::compile;
 use crate::config::TargetSelection;
 use crate::dist;
+use crate::doc::DocumentationFormat;
 use crate::flags::Subcommand;
 use crate::native;
 use crate::tool::{self, SourceType, Tool};
@@ -822,7 +823,11 @@ impl Step for RustdocJSStd {
                     command.arg("--test-file").arg(path);
                 }
             }
-            builder.ensure(crate::doc::Std { target: self.target, stage: builder.top_stage });
+            builder.ensure(crate::doc::Std {
+                target: self.target,
+                stage: builder.top_stage,
+                format: DocumentationFormat::HTML,
+            });
             builder.run(&mut command);
         } else {
             builder.info("No nodejs found, skipping \"src/test/rustdoc-js-std\" tests");


### PR DESCRIPTION
Fix the `--json` flag not working with x.py (Closes #103816)

While this works I'm not sure about the `should_run` of `JsonStd`, had to change it because https://github.com/rust-lang/rust/blob/ab5a2bc7316012ee9b2a4a4f3821673f2677f3d5/src/bootstrap/builder.rs#L334 would match with JsonStd and remove the paths that Std matched. So I did [this](https://github.com/viandoxdev/rust/blob/ffd4078264c4892b5098d6191e0adfe3564d62ca/src/bootstrap/doc.rs#L526-L534) but that looks more like a hack/workaround than anything. I'm guessing there's something to do with the default condition thing but idk how it works