### PR TITLE
rustdoc: remove no-op CSS `#main-content > .item-info { margin-top: 0 }`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -677,7 +677,6 @@ pre, .rustdoc.source .example-wrap {
 }
 
 #main-content > .item-info {
-	margin-top: 0;
 	margin-left: 0;
 }
 


### PR DESCRIPTION
When this line was added in 04b4c40682c01cad8f9bc8d5b3907be91d6f81d4, it overrode a negative `margin-top` that was set on it by default.

https://github.com/rust-lang/rust/blob/04b4c40682c01cad8f9bc8d5b3907be91d6f81d4/src/librustdoc/html/static/rustdoc.css#L500-L516

That negative top margin was removed in 593d6d1cb15c55c88319470dabb40126c7b7f1e2.