### PR TITLE
Make underscore_literal_suffix a hard error.

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -88,7 +88,9 @@ pub enum TokenKind {
     /// tokens.
     UnknownPrefix,
 
-    /// Examples: `"12_u8"`, `"1.0e-40"`, `b"123`.
+    /// Examples: `12u8`, `1.0e-40`, `b"123"`. Note that `_` is an invalid
+    /// suffix, but may be present here on string and float literals. Users of
+    /// this type will need to check for and reject that case.
     ///
     /// See [LiteralKind] for more details.
     Literal { kind: LiteralKind, suffix_start: u32 },
@@ -840,12 +842,13 @@ impl Cursor<'_> {
         self.eat_decimal_digits()
     }
 
-    // Eats the suffix of the literal, e.g. "_u8".
+    // Eats the suffix of the literal, e.g. "u8".
     fn eat_literal_suffix(&mut self) {
         self.eat_identifier();
     }
 
-    // Eats the identifier.
+    // Eats the identifier. Note: succeeds on `_`, which isn't a valid
+    // identifer.
     fn eat_identifier(&mut self) {
         if !is_id_start(self.first()) {
             return;

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -175,19 +175,9 @@ impl<'a> StringReader<'a> {
                         if string == "_" {
                             self.sess
                                 .span_diagnostic
-                                .struct_span_warn(
+                                .struct_span_err(
                                     self.mk_sp(suffix_start, self.pos),
                                     "underscore literal suffix is not allowed",
-                                )
-                                .warn(
-                                    "this was previously accepted by the compiler but is \
-                                       being phased out; it will become a hard error in \
-                                       a future release!",
-                                )
-                                .note(
-                                    "see issue #42326 \
-                                     <https://github.com/rust-lang/rust/issues/42326> \
-                                     for more information",
                                 )
                                 .emit();
                             None

--- a/src/test/ui/parser/underscore-suffix-for-string.rs
+++ b/src/test/ui/parser/underscore-suffix-for-string.rs
@@ -1,8 +1,17 @@
-// check-pass
+macro_rules! sink {
+    ($tt:tt) => {()}
+}
 
 fn main() {
     let _ = "Foo"_;
-    //~^ WARNING underscore literal suffix is not allowed
-    //~| WARNING this was previously accepted
-    //~| NOTE issue #42326
+    //~^ ERROR underscore literal suffix is not allowed
+
+    // This is ok, because `__` is a valid identifier and the macro consumes it
+    // before proper parsing happens.
+    let _ = sink!("Foo"__);
+
+    // This is not ok, even as an input to a macro, because the `_` suffix is
+    // never allowed.
+    sink!("Foo"_);
+    //~^ ERROR underscore literal suffix is not allowed
 }

--- a/src/test/ui/parser/underscore-suffix-for-string.stderr
+++ b/src/test/ui/parser/underscore-suffix-for-string.stderr
@@ -1,11 +1,14 @@
-warning: underscore literal suffix is not allowed
-  --> $DIR/underscore-suffix-for-string.rs:4:18
+error: underscore literal suffix is not allowed
+  --> $DIR/underscore-suffix-for-string.rs:6:18
    |
 LL |     let _ = "Foo"_;
    |                  ^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: see issue #42326 <https://github.com/rust-lang/rust/issues/42326> for more information
 
-warning: 1 warning emitted
+error: underscore literal suffix is not allowed
+  --> $DIR/underscore-suffix-for-string.rs:15:16
+   |
+LL |     sink!("Foo"_);
+   |                ^
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
It's been a warning for 5.5 years. Time to make it a hard error.

Closes #42326.

r? @pnkfelix 