### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d855aeef205b43f65a5001e0997d81f8efca7badad4fad7d897aa7f0d0651f"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
 dependencies = [
  "curl-sys",
  "libc",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.55+curl-7.83.1"
+version = "0.4.59+curl-7.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23734ec77368ec583c2e61dd3f0b0e5c98b93abe6d2a004ca06b91dd7e3e2762"
+checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
14 commits in 7e484fc1a766f56dbc95380f45719698e0c82749..810cbad9a123ad4ee0a55a96171b8f8478ff1c03
2022-10-27 15:20:57 +0000 to 2022-11-02 21:04:31 +0000
- Update curl-sys (rust-lang/cargo#11326)
- Mention fix on build script deadlock (rust-lang/cargo#11325)
- Make cargo forward pre-existing CARGO if set (rust-lang/cargo#11285)
- Clean up workspace dependencies after cargo remove (rust-lang/cargo#11242)
- Update the outdated link for rust-semverver (rust-lang/cargo#11322)
- Fix broken link to compilation entry point (rust-lang/cargo#11317)
- Only remove fingerprints and build script artifacts of the requested package (rust-lang/cargo#10621)
- Newer anyhow features are required (rust-lang/cargo#11316)
- Clean stale git temp files (rust-lang/cargo#11308)
- Report crate size on package and publish (rust-lang/cargo#11270)
- add a note that some warnings (and/or errors) can be auto-fixed (rust-lang/cargo#10989)
- Update libcurl (rust-lang/cargo#11307)
- artifact deps shoud works when target field specified coexists with `optional = true` (rust-lang/cargo#11183)
- Fix singular verb in tests page (rust-lang/cargo#11300)




r? @ghost 