### PR TITLE
`align_of` takes a `T: ?Sized`

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -893,7 +893,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`core::mem::align_of`].
     #[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
     #[cfg_attr(not(bootstrap), rustc_safe_intrinsic)]
-    pub fn min_align_of<T>() -> usize;
+    pub fn min_align_of<T: ?Sized>() -> usize;
     /// The preferred alignment of a type.
     ///
     /// This intrinsic does not have a stable counterpart.

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -460,7 +460,7 @@ pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_promotable]
 #[rustc_const_stable(feature = "const_align_of", since = "1.24.0")]
-pub const fn align_of<T>() -> usize {
+pub const fn align_of<T: ?Sized>() -> usize {
     intrinsics::min_align_of::<T>()
 }
 


### PR DESCRIPTION
IIUC there's no reason that `align_of` needs to be restricted to `Sized` types.