### PR TITLE
Remove `ptr::eq()` from `Cell::swap()`

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -381,9 +381,6 @@ impl<T> Cell<T> {
     #[inline]
     #[stable(feature = "move_cell", since = "1.17.0")]
     pub fn swap(&self, other: &Self) {
-        if ptr::eq(self, other) {
-            return;
-        }
         // SAFETY: This can be risky if called from separate threads, but `Cell`
         // is `!Sync` so this won't happen. This also won't invalidate any
         // pointers since `Cell` makes sure nothing else will be pointing into


### PR DESCRIPTION
It looks redundant to me, since we use `ptr::swap()` and not `swap_nonoverlapping()` so even if they are the same cell it's fine, no?

I think we could also leave the comparison and use `swap_nonoverlapping()` but I'm less sure about that, since maybe we have a valid way to obtain partially overlapping cells? I can't think of such way, but I am not sure.