### PR TITLE
Fix artifact version/channel detection for stable

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -269,8 +269,8 @@ fn download_ci_llvm(builder: &Builder<'_>, llvm_sha: &str) {
     } else {
         &builder.config.stage0_metadata.config.artifacts_server
     };
-    let channel = builder.config.artifact_channel(builder, llvm_sha);
-    let filename = format!("rust-dev-{}-{}.tar.xz", channel, builder.build.build.triple);
+    let version = builder.config.artifact_version_part(builder, llvm_sha);
+    let filename = format!("rust-dev-{}-{}.tar.xz", version, builder.build.build.triple);
     let tarball = rustc_cache.join(&filename);
     if !tarball.exists() {
         let help_on_error = "error: failed to download llvm from ci


### PR DESCRIPTION
On stable, our artifacts are uploaded with the raw version number (e.g., 1.65.0), not the channel. This adjusts our detection logic to use the version number from src/version when we detect the stable channel.

This is really only important for stable channel re-builds, I think, but those do happen from time to time. I'm backporting a similar commit in https://github.com/rust-lang/rust/pull/103859 to make that PR pass CI.