### PR TITLE
Move browser opening logic in `Builder`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -2207,6 +2207,24 @@ impl<'a> Builder<'a> {
 
         false
     }
+
+    pub(crate) fn maybe_open_in_browser<S: Step>(&self, path: impl AsRef<Path>) {
+        if self.was_invoked_explicitly::<S>(Kind::Doc) {
+            self.open_in_browser(path);
+        }
+    }
+
+    pub(crate) fn open_in_browser(&self, path: impl AsRef<Path>) {
+        if self.config.dry_run || !self.config.cmd.open() {
+            return;
+        }
+
+        let path = path.as_ref();
+        self.info(&format!("Opening doc {}", path.display()));
+        if let Err(err) = opener::open(path) {
+            self.info(&format!("{}\n", err));
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use crate::builder::{Builder, Compiler, RunConfig, ShouldRun, Step};
+use crate::builder::{Builder, Compiler, Kind, RunConfig, ShouldRun, Step};
 use crate::cache::{Interned, INTERNER};
 use crate::compile;
 use crate::config::{Config, TargetSelection};
@@ -370,7 +370,10 @@ impl Step for Standalone {
 
         // We open doc/index.html as the default if invoked as `x.py doc --open`
         // with no particular explicit doc requested (e.g. library/core).
-        builder.maybe_open_in_browser::<Self>(out.join("index.html"));
+        if builder.paths.is_empty() || builder.was_invoked_explicitly::<Self>(Kind::Doc) {
+            let index = out.join("index.html");
+            builder.open_in_browser(&index);
+        }
     }
 }
 


### PR DESCRIPTION
This allows `open()` to be called from other places in bootstrap (I need this for Ferrocene, as we keep our custom steps in `src/bootstrap/ferrocene`), and it simplifies the callers by moving the `was_invoked_explicitly` check into the function.