### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -177,11 +177,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             .all_traits()
             .filter(|trait_def_id| {
                 let viz = self.tcx().visibility(*trait_def_id);
-                if let Some(def_id) = self.item_def_id() {
-                    viz.is_accessible_from(def_id, self.tcx())
-                } else {
-                    viz.is_visible_locally()
-                }
+                let def_id = self.item_def_id();
+                viz.is_accessible_from(def_id, self.tcx())
             })
             .collect();
 

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -54,7 +54,7 @@ pub struct PathSeg(pub DefId, pub usize);
 pub trait AstConv<'tcx> {
     fn tcx<'a>(&'a self) -> TyCtxt<'tcx>;
 
-    fn item_def_id(&self) -> Option<DefId>;
+    fn item_def_id(&self) -> DefId;
 
     /// Returns predicates in scope of the form `X: Foo<T>`, where `X`
     /// is a type parameter `X` with the given id `def_id` and T
@@ -2079,17 +2079,14 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
             debug!("qpath_to_ty: self.item_def_id()={:?}", def_id);
 
-            let parent_def_id = def_id
-                .and_then(|def_id| {
-                    def_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
-                })
+            let parent_def_id = def_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
                 .map(|hir_id| tcx.hir().get_parent_item(hir_id).to_def_id());
 
             debug!("qpath_to_ty: parent_def_id={:?}", parent_def_id);
 
             // If the trait in segment is the same as the trait defining the item,
             // use the `<Self as ..>` syntax in the error.
