### PR TITLE
rustdoc: remove unused mobile CSS `.rustdoc { padding-top: 0 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1677,7 +1677,6 @@ in storage.js
 	}
 
 	.rustdoc {
-		padding-top: 0px;
 		/* Sidebar should overlay main content, rather than pushing main content to the right.
 		   Turn off `display: flex` on the body element. */
 		display: block;


### PR DESCRIPTION
When this rule was added in dd437ee6ed81f85c715bf415d261feca484bb39f, as `body { padding-top: 0 }`, the desktop body tag had non-zero top padding. This padding was removed in 135281ed1525db15edd8ebd092aa10aa40df2386.

This rule no longer overrides a rule in rustdoc's desktop styles, and also doesn't override the UA stylesheet, since the [HTML standard] has only margin, not padding, on the page body.

[HTML standard]: https://html.spec.whatwg.org/multipage/rendering.html#the-page