### PR TITLE
Revert "Update cargo"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "37d855aeef205b43f65a5001e0997d81f8efca7badad4fad7d897aa7f0d0651f"
 dependencies = [
  "curl-sys",
  "libc",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.59+curl-7.86.0"
+version = "0.4.55+curl-7.83.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
+checksum = "23734ec77368ec583c2e61dd3f0b0e5c98b93abe6d2a004ca06b91dd7e3e2762"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
This reverts commit 331aa4509315f670803b7e232486be84d84ea686.

This Cargo upgrade introduced a regression into dependency resolution, so reverting the upgrade until we can fix that.

cc https://github.com/rust-lang/rust/pull/103860,
https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/cargo.20and.20rustc.20benchmarks.20broken