-            let is_part_of_self_trait_constraints = def_id == Some(trait_def_id);
+            let is_part_of_self_trait_constraints = def_id == trait_def_id;
             let is_part_of_fn_in_self_trait = parent_def_id == Some(trait_def_id);
 
             let type_name = if is_part_of_self_trait_constraints || is_part_of_fn_in_self_trait {

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -501,6 +501,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     }
                     GenericParamDefKind::Const { has_default } => {
                         let ty = tcx.at(self.span).type_of(param.def_id);
+                        if ty.references_error() {
+                            return tcx.const_error(ty).into();
+                        }
                         if !infer_args && has_default {
                             tcx.bound_const_param_default(param.def_id)
                                 .subst(tcx, substs.unwrap())

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -379,8 +379,8 @@ impl<'tcx> AstConv<'tcx> for ItemCtxt<'tcx> {
         self.tcx
     }
 
-    fn item_def_id(&self) -> Option<DefId> {
-        Some(self.item_def_id)
+    fn item_def_id(&self) -> DefId {
+        self.item_def_id
     }
 
     fn get_type_parameter_bounds(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -194,8 +194,8 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
         self.tcx
     }
 
-    fn item_def_id(&self) -> Option<DefId> {
-        None
+    fn item_def_id(&self) -> DefId {
+        self.body_id.owner.to_def_id()
     }
 
     fn get_type_parameter_bounds(

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -738,7 +738,7 @@ impl Default for Options {
             actually_rustdoc: false,
             trimmed_def_paths: TrimmedDefPaths::default(),
             cli_forced_codegen_units: None,
-            cli_forced_thinlto_off: false,
+            cli_forced_local_thinlto_off: false,
             remap_path_prefix: Vec::new(),
             real_rust_source_base_dir: None,
             edition: DEFAULT_EDITION,
@@ -1720,7 +1720,7 @@ fn should_override_cgus_and_disable_thinlto(
     error_format: ErrorOutputType,
     mut codegen_units: Option<usize>,
 ) -> (bool, Option<usize>) {
-    let mut disable_thinlto = false;
+    let mut disable_local_thinlto = false;
     // Issue #30063: if user requests LLVM-related output to one
     // particular path, disable codegen-units.
     let incompatible: Vec<_> = output_types
@@ -1745,12 +1745,12 @@ fn should_override_cgus_and_disable_thinlto(
                     }
                     early_warn(error_format, "resetting to default -C codegen-units=1");
                     codegen_units = Some(1);
-                    disable_thinlto = true;
+                    disable_local_thinlto = true;
                 }
             }
             _ => {
                 codegen_units = Some(1);
-                disable_thinlto = true;
+                disable_local_thinlto = true;
             }
         }
     }
@@ -1759,7 +1759,7 @@ fn should_override_cgus_and_disable_thinlto(
         early_error(error_format, "value for codegen units must be a positive non-zero integer");
     }
 
-    (disable_thinlto, codegen_units)
+    (disable_local_thinlto, codegen_units)
 }
 
 fn check_thread_count(unstable_opts: &UnstableOptions, error_format: ErrorOutputType) {
@@ -2249,7 +2249,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     let output_types = parse_output_types(&unstable_opts, matches, error_format);
 
     let mut cg = CodegenOptions::build(matches, error_format);
-    let (disable_thinlto, mut codegen_units) = should_override_cgus_and_disable_thinlto(
+    let (disable_local_thinlto, mut codegen_units) = should_override_cgus_and_disable_thinlto(
         &output_types,
         matches,
         error_format,
@@ -2492,7 +2492,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         actually_rustdoc: false,
         trimmed_def_paths: TrimmedDefPaths::default(),
         cli_forced_codegen_units: codegen_units,
-        cli_forced_thinlto_off: disable_thinlto,
+        cli_forced_local_thinlto_off: disable_local_thinlto,
         remap_path_prefix,
         real_rust_source_base_dir,
         edition,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -181,7 +181,7 @@ top_level_options!(
         #[rustc_lint_opt_deny_field_access("use `Session::codegen_units` instead of this field")]
         cli_forced_codegen_units: Option<usize> [UNTRACKED],
         #[rustc_lint_opt_deny_field_access("use `Session::lto` instead of this field")]
-        cli_forced_thinlto_off: bool [UNTRACKED],
+        cli_forced_local_thinlto_off: bool [UNTRACKED],
 
         /// Remap source path prefixes in all output (messages, object files, debug, etc.).
         remap_path_prefix: Vec<(PathBuf, PathBuf)> [TRACKED_NO_CRATE_HASH],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -991,11 +991,8 @@ impl Session {
                 return config::Lto::Fat;
             }
             config::LtoCli::Thin => {
-                return if self.opts.cli_forced_thinlto_off {
-                    config::Lto::Fat
-                } else {
-                    config::Lto::Thin
-                };
+                // The user explicitly asked for ThinLTO
+                return config::Lto::Thin;
             }
         }
 
@@ -1007,7 +1004,7 @@ impl Session {
 
         // If processing command line options determined that we're incompatible
         // with ThinLTO (e.g., `-C lto --emit llvm-ir`) then return that option.
-        if self.opts.cli_forced_thinlto_off {
+        if self.opts.cli_forced_local_thinlto_off {
             return config::Lto::No;
         }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1677,7 +1677,6 @@ in storage.js
 	}
 
 	.rustdoc {
-		padding-top: 0px;
 		/* Sidebar should overlay main content, rather than pushing main content to the right.
 		   Turn off `display: flex` on the body element. */
 		display: block;

--- a/src/test/rustdoc/local-reexport-doc.rs
+++ b/src/test/rustdoc/local-reexport-doc.rs
@@ -1,0 +1,16 @@
+// This test ensures that the reexports of local items also get the doc from
+// the reexport.
+
+#![crate_name = "foo"]
+
+// @has 'foo/fn.g.html'
+// @has - '//*[@class="rustdoc-toggle top-doc"]/*[@class="docblock"]' \
+// 'outer module inner module'
+
+mod inner_mod {
+    /// inner module
+    pub fn g() {}
+}
+
+/// outer module
+pub use inner_mod::g;

--- a/src/test/ui/const-generics/generic_const_exprs/issue-99705.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-99705.rs
@@ -1,0 +1,33 @@
+// check-pass
+#![crate_type = "lib"]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+pub trait MyIterator {
+    type Output;
+}
+
+pub trait Foo {
+    const ABC: usize;
+}
+
+pub struct IteratorStruct<const N: usize>{
+
+}
+
+pub struct Bar<const N: usize> {
+    pub data: [usize; N]
+}
+
+impl<const N: usize> MyIterator for IteratorStruct<N> {
+    type Output = Bar<N>;
+}
+
+pub fn test1<T: Foo>() -> impl MyIterator<Output = Bar<{T::ABC}>> where [(); T::ABC]: Sized {
+    IteratorStruct::<{T::ABC}>{}
+}
+
+pub trait Baz<const N: usize>{}
+impl<const N: usize> Baz<N> for Bar<N> {}
+pub fn test2<T: Foo>() -> impl MyIterator<Output = impl Baz<{ T::ABC }>> where [(); T::ABC]: Sized {
+    IteratorStruct::<{T::ABC}>{}
+}

--- a/src/test/ui/consts/issue-103790.rs
+++ b/src/test/ui/consts/issue-103790.rs
@@ -1,0 +1,10 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+struct S<const S: (), const S: S = { S }>;
+//~^ ERROR the name `S` is already used for a generic parameter in this item's generic parameters
+//~| ERROR missing generics for struct `S`
+//~| ERROR cycle detected when computing type of `S::S`
+//~| ERROR cycle detected when computing type of `S`
+
+fn main() {}

--- a/src/test/ui/consts/issue-103790.stderr
+++ b/src/test/ui/consts/issue-103790.stderr
@@ -1,0 +1,65 @@
+error[E0403]: the name `S` is already used for a generic parameter in this item's generic parameters
+  --> $DIR/issue-103790.rs:4:29
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |                -            ^ already used
+   |                |
+   |                first use of `S`
+
+error[E0107]: missing generics for struct `S`
+  --> $DIR/issue-103790.rs:4:32
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |                                ^ expected at least 1 generic argument
+   |
+note: struct defined here, with at least 1 generic parameter: `S`
+  --> $DIR/issue-103790.rs:4:8
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |        ^ -----------
+help: add missing generic argument
+   |
+LL | struct S<const S: (), const S: S<S> = { S }>;
+   |                                ~~~~
+
+error[E0391]: cycle detected when computing type of `S::S`
+  --> $DIR/issue-103790.rs:4:32
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |                                ^
+   |
+   = note: ...which immediately requires computing type of `S::S` again
+note: cycle used when computing type of `S`
+  --> $DIR/issue-103790.rs:4:1
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0391]: cycle detected when computing type of `S`
+  --> $DIR/issue-103790.rs:4:1
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires computing type of `S::S`...
+  --> $DIR/issue-103790.rs:4:32
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |                                ^
+   = note: ...which again requires computing type of `S`, completing the cycle
+note: cycle used when collecting item types in top-level module
+  --> $DIR/issue-103790.rs:1:1
+   |
+LL | / #![feature(generic_const_exprs)]
+LL | | #![allow(incomplete_features)]
+LL | |
+LL | | struct S<const S: (), const S: S = { S }>;
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0391, E0403.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - #99801 (fix(generic_const_exprs): Fix predicate inheritance for children of opaque types)
 - #103610 (Allow use of `-Clto=thin` with `-Ccodegen-units=1` in general)
 - #103870 (Fix `inferred_kind` ICE)
 - #103875 (Simplify astconv item def id handling)
 - #103886 (rustdoc: Fix merge of attributes for reexports of local items)
 - #103890 (rustdoc: remove unused mobile CSS `.rustdoc { padding-top: 0 }`)

Failed merges:

 - #103884 (Add visit_fn_ret_ty to hir intravisit)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99801,103610,103870,103875,103886,103890)
<!-- homu-ignore:end -->