### PR TITLE
Retry failed macro matching for diagnostics

### DIFF
--- a/compiler/rustc_expand/src/mbe.rs
+++ b/compiler/rustc_expand/src/mbe.rs
@@ -52,7 +52,7 @@ impl KleeneToken {
 /// A Kleene-style [repetition operator](https://en.wikipedia.org/wiki/Kleene_star)
 /// for token sequences.
 #[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy)]
-enum KleeneOp {
+pub(crate) enum KleeneOp {
     /// Kleene star (`*`) for zero or more repetitions
     ZeroOrMore,
     /// Kleene plus (`+`) for one or more repetitions

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -451,7 +451,7 @@ impl TtParser {
                         // Try zero matches of this sequence, by skipping over it.
                         self.cur_mps.push(MatcherPos {
                             idx: idx_first_after,
-                            matches: mp.matches.clone(), // a cheap clone
+                            matches: Lrc::clone(&mp.matches),
                         });
                     }
 
@@ -464,8 +464,8 @@ impl TtParser {
                     // sequence. If that's not possible, `ending_mp` will fail quietly when it is
                     // processed next time around the loop.
                     let ending_mp = MatcherPos {
-                        idx: mp.idx + 1,             // +1 skips the Kleene op
-                        matches: mp.matches.clone(), // a cheap clone
+                        idx: mp.idx + 1, // +1 skips the Kleene op
+                        matches: Lrc::clone(&mp.matches),
                     };
                     self.cur_mps.push(ending_mp);
 
@@ -480,8 +480,8 @@ impl TtParser {
                     // separator yet. Try ending the sequence. If that's not possible, `ending_mp`
                     // will fail quietly when it is processed next time around the loop.
                     let ending_mp = MatcherPos {
-                        idx: mp.idx + 2,             // +2 skips the separator and the Kleene op
-                        matches: mp.matches.clone(), // a cheap clone
+                        idx: mp.idx + 2, // +2 skips the separator and the Kleene op
+                        matches: Lrc::clone(&mp.matches),
                     };
                     self.cur_mps.push(ending_mp);
 

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -277,7 +277,11 @@ pub(crate) enum ParseResult<T> {
 /// A `ParseResult` where the `Success` variant contains a mapping of
 /// `MacroRulesNormalizedIdent`s to `NamedMatch`es. This represents the mapping
 /// of metavars to the token trees they bind to.
-pub(crate) type NamedParseResult = ParseResult<FxHashMap<MacroRulesNormalizedIdent, NamedMatch>>;
+pub(crate) type NamedParseResult = ParseResult<NamedMatches>;
+
+/// Contains a mapping of `MacroRulesNormalizedIdent`s to `NamedMatch`es.
+/// This represents the mapping of metavars to the token trees they bind to.
+pub(crate) type NamedMatches = FxHashMap<MacroRulesNormalizedIdent, NamedMatch>;
 
 /// Count how many metavars declarations are in `matcher`.
 pub(super) fn count_metavar_decls(matcher: &[TokenTree]) -> usize {

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -70,7 +70,6 @@
 //! eof: [a $( a )* a b ·]
 //! ```
 
-use rustc_errors::ErrorGuaranteed;
 pub(crate) use NamedMatch::*;
 pub(crate) use ParseResult::*;
 
@@ -79,6 +78,7 @@ use crate::mbe::{macro_rules::Tracker, KleeneOp, TokenTree};
 use rustc_ast::token::{self, DocComment, Nonterminal, NonterminalKind, Token};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
+use rustc_errors::ErrorGuaranteed;
 use rustc_lint_defs::pluralize;
 use rustc_parse::parser::{NtOrTt, Parser};
 use rustc_span::symbol::Ident;
@@ -96,7 +96,7 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 ///
 /// This means a matcher can be represented by `&[MatcherLoc]`, and traversal mostly involves
 /// simply incrementing the current matcher position index by one.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub(crate) enum MatcherLoc {
     Token {
         token: Token,

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -333,7 +333,7 @@ fn expand_macro<'cx>(
                 cx.struct_span_err(span, &msg).emit();
                 return DummyResult::any(span);
             }
-            ErrorReported => return DummyResult::any(sp),
+            ErrorReported(_) => return DummyResult::any(sp),
         }
 
         // The matcher was not `Success(..)`ful.
@@ -470,7 +470,7 @@ pub fn compile_declarative_macro(
                 .emit();
             return dummy_syn_ext();
         }
-        ErrorReported => {
+        ErrorReported(_) => {
             return dummy_syn_ext();
         }
     };

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -210,18 +210,18 @@ fn trace_macros_note(cx_expansions: &mut FxIndexMap<Span, Vec<String>>, sp: Span
 }
 
 pub(super) trait Tracker<'matcher> {
-    /// This is called before trying to match next MatcherLoc on the current token
+    /// This is called before trying to match next MatcherLoc on the current token.
     fn before_match_loc(&mut self, parser: &TtParser, matcher: &'matcher MatcherLoc);
 
     /// This is called after an arm has been parsed, either successfully or unsuccessfully. When this is called,
-    /// `before_match_loc` was called at least once (with a `MatcherLoc::Eof`)
+    /// `before_match_loc` was called at least once (with a `MatcherLoc::Eof`).
     fn after_arm(&mut self, result: &NamedParseResult);
 
-    /// For tracing
+    /// For tracing.
     fn description() -> &'static str;
 }
 
-/// A noop tracker that is used in the hot path of the expansion, has zero overhead thanks to monomorphization
+/// A noop tracker that is used in the hot path of the expansion, has zero overhead thanks to monomorphization.
 struct NoopTracker;
 
 impl<'matcher> Tracker<'matcher> for NoopTracker {
@@ -256,7 +256,7 @@ fn expand_macro<'cx>(
         trace_macros_note(&mut cx.expansions, sp, msg);
     }
 
-    // Track nothing for the best performance
+    // Track nothing for the best performance.
     let try_success_result = try_match_macro(sess, name, &arg, lhses, &mut NoopTracker);
 
     match try_success_result {
@@ -326,7 +326,7 @@ fn expand_macro<'cx>(
         }
     }
 
-    // An error occured, try the expansion again, tracking the expansion closely for better diagnostics
+    // An error occurred, try the expansion again, tracking the expansion closely for better diagnostics.
     let mut tracker = CollectTrackerAndEmitter::new(cx, sp);
 
     let try_success_result = try_match_macro(sess, name, &arg, lhses, &mut tracker);
@@ -378,7 +378,7 @@ fn expand_macro<'cx>(
     DummyResult::any(sp)
 }
 
-/// The tracker used for the slow error path that collects useful info for diagnostics
+/// The tracker used for the slow error path that collects useful info for diagnostics.
 struct CollectTrackerAndEmitter<'a, 'cx> {
     cx: &'a mut ExtCtxt<'cx>,
     /// Which arm's failure should we report? (the one furthest along)
@@ -427,7 +427,7 @@ enum CanRetry {
     No(ErrorGuaranteed),
 }
 
-/// Try expanding the macro. Returns the index of the sucessful arm and its named_matches if it was successful,
+/// Try expanding the macro. Returns the index of the successful arm and its named_matches if it was successful,
 /// and nothing if it failed. On failure, it's the callers job to use `track` accordingly to record all errors
 /// correctly.
 #[instrument(level = "debug", skip(sess, arg, lhses, track), fields(tracking = %T::description()))]
@@ -485,15 +485,16 @@ fn try_match_macro<'matcher, T: Tracker<'matcher>>(
             }
             Failure(_, _) => {
                 trace!("Failed to match arm, trying the next one");
-                // Try the next arm
+                // Try the next arm.
             }
             Error(_, _) => {
                 debug!("Fatal error occurred during matching");
-                // We haven't emitted an error yet
+                // We haven't emitted an error yet, so we can retry.
                 return Err(CanRetry::Yes);
             }
             ErrorReported(guarantee) => {
                 debug!("Fatal error occurred and was reported during matching");
+                // An error has been reported already, we cannot retry as that would cause duplicate errors.
                 return Err(CanRetry::No(guarantee));
             }
         }


### PR DESCRIPTION
When a declarative macro fails to match, retry the matching to collect diagnostic info instead of collecting it on the fly in the hot path. Split out of #103439.

You made a bunch of changes to declarative macro matching, so
r? @nnethercote

This change should produce a few small perf wins: https://github.com/rust-lang/rust/pull/103439#issuecomment-1294249602