### PR TITLE
rustdoc: Fix merge of attributes for reexports of local items

### DIFF
--- a/src/test/rustdoc/local-reexport-doc.rs
+++ b/src/test/rustdoc/local-reexport-doc.rs
@@ -1,0 +1,16 @@
+// This test ensures that the reexports of local items also get the doc from
+// the reexport.
+
+#![crate_name = "foo"]
+
+// @has 'foo/fn.g.html'
+// @has - '//*[@class="rustdoc-toggle top-doc"]/*[@class="docblock"]' \
+// 'outer module inner module'
+
+mod inner_mod {
+    /// inner module
+    pub fn g() {}
+}
+
+/// outer module
+pub use inner_mod::g;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/84619.

The problem was that we didn't merge attributes between the the reexport and the item.

r? @notriddle 