### PR TITLE
rustdoc: remove redundant mobile CSS `.sidebar-elems { background }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1797,7 +1797,6 @@ in storage.js
 
 	.sidebar-elems {
 		margin-top: 1em;
-		background-color: var(--sidebar-background-color);
 	}
 
 	.content {


### PR DESCRIPTION
The exact same background is already set for its parent, the `nav.sidebar`.