### PR TITLE
Don't remap early-bound regions for return-position `impl Trait` in trait originating from `impl`

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_method.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_method.rs
@@ -590,7 +590,13 @@ pub fn collect_trait_impl_trait_tys<'tcx>(
                 let num_trait_substs = trait_to_impl_substs.len();
                 let num_impl_substs = tcx.generics_of(impl_m.container_id(tcx)).params.len();
                 let ty = tcx.fold_regions(ty, |region, _| {
-                    let (ty::ReFree(_) | ty::ReEarlyBound(_)) = region.kind() else { return region; };
+                    match region.kind() {
+                        // Remap all free regions, which correspond to late-bound regions in the function.
+                        ty::ReFree(_) => {}
+                        // Remap early-bound regions as long as they don't come from the `impl` itself.
+                        ty::ReEarlyBound(ebr) if tcx.parent(ebr.def_id) != impl_m.container_id(tcx) => {}
+                        _ => return region,
+                    }
                     let Some(ty::ReEarlyBound(e)) = map.get(&region.into()).map(|r| r.expect_region().kind())
                     else {
                         tcx

--- a/src/test/ui/async-await/in-trait/early-bound-1.rs
+++ b/src/test/ui/async-await/in-trait/early-bound-1.rs
@@ -1,0 +1,17 @@
+// check-pass
+// edition:2021
+
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
+
+pub trait Foo {
+    async fn foo(&mut self);
+}
+
+struct MyFoo<'a>(&'a mut ());
+
+impl<'a> Foo for MyFoo<'a> {
+    async fn foo(&mut self) {}
+}
+
+fn main() {}

--- a/src/test/ui/async-await/in-trait/early-bound-2.rs
+++ b/src/test/ui/async-await/in-trait/early-bound-2.rs
@@ -1,0 +1,15 @@
+// check-pass
+// edition:2021
+
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
+
+pub trait Foo {
+    async fn foo(&mut self);
+}
+
+impl<T: Foo> Foo for &mut T {
+    async fn foo(&mut self) {}
+}
+
+fn main() {}


### PR DESCRIPTION
long title :sweat: 

We don't want to remap early-bound regions that originate from the `impl`s themselves, since they have no corresponding region in the trait. Not sure if there's a better condition than checking if the EBR's def-id's parent is the impl -- maybe we should be checking if the region comes from the method or RPITIT... :shrug: 

r? types

Fixes #103850