### PR TITLE
Remove `has_errors` from `FnCtxt`

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -220,7 +220,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Hide the outer diverging and has_errors flags.
         let old_diverges = self.diverges.replace(Diverges::Maybe);
-        let old_has_errors = self.has_errors.replace(false);
 
         let ty = ensure_sufficient_stack(|| match &expr.kind {
             hir::ExprKind::Path(
@@ -259,7 +258,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Combine the diverging and has_error flags.
         self.diverges.set(self.diverges.get() | old_diverges);
-        self.has_errors.set(self.has_errors.get() | old_has_errors);
 
         debug!("type of {} is...", self.tcx.hir().node_to_string(expr.hir_id));
         debug!("... {:?}, expected is {:?}", ty, expected);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -143,7 +143,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.typeck_results.borrow_mut().node_types_mut().insert(id, ty);
 
         if ty.references_error() {
-            self.has_errors.set(true);
             self.set_tainted_by_errors();
         }
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1334,7 +1334,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Hide the outer diverging and `has_errors` flags.
         let old_diverges = self.diverges.replace(Diverges::Maybe);
-        let old_has_errors = self.has_errors.replace(false);
 
         match stmt.kind {
             hir::StmtKind::Local(l) => {
@@ -1364,7 +1363,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Combine the diverging and `has_error` flags.
         self.diverges.set(self.diverges.get() | old_diverges);
-        self.has_errors.set(self.has_errors.get() | old_has_errors);
     }
 
     pub fn check_block_no_value(&self, blk: &'tcx hir::Block<'tcx>) {
@@ -1544,11 +1542,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.diverges.set(prev_diverges);
         }
 
-        let mut ty = ctxt.coerce.unwrap().complete(self);
-
-        if self.has_errors.get() || ty.references_error() {
-            ty = self.tcx.ty_error()
-        }
+        let ty = ctxt.coerce.unwrap().complete(self);
 
         self.write_ty(blk.hir_id, ty);
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -112,9 +112,6 @@ pub struct FnCtxt<'a, 'tcx> {
     /// the diverges flag is set to something other than `Maybe`.
     pub(super) diverges: Cell<Diverges>,
 
-    /// Whether any child nodes have any type errors.
-    pub(super) has_errors: Cell<bool>,
-
     pub(super) enclosing_breakables: RefCell<EnclosingBreakables<'tcx>>,
 
     pub(super) inh: &'a Inherited<'tcx>,
@@ -145,7 +142,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             resume_yield_tys: None,
             ps: Cell::new(UnsafetyState::function(hir::Unsafety::Normal, hir::CRATE_HIR_ID)),
             diverges: Cell::new(Diverges::Maybe),
-            has_errors: Cell::new(false),
             enclosing_breakables: RefCell::new(EnclosingBreakables {
                 stack: Vec::new(),
                 by_id: Default::default(),

--- a/src/test/ui/error-codes/E0767.rs
+++ b/src/test/ui/error-codes/E0767.rs
@@ -1,6 +1,7 @@
-fn main () {
+fn main() {
     'a: loop {
         || {
+            //~^ ERROR mismatched types
             loop { break 'a; } //~ ERROR E0767
         }
     }

--- a/src/test/ui/error-codes/E0767.stderr
+++ b/src/test/ui/error-codes/E0767.stderr
@@ -1,14 +1,27 @@
 error[E0767]: use of unreachable label `'a`
-  --> $DIR/E0767.rs:4:26
+  --> $DIR/E0767.rs:5:26
    |
 LL |     'a: loop {
    |     -- unreachable label defined here
-LL |         || {
+...
 LL |             loop { break 'a; }
    |                          ^^ unreachable label `'a`
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/E0767.rs:3:9
+   |
+LL | /         || {
+LL | |
+LL | |             loop { break 'a; }
+LL | |         }
+   | |_________^ expected `()`, found closure
+   |
+   = note: expected unit type `()`
+                found closure `[closure@$DIR/E0767.rs:3:9: 3:11]`
 
-For more information about this error, try `rustc --explain E0767`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0767.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
It doesn't seem like this `has_errors` flag actually suppresses any errors (at least in the UI test suite) --- except for one test (`E0767.rs`), and I think that error really should be considered legitimate, since it has nothing to do with the error code and continues to exist after you fix the first error...

This flag was added by @eddyb in 6b3cc0b8c8094407a3b5ea75f946c682d6d0142a, and it's likely that it was made redundant due to subsequent restructuring of the compiler.

It only affects block type-checking anyways, so its effect does seem limited these days anyway.