### PR TITLE
[EXPERIMENT] Disallow all literal suffixes except the standard numeric ones

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1729,9 +1729,9 @@ pub enum LitFloatType {
     Unsuffixed,
 }
 
-/// Literal kind.
-///
-/// E.g., `"foo"`, `42`, `12.34`, or `bool`.
+/// Note that the entire literal (including the suffix) is considered when
+/// deciding the `LitKind`. This means that float literals like `1f32` are
+/// classified by this type as `Float`.
 #[derive(Clone, Encodable, Decodable, Debug, Hash, Eq, PartialEq, HashStable_Generic)]
 pub enum LitKind {
     /// A string literal (`"foo"`). The symbol is unescaped, and so may differ
@@ -1745,8 +1745,8 @@ pub enum LitKind {
     Char(char),
     /// An integer literal (`1`).
     Int(u128, LitIntType),
-    /// A float literal (`1f64` or `1E10f64`). Stored as a symbol rather than
-    /// `f64` so that `LitKind` can impl `Eq` and `Hash`.
+    /// A float literal (`1.0`, `1f64` or `1E10f64`). Stored as a symbol rather
+    /// than `f64` so that `LitKind` can impl `Eq` and `Hash`.
     Float(Symbol, LitFloatType),
     /// A boolean literal.
     Bool(bool),

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -58,13 +58,16 @@ pub enum Delimiter {
     Invisible,
 }
 
+/// Note that the entire literal (including the suffix) is considered when
+/// deciding the `LitKind`. This means that float literals like `1f32` are
+/// classified by this type as `Float`.
 #[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
 pub enum LitKind {
     Bool, // AST only, must never appear in a `Token`
     Byte,
     Char,
-    Integer,
-    Float,
+    Integer, // e.g. `1`, `1u8`
+    Float,   // e.g. `1.`, `1.0`, `1f32`, `1e3f32`
     Str,
     StrRaw(u8), // raw string delimited by `n` hash symbols
     ByteStr,
@@ -77,7 +80,7 @@ pub enum LitKind {
 pub struct Lit {
     pub kind: LitKind,
     pub symbol: Symbol,
-    pub suffix: Option<Symbol>,
+    pub suffix: Option<Symbol>, // njn: change to a type?
 }
 
 impl fmt::Display for Lit {
@@ -117,19 +120,6 @@ impl LitKind {
         match self {
             Integer | Err => "an",
             _ => "a",
-        }
-    }
-
-    pub fn descr(self) -> &'static str {
-        match self {
-            Bool => panic!("literal token contains `Lit::Bool`"),
-            Byte => "byte",
-            Char => "char",
-            Integer => "integer",
-            Float => "float",
-            Str | StrRaw(..) => "string",
-            ByteStr | ByteStrRaw(..) => "byte string",
-            Err => "error",
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -962,6 +962,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 let lit = if let ExprKind::Lit(lit) = &expr.kind {
                     lit.clone()
                 } else {
+                    // njn: use Lit::from_token_lit here?
                     Lit {
                         token_lit: token::Lit::new(token::LitKind::Err, kw::Empty, None),
                         kind: LitKind::Err,

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -165,9 +165,13 @@ pub enum DocStyle {
     Inner,
 }
 
+// Note that the suffix is *not* considered when deciding the `LiteralKind` in
+// this type. This means that float literals like `1f32` are classified by this
+// type as `Int`. (Compare against `rustc_ast::token::LitKind` and
+// `rustc_ast::ast::LitKind.)
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LiteralKind {
-    /// "12_u8", "0o100", "0b120i99"
+    /// "12_u8", "0o100", "0b120i99", "1f32".
     Int { base: Base, empty_int: bool },
     /// "12.34f32", "0b100.100"
     Float { base: Base, empty_exponent: bool },
@@ -185,6 +189,19 @@ pub enum LiteralKind {
     /// "br"abc"", "br#"abc"#", "br####"ab"###"c"####", "br#"a". `None`
     /// indicates an invalid literal.
     RawByteStr { n_hashes: Option<u8> },
+}
+
+impl LiteralKind {
+    pub fn descr(self) -> &'static str {
+        match self {
+            Int { .. } => "integer",
+            Float { .. } => "float",
+            Char { .. } => "char",
+            Byte { .. } => "byte",
+            Str { .. } | RawStr { .. } => "string",
+            ByteStr { .. } | RawByteStr { .. } => "byte string",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/test/ui/extenv/issue-55897.stderr
+++ b/src/test/ui/extenv/issue-55897.stderr
@@ -1,3 +1,9 @@
+error: suffixes on string literals are invalid
+  --> $DIR/issue-55897.rs:16:22
+   |
+LL |     include!(concat!("NON_EXISTENT"suffix, "/data.rs"));
+   |                      ^^^^^^^^^^^^^^^^^^^^ invalid suffix `suffix`
+
 error: environment variable `NON_EXISTENT` not defined
   --> $DIR/issue-55897.rs:11:22
    |
@@ -5,12 +11,6 @@ LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: suffixes on string literals are invalid
-  --> $DIR/issue-55897.rs:16:22
-   |
-LL |     include!(concat!("NON_EXISTENT"suffix, "/data.rs"));
-   |                      ^^^^^^^^^^^^^^^^^^^^ invalid suffix `suffix`
 
 error[E0432]: unresolved import `prelude`
   --> $DIR/issue-55897.rs:1:5

--- a/src/test/ui/lexer/lex-bad-numeric-literals.stderr
+++ b/src/test/ui/lexer/lex-bad-numeric-literals.stderr
@@ -5,6 +5,12 @@ LL |     0o1.0;
    |     ^^^^^
 
 error: octal float literal is not supported
+  --> $DIR/lex-bad-numeric-literals.rs:3:5
+   |
+LL |     0o2f32;
+   |     ^^^
+
+error: octal float literal is not supported
   --> $DIR/lex-bad-numeric-literals.rs:4:5
    |
 LL |     0o3.0f32;
@@ -95,22 +101,28 @@ LL |     0b;
    |     ^^
 
 error: octal float literal is not supported
+  --> $DIR/lex-bad-numeric-literals.rs:23:5
+   |
+LL |     0o123f64;
+   |     ^^^^^
+
+error: octal float literal is not supported
   --> $DIR/lex-bad-numeric-literals.rs:24:5
    |
 LL |     0o123.456;
    |     ^^^^^^^^^
 
 error: binary float literal is not supported
+  --> $DIR/lex-bad-numeric-literals.rs:25:5
+   |
+LL |     0b101f64;
+   |     ^^^^^
+
+error: binary float literal is not supported
   --> $DIR/lex-bad-numeric-literals.rs:26:5
    |
 LL |     0b111.101;
    |     ^^^^^^^^^
-
-error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:3:5
-   |
-LL |     0o2f32;
-   |     ^^^^^^ not supported
 
 error: integer literal is too large
   --> $DIR/lex-bad-numeric-literals.rs:14:5
@@ -123,18 +135,6 @@ error: integer literal is too large
    |
 LL |     9900000000000000000000000000999999999999999999999999999999;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:23:5
-   |
-LL |     0o123f64;
-   |     ^^^^^^^^ not supported
-
-error: binary float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:25:5
-   |
-LL |     0b101f64;
-   |     ^^^^^^^^ not supported
 
 error: aborting due to 23 previous errors
 

--- a/src/test/ui/parser/issues/issue-59418.rs
+++ b/src/test/ui/parser/issues/issue-59418.rs
@@ -3,16 +3,20 @@ struct X(i32,i32,i32);
 fn main() {
     let a = X(1, 2, 3);
     let b = a.1suffix;
-    //~^ ERROR suffixes on a tuple index are invalid
+    //~^ ERROR invalid suffix `suffix` for number literal
+    //~^^ ERROR suffixes on a tuple index are invalid
     println!("{}", b);
     let c = (1, 2, 3);
     let d = c.1suffix;
-    //~^ ERROR suffixes on a tuple index are invalid
+    //~^ ERROR invalid suffix `suffix` for number literal
+    //~^^ ERROR suffixes on a tuple index are invalid
     println!("{}", d);
     let s = X { 0suffix: 0, 1: 1, 2: 2 };
-    //~^ ERROR suffixes on a tuple index are invalid
+    //~^ ERROR invalid suffix `suffix` for number literal
+    //~^^ ERROR suffixes on a tuple index are invalid
     match s {
         X { 0suffix: _, .. } => {}
-        //~^ ERROR suffixes on a tuple index are invalid
+        //~^ ERROR invalid suffix `suffix` for number literal
+        //~^^ ERROR suffixes on a tuple index are invalid
     }
 }

--- a/src/test/ui/parser/issues/issue-59418.stderr
+++ b/src/test/ui/parser/issues/issue-59418.stderr
@@ -1,3 +1,35 @@
+error: invalid suffix `suffix` for number literal
+  --> $DIR/issue-59418.rs:5:15
+   |
+LL |     let b = a.1suffix;
+   |               ^^^^^^^ invalid suffix `suffix`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: invalid suffix `suffix` for number literal
+  --> $DIR/issue-59418.rs:10:15
+   |
+LL |     let d = c.1suffix;
+   |               ^^^^^^^ invalid suffix `suffix`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: invalid suffix `suffix` for number literal
+  --> $DIR/issue-59418.rs:14:17
+   |
+LL |     let s = X { 0suffix: 0, 1: 1, 2: 2 };
+   |                 ^^^^^^^ invalid suffix `suffix`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: invalid suffix `suffix` for number literal
+  --> $DIR/issue-59418.rs:18:13
+   |
+LL |         X { 0suffix: _, .. } => {}
+   |             ^^^^^^^ invalid suffix `suffix`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
 error: suffixes on a tuple index are invalid
   --> $DIR/issue-59418.rs:5:15
    |
@@ -5,22 +37,22 @@ LL |     let b = a.1suffix;
    |               ^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/issue-59418.rs:9:15
+  --> $DIR/issue-59418.rs:10:15
    |
 LL |     let d = c.1suffix;
    |               ^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/issue-59418.rs:12:17
+  --> $DIR/issue-59418.rs:14:17
    |
 LL |     let s = X { 0suffix: 0, 1: 1, 2: 2 };
    |                 ^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/issue-59418.rs:15:13
+  --> $DIR/issue-59418.rs:18:13
    |
 LL |         X { 0suffix: _, .. } => {}
    |             ^^^^^^^ invalid suffix `suffix`
 
-error: aborting due to 4 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/parser/no-binary-float-literal.stderr
+++ b/src/test/ui/parser/no-binary-float-literal.stderr
@@ -1,14 +1,14 @@
 error: binary float literal is not supported
+  --> $DIR/no-binary-float-literal.rs:2:5
+   |
+LL |     0b101010f64;
+   |     ^^^^^^^^
+
+error: binary float literal is not supported
   --> $DIR/no-binary-float-literal.rs:4:5
    |
 LL |     0b101.010;
    |     ^^^^^^^^^
-
-error: binary float literal is not supported
-  --> $DIR/no-binary-float-literal.rs:2:5
-   |
-LL |     0b101010f64;
-   |     ^^^^^^^^^^^ not supported
 
 error: invalid suffix `p4f64` for number literal
   --> $DIR/no-binary-float-literal.rs:6:5

--- a/src/test/ui/parser/no-hex-float-literal.rs
+++ b/src/test/ui/parser/no-hex-float-literal.rs
@@ -4,6 +4,6 @@ fn main() {
     0x567.89;
     //~^ ERROR hexadecimal float literal is not supported
     0xDEAD.BEEFp-2f;
-    //~^ ERROR invalid suffix `f` for float literal
+    //~^ ERROR invalid suffix `f` for number literal
     //~| ERROR `{integer}` is a primitive type and therefore doesn't have fields
 }

--- a/src/test/ui/parser/no-hex-float-literal.stderr
+++ b/src/test/ui/parser/no-hex-float-literal.stderr
@@ -4,13 +4,13 @@ error: hexadecimal float literal is not supported
 LL |     0x567.89;
    |     ^^^^^^^^
 
-error: invalid suffix `f` for float literal
+error: invalid suffix `f` for number literal
   --> $DIR/no-hex-float-literal.rs:6:18
    |
 LL |     0xDEAD.BEEFp-2f;
    |                  ^^ invalid suffix `f`
    |
-   = help: valid suffixes are `f32` and `f64`
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
 error[E0610]: `{integer}` is a primitive type and therefore doesn't have fields
   --> $DIR/no-hex-float-literal.rs:2:11

--- a/src/test/ui/parser/underscore-suffix-for-string.rs
+++ b/src/test/ui/parser/underscore-suffix-for-string.rs
@@ -1,8 +1,12 @@
-// check-pass
+// check-fail
+
+// njn: not sure about the change to this one...
 
 fn main() {
     let _ = "Foo"_;
-    //~^ WARNING underscore literal suffix is not allowed
+    //~^ ERROR suffixes on string literals are invalid
+    //~| NOTE invalid suffix `_`
+    //~^^^ WARNING underscore literal suffix is not allowed
     //~| WARNING this was previously accepted
     //~| NOTE issue #42326
 }

--- a/src/test/ui/parser/underscore-suffix-for-string.stderr
+++ b/src/test/ui/parser/underscore-suffix-for-string.stderr
@@ -1,5 +1,11 @@
+error: suffixes on string literals are invalid
+  --> $DIR/underscore-suffix-for-string.rs:6:13
+   |
+LL |     let _ = "Foo"_;
+   |             ^^^^^^ invalid suffix `_`
+
 warning: underscore literal suffix is not allowed
-  --> $DIR/underscore-suffix-for-string.rs:4:18
+  --> $DIR/underscore-suffix-for-string.rs:6:18
    |
 LL |     let _ = "Foo"_;
    |                  ^
@@ -7,5 +13,5 @@ LL |     let _ = "Foo"_;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: see issue #42326 <https://github.com/rust-lang/rust/issues/42326> for more information
 
-warning: 1 warning emitted
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/proc-macro/auxiliary/api/parse.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/parse.rs
@@ -38,8 +38,6 @@ fn test_parse_literal() {
     assert_eq!("\"\n\"".parse::<Literal>().unwrap().to_string(), "\"\n\"");
     assert_eq!("b\"\"".parse::<Literal>().unwrap().to_string(), "b\"\"");
     assert_eq!("r##\"\"##".parse::<Literal>().unwrap().to_string(), "r##\"\"##");
-    assert_eq!("10ulong".parse::<Literal>().unwrap().to_string(), "10ulong");
-    assert_eq!("-10ulong".parse::<Literal>().unwrap().to_string(), "-10ulong");
 
     assert!("true".parse::<Literal>().is_err());
     assert!(".8".parse::<Literal>().is_err());

--- a/src/test/ui/proc-macro/debug/dump-debug-span-debug.rs
+++ b/src/test/ui/proc-macro/debug/dump-debug-span-debug.rs
@@ -29,18 +29,6 @@ dump_debug! {
     br##"BR"##
     'C'
     b'B'
-
-    // suffixed literals
-    0q
-    1.0q
-    "S"q
-    b"B"q
-    r"R"q
-    r##"R"##q
-    br"BR"q
-    br##"BR"##q
-    'C'q
-    b'B'q
 }
 
 fn main() {}

--- a/src/test/ui/proc-macro/debug/dump-debug-span-debug.stderr
+++ b/src/test/ui/proc-macro/debug/dump-debug-span-debug.stderr
@@ -1,4 +1,4 @@
-TokenStream [Ident { ident: "ident", span: $DIR/dump-debug-span-debug.rs:10:5: 10:10 (#0) }, Ident { ident: "r#ident", span: $DIR/dump-debug-span-debug.rs:11:5: 11:12 (#0) }, Punct { ch: ',', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:12:5: 12:6 (#0) }, Punct { ch: '&', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:13:5: 13:6 (#0) }, Punct { ch: '&', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:13:6: 13:7 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:14:5: 14:6 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:14:6: 14:7 (#0) }, Punct { ch: '>', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:14:7: 14:8 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:15:5: 15:6 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:15:6: 15:7 (#0) }, Punct { ch: '<', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:15:7: 15:8 (#0) }, Punct { ch: '<', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:15:8: 15:9 (#0) }, Punct { ch: '.', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:16:5: 16:6 (#0) }, Punct { ch: '.', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:16:6: 16:7 (#0) }, Punct { ch: '=', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:16:7: 16:8 (#0) }, Punct { ch: '<', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:17:5: 17:6 (#0) }, Punct { ch: '<', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:17:6: 17:7 (#0) }, Punct { ch: '=', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:17:7: 17:8 (#0) }, Punct { ch: '!', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:17:8: 17:9 (#0) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: $DIR/dump-debug-span-debug.rs:18:5: 18:7 (#0) }, Group { delimiter: Bracket, stream: TokenStream [Ident { ident: "_", span: $DIR/dump-debug-span-debug.rs:19:6: 19:7 (#0) }], span: $DIR/dump-debug-span-debug.rs:19:5: 19:8 (#0) }, Literal { kind: Integer, symbol: "0", suffix: None, span: $DIR/dump-debug-span-debug.rs:22:5: 22:6 (#0) }, Literal { kind: Float, symbol: "1.0", suffix: None, span: $DIR/dump-debug-span-debug.rs:23:5: 23:8 (#0) }, Literal { kind: Str, symbol: "S", suffix: None, span: $DIR/dump-debug-span-debug.rs:24:5: 24:8 (#0) }, Literal { kind: ByteStr, symbol: "B", suffix: None, span: $DIR/dump-debug-span-debug.rs:25:5: 25:9 (#0) }, Literal { kind: StrRaw(0), symbol: "R", suffix: None, span: $DIR/dump-debug-span-debug.rs:26:5: 26:9 (#0) }, Literal { kind: StrRaw(2), symbol: "R", suffix: None, span: $DIR/dump-debug-span-debug.rs:27:5: 27:13 (#0) }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: None, span: $DIR/dump-debug-span-debug.rs:28:5: 28:11 (#0) }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: None, span: $DIR/dump-debug-span-debug.rs:29:5: 29:15 (#0) }, Literal { kind: Char, symbol: "C", suffix: None, span: $DIR/dump-debug-span-debug.rs:30:5: 30:8 (#0) }, Literal { kind: Byte, symbol: "B", suffix: None, span: $DIR/dump-debug-span-debug.rs:31:5: 31:9 (#0) }, Literal { kind: Integer, symbol: "0", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:34:5: 34:7 (#0) }, Literal { kind: Float, symbol: "1.0", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:35:5: 35:9 (#0) }, Literal { kind: Str, symbol: "S", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:36:5: 36:9 (#0) }, Literal { kind: ByteStr, symbol: "B", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:37:5: 37:10 (#0) }, Literal { kind: StrRaw(0), symbol: "R", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:38:5: 38:10 (#0) }, Literal { kind: StrRaw(2), symbol: "R", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:39:5: 39:14 (#0) }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:40:5: 40:12 (#0) }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:41:5: 41:16 (#0) }, Literal { kind: Char, symbol: "C", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:42:5: 42:9 (#0) }, Literal { kind: Byte, symbol: "B", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:43:5: 43:10 (#0) }]
+TokenStream [Ident { ident: "ident", span: $DIR/dump-debug-span-debug.rs:10:5: 10:10 (#0) }, Ident { ident: "r#ident", span: $DIR/dump-debug-span-debug.rs:11:5: 11:12 (#0) }, Punct { ch: ',', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:12:5: 12:6 (#0) }, Punct { ch: '&', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:13:5: 13:6 (#0) }, Punct { ch: '&', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:13:6: 13:7 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:14:5: 14:6 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:14:6: 14:7 (#0) }, Punct { ch: '>', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:14:7: 14:8 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:15:5: 15:6 (#0) }, Punct { ch: '|', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:15:6: 15:7 (#0) }, Punct { ch: '<', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:15:7: 15:8 (#0) }, Punct { ch: '<', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:15:8: 15:9 (#0) }, Punct { ch: '.', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:16:5: 16:6 (#0) }, Punct { ch: '.', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:16:6: 16:7 (#0) }, Punct { ch: '=', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:16:7: 16:8 (#0) }, Punct { ch: '<', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:17:5: 17:6 (#0) }, Punct { ch: '<', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:17:6: 17:7 (#0) }, Punct { ch: '=', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:17:7: 17:8 (#0) }, Punct { ch: '!', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:17:8: 17:9 (#0) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: $DIR/dump-debug-span-debug.rs:18:5: 18:7 (#0) }, Group { delimiter: Bracket, stream: TokenStream [Ident { ident: "_", span: $DIR/dump-debug-span-debug.rs:19:6: 19:7 (#0) }], span: $DIR/dump-debug-span-debug.rs:19:5: 19:8 (#0) }, Literal { kind: Integer, symbol: "0", suffix: None, span: $DIR/dump-debug-span-debug.rs:22:5: 22:6 (#0) }, Literal { kind: Float, symbol: "1.0", suffix: None, span: $DIR/dump-debug-span-debug.rs:23:5: 23:8 (#0) }, Literal { kind: Str, symbol: "S", suffix: None, span: $DIR/dump-debug-span-debug.rs:24:5: 24:8 (#0) }, Literal { kind: ByteStr, symbol: "B", suffix: None, span: $DIR/dump-debug-span-debug.rs:25:5: 25:9 (#0) }, Literal { kind: StrRaw(0), symbol: "R", suffix: None, span: $DIR/dump-debug-span-debug.rs:26:5: 26:9 (#0) }, Literal { kind: StrRaw(2), symbol: "R", suffix: None, span: $DIR/dump-debug-span-debug.rs:27:5: 27:13 (#0) }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: None, span: $DIR/dump-debug-span-debug.rs:28:5: 28:11 (#0) }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: None, span: $DIR/dump-debug-span-debug.rs:29:5: 29:15 (#0) }, Literal { kind: Char, symbol: "C", suffix: None, span: $DIR/dump-debug-span-debug.rs:30:5: 30:8 (#0) }, Literal { kind: Byte, symbol: "B", suffix: None, span: $DIR/dump-debug-span-debug.rs:31:5: 31:9 (#0) }]
 TokenStream [
     Ident {
         ident: "ident",
@@ -167,65 +167,5 @@ TokenStream [
         symbol: "B",
         suffix: None,
         span: $DIR/dump-debug-span-debug.rs:31:5: 31:9 (#0),
-    },
-    Literal {
-        kind: Integer,
-        symbol: "0",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:34:5: 34:7 (#0),
-    },
-    Literal {
-        kind: Float,
-        symbol: "1.0",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:35:5: 35:9 (#0),
-    },
-    Literal {
-        kind: Str,
-        symbol: "S",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:36:5: 36:9 (#0),
-    },
-    Literal {
-        kind: ByteStr,
-        symbol: "B",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:37:5: 37:10 (#0),
-    },
-    Literal {
-        kind: StrRaw(0),
-        symbol: "R",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:38:5: 38:10 (#0),
-    },
-    Literal {
-        kind: StrRaw(2),
-        symbol: "R",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:39:5: 39:14 (#0),
-    },
-    Literal {
-        kind: ByteStrRaw(0),
-        symbol: "BR",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:40:5: 40:12 (#0),
-    },
-    Literal {
-        kind: ByteStrRaw(2),
-        symbol: "BR",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:41:5: 41:16 (#0),
-    },
-    Literal {
-        kind: Char,
-        symbol: "C",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:42:5: 42:9 (#0),
-    },
-    Literal {
-        kind: Byte,
-        symbol: "B",
-        suffix: Some("q"),
-        span: $DIR/dump-debug-span-debug.rs:43:5: 43:10 (#0),
     },
 ]

--- a/src/test/ui/proc-macro/debug/dump-debug.rs
+++ b/src/test/ui/proc-macro/debug/dump-debug.rs
@@ -23,18 +23,6 @@ dump_debug! {
     br##"BR"##
     'C'
     b'B'
-
-    // suffixed literals
-    0q
-    1.0q
-    "S"q
-    b"B"q
-    r"R"q
-    r##"R"##q
-    br"BR"q
-    br##"BR"##q
-    'C'q
-    b'B'q
 }
 
 fn main() {}

--- a/src/test/ui/proc-macro/debug/dump-debug.stderr
+++ b/src/test/ui/proc-macro/debug/dump-debug.stderr
@@ -1,4 +1,4 @@
-TokenStream [Ident { ident: "ident", span: #0 bytes(130..135) }, Ident { ident: "r#ident", span: #0 bytes(151..158) }, Punct { ch: ',', spacing: Alone, span: #0 bytes(176..177) }, Punct { ch: '=', spacing: Joint, span: #0 bytes(203..204) }, Punct { ch: '=', spacing: Joint, span: #0 bytes(204..205) }, Punct { ch: '>', spacing: Alone, span: #0 bytes(205..206) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(230..232) }, Group { delimiter: Bracket, stream: TokenStream [Ident { ident: "_", span: #0 bytes(258..259) }], span: #0 bytes(257..260) }, Literal { kind: Integer, symbol: "0", suffix: None, span: #0 bytes(315..316) }, Literal { kind: Float, symbol: "1.0", suffix: None, span: #0 bytes(321..324) }, Literal { kind: Str, symbol: "S", suffix: None, span: #0 bytes(329..332) }, Literal { kind: ByteStr, symbol: "B", suffix: None, span: #0 bytes(337..341) }, Literal { kind: StrRaw(0), symbol: "R", suffix: None, span: #0 bytes(346..350) }, Literal { kind: StrRaw(2), symbol: "R", suffix: None, span: #0 bytes(355..363) }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: None, span: #0 bytes(368..374) }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: None, span: #0 bytes(379..389) }, Literal { kind: Char, symbol: "C", suffix: None, span: #0 bytes(394..397) }, Literal { kind: Byte, symbol: "B", suffix: None, span: #0 bytes(402..406) }, Literal { kind: Integer, symbol: "0", suffix: Some("q"), span: #0 bytes(437..439) }, Literal { kind: Float, symbol: "1.0", suffix: Some("q"), span: #0 bytes(444..448) }, Literal { kind: Str, symbol: "S", suffix: Some("q"), span: #0 bytes(453..457) }, Literal { kind: ByteStr, symbol: "B", suffix: Some("q"), span: #0 bytes(462..467) }, Literal { kind: StrRaw(0), symbol: "R", suffix: Some("q"), span: #0 bytes(472..477) }, Literal { kind: StrRaw(2), symbol: "R", suffix: Some("q"), span: #0 bytes(482..491) }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: Some("q"), span: #0 bytes(496..503) }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: Some("q"), span: #0 bytes(508..519) }, Literal { kind: Char, symbol: "C", suffix: Some("q"), span: #0 bytes(524..528) }, Literal { kind: Byte, symbol: "B", suffix: Some("q"), span: #0 bytes(533..538) }]
+TokenStream [Ident { ident: "ident", span: #0 bytes(130..135) }, Ident { ident: "r#ident", span: #0 bytes(151..158) }, Punct { ch: ',', spacing: Alone, span: #0 bytes(176..177) }, Punct { ch: '=', spacing: Joint, span: #0 bytes(203..204) }, Punct { ch: '=', spacing: Joint, span: #0 bytes(204..205) }, Punct { ch: '>', spacing: Alone, span: #0 bytes(205..206) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(230..232) }, Group { delimiter: Bracket, stream: TokenStream [Ident { ident: "_", span: #0 bytes(258..259) }], span: #0 bytes(257..260) }, Literal { kind: Integer, symbol: "0", suffix: None, span: #0 bytes(315..316) }, Literal { kind: Float, symbol: "1.0", suffix: None, span: #0 bytes(321..324) }, Literal { kind: Str, symbol: "S", suffix: None, span: #0 bytes(329..332) }, Literal { kind: ByteStr, symbol: "B", suffix: None, span: #0 bytes(337..341) }, Literal { kind: StrRaw(0), symbol: "R", suffix: None, span: #0 bytes(346..350) }, Literal { kind: StrRaw(2), symbol: "R", suffix: None, span: #0 bytes(355..363) }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: None, span: #0 bytes(368..374) }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: None, span: #0 bytes(379..389) }, Literal { kind: Char, symbol: "C", suffix: None, span: #0 bytes(394..397) }, Literal { kind: Byte, symbol: "B", suffix: None, span: #0 bytes(402..406) }]
 TokenStream [
     Ident {
         ident: "ident",
@@ -102,65 +102,5 @@ TokenStream [
         symbol: "B",
         suffix: None,
         span: #0 bytes(402..406),
-    },
-    Literal {
-        kind: Integer,
-        symbol: "0",
-        suffix: Some("q"),
-        span: #0 bytes(437..439),
-    },
-    Literal {
-        kind: Float,
-        symbol: "1.0",
-        suffix: Some("q"),
-        span: #0 bytes(444..448),
-    },
-    Literal {
-        kind: Str,
-        symbol: "S",
-        suffix: Some("q"),
-        span: #0 bytes(453..457),
-    },
-    Literal {
-        kind: ByteStr,
-        symbol: "B",
-        suffix: Some("q"),
-        span: #0 bytes(462..467),
-    },
-    Literal {
-        kind: StrRaw(0),
-        symbol: "R",
-        suffix: Some("q"),
-        span: #0 bytes(472..477),
-    },
-    Literal {
-        kind: StrRaw(2),
-        symbol: "R",
-        suffix: Some("q"),
-        span: #0 bytes(482..491),
-    },
-    Literal {
-        kind: ByteStrRaw(0),
-        symbol: "BR",
-        suffix: Some("q"),
-        span: #0 bytes(496..503),
-    },
-    Literal {
-        kind: ByteStrRaw(2),
-        symbol: "BR",
-        suffix: Some("q"),
-        span: #0 bytes(508..519),
-    },
-    Literal {
-        kind: Char,
-        symbol: "C",
-        suffix: Some("q"),
-        span: #0 bytes(524..528),
-    },
-    Literal {
-        kind: Byte,
-        symbol: "B",
-        suffix: Some("q"),
-        span: #0 bytes(533..538),
     },
 ]


### PR DESCRIPTION
Partly out of curiosity, and partly because this would significantly simplify parts of the lexer and parser.

r? @ghost