### PR TITLE
rustdoc: clean up hardcoded CSS border color on search results

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -894,7 +894,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	/* A little margin ensures the browser's outlining of focused links has room to display. */
 	margin-left: 2px;
 	margin-right: 2px;
-	border-bottom: 1px solid #aaa3;
+	border-bottom: 1px solid var(--border-color);
 }
 
 .search-results > a > div {
@@ -1875,7 +1875,6 @@ in storage.js
 
 	/* Display an alternating layout on tablets and phones */
 	.search-results > a {
-		border-bottom: 1px solid #aaa9;
 		padding: 5px 0px;
 	}
 	.search-results .result-name, .search-results div.desc {

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -75,6 +75,12 @@ assert-css: (
     {"color": "rgb(0, 150, 207)"},
 )
 
+// Checking the color of the bottom border.
+assert-css: (
+    ".search-results > a",
+    {"border-bottom-color": "rgb(92, 103, 115)"}
+)
+
 // Checking the color of "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
@@ -181,6 +187,12 @@ assert-css: (
     {"color": "rgb(221, 221, 221)"},
 )
 
+// Checking the color of the bottom border.
+assert-css: (
+    ".search-results > a",
+    {"border-bottom-color": "rgb(224, 224, 224)"}
+)
+
 // Checking the color for "keyword" text.
 assert-css: (
     "//*[@class='result-name']//*[text()='(keyword)']",
@@ -270,6 +282,12 @@ assert-css: (
 assert-css: (
     "//*[@class='result-name']/*[text()='test_docs::']",
     {"color": "rgb(0, 0, 0)"},
+)
+
+// Checking the color of the bottom border.
+assert-css: (
+    ".search-results > a",
+    {"border-bottom-color": "rgb(224, 224, 224)"}
 )
 
 // Checking the color for "keyword" text.


### PR DESCRIPTION
Hardcoded colors in rustdoc.css should usually be avoided.

Preview: http://notriddle.com/notriddle-rustdoc-demos/border-bottom-search/test_dingus/?search=